### PR TITLE
chore: add separate query worker for dev environments

### DIFF
--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -1,0 +1,80 @@
+# Docker Configuration for Lightdash Development
+
+<summary>
+Docker Compose configurations for running Lightdash in different environments. Provides isolated services for the main backend, query worker, database, and supporting infrastructure like MinIO and Prometheus.
+</summary>
+
+<howToUse>
+The main entry point is `docker-compose.dev.yml` for local development:
+
+```bash
+# Start all services
+docker compose -p lightdash-app -f docker/docker-compose.dev.yml --env-file .env.development.local up --detach --remove-orphans
+```
+
+Key services:
+
+-   `lightdash-dev`: Main backend API (ports 8080, 3000, 9090, 6006)
+-   `lightdash-query-worker`: Isolated warehouse query execution
+-   `db-dev`: PostgreSQL with pgvector extension
+-   `minio`: S3-compatible storage for development
+-   `prometheus`: Metrics collection
+
+</howToUse>
+
+<codeExample>
+
+```yaml
+# Service architecture with shared configuration
+x-lightdash-base: &lightdash-base
+  build: *lightdash-build
+  volumes: *lightdash-volumes
+  environment: *lightdash-environment
+
+services:
+  lightdash-dev:
+    <<: *lightdash-base
+    environment:
+      SCHEDULER_EXCLUDE_TASKS: runAsyncWarehouseQuery
+    ports: ['8080:8080', '3000:3000']
+
+  lightdash-query-worker:
+    <<: *lightdash-base
+    environment:
+      SCHEDULER_INCLUDE_TASKS: runAsyncWarehouseQuery
+    restart: unless-stopped
+```
+
+</codeExample>
+
+<importantToKnow>
+**Service Separation**: The main backend and query worker run in separate containers. The main service handles API requests while the worker processes warehouse queries.
+
+**Development Workflow**:
+
+-   `lightdash-dev` starts with `sleep infinity` for manual setup (migrations, builds)
+-   `lightdash-query-worker` depends on the main service and auto-restarts on failure
+-   Environment variables are deduplicated using YAML anchors (`x-lightdash-*`)
+
+**Port Allocation**:
+
+-   8080: Backend API
+-   3000: Frontend development server
+-   9090: Prometheus metrics
+-   5432: PostgreSQL database
+-   9000/9001: MinIO storage
+
+**Configuration Files**:
+
+-   `docker-compose.dev.yml`: Full development environment
+-   `docker-compose.dev.mini.yml`: Minimal setup
+-   `docker-compose.preview.yml`: Preview deployments
+
+</importantToKnow>
+
+<links>
+- Development setup: @/README.md
+- Environment variables: @/.env.example
+- Prometheus config: @/docker/dev-configs/prometheus.dev.yml
+- Production dockerfile: @/dockerfile
+</links>

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,6 +2,85 @@ version: '3.8'
 volumes:
     node_modules:
 
+# Common configuration for Lightdash services
+x-lightdash-build: &lightdash-build
+    context: ..
+    dockerfile: dockerfile
+    target: dev
+
+x-lightdash-volumes: &lightdash-volumes
+    - '../:/usr/app'
+    - '../examples/full-jaffle-shop-demo/dbt:/usr/app/dbt'
+    - 'node_modules:/usr/app/node_modules/' # clears the node_modules directory so it doesn't sync (v.slow on MacOS)
+    # - ${HOME}/.config/gcloud:/root/.config/gcloud # Uncomment this line if you want to use your credential as gcloud ADC in dev container
+
+x-lightdash-environment: &lightdash-environment
+    PGHOST: ${PGHOST}
+    PGPORT: ${PGPORT}
+    PGUSER: ${PGUSER}
+    PGPASSWORD: ${PGPASSWORD}
+    PGDATABASE: ${PGDATABASE}
+    RUDDERSTACK_WRITE_KEY: ${RUDDERSTACK_WRITE_KEY}
+    RUDDERSTACK_DATA_PLANE_URL: ${RUDDERSTACK_DATA_PLANE_URL}
+    SECURE_COOKIES: ${SECURE_COOKIES}
+    LIGHTDASH_SECRET: ${LIGHTDASH_SECRET}
+    LIGHTDASH_LOG_LEVEL: ${LIGHTDASH_LOG_LEVEL}
+    LIGHTDASH_LICENSE_KEY: ${LIGHTDASH_LICENSE_KEY}
+    NODE_ENV: ${NODE_ENV}
+    DBT_DEMO_DIR: ${DBT_DEMO_DIR}
+    AUTH_DISABLE_PASSWORD_AUTHENTICATION: ${AUTH_DISABLE_PASSWORD_AUTHENTICATION}
+    AUTH_ENABLE_GROUP_SYNC: ${AUTH_ENABLE_GROUP_SYNC}
+    SITE_URL: ${SITE_URL}
+    EXPOSED_SITE_URL: ${EXPOSED_SITE_URL}
+    ALLOW_MULTIPLE_ORGS: ${ALLOW_MULTIPLE_ORGS}
+    LIGHTDASH_QUERY_MAX_LIMIT: ${LIGHTDASH_QUERY_MAX_LIMIT}
+    HEADLESS_BROWSER_HOST: ${HEADLESS_BROWSER_HOST}
+    HEADLESS_BROWSER_PORT: ${HEADLESS_BROWSER_PORT}
+    INTERNAL_LIGHTDASH_HOST: ${INTERNAL_LIGHTDASH_HOST}
+    USE_SECURE_BROWSER: ${USE_SECURE_BROWSER}
+    GROUPS_ENABLED: ${GROUPS_ENABLED}
+    POSTHOG_PROJECT_API_KEY: ${POSTHOG_PROJECT_API_KEY}
+    OPENAI_API_KEY: ${OPENAI_API_KEY}
+    ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    AI_COPILOT_ENABLED: ${AI_COPILOT_ENABLED}
+    POSTHOG_FE_API_HOST: ${POSTHOG_FE_API_HOST}
+    POSTHOG_BE_API_HOST: ${POSTHOG_BE_API_HOST}
+    SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET}
+    SLACK_CLIENT_ID: ${SLACK_CLIENT_ID}
+    SLACK_CLIENT_SECRET: ${SLACK_CLIENT_SECRET}
+    SLACK_STATE_SECRET: ${SLACK_STATE_SECRET}
+    GITHUB_PRIVATE_KEY: ${GITHUB_PRIVATE_KEY}
+    GITHUB_APP_ID: ${GITHUB_APP_ID}
+    GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+    GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+    GITHUB_APP_NAME: ${GITHUB_APP_NAME}
+    GITHUB_REDIRECT_DOMAIN: ${GITHUB_REDIRECT_DOMAIN}
+    GOOGLE_DRIVE_API_KEY: ${GOOGLE_DRIVE_API_KEY}
+    AUTH_ENABLE_GCLOUD_ADC: ${AUTH_ENABLE_GCLOUD_ADC}
+    AUTH_GOOGLE_OAUTH2_CLIENT_ID: ${AUTH_GOOGLE_OAUTH2_CLIENT_ID}
+    AUTH_GOOGLE_OAUTH2_CLIENT_SECRET: ${AUTH_GOOGLE_OAUTH2_CLIENT_SECRET}
+    S3_ENDPOINT: ${S3_ENDPOINT}
+    S3_REGION: ${S3_REGION}
+    S3_BUCKET: ${S3_BUCKET}
+    S3_ACCESS_KEY: ${S3_ACCESS_KEY}
+    S3_SECRET_KEY: ${S3_SECRET_KEY}
+    S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE}
+    S3_EXPIRATION_TIME: ${S3_EXPIRATION_TIME}
+    RESULTS_S3_REGION: ${RESULTS_S3_REGION:-${RESULTS_CACHE_S3_REGION}}
+    RESULTS_S3_BUCKET: ${RESULTS_S3_BUCKET:-${RESULTS_CACHE_S3_BUCKET}}
+    RESULTS_S3_SECRET_KEY: ${RESULTS_S3_SECRET_KEY:-${RESULTS_CACHE_S3_SECRET_KEY}}
+    RESULTS_S3_ACCESS_KEY: ${RESULTS_S3_ACCESS_KEY:-${RESULTS_CACHE_S3_ACCESS_KEY}}
+    LIGHTDASH_PROMETHEUS_ENABLED: ${LIGHTDASH_PROMETHEUS_ENABLED}
+
+x-lightdash-base: &lightdash-base
+    build: *lightdash-build
+    depends_on:
+        - minio
+        - db-dev
+    volumes: *lightdash-volumes
+    environment:
+        <<: *lightdash-environment
+
 services:
     minio:
         image: bitnami/minio:latest
@@ -15,80 +94,14 @@ services:
             - MINIO_BROWSER=${MINIO_BROWSER:-off}
 
     lightdash-dev:
-        build:
-            context: ..
-            dockerfile: dockerfile
-            target: dev
-        depends_on:
-            - minio
-            - db-dev
+        <<: *lightdash-base
         environment:
-            - PGHOST=${PGHOST}
-            - PGPORT=${PGPORT}
-            - PGUSER=${PGUSER}
-            - PGPASSWORD=${PGPASSWORD}
-            - PGDATABASE=${PGDATABASE}
-            - RUDDERSTACK_WRITE_KEY=${RUDDERSTACK_WRITE_KEY}
-            - RUDDERSTACK_DATA_PLANE_URL=${RUDDERSTACK_DATA_PLANE_URL}
-            - SECURE_COOKIES=${SECURE_COOKIES}
-            - LIGHTDASH_SECRET=${LIGHTDASH_SECRET}
-            - LIGHTDASH_LOG_LEVEL=${LIGHTDASH_LOG_LEVEL}
-            - LIGHTDASH_LICENSE_KEY=${LIGHTDASH_LICENSE_KEY}
-            - NODE_ENV=${NODE_ENV}
-            - DBT_DEMO_DIR=${DBT_DEMO_DIR}
-            - AUTH_DISABLE_PASSWORD_AUTHENTICATION=${AUTH_DISABLE_PASSWORD_AUTHENTICATION}
-            - AUTH_ENABLE_GROUP_SYNC=${AUTH_ENABLE_GROUP_SYNC}
-            - SITE_URL=${SITE_URL}
-            - EXPOSED_SITE_URL=${EXPOSED_SITE_URL}
-            - ALLOW_MULTIPLE_ORGS=${ALLOW_MULTIPLE_ORGS}
-            - LIGHTDASH_QUERY_MAX_LIMIT=${LIGHTDASH_QUERY_MAX_LIMIT}
-            - HEADLESS_BROWSER_HOST=${HEADLESS_BROWSER_HOST}
-            - HEADLESS_BROWSER_PORT=${HEADLESS_BROWSER_PORT}
-            - INTERNAL_LIGHTDASH_HOST=${INTERNAL_LIGHTDASH_HOST}
-            - USE_SECURE_BROWSER=${USE_SECURE_BROWSER}
-            - SCHEDULER_ENABLED=${SCHEDULER_ENABLED}
-            - SCHEDULER_INCLUDE_TASKS=${SCHEDULER_INCLUDE_TASKS}
-            - SCHEDULER_EXCLUDE_TASKS=${SCHEDULER_EXCLUDE_TASKS}
-            - GROUPS_ENABLED=${GROUPS_ENABLED}
-            - POSTHOG_PROJECT_API_KEY=${POSTHOG_PROJECT_API_KEY}
-            - OPENAI_API_KEY=${OPENAI_API_KEY}
-            - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-            - AI_COPILOT_ENABLED=${AI_COPILOT_ENABLED}
-            - POSTHOG_FE_API_HOST=${POSTHOG_FE_API_HOST}
-            - POSTHOG_BE_API_HOST=${POSTHOG_BE_API_HOST}
-            - SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET}
-            - SLACK_CLIENT_ID=${SLACK_CLIENT_ID}
-            - SLACK_CLIENT_SECRET=${SLACK_CLIENT_SECRET}
-            - SLACK_STATE_SECRET=${SLACK_STATE_SECRET}
-            - GITHUB_PRIVATE_KEY=${GITHUB_PRIVATE_KEY}
-            - GITHUB_APP_ID=${GITHUB_APP_ID}
-            - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
-            - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
-            - GITHUB_APP_NAME=${GITHUB_APP_NAME}
-            - GITHUB_REDIRECT_DOMAIN=${GITHUB_REDIRECT_DOMAIN}
-            - GOOGLE_DRIVE_API_KEY=${GOOGLE_DRIVE_API_KEY}
-            - AUTH_ENABLE_GCLOUD_ADC=${AUTH_ENABLE_GCLOUD_ADC}
-            - AUTH_GOOGLE_OAUTH2_CLIENT_ID=${AUTH_GOOGLE_OAUTH2_CLIENT_ID}
-            - AUTH_GOOGLE_OAUTH2_CLIENT_SECRET=${AUTH_GOOGLE_OAUTH2_CLIENT_SECRET}
-            - S3_ENDPOINT=${S3_ENDPOINT}
-            - S3_REGION=${S3_REGION}
-            - S3_BUCKET=${S3_BUCKET}
-            - S3_ACCESS_KEY=${S3_ACCESS_KEY}
-            - S3_SECRET_KEY=${S3_SECRET_KEY}
-            - S3_FORCE_PATH_STYLE=${S3_FORCE_PATH_STYLE}
-            - S3_EXPIRATION_TIME=${S3_EXPIRATION_TIME}
-            - RESULTS_S3_REGION=${RESULTS_S3_REGION:-${RESULTS_CACHE_S3_REGION}}
-            - RESULTS_S3_BUCKET=${RESULTS_S3_BUCKET:-${RESULTS_CACHE_S3_BUCKET}}
-            - RESULTS_S3_SECRET_KEY=${RESULTS_S3_SECRET_KEY:-${RESULTS_CACHE_S3_SECRET_KEY}}
-            - RESULTS_S3_ACCESS_KEY=${RESULTS_S3_ACCESS_KEY:-${RESULTS_CACHE_S3_ACCESS_KEY}}
-            - LIGHTDASH_PROMETHEUS_ENABLED=${LIGHTDASH_PROMETHEUS_ENABLED}
-            - LIGHTDASH_PROMETHEUS_PORT=${LIGHTDASH_PROMETHEUS_PORT}
-            - LIGHTDASH_PROMETHEUS_PATH=${LIGHTDASH_PROMETHEUS_PATH}
-        volumes:
-            - '../:/usr/app'
-            - '../examples/full-jaffle-shop-demo/dbt:/usr/app/dbt'
-            - 'node_modules:/usr/app/node_modules/' # clears the node_modules directory so it doesn't sync (v.slow on MacOS)
-            # - ${HOME}/.config/gcloud:/root/.config/gcloud # Uncomment this line if you want to use your credential as gcloud ADC in dev container
+            <<: *lightdash-environment
+            SCHEDULER_ENABLED: ${SCHEDULER_ENABLED}
+            SCHEDULER_INCLUDE_TASKS: ${SCHEDULER_INCLUDE_TASKS}
+            SCHEDULER_EXCLUDE_TASKS: ${SCHEDULER_EXCLUDE_TASKS:-runAsyncWarehouseQuery}
+            LIGHTDASH_PROMETHEUS_PORT: ${LIGHTDASH_PROMETHEUS_PORT}
+            LIGHTDASH_PROMETHEUS_PATH: ${LIGHTDASH_PROMETHEUS_PATH}
         ports:
             - '8080:8080'
             - '9090:9090'
@@ -96,6 +109,20 @@ services:
             - '6006:6006'
         command: ''
         entrypoint: ['/bin/sh', '-c', 'sleep infinity']
+
+    lightdash-query-worker:
+        <<: *lightdash-base
+        depends_on:
+            - minio
+            - db-dev
+            - lightdash-dev
+        restart: unless-stopped
+        environment:
+            <<: *lightdash-environment
+            SCHEDULER_ENABLED: true
+            SCHEDULER_INCLUDE_TASKS: runAsyncWarehouseQuery
+        command: ''
+        entrypoint: ['/bin/sh', '-c', 'pnpm -F backend scheduler-dev']
 
     db-dev:
         image: pgvector/pgvector:pg16


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
### Summary

  Adds `lightdash-query-worker` service to isolate warehouse query execution from the main backend bringing it closer to a production setup.

### Changes

  - New Service: lightdash-query-worker runs scheduler with only `runAsyncWarehouseQuery` tasks
  - Main Backend: lightdash-dev excludes `runAsyncWarehouseQuery` via `SCHEDULER_EXCLUDE_TASKS`
  - Deduplication: Added YAML anchors (x-lightdash-*) to eliminate ~90% config duplication
  - Dependencies: Query worker depends on main service and auto-restarts on failure

### Configuration

```yaml
  lightdash-dev:
    SCHEDULER_EXCLUDE_TASKS: runAsyncWarehouseQuery  # API only

  lightdash-query-worker:
    SCHEDULER_INCLUDE_TASKS: runAsyncWarehouseQuery  # Queries only
    restart: unless-stopped
```