### PR TITLE
feat: apply req.account to apiKey and serviceAccounts

### DIFF
--- a/packages/backend/src/controllers/authentication/middlewares.ts
+++ b/packages/backend/src/controllers/authentication/middlewares.ts
@@ -8,15 +8,11 @@ import {
     LightdashMode,
 } from '@lightdash/common';
 import OAuth2Server from '@node-oauth/oauth2-server';
-import {
-    ErrorRequestHandler,
-    NextFunction,
-    Request,
-    RequestHandler,
-} from 'express';
+import { ErrorRequestHandler, Request, RequestHandler } from 'express';
 
 import passport from 'passport';
 import { URL } from 'url';
+import { fromApiKey } from '../../auth/account/account';
 import { lightdashConfig } from '../../config/lightdashConfig';
 import { authenticateServiceAccount } from '../../ee/authentication';
 import Logger from '../../logging/logger';
@@ -107,7 +103,15 @@ export const allowApiKeyAuthentication: RequestHandler = (req, res, next) => {
         passport.authenticate('headerapikey', { session: false })(
             req,
             res,
-            next,
+            () => {
+                if (req.user) {
+                    req.account = fromApiKey(
+                        req.user!,
+                        req.headers.authorization || '',
+                    );
+                }
+                next();
+            },
         );
     };
     try {

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -9,6 +9,7 @@ import {
     type MemberAbility,
 } from '@lightdash/common';
 import { RequestHandler } from 'express';
+import { fromServiceAccount } from '../../auth/account/account';
 import { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
 
 const getRoleForScopes = (scopes: ServiceAccountScope[]) => {
@@ -131,6 +132,9 @@ export const authenticateServiceAccount: RequestHandler = async (
                 serviceAccount.organizationUuid,
             );
 
+        // TODO: This uses the hacky method of copying over an admin user. Long-term, we'll want to have a proper
+        // service-account/principle-user unrelated to a real admin-user.
+        // @see https://github.com/lightdash/lightdash/issues/15466
         req.user = {
             userUuid: adminUser.userUuid,
             email: 'service-account@lightdash.com',
@@ -150,6 +154,7 @@ export const authenticateServiceAccount: RequestHandler = async (
             createdAt: serviceAccount.createdAt,
             updatedAt: serviceAccount.createdAt,
         };
+        req.account = fromServiceAccount(req.user!, token);
         next();
     } catch (error) {
         next(new AuthorizationError(getErrorMessage(error)));

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -23,13 +23,12 @@ export enum AuthTokenPrefix {
     OAUTH_REFRESH = 'ldref_',
 }
 
-export type AuthType =
-    | 'session'
-    | 'pat'
-    | 'service-account'
-    | 'jwt'
-    | 'browserless'
-    | 'scim';
+export type AuthType = 'session' | 'pat' | 'service-account' | 'jwt';
+
+export type PersonalAccessTokenAuth = {
+    type: 'pat';
+    source: string; // The api key
+};
 
 export type SessionAuth = {
     type: 'session';
@@ -47,7 +46,11 @@ export type ServiceAccountAuth = {
     source: string; // The service account token
 };
 
-export type Authentication = SessionAuth | JwtAuth | ServiceAccountAuth;
+export type Authentication =
+    | SessionAuth
+    | JwtAuth
+    | ServiceAccountAuth
+    | PersonalAccessTokenAuth;
 
 export type UserAccessControls = {
     userAttributes: UserAttributeValueMap;
@@ -74,6 +77,10 @@ export type AccountHelpers = {
     isSessionUser: () => boolean;
     /** Is this account for a JWT user? */
     isJwtUser: () => boolean;
+    /** Is this account for a service account? */
+    isServiceAccount: () => boolean;
+    /** Is this account for a personal access token? */
+    isPatUser: () => boolean;
 };
 
 export type AccountOrganization = Partial<
@@ -109,7 +116,21 @@ export type AnonymousAccount = BaseAccountWithHelpers & {
     access: DashboardAccess;
 };
 
-export type Account = SessionAccount | AnonymousAccount;
+export type ApiKeyAccount = BaseAccountWithHelpers & {
+    authentication: PersonalAccessTokenAuth;
+    user: LightdashSessionUser;
+};
+
+export type ServiceAcctAccount = BaseAccountWithHelpers & {
+    authentication: ServiceAccountAuth;
+    user: LightdashSessionUser;
+};
+
+export type Account =
+    | SessionAccount
+    | AnonymousAccount
+    | ApiKeyAccount
+    | ServiceAcctAccount;
 
 export function assertEmbeddedAuth(
     account: Account | undefined,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Adds support for API Key and Service Account authentication types in the account system.  This should give us broader coverage of req.account and prevent unexpected breaks in endpoints that now expect a req.account to be there. Previously, we only were creating req.account for cookies and JWT auth. 

Context: 
- https://github.com/lightdash/lightdash/pull/16007
- [Slack](https://lightdash.slack.com/archives/C02GQKJK84Q/p1753376104001839)

### AI Breakdown
- Extends the `Account` type to include `ApiKeyAccount` and `ServiceAcctAccount`
- Adds helper methods to identify service accounts and personal access tokens
- Implements `fromApiKey` and `fromServiceAccount` functions to create accounts from these auth types
- Refactors the account creation logic to handle all account types consistently
- Adds a shared helper function `extractOrganizationFromUser` to reduce code duplication
- Updates middleware to properly set account information for API key authentication
- Enhances type definitions in the auth system
