### PR TITLE
fix: make spotlight required and merge with default config

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.test.ts
@@ -38,7 +38,8 @@ describe('getLightdashProjectConfig', () => {
         },
     };
 
-    const INVALID_CONFIG_CONTENTS = 'I am invalid';
+    const INVALID_CONFIG_CONTENTS =
+        'spotlight:\n default_visibility: invalid_value';
 
     const readFileSpy = jest.spyOn(fs, 'readFile');
 

--- a/packages/cli/src/lightdash-config/lightdash-config.test.ts
+++ b/packages/cli/src/lightdash-config/lightdash-config.test.ts
@@ -30,7 +30,8 @@ const VALID_CONFIG: LightdashProjectConfig = {
     },
 };
 
-const INVALID_CONFIG_CONTENTS = 'I am invalid';
+const INVALID_CONFIG_CONTENTS =
+    'spotlight:\n  default_visibility: invalid_value';
 
 const readFileSpy = jest.spyOn(fs, 'readFile');
 

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -2,6 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://schemas.lightdash.com/lightdash/config.json",
     "type": ["object", "null"],
+    "required": ["spotlight"],
     "properties": {
         "spotlight": {
             "type": ["object", "null"],

--- a/packages/common/src/utils/loadLightdashProjectConfig.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.ts
@@ -8,16 +8,25 @@ import {
     type LightdashProjectConfig,
 } from '../types/lightdashProjectConfig';
 
+const defaultConfig: LightdashProjectConfig = {
+    spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+};
 export const loadLightdashProjectConfig = async (
     yamlFileContents: string,
     onLoaded?: (config: LightdashProjectConfig) => Promise<void>,
 ): Promise<LightdashProjectConfig> => {
     if (yamlFileContents.trim() === '') {
-        return {
-            spotlight: DEFAULT_SPOTLIGHT_CONFIG,
-        };
+        return defaultConfig;
     }
-    const configFile = yaml.load(yamlFileContents);
+    // Type assertion for the loaded YAML config
+    const loadedConfig = yaml.load(
+        yamlFileContents,
+    ) as Partial<LightdashProjectConfig>;
+    // Merge the loaded config with the default config
+    const configFile: LightdashProjectConfig = {
+        ...defaultConfig,
+        ...loadedConfig,
+    };
     const ajv = new Ajv({ coerceTypes: true });
     const validate = ajv.compile<LightdashProjectConfig>(
         lightdashProjectConfigSchema,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Made the `spotlight` field required in the Lightdash project config schema and improved the config loading process by properly merging default values with user-provided configuration. This ensures that even if a user doesn't explicitly define spotlight settings, the default configuration will be applied consistently.

### Reproduce steps

Update `examples/full-jaffle-shop-demo/dbt/lightdash.config.yml` to only have parameters:
```
parameters:
  subscription_status:
    label: "Subscription Status"
    description: "Filter subscriptions by their current status"
    default: "all"
    options:
      - "all"
      - "Current"
      - "Expired"
      - "Cancelled"
```

Run deploy

```
pnpm cli-build
node ./packages/cli/dist/index.js login http://localhost:3000
node ./packages/cli/dist/index.js deploy --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles
```

Current: 

<img width="1110" height="448" alt="Screenshot 2025-07-23 at 16 09 25" src="https://github.com/user-attachments/assets/62f79a40-038a-43d3-8403-975a48dca693" />


With fix:

<img width="1125" height="516" alt="Screenshot 2025-07-23 at 16 16 37" src="https://github.com/user-attachments/assets/26727c67-5e16-4723-bb54-6794d0941c55" />
