### PR TITLE
fix(sql-runner): apply limit in final query

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2512,11 +2512,6 @@ export class AsyncQueryService extends ProjectService {
             return acc;
         }, {} as ResultColumns);
 
-        const sqlWithLimit = applyLimitToSqlQuery({
-            sqlQuery: sql,
-            limit,
-        });
-
         // ! VizColumns, virtualView, dimensions and query are not needed for SQL queries since we pass just sql the to `executeAsyncQuery`
         // ! We keep them here for backwards compatibility until we remove them as a required argument
         const vizColumns = columns.map((col) => ({
@@ -2526,7 +2521,7 @@ export class AsyncQueryService extends ProjectService {
 
         const virtualView = createVirtualViewObject(
             SQL_QUERY_MOCK_EXPLORER_NAME,
-            sqlWithLimit,
+            sql,
             vizColumns,
             warehouseConnection.warehouseClient,
         );
@@ -2608,7 +2603,7 @@ export class AsyncQueryService extends ProjectService {
             {
                 referenceMap,
                 select: selectColumns,
-                from: { name: 'sql_query', sql: sqlWithLimit },
+                from: { name: 'sql_query', sql },
                 filters: appliedDashboardFilters
                     ? {
                           id: uuidv4(),
@@ -2616,6 +2611,7 @@ export class AsyncQueryService extends ProjectService {
                       }
                     : undefined,
                 parameters,
+                limit,
             },
             {
                 fieldQuoteChar,

--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.class.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.class.test.ts
@@ -26,6 +26,7 @@ describe('QueryBuilder class', () => {
                     referenceMap: {},
                     select: [],
                     from: { name: 'test_table' },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -43,6 +44,7 @@ describe('QueryBuilder class', () => {
                         id: 'filter_group_1',
                         and: [SIMPLE_FILTER_RULE, SECOND_FILTER_RULE],
                     },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -58,6 +60,7 @@ describe('QueryBuilder class', () => {
                     referenceMap: SIMPLE_REFERENCE_MAP,
                     select: ['test_field'],
                     from: { name: 'test_table' },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -74,6 +77,7 @@ describe('QueryBuilder class', () => {
                         id: 'filter_group_1',
                         and: [SIMPLE_FILTER_RULE],
                     },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -90,6 +94,7 @@ describe('QueryBuilder class', () => {
                         id: 'filter_group_1',
                         and: [SIMPLE_FILTER_RULE, SECOND_FILTER_RULE],
                     },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -110,6 +115,7 @@ describe('QueryBuilder class', () => {
                         name: 'subquery',
                         sql: 'SELECT test_field FROM source_table WHERE test_field IS NOT NULL',
                     },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -160,6 +166,7 @@ describe('QueryBuilder class', () => {
                             },
                         ],
                     },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -172,6 +179,7 @@ describe('QueryBuilder class', () => {
                     referenceMap: {},
                     select: [],
                     from: { name: 'test_table' },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );
@@ -186,6 +194,7 @@ describe('QueryBuilder class', () => {
                     referenceMap: {},
                     select: ['unknown_field'],
                     from: { name: 'test_table' },
+                    limit: undefined,
                 },
                 DEFAULT_CONFIG,
             );

--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.ts
@@ -1205,6 +1205,8 @@ export class QueryBuilder {
 
     private readonly parameters?: ParametersValuesMap;
 
+    private readonly limit: number | undefined;
+
     constructor(
         args: {
             referenceMap: ReferenceMap;
@@ -1212,6 +1214,7 @@ export class QueryBuilder {
             from: From;
             filters?: FilterGroup;
             parameters?: ParametersValuesMap;
+            limit: number | undefined;
         },
         private config: {
             fieldQuoteChar: string;
@@ -1227,6 +1230,7 @@ export class QueryBuilder {
         this.filters = args.filters;
         this.referenceMap = args.referenceMap;
         this.parameters = args.parameters;
+        this.limit = args.limit;
     }
 
     private quotedName(value: string) {
@@ -1315,9 +1319,21 @@ export class QueryBuilder {
         return undefined;
     }
 
+    private limitToSql() {
+        if (this.limit) {
+            return `LIMIT ${this.limit}`;
+        }
+        return undefined;
+    }
+
     getSqlAndReferences() {
         // Combine all parts of the query
-        const sql = [this.selectsToSql(), this.fromToSql(), this.filtersToSql()]
+        const sql = [
+            this.selectsToSql(),
+            this.fromToSql(),
+            this.filtersToSql(),
+            this.limitToSql(),
+        ]
             .filter((l) => l !== undefined)
             .join('\n');
 


### PR DESCRIPTION
Related to: #15984

The PR was reverted as it was causing some SQL runner charts to fail in dashboards.

We stopped using the util function that overrides the limit. This function was also removing the semicolons, which is essential because we use the raw SQL as a subquery and a semicolon will make the entire SQL invalid. 
We need a new util function specifically for removing the semicolon.