### PR TITLE
fix: improve custom visualization sizing and layout

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -6,7 +6,6 @@ import { type CustomVisualizationConfigAndData } from '../../hooks/useCustomVisu
 import { isCustomVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import { LoadingChart } from '../SimpleChart';
-import { COLLAPSIBLE_CARD_GAP_SIZE } from '../common/CollapsableCard/constants';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 
 const VegaLite = lazy(() =>
@@ -87,14 +86,12 @@ const CustomVisualization: FC<Props> = (props) => {
                 <VegaLite
                     style={{
                         width: rect.width,
-                        // NOTE: We need to subtract the gap size because the bounding rect
-                        // does not take into account the padding/margin of the parent element
-                        height: rect.height - COLLAPSIBLE_CARD_GAP_SIZE,
+                        height: rect.height,
                     }}
                     config={{
                         autosize: {
                             resize: true,
-                            type: 'fit-x',
+                            type: 'fit',
                         },
                     }}
                     // TODO: We are ignoring some typescript errors here because the type

--- a/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
@@ -175,9 +175,14 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                                     overflow: 'hidden',
                                     display: 'flex',
                                     flexDirection: 'column',
-                                    paddingTop: COLLAPSIBLE_CARD_GAP_SIZE,
                                 }}
                             >
+                                <div
+                                    style={{
+                                        height: COLLAPSIBLE_CARD_GAP_SIZE,
+                                        minHeight: COLLAPSIBLE_CARD_GAP_SIZE,
+                                    }}
+                                />
                                 {children}
                             </div>
                         </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #

### Description:
Fixed the custom visualization sizing by changing the autosize type from 'fit-x' to 'fit' and restructuring the padding in CollapsableCard. Instead of subtracting the gap size from the height calculation, the gap is now implemented as a separate div element, ensuring proper visualization dimensions.