### PR TITLE
feat: do not duplicate embed headers

### DIFF
--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -27,6 +27,16 @@ const defaultHeaders = {
     [LightdashVersionHeader]: __APP_VERSION__,
 };
 
+const isSafeToAddEmbedHeader = (
+    headers: Record<string, string> | undefined,
+) => {
+    if (!headers) return true;
+
+    const isEmbedHeader = (header: string) =>
+        header.toLowerCase() === JWT_HEADER_NAME.toLowerCase();
+    return !Object.keys(headers).some(isEmbedHeader);
+};
+
 const finalizeHeaders = (
     headers: Record<string, string> | undefined,
     embed: InMemoryEmbed | undefined,
@@ -37,7 +47,7 @@ const finalizeHeaders = (
         ...headers,
     };
 
-    if (embed?.token) {
+    if (embed?.token && isSafeToAddEmbedHeader(headers)) {
         requestHeaders[JWT_HEADER_NAME] = embed.token;
     }
 

--- a/packages/frontend/src/utils/inMemoryStorage.ts
+++ b/packages/frontend/src/utils/inMemoryStorage.ts
@@ -11,3 +11,7 @@ export const getFromInMemoryStorage = <T>(key: string): T | undefined => {
 export const setToInMemoryStorage = <T>(key: string, value: T): void => {
     inMemoryStore.set(key, value);
 };
+
+export const clearInMemoryStorage = (): void => {
+    inMemoryStore.clear();
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Prevents duplicate JWT headers in API requests by adding a safety check before adding embed tokens. This ensures that if an explicit JWT header is already provided, the system won't add another one from the embed token.

Added a new `isSafeToAddEmbedHeader` function that checks if JWT headers already exist before adding the embed token header.

Also added a `clearInMemoryStorage` utility function and created a test case to verify the prevention of duplicate token headers.