### PR TITLE
fix: improve SQL runner error handling

### DIFF
--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -9,7 +9,7 @@ import {
     type VizTableColumnsConfig,
     type VizTableConfig,
 } from '@lightdash/common';
-import type { PayloadAction } from '@reduxjs/toolkit';
+import type { PayloadAction, SerializedError } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { format, type FormatOptionsWithLanguage } from 'sql-formatter';
@@ -128,7 +128,7 @@ export interface SqlRunnerState {
     fetchResultsOnLoad: boolean;
     mode: 'default' | 'virtualView';
     queryIsLoading: boolean;
-    queryError: ApiErrorDetail | undefined;
+    queryError: ApiErrorDetail | SerializedError | Error | undefined;
     editorHighlightError: MonacoHighlightChar | undefined;
 }
 
@@ -404,7 +404,10 @@ export const sqlRunnerSlice = createSlice({
             })
             .addCase(runSqlQuery.rejected, (state, action) => {
                 state.queryIsLoading = false;
-                state.queryError = action.payload ?? undefined;
+                state.queryError =
+                    action.payload ??
+                    action.error ??
+                    new Error('Unexpected query error');
 
                 state.editorHighlightError = action.payload?.data
                     ? {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15865

### Description

- Fixed error handling in SQL Runner to properly display query execution errors
- Updated Redux state management to handle different error types (SerializedError, Error, ApiErrorDetail)
- Ensures users see meaningful error messages when SQL queries fail instead of silent failures

### Problem

When SQL queries failed with execution errors (e.g., "Unrecognized name: f0\_ at [2:1]"), the errors were being swallowed and not displayed to users. The Redux store was only handling `ApiErrorDetail` errors from the payload
