### PR TITLE
feat: add create_by_account to query_history

### DIFF
--- a/packages/backend/src/database/entities/queryHistory.ts
+++ b/packages/backend/src/database/entities/queryHistory.ts
@@ -18,6 +18,7 @@ export type DbQueryHistory = {
     query_uuid: string;
     created_at: Date;
     created_by_user_uuid: string | null;
+    created_by_account: string | null;
     project_uuid: string | null;
     organization_uuid: string;
     context: QueryExecutionContext;

--- a/packages/backend/src/ee/database/migrations/20250713101551_add_query_history_account.ts
+++ b/packages/backend/src/ee/database/migrations/20250713101551_add_query_history_account.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+
+const QUERY_HISTORY_TABLE = 'query_history';
+const CREATED_BY_ACCOUNT_COLUMN = 'created_by_account';
+
+export async function up(knex: Knex): Promise<void> {
+    // 1. Add a new nullable "createdByAccount" column of type string
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.string(CREATED_BY_ACCOUNT_COLUMN).nullable();
+    });
+
+    // 2. Add indexes on the new column
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.index([CREATED_BY_ACCOUNT_COLUMN]);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // Remove index
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.dropIndex([CREATED_BY_ACCOUNT_COLUMN]);
+    });
+
+    // Remove the created_by_account column
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.dropColumn(CREATED_BY_ACCOUNT_COLUMN);
+    });
+}

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -297,7 +297,6 @@ describe('AsyncQueryService', () => {
             ).toHaveBeenCalledWith(
                 'test-query-uuid',
                 projectUuid,
-                user.userUuid,
                 {
                     status: QueryHistoryStatus.READY,
                     error: null,
@@ -312,6 +311,7 @@ describe('AsyncQueryService', () => {
                     pivot_total_column_count: null,
                     pivot_values_columns: null,
                 },
+                user.userUuid,
             );
 
             // Verify that the warehouse client executeAsyncQuery method was not called
@@ -519,6 +519,7 @@ describe('AsyncQueryService', () => {
                 createdAt: new Date(),
                 organizationUuid: user.organizationUuid!,
                 createdByUserUuid: user.userUuid,
+                createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
                 status: QueryHistoryStatus.ERROR,
@@ -573,6 +574,7 @@ describe('AsyncQueryService', () => {
                 createdAt: new Date(),
                 organizationUuid: user.organizationUuid!,
                 createdByUserUuid: user.userUuid,
+                createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
                 status: QueryHistoryStatus.PENDING,
@@ -629,6 +631,7 @@ describe('AsyncQueryService', () => {
                 createdAt: new Date(),
                 organizationUuid: user.organizationUuid!,
                 createdByUserUuid: user.userUuid,
+                createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
                 status: QueryHistoryStatus.CANCELLED,
@@ -682,6 +685,7 @@ describe('AsyncQueryService', () => {
                 createdAt: new Date(),
                 organizationUuid: user.organizationUuid!,
                 createdByUserUuid: user.userUuid,
+                createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
                 status: QueryHistoryStatus.READY,
@@ -771,6 +775,7 @@ describe('AsyncQueryService', () => {
                 createdAt: new Date(),
                 organizationUuid: user.organizationUuid!,
                 createdByUserUuid: user.userUuid,
+                createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
                 status: QueryHistoryStatus.READY,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -358,10 +358,10 @@ export class AsyncQueryService extends ProjectService {
         await this.queryHistoryModel.update(
             queryUuid,
             projectUuid,
-            user.userUuid,
             {
                 status: QueryHistoryStatus.CANCELLED,
             },
+            user.userUuid,
         );
     }
 
@@ -536,10 +536,10 @@ export class AsyncQueryService extends ProjectService {
             await this.queryHistoryModel.update(
                 queryHistory.queryUuid,
                 projectUuid,
-                user.userUuid,
                 {
                     default_page_size: defaultedPageSize,
                 },
+                user.userUuid,
             );
         }
 
@@ -1270,7 +1270,6 @@ export class AsyncQueryService extends ProjectService {
             await this.queryHistoryModel.update(
                 queryHistoryUuid,
                 projectUuid,
-                userUuid,
                 {
                     warehouse_query_id: queryId,
                     warehouse_query_metadata: queryMetadata,
@@ -1291,6 +1290,7 @@ export class AsyncQueryService extends ProjectService {
                     columns,
                     original_columns: originalColumns,
                 },
+                userUuid,
             );
         } catch (e) {
             this.analytics.track({
@@ -1305,11 +1305,11 @@ export class AsyncQueryService extends ProjectService {
             await this.queryHistoryModel.update(
                 queryHistoryUuid,
                 projectUuid,
-                userUuid,
                 {
                     status: QueryHistoryStatus.ERROR,
                     error: getErrorMessage(e),
                 },
+                userUuid,
             );
         } finally {
             void sshTunnel?.disconnect();
@@ -1563,7 +1563,6 @@ export class AsyncQueryService extends ProjectService {
                         await this.queryHistoryModel.update(
                             queryHistoryUuid,
                             projectUuid,
-                            user.userUuid,
                             {
                                 status: QueryHistoryStatus.READY,
                                 error: null,
@@ -1580,6 +1579,7 @@ export class AsyncQueryService extends ProjectService {
                                     resultsCache.pivotTotalColumnCount,
                                 warehouse_execution_time_ms: 0, // When cache is hit, no query is executed
                             },
+                            user.userUuid,
                         );
 
                         return {

--- a/packages/common/src/types/queryHistory.ts
+++ b/packages/common/src/types/queryHistory.ts
@@ -30,6 +30,7 @@ export type QueryHistory = {
     queryUuid: string;
     createdAt: Date;
     createdByUserUuid: string | null;
+    createdByAccount: string | null;
     organizationUuid: string;
     projectUuid: string | null;
     warehouseQueryId: string | null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15847

### Description:
Added support for tracking queries by account in query history. `account` encapsulates identity that is not userUuid—which would include an external ID. 

These changes are needed so that embedded users can make async queries and have query history associated to their external ID. 

This change:

- Added a new `created_by_account` column to the query history table
- Created a migration to add the column and appropriate indexes
- Updated the QueryHistoryModel to support filtering by account instead of user UUID
- Modified method signatures in AsyncQueryService to accommodate the new account parameter
- Updated type definitions to include the new field

This enhancement allows queries to be associated with either a user UUID or an account identifier, enabling better tracking of query history for different authentication methods.

Moving forward, we'll also be able to run a clean up job on `query_history` with the new index to remove expired history. 