### PR TITLE
fix: validate field existence in visualization tools

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -15,7 +15,10 @@ import type {
 } from '../types/aiAgentDependencies';
 import { renderEcharts } from '../utils/renderEcharts';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import { validateFilterRules } from '../utils/validators';
+import {
+    validateFilterRules,
+    validateSelectedFieldsExistence,
+} from '../utils/validators';
 import { renderVerticalBarViz } from '../visualizations/vizVerticalBar';
 
 type Dependencies = {
@@ -54,6 +57,15 @@ export const getGenerateBarVizConfig = ({
                 const explore = await getExplore({
                     exploreName: vizTool.vizConfig.exploreName,
                 });
+                const fieldsToValidate = [
+                    vizTool.vizConfig.xDimension,
+                    vizTool.vizConfig.breakdownByDimension,
+                    ...vizTool.vizConfig.yMetrics,
+                    ...vizTool.vizConfig.sorts.map(
+                        (sortField) => sortField.fieldId,
+                    ),
+                ].filter((x) => typeof x === 'string');
+                validateSelectedFieldsExistence(explore, fieldsToValidate);
                 validateFilterRules(explore, filterRules);
                 // end of TODO
 

--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -18,7 +18,10 @@ import type {
 } from '../types/aiAgentDependencies';
 import { serializeData } from '../utils/serializeData';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import { validateFilterRules } from '../utils/validators';
+import {
+    validateFilterRules,
+    validateSelectedFieldsExistence,
+} from '../utils/validators';
 import { renderTableViz } from '../visualizations/vizTable';
 
 type Dependencies = {
@@ -57,6 +60,14 @@ export const getGenerateTableVizConfig = ({
                 const explore = await getExplore({
                     exploreName: vizTool.vizConfig.exploreName,
                 });
+                const fieldsToValidate = [
+                    ...(vizTool.vizConfig.dimensions ?? []),
+                    ...vizTool.vizConfig.metrics,
+                    ...vizTool.vizConfig.sorts.map(
+                        (sortField) => sortField.fieldId,
+                    ),
+                ].filter((x) => typeof x === 'string');
+                validateSelectedFieldsExistence(explore, fieldsToValidate);
                 validateFilterRules(explore, filterRules);
                 // end of TODO
 

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -15,7 +15,10 @@ import type {
 } from '../types/aiAgentDependencies';
 import { renderEcharts } from '../utils/renderEcharts';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import { validateFilterRules } from '../utils/validators';
+import {
+    validateFilterRules,
+    validateSelectedFieldsExistence,
+} from '../utils/validators';
 import { renderTimeSeriesViz } from '../visualizations/vizTimeSeries';
 
 type Dependencies = {
@@ -53,6 +56,15 @@ export const getGenerateTimeSeriesVizConfig = ({
                 const explore = await getExplore({
                     exploreName: vizTool.vizConfig.exploreName,
                 });
+                const fieldsToValidate = [
+                    vizTool.vizConfig.xDimension,
+                    vizTool.vizConfig.breakdownByDimension,
+                    ...vizTool.vizConfig.yMetrics,
+                    ...vizTool.vizConfig.sorts.map(
+                        (sortField) => sortField.fieldId,
+                    ),
+                ].filter((x) => typeof x === 'string');
+                validateSelectedFieldsExistence(explore, fieldsToValidate);
                 validateFilterRules(explore, filterRules);
                 // end of TODO
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15919

### Description:

Added field validation to AI visualization tools to ensure that selected fields exist in the explore before generating visualizations. This validation is now implemented across bar, table, and time series visualization configurations, preventing errors from non-existent fields.

Tool call with a wrong field name:
![CleanShot 2025-07-21 at 18.31.29@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/3fb80069-d9f8-4b68-8088-2493995de99c.png)

Response:
![CleanShot 2025-07-21 at 18.31.11@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/05c71e3f-7edf-4a88-ad87-f7f99292e227.png)

