### PR TITLE
feat: add SQL parameters support in project config

### DIFF
--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -44,6 +44,33 @@
                     }
                 }
             }
+        },
+        "parameters": {
+            "type": ["object", "null"],
+            "description": "Define parameters that can be used in SQL queries",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "description": "The label of the parameter as it will be displayed in the UI",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "A description of the parameter",
+                            "type": "string"
+                        },
+                        "options": {
+                            "description": "A list of possible values for the parameter",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": ["label"]
+                }
+            }
         }
     }
 }

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -46,6 +46,7 @@ export type CompiledTable = TableBase & {
     lineageGraph: LineageGraph;
     source?: Source | undefined;
     uncompiledSqlWhere?: string;
+    parametersReferences?: string[];
 };
 
 export enum ExploreType {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -445,14 +445,17 @@ export interface Dimension extends Field {
     aiHint?: string;
 }
 
-export interface CompiledDimension extends Dimension {
+type CompiledProperties = {
     compiledSql: string; // sql string with resolved template variables
     tablesReferences: Array<string> | undefined;
     tablesRequiredAttributes?: Record<
         string,
         Record<string, string | string[]>
     >;
-}
+    parametersReferences?: string[];
+};
+export type CompiledDimension = Dimension & CompiledProperties;
+export type CompiledMetric = Metric & CompiledProperties;
 
 export type CompiledField = CompiledDimension | CompiledMetric;
 
@@ -460,15 +463,6 @@ export const isDimension = (
     field: ItemsMap[string] | AdditionalMetric | undefined, // NOTE: `ItemsMap converts AdditionalMetric to Metric
 ): field is Dimension =>
     isField(field) && field.fieldType === FieldType.DIMENSION;
-
-export interface CompiledMetric extends Metric {
-    compiledSql: string;
-    tablesReferences: Array<string> | undefined;
-    tablesRequiredAttributes?: Record<
-        string,
-        Record<string, string | string[]>
-    >;
-}
 
 export interface FilterableDimension extends Dimension {
     type:

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -10,8 +10,15 @@ type SpotlightConfig = {
     };
 };
 
+type LightdashParameter = {
+    label: string;
+    description?: string;
+    options?: string[];
+};
+
 export type LightdashProjectConfig = {
     spotlight: SpotlightConfig;
+    parameters?: Record<string, LightdashParameter>; // keys must be ^[a-zA-Z0-9_-]+$
 };
 
 export const DEFAULT_SPOTLIGHT_CONFIG: SpotlightConfig = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added support for SQL parameters in project configuration. This allows users to define parameters that can be used in SQL queries with customizable labels, descriptions, and predefined options. The schema now includes validation for parameter names, requiring them to match the pattern `^[a-zA-Z0-9_-]+$`.

The implementation tracks parameter references in compiled SQL through new properties added to the `CompiledProperties` type, which is now shared between `CompiledDimension` and `CompiledMetric` types for better code organization.