### PR TITLE
fix: get virtual views when cli-validate project

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -944,6 +944,23 @@ export class ProjectModel {
         );
     }
 
+    async findVirtualViewsFromCache(
+        projectUuid: string,
+    ): Promise<Record<string, Explore | ExploreError>> {
+        const virtualViews = await this.database(CachedExploreTableName)
+            .select('explore')
+            .where('project_uuid', projectUuid)
+            .whereRaw("explore->>'type' = ?", [ExploreType.VIRTUAL]);
+
+        return virtualViews.reduce<Record<string, Explore | ExploreError>>(
+            (acc, { explore }) => {
+                acc[explore.name] = explore;
+                return acc;
+            },
+            {},
+        );
+    }
+
     async getAllExploresFromCache(
         projectUuid: string,
     ): Promise<{ [exploreUuid: string]: Explore | ExploreError }> {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -607,9 +607,7 @@ export class ValidationService extends BaseService {
             const virtualViews =
                 await this.projectModel.findVirtualViewsFromCache(projectUuid);
 
-            explores = Array.from(
-                compiledExplores.concat(Object.values(virtualViews)),
-            );
+            explores = compiledExplores.concat(Object.values(virtualViews));
             this.logger.debug(
                 `Merged ${compiledExplores.length} compiled explores with ${
                     Object.values(virtualViews).length

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -601,14 +601,25 @@ export class ValidationService extends BaseService {
             }`,
         );
 
-        const explores =
-            compiledExplores !== undefined
-                ? compiledExplores
-                : Object.values(
-                      await this.projectModel.findExploresFromCache(
-                          projectUuid,
-                      ),
-                  );
+        let explores: (Explore | ExploreError)[];
+        if (compiledExplores !== undefined) {
+            // For CLI validation, when compiled Explores are provided, merge them with virtual views from cache
+            const virtualViews =
+                await this.projectModel.findVirtualViewsFromCache(projectUuid);
+
+            explores = Array.from(
+                compiledExplores.concat(Object.values(virtualViews)),
+            );
+            this.logger.debug(
+                `Merged ${compiledExplores.length} compiled explores with ${
+                    Object.values(virtualViews).length
+                } virtual views for validation`,
+            );
+        } else {
+            explores = Object.values(
+                await this.projectModel.findExploresFromCache(projectUuid),
+            );
+        }
 
         const exploreFields =
             explores?.reduce<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15903


### Description:

Get compiled explores + virtual views with new method so that these can be merged and checked when validating with the CLI

How to test:
- Go to SQL runner and create a virtual view
- Validate project with the CLI (see cli/README)
- See that `compiledExplores` has no virtual views, so we add them



