### PR TITLE
chore: fix debug command for dev and add debug port to service

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -107,6 +107,7 @@ services:
             - '9090:9090'
             - '3000:3000'
             - '6006:6006'
+            - '9229:9229'
         command: ''
         entrypoint: ['/bin/sh', '-c', 'sleep infinity']
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -150,7 +150,7 @@
         "generate-api": "tsoa spec-and-routes --configuration tsoa.yml",
         "generate-api-dev": "chokidar './src/controllers/**/*.ts' -c 'pnpm run generate-api'",
         "dev": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false src/index.ts",
-        "debug": "tsx watch --clear-screen=false --inspect-brk=0.0.0.0:9229 src/index.ts",
+        "debug": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false --inspect-brk=0.0.0.0:9229 src/index.ts",
         "build": "tsc --build tsconfig.json",
         "build-sourcemaps": "tsc --build tsconfig.sentry.json",
         "typecheck": "tsc --project tsconfig.json --noEmit",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Expose port 9229 in the development Docker environment and set `LIGHTDASH_MODE=development` and `HEADLESS=true` for the debug script to ensure consistent environment variables between development and debugging modes.