### PR TITLE
fix: add missing parameters field to GROUP BY clause

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1319,7 +1319,7 @@ export class SavedChartModel {
                 'saved_queries_versions.saved_queries_version_id',
                 'sqvs.saved_queries_version_id',
             )
-            .groupBy(1, 2, 3, 4, 5);
+            .groupBy(1, 2, 3, 4, 5, 6);
 
         // Filter out charts that are saved in a dashboard and don't belong to any tile in their dashboard last version
         const chartsNotInTilesUuids = await this.getChartsNotInTilesUuids(


### PR DESCRIPTION
### Description:
Fixed bug in query for retrieving saved charts by adding column 6 to the `groupBy` clause that was missing:

```
"saved_queries_versions"."saved_queries_version_id" = "sqvs"."saved_queries_version_id" group by 1, 2, 3, 4, 5 - column "saved_queries_versions.parameters" must appear in the GROUP BY clause or be used in an aggregate function
```