### PR TITLE
feat: add useAccount hook

### DIFF
--- a/examples/api/embedding.http
+++ b/examples/api/embedding.http
@@ -46,10 +46,25 @@ Content-Type: application/json
     "chartUuid": "e6efe2fa-f884-47ea-ac9b-1e3ebe303b30"
 }
 
-### Generate embed url
+### Generate embed url - use the dashboardUuid you want to embed
+
+@dashboardUuid = e45dcfb9-d5fe-4c0e-9d8c-70871e904aea
+
 POST http://localhost:8080/api/v1/embed/3675b69e-8324-4110-bdca-059031aa8da3/get-embed-url
 Content-Type: application/json
 
 {
-  "dashboardUuid": "53c634a4-203b-48c3-9336-f6e7c3117b0b"
+    "user": {
+        "externalId": "steve@here.com"
+    },
+    "content": {
+        "type": "dashboard",
+        "dashboardUuid": "{{dashboardUuid}}",
+        "canExplore": true,
+        "canExportCsv": true,
+        "canExportImages": true,
+        "canDateZoom": true,
+        "canExportPagePdf": true,
+        "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3"
+    }
 }

--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -3,11 +3,12 @@
 import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     Account,
-    AccountHelpers,
     AccountOrganization,
+    AccountWithoutHelpers,
     AnonymousAccount,
     ApiKeyAccount,
     applyEmbeddedAbility,
+    buildAccountHelpers,
     CreateEmbedJwt,
     Embed,
     ForbiddenError,
@@ -33,39 +34,20 @@ const getExternalId = (
     return `external::${baseId}`.slice(0, 254);
 };
 
-type WithoutHelpers<T extends Account> = Omit<T, keyof AccountHelpers>;
-
-function createAccount(account: WithoutHelpers<SessionAccount>): SessionAccount;
-function createAccount(
-    account: WithoutHelpers<AnonymousAccount>,
-): AnonymousAccount;
-function createAccount(account: WithoutHelpers<ApiKeyAccount>): ApiKeyAccount;
-function createAccount(
-    account: WithoutHelpers<ServiceAcctAccount>,
-): ServiceAcctAccount;
-function createAccount(account: WithoutHelpers<Account>): Account {
+const createAccount = <T extends Account>(
+    account: AccountWithoutHelpers<T>,
+): T => {
     if (!account.user?.ability || !account.user?.abilityRules) {
         throw new ForbiddenError(
             'User ability and abilityRules are required for permissions',
         );
     }
 
-    const helpers: AccountHelpers = {
-        isAuthenticated: () => !!account.authentication && !!account.user?.id,
-        isRegisteredUser: () => account.user?.type === 'registered',
-        isAnonymousUser: () => account.user?.type === 'anonymous',
-        isSessionUser: () => account.authentication?.type === 'session',
-        isJwtUser: () => account.authentication?.type === 'jwt',
-        isServiceAccount: () =>
-            account.authentication?.type === 'service-account',
-        isPatUser: () => account.authentication?.type === 'pat',
-    };
-
     return {
         ...account,
-        ...helpers,
-    } as Account;
-}
+        ...buildAccountHelpers(account),
+    } as T;
+};
 
 /**
  * Shared helper function to extract organization data and user data from SessionUser

--- a/packages/common/src/authorization/buildAccountHelpers.ts
+++ b/packages/common/src/authorization/buildAccountHelpers.ts
@@ -1,0 +1,17 @@
+import {
+    type Account,
+    type AccountHelpers,
+    type AccountWithoutHelpers,
+} from '../types/auth';
+
+export const buildAccountHelpers = <T extends Account>(
+    account: AccountWithoutHelpers<T>,
+): AccountHelpers => ({
+    isAuthenticated: () => !!account.authentication && !!account.user?.id,
+    isRegisteredUser: () => account.user?.type === 'registered',
+    isAnonymousUser: () => account.user?.type === 'anonymous',
+    isSessionUser: () => account.authentication?.type === 'session',
+    isJwtUser: () => account.authentication?.type === 'jwt',
+    isServiceAccount: () => account.authentication?.type === 'service-account',
+    isPatUser: () => account.authentication?.type === 'pat',
+});

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -16,7 +16,9 @@ type UserAbilityBuilderArgs = {
     permissionsConfig: OrganizationMemberAbilitiesArgs['permissionsConfig'];
 };
 
+export * from './buildAccountHelpers';
 export * from './jwtAbility';
+export * from './parseAccount';
 export * from './serviceAccountAbility';
 
 export const JWT_HEADER_NAME = 'lightdash-embed-token';

--- a/packages/common/src/authorization/parseAccount.ts
+++ b/packages/common/src/authorization/parseAccount.ts
@@ -1,0 +1,44 @@
+import { Ability } from '@casl/ability';
+import {
+    type Account,
+    type AccountWithoutHelpers,
+    type AnonymousAccount,
+    type ApiKeyAccount,
+    type ServiceAcctAccount,
+    type SessionAccount,
+} from '../types/auth';
+import { buildAccountHelpers } from './buildAccountHelpers';
+import { type PossibleAbilities } from './types';
+
+/**
+ * Reconstruct the full account with abilities and helper methods
+ */
+export const parseAccount = (
+    deserializedAccount: AccountWithoutHelpers<Account>,
+) => {
+    const account = {
+        ...deserializedAccount,
+        user: {
+            ...deserializedAccount.user,
+            ability: new Ability<PossibleAbilities>(
+                deserializedAccount.user.abilityRules,
+            ),
+        },
+        ...buildAccountHelpers(
+            deserializedAccount as AccountWithoutHelpers<Account>,
+        ),
+    };
+
+    switch (account.authentication.type) {
+        case 'session':
+            return account as SessionAccount;
+        case 'pat':
+            return account as ApiKeyAccount;
+        case 'jwt':
+            return account as AnonymousAccount;
+        case 'service-account':
+            return account as ServiceAcctAccount;
+        default:
+            return account;
+    }
+};

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -132,6 +132,11 @@ export type Account =
     | ApiKeyAccount
     | ServiceAcctAccount;
 
+export type AccountWithoutHelpers<T extends Account> = Omit<
+    T,
+    keyof AccountHelpers
+>;
+
 export function assertEmbeddedAuth(
     account: Account | undefined,
 ): asserts account is AnonymousAccount {

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -1,6 +1,8 @@
 import { type LanguageMap } from '@lightdash/common';
 import { get } from 'lodash';
-import { useMemo, useState, type FC } from 'react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { useAccount } from '../../../hooks/user/useAccount';
+import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import {
     getFromInMemoryStorage,
     setToInMemoryStorage,
@@ -25,6 +27,16 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
 }) => {
     const [isInitialized, setIsInitialized] = useState(false);
     const embed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
+    const { data: account, isLoading } = useAccount();
+    const ability = useAbilityContext();
+
+    // Set ability rules for the embedded user. We should only get abilities from abilityContext
+    // rather than directly on the user or account.
+    useEffect(() => {
+        if (!isLoading && account?.user) {
+            ability.update(account.user.abilityRules);
+        }
+    }, [ability, account, isLoading]);
 
     // There is method to this madness:
     // When we get an embedded URL, the JWT token is added as a hash to the URL location.

--- a/packages/frontend/src/hooks/user/useAccount.ts
+++ b/packages/frontend/src/hooks/user/useAccount.ts
@@ -1,0 +1,32 @@
+import {
+    type Account,
+    type AccountWithoutHelpers,
+    type ApiError,
+    parseAccount,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+/**
+ * Returns a discriminated union of account if we get a type parameter, otherwise returns the union Account.
+ * If you're uncertain of the type, use a type guard against the union Account to get the specified type at runtime..
+ */
+const getAccount = async <T extends Account>(): Promise<T> => {
+    const accountData = await lightdashApi<Account>({
+        url: `/user/account`,
+        method: 'GET',
+    });
+
+    return parseAccount(accountData as AccountWithoutHelpers<Account>) as T;
+};
+
+export const useAccount = <T extends Account>(
+    isAuthenticated: boolean = true,
+) => {
+    return useQuery<T, ApiError>({
+        queryKey: ['account'],
+        queryFn: getAccount,
+        enabled: isAuthenticated,
+        retry: false,
+    });
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Foundational work for allowing abilities to power new embedded features. This gives us a hook to fetch the account and then use that entity to hydrate abilities using AbilityContext via the EmbedProvider. This works for both embed URLs and SDK. 

### AI Assisted
Enhances the embedding API example with a more comprehensive payload that includes user information and content permissions. Adds detailed documentation for the authentication module in a new CLAUDE.md file, explaining how to use session-based and JWT-based authentication.

Implements a new `buildAccountHelpers` utility in the common package to standardize account helper methods across the codebase. Creates a new `useAccount` hook in the frontend to fetch and properly construct account objects with abilities.

Updates the EmbedProvider to properly set ability rules for embedded users, ensuring correct permissions are applied in embedded contexts.