### PR TITLE
feat: add trackAccount to LightdashAnalytics

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1,6 +1,6 @@
 /// <reference path="../@types/rudder-sdk-node.d.ts" />
-import { Type } from '@aws-sdk/client-s3';
 import {
+    Account,
     AnyType,
     CacheMetadata,
     CartesianSeriesType,
@@ -20,11 +20,9 @@ import {
     QueryHistoryStatus,
     RequestMethod,
     SchedulerFormat,
-    SqlRunnerQuery,
     TableSelectionType,
     ValidateProjectPayload,
     WarehouseTypes,
-    getErrorMessage,
     getRequestMethod,
 } from '@lightdash/common';
 import Analytics, {
@@ -33,7 +31,6 @@ import Analytics, {
 import { Request } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
-import Logger from '../logging/logger';
 import { VERSION } from '../version';
 
 type Identify = {
@@ -1563,5 +1560,34 @@ export class LightdashAnalytics extends Analytics {
             ...payload,
             context: { ...this.lightdashContext }, // NOTE: spread because rudderstack manipulates arg
         });
+    }
+
+    /**
+     * Track events from an account. This lets us centralize common properties that are found in req.account.
+     */
+    trackAccount<T extends BaseTrack>(
+        account: Account,
+        basePayload: TypedEvent | UntypedEvent<T>,
+    ) {
+        const payload = {
+            ...basePayload,
+        };
+
+        if (!payload.properties) {
+            payload.properties = {};
+        }
+
+        if (account.user.type === 'known') {
+            payload.userId = account.user.id;
+        } else {
+            payload.anonymousId = 'embed';
+            payload.properties.externalId = account.user.id;
+        }
+
+        // TODO: Could these be top-level fields rather than properties?
+        payload.properties.organizationId =
+            account.organization.organizationUuid;
+
+        this.track(payload);
     }
 }

--- a/packages/backend/src/ee/analytics/index.ts
+++ b/packages/backend/src/ee/analytics/index.ts
@@ -7,10 +7,8 @@ type BaseTrack = Omit<AnalyticsTrack, 'context'>;
 export type EmbedDashboardViewed = BaseTrack & {
     event: 'embed_dashboard.viewed';
     properties: {
-        organizationId: string;
         projectId: string;
         dashboardId: string;
-        externalId: string;
         context: 'preview' | 'production';
         dashboardFiltersInteractivity?: DashboardFilterInteractivityOptions;
         canExportCsv?: boolean;
@@ -23,11 +21,9 @@ export type EmbedDashboardViewed = BaseTrack & {
 export type EmbedQueryViewed = BaseTrack & {
     event: 'embed_query.executed';
     properties: {
-        organizationId: string;
         projectId: string;
         dashboardId: string;
         chartId: string;
-        externalId: string;
     };
 };
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -354,14 +354,11 @@ export class EmbedService extends BaseService {
             canDateZoom,
         } = decodedToken.content;
 
-        this.analytics.track<EmbedDashboardViewed>({
-            anonymousId: 'embed',
+        this.analytics.trackAccount<EmbedDashboardViewed>(account, {
             event: 'embed_dashboard.viewed',
             properties: {
-                organizationId: dashboard.organizationUuid,
                 projectId: dashboard.projectUuid,
                 dashboardId: dashboard.uuid,
-                externalId,
                 context: isPreview ? 'preview' : 'production',
                 tilesCount: dashboard.tiles.length,
                 chartTilesCount: dashboard.tiles.filter(
@@ -806,15 +803,12 @@ export class EmbedService extends BaseService {
         };
 
         const externalId = account.user.id;
-        this.analytics.track<EmbedQueryViewed>({
-            anonymousId: 'embed',
+        this.analytics.trackAccount<EmbedQueryViewed>(account, {
             event: 'embed_query.executed',
             properties: {
-                organizationId: organizationUuid,
                 projectId: projectUuid,
                 dashboardId: dashboardUuid,
                 chartId: chart.uuid,
-                externalId,
             },
         });
 

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -12,7 +12,8 @@ export type AccountUser = {
     isActive: boolean;
     abilityRules: AbilityBuilder<MemberAbility>['rules'];
     ability: MemberAbility;
-    type: 'lightdash' | 'external';
+    /* Is this a known user in our DB or an anonymous external user? */
+    type: 'known' | 'external';
 };
 
 export interface LightdashUser {
@@ -37,7 +38,7 @@ export interface LightdashUser {
 }
 
 export interface LightdashSessionUser extends AccountUser {
-    type: 'lightdash';
+    type: 'known';
     // The current effective primary key for users. It duplicates user.id.
     userUuid: string;
     // The old sequential primary key for users


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15547

### Description:
Added a new `trackAccount` method to `LightdashAnalytics` class to centralize tracking events from an account. This method automatically extracts common properties like `userId`, `anonymousId`, `externalId`, and `organizationId` from the account object, reducing code duplication.

Updated embed analytics to use this new method, simplifying the tracking code in `EmbedService` by removing redundant properties that are now handled automatically.