### PR TITLE
feat: split CLI tests into dbt and non-dbt workflows

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -43,7 +43,43 @@ jobs:
                   echo "Render environment ${{ github.event.deployment.environment }} is not ready: ${{ github.event.deployment_status.state }} ${{ github.event.deployment_status.environment_url }}"
                   exit 1
 
-    cli-tests:
+    # CLI tests without dbt
+    # This is used to test the CLI commands and content as code
+    # We don't need to install dbt dependencies for this.
+    cli-tests: 
+        timeout-minutes: 30
+        runs-on: ubuntu-latest
+        needs: prepare-preview
+        name: CLI tests without dbt
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup Node, PNPM, and Cypress
+              uses: ./.github/workflows/_setup_node_pnpm_cypress
+
+            # Build packages
+            - name: Build packages/common module
+              run: pnpm common-build
+            - name: Build packages/warehouses module
+              run: pnpm warehouses-build
+            - name: Build and install packages/cli module
+              run: cd packages/cli && pnpm build && npm install -g
+            - name: Test lightdash version
+              run: |
+                  lightdash_version=$(lightdash --version)
+                  package_version="$(pnpm m ls --depth=-1 | grep '@lightdash/cli@' | sed -E 's/.*@lightdash\/cli@([0-9.]+).*/\1/')"
+                  if [ $package_version = $lightdash_version ]; then exit 0 ; else echo "Version mismatch"; exit 1; fi
+
+            # Run Cypress
+            - name: Run Cypress
+              uses: cypress-io/github-action@v6
+              with:
+                  install: false
+                  working-directory: packages/e2e
+                  spec: cypress/cli/*
+                  config: 'baseUrl=${{needs.prepare-preview.outputs.url}}'
+
+    cli-dbt-tests:
         timeout-minutes: 30
         runs-on: ubuntu-latest
         needs: prepare-preview
@@ -116,7 +152,7 @@ jobs:
               with:
                   install: false
                   working-directory: packages/e2e
-                  spec: cypress/cli/**/*
+                  spec: cypress/cli/dbt/*
                   config: 'baseUrl=${{needs.prepare-preview.outputs.url}}'
               env:
                   CYPRESS_PGHOST: ${{secrets.PGHOST}}

--- a/packages/e2e/cypress/cli/commands.cy.ts
+++ b/packages/e2e/cypress/cli/commands.cy.ts
@@ -1,0 +1,16 @@
+describe('CLI', () => {
+    const cliCommand = `lightdash`;
+
+    after(() => {});
+
+    it('Should test lightdash command help', () => {
+        cy.exec(`${cliCommand} help`)
+            .its('stdout')
+            .should('contain', 'Developer tools for dbt and Lightdash.');
+    });
+    it('Should get version', () => {
+        cy.exec(`${cliCommand} --version`)
+            .its('stdout')
+            .should('contain', '0.');
+    });
+});

--- a/packages/e2e/cypress/cli/dbt/cli.cy.ts
+++ b/packages/e2e/cypress/cli/dbt/cli.cy.ts
@@ -1,9 +1,9 @@
-const lightdashUrl = Cypress.config('baseUrl');
-const projectDir = `../../examples/full-jaffle-shop-demo/dbt`;
-const profilesDir = `../../examples/full-jaffle-shop-demo/profiles`;
-const cliCommand = `lightdash`;
-
 describe('CLI', () => {
+    const lightdashUrl = Cypress.config('baseUrl');
+    const projectDir = `../../examples/full-jaffle-shop-demo/dbt`;
+    const profilesDir = `../../examples/full-jaffle-shop-demo/profiles`;
+    const cliCommand = `lightdash`;
+
     const previewName = `e2e preview ${new Date().getTime()}`;
     let projectToDelete: string;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
There is no point on running non dbt specific CLI commands against multiple dbt vresions (eg: download/upload) 

I am planning to add more non dbt tests , eg: oauthLogin 

<img width="816" height="296" alt="image" src="https://github.com/user-attachments/assets/017acb8a-4b62-4776-ba82-47b56caea0a4" />


<img width="892" height="793" alt="image" src="https://github.com/user-attachments/assets/d10093c0-3a28-47d9-9a2a-bb5f4acfb069" />

<img width="892" height="793" alt="image" src="https://github.com/user-attachments/assets/b634af65-937d-4bd4-a115-7b08a610abaa" />

### Description:
Split CLI tests into two separate jobs: one for basic CLI commands without dbt dependencies, and another for dbt-specific tests. This separation allows faster testing of basic CLI functionality without requiring dbt setup.

Also added basic CLI command tests to verify help and version commands work correctly.

test-cli