### PR TITLE
feat: add yaml_tags to catalog search for AI visibility filtering

### DIFF
--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -22,6 +22,7 @@ export type DbCatalog = {
     icon: CatalogItemIcon | null;
     table_name: string;
     spotlight_show: boolean;
+    yaml_tags: string[] | null;
 };
 
 export type DbCatalogIn = Pick<
@@ -37,6 +38,7 @@ export type DbCatalogIn = Pick<
     | 'chart_usage'
     | 'table_name'
     | 'spotlight_show'
+    | 'yaml_tags'
 >;
 export type DbCatalogRemove = Pick<DbCatalog, 'project_uuid' | 'name'>;
 export type DbCatalogUpdate =

--- a/packages/backend/src/database/migrations/20250722164009_add_yaml_tags_to_catalog_search.ts
+++ b/packages/backend/src/database/migrations/20250722164009_add_yaml_tags_to_catalog_search.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+const TABLE_NAME = 'catalog_search';
+const COLUMN_NAME = 'yaml_tags';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.specificType(COLUMN_NAME, 'TEXT[]').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.dropColumn(COLUMN_NAME);
+    });
+}

--- a/packages/backend/src/database/migrations/20250722164436_add_index_on_yaml_tags_of_catalog_search.ts
+++ b/packages/backend/src/database/migrations/20250722164436_add_index_on_yaml_tags_of_catalog_search.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+const TABLE_NAME = 'catalog_search';
+const COLUMN_NAME = 'yaml_tags';
+const INDEX_NAME = 'catalog_search_yaml_tags_gin_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.index([COLUMN_NAME], INDEX_NAME, 'gin');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.dropIndex([COLUMN_NAME], INDEX_NAME);
+    });
+}

--- a/packages/backend/src/models/CatalogModel/CLAUDE.md
+++ b/packages/backend/src/models/CatalogModel/CLAUDE.md
@@ -1,0 +1,43 @@
+# Catalog Model
+
+## `CatalogModel` Overview
+
+The `CatalogModel` powers the Lightdash Spotlight feature (a.k.a. Metrics Explorer, a.k.a. Data Catalog). It’s built on top of the cached_explores table, which stores the full structure of a project’s explores parsed from dbt + Lightdash YAML files.
+
+Its core responsibilities include:
+
+-   **Indexing:** The `indexCatalog` method transforms structured `Explore` objects (originating from YAML files) from a project into a flattened, searchable format. It processes tables, dimensions, and metrics, storing them as individual items in the `catalog_search` table. This process also handles the association of metadata like YAML-defined tags, user-defined tags, and chart usage statistics.
+-   **Searching:** The `search` method provides a powerful and flexible interface for querying the catalog. It supports a wide range of filtering criteria, including full-text search, pagination, sorting, and filtering based on user attributes, table configurations, and various tagging systems. All filtering is executed directly within the database (using Knex.js) to ensure high performance.
+-   **Metadata Management:** Beyond indexing and searching, the model manages other catalog-related entities, such as UI-applied tags, metric dependency trees (`Metric Trees`), and chart usage metrics.
+
+## The `search` Method
+
+The `search` method is the main entry point for querying the data catalog. It is designed to handle complex filtering scenarios by combining multiple parameters into a single, efficient database query.
+
+### Filtering with `yamlTags`
+
+The `yamlTags` parameter provides a mechanism to filter catalog items based on tags defined in the project's dbt YAML files. This is primarily used to control exposure for AI features.
+
+The parameter accepts an array of strings (`string[] | null`):
+
+-   If `yamlTags` is `null`, no tag-based filtering is applied. This corresponds to the "No tags configured in settings UI" scenario where everything is visible by default.
+-   If `yamlTags` is an empty array (`[]`), the query will correctly return no results, as no item can match a tag from an empty set.
+
+#### Filtering Logic and Visibility Rules
+
+The filtering logic follows a specific set of rules to determine which catalog items (explores, tables, and fields) are visible.
+
+**No tags are configured in settings UI:**
+
+| Tagging Scenario                  | AI Visibility                    |
+| --------------------------------- | -------------------------------- |
+| No tags configured in settings UI | Everything is visible by default |
+
+**Tags are configured in settings UI:**
+
+| Tagging Scenario                     | AI Visibility             |
+| ------------------------------------ | ------------------------- |
+| Explore only (with matching tag)     | All fields in the Explore |
+| Some fields only (with matching tag) | Only those tagged fields  |
+| Explore + some fields (with match)   | Only those tagged fields  |
+| No matching tags                     | Nothing is visible        |

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -58,6 +58,10 @@ export const convertExploresToCatalog = (
                 chart_usage: null, // Tables don't have chart usage
                 table_name: explore.baseTable,
                 spotlight_show: getSpotlightShow(explore.spotlight),
+                yaml_tags:
+                    Array.isArray(explore.tags) && explore.tags.length > 0
+                        ? explore.tags
+                        : null,
             };
 
             const dimensionsAndMetrics = [
@@ -110,6 +114,10 @@ export const convertExploresToCatalog = (
                                 : explore.spotlight,
                         ),
                         assigned_yaml_tags: assignedYamlTags,
+                        yaml_tags:
+                            Array.isArray(field.tags) && field.tags.length > 0
+                                ? field.tags
+                                : null,
                     };
                 },
             );

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -258,6 +258,7 @@ export class CatalogService<
                             userAttributes,
                             sortArgs,
                             context,
+                            yamlTags: null,
                         }),
                 ),
         );
@@ -1251,6 +1252,7 @@ export class CatalogService<
             tablesConfiguration: await this.projectModel.getTablesConfiguration(
                 projectUuid,
             ),
+            yamlTags: null,
         });
 
         const filteredMetrics = allCatalogMetrics.data.filter(
@@ -1313,6 +1315,7 @@ export class CatalogService<
             tablesConfiguration: await this.projectModel.getTablesConfiguration(
                 projectUuid,
             ),
+            yamlTags: null,
         });
 
         const allDimensions = catalogDimensions.data


### PR DESCRIPTION
### Description:
Add YAML tags support to catalog search for AI feature visibility control

This PR adds a new `yaml_tags` column to the catalog search table to store tags defined in dbt YAML files. It implements a sophisticated filtering mechanism that controls which catalog items (explores, tables, and fields) are visible based on tag configuration:

- When no tags are configured, everything is visible by default
- When tags are configured, visibility follows these rules:
  - If an explore has a matching tag, all fields in that explore are visible
  - If specific fields have matching tags, only those fields are visible
  - If both an explore and some fields have matching tags, only those tagged fields are visible
  - If no matching tags exist, nothing is visible

The implementation includes database migrations to add the column and create a GIN index for efficient tag-based filtering.