### PR TITLE
refactor: update OAuth controller to use request services

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -131,16 +131,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    OAuthErrorResponse: {
-        dataType: 'refObject',
-        properties: {
-            error: { dataType: 'string', required: true },
-            error_description: { dataType: 'string' },
-            error_uri: { dataType: 'string' },
-        },
-        additionalProperties: true,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiSuccessEmpty: {
         dataType: 'refAlias',
         type: {
@@ -11649,7 +11639,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11659,7 +11649,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -11669,7 +11659,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -11682,7 +11672,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -29630,6 +29620,60 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOAuthController_discovery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/oauth/.well-known/oauth-authorization-server',
+        ...fetchMiddlewares<RequestHandler>(OAuthController),
+        ...fetchMiddlewares<RequestHandler>(
+            OAuthController.prototype.discovery,
+        ),
+
+        async function OAuthController_discovery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOAuthController_discovery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<OAuthController>(
+                    OAuthController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'discovery',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsOAuthController_authorize: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -29879,60 +29923,6 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'revoke',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: undefined,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsOAuthController_discovery: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-    };
-    app.get(
-        '/api/v1/oauth/.well-known/oauth-authorization-server',
-        ...fetchMiddlewares<RequestHandler>(OAuthController),
-        ...fetchMiddlewares<RequestHandler>(
-            OAuthController.prototype.discovery,
-        ),
-
-        async function OAuthController_discovery(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsOAuthController_discovery,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<OAuthController>(
-                    OAuthController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'discovery',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -45,22 +45,6 @@
                 "type": "object",
                 "description": "The Error object is returned from the api any time there is an error.\nThe message contains"
             },
-            "OAuthErrorResponse": {
-                "properties": {
-                    "error": {
-                        "type": "string"
-                    },
-                    "error_description": {
-                        "type": "string"
-                    },
-                    "error_uri": {
-                        "type": "string"
-                    }
-                },
-                "required": ["error"],
-                "type": "object",
-                "additionalProperties": true
-            },
             "ApiSuccessEmpty": {
                 "properties": {
                     "results": {},
@@ -12509,22 +12493,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -24762,207 +24746,6 @@
                 ]
             }
         },
-        "/api/v1/oauth/authorize": {
-            "get": {
-                "operationId": "OAuthAuthorize",
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OAuthErrorResponse"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "OAuth2 Authorization endpoint\nInitiates the authorization code flow with PKCE support",
-                "tags": ["OAuth"],
-                "security": [],
-                "parameters": [
-                    {
-                        "description": "Must be 'code'",
-                        "in": "query",
-                        "name": "response_type",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "The redirect URI",
-                        "in": "query",
-                        "name": "redirect_uri",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "query",
-                        "name": "scopes",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Optional state parameter",
-                        "in": "query",
-                        "name": "state",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "PKCE code challenge",
-                        "in": "query",
-                        "name": "code_challenge",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "PKCE code challenge method (S256 or plain)",
-                        "in": "query",
-                        "name": "code_challenge_method",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "enum": ["S256", "plain"]
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/oauth/token": {
-            "post": {
-                "operationId": "OAuthToken",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OAuthTokenResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OAuthErrorResponse"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "OAuth2 Token endpoint\nExchanges authorization code for access token with PKCE validation",
-                "tags": ["OAuth"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "Token request parameters",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/OAuthTokenRequest",
-                                "description": "Token request parameters"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/oauth/introspect": {
-            "post": {
-                "operationId": "OAuthIntrospect",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OAuthIntrospectResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OAuthErrorResponse"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "OAuth2 Token Introspection endpoint\nReturns information about a token",
-                "tags": ["OAuth"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "Introspection request parameters",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/OAuthIntrospectRequest",
-                                "description": "Introspection request parameters"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/oauth/revoke": {
-            "post": {
-                "operationId": "OAuthRevoke",
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OAuthErrorResponse"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "OAuth2 Token Revocation endpoint\nRevokes an access or refresh token",
-                "tags": ["OAuth"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "description": "Revocation request parameters",
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/OAuthRevokeRequest",
-                                "description": "Revocation request parameters"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/oauth/.well-known/oauth-authorization-server": {
             "get": {
                 "operationId": "OAuthDiscovery",
@@ -25039,22 +24822,173 @@
                                 }
                             }
                         }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OAuthErrorResponse"
-                                }
-                            }
-                        }
                     }
                 },
                 "description": "OAuth2 Discovery endpoint\nReturns OAuth2 server metadata with PKCE support",
                 "tags": ["OAuth"],
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v1/oauth/authorize": {
+            "get": {
+                "operationId": "OAuthAuthorize",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                },
+                "description": "OAuth2 Authorization endpoint\nInitiates the authorization code flow with PKCE support",
+                "tags": ["OAuth"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "Must be 'code'",
+                        "in": "query",
+                        "name": "response_type",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The redirect URI",
+                        "in": "query",
+                        "name": "redirect_uri",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "scopes",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Optional state parameter",
+                        "in": "query",
+                        "name": "state",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "PKCE code challenge",
+                        "in": "query",
+                        "name": "code_challenge",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "PKCE code challenge method (S256 or plain)",
+                        "in": "query",
+                        "name": "code_challenge_method",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["S256", "plain"]
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/oauth/token": {
+            "post": {
+                "operationId": "OAuthToken",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OAuthTokenResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "OAuth2 Token endpoint\nExchanges authorization code for access token with PKCE validation",
+                "tags": ["OAuth"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "Token request parameters",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OAuthTokenRequest",
+                                "description": "Token request parameters"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/oauth/introspect": {
+            "post": {
+                "operationId": "OAuthIntrospect",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OAuthIntrospectResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "OAuth2 Token Introspection endpoint\nReturns information about a token",
+                "tags": ["OAuth"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "Introspection request parameters",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OAuthIntrospectRequest",
+                                "description": "Introspection request parameters"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/oauth/revoke": {
+            "post": {
+                "operationId": "OAuthRevoke",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                },
+                "description": "OAuth2 Token Revocation endpoint\nRevokes an access or refresh token",
+                "tags": ["OAuth"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "description": "Revocation request parameters",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OAuthRevokeRequest",
+                                "description": "Revocation request parameters"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/notifications": {
@@ -28644,10 +28578,6 @@
             "externalDocs": {
                 "url": "https://docs.lightdash.com/references/roles"
             }
-        },
-        {
-            "name": "OAuth",
-            "description": "OAuth2 endpoints for client authentication and authorization. Supports authorization code flow with PKCE for secure CLI authentication."
         }
     ]
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Refactored OAuth controller to improve request handling and standardize responses. Key changes include:

1. Added `AnyType` import and removed unused `Response` import
2. Reordered methods to match API route order in the generated swagger docs
3. Removed global `@Response<OAuthErrorResponse>` decorator in favor of more specific error handling
4. Updated service access to use `req.services` instead of `this.services`
5. Added proper status code setting with `this.setStatus(200)` for token endpoint
6. Improved OAuth server response handling to properly set headers and status codes

These changes ensure more consistent OAuth endpoint behavior and better align with the API documentation.