### PR TITLE
fix: remove nullable (can be an empty array) from tableVizConfigSchema dimensions

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -61,7 +61,7 @@ export const getGenerateTableVizConfig = ({
                     exploreName: vizTool.vizConfig.exploreName,
                 });
                 const fieldsToValidate = [
-                    ...(vizTool.vizConfig.dimensions ?? []),
+                    ...vizTool.vizConfig.dimensions,
                     ...vizTool.vizConfig.metrics,
                     ...vizTool.vizConfig.sorts.map(
                         (sortField) => sortField.fieldId,

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -19,7 +19,6 @@ export const tableVizConfigSchema = z
             ),
         dimensions: z
             .array(getFieldIdSchema({ additionalDescription: null }))
-            .nullable()
             .describe(
                 'The field id for the dimensions to group the metrics by',
             ),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removes the nullable option from the dimensions array in the table visualization configuration schema. This change ensures that dimensions are always treated as an array, eliminating the need for null checks when accessing dimensions in the code.
