### PR TITLE
chore: remove extra newline in InstanceConfigurationServiceArguments

### DIFF
--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -63,7 +63,6 @@ type InstanceConfigurationServiceArguments = {
     organizationModel: OrganizationModel;
     projectModel: ProjectModel;
     userModel: UserModel;
-
     organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
     personalAccessTokenModel: PersonalAccessTokenModel;
     emailModel: EmailModel;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Removed an unnecessary blank line in the `InstanceConfigurationServiceArguments` type definition between `userModel` and `organizationAllowedEmailDomainsModel` properties to maintain consistent formatting.

frontend-test backend-test