### PR TITLE
feat: use openid-client on CLI and build HTML with handlebards

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -925,6 +925,10 @@ export type AuthConfig = {
         allowedOrgRoles: OrganizationMemberRole[];
         maxExpirationTimeInDays: number | undefined;
     };
+    oauthServer?: {
+        accessTokenLifetime: number; // in seconds (default = 1 hour)
+        refreshTokenLifetime: number; // in seconds (default = 2 weeks)
+    };
 };
 
 export type SmtpConfig = {
@@ -1264,6 +1268,16 @@ export const parseConfig = (): LightdashConfig => {
                 tokenEndpoint: process.env.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT,
                 loginPath: '/login/snowflake',
                 callbackPath: '/oauth/redirect/snowflake',
+            },
+            oauthServer: {
+                accessTokenLifetime:
+                    getIntegerFromEnvironmentVariable(
+                        'AUTH_OAUTH_SERVER_ACCESS_TOKEN_LIFETIME',
+                    ) || 60 * 60, // 1 hour
+                refreshTokenLifetime:
+                    getIntegerFromEnvironmentVariable(
+                        'AUTH_OAUTH_SERVER_REFRESH_TOKEN_LIFETIME',
+                    ) || 60 * 60 * 24 * 14, // 2 weeks
             },
         },
         intercom: {

--- a/packages/backend/src/services/OAuthService/OAuthService.test.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.test.ts
@@ -45,7 +45,10 @@ describe('OAuthService', () => {
                 organizationUuid: 'org-uuid',
             },
         });
-        mockLightdashConfig = { siteUrl: 'https://lightdash.com' } as AnyType;
+        mockLightdashConfig = {
+            siteUrl: 'https://lightdash.com',
+            auth: {},
+        } as AnyType;
         oauthService = new TestOAuthService({
             userModel: mockUserModel,
             oauthModel: mockOAuthModel,
@@ -153,7 +156,10 @@ describe('OAuthService edge cases', () => {
             revokeToken: jest.fn(),
             revokeRefreshToken: jest.fn(),
         } as AnyType;
-        mockLightdashConfig = { siteUrl: 'https://lightdash.com' } as AnyType;
+        mockLightdashConfig = {
+            siteUrl: 'https://lightdash.com',
+            auth: {},
+        } as AnyType;
         oauthService = new TestOAuthService({
             userModel: mockUserModel,
             oauthModel: mockOAuthModel,

--- a/packages/backend/src/services/OAuthService/OAuthService.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.ts
@@ -42,9 +42,11 @@ export class OAuthService extends BaseService {
     private initializeOAuthServer(): void {
         this.oauthServer = new OAuth2Server({
             model: this.oauthModel,
-            accessTokenLifetime: 60 * 60,
-            refreshTokenLifetime: 60 * 60 * 24 * 30,
             allowBearerTokensInQueryString: true,
+            accessTokenLifetime:
+                this.lightdashConfig.auth.oauthServer?.accessTokenLifetime,
+            refreshTokenLifetime:
+                this.lightdashConfig.auth.oauthServer?.refreshTokenLifetime,
         });
     }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
         "lodash": "^4.17.21",
         "node-fetch": "^2.7.0",
         "nunjucks": "^3.2.3",
+        "openid-client": "^5.6.4",
         "ora": "5.4.1",
         "parse-node-version": "^2.0.0",
         "unique-names-generator": "^4.7.1",

--- a/packages/cli/src/handlers/oauthLogin.ts
+++ b/packages/cli/src/handlers/oauthLogin.ts
@@ -2,28 +2,20 @@ import {
     AuthorizationError,
     CreatePersonalAccessToken,
     formatDate,
-    oauthPageStyles,
+    generateOAuthErrorResponse,
+    generateOAuthSuccessResponse,
 } from '@lightdash/common';
 import { exec } from 'child_process';
-import * as crypto from 'crypto';
 import * as http from 'http';
 import { createServer } from 'net';
 import fetch from 'node-fetch';
+import { generators, Issuer } from 'openid-client';
 import { URL } from 'url';
 import { promisify } from 'util';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 
-// Shared CSS styles for OAuth response pages - matching Lightdash login design
-
 const execAsync = promisify(exec);
-
-// PKCE helper functions
-const generateCodeVerifier = (): string =>
-    crypto.randomBytes(32).toString('base64url');
-
-const generateCodeChallenge = (verifier: string): string =>
-    crypto.createHash('sha256').update(verifier).digest('base64url');
 
 const generatePersonalAccessToken = async (
     accessToken: string,
@@ -112,14 +104,30 @@ const openBrowser = async (url: string): Promise<void> => {
 export const loginWithOauth = async (
     url: string,
 ): Promise<{ userUuid: string; organizationUuid: string; token: string }> => {
-    // Generate PKCE values
-    const codeVerifier = generateCodeVerifier();
-    const codeChallenge = generateCodeChallenge(codeVerifier);
-    const state = crypto.randomBytes(16).toString('hex');
-
     // Find an available port
     const port = await findAvailablePort(8100, 8110);
     const redirectUri = `http://localhost:${port}/callback`;
+
+    // Create OAuth2 issuer and client using openid-client
+    const issuerUrl = new URL('/api/v1/oauth', url).href;
+    const issuer = new Issuer({
+        issuer: issuerUrl,
+        authorization_endpoint: new URL('/api/v1/oauth/authorize', url).href,
+        token_endpoint: new URL('/api/v1/oauth/token', url).href,
+    });
+
+    const client = new issuer.Client({
+        client_id: 'lightdash-cli',
+        redirect_uris: [redirectUri],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none', // Public client (no client secret)
+        id_token_signed_response_alg: 'none', // Disable ID token validation for OAuth2
+    });
+
+    // Generate PKCE values using openid-client generators
+    const codeVerifier = generators.codeVerifier();
+    const codeChallenge = generators.codeChallenge(codeVerifier);
+    const state = generators.state();
 
     // Create a promise that will be resolved when we get the authorization code
     let resolveAuth: (value: { code: string; state: string }) => void;
@@ -139,30 +147,26 @@ export const loginWithOauth = async (
             const returnedState = callbackUrl.searchParams.get('state');
             const error = callbackUrl.searchParams.get('error');
 
+            res.setHeader('Content-Type', 'text/html');
+
+            if (error === 'access_denied') {
+                rejectAuth(new AuthorizationError(`OAuth error: ${error}`));
+                res.writeHead(400);
+                res.end(
+                    generateOAuthErrorResponse('Authentication Failed', [
+                        `Access denied from the Lightdash page.`,
+                    ]),
+                );
+                return;
+            }
             if (error) {
                 rejectAuth(new AuthorizationError(`OAuth error: ${error}`));
-                res.writeHead(400, { 'Content-Type': 'text/html' });
-                res.end(`
-                    <html>
-                        <head>
-                            <style>${oauthPageStyles}</style>
-                        </head>
-                        <body>
-                            <div class="stack">
-                                
-                                <div class="container error">
-                                    <svg class="icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                                        <path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                    </svg>
-                                    <h1>Authentication Failed</h1>
-                                    <p>Error: ${error}</p>
-                                    <p>You can close this window and try again.</p>
-                                </div>
-                            </div>
-                        </body>
-                    </html>
-                `);
+                res.writeHead(400);
+                res.end(
+                    generateOAuthErrorResponse('Authentication Failed', [
+                        `Error: ${error}`,
+                    ]),
+                );
                 return;
             }
 
@@ -172,28 +176,12 @@ export const loginWithOauth = async (
                         'Missing authorization code or state',
                     ),
                 );
-                res.writeHead(400, { 'Content-Type': 'text/html' });
-                res.end(`
-                    <html>
-                        <head>
-                            <style>${oauthPageStyles}</style>
-                        </head>
-                        <body>
-                            <div class="stack">
-                               
-                                <div class="container error">
-                                    <svg class="icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                                        <path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                    </svg>
-                                    <h1>Authentication Failed</h1>
-                                    <p>Missing authorization code or state parameter.</p>
-                                    <p>You can close this window and try again.</p>
-                                </div>
-                            </div>
-                        </body>
-                    </html>
-                `);
+                res.writeHead(400);
+                res.end(
+                    generateOAuthErrorResponse('Authentication Failed', [
+                        'Missing authorization code or state parameter.',
+                    ]),
+                );
                 return;
             }
 
@@ -203,57 +191,26 @@ export const loginWithOauth = async (
                         'Authentication session expired or invalid',
                     ),
                 );
-                res.writeHead(400, { 'Content-Type': 'text/html' });
-                res.end(`
-                    <html>
-                        <head>
-                            <style>${oauthPageStyles}</style>
-                        </head>
-                        <body>
-                            <div class="stack">
-                               
-                                <div class="container error">
-                                    <svg class="icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                                        <path d="M12 6v6l4 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                    </svg>
-                                    <h1>Authentication Failed</h1>
-                                    <p>Your authentication session has expired or is invalid.</p>
-                                    <p>This can happen if you used an old link.</p>
-                                    <p>Please close this window and try logging in again.</p>
-                                </div>
-                            </div>
-                        </body>
-                    </html>
-                `);
+                res.writeHead(400);
+                res.end(
+                    generateOAuthErrorResponse(
+                        'Authentication Failed',
+                        [
+                            'Your authentication session has expired or is invalid.',
+                            'This can happen if you used an old link.',
+                            'Please close this window and try logging in again.',
+                        ],
+                        'sessionExpired',
+                    ),
+                );
                 return;
             }
 
             // Success - resolve the promise
             resolveAuth({ code, state: returnedState });
 
-            res.writeHead(200, { 'Content-Type': 'text/html' });
-            res.end(`
-                <html>
-                    <head>
-                        <style>${oauthPageStyles}</style>
-                    </head>
-                    <body>
-                        <div class="stack">
-                           
-                            <div class="container success">
-                                <svg class="icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                    <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                                    <path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                </svg>
-                                <h1>Authentication Successful!</h1>
-                                <p>You have been successfully authenticated with Lightdash.</p>
-                                <p>You can close this window and return to the CLI.</p>
-                            </div>
-                        </div>
-                    </body>
-                </html>
-            `);
+            res.writeHead(200);
+            res.end(generateOAuthSuccessResponse());
         } else {
             res.writeHead(404, { 'Content-Type': 'text/plain' });
             res.end('Not Found');
@@ -271,25 +228,23 @@ export const loginWithOauth = async (
     });
 
     try {
-        // Construct the authorization URL
-        const authUrl = new URL('/api/v1/oauth/authorize', url);
-        authUrl.searchParams.set('response_type', 'code');
-        authUrl.searchParams.set('client_id', 'lightdash-cli');
-        authUrl.searchParams.set('redirect_uri', redirectUri);
-        authUrl.searchParams.set('scope', 'read write');
-        authUrl.searchParams.set('state', state);
-        authUrl.searchParams.set('code_challenge', codeChallenge);
-        authUrl.searchParams.set('code_challenge_method', 'S256');
+        // Generate the authorization URL using openid-client
+        const authUrl = client.authorizationUrl({
+            scope: 'read write',
+            state,
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+        });
 
         console.error(`\n${styles.title('🔐 OAuth Authentication')}`);
         console.error(`Opening browser for authentication...`);
         console.error(
             `If the browser doesn't open automatically, please visit:`,
         );
-        console.error(`${styles.secondary(authUrl.href)}\n`);
+        console.error(`${styles.secondary(authUrl)}\n`);
 
         // Try to open the browser
-        await openBrowser(authUrl.href);
+        await openBrowser(authUrl);
 
         // Wait for the authorization code
         const { code } = await authPromise;
@@ -298,9 +253,9 @@ export const loginWithOauth = async (
             `> Got authorization code ${code.substring(0, 10)}...`,
         );
 
-        GlobalState.debug(`> Getting token for authorization code `);
+        GlobalState.debug(`> Getting token for authorization code`);
 
-        // Exchange the authorization code for an access token
+        // Exchange the authorization code for an access token manually (pure OAuth2)
         const tokenUrl = new URL('/api/v1/oauth/token', url);
         const tokenResponse = await fetch(tokenUrl.href, {
             method: 'POST',
@@ -330,8 +285,9 @@ export const loginWithOauth = async (
                 'No access token received from OAuth server',
             );
         }
+
         GlobalState.debug(
-            `> Oauth access token: ${accessToken.substring(0, 10)}...`,
+            `> OAuth access token: ${accessToken.substring(0, 10)}...`,
         );
         GlobalState.debug(`> Creating PAT for user`);
 
@@ -339,7 +295,7 @@ export const loginWithOauth = async (
         const pat = await generatePersonalAccessToken(accessToken, url);
         GlobalState.debug(`> PAT: ${pat.substring(0, 10)}...`);
 
-        // Get user information using the access token
+        // Get user information using the PAT
         const userInfoUrl = new URL('/api/v1/user', url);
         const userResponse = await fetch(userInfoUrl.href, {
             method: 'GET',

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,6 +9,7 @@
     ],
     "license": "MIT",
     "devDependencies": {
+        "@types/handlebars": "^4.1.0",
         "@types/js-yaml": "^4.0.9",
         "@types/pegjs": "^0.10.3",
         "@types/sanitize-html": "^2.11.0",
@@ -20,6 +21,7 @@
         "ajv": "^8.3.0",
         "ajv-formats": "^2.1.0",
         "better-ajv-errors": "^1.2.0",
+        "handlebars": "^4.7.8",
         "cronstrue": "^2.23.0",
         "dayjs": "^1.11.9",
         "dependency-graph": "^0.11.0",

--- a/packages/common/src/utils/oauth.ts
+++ b/packages/common/src/utils/oauth.ts
@@ -1,3 +1,5 @@
+import { compile } from 'handlebars';
+
 export const oauthPageStyles = `
     body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Open Sans', 'Helvetica Neue', sans-serif;
@@ -58,3 +60,84 @@ export const oauthPageStyles = `
         gap: 16px;
     }
 `;
+
+// OAuth response HTML template
+const OAUTH_RESPONSE_TEMPLATE = `
+<html>
+    <head>
+        <style>{{{styles}}}</style>
+    </head>
+    <body>
+        <div class="stack">
+            <div class="container {{status}}">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    {{{icon}}}
+                </svg>
+                <h1>{{title}}</h1>
+                {{#each messages}}
+                <p>{{this}}</p>
+                {{/each}}
+            </div>
+        </div>
+    </body>
+</html>
+`;
+
+// SVG icons for different response types
+const OAUTH_ICONS = {
+    success:
+        '<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/><path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
+    error: '<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/><path d="M15 9l-6 6M9 9l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
+    sessionExpired:
+        '<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/><path d="M12 6v6l4 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
+} as const;
+
+// Compile the template once with proper type safety
+const compiledTemplate = compile(OAUTH_RESPONSE_TEMPLATE);
+
+export type OAuthResponseStatus = 'success' | 'error';
+export type OAuthIconType = keyof typeof OAUTH_ICONS;
+
+/**
+ * Generates an OAuth response HTML page using Handlebars templating
+ * This prevents XSS issues by auto-escaping content while still allowing safe HTML in icons and styles
+ */
+export const generateOAuthResponseHtml = (
+    status: OAuthResponseStatus,
+    title: string,
+    messages: string[],
+    iconType: OAuthIconType = status === 'success' ? 'success' : 'error',
+): string =>
+    compiledTemplate({
+        styles: oauthPageStyles,
+        status,
+        title,
+        messages,
+        icon: OAUTH_ICONS[iconType],
+    });
+
+/**
+ * Generates a success OAuth response
+ */
+export const generateOAuthSuccessResponse = (
+    title: string = 'Authentication Successful!',
+    messages: string[] = [
+        'You have been successfully authenticated with Lightdash.',
+        'You can close this window and return to the CLI.',
+    ],
+): string => generateOAuthResponseHtml('success', title, messages, 'success');
+
+/**
+ * Generates an error OAuth response
+ */
+export const generateOAuthErrorResponse = (
+    title: string,
+    messages: string[],
+    iconType: OAuthIconType = 'error',
+): string =>
+    generateOAuthResponseHtml(
+        'error',
+        title,
+        [...messages, 'You can close this window and try again.'],
+        iconType,
+    );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,9 @@ importers:
       nunjucks:
         specifier: ^3.2.3
         version: 3.2.3(chokidar@3.6.0)
+      openid-client:
+        specifier: ^5.6.4
+        version: 5.6.4
       ora:
         specifier: 5.4.1
         version: 5.4.1
@@ -643,6 +646,9 @@ importers:
       dependency-graph:
         specifier: ^0.11.0
         version: 0.11.0
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -680,6 +686,9 @@ importers:
         specifier: ^3.25.55
         version: 3.25.55
     devDependencies:
+      '@types/handlebars':
+        specifier: ^4.1.0
+        version: 4.1.0
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -5346,6 +5355,10 @@ packages:
 
   '@types/graceful-fs@4.1.5':
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
+
+  '@types/handlebars@4.1.0':
+    resolution: {integrity: sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==}
+    deprecated: This is a stub types definition. handlebars provides its own type definitions, so you do not need this installed.
 
   '@types/hast@2.3.1':
     resolution: {integrity: sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==}
@@ -19624,6 +19637,10 @@ snapshots:
   '@types/graceful-fs@4.1.5':
     dependencies:
       '@types/node': 22.15.3
+
+  '@types/handlebars@4.1.0':
+    dependencies:
+      handlebars: 4.7.8
 
   '@types/hast@2.3.1':
     dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:


3 changes: 

- Add configurable OAuth token lifetimes 
- use openid-client to authenticate with oauth in the client 
- extract html rendering into common package, and use handlebars

Same functionality. 


<img width="530" height="353" alt="image" src="https://github.com/user-attachments/assets/c4b2d516-6add-4324-9d92-644d80abc5cb" />

## Ai description: 

Add configurable OAuth token lifetimes and improve CLI OAuth flow

This PR adds configuration options for OAuth access and refresh token lifetimes through environment variables:
- `AUTH_OAUTH_SERVER_ACCESS_TOKEN_LIFETIME` (default: 1 hour)
- `AUTH_OAUTH_SERVER_REFRESH_TOKEN_LIFETIME` (default: 2 weeks)

The CLI OAuth login flow has been completely refactored to use the `openid-client` library for better security and standards compliance. The authentication UI has been improved with better error handling and templated responses using Handlebars to prevent XSS issues.