### PR TITLE
feat: hide embed explore UI elements via CASL

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -91,6 +91,7 @@ import useToaster from '../../hooks/toaster/useToaster';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import {
     useInfiniteQueryResults,
     type InfiniteQueryResults,
@@ -98,6 +99,7 @@ import {
 import { useDuplicateChartMutation } from '../../hooks/useSavedQuery';
 import { useCreateShareMutation } from '../../hooks/useShare';
 import { Can } from '../../providers/Ability';
+import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import useTracking from '../../providers/Tracking/useTracking';
@@ -1350,7 +1352,8 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         explore,
         executeQueryResponse: { fields },
     } = dashboardChartReadyQuery;
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
+    const ability = useAbilityContext();
     const [echartRef, setEchartRef] = useState<
         RefObject<EChartsReact | null> | undefined
     >();
@@ -1366,8 +1369,16 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         }
     }, [onExplore, chart]);
 
-    // FIXME: This is just a stub for CASL permissions in the next PR.
-    const isEmbeddedExploreEnabled = typeof onExplore === 'function';
+    const canExplore = ability.can(
+        'view',
+        subject('Explore', {
+            organizationUuid: chart.organizationUuid,
+            projectUuid,
+        }),
+    );
+
+    const isEmbeddedExploreEnabled =
+        canExplore && typeof onExplore === 'function';
 
     return (
         <TileBase

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { ExploreType, type SummaryExplore } from '@lightdash/common';
 import {
     ActionIcon,
@@ -16,8 +17,11 @@ import {
 import Fuse from 'fuse.js';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplores } from '../../../hooks/useExplores';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { Can } from '../../../providers/Ability';
+import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
@@ -48,6 +52,7 @@ const BasePanel = () => {
     const projectUuid = useProjectUuid();
     const [search, setSearch] = useState<string>('');
     const exploresResult = useExplores(projectUuid, true);
+    const { data: org } = useOrganization();
 
     const [exploreGroupMap, defaultUngroupedExplores, customUngroupedExplores] =
         useMemo(() => {
@@ -118,10 +123,18 @@ const BasePanel = () => {
             <>
                 <ItemDetailProvider>
                     <Stack h="100%" sx={{ flexGrow: 1 }}>
-                        <PageBreadcrumbs
-                            size="md"
-                            items={[{ title: 'Tables', active: true }]}
-                        />
+                        <Can
+                            I="manage"
+                            this={subject('Explore', {
+                                organizationUuid: org?.organizationUuid,
+                                projectUuid,
+                            })}
+                        >
+                            <PageBreadcrumbs
+                                size="md"
+                                items={[{ title: 'Tables', active: true }]}
+                            />
+                        </Can>
 
                         <TextInput
                             icon={<MantineIcon icon={IconSearch} />}
@@ -225,12 +238,21 @@ const ExploreSideBar = memo(() => {
     const tableName = useExplorerContext(
         (context) => context.state.unsavedChartVersion.tableName,
     );
+    const ability = useAbilityContext();
+    const { data: org } = useOrganization();
 
     const clearExplore = useExplorerContext(
         (context) => context.actions.clearExplore,
     );
     const navigate = useNavigate();
 
+    const canManageExplore = ability.can(
+        'manage',
+        subject('Explore', {
+            organizationUuid: org?.organizationUuid,
+            projectUuid,
+        }),
+    );
     const handleBack = useCallback(() => {
         clearExplore();
         void navigate(`/projects/${projectUuid}/tables`);
@@ -238,7 +260,13 @@ const ExploreSideBar = memo(() => {
 
     return (
         <TrackSection name={SectionName.SIDEBAR}>
-            {!tableName ? <BasePanel /> : <ExplorePanel onBack={handleBack} />}
+            {!tableName ? (
+                <BasePanel />
+            ) : (
+                <ExplorePanel
+                    onBack={canManageExplore ? handleBack : undefined}
+                />
+            )}
         </TrackSection>
     );
 });

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { FeatureFlags } from '@lightdash/common';
 import { Badge, Box, Group, Tooltip } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
@@ -8,6 +9,7 @@ import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
 import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
+import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import { RefreshButton } from '../../RefreshButton';
@@ -151,10 +153,18 @@ const ExplorerHeader: FC = memo(() => {
                 {!savedChart && userCanCreateCharts && (
                     <SaveChartButton isExplorer />
                 )}
-                <ShareShortLinkButton
-                    disabled={!isValidQuery}
-                    url={urlToShare}
-                />
+                <Can
+                    I="update"
+                    this={subject('Explore', {
+                        organizationUuid: user.data?.organizationUuid,
+                        projectUuid,
+                    })}
+                >
+                    <ShareShortLinkButton
+                        disabled={!isValidQuery}
+                        url={urlToShare}
+                    />
+                </Can>
             </Group>
         </Group>
     );

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -100,13 +100,21 @@ const ResultsCard: FC = memo(() => {
                 resultsIsOpen &&
                 tableName && (
                     <>
-                        {isEditMode && <AddColumnButton />}
+                        <Can
+                            I="manage"
+                            this={subject('Explore', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid,
+                            })}
+                        >
+                            {isEditMode && <AddColumnButton />}
+                        </Can>
 
                         <Can
                             I="manage"
                             this={subject('ExportCsv', {
                                 organizationUuid: user.data?.organizationUuid,
-                                projectUuid: projectUuid,
+                                projectUuid,
                             })}
                         >
                             <Popover

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ECHARTS_DEFAULT_COLORS,
     getHiddenTableFields,
@@ -23,6 +24,7 @@ import { type EChartSeries } from '../../../hooks/echarts/useEchartsCartesianCon
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../hooks/useExplore';
+import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
@@ -246,16 +248,24 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                                         )!,
                                     )}
 
-                                {!!projectUuid && (
-                                    <ChartDownloadMenu
-                                        getDownloadQueryUuid={
-                                            getDownloadQueryUuid
-                                        }
-                                        projectUuid={projectUuid}
-                                        chartName={savedChart?.name}
-                                        getGsheetLink={getGsheetLink}
-                                    />
-                                )}
+                                <Can
+                                    I="manage"
+                                    this={subject('Explore', {
+                                        organizationUuid: org?.organizationUuid,
+                                        projectUuid,
+                                    })}
+                                >
+                                    {!!projectUuid && (
+                                        <ChartDownloadMenu
+                                            getDownloadQueryUuid={
+                                                getDownloadQueryUuid
+                                            }
+                                            projectUuid={projectUuid}
+                                            chartName={savedChart?.name}
+                                            getGsheetLink={getGsheetLink}
+                                        />
+                                    )}
+                                </Can>
                             </>
                         )
                     }

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -1,8 +1,11 @@
+import { subject } from '@casl/ability';
 import { Stack } from '@mantine/core';
 import { memo, type FC } from 'react';
+import { useOrganization } from '../../hooks/organization/useOrganization';
 import { useCompiledSql } from '../../hooks/useCompiledSql';
 import { useExplore } from '../../hooks/useExplore';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
+import { Can } from '../../providers/Ability';
 import useExplorerContext from '../../providers/Explorer/useExplorerContext';
 import { DrillDownModal } from '../MetricQueryData/DrillDownModal';
 import MetricQueryDataProvider from '../MetricQueryData/MetricQueryDataProvider';
@@ -41,6 +44,8 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             enabled: !!unsavedChartVersionTableName,
         });
 
+        const { data: org } = useOrganization();
+
         return (
             <MetricQueryDataProvider
                 metricQuery={unsavedChartVersionMetricQuery}
@@ -65,7 +70,15 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
 
                     <ResultsCard />
 
-                    {!!projectUuid && <SqlCard projectUuid={projectUuid} />}
+                    <Can
+                        I="manage"
+                        this={subject('Explore', {
+                            organizationUuid: org?.organizationUuid,
+                            projectUuid,
+                        })}
+                    >
+                        {!!projectUuid && <SqlCard projectUuid={projectUuid} />}
+                    </Can>
                 </Stack>
 
                 <UnderlyingDataModal />

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -15,8 +15,8 @@ import { useEffect, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useProject } from '../../hooks/useProject';
 import { useRefreshServer } from '../../hooks/useRefreshServer';
+import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
-import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
@@ -39,9 +39,9 @@ const RefreshDbtButton: FC<{
     const { activeJob } = useActiveJob();
     const { mutate: refreshDbtServer } = useRefreshServer();
     const [isLoading, setIsLoading] = useState(false);
+    const ability = useAbilityContext();
 
     const { track } = useTracking();
-    const { user } = useApp();
 
     useEffect(() => {
         if (activeJob) {
@@ -64,8 +64,8 @@ const RefreshDbtButton: FC<{
     }, [activeJob, activeJob?.jobStatus]);
 
     if (
-        user.data?.ability?.cannot('manage', 'Job') ||
-        user.data?.ability?.cannot('manage', 'CompileProject')
+        ability?.cannot('manage', 'Job') ||
+        ability?.cannot('manage', 'CompileProject')
     )
         return null;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15542

### Description:
Implemented CASL permissions for the Explorer component to control access based on user abilities. This hides a number of UI elements that should not be available for embed users. These elements are hidden without referring to embedding or JWTs all—all CASL ability based. 

- Added permission checks for Explorer actions like managing explores, sharing links, and downloading charts
- Used the `Can` component to conditionally render elements based on ability rules

You can see below elements that aren't visible for embed users:
- Sidebar Breadcrumbs going back to all tables
- Refresh dbt
- Edit/save
- Share buttons
- Table Calculations
- Export widgets (to start we won't export embedded Explores)

![Screen Cast 2025-07-28 at 3 38 34 PM](https://github.com/user-attachments/assets/271f8214-18c4-4ea5-a694-d98d201e1e58)

## Testing

1. Run the dev server locally
2. Use examples/embedding.http to interact with the API to login and get an embed URL
  - [Login](https://github.com/lightdash/lightdash/blob/f6d3e47380ef42be1bdf915516b9dce166496923/examples/api/embedding.http#L2-L9)
  - [Create the embed URL](https://github.com/lightdash/lightdash/blob/f6d3e47380ef42be1bdf915516b9dce166496923/examples/api/embedding.http#L49-L70). Be sure to set `canExplore: true` in the body
3. Copy the embed URL in the response
4. Start the sdk-example-app
5. Paste the copied embed URL into the example app
6. You should now be able to `Explore from here` on the embedded dashboard