### PR TITLE
fix: worker max pool size warning when concurrency is over 10

### DIFF
--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -49,12 +49,20 @@ export class SchedulerWorker extends SchedulerTask {
         // Run a worker to execute jobs:
         Logger.info('Running scheduler');
 
+        // According to docs, this defaults to the node-postgres default (10)
+        // So we're keeping the setting the same when concurrency is less than 10
+        const maxPoolSize =
+            this.lightdashConfig.scheduler.concurrency > 10
+                ? this.lightdashConfig.scheduler.concurrency
+                : 10;
+
         this.runner = await runGraphileWorker({
             connectionString: this.lightdashConfig.database.connectionUri,
             logger: workerLogger,
             concurrency: this.lightdashConfig.scheduler.concurrency,
             noHandleSignals: true,
             pollInterval: 1000,
+            maxPoolSize,
             parsedCronItems: parseCronItems([
                 {
                     task: 'generateDailyJobs',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
