### PR TITLE
fix: handle empty analytics track of slack vote

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1649,14 +1649,16 @@ export class AiAgentService {
 
     // TODO: user permissions
     async updateHumanScoreForSlackPrompt(
+        userId: string,
+        organizationUuid: string | undefined,
         promptUuid: string,
         humanScore: number,
     ) {
         this.analytics.track<AiAgentPromptFeedbackEvent>({
             event: 'ai_agent_prompt.feedback',
-            userId: undefined,
+            userId,
             properties: {
-                organizationId: undefined,
+                organizationId: organizationUuid ?? '',
                 humanScore,
                 messageId: promptUuid,
                 context: 'slack',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15981

### Description:

This PR fixes a bug where users couldn't up/downvote slack messages bc of an empty user id property

Key changes:
- Added user ID and organization UUID parameters to `updateHumanScoreForSlackPrompt`
- Properly passing user ID and organization data to analytics tracking
