### PR TITLE
fix: Revert "fix(sql-runner): apply limit in final query (#15887)"

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2512,6 +2512,11 @@ export class AsyncQueryService extends ProjectService {
             return acc;
         }, {} as ResultColumns);
 
+        const sqlWithLimit = applyLimitToSqlQuery({
+            sqlQuery: sql,
+            limit,
+        });
+
         // ! VizColumns, virtualView, dimensions and query are not needed for SQL queries since we pass just sql the to `executeAsyncQuery`
         // ! We keep them here for backwards compatibility until we remove them as a required argument
         const vizColumns = columns.map((col) => ({
@@ -2521,7 +2526,7 @@ export class AsyncQueryService extends ProjectService {
 
         const virtualView = createVirtualViewObject(
             SQL_QUERY_MOCK_EXPLORER_NAME,
-            sql,
+            sqlWithLimit,
             vizColumns,
             warehouseConnection.warehouseClient,
         );
@@ -2603,7 +2608,7 @@ export class AsyncQueryService extends ProjectService {
             {
                 referenceMap,
                 select: selectColumns,
-                from: { name: 'sql_query', sql },
+                from: { name: 'sql_query', sql: sqlWithLimit },
                 filters: appliedDashboardFilters
                     ? {
                           id: uuidv4(),
@@ -2611,7 +2616,6 @@ export class AsyncQueryService extends ProjectService {
                       }
                     : undefined,
                 parameters,
-                limit,
             },
             {
                 fieldQuoteChar,

--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.class.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.class.test.ts
@@ -26,7 +26,6 @@ describe('QueryBuilder class', () => {
                     referenceMap: {},
                     select: [],
                     from: { name: 'test_table' },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -44,7 +43,6 @@ describe('QueryBuilder class', () => {
                         id: 'filter_group_1',
                         and: [SIMPLE_FILTER_RULE, SECOND_FILTER_RULE],
                     },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -60,7 +58,6 @@ describe('QueryBuilder class', () => {
                     referenceMap: SIMPLE_REFERENCE_MAP,
                     select: ['test_field'],
                     from: { name: 'test_table' },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -77,7 +74,6 @@ describe('QueryBuilder class', () => {
                         id: 'filter_group_1',
                         and: [SIMPLE_FILTER_RULE],
                     },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -94,7 +90,6 @@ describe('QueryBuilder class', () => {
                         id: 'filter_group_1',
                         and: [SIMPLE_FILTER_RULE, SECOND_FILTER_RULE],
                     },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -115,7 +110,6 @@ describe('QueryBuilder class', () => {
                         name: 'subquery',
                         sql: 'SELECT test_field FROM source_table WHERE test_field IS NOT NULL',
                     },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -166,7 +160,6 @@ describe('QueryBuilder class', () => {
                             },
                         ],
                     },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -179,7 +172,6 @@ describe('QueryBuilder class', () => {
                     referenceMap: {},
                     select: [],
                     from: { name: 'test_table' },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -194,7 +186,6 @@ describe('QueryBuilder class', () => {
                     referenceMap: {},
                     select: ['unknown_field'],
                     from: { name: 'test_table' },
-                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );

--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
@@ -1205,8 +1205,6 @@ export class QueryBuilder {
 
     private readonly parameters?: ParametersValuesMap;
 
-    private readonly limit: number | undefined;
-
     constructor(
         args: {
             referenceMap: ReferenceMap;
@@ -1214,7 +1212,6 @@ export class QueryBuilder {
             from: From;
             filters?: FilterGroup;
             parameters?: ParametersValuesMap;
-            limit: number | undefined;
         },
         private config: {
             fieldQuoteChar: string;
@@ -1230,7 +1227,6 @@ export class QueryBuilder {
         this.filters = args.filters;
         this.referenceMap = args.referenceMap;
         this.parameters = args.parameters;
-        this.limit = args.limit;
     }
 
     private quotedName(value: string) {
@@ -1319,21 +1315,9 @@ export class QueryBuilder {
         return undefined;
     }
 
-    private limitToSql() {
-        if (this.limit) {
-            return `LIMIT ${this.limit}`;
-        }
-        return undefined;
-    }
-
     getSqlAndReferences() {
         // Combine all parts of the query
-        const sql = [
-            this.selectsToSql(),
-            this.fromToSql(),
-            this.filtersToSql(),
-            this.limitToSql(),
-        ]
+        const sql = [this.selectsToSql(), this.fromToSql(), this.filtersToSql()]
             .filter((l) => l !== undefined)
             .join('\n');
 


### PR DESCRIPTION
This reverts commit c34ca84c1110399da422f6c2af1c20f6b128c5e8.

These changes are currently breaking sql creation as it's not removing semicolons correctly. Reverting the changes in this pr for new deployment, will work on a solution afterwards
