### PR TITLE
fix: add --full-refresh flag to dbt run command in CLI tests

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -86,7 +86,7 @@ jobs:
 
             ## DBT run
             - name: Run DBT
-              run: dbt run --profiles-dir $PROFILES_DIR --project-dir $PROJECT_DIR
+              run: dbt run --profiles-dir $PROFILES_DIR --project-dir $PROJECT_DIR --full-refresh
               env:
                   PROJECT_DIR: './examples/full-jaffle-shop-demo/dbt'
                   PROFILES_DIR: './examples/full-jaffle-shop-demo/profiles'


### PR DESCRIPTION
## Description

Fix CLI tests failing due to dbt relation conflicts by adding `--full-refresh` flag to `dbt run` command.

## Problem

CLI tests were failing with:

```
Database Error in model stg_customers (models/staging/stg_customers.sql)
  relation "stg_customers" already exists
Database Error in model stg_orders (models/staging/stg_orders.sql)
  relation "stg_orders" already exists
Database Error in model stg_payments (models/staging/stg_payments.sql)
  relation "stg_payments" already exists
```

Example: https://github.com/lightdash/lightdash/runs/45986599501


Example of `--full-refresh` https://github.com/lightdash/lightdash/blob/207bbd4999473f8ca693fa5e43c72e2d7d102fb7/examples/full-jaffle-shop-demo/renderDeployHook.sh#L7
