### PR TITLE
feat: add role management to SCIM user provisioning

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -1,3 +1,7 @@
+import {
+    OrganizationMemberProfile,
+    OrganizationMemberRole,
+} from '@lightdash/common';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
 import { EmailModel } from '../../../models/EmailModel';
@@ -8,14 +12,52 @@ import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagMo
 import { ServiceAccountModel } from '../../models/ServiceAccountModel';
 import { ScimService } from './ScimService';
 
+// Mock user for testing
+export const mockUser: OrganizationMemberProfile = {
+    userUuid: 'test-uuid',
+    firstName: 'Test',
+    lastName: 'User',
+    email: 'test@example.com',
+    isActive: true,
+    role: OrganizationMemberRole.MEMBER,
+    userCreatedAt: new Date(),
+    userUpdatedAt: new Date(),
+    organizationUuid: 'org-uuid',
+};
+
+// Mock organization member profile model
+const organizationMemberProfileModelMock = {
+    getOrganizationMemberByUuid: jest.fn().mockResolvedValue(mockUser),
+    updateOrganizationMember: jest.fn().mockResolvedValue(mockUser),
+} as unknown as OrganizationMemberProfileModel;
+
+// Mock user model
+const userModelMock = {
+    updateUser: jest.fn().mockResolvedValue({
+        userId: 1,
+        userUuid: mockUser.userUuid,
+        firstName: mockUser.firstName,
+        lastName: mockUser.lastName,
+        email: mockUser.email,
+        isActive: mockUser.isActive,
+        organizationUuid: mockUser.organizationUuid,
+    }),
+    getUserDetailsById: jest.fn().mockResolvedValue(mockUser),
+} as unknown as UserModel;
+
+// Mock analytics
+const analyticsMock = {
+    track: jest.fn(),
+} as unknown as LightdashAnalytics;
+
 export const ScimServiceArgumentsMock: ConstructorParameters<
     typeof ScimService
 >[0] = {
     lightdashConfig: lightdashConfigMock,
-    organizationMemberProfileModel: {} as OrganizationMemberProfileModel,
-    userModel: {} as UserModel,
+    organizationMemberProfileModel: organizationMemberProfileModelMock,
+    userModel: userModelMock,
     emailModel: {} as EmailModel,
-    analytics: {} as LightdashAnalytics,
+    analytics: analyticsMock,
     groupsModel: {} as GroupsModel,
     serviceAccountModel: {} as ServiceAccountModel,
     commercialFeatureFlagModel: {} as CommercialFeatureFlagModel,

--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -29,10 +29,20 @@ export const mockUser: OrganizationMemberProfile = {
 const organizationMemberProfileModelMock = {
     getOrganizationMemberByUuid: jest.fn().mockResolvedValue(mockUser),
     updateOrganizationMember: jest.fn().mockResolvedValue(mockUser),
+    createOrganizationMembershipByUuid: jest.fn().mockResolvedValue(mockUser),
 } as unknown as OrganizationMemberProfileModel;
 
 // Mock user model
 const userModelMock = {
+    createUser: jest.fn().mockResolvedValue({
+        userId: 1,
+        userUuid: mockUser.userUuid,
+        firstName: mockUser.firstName,
+        lastName: mockUser.lastName,
+        email: mockUser.email,
+        isActive: mockUser.isActive,
+        organizationUuid: mockUser.organizationUuid,
+    }),
     updateUser: jest.fn().mockResolvedValue({
         userId: 1,
         userUuid: mockUser.userUuid,
@@ -50,13 +60,18 @@ const analyticsMock = {
     track: jest.fn(),
 } as unknown as LightdashAnalytics;
 
+// Mock email model
+const emailModelMock = {
+    verifyUserEmailIfExists: jest.fn().mockResolvedValue(undefined),
+} as unknown as EmailModel;
+
 export const ScimServiceArgumentsMock: ConstructorParameters<
     typeof ScimService
 >[0] = {
     lightdashConfig: lightdashConfigMock,
     organizationMemberProfileModel: organizationMemberProfileModelMock,
     userModel: userModelMock,
-    emailModel: {} as EmailModel,
+    emailModel: emailModelMock,
     analytics: analyticsMock,
     groupsModel: {} as GroupsModel,
     serviceAccountModel: {} as ServiceAccountModel,

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -1,8 +1,289 @@
+import {
+    LightdashUser,
+    OrganizationMemberRole,
+    ScimSchemaType,
+} from '@lightdash/common';
+import { ScimPatch } from 'scim-patch';
 import { ScimService } from './ScimService';
-import { ScimServiceArgumentsMock } from './ScimService.mock';
+import { ScimServiceArgumentsMock, mockUser } from './ScimService.mock';
 
 describe('ScimService', () => {
     const service = new ScimService(ScimServiceArgumentsMock);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('convertLightdashUserToScimUser', () => {
+        test('should correctly add role to extension schema', () => {
+            // Access the private method using type assertion
+            // @ts-ignore
+            const convertMethod =
+                service.convertLightdashUserToScimUser.bind(service);
+
+            // Create a test user with a role
+            const testUser: LightdashUser = {
+                userUuid: 'test-uuid',
+                firstName: 'Test',
+                lastName: 'User',
+                email: 'test@example.com',
+                isActive: true,
+                role: OrganizationMemberRole.ADMIN,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                organizationUuid: 'org-uuid',
+                userId: 0,
+                isTrackingAnonymized: false,
+                isMarketingOptedIn: false,
+                isSetupComplete: false,
+            };
+
+            // Convert the user to a SCIM user
+            const scimUser = convertMethod(testUser);
+
+            // Verify the entire SCIM user object
+            expect(scimUser).toEqual({
+                schemas: [
+                    ScimSchemaType.USER,
+                    ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+                ],
+                id: testUser.userUuid,
+                userName: testUser.email,
+                name: {
+                    givenName: testUser.firstName,
+                    familyName: testUser.lastName,
+                },
+                active: testUser.isActive,
+                emails: [
+                    {
+                        value: testUser.email,
+                        primary: true,
+                    },
+                ],
+                [ScimSchemaType.LIGHTDASH_USER_EXTENSION]: {
+                    role: OrganizationMemberRole.ADMIN,
+                },
+                meta: {
+                    resourceType: 'User',
+                    created: testUser.createdAt,
+                    lastModified: testUser.updatedAt,
+                    location: expect.stringContaining(
+                        `/api/v1/scim/v2/Users/${testUser.userUuid}`,
+                    ),
+                },
+            });
+        });
+
+        test('should not add extension schema if user has no role', () => {
+            // Access the private method using type assertion
+            // @ts-ignore
+            const convertMethod =
+                service.convertLightdashUserToScimUser.bind(service);
+
+            // Create a test user without a role
+            const testUser: LightdashUser = {
+                userUuid: 'test-uuid',
+                firstName: 'Test',
+                lastName: 'User',
+                email: 'test@example.com',
+                isActive: true,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                organizationUuid: 'org-uuid',
+                userId: 0,
+                isTrackingAnonymized: false,
+                isMarketingOptedIn: false,
+                isSetupComplete: false,
+            };
+
+            // Convert the user to a SCIM user
+            const scimUser = convertMethod(testUser);
+
+            // Verify the entire SCIM user object
+            expect(scimUser).toEqual({
+                schemas: [ScimSchemaType.USER],
+                id: testUser.userUuid,
+                userName: testUser.email,
+                name: {
+                    givenName: testUser.firstName,
+                    familyName: testUser.lastName,
+                },
+                active: testUser.isActive,
+                emails: [
+                    {
+                        value: testUser.email,
+                        primary: true,
+                    },
+                ],
+                meta: {
+                    resourceType: 'User',
+                    created: testUser.createdAt,
+                    lastModified: testUser.updatedAt,
+                    location: expect.stringContaining(
+                        `/api/v1/scim/v2/Users/${testUser.userUuid}`,
+                    ),
+                },
+            });
+
+            // Additional verification that the extension schema is not present
+            expect(scimUser.schemas).not.toContain(
+                ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+            );
+            expect(
+                scimUser[ScimSchemaType.LIGHTDASH_USER_EXTENSION],
+            ).toBeUndefined();
+        });
+    });
+
+    describe('getScimUserEmail', () => {
+        test('should return email when username is a valid email', () => {
+            const validEmail = mockUser.email;
+            const result = ScimService.getScimUserEmail({
+                userName: validEmail,
+            });
+            expect(result).toBe(validEmail);
+        });
+
+        test('should throw error when username is not a valid email', () => {
+            expect(() => {
+                ScimService.getScimUserEmail({ userName: 'not-an-email' });
+            }).toThrow('Username must be a valid email');
+
+            expect(() => {
+                ScimService.getScimUserEmail({ userName: '' });
+            }).toThrow('Username must be a valid email');
+
+            expect(() => {
+                // @ts-ignore
+                ScimService.getScimUserEmail({ userName: undefined });
+            }).toThrow('Username must be a valid email');
+        });
+    });
+
+    describe('updateUser', () => {
+        test('should throw error when an invalid role is provided', async () => {
+            // Create a SCIM user with an invalid role in the extension schema
+            const scimUser = {
+                schemas: [
+                    ScimSchemaType.USER,
+                    ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+                ],
+                userName: mockUser.email,
+                name: {
+                    givenName: mockUser.firstName,
+                    familyName: mockUser.lastName,
+                },
+                active: mockUser.isActive,
+                emails: [
+                    {
+                        value: mockUser.email,
+                        primary: true,
+                    },
+                ],
+                [ScimSchemaType.LIGHTDASH_USER_EXTENSION]: {
+                    role: 'invalid_role', // This is not a valid OrganizationMemberRole
+                },
+            };
+
+            // Call updateUser with the invalid role and expect it to throw an error
+            await expect(
+                service.updateUser({
+                    user: scimUser,
+                    userUuid: mockUser.userUuid,
+                    organizationUuid: mockUser.organizationUuid,
+                }),
+            ).rejects.toThrow(/Invalid role/);
+        });
+
+        test('should update user role when a valid role is provided', async () => {
+            // Create a SCIM user with a valid role in the extension schema
+            const scimUser = {
+                schemas: [
+                    ScimSchemaType.USER,
+                    ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+                ],
+                userName: mockUser.email,
+                name: {
+                    givenName: mockUser.firstName,
+                    familyName: mockUser.lastName,
+                },
+                active: mockUser.isActive,
+                emails: [
+                    {
+                        value: mockUser.email,
+                        primary: true,
+                    },
+                ],
+                [ScimSchemaType.LIGHTDASH_USER_EXTENSION]: {
+                    role: OrganizationMemberRole.ADMIN, // This is a valid OrganizationMemberRole
+                },
+            };
+
+            // Reset mocks to ensure clean state
+            jest.clearAllMocks();
+
+            // Call updateUser with the valid role
+            await service.updateUser({
+                user: scimUser,
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            // Verify that updateOrganizationMember was called with the correct role
+            const { organizationMemberProfileModel } = ScimServiceArgumentsMock;
+            expect(
+                organizationMemberProfileModel.updateOrganizationMember,
+            ).toHaveBeenCalledWith(
+                mockUser.organizationUuid,
+                mockUser.userUuid,
+                {
+                    role: OrganizationMemberRole.ADMIN,
+                },
+            );
+        });
+    });
+
+    describe('patchUser', () => {
+        test('should update user role when a valid role is provided in patch operation with path', async () => {
+            // Mock the updateUser method to return a SCIM user
+            const updateUserMethod = jest.spyOn(service, 'updateUser');
+
+            // Create a patch operation to update the role with path
+            const patchOp: ScimPatch = {
+                schemas: [ScimSchemaType.PATCH],
+                Operations: [
+                    {
+                        op: 'Add',
+                        path: `${ScimSchemaType.LIGHTDASH_USER_EXTENSION}:role`,
+                        value: OrganizationMemberRole.ADMIN,
+                    },
+                ],
+            };
+
+            // Call patchUser with the patch operation
+            await service.patchUser({
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+                patchOp,
+            });
+
+            // Verify that updateUser was called with correct role
+            expect(updateUserMethod).toHaveBeenCalledTimes(1);
+            expect(updateUserMethod).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    user: expect.objectContaining({
+                        schemas: [
+                            ScimSchemaType.USER,
+                            ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+                        ],
+                        [ScimSchemaType.LIGHTDASH_USER_EXTENSION]: {
+                            role: OrganizationMemberRole.ADMIN,
+                        },
+                    }),
+                }),
+            );
+        });
+    });
 
     describe('convertScimToKnexPagination', () => {
         test('should return correct pagination for valid startIndex multiple of count', () => {

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -12,4 +12,5 @@ export enum ScimSchemaType {
     LIST_RESPONSE = 'urn:ietf:params:scim:api:messages:2.0:ListResponse',
     SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Schema',
     PATCH = 'urn:ietf:params:scim:api:messages:2.0:PatchOp',
+    LIGHTDASH_USER_EXTENSION = 'urn:lightdash:params:scim:schemas:extension:2.0:User',
 }

--- a/packages/common/src/ee/scim/types.ts
+++ b/packages/common/src/ee/scim/types.ts
@@ -16,6 +16,10 @@ export interface ScimResource {
     };
 }
 
+export interface LightdashScimExtension {
+    role?: string;
+}
+
 export interface ScimUser extends ScimResource {
     schemas: string[];
     userName: string;
@@ -28,6 +32,7 @@ export interface ScimUser extends ScimResource {
         value: string;
         primary: boolean;
     }[];
+    [ScimSchemaType.LIGHTDASH_USER_EXTENSION]?: LightdashScimExtension;
 }
 
 export interface ScimGroup extends ScimResource {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Added support for user roles in SCIM provisioning. This enhancement allows identity providers to specify and manage user roles (admin, member, etc.) when provisioning users through SCIM.

The implementation:
- Adds a Lightdash extension schema to the SCIM user object
- Enables setting roles during user creation
- Supports updating roles through SCIM PATCH operations
- Includes validation to ensure only valid organization member roles are used
- Maintains backward compatibility with existing SCIM implementations

This makes it easier for organizations to manage user permissions directly from their identity provider without requiring additional steps in Lightdash.