### PR TITLE
fix: add timeout to fullPage boundingBox in UnfurlService

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -940,7 +940,9 @@ export class UnfurlService extends BaseService {
                     }
 
                     const fullPage = await page.locator(finalSelector);
-                    const fullPageSize = await fullPage?.boundingBox();
+                    const fullPageSize = await fullPage?.boundingBox({
+                        timeout: RESPONSE_TIMEOUT_MS,
+                    });
 
                     if (
                         chartType !== ChartType.BIG_NUMBER &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a timeout parameter to the `boundingBox()` method call in the UnfurlService to prevent potential hanging operations. This ensures that the operation will fail gracefully after the specified `RESPONSE_TIMEOUT_MS` period rather than waiting indefinitely.
