### PR TITLE
refactor: change selects from array to record in QueryBuilder

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.yml
@@ -17,6 +17,8 @@ models:
         description: This is a unique identifier for a payment
         config:
           meta:
+            dimension:
+              sql: CAST(payment_id AS TEXT)
             metrics:
               unique_payment_count:
                 type: count_distinct

--- a/examples/full-jaffle-shop-demo/dbt/models/payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.yml
@@ -17,8 +17,6 @@ models:
         description: This is a unique identifier for a payment
         config:
           meta:
-            dimension:
-              sql: CAST(payment_id AS TEXT)
             metrics:
               unique_payment_count:
                 type: count_distinct

--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.mock.ts
@@ -1409,8 +1409,7 @@ export const EXPECTED_SQL_WITH_CUSTOM_DIMENSION_BIN_NUMBER = `WITH age_range_cte
                                                                                      age_range_cte.bin_width * 2, ' - ',
                                                                                      age_range_cte.max_id)
                                                                          END
-                                                                                                 AS \`age_range\`
-                                                                      ,
+                                                                                                 AS \`age_range\`,
                                                                      MAX("table1".number_column) AS \`table1_metric1\`
                                                               FROM "db"."schema"."table1" AS \`table1\`
 
@@ -1479,8 +1478,7 @@ export const EXPECTED_SQL_WITH_CUSTOM_DIMENSION_AND_TABLE_CALCULATION = `WITH ag
                                                                                                          ' - ',
                                                                                                          age_range_cte.max_id)
                                                                                                  END
-                                                                                                                         AS \`age_range\`
-                                                                                              ,
+                                                                                                                         AS \`age_range\`,
                                                                                              MAX("table1".number_column) AS \`table1_metric1\`
                                                                                       FROM "db"."schema"."table1" AS \`table1\`
 

--- a/packages/backend/src/utils/QueryBuilder/utils.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.test.ts
@@ -282,7 +282,7 @@ describe('with custom dimensions', () => {
                 customDimensions: [CUSTOM_SQL_DIMENSION],
             }),
         ).toStrictEqual({
-            selects: ['  ("table1".dim1 < 18) AS `is_adult`'],
+            selects: { is_adult: '  ("table1".dim1 < 18) AS `is_adult`' },
             tables: ['table1'],
         });
     });
@@ -312,16 +312,15 @@ describe('with custom dimensions', () => {
                 )`,
             ],
             join: 'CROSS JOIN age_range_cte',
-            selects: [
-                `CASE
-                        WHEN "table1".dim1 IS NULL THEN NULL
+            selects: {
+                age_range: `CASE
+                    WHEN "table1".dim1 IS NULL THEN NULL
 WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 0, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 1)
 WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 1, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 2)
 ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range_cte.max_id)
-                        END
-                        AS \`age_range\`
-                    `,
-            ],
+                    END
+                    AS \`age_range\``,
+            },
             tables: ['table1'],
         });
     });
@@ -358,9 +357,9 @@ ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range
                 )`,
             ],
             join: 'CROSS JOIN age_range_cte',
-            selects: [
-                `CONCAT(age_range_cte.min_id, ' - ', age_range_cte.max_id) AS \`age_range\``,
-            ],
+            selects: {
+                age_range: `CONCAT(age_range_cte.min_id, ' - ', age_range_cte.max_id) AS \`age_range\``,
+            },
             tables: ['table1'],
         });
     });
@@ -389,22 +388,22 @@ ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range
                 )`,
             ],
             join: 'CROSS JOIN age_range_cte',
-            selects: [
-                `CASE
-                            WHEN "table1".dim1 IS NULL THEN NULL
+            selects: {
+                age_range: `CASE
+                    WHEN "table1".dim1 IS NULL THEN NULL
 WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 0, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 1)
 WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 1, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 2)
 ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range_cte.max_id)
-                            END
-                            AS \`age_range\``,
-                `CASE
-                            WHEN "table1".dim1 IS NULL THEN 3
+                    END
+                    AS \`age_range\``,
+                age_range_order: `CASE
+                        WHEN "table1".dim1 IS NULL THEN 3
 WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN 0
 WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN 1
 ELSE 2
-                            END
-                            AS \`age_range_order\``,
-            ],
+                        END
+                        AS \`age_range_order\``,
+            },
             tables: ['table1'],
         });
     });

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -520,15 +520,17 @@ export const getCustomSqlDimensionSql = ({
 }: {
     warehouseSqlBuilder: WarehouseSqlBuilder;
     customDimensions: CompiledCustomSqlDimension[] | undefined;
-}): { selects: string[]; tables: string[] } | undefined => {
+}): { selects: Record<string, string>; tables: string[] } | undefined => {
     if (customDimensions === undefined || customDimensions.length === 0) {
         return undefined;
     }
     const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
-    const selects = customDimensions.map<string>(
-        (customDimension) =>
-            `  (${customDimension.compiledSql}) AS ${fieldQuoteChar}${customDimension.id}${fieldQuoteChar}`,
-    );
+    const selects: Record<string, string> = {};
+
+    customDimensions.forEach(({ id, compiledSql }) => {
+        const quotedAlias = `${fieldQuoteChar}${id}${fieldQuoteChar}`;
+        selects[id] = `  (${compiledSql}) AS ${quotedAlias}`;
+    });
 
     return {
         selects,
@@ -555,7 +557,7 @@ export const getCustomBinDimensionSql = ({
           ctes: string[];
           join: string | undefined;
           tables: string[];
-          selects: string[];
+          selects: Record<string, string>;
       }
     | undefined => {
     const startOfWeek = warehouseSqlBuilder.getStartOfWeek();
@@ -630,90 +632,119 @@ export const getCustomBinDimensionSql = ({
         (customDimension) => customDimension.table,
     );
 
-    const selects = customDimensions.reduce<string[]>(
-        (acc, customDimension) => {
-            const dimension = getDimensionFromId(
-                customDimension.dimensionId,
-                explore,
-                adapterType,
-                startOfWeek,
+    const selects: Record<string, string> = {};
+
+    customDimensions.forEach((customDimension) => {
+        const dimension = getDimensionFromId(
+            customDimension.dimensionId,
+            explore,
+            adapterType,
+            startOfWeek,
+        );
+        // Check required attribute permission for parent dimension
+        assertValidDimensionRequiredAttribute(
+            dimension,
+            userAttributes,
+            `custom dimension: "${customDimension.name}"`,
+        );
+
+        const dimensionId = getItemId(customDimension);
+        const orderDimensionId = `${dimensionId}_order`;
+        const quotedDimensionName = `${fieldQuoteChar}${dimensionId}${fieldQuoteChar}`;
+        const quotedDimensionOrder = `${fieldQuoteChar}${orderDimensionId}${fieldQuoteChar}`;
+        const cte = `${getCteReference(customDimension)}`;
+
+        // If a custom dimension is sorted, we need to generate a special SQL select that returns a number
+        // and not the range as a string
+        const isSorted =
+            sorts.length > 0 &&
+            sorts.find(
+                (sortField) => getItemId(customDimension) === sortField.fieldId,
             );
-            // Check required attribute permission for parent dimension
-            assertValidDimensionRequiredAttribute(
-                dimension,
-                userAttributes,
-                `custom dimension: "${customDimension.name}"`,
-            );
+        const quoteChar = warehouseSqlBuilder.getStringQuoteChar();
+        const dash = `${quoteChar} - ${quoteChar}`;
 
-            const customDimensionName = `${fieldQuoteChar}${getItemId(
-                customDimension,
-            )}${fieldQuoteChar}`;
-            const customDimensionOrder = `${fieldQuoteChar}${getItemId(
-                customDimension,
-            )}_order${fieldQuoteChar}`;
-            const cte = `${getCteReference(customDimension)}`;
+        switch (customDimension.binType) {
+            case BinType.FIXED_WIDTH:
+                if (!customDimension.binWidth) {
+                    throw new Error(
+                        `Undefined binWidth for custom dimension ${BinType.FIXED_WIDTH} `,
+                    );
+                }
 
-            // If a custom dimension is sorted, we need to generate a special SQL select that returns a number
-            // and not the range as a string
-            const isSorted =
-                sorts.length > 0 &&
-                sorts.find(
-                    (sortField) =>
-                        getItemId(customDimension) === sortField.fieldId,
-                );
-            const quoteChar = warehouseSqlBuilder.getStringQuoteChar();
-            const dash = `${quoteChar} - ${quoteChar}`;
+                const width = customDimension.binWidth;
+                const widthSql = `${getFixedWidthBinSelectSql({
+                    binWidth: customDimension.binWidth || 1,
+                    baseDimensionSql: dimension.compiledSql,
+                    warehouseSqlBuilder,
+                })} AS ${quotedDimensionName}`;
 
-            switch (customDimension.binType) {
-                case BinType.FIXED_WIDTH:
-                    if (!customDimension.binWidth) {
-                        throw new Error(
-                            `Undefined binWidth for custom dimension ${BinType.FIXED_WIDTH} `,
-                        );
+                selects[dimensionId] = widthSql;
+
+                if (isSorted) {
+                    selects[
+                        orderDimensionId
+                    ] = `FLOOR(${dimension.compiledSql} / ${width}) * ${width} AS ${quotedDimensionOrder}`;
+                }
+                break;
+            case BinType.FIXED_NUMBER:
+                if (!customDimension.binNumber) {
+                    throw new Error(
+                        `Undefined binNumber for custom dimension ${BinType.FIXED_NUMBER} `,
+                    );
+                }
+
+                if (customDimension.binNumber <= 1) {
+                    // Edge case, bin number with only one bucket does not need a CASE statement
+                    selects[dimensionId] = `${warehouseSqlBuilder.concatString(
+                        `${cte}.min_id`,
+                        dash,
+                        `${cte}.max_id`,
+                    )} AS ${quotedDimensionName}`;
+                    break;
+                }
+
+                const binWidth = `${cte}.bin_width`;
+
+                const from = (i: number) =>
+                    `${cte}.min_id + ${binWidth} * ${i}`;
+                const to = (i: number) =>
+                    `${cte}.min_id + ${binWidth} * ${i + 1}`;
+
+                const binWhens = Array.from(
+                    Array(customDimension.binNumber).keys(),
+                ).map((i) => {
+                    if (i !== customDimension.binNumber! - 1) {
+                        return `WHEN ${dimension.compiledSql} >= ${from(
+                            i,
+                        )} AND ${dimension.compiledSql} < ${to(
+                            i,
+                        )} THEN ${warehouseSqlBuilder.concatString(
+                            from(i),
+                            dash,
+                            to(i),
+                        )}`;
                     }
+                    return `ELSE ${warehouseSqlBuilder.concatString(
+                        from(i),
+                        dash,
+                        `${cte}.max_id`,
+                    )}`;
+                });
 
-                    const width = customDimension.binWidth;
-                    const widthSql = `${getFixedWidthBinSelectSql({
-                        binWidth: customDimension.binWidth || 1,
-                        baseDimensionSql: dimension.compiledSql,
-                        warehouseSqlBuilder,
-                    })} AS ${customDimensionName}`;
+                // Add a NULL case for when the dimension is NULL, returning null as the value so it get's correctly formated with the symbol ∅
+                const whens = [
+                    `WHEN ${dimension.compiledSql} IS NULL THEN NULL`,
+                    ...binWhens,
+                ];
 
-                    if (isSorted) {
-                        return [
-                            ...acc,
-                            widthSql,
-                            `FLOOR(${dimension.compiledSql} / ${width}) * ${width} AS ${customDimensionOrder}`,
-                        ];
-                    }
-                    return [...acc, widthSql];
-                case BinType.FIXED_NUMBER:
-                    if (!customDimension.binNumber) {
-                        throw new Error(
-                            `Undefined binNumber for custom dimension ${BinType.FIXED_NUMBER} `,
-                        );
-                    }
+                selects[dimensionId] = `CASE
+                    ${whens.join('\n')}
+                    END
+                    AS ${quotedDimensionName}`;
 
-                    if (customDimension.binNumber <= 1) {
-                        // Edge case, bin number with only one bucket does not need a CASE statement
-                        return [
-                            ...acc,
-                            `${warehouseSqlBuilder.concatString(
-                                `${cte}.min_id`,
-                                dash,
-                                `${cte}.max_id`,
-                            )} AS ${customDimensionName}`,
-                        ];
-                    }
-
-                    const binWidth = `${cte}.bin_width`;
-
-                    const from = (i: number) =>
-                        `${cte}.min_id + ${binWidth} * ${i}`;
-                    const to = (i: number) =>
-                        `${cte}.min_id + ${binWidth} * ${i + 1}`;
-
-                    const binWhens = Array.from(
+                if (isSorted) {
+                    const sortBinWhens = Array.from(
                         Array(customDimension.binNumber).keys(),
                     ).map((i) => {
                         if (i !== customDimension.binNumber! - 1) {
@@ -721,118 +752,70 @@ export const getCustomBinDimensionSql = ({
                                 i,
                             )} AND ${dimension.compiledSql} < ${to(
                                 i,
-                            )} THEN ${warehouseSqlBuilder.concatString(
-                                from(i),
-                                dash,
-                                to(i),
-                            )}`;
+                            )} THEN ${i}`;
                         }
-                        return `ELSE ${warehouseSqlBuilder.concatString(
-                            from(i),
-                            dash,
-                            `${cte}.max_id`,
-                        )}`;
+                        return `ELSE ${i}`;
                     });
 
-                    // Add a NULL case for when the dimension is NULL, returning null as the value so it get's correctly formated with the symbol ∅
-                    const whens = [
-                        `WHEN ${dimension.compiledSql} IS NULL THEN NULL`,
-                        ...binWhens,
+                    const sortWhens = [
+                        `WHEN ${dimension.compiledSql} IS NULL THEN ${customDimension.binNumber}`,
+                        ...sortBinWhens,
                     ];
 
-                    if (isSorted) {
-                        const sortBinWhens = Array.from(
-                            Array(customDimension.binNumber).keys(),
-                        ).map((i) => {
-                            if (i !== customDimension.binNumber! - 1) {
-                                return `WHEN ${dimension.compiledSql} >= ${from(
-                                    i,
-                                )} AND ${dimension.compiledSql} < ${to(
-                                    i,
-                                )} THEN ${i}`;
-                            }
-                            return `ELSE ${i}`;
-                        });
-
-                        const sortWhens = [
-                            `WHEN ${dimension.compiledSql} IS NULL THEN ${customDimension.binNumber}`,
-                            ...sortBinWhens,
-                        ];
-
-                        return [
-                            ...acc,
-                            `CASE
-                            ${whens.join('\n')}
-                            END
-                            AS ${customDimensionName}`,
-                            `CASE
-                            ${sortWhens.join('\n')}
-                            END
-                            AS ${customDimensionOrder}`,
-                        ];
-                    }
-
-                    return [
-                        ...acc,
-                        `CASE
-                        ${whens.join('\n')}
+                    selects[orderDimensionId] = `CASE
+                        ${sortWhens.join('\n')}
                         END
-                        AS ${customDimensionName}
-                    `,
-                    ];
-                case BinType.CUSTOM_RANGE:
-                    if (!customDimension.customRange) {
-                        throw new Error(
-                            `Undefined customRange for custom dimension ${BinType.CUSTOM_RANGE} `,
-                        );
-                    }
-
-                    const customRangeSql = `${getCustomRangeSelectSql({
-                        binRanges: customDimension.customRange || [],
-                        baseDimensionSql: dimension.compiledSql,
-                        warehouseSqlBuilder,
-                    })} AS ${customDimensionName}`;
-
-                    if (isSorted) {
-                        const sortedRangeWhens =
-                            customDimension.customRange.map((range, i) => {
-                                if (range.from === undefined) {
-                                    return `WHEN ${dimension.compiledSql} < ${range.to} THEN ${i}`;
-                                }
-                                if (range.to === undefined) {
-                                    return `ELSE ${i}`;
-                                }
-
-                                return `WHEN ${dimension.compiledSql} >= ${range.from} AND ${dimension.compiledSql} < ${range.to} THEN ${i}`;
-                            });
-
-                        const sortedWhens = [
-                            `WHEN ${dimension.compiledSql} IS NULL THEN ${customDimension.customRange.length}`,
-                            ...sortedRangeWhens,
-                        ];
-
-                        return [
-                            ...acc,
-                            customRangeSql,
-                            `CASE
-                        ${sortedWhens.join('\n')}
-                        END
-                        AS ${customDimensionOrder}`,
-                        ];
-                    }
-
-                    return [...acc, customRangeSql];
-
-                default:
-                    assertUnreachable(
-                        customDimension.binType,
-                        `Unknown bin type on sql: ${customDimension.binType}`,
+                        AS ${quotedDimensionOrder}`;
+                }
+                break;
+            case BinType.CUSTOM_RANGE:
+                if (!customDimension.customRange) {
+                    throw new Error(
+                        `Undefined customRange for custom dimension ${BinType.CUSTOM_RANGE} `,
                     );
-            }
-            return acc;
-        },
-        [],
-    );
+                }
+
+                const customRangeSql = `${getCustomRangeSelectSql({
+                    binRanges: customDimension.customRange || [],
+                    baseDimensionSql: dimension.compiledSql,
+                    warehouseSqlBuilder,
+                })} AS ${quotedDimensionName}`;
+
+                selects[dimensionId] = customRangeSql;
+
+                if (isSorted) {
+                    const sortedRangeWhens = customDimension.customRange.map(
+                        (range, i) => {
+                            if (range.from === undefined) {
+                                return `WHEN ${dimension.compiledSql} < ${range.to} THEN ${i}`;
+                            }
+                            if (range.to === undefined) {
+                                return `ELSE ${i}`;
+                            }
+
+                            return `WHEN ${dimension.compiledSql} >= ${range.from} AND ${dimension.compiledSql} < ${range.to} THEN ${i}`;
+                        },
+                    );
+
+                    const sortedWhens = [
+                        `WHEN ${dimension.compiledSql} IS NULL THEN ${customDimension.customRange.length}`,
+                        ...sortedRangeWhens,
+                    ];
+
+                    selects[orderDimensionId] = `CASE
+                    ${sortedWhens.join('\n')}
+                    END
+                    AS ${quotedDimensionOrder}`;
+                }
+                break;
+
+            default:
+                assertUnreachable(
+                    customDimension.binType,
+                    `Unknown bin type on select: ${customDimension.binType}`,
+                );
+        }
+    });
 
     return {
         ctes,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #

### Description:
Refactored the QueryBuilder to use a Record<string, string> for selects instead of an array of strings. This change improves the handling of dimension aliases by storing them as keys in the record, making it easier to access and manipulate them throughout the code.

The main improvements include:
- Changed `selects` from string[] to Record<string, string> for better organization
- Fixed SQL formatting in the expected SQL test cases
- Simplified dimension alias extraction by using object keys instead of parsing SQL
- Eliminated duplicate selects by using object assignment
- Made the code more maintainable by using consistent patterns for handling dimension identifiers