### PR TITLE
fix: Dashboard screenshot with tabs & filters

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -494,7 +494,7 @@ export class UnfurlService extends BaseService {
                     dashboard.projectUuid
                 }/dashboards/${dashboardUuid}${queryFilters}${
                     selectedTabsParams.toString()
-                        ? `${selectedTabsParams.toString()}`
+                        ? `&${selectedTabsParams.toString()}`
                         : ''
                 }`,
                 this.lightdashConfig.headlessBrowser.internalLightdashHost,


### PR DESCRIPTION

Fix Minimal Url generation when both `filters` and `selectedTabs` params are present. 

Before:
```
...filters=%7B%22dimensions%...%7DselectedTabs=%5B%...%5D
```

After:
```
...filters=%7B%22dimensions%...%7D&selectedTabs=%5B%...%5D
```