### PR TITLE
fix: return 'NaT' for invalid timestamp formats

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -833,6 +833,57 @@ describe('Formatting', () => {
                 ),
             ).toEqual('1K');
         });
+
+        describe('formatItemValue timestamp handling', () => {
+            const mockTimestampField = {
+                type: DimensionType.TIMESTAMP,
+                name: 'test_timestamp',
+                table: 'test',
+                fieldType: FieldType.DIMENSION,
+                label: 'Test Timestamp',
+                sql: 'test.timestamp',
+                tableLabel: 'Test',
+                hidden: false,
+            };
+
+            test('should handle valid timestamp formats', () => {
+                const validTimestamps = [
+                    '2020-08-11T16:44:00Z',
+                    '2020-08-11 16:44:00',
+                    '2020-08-11T16:44:00.123Z',
+                    new Date('2020-08-11T16:44:00Z'),
+                    moment('2020-08-11T16:44:00Z'),
+                ];
+
+                validTimestamps.forEach((timestamp) => {
+                    const result = formatItemValue(
+                        mockTimestampField,
+                        timestamp,
+                    );
+                    expect(result).not.toBe('NaT');
+                    expect(result).not.toContain('Invalid');
+                });
+            });
+
+            test('should return NaT for invalid formats', () => {
+                const invalidTimestamps = [
+                    'invalid-date-string',
+                    '2020-13-45',
+                    '2020-08-11T25:00:00',
+                    '',
+                    'not-a-date',
+                    '2025-07-08 23:59:58.656000 Asia/Bangkok',
+                ];
+
+                invalidTimestamps.forEach((timestamp) => {
+                    const result = formatItemValue(
+                        mockTimestampField,
+                        timestamp,
+                    );
+                    expect(result).toBe('NaT');
+                });
+            });
+        });
     });
     describe('additional metric formatting', () => {
         test('format additional metric with custom format DATE', () => {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -131,6 +131,11 @@ export function formatDate(
     convertToUTC: boolean = false,
 ): string {
     const momentDate = convertToUTC ? moment(date).utc() : moment(date);
+
+    if (!momentDate.isValid()) {
+        return 'NaT';
+    }
+
     return momentDate.format(getDateFormat(timeInterval));
 }
 
@@ -140,6 +145,11 @@ export function formatTimestamp(
     convertToUTC: boolean = false,
 ): string {
     const momentDate = convertToUTC ? moment(value).utc() : moment(value);
+
+    if (!momentDate.isValid()) {
+        return 'NaT';
+    }
+
     return momentDate.format(getTimeFormat(timeInterval));
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15880

### Description:

Adds validation for timestamp formatting to handle invalid date inputs gracefully. When an invalid timestamp is encountered, the formatter now returns "NaT" (Not a Timestamp) instead of potentially displaying incorrect or confusing values.

```
          additional_dimensions:
            timestamp_malformed:
              type: timestamp
              label: 'Malformed Timestamp'
              description: 'Returns intentionally malformed timestamp'
              sql: "'2025-08-11 25:99:99.999999'"
```

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/39c77313-82eb-456f-8645-979ea09dd749.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/6ef70bd5-93da-420a-861a-a450b5c3e106.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/8993284d-e9d7-4569-93f7-d2b57ae9e8ec.png)

