### PR TITLE
fix: order credentials by created_at desc and pass refresh token for SSO

### DIFF
--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -145,7 +145,7 @@ export class UserWarehouseCredentialsModel {
             .select('*')
             .where('warehouse_type', warehouseType)
             .andWhere('user_uuid', userUuid)
-            .orderBy('created_at')
+            .orderBy('created_at', 'desc') // Get the most recent credentials
             .first();
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -701,8 +701,12 @@ export class ProjectService extends BaseService {
             args.warehouseConnection.type === WarehouseTypes.SNOWFLAKE &&
             args.warehouseConnection.authenticationType === 'sso'
         ) {
+            const refreshToken = await this.userModel.getRefreshToken(
+                userUuid,
+                OpenIdIdentityIssuerType.SNOWFLAKE,
+            );
             const credentials = await this.refreshCredentials(
-                args.warehouseConnection,
+                { ...args.warehouseConnection, token: refreshToken },
                 userUuid,
             );
             return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
This PR fixes an issue with warehouse credentials retrieval by:

1. Updating the `findByUserUuidAndWarehouseType` method to order credentials by `created_at` in descending order, ensuring we get the most recent credentials first.

2. Enhancing the SSO authentication flow for Snowflake by retrieving the user's refresh token before refreshing credentials, and passing it to the `refreshCredentials` method.

These changes improve the reliability of warehouse connections, particularly for Snowflake SSO authentication.