### PR TITLE
chore: update dependencies for databricks/sql and node-canvas support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -199,11 +199,23 @@
               libpq
               libpq.pg_config
               openssl
+
+              # for @databricks/sql
+              lz4
+
+              # for node-canvas
+              pixman
+              cairo
+              pango
+              libjpeg
+              libpng
+              librsvg
+              giflib
             ];
 
             buildInputs = with pkgs; [
-              nodejs_22
-              pnpm
+              nodejs_20
+              corepack
 
               # for dbt
               python312


### PR DESCRIPTION
### Description:
Updated development dependencies in flake.nix to support new packages and changed Node.js version:

- Downgraded from Node.js 22 to Node.js 20 <<<<<<< we are using node 20 in our image builds, just matching that.
- Replaced pnpm with corepack
- Added libraries required for @databricks/sql: lz4
- Added libraries needed for node-canvas: pixman, cairo, pango, libjpeg, libpng, librsvg, and giflib