### PR TITLE
feat: add organization default role configuration

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1,5 +1,7 @@
 import {
     ALL_TASK_NAMES,
+    AllowedEmailDomainsRole,
+    AllowedEmailDomainsRoles,
     AnyType,
     AuthTokenPrefix,
     cleanColorArray,
@@ -336,9 +338,9 @@ const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
                 },
                 emailDomain: process.env.LD_SETUP_ORGANIZATION_EMAIL_DOMAIN,
                 defaultRole:
-                    parseEnum<OrganizationMemberRole>(
+                    parseEnum<AllowedEmailDomainsRole>(
                         process.env.LD_SETUP_ORGANIZATION_DEFAULT_ROLE,
-                        OrganizationMemberRole,
+                        AllowedEmailDomainsRoles,
                     ) || OrganizationMemberRole.VIEWER,
                 name: process.env.LD_SETUP_ORGANIZATION_NAME!,
             },
@@ -428,6 +430,11 @@ export const getUpdateSetupConfig = (): LightdashConfig['updateSetup'] => {
             admin: {
                 email: process.env.LD_SETUP_ADMIN_EMAIL,
             },
+            emailDomain: process.env.LD_SETUP_ORGANIZATION_EMAIL_DOMAIN,
+            defaultRole: parseEnum<AllowedEmailDomainsRole>(
+                process.env.LD_SETUP_ORGANIZATION_DEFAULT_ROLE,
+                AllowedEmailDomainsRoles,
+            ),
         },
         apiKey: {
             token: process.env.LD_SETUP_ADMIN_API_KEY,
@@ -738,7 +745,7 @@ export type LightdashConfig = {
             };
             emailDomain?: string;
             name: string;
-            defaultRole: OrganizationMemberRole;
+            defaultRole: AllowedEmailDomainsRole;
         };
         apiKey?: {
             token: string;
@@ -755,10 +762,12 @@ export type LightdashConfig = {
         dbt: DbtGithubProjectConfig;
     };
     updateSetup?: {
-        organization: {
+        organization?: {
             admin: {
                 email?: string;
             };
+            emailDomain?: string;
+            defaultRole?: AllowedEmailDomainsRole;
         };
         apiKey: {
             token?: string;

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
@@ -398,6 +398,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     update: jest.fn().mockResolvedValue(undefined),
                 },
                 updateSetup: {
+                    organization: {},
                     dbt: {
                         personal_access_token: 'new-dbt-token',
                     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash-internal-work/issues/3579

Before

<img width="941" height="265" alt="Screenshot from 2025-07-21 15-56-02" src="https://github.com/user-attachments/assets/47040b56-221a-4cfe-b598-b7abe0778830" />

After

`export LD_SETUP_ORGANIZATION_DEFAULT_ROLE=editor`

<img width="941" height="265" alt="Screenshot from 2025-07-21 15-57-16" src="https://github.com/user-attachments/assets/47fec81b-8900-405c-b841-c2c03ff83dde" />


### Description:
Added support for configuring the default role for new organization members through environment variables. This allows administrators to set a custom default role (e.g., VIEWER, EDITOR, ADMIN) for users joining via allowed email domains by setting the `LD_SETUP_ORGANIZATION_DEFAULT_ROLE` environment variable.

The PR includes:
- Added `defaultRole` to the organization configuration schema
- Updated the instance configuration service to apply the default role when creating or updating allowed email domains
- Added a new method to update the default role for existing organizations