### PR TITLE
fix: Rename service should use existing explore name if needed

### DIFF
--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -433,6 +433,7 @@ export class RenameService extends BaseService {
                         // When filtering explores, we need to check if the explore exists on from, or to
                         // since people might be running this rename method before or after dbt is updated
 
+                        let useFromExplore = true;
                         try {
                             await this.projectModel.getExploreFromCache(
                                 projectUuid,
@@ -444,13 +445,14 @@ export class RenameService extends BaseService {
                                     projectUuid,
                                     to,
                                 );
+                                useFromExplore = false;
                             } catch (err) {
                                 throw new NotFoundError(
                                     `Neither "${from}" nor "${to}" explores exist in the project.`,
                                 );
                             }
                         }
-                        exploreName = from;
+                        exploreName = useFromExplore ? from : to;
 
                         nameChanges = {
                             from, // this is just the  table prefix


### PR DESCRIPTION
### Description:
Fixed a bug where the RenameService fails to rename model references in saved charts when the old dbt model no longer exists. This occurs when users update dbt models first, then run Lightdash validation.

The services was always using the `from` explore name for chart filtering, even when `to` existed, causing `NotExistsError: Explore "old_model_name" does not exist.` error. 
