### PR TITLE
fix: worker poolSize and concurrency going over db max connections

### DIFF
--- a/packages/backend/src/knexfile.ts
+++ b/packages/backend/src/knexfile.ts
@@ -10,6 +10,8 @@ const CONNECTION = lightdashConfig.database.connectionUri
     ? parse(lightdashConfig.database.connectionUri)
     : {};
 
+export const DEFAULT_DB_MAX_CONNECTIONS = 10;
+
 // Condition to be removed once we require Postgres vector extension
 const hasEnterpriseLicense = !!lightdashConfig.license.licenseKey;
 
@@ -18,7 +20,9 @@ const development: Knex.Config<Knex.PgConnectionConfig> = {
     connection: CONNECTION,
     pool: {
         min: lightdashConfig.database.minConnections || 0,
-        max: lightdashConfig.database.maxConnections || 10,
+        max:
+            lightdashConfig.database.maxConnections ||
+            DEFAULT_DB_MAX_CONNECTIONS,
         acquireTimeoutMillis: 30000, // (default) 30 seconds - max time the application will wait for a connection from the pool before failing (awaited connect will reject)
         createTimeoutMillis: 30000, // (default) 30 seconds - max time that the knex pool will wait for a connection to the postgres database to be created before failing (create operation is cancelled)
         destroyTimeoutMillis: 5000, // (default) 5 seconds - max time that the knex pool will wait for a connection to be destroyed before failing (new resources are created after timeout)

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -13,6 +13,7 @@ import {
     Runner,
 } from 'graphile-worker';
 import moment from 'moment';
+import { DEFAULT_DB_MAX_CONNECTIONS } from '../knexfile';
 import Logger from '../logging/logger';
 import { SchedulerClient } from './SchedulerClient';
 import { tryJobOrTimeout } from './SchedulerJobTimeout';
@@ -49,12 +50,19 @@ export class SchedulerWorker extends SchedulerTask {
         // Run a worker to execute jobs:
         Logger.info('Running scheduler');
 
-        // According to docs, this defaults to the node-postgres default (10)
+        const dbMaxConnections =
+            this.lightdashConfig.database.maxConnections ||
+            DEFAULT_DB_MAX_CONNECTIONS;
+
+        // According to Graphile TS docs, this defaults to the node-postgres default (10)
         // So we're keeping the setting the same when concurrency is less than 10
-        const maxPoolSize =
+        const desiredPoolSize =
             this.lightdashConfig.scheduler.concurrency > 10
                 ? this.lightdashConfig.scheduler.concurrency
                 : 10;
+
+        // We don't want to exceed the max number of connections to the database
+        const maxPoolSize = Math.min(desiredPoolSize, dbMaxConnections);
 
         this.runner = await runGraphileWorker({
             connectionString: this.lightdashConfig.database.connectionUri,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Adds a constraint to ensure the scheduler worker's pool size doesn't exceed the database's maximum connections. This PR:

- Extracts the default database max connections (10) into a constant
- Modifies the scheduler worker to calculate the maximum pool size as the minimum between the desired pool size and the database max connections
- Ensures the scheduler won't attempt to use more connections than the database can handle

This change prevents potential connection issues when the scheduler is configured with high concurrency values that exceed the database's connection limit.