### PR TITLE
fix: Revert "fix: Revert "feat: refactor AsyncQuery and Project service to use account where needed for Embedded Explores (#15893)" (#16007)"

### DIFF
--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -64,7 +64,7 @@ describe('account', () => {
             );
             expect(result.access.controls).toBe(mockUserAttributes);
 
-            expect(result.user.id).toBe('external-user-123');
+            expect(result.user.id).toBe('external::external-user-123');
             expect(result.user.type).toBe('anonymous');
             expect(result.user.email).toBe('external@example.com');
             expect(result.user.isActive).toBe(true);
@@ -101,7 +101,7 @@ describe('account', () => {
             });
 
             expect(result.user.id).toBe(
-                `anonymous-jwt::${mockOrganization.organizationUuid}_anonymous-jwt-token`,
+                `external::${mockOrganization.organizationUuid}_anonymous-jwt-token`,
             );
             expect(result.user.email).toBe('anonymous@example.com');
             expect(result.isAuthenticated()).toBe(true);
@@ -128,7 +128,7 @@ describe('account', () => {
             });
 
             expect(result.user.id).toBe(
-                `anonymous-jwt::${mockOrganization.organizationUuid}_no-user-jwt-token`,
+                `external::${mockOrganization.organizationUuid}_no-user-jwt-token`,
             );
             expect(result.user.email).toBeUndefined();
             expect(result.isAuthenticated()).toBe(true);

--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -19,13 +19,19 @@ import {
     UserAccessControls,
 } from '@lightdash/common';
 
+/**
+ * Creates an ID for the external user. We prefix the ID to prevent hijacking a real user ID.
+ * For the default ID, we limit the length to under 255 characters as that's the varchar limit for Postgres.
+ */
 const getExternalId = (
     decodedToken: CreateEmbedJwt,
     embedToken: string,
     organization: Pick<Organization, 'organizationUuid' | 'name'>,
-): string =>
-    decodedToken.user?.externalId ||
-    `anonymous-jwt::${organization.organizationUuid}_${embedToken}`;
+): string => {
+    const defaultBase = `${organization.organizationUuid}_${embedToken}`;
+    const baseId = decodedToken.user?.externalId || defaultBase;
+    return `external::${baseId}`.slice(0, 254);
+};
 
 type WithoutHelpers<T extends Account> = Omit<T, keyof AccountHelpers>;
 

--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -96,7 +96,7 @@ export class ExploreController extends BaseController {
         this.setStatus(200);
         const results = await this.services
             .getProjectService()
-            .getExplore(req.user!, projectUuid, exploreId, undefined, false);
+            .getExplore(req.account!, projectUuid, exploreId, undefined, false);
 
         return {
             status: 'ok',
@@ -120,7 +120,7 @@ export class ExploreController extends BaseController {
         const { parameterReferences, query } = await this.services
             .getProjectService()
             .compileQuery({
-                user: req.user!,
+                account: req.account!,
                 body,
                 projectUuid,
                 exploreName: exploreId,

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -373,7 +373,7 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         const totalResult = await this.services
             .getProjectService()
-            .calculateTotalFromQuery(req.user!, projectUuid, body);
+            .calculateTotalFromQuery(req.account!, projectUuid, body);
         return {
             status: 'ok',
             results: totalResult,
@@ -392,7 +392,7 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         const subtotalsResult = await this.services
             .getProjectService()
-            .calculateSubtotalsFromQuery(req.user!, projectUuid, body);
+            .calculateSubtotalsFromQuery(req.account!, projectUuid, body);
         return {
             status: 'ok',
             results: subtotalsResult,

--- a/packages/backend/src/controllers/runQueryController.ts
+++ b/packages/backend/src/controllers/runQueryController.ts
@@ -100,7 +100,7 @@ export class RunViewChartQueryController extends BaseController {
         const results: ApiQueryResults = await this.services
             .getProjectService()
             .runUnderlyingDataQuery(
-                req.user!,
+                req.account!,
                 metricQuery,
                 projectUuid,
                 exploreId,
@@ -170,7 +170,7 @@ export class RunViewChartQueryController extends BaseController {
         const results: ApiQueryResults = await this.services
             .getProjectService()
             .runExploreQuery(
-                req.user!,
+                req.account!,
                 metricQuery,
                 projectUuid,
                 exploreId,

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -91,7 +91,7 @@ export class SavedChartController extends BaseController {
         return {
             status: 'ok',
             results: await this.services.getProjectService().runViewChartQuery({
-                user: req.user!,
+                account: req.account!,
                 chartUuid,
                 versionUuid: undefined,
                 invalidateCache: body.invalidateCache,
@@ -124,7 +124,7 @@ export class SavedChartController extends BaseController {
             results: await this.services
                 .getProjectService()
                 .getChartAndResults({
-                    user: req.user!,
+                    account: req.account!,
                     chartUuid,
                     dashboardFilters: body.dashboardFilters,
                     invalidateCache: body.invalidateCache,
@@ -225,7 +225,7 @@ export class SavedChartController extends BaseController {
         return {
             status: 'ok',
             results: await this.services.getProjectService().runViewChartQuery({
-                user: req.user!,
+                account: req.account!,
                 chartUuid,
                 versionUuid,
                 context,
@@ -284,7 +284,7 @@ export class SavedChartController extends BaseController {
         const totalResult = await this.services
             .getProjectService()
             .calculateTotalFromSavedChart(
-                req.user!,
+                req.account!,
                 chartUuid,
                 body.dashboardFilters,
                 body.invalidateCache,

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -433,7 +433,7 @@ export class SqlRunnerController extends BaseController {
 
         const virtualViewName = await this.services
             .getProjectService()
-            .createVirtualView(req.user!, projectUuid, {
+            .createVirtualView(req.account!, projectUuid, {
                 name,
                 sql,
                 columns,
@@ -458,7 +458,7 @@ export class SqlRunnerController extends BaseController {
         this.setStatus(200);
         const { name: virtualViewName } = await this.services
             .getProjectService()
-            .updateVirtualView(req.user!, projectUuid, name, body);
+            .updateVirtualView(req.account!, projectUuid, name, body);
 
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -27,7 +27,6 @@ import {
 import {
     Body,
     Get,
-    Hidden,
     Middlewares,
     OperationId,
     Path,
@@ -73,7 +72,7 @@ export class QueryController extends BaseController {
         const results = await this.services
             .getAsyncQueryService()
             .getAsyncQueryResults({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 queryUuid,
                 page,
@@ -98,7 +97,7 @@ export class QueryController extends BaseController {
         this.setStatus(200);
 
         await this.services.getAsyncQueryService().cancelAsyncQuery({
-            user: req.user!,
+            account: req.account!,
             projectUuid,
             queryUuid,
         });
@@ -139,7 +138,7 @@ export class QueryController extends BaseController {
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncMetricQuery({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 invalidateCache: body.invalidateCache,
                 metricQuery,
@@ -171,7 +170,7 @@ export class QueryController extends BaseController {
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncSavedChartQuery({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 invalidateCache: body.invalidateCache,
                 chartUuid: body.chartUuid,
@@ -204,7 +203,7 @@ export class QueryController extends BaseController {
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncDashboardChartQuery({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 invalidateCache: body.invalidateCache,
                 chartUuid: body.chartUuid,
@@ -240,7 +239,7 @@ export class QueryController extends BaseController {
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncUnderlyingDataQuery({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 invalidateCache: body.invalidateCache,
                 underlyingDataSourceQueryUuid:
@@ -275,7 +274,7 @@ export class QueryController extends BaseController {
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncSqlQuery({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 invalidateCache: body.invalidateCache ?? false,
                 sql: body.sql,
@@ -307,7 +306,7 @@ export class QueryController extends BaseController {
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncSqlChartQuery({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 invalidateCache: body.invalidateCache ?? false,
                 context: context ?? QueryExecutionContext.SQL_RUNNER,
@@ -340,7 +339,7 @@ export class QueryController extends BaseController {
         const results = await this.services
             .getAsyncQueryService()
             .executeAsyncDashboardSqlChartQuery({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 invalidateCache: body.invalidateCache ?? false,
                 dashboardUuid: body.dashboardUuid,
@@ -380,7 +379,7 @@ export class QueryController extends BaseController {
         const readStream = await this.services
             .getAsyncQueryService()
             .getResultsStream({
-                user: req.user!,
+                account: req.account!,
                 projectUuid,
                 queryUuid,
             });
@@ -416,7 +415,7 @@ export class QueryController extends BaseController {
         this.setStatus(200);
 
         const results = await this.services.getAsyncQueryService().download({
-            user: req.user!,
+            account: req.account!,
             projectUuid,
             queryUuid,
             type: body.type,

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     AiAgent,
     AiAgentThread,
     AiAgentThreadSummary,
@@ -59,6 +60,7 @@ import {
     AiAgentUpdatedEvent,
     LightdashAnalytics,
 } from '../../analytics/LightdashAnalytics';
+import { fromSession } from '../../auth/account';
 import { type SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
@@ -231,13 +233,13 @@ export class AiAgentService {
 
     // from AiService getToolUtilities
     private async getExplore(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         availableTags: string[] | null,
         exploreName: string,
     ) {
         const explore = await this.projectService.getExplore(
-            user,
+            account,
             projectUuid,
             exploreName,
         );
@@ -260,8 +262,9 @@ export class AiAgentService {
         projectUuid: string,
         metricQuery: AiMetricQueryWithFilters,
     ) {
+        const account = fromSession(user);
         const explore = await this.getExplore(
-            user,
+            account,
             projectUuid,
             null,
             metricQuery.exploreName,
@@ -275,7 +278,7 @@ export class AiAgentService {
         validateSelectedFieldsExistence(explore, metricQueryFields);
 
         return this.projectService.runExploreQuery(
-            user,
+            account,
             {
                 ...metricQuery,
                 // TODO: add tableCalculations
@@ -294,8 +297,9 @@ export class AiAgentService {
         projectUuid: string,
         metricQuery: AiMetricQueryWithFilters,
     ) {
+        const account = fromSession(user);
         const explore = await this.getExplore(
-            user,
+            account,
             projectUuid,
             null,
             metricQuery.exploreName,
@@ -310,7 +314,7 @@ export class AiAgentService {
 
         const asyncQuery = await this.asyncQueryService.executeAsyncMetricQuery(
             {
-                user,
+                account,
                 projectUuid,
                 metricQuery: {
                     ...metricQuery,
@@ -1289,8 +1293,9 @@ export class AiAgentService {
                 false,
             );
 
+        const account = fromSession(user);
         const explores = await this.projectService.findExplores({
-            user,
+            account,
             projectUuid,
             exploreNames: exploreSummaries.map((s) => s.name),
         });
@@ -1442,8 +1447,9 @@ export class AiAgentService {
         const getExplore: GetExploreFn = async ({ exploreName }) => {
             const agentSettings = await this.getAgentSettings(user, prompt);
 
+            const account = fromSession(user);
             const explore = await this.projectService.getExplore(
-                user,
+                account,
                 projectUuid,
                 exploreName,
             );
@@ -1491,7 +1497,7 @@ export class AiAgentService {
             );
 
             const explores = await this.projectService.findExplores({
-                user,
+                account: fromSession(user),
                 projectUuid,
                 exploreNames: catalogFields.map((s) => s.tableName),
             });
@@ -1548,8 +1554,9 @@ export class AiAgentService {
 
             validateSelectedFieldsExistence(explore, metricQueryFields);
 
+            const account = fromSession(user);
             return this.projectService.runMetricQuery({
-                user,
+                account,
                 projectUuid,
                 metricQuery: {
                     ...metricQuery,

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -13,6 +13,7 @@ import {
     isField,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import { fromSession } from '../../../auth/account';
 import { LightdashConfig } from '../../../config/parseConfig';
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
 import { isFeatureFlagEnabled } from '../../../postHog';
@@ -106,7 +107,7 @@ export class AiService {
         const chartResultPromises = chartUuids.map(async (chartUuid) => {
             const chartAndResults =
                 await this.projectService.getChartAndResults({
-                    user,
+                    account: fromSession(user),
                     dashboardUuid: dashboard.uuid,
                     chartUuid,
                     dashboardFilters: dashboard.filters,

--- a/packages/backend/src/ee/services/SupportService/SupportService.ts
+++ b/packages/backend/src/ee/services/SupportService/SupportService.ts
@@ -8,6 +8,7 @@ import { KnownBlock } from '@slack/web-api';
 import { IncomingHttpHeaders } from 'http';
 import { nanoid } from 'nanoid';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import { fromSession } from '../../../auth/account';
 import { S3Client } from '../../../clients/Aws/S3Client';
 import { LightdashConfig } from '../../../config/parseConfig';
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
@@ -114,7 +115,7 @@ export class SupportService extends BaseService {
         );
 
         const query = await this.projectService.compileQuery({
-            user,
+            account: fromSession(user),
             body: savedChart.metricQuery,
             projectUuid,
             exploreName: savedChart.tableName,

--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -150,7 +150,7 @@ dashboardRouter.post(
         try {
             const results = await req.services
                 .getProjectService()
-                .getAvailableFiltersForSavedQueries(req.user!, req.body);
+                .getAvailableFiltersForSavedQueries(req.account!, req.body);
 
             res.json({
                 status: 'ok',

--- a/packages/backend/src/routers/savedChartRouter.ts
+++ b/packages/backend/src/routers/savedChartRouter.ts
@@ -55,7 +55,7 @@ savedChartRouter.get(
         req.services
             .getProjectService()
             .getAvailableFiltersForSavedQuery(
-                req.user!,
+                req.account!,
                 getObjectValue(req.params, 'savedQueryUuid'),
             )
             .then((results) => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -64,6 +64,7 @@ import {
     projectSummary,
     projectWithSensitiveFields,
     resultsWith1Row,
+    sessionAccount,
     spacesWithSavedCharts,
     tablesConfiguration,
     user,
@@ -273,7 +274,7 @@ describe('AsyncQueryService', () => {
 
             const result = await serviceWithCache.executeAsyncQuery(
                 {
-                    user,
+                    account: sessionAccount,
                     projectUuid,
                     metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
@@ -319,7 +320,7 @@ describe('AsyncQueryService', () => {
                     pivot_total_column_count: null,
                     pivot_values_columns: null,
                 },
-                user.userUuid,
+                sessionAccount,
             );
 
             // Verify that the warehouse client executeAsyncQuery method was not called
@@ -353,7 +354,7 @@ describe('AsyncQueryService', () => {
 
             const result = await serviceWithCache.executeAsyncQuery(
                 {
-                    user,
+                    account: sessionAccount,
                     projectUuid,
                     metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
@@ -403,8 +404,12 @@ describe('AsyncQueryService', () => {
             expect(schedulerClientScheduleTaskSpy).toHaveBeenCalledWith(
                 SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY,
                 expect.objectContaining({
-                    organizationUuid: user.organizationUuid!,
-                    userUuid: user.userUuid,
+                    organizationUuid:
+                        sessionAccount.organization.organizationUuid!,
+                    userUuid: sessionAccount.user.id,
+                    userId: sessionAccount.user.id,
+                    isSessionUser: true,
+                    isRegisteredUser: true,
                     projectUuid,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
@@ -438,7 +443,7 @@ describe('AsyncQueryService', () => {
 
             await serviceWithCache.executeAsyncQuery(
                 {
-                    user,
+                    account: sessionAccount,
                     projectUuid,
                     metricQuery: metricQueryMock,
                     context: QueryExecutionContext.EXPLORE,
@@ -486,8 +491,12 @@ describe('AsyncQueryService', () => {
             expect(schedulerClientScheduleTaskSpy).toHaveBeenCalledWith(
                 SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY,
                 expect.objectContaining({
-                    organizationUuid: user.organizationUuid!,
-                    userUuid: user.userUuid,
+                    organizationUuid:
+                        sessionAccount.organization.organizationUuid!,
+                    userUuid: sessionAccount.user.id,
+                    userId: sessionAccount.user.id,
+                    isSessionUser: true,
+                    isRegisteredUser: true,
                     projectUuid,
                     queryTags: {
                         query_context: QueryExecutionContext.EXPLORE,
@@ -527,8 +536,9 @@ describe('AsyncQueryService', () => {
             // Mock the queryHistoryModel.get to return a query with ERROR status
             const mockQueryHistory: QueryHistory = {
                 createdAt: new Date(),
-                organizationUuid: user.organizationUuid!,
-                createdByUserUuid: user.userUuid,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                createdByUserUuid: sessionAccount.user.id,
+                createdBy: sessionAccount.user.id,
                 createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
@@ -564,7 +574,7 @@ describe('AsyncQueryService', () => {
                 .mockResolvedValue(validExplore);
 
             const result = await serviceWithCache.getAsyncQueryResults({
-                user,
+                account: sessionAccount,
                 projectUuid,
                 queryUuid: 'test-query-uuid',
                 page: 1,
@@ -582,8 +592,9 @@ describe('AsyncQueryService', () => {
             // Mock the queryHistoryModel.get to return a query with PENDING status
             const mockQueryHistory: QueryHistory = {
                 createdAt: new Date(),
-                organizationUuid: user.organizationUuid!,
-                createdByUserUuid: user.userUuid,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                createdByUserUuid: sessionAccount.user.id,
+                createdBy: sessionAccount.user.id,
                 createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
@@ -622,7 +633,7 @@ describe('AsyncQueryService', () => {
                 .mockResolvedValue(validExplore);
 
             const result = await serviceWithCache.getAsyncQueryResults({
-                user,
+                account: sessionAccount,
                 projectUuid,
                 queryUuid: 'test-query-uuid',
                 page: 1,
@@ -639,8 +650,9 @@ describe('AsyncQueryService', () => {
             // Mock the queryHistoryModel.get to return a query with CANCELLED status
             const mockQueryHistory: QueryHistory = {
                 createdAt: new Date(),
-                organizationUuid: user.organizationUuid!,
-                createdByUserUuid: user.userUuid,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                createdByUserUuid: sessionAccount.user.id,
+                createdBy: sessionAccount.user.id,
                 createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
@@ -676,7 +688,7 @@ describe('AsyncQueryService', () => {
                 .mockResolvedValue(validExplore);
 
             const result = await serviceWithCache.getAsyncQueryResults({
-                user,
+                account: sessionAccount,
                 projectUuid,
                 queryUuid: 'test-query-uuid',
                 page: 1,
@@ -693,8 +705,9 @@ describe('AsyncQueryService', () => {
             // Mock the queryHistoryModel.get to return a READY query with null resultsFileName
             const mockQueryHistory: QueryHistory = {
                 createdAt: new Date(),
-                organizationUuid: user.organizationUuid!,
-                createdByUserUuid: user.userUuid,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                createdByUserUuid: sessionAccount.user.id,
+                createdBy: sessionAccount.user.id,
                 createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
@@ -732,7 +745,7 @@ describe('AsyncQueryService', () => {
 
             await expect(
                 serviceWithCache.getAsyncQueryResults({
-                    user,
+                    account: sessionAccount,
                     projectUuid,
                     queryUuid: 'test-query-uuid',
                     page: 1,
@@ -783,8 +796,9 @@ describe('AsyncQueryService', () => {
 
             const mockQueryHistory: QueryHistory = {
                 createdAt: new Date(),
-                organizationUuid: user.organizationUuid!,
-                createdByUserUuid: user.userUuid,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                createdByUserUuid: sessionAccount.user.id,
+                createdBy: sessionAccount.user.id,
                 createdByAccount: null,
                 queryUuid: 'test-query-uuid',
                 projectUuid,
@@ -822,7 +836,7 @@ describe('AsyncQueryService', () => {
                 });
 
             const result = await serviceWithCache.getAsyncQueryResults({
-                user,
+                account: sessionAccount,
                 projectUuid,
                 queryUuid: 'test-query-uuid',
                 page: 1,
@@ -896,7 +910,7 @@ describe('AsyncQueryService', () => {
 
             await serviceWithCache.executeAsyncQuery(
                 {
-                    user,
+                    account: sessionAccount,
                     projectUuid,
                     metricQuery: metricQueryMock,
                     context: QueryExecutionContext.SQL_RUNNER,
@@ -945,7 +959,7 @@ describe('AsyncQueryService', () => {
                 });
 
                 const args = {
-                    user,
+                    account: sessionAccount,
                     projectUuid,
                     context: QueryExecutionContext.EXPLORE,
                     metricQuery: metricQueryMock,
@@ -985,7 +999,7 @@ describe('AsyncQueryService', () => {
                 });
 
                 const args = {
-                    user,
+                    account: sessionAccount,
                     projectUuid,
                     context: QueryExecutionContext.EXPLORE,
                     metricQuery: metricQueryMock,
@@ -1006,8 +1020,12 @@ describe('AsyncQueryService', () => {
                 expect(schedulerSpy).toHaveBeenCalledWith(
                     SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY,
                     expect.objectContaining({
-                        organizationUuid: user.organizationUuid!,
-                        userUuid: user.userUuid,
+                        organizationUuid:
+                            sessionAccount.organization.organizationUuid!,
+                        userUuid: sessionAccount.user.id,
+                        userId: sessionAccount.user.id,
+                        isSessionUser: true,
+                        isRegisteredUser: true,
                         projectUuid,
                         queryTags: {
                             query_context: QueryExecutionContext.EXPLORE,
@@ -1090,7 +1108,9 @@ describe('AsyncQueryService', () => {
                 );
 
                 const runAsyncArgs: RunAsyncWarehouseQueryArgs = {
-                    userUuid: user.userUuid,
+                    userId: sessionAccount.user.id,
+                    isSessionUser: true,
+                    isRegisteredUser: true,
                     projectUuid,
                     query: 'SELECT * FROM test',
                     fieldsMap: {},

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -1,26 +1,24 @@
 import {
+    Account,
     DownloadFileType,
     GroupByColumn,
-    ItemsMap,
     MetricQuery,
     PivotConfig,
     SortBy,
     ValuesColumn,
     type CacheMetadata,
     type DashboardFilters,
-    type DateGranularity,
     type DateZoom,
     type Filters,
     type ParametersValuesMap,
     type PivotIndexColum,
     type QueryExecutionContext,
     type ResultsPaginationArgs,
-    type SessionUser,
     type SortField,
 } from '@lightdash/common';
 
 export type CommonAsyncQueryArgs = {
-    user: SessionUser;
+    account: Account;
     projectUuid: string;
     invalidateCache?: boolean;
     context: QueryExecutionContext;

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -65,6 +65,7 @@ import {
     LightdashAnalytics,
     parseAnalyticsLimit,
 } from '../../analytics/LightdashAnalytics';
+import * as Account from '../../auth/account';
 import { S3Client } from '../../clients/Aws/S3Client';
 import { AttachmentUrl } from '../../clients/EmailClient/EmailClient';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
@@ -644,8 +645,9 @@ export class CsvService extends BaseService {
             });
         }
 
+        const account = Account.fromSession(user);
         const explore = await this.projectService.getExplore(
-            user,
+            account,
             chart.projectUuid,
             exploreId,
         );
@@ -677,7 +679,7 @@ export class CsvService extends BaseService {
         };
 
         const { rows, fields } = await this.projectService.runMetricQuery({
-            user,
+            account,
             metricQuery: metricQueryWithDashboardFilters,
             projectUuid: chart.projectUuid,
             exploreName: exploreId,
@@ -977,8 +979,10 @@ export class CsvService extends BaseService {
             tableConfig,
             chartConfig,
         } = chart;
+
+        const account = Account.fromSession(user);
         const explore = await this.projectService.getExplore(
-            user,
+            account,
             projectUuid,
             tableName,
         );
@@ -1166,8 +1170,9 @@ export class CsvService extends BaseService {
                 explore_name: exploreId,
             };
 
+            const account = Account.fromSession(user);
             const { rows, fields } = await this.projectService.runMetricQuery({
-                user,
+                account,
                 metricQuery,
                 projectUuid,
                 exploreName: exploreId,

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -33,6 +33,7 @@ import {
     type TimeDimensionConfig,
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
+import { fromSession } from '../../auth/account';
 import type { LightdashConfig } from '../../config/parseConfig';
 import { measureTime } from '../../logging/measureTime';
 import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
@@ -117,7 +118,7 @@ export class MetricsExplorerService<
 
         const { rows, fields } =
             await this.projectService.runMetricExplorerQuery(
-                user,
+                fromSession(user),
                 projectUuid,
                 exploreName,
                 adjustedMetricQuery,
@@ -213,7 +214,7 @@ export class MetricsExplorerService<
 
         const { rows, fields } =
             await this.projectService.runMetricExplorerQuery(
-                user,
+                fromSession(user),
                 projectUuid,
                 sourceMetricExploreName,
                 metricQuery,
@@ -290,7 +291,7 @@ export class MetricsExplorerService<
         };
 
         const { rows } = await this.projectService.runMetricExplorerQuery(
-            user,
+            fromSession(user),
             projectUuid,
             exploreName,
             getSegmentsMetricQuery,
@@ -412,7 +413,7 @@ export class MetricsExplorerService<
 
         const { rows: currentResults, fields } =
             await this.projectService.runMetricExplorerQuery(
-                user,
+                fromSession(user),
                 projectUuid,
                 exploreName,
                 metricQuery,
@@ -642,7 +643,7 @@ export class MetricsExplorerService<
 
         const { rows: currentRows } =
             await this.projectService.runMetricExplorerQuery(
-                user,
+                fromSession(user),
                 projectUuid,
                 exploreName,
                 metricQuery,
@@ -672,7 +673,7 @@ export class MetricsExplorerService<
 
             compareRows = (
                 await this.projectService.runMetricExplorerQuery(
-                    user,
+                    fromSession(user),
                     projectUuid,
                     exploreName,
                     compareMetricQuery,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -1,5 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
+    Account,
+    AccountUser,
     ApiQueryResults,
     ChartKind,
     ChartType,
@@ -16,6 +18,7 @@ import {
     JobStepStatusType,
     JobStepType,
     JobType,
+    LightdashSessionUser,
     MetricQuery,
     MetricType,
     OrganizationMemberRole,
@@ -37,14 +40,13 @@ import {
 import { LightdashConfig } from '../../config/parseConfig';
 import { projectUuid } from '../../models/ProjectModel/ProjectModel.mock';
 
+const userId = 'userId';
+
 export const user: SessionUser = {
-    userUuid: 'userUuid',
+    userUuid: userId,
     email: 'email',
     firstName: 'firstName',
     lastName: 'lastName',
-    organizationUuid: 'organizationUuid',
-    organizationName: 'organizationName',
-    organizationCreatedAt: new Date(),
     isTrackingAnonymized: false,
     isMarketingOptedIn: false,
     isSetupComplete: true,
@@ -61,6 +63,33 @@ export const user: SessionUser = {
     createdAt: new Date(),
     updatedAt: new Date(),
 };
+
+export const buildAccount = ({
+    accountType = 'session',
+    userType = 'registered',
+}: {
+    accountType?: Account['authentication']['type'];
+    userType?: AccountUser['type'];
+} = {}) =>
+    ({
+        user: {
+            ...user,
+            id: userId,
+            type: userType,
+        },
+        organization: {
+            organizationUuid: 'organizationUuid',
+            createdAt: new Date(),
+            name: 'organizationName',
+        },
+        authentication: {
+            type: accountType,
+        },
+        isSessionUser: () => accountType === 'session',
+        isRegisteredUser: () => userType === 'registered',
+        isJwtUser: () => accountType === 'jwt',
+        isAnonymousUser: () => userType === 'anonymous',
+    } as unknown as Account);
 
 export const validExplore: Explore = {
     targetDatabase: SupportedDbtAdapter.POSTGRES,
@@ -252,8 +281,10 @@ export const expectedCatalog = {
     },
 };
 
+export const sessionAccount = buildAccount();
+
 export const projectWithSensitiveFields: Project = {
-    organizationUuid: user.organizationUuid!,
+    organizationUuid: sessionAccount.organization.organizationUuid!,
     projectUuid: 'projectUuid',
     name: 'name',
     type: ProjectType.DEFAULT,
@@ -264,11 +295,11 @@ export const projectWithSensitiveFields: Project = {
         environment_id: 'environment_id',
     },
     schedulerTimezone: 'UTC',
-    createdByUserUuid: user.userUuid,
+    createdByUserUuid: sessionAccount.user.id,
 };
 
 export const projectSummary: ProjectSummary = {
-    organizationUuid: user.organizationUuid!,
+    organizationUuid: sessionAccount.organization.organizationUuid!,
     projectUuid: 'projectUuid',
     name: 'name',
     type: ProjectType.DEFAULT,
@@ -277,7 +308,7 @@ export const defaultProject: OrganizationProject = {
     projectUuid: 'projectUuid',
     name: 'name',
     type: ProjectType.DEFAULT,
-    createdByUserUuid: user.userUuid,
+    createdByUserUuid: sessionAccount.user.id,
     upstreamProjectUuid: null,
     warehouseType: WarehouseTypes.POSTGRES,
     requireUserCredentials: false,
@@ -285,7 +316,7 @@ export const defaultProject: OrganizationProject = {
 
 export const spacesWithSavedCharts: Space[] = [
     {
-        organizationUuid: user.organizationUuid!,
+        organizationUuid: sessionAccount.organization.organizationUuid!,
         name: 'space',
         slug: 'space',
         parentSpaceUuid: null,
@@ -325,7 +356,7 @@ export const spacesWithSavedCharts: Space[] = [
 
 export const spacesWithNoSavedCharts: Space[] = [
     {
-        organizationUuid: user.organizationUuid!,
+        organizationUuid: sessionAccount.organization.organizationUuid!,
         name: 'space',
         slug: 'space',
         parentSpaceUuid: null,
@@ -347,7 +378,7 @@ export const spacesWithNoSavedCharts: Space[] = [
 export const job: Job = {
     jobUuid: 'jobUuid',
     projectUuid: 'projectUuid',
-    userUuid: user.userUuid,
+    userUuid: sessionAccount.user.id,
     createdAt: new Date(),
     updatedAt: new Date(),
     jobStatus: JobStatusType.DONE,
@@ -370,7 +401,7 @@ export const job: Job = {
 export const jobError: Job = {
     jobUuid: 'jobUuid',
     projectUuid: 'projectUuid',
-    userUuid: user.userUuid,
+    userUuid: sessionAccount.user.id,
     createdAt: new Date(),
     updatedAt: new Date(),
     jobStatus: JobStatusType.ERROR,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -56,6 +56,7 @@ import {
     projectWithSensitiveFields,
     resultsWith1Row,
     resultsWith501Rows,
+    sessionAccount,
     spacesWithSavedCharts,
     tablesConfiguration,
     tablesConfigurationWithNames,
@@ -193,7 +194,7 @@ describe('ProjectService', () => {
     describe('runExploreQuery', () => {
         test('should get results with 1 row', async () => {
             const result = await service.runExploreQuery(
-                user,
+                sessionAccount,
                 metricQueryMock,
                 projectUuid,
                 'valid_explore',
@@ -212,7 +213,7 @@ describe('ProjectService', () => {
             }));
 
             const result = await service.runExploreQuery(
-                user,
+                sessionAccount,
                 metricQueryMock,
                 projectUuid,
                 'valid_explore',

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -25,6 +25,7 @@ const addBaseAbilities: EmbeddedAbilityBuilder = ({
         dashboardUuid,
         organizationUuid: organization.organizationUuid,
     });
+
     return { embedUser, dashboardUuid, organization, builder };
 };
 

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -147,3 +147,31 @@ export function assertSessionAuth(
         throw new ForbiddenError('Account is not a session account');
     }
 }
+
+export const assertIsAccountWithOrg = (
+    account: Account,
+): asserts account is Account & {
+    organization: {
+        organizationUuid: string;
+        name: string;
+        createdAt: Date;
+    };
+} => {
+    const { organization } = account;
+    const isValidOrg =
+        typeof organization.organizationUuid === 'string' &&
+        typeof organization.name === 'string' &&
+        organization.createdAt instanceof Date;
+
+    if (!isValidOrg) {
+        throw new ForbiddenError('Account is not part of an organization');
+    }
+
+    if (account.isSessionUser()) {
+        const sessionAccount = account as SessionAccount;
+        if (typeof sessionAccount.user.role !== 'string')
+            throw new ForbiddenError(
+                'Session user does not have a role in an organization',
+            );
+    }
+};

--- a/packages/common/src/types/queryHistory.ts
+++ b/packages/common/src/types/queryHistory.ts
@@ -29,6 +29,7 @@ export enum QueryHistoryStatus {
 export type QueryHistory = {
     queryUuid: string;
     createdAt: Date;
+    createdBy: string | null;
     createdByUserUuid: string | null;
     createdByAccount: string | null;
     organizationUuid: string;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -534,7 +534,11 @@ export type ExportCsvDashboardPayload = TraceTaskBase & {
 
 // ! Type defined here because it's used in both AsyncQueryService and SchedulerTask
 export type RunAsyncWarehouseQueryArgs = {
-    userUuid: string;
+    userId: string;
+    // Can the user have credentials?
+    isSessionUser: boolean;
+    // Is the user in the database?
+    isRegisteredUser: boolean;
     projectUuid: string;
     queryTags: RunQueryTags;
     query: string;

--- a/packages/e2e/cypress/e2e/api/async-query.cy.ts
+++ b/packages/e2e/cypress/e2e/api/async-query.cy.ts
@@ -306,5 +306,20 @@ describe('Async Query API', () => {
                 });
             });
         });
+
+        it('should execute async query and get all results paged using JWT authentication', () => {
+            cy.getJwtToken(projectUuid, { canExplore: true }).then((jwt) => {
+                runAsyncQueryTest(SEED_PROJECT.project_uuid, jwt);
+            });
+        });
+
+        it('should execute async query and get all results paged using JWT authentication empty external ID', () => {
+            cy.getJwtToken(projectUuid, {
+                userExternalId: null,
+                canExplore: true,
+            }).then((jwt) => {
+                runAsyncQueryTest(SEED_PROJECT.project_uuid, jwt);
+            });
+        });
     });
 });

--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -47,6 +47,7 @@ describe('Explore', () => {
         cy.findByTestId('page-spinner').should('not.exist');
 
         cy.findByText('Orders').click();
+        cy.findByText('Dimensions');
         cy.findByText('Customers').click();
         cy.findByText('First name').click();
         cy.findByText('Unique order count').click();
@@ -217,6 +218,7 @@ describe('Explore', () => {
             cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
             cy.findByText('Orders').click();
+            cy.findByText('Dimensions');
             cy.findByText('Customers').click();
             cy.findByText('First name').click();
             cy.findByText('Unique order count').click();

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -80,7 +80,7 @@ declare global {
                 projectPermissions: ProjectPermission[],
             ): Chainable<Element>;
 
-            loginWithEmail: (email: string) => Chainable<Element>;
+            loginWithEmail(email: string): Chainable<Element>;
 
             getApiToken(): Chainable<string>;
 
@@ -110,7 +110,7 @@ declare global {
                 projectUuid: string,
                 options?: {
                     userEmail?: string;
-                    userExternalId?: string;
+                    userExternalId?: string | null;
                     canExportCsv?: boolean;
                     canExportImages?: boolean;
                     canExportPagePdf?: boolean;
@@ -661,7 +661,7 @@ Cypress.Commands.add(
         projectUuid: string,
         options: {
             userEmail?: string;
-            userExternalId?: string;
+            userExternalId?: string | null;
             canExportCsv?: boolean;
             canExportImages?: boolean;
             canExportPagePdf?: boolean;
@@ -716,11 +716,11 @@ Cypress.Commands.add(
                     },
                     userAttributes: {
                         email: userEmail,
-                        externalId: userExternalId,
+                        externalId: userExternalId || '',
                     },
                     user: {
                         email: userEmail,
-                        externalId: userExternalId,
+                        externalId: userExternalId || undefined,
                     },
                     expiresIn: '1h',
                 };


### PR DESCRIPTION
This reverts commit 9356f4e354880d168139cc63e57ed2b3475580eb.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Reverting the revert from yesterday. 

1. The original PR (#15893) refactored AsyncQuery and Project services to use req.account instead of req.user for async query endpoints needed for embedded Explores. 
2. @almeidabbm [found a bug](https://lightdash.slack.com/archives/C02GQKJK84Q/p1753376104001839) I'd overlooked where we need Personal Access Token auth to be available
3. We reverted 1️⃣ (#16007)
4. Updated API Token and Service Account auth to create req.account (#16016)
5. Now we can reverse the reversal/revert the revert

Only changes from the original diff handled a merge conflict from the PR in 4️⃣ (#16016). Other than that, it's the same. 

<!-- Even better add a screenshot / gif / loom -->
