### PR TITLE
feat: implement field search for AI agent with user attributes and ai tags

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -53,6 +53,7 @@ export const aiCopilotConfigSchema = z
         requiresFeatureFlag: z.boolean(),
         telemetryEnabled: z.boolean(),
         debugLoggingEnabled: z.boolean(),
+        __experimental__toolFindFields: z.boolean().default(false),
     })
     .refine(
         ({ providers, defaultProvider, enabled }) =>

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -194,6 +194,7 @@ export const lightdashConfigMock: LightdashConfig = {
                     modelName: 'mock_model_name',
                 },
             },
+            __experimental__toolFindFields: false,
         },
     },
     embedding: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1058,6 +1058,8 @@ export const parseConfig = (): LightdashConfig => {
                   }
                 : undefined,
         },
+        __experimental__toolFindFields:
+            process.env.AI_COPILOT_EXPERIMENTAL_TOOL_FIND_FIELDS === 'true',
     };
 
     const copilotConfigParse =

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -94,6 +94,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectService: repository.getProjectService(),
                     catalogService: repository.getCatalogService(),
                     asyncQueryService: repository.getAsyncQueryService(),
+                    userAttributesModel: models.getUserAttributesModel(),
                 }),
             scimService: ({ models, context }) =>
                 new ScimService({

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -11,10 +11,11 @@ import type { ZodType } from 'zod';
 import Logger from '../../../../logging/logger';
 import { getSystemPrompt } from '../prompts/system';
 import { getFindExplores } from '../tools/findExplores';
-import { getFindFields } from '../tools/findFields';
+import { getFindFields as getFindFieldsOld } from '../tools/findFields';
 import { getGenerateBarVizConfig } from '../tools/generateBarVizConfig';
 import { getGenerateTableVizConfig } from '../tools/generateTableVizConfig';
 import { getGenerateTimeSeriesVizConfig } from '../tools/generateTimeSeriesVizConfig';
+import { getFindFields as getFindFieldsNew } from '../tools/newFindFields';
 import type {
     AiAgentArgs,
     AiAgentDependencies,
@@ -57,13 +58,19 @@ const getAgentTools = (
             `[AiAgent][Agent Tools] Getting agent tools for agent: ${args.agentSettings.name}`,
         );
     }
+
     const findExplores = getFindExplores({
         getExplores: dependencies.getExplores,
     });
 
-    const findFields = getFindFields({
-        getExplore: dependencies.getExplore,
-    });
+    const findFields = args.__experimental__toolFindFields
+        ? getFindFieldsNew({
+              findFields: dependencies.findFields,
+              getExplore: dependencies.getExplore,
+          })
+        : getFindFieldsOld({
+              getExplore: dependencies.getExplore,
+          });
 
     const generateBarVizConfig = getGenerateBarVizConfig({
         getExplore: dependencies.getExplore,
@@ -124,6 +131,7 @@ const getAgentMessages = (args: AiAgentArgs) => {
         }),
         ...args.messageHistory,
     ];
+
     if (args.debugLoggingEnabled) {
         Logger.debug(
             `[AiAgent][Agent Messages] Retrieved ${messages.length} messages.`,

--- a/packages/backend/src/ee/services/ai/agents/tests/testUtils.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/testUtils.ts
@@ -391,6 +391,7 @@ export const createArgs =
             maxLimit: 5_000,
             organizationId: 'org-uuid',
             userId: 'user-uuid',
+            __experimental__toolFindFields: false,
             ...options,
         } satisfies AiAgentArgs;
     };
@@ -408,7 +409,7 @@ const getExplore = jest.fn().mockImplementation(async ({ exploreName }) => {
     return data;
 });
 
-const searchFields = jest.fn().mockImplementation(async ({ exploreName }) => {
+const findFields = jest.fn().mockImplementation(async ({ exploreName }) => {
     const explore = mockExploresSummary.find((e) => e.name === exploreName);
     if (!explore) {
         throw new Error(`Explore '${exploreName}' not found`);
@@ -492,7 +493,7 @@ export const createMockDepsFactory = () => {
         dependencies: {
             getExplores,
             getExplore,
-            searchFields,
+            findFields,
             runMiniMetricQuery,
 
             getPrompt: jest.fn().mockImplementation(async () => ({

--- a/packages/backend/src/ee/services/ai/tools/newFindFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/newFindFields.ts
@@ -1,0 +1,111 @@
+import {
+    CatalogField,
+    CompiledDimension,
+    CompiledMetric,
+    convertToAiHints,
+    getItemId,
+    isEmojiIcon,
+    toolFindFieldsArgsSchema,
+    toolNewFindFieldsArgsSchema,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import type { FindFieldFn, GetExploreFn } from '../types/aiAgentDependencies';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+
+type Dependencies = {
+    findFields: FindFieldFn;
+    getExplore: GetExploreFn;
+};
+
+const getFieldText = ({
+    catalogField,
+    exploreField,
+}: {
+    catalogField: CatalogField;
+    exploreField: CompiledDimension | CompiledMetric;
+}) => {
+    const aiHints = convertToAiHints(exploreField.aiHint);
+
+    return `
+    <Field fieldId="${getItemId(exploreField)}" fieldType="${
+        exploreField.fieldType
+    }">
+        <Name>${exploreField.name}</Name>
+        <Label>${exploreField.label}</Label>
+        <Type>${exploreField.type}</Type>
+        ${
+            aiHints && aiHints.length > 0
+                ? `
+        <AI Hints>
+            ${aiHints.map((hint) => `<Hint>${hint}</Hint>`).join('\n')}
+        </AI Hints>`.trim()
+                : ''
+        }
+        ${
+            exploreField.tags && exploreField.tags.length > 0
+                ? `<Tags>${exploreField.tags.join(', ')}</Tags>`
+                : ''
+        }
+        <Table id="${exploreField.table}">${exploreField.tableLabel}</Table>
+        <Usage alt="field usage in charts">${catalogField.chartUsage}</Usage>
+        ${
+            isEmojiIcon(catalogField.icon)
+                ? `<Emoji>${catalogField.icon.unicode}</Emoji>`
+                : ''
+        }
+        <Description>${catalogField.description}</Description>
+    </Field>
+    `.trim();
+};
+
+const getFieldsText = (args: {
+    index: number;
+    name: string;
+    description: string;
+    results: {
+        catalogField: CatalogField;
+        exploreField: CompiledDimension | CompiledMetric;
+    }[];
+}) =>
+    `
+<SearchResults index="${args.index}" name="${args.name}" description="${
+        args.description
+    }">
+    ${args.results.map((field) => getFieldText(field)).join('\n\n')}
+</SearchResults>
+`.trim();
+
+export const getFindFields = ({ findFields }: Dependencies) => {
+    const schema = toolNewFindFieldsArgsSchema;
+
+    return tool({
+        description: `Use this tool to find the most relevant Fields (Metrics and Dimensions) across all available Explores based on the user's request.
+If the results aren't satisfactory, retry with different search terms.`,
+        parameters: schema,
+        execute: async ({ fieldSearchQueries }) => {
+            try {
+                const fieldSearchQueryResults = await Promise.all(
+                    fieldSearchQueries.map(async (fieldSearchQuery, index) => ({
+                        index,
+                        ...fieldSearchQuery,
+                        results: await findFields({ fieldSearchQuery }),
+                    })),
+                );
+
+                const fieldsText = fieldSearchQueryResults
+                    .map((fieldSearchQueryResult) =>
+                        getFieldsText(fieldSearchQueryResult),
+                    )
+                    .join('\n\n');
+
+                return fieldsText;
+            } catch (error) {
+                return toolErrorHandler(
+                    error,
+                    // TODO: error
+                    `Error finding fields.`,
+                );
+            }
+        },
+    });
+};

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -1,11 +1,11 @@
 import { AiAgent } from '@lightdash/common';
 import { CoreMessage, LanguageModelV1 } from 'ai';
 import {
+    FindFieldFn,
     GetExploreFn,
     GetExploresFn,
     GetPromptFn,
     RunMiniMetricQueryFn,
-    SearchFieldsFn,
     SendFileFn,
     StoreToolCallFn,
     StoreToolResultsFn,
@@ -24,12 +24,13 @@ export type AiAgentArgs = {
     organizationId: string;
     userId: string;
     debugLoggingEnabled: boolean;
+    __experimental__toolFindFields: boolean;
 };
 
 export type AiAgentDependencies = {
+    findFields: FindFieldFn;
     getExplores: GetExploresFn;
     getExplore: GetExploreFn;
-    searchFields: SearchFieldsFn | undefined;
     runMiniMetricQuery: RunMiniMetricQueryFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -3,7 +3,11 @@ import {
     AiWebAppPrompt,
     AnyType,
     CacheMetadata,
+    CatalogField,
+    CompiledDimension,
+    CompiledMetric,
     Explore,
+    FieldSearchQuery,
     ItemsMap,
     SlackPrompt,
     UpdateSlackResponse,
@@ -15,9 +19,16 @@ import { AiAgentExploreSummary } from './aiAgentExploreSummary';
 
 export type GetExploresFn = () => Promise<AiAgentExploreSummary[]>;
 
-export type GetExploreFn = (args: { exploreName: string }) => Promise<Explore>;
+export type FindFieldFn = (args: {
+    fieldSearchQuery: FieldSearchQuery;
+}) => Promise<
+    {
+        catalogField: CatalogField;
+        exploreField: CompiledDimension | CompiledMetric;
+    }[]
+>;
 
-export type SearchFieldsFn = (args: {}) => Promise<unknown>;
+export type GetExploreFn = (args: { exploreName: string }) => Promise<Explore>;
 
 export type UpdateProgressFn = (progress: string) => Promise<void>;
 

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -57,6 +57,7 @@ export enum CatalogSearchContext {
     SPOTLIGHT = 'spotlight',
     CATALOG = 'catalog',
     METRICS_EXPLORER = 'metricsExplorer',
+    AI_AGENT = 'aiAgent',
 }
 
 export type CatalogModelArguments = {

--- a/packages/common/src/ee/AiAgent/schemas/fieldSearchQuery.ts
+++ b/packages/common/src/ee/AiAgent/schemas/fieldSearchQuery.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { fieldIdSchemaUnknown } from './fieldId';
+
+export const fieldSearchQuerySchema = z.object({
+    name: fieldIdSchemaUnknown,
+    description: z.string().describe(`Description of a field to search for.`),
+});
+
+export type FieldSearchQuery = z.infer<typeof fieldSearchQuerySchema>;

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -1,17 +1,22 @@
 import { z } from 'zod';
+import {
+    toolFindExploresArgsSchema,
+    toolFindFieldsArgsSchema,
+    toolNewFindFieldsArgsSchema,
+    toolTableVizArgsSchema,
+    toolTimeSeriesArgsSchema,
+    toolVerticalBarArgsSchema,
+} from './tools';
 
-import { toolFindExploresArgsSchema } from './tools/toolFindExploresArgs';
-import { toolFindFieldsArgsSchema } from './tools/toolFindFieldsArgs';
-import { toolTableVizArgsSchema } from './tools/toolTableVizArgs';
-import { toolTimeSeriesArgsSchema } from './tools/toolTimeSeriesArgs';
-import { toolVerticalBarArgsSchema } from './tools/toolVerticalBarArgs';
-
+export * from './fieldSearchQuery';
 export * from './filters';
 export * from './tools';
 export * from './visualizations';
 
-export const AgentToolCallArgsSchema = z.discriminatedUnion('type', [
+// TODO: use `discriminatedUnion` after removing old find fields tool
+export const AgentToolCallArgsSchema = z.union([
     toolFindFieldsArgsSchema,
+    toolNewFindFieldsArgsSchema,
     toolVerticalBarArgsSchema,
     toolTableVizArgsSchema,
     toolTimeSeriesArgsSchema,

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -1,5 +1,6 @@
 export * from './toolFindExploresArgs';
 export * from './toolFindFieldsArgs';
+export * from './toolNewFindFieldsArgs';
 export * from './toolTableVizArgs';
 export * from './toolTimeSeriesArgs';
 export * from './toolVerticalBarArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
@@ -8,4 +8,5 @@ export const toolFindFieldsArgsSchema = z.object({
 export type ToolFindFieldsArgs = z.infer<typeof toolFindFieldsArgsSchema>;
 
 export const toolFindFieldsArgsSchemaTransformed = toolFindFieldsArgsSchema;
+
 export type ToolFindFieldsArgsTransformed = ToolFindFieldsArgs;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolNewFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolNewFindFieldsArgs.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { fieldSearchQuerySchema } from '../fieldSearchQuery';
+
+export const toolNewFindFieldsArgsSchema = z.object({
+    type: z.literal('find_fields'),
+    fieldSearchQueries: z
+        .array(fieldSearchQuerySchema)
+        .describe('The Fields (Metrics or Dimensions) to search for.'),
+});
+
+export type ToolNewFindFieldsArgs = z.infer<typeof toolNewFindFieldsArgsSchema>;
+
+export const toolNewFindFieldsArgsSchemaTransformed =
+    toolNewFindFieldsArgsSchema;
+
+export type ToolNewFindFieldsArgsTransformed = ToolNewFindFieldsArgs;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -293,6 +293,7 @@ export * from './utils/customDimensions';
 export * from './utils/dashboard';
 export * from './utils/dbt';
 export * from './utils/email';
+export * from './utils/explore';
 export * from './utils/fields';
 export * from './utils/filters';
 export * from './utils/formatting';

--- a/packages/common/src/utils/explore.ts
+++ b/packages/common/src/utils/explore.ts
@@ -1,0 +1,19 @@
+import type { Explore } from '../types/explore';
+
+export const findFieldInExplores = (
+    explores: Explore[],
+    tableName: string,
+    fieldName: string,
+) => {
+    const matchingExplore = explores.find(
+        (explore) => explore.tables[tableName],
+    );
+    if (!matchingExplore) return null;
+
+    const table = matchingExplore.tables[tableName];
+    if (!table) return null;
+
+    if (table.dimensions[fieldName]) return table.dimensions[fieldName];
+    if (table.metrics[fieldName]) return table.metrics[fieldName];
+    return null;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -15,6 +15,7 @@ import {
     Collapse,
     Group,
     Paper,
+    rem,
     Stack,
     Text,
     Timeline,
@@ -114,14 +115,38 @@ const ToolCallDescription: FC<{
 
     switch (toolArgs.type) {
         case 'find_explores':
-            return null;
-        case 'find_fields':
-            const { exploreName } = toolArgs;
-
             return (
-                <>
+                <Text c="dimmed" size="xs">
+                    Searched relevant explores
+                </Text>
+            );
+        case 'find_fields':
+            if ('fieldSearchQueries' in toolArgs) {
+                return (
                     <Text c="dimmed" size="xs">
-                        Found relevant fields in{' '}
+                        Searched for fields{' '}
+                        {toolArgs.fieldSearchQueries.map((query) => (
+                            <Badge
+                                key={query.name}
+                                color="gray"
+                                variant="light"
+                                size="xs"
+                                mx={rem(2)}
+                                radius="sm"
+                                style={{
+                                    textTransform: 'none',
+                                    fontWeight: 400,
+                                }}
+                            >
+                                {query.name}
+                            </Badge>
+                        ))}
+                    </Text>
+                );
+            } else {
+                return (
+                    <Text c="dimmed" size="xs">
+                        Searched for fields in explore{' '}
                         <Badge
                             color="gray"
                             variant="light"
@@ -132,11 +157,11 @@ const ToolCallDescription: FC<{
                                 fontWeight: 400,
                             }}
                         >
-                            {exploreName}
+                            {toolArgs.exploreName}
                         </Badge>
                     </Text>
-                </>
-            );
+                );
+            }
         case AiResultType.VERTICAL_BAR_RESULT:
             const barVizConfigToolArgs = toolArgs;
 


### PR DESCRIPTION
Closes: #

### Description:
Implements field search functionality for AI agents, allowing them to search for relevant fields across all available explores. This replaces the previous approach where agents had to first find explores and then search for fields within them.

Key changes:
- Added a new `findFields` function that uses the catalog service to find fields matching search queries
- Updated the `findFields` tool to accept search queries instead of explore names
- Added user attributes support to ensure proper access control for field searches
- Enhanced field search results with detailed metadata including descriptions, tags, and AI hints
- Updated the UI to display search terms instead of explore names in tool call descriptions

This change improves the AI agent's ability to find relevant fields across the entire project, rather than being limited to searching within a single explore at a time.