### PR TITLE
feat: add group service enablement check with config integration

### DIFF
--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -10,6 +10,7 @@ import {
     UpdateGroupWithMembers,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import { LightdashConfig } from '../config/parseConfig';
 import { UpdateDBProjectGroupAccess } from '../database/entities/projectGroupAccess';
 import { GroupsModel } from '../models/GroupsModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
@@ -19,9 +20,12 @@ type GroupServiceArguments = {
     analytics: LightdashAnalytics;
     groupsModel: GroupsModel;
     projectModel: ProjectModel;
+    lightdashConfig: LightdashConfig;
 };
 
 export class GroupsService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
     private readonly analytics: LightdashAnalytics;
 
     private readonly groupsModel: GroupsModel;
@@ -30,15 +34,24 @@ export class GroupsService extends BaseService {
 
     constructor(args: GroupServiceArguments) {
         super();
+        this.lightdashConfig = args.lightdashConfig;
         this.analytics = args.analytics;
         this.groupsModel = args.groupsModel;
         this.projectModel = args.projectModel;
+    }
+
+    private isGroupServiceEnabled(): boolean {
+        return this.lightdashConfig?.groups.enabled ?? false;
     }
 
     async addGroupMember(
         actor: SessionUser,
         member: GroupMembership,
     ): Promise<GroupMembership | undefined> {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group = await this.groupsModel.getGroup(member.groupUuid);
         if (
             actor.ability.cannot(
@@ -78,6 +91,10 @@ export class GroupsService extends BaseService {
         actor: SessionUser,
         member: GroupMembership,
     ): Promise<boolean> {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group = await this.groupsModel.getGroup(member.groupUuid);
         if (
             actor.ability.cannot(
@@ -114,6 +131,10 @@ export class GroupsService extends BaseService {
     }
 
     async delete(actor: SessionUser, groupUuid: string): Promise<void> {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group = await this.groupsModel.getGroup(groupUuid);
         if (
             actor.ability.cannot(
@@ -143,6 +164,10 @@ export class GroupsService extends BaseService {
         includeMembers?: number,
         offset?: number,
     ): Promise<Group | GroupWithMembers> {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group =
             includeMembers === undefined
                 ? await this.groupsModel.getGroup(groupUuid)
@@ -170,6 +195,10 @@ export class GroupsService extends BaseService {
         groupUuid: string,
         update: UpdateGroupWithMembers,
     ): Promise<Group | GroupWithMembers> {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group = await this.groupsModel.getGroup(groupUuid);
         if (
             actor.ability.cannot(
@@ -205,6 +234,10 @@ export class GroupsService extends BaseService {
         actor: SessionUser,
         groupUuid: string,
     ): Promise<GroupMember[]> {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group = await this.groupsModel.getGroupWithMembers(groupUuid);
         if (
             actor.ability.cannot(
@@ -223,6 +256,10 @@ export class GroupsService extends BaseService {
         actor: SessionUser,
         { groupUuid, projectUuid, role }: ProjectGroupAccess,
     ): Promise<ProjectGroupAccess> {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
@@ -272,6 +309,10 @@ export class GroupsService extends BaseService {
             projectUuid,
         }: Pick<ProjectGroupAccess, 'groupUuid' | 'projectUuid'>,
     ) {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
@@ -317,6 +358,10 @@ export class GroupsService extends BaseService {
         }: Pick<ProjectGroupAccess, 'groupUuid' | 'projectUuid'>,
         updateAttributes: UpdateDBProjectGroupAccess,
     ): Promise<ProjectGroupAccess> {
+        if (!this.isGroupServiceEnabled()) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 

--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -12,7 +12,6 @@ import {
     UpdateGroupWithMembers,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
-import { LightdashConfig } from '../config/parseConfig';
 import { UpdateDBProjectGroupAccess } from '../database/entities/projectGroupAccess';
 import { GroupsModel } from '../models/GroupsModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
@@ -57,7 +56,7 @@ export class GroupsService extends BaseService {
         actor: SessionUser,
         member: GroupMembership,
     ): Promise<GroupMembership | undefined> {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -100,7 +99,7 @@ export class GroupsService extends BaseService {
         actor: SessionUser,
         member: GroupMembership,
     ): Promise<boolean> {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -140,7 +139,7 @@ export class GroupsService extends BaseService {
     }
 
     async delete(actor: SessionUser, groupUuid: string): Promise<void> {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -173,7 +172,7 @@ export class GroupsService extends BaseService {
         includeMembers?: number,
         offset?: number,
     ): Promise<Group | GroupWithMembers> {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -204,7 +203,7 @@ export class GroupsService extends BaseService {
         groupUuid: string,
         update: UpdateGroupWithMembers,
     ): Promise<Group | GroupWithMembers> {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -243,7 +242,7 @@ export class GroupsService extends BaseService {
         actor: SessionUser,
         groupUuid: string,
     ): Promise<GroupMember[]> {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -265,7 +264,7 @@ export class GroupsService extends BaseService {
         actor: SessionUser,
         { groupUuid, projectUuid, role }: ProjectGroupAccess,
     ): Promise<ProjectGroupAccess> {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -318,7 +317,7 @@ export class GroupsService extends BaseService {
             projectUuid,
         }: Pick<ProjectGroupAccess, 'groupUuid' | 'projectUuid'>,
     ) {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -367,7 +366,7 @@ export class GroupsService extends BaseService {
         }: Pick<ProjectGroupAccess, 'groupUuid' | 'projectUuid'>,
         updateAttributes: UpdateDBProjectGroupAccess,
     ): Promise<ProjectGroupAccess> {
-        if (!this.isGroupServiceEnabled(actor)) {
+        if (!(await this.isGroupServiceEnabled(actor))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -362,6 +362,7 @@ export class ServiceRepository
                     analytics: this.context.lightdashAnalytics,
                     groupsModel: this.models.getGroupsModel(),
                     projectModel: this.models.getProjectModel(),
+                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -40,7 +40,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
 }) => {
     const { user } = useApp();
 
-    const { data: userGroupsFeatureFlag } = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
     const ability = useAbilityContext();
@@ -56,7 +56,11 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
 
     const { data: groups } = useOrganizationGroups(
         { includeMembers: 5 },
-        { enabled: !!userGroupsFeatureFlag?.enabled },
+        {
+            enabled:
+                userGroupsFeatureFlagQuery.isSuccess &&
+                userGroupsFeatureFlagQuery.data.enabled,
+        },
     );
 
     const { data: projectAccess, isInitialLoading: isProjectAccessLoading } =

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    FeatureFlags,
     ProjectMemberRole,
     convertOrganizationRoleToProjectRole,
     convertProjectRoleToOrganizationRole,
@@ -14,6 +15,7 @@ import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
 import { useProjectGroupAccessList } from '../../features/projectGroupAccess/hooks/useProjectGroupAccess';
 import { useTableStyles } from '../../hooks/styles/useTableStyles';
+import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
 import { useOrganizationGroups } from '../../hooks/useOrganizationGroups';
 import { useOrganizationUsers } from '../../hooks/useOrganizationUsers';
 import { useProjectAccess } from '../../hooks/useProjectAccess';
@@ -37,6 +39,10 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
     onAddProjectAccessClose,
 }) => {
     const { user } = useApp();
+
+    const { data: userGroupsFeatureFlag } = useFeatureFlag(
+        FeatureFlags.UserGroupsEnabled,
+    );
     const ability = useAbilityContext();
 
     const { cx, classes } = useTableStyles();
@@ -48,7 +54,10 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
         isInitialLoading: isOrganizationUsersLoading,
     } = useOrganizationUsers();
 
-    const { data: groups } = useOrganizationGroups({ includeMembers: 5 });
+    const { data: groups } = useOrganizationGroups(
+        { includeMembers: 5 },
+        { enabled: !!userGroupsFeatureFlag?.enabled },
+    );
 
     const { data: projectAccess, isInitialLoading: isProjectAccessLoading } =
         useProjectAccess(projectUuid);

--- a/packages/frontend/src/components/ProjectAccess/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/index.tsx
@@ -16,7 +16,7 @@ interface ProjectUserAccessProps {
 
 const ProjectUserAccess: FC<ProjectUserAccessProps> = ({ projectUuid }) => {
     const { user } = useApp();
-    const { data: UserGroupsFeatureFlag } = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 
@@ -24,9 +24,16 @@ const ProjectUserAccess: FC<ProjectUserAccessProps> = ({ projectUuid }) => {
     const [showProjectGroupAccessAdd, setShowProjectGroupAccessAdd] =
         useState(false);
 
-    if (!user.data || !UserGroupsFeatureFlag) return null;
+    if (!user.data) return null;
 
-    const isGroupManagementEnabled = UserGroupsFeatureFlag?.enabled;
+    if (userGroupsFeatureFlagQuery.isError) {
+        console.error(userGroupsFeatureFlagQuery.error);
+        throw new Error('Error fetching user groups feature flag');
+    }
+
+    const isGroupManagementEnabled =
+        userGroupsFeatureFlagQuery.isSuccess &&
+        userGroupsFeatureFlagQuery.data.enabled;
 
     return (
         <Stack>

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -40,7 +40,7 @@ const UserAttributeModal: FC<{
     allUserAttributes: UserAttribute[];
     onClose: () => void;
 }> = ({ opened, userAttribute, allUserAttributes, onClose }) => {
-    const { data: userGroupsFeatureFlag } = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 
@@ -134,15 +134,20 @@ const UserAttributeModal: FC<{
         handleClose();
     };
 
+    if (userGroupsFeatureFlagQuery.isError) {
+        console.error(userGroupsFeatureFlagQuery.error);
+        throw new Error('Error fetching user groups feature flag');
+    }
+
+    const isGroupManagementEnabled =
+        userGroupsFeatureFlagQuery.isSuccess &&
+        userGroupsFeatureFlagQuery.data.enabled;
+
     const { data: orgUsers } = useOrganizationUsers();
     const { data: groups } = useOrganizationGroups(
         {},
-        { enabled: !!userGroupsFeatureFlag?.enabled },
+        { enabled: isGroupManagementEnabled },
     );
-
-    if (!userGroupsFeatureFlag) return null;
-
-    const isGroupManagementEnabled = userGroupsFeatureFlag?.enabled;
 
     return (
         <Modal

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -40,7 +40,7 @@ const UserAttributeModal: FC<{
     allUserAttributes: UserAttribute[];
     onClose: () => void;
 }> = ({ opened, userAttribute, allUserAttributes, onClose }) => {
-    const { data: UserGroupsFeatureFlag } = useFeatureFlag(
+    const { data: userGroupsFeatureFlag } = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 
@@ -135,15 +135,14 @@ const UserAttributeModal: FC<{
     };
 
     const { data: orgUsers } = useOrganizationUsers();
-    const { data: groups } = useOrganizationGroups({
-        queryOptions: {
-            enabled: !!UserGroupsFeatureFlag?.enabled,
-        },
-    });
+    const { data: groups } = useOrganizationGroups(
+        {},
+        { enabled: !!userGroupsFeatureFlag?.enabled },
+    );
 
-    if (!UserGroupsFeatureFlag) return null;
+    if (!userGroupsFeatureFlag) return null;
 
-    const isGroupManagementEnabled = UserGroupsFeatureFlag?.enabled;
+    const isGroupManagementEnabled = userGroupsFeatureFlag?.enabled;
 
     return (
         <Modal

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -142,7 +142,7 @@ const UserListItem: FC<{
 const UserAttributesPanel: FC = () => {
     const { classes } = useTableStyles();
     const { user } = useApp();
-    const { data: UserGroupsFeatureFlag } = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
     const [showAddAttributeModal, addAttributeModal] = useDisclosure(false);
@@ -164,12 +164,20 @@ const UserAttributesPanel: FC = () => {
         return <ForbiddenPanel />;
     }
 
-    if (isInitialLoading)
+    if (isInitialLoading) {
         return <LoadingState title="Loading user attributes" />;
+    }
 
-    if (!user.data || !UserGroupsFeatureFlag) return null;
+    if (userGroupsFeatureFlagQuery.isError) {
+        console.error(userGroupsFeatureFlagQuery.error);
+        throw new Error('Error fetching user groups feature flag');
+    }
 
-    const isGroupManagementEnabled = UserGroupsFeatureFlag?.enabled;
+    if (!user.data) return null;
+
+    const isGroupManagementEnabled =
+        userGroupsFeatureFlagQuery.isSuccess &&
+        userGroupsFeatureFlagQuery.data.enabled;
 
     return (
         <Stack>

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
@@ -347,7 +347,7 @@ const UserListItem: FC<{
 const UsersView: FC = () => {
     const [showInviteModal, setShowInviteModal] = useState(false);
     const { user } = useApp();
-    const { data: UserGroupsFeatureFlag } = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
     const { classes } = useTableStyles();
@@ -384,9 +384,16 @@ const UsersView: FC = () => {
         return paginatedUsers?.pagination;
     }, [paginatedUsers]);
 
-    if (!user.data || !UserGroupsFeatureFlag) return null;
+    if (!user.data) return null;
 
-    const isGroupManagementEnabled = UserGroupsFeatureFlag?.enabled;
+    if (userGroupsFeatureFlagQuery.isError) {
+        console.error(userGroupsFeatureFlagQuery.error);
+        throw new Error('Error fetching user groups feature flag');
+    }
+
+    const isGroupManagementEnabled =
+        userGroupsFeatureFlagQuery.isSuccess &&
+        userGroupsFeatureFlagQuery.data.enabled;
 
     return (
         <Stack spacing="xs">

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
@@ -13,17 +13,24 @@ import UsersView from './UsersView';
 
 const UsersAndGroupsPanel: FC = () => {
     const { user } = useApp();
-    const { data: UserGroupsFeatureFlag } = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 
-    if (!user.data || !UserGroupsFeatureFlag) return null;
+    if (!user.data) return null;
 
     if (user.data.ability.cannot('view', 'OrganizationMemberProfile')) {
         return <ForbiddenPanel />;
     }
 
-    const isGroupManagementEnabled = UserGroupsFeatureFlag?.enabled;
+    if (userGroupsFeatureFlagQuery.isError) {
+        console.error(userGroupsFeatureFlagQuery.error);
+        throw new Error('Error fetching user groups feature flag');
+    }
+
+    const isGroupManagementEnabled =
+        userGroupsFeatureFlagQuery.isSuccess &&
+        userGroupsFeatureFlagQuery.data.enabled;
 
     return (
         <Stack spacing="sm">

--- a/packages/frontend/src/hooks/useOrganizationGroups.ts
+++ b/packages/frontend/src/hooks/useOrganizationGroups.ts
@@ -42,18 +42,19 @@ const getOrganizationGroupsQuery = async (
     });
 };
 
-export const useOrganizationGroups = ({
-    searchInput,
-    includeMembers,
-    queryOptions,
-}: {
-    searchInput?: string;
-    includeMembers?: number;
+export const useOrganizationGroups = (
+    {
+        searchInput,
+        includeMembers,
+    }: {
+        searchInput?: string;
+        includeMembers?: number;
+    },
     queryOptions?: UseQueryOptions<
         ApiGroupListResponse['results']['data'],
         ApiError
-    >;
-}) => {
+    >,
+) => {
     const setErrorResponse = useQueryError();
     return useQuery<ApiGroupListResponse['results']['data'], ApiError>({
         queryKey: ['organization_groups', includeMembers, searchInput],

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -81,9 +81,11 @@ const Settings: FC = () => {
         },
         user: { data: user, isInitialLoading: isUserLoading, error: userError },
     } = useApp();
-    const { data: UserGroupFeatureFlag } = useFeatureFlag(
+
+    const userGroupsFeatureFlagQuery = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
+
     const { track } = useTracking();
     const {
         data: organization,
@@ -108,7 +110,15 @@ const Settings: FC = () => {
         health?.auth.azuread.enabled ||
         health?.auth.oidc.enabled;
 
-    const isGroupManagementEnabled = UserGroupFeatureFlag?.enabled;
+    if (userGroupsFeatureFlagQuery.isError) {
+        console.error(userGroupsFeatureFlagQuery.error);
+        throw new Error('Error fetching user groups feature flag');
+    }
+
+    const isGroupManagementEnabled =
+        userGroupsFeatureFlagQuery.isSuccess &&
+        userGroupsFeatureFlagQuery.data.enabled;
+
     // This allows us to enable service accounts in the UI for on-premise installations
     const isServiceAccountsEnabled =
         health?.isServiceAccountEnabled || isServiceAccountFeatureFlagEnabled;


### PR DESCRIPTION
Added a feature flag to enable/disable the Group service functionality. This PR introduces a check in all Group service methods to verify if the service is enabled before proceeding with operations. If the service is disabled, a ForbiddenError is thrown with the message "Group service is not enabled".