### PR TITLE
fix: filter projects by default type in getDefaultProjectUuids

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -378,8 +378,10 @@ export class ProjectModel {
         return parseInt(results.count, 10) > 0;
     }
 
-    async getProjectUuids(): Promise<string[]> {
-        const projects = await this.database('projects').select('project_uuid');
+    async getDefaultProjectUuids(): Promise<string[]> {
+        const projects = await this.database('projects')
+            .where('project_type', ProjectType.DEFAULT)
+            .select('project_uuid');
         return projects.map((project) => project.project_uuid);
     }
 

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
@@ -72,7 +72,7 @@ const createMockService = (overrides: AnyType = {}) => {
     };
 
     const projectModel = {
-        getProjectUuids: jest.fn(),
+        getDefaultProjectUuids: jest.fn(),
         getWithSensitiveFields: jest.fn(),
         update: jest.fn(),
         ...overrides.projectModel,
@@ -129,7 +129,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                         .mockResolvedValue(['org-1', 'org-2']),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue(['project-1', 'project-2']),
                 },
@@ -170,7 +170,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue(['project-1', 'project-2']),
                 },
@@ -197,7 +197,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                 },
@@ -249,7 +249,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                 },
@@ -292,7 +292,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                 },
@@ -346,7 +346,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                     getWithSensitiveFields: jest
@@ -389,7 +389,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                     getWithSensitiveFields: jest
@@ -443,7 +443,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                     getWithSensitiveFields: jest
@@ -476,7 +476,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                     getWithSensitiveFields: jest
@@ -504,7 +504,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                 },
@@ -528,7 +528,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
                 },
                 projectModel: {
-                    getProjectUuids: jest
+                    getDefaultProjectUuids: jest
                         .fn()
                         .mockResolvedValue([mockProjectUuid]),
                     getWithSensitiveFields: jest

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -421,7 +421,7 @@ export class InstanceConfigurationService extends BaseService {
     }
 
     private async getSingleProject() {
-        const projectUuids = await this.projectModel.getProjectUuids();
+        const projectUuids = await this.projectModel.getDefaultProjectUuids();
         if (projectUuids.length !== 1) {
             throw new ParameterError(
                 `There must be exactly 1 project to update instance configuration, remove all the LD_SETUP* env variables or keep only one project to continue`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Renamed `getProjectUuids()` to `getDefaultProjectUuids()` in ProjectModel and updated the method to only return projects with type DEFAULT. Updated the reference in InstanceConfigurationService to use the new method name.

This change ensures that only default projects are considered when validating single project configuration, which prevents errors when multiple project types exist but only one default project is present.