### PR TITLE
feat: add custom values support for parameter inputs

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
+++ b/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
@@ -15,11 +15,16 @@ parameters:
     label: "Subscription Status"
     description: "Filter subscriptions by their current status"
     default: "all"
+    allow_custom_values: true
+    multiple: false
     options:
       - "all"
       - "Current"
       - "Expired"
       - "Cancelled"
+    options_from_dimension:
+      model: orders
+      dimension: status
   min_duration_months:
     label: "Minimum Duration (Months)"
     description: "Filter subscriptions by minimum duration in months"

--- a/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
+++ b/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
@@ -15,16 +15,11 @@ parameters:
     label: "Subscription Status"
     description: "Filter subscriptions by their current status"
     default: "all"
-    allow_custom_values: true
-    multiple: false
     options:
       - "all"
       - "Current"
       - "Expired"
       - "Cancelled"
-    options_from_dimension:
-      model: orders
-      dimension: status
   min_duration_months:
     label: "Minimum Duration (Months)"
     description: "Filter subscriptions by minimum duration in months"

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12045,7 +12045,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12055,7 +12055,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12065,7 +12065,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -12078,7 +12078,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -16545,6 +16545,8 @@ const models: TsoaRoute.Models = {
                         model: { dataType: 'string', required: true },
                     },
                 },
+                options: { dataType: 'array', array: { dataType: 'string' } },
+                allow_custom_values: { dataType: 'boolean' },
                 multiple: { dataType: 'boolean' },
                 default: {
                     dataType: 'union',
@@ -16553,7 +16555,6 @@ const models: TsoaRoute.Models = {
                         { dataType: 'array', array: { dataType: 'string' } },
                     ],
                 },
-                options: { dataType: 'array', array: { dataType: 'string' } },
                 description: { dataType: 'string' },
                 label: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12837,22 +12837,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -17328,6 +17328,15 @@
                         "required": ["dimension", "model"],
                         "type": "object"
                     },
+                    "options": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "allow_custom_values": {
+                        "type": "boolean"
+                    },
                     "multiple": {
                         "type": "boolean"
                     },
@@ -17343,12 +17352,6 @@
                                 "type": "array"
                             }
                         ]
-                    },
-                    "options": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
                     },
                     "description": {
                         "type": "string"
@@ -18052,7 +18055,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1846.0",
+        "version": "0.1853.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -84,6 +84,10 @@
                             "description": "Whether the parameter input will be a multi select",
                             "type": "boolean"
                         },
+                        "allow_custom_values": {
+                            "description": "Whether users can input custom values beyond predefined options",
+                            "type": "boolean"
+                        },
                         "options_from_dimension": {
                             "description": "Get parameter options from a dimension in a model",
                             "type": "object",

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -13,10 +13,12 @@ type SpotlightConfig = {
 export type LightdashProjectParameter = {
     label: string;
     description?: string;
-    options?: string[];
     default?: string | string[];
     multiple?: boolean; // the parameter input will be a multi select
+    allow_custom_values?: boolean; // allows users to input custom values beyond predefined options
+    options?: string[]; // hardcoded options
     options_from_dimension?: {
+        // options will be populated from dimension values
         model: string;
         dimension: string;
     };

--- a/packages/frontend/src/features/parameters/components/ParameterInput.tsx
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.tsx
@@ -103,7 +103,7 @@ const ParameterStringAutoComplete: FC<ParameterStringAutoCompleteProps> = ({
     singleValue,
     parameterValues,
     size,
-                                                                               creatable = false,
+    creatable = false,
     ...rest
 }) => {
     const multiSelectRef = useRef<HTMLInputElement>(null);

--- a/packages/frontend/src/features/parameters/components/ParameterInput.tsx
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.tsx
@@ -38,6 +38,14 @@ import {
     useFieldValues,
 } from '../../../hooks/useFieldValues';
 
+// Consistent create label component for all parameter inputs
+const CreateParameterLabel: FC<{ query: string }> = ({ query }) => (
+    <Group spacing="xxs">
+        <MantineIcon icon={IconPlus} color="blue" size="sm" />
+        <Text color="blue">Add "{query}"</Text>
+    </Group>
+);
+
 type ParameterInputProps = {
     paramKey: string;
     parameter: LightdashProjectParameter;
@@ -95,6 +103,7 @@ const ParameterStringAutoComplete: FC<ParameterStringAutoCompleteProps> = ({
     singleValue,
     parameterValues,
     size,
+                                                                               creatable = false,
     ...rest
 }) => {
     const multiSelectRef = useRef<HTMLInputElement>(null);
@@ -299,20 +308,13 @@ const ParameterStringAutoComplete: FC<ParameterStringAutoCompleteProps> = ({
                     values.length > 0 || disabled ? undefined : placeholder
                 }
                 disabled={disabled}
-                creatable
                 valueComponent={singleValue ? SingleValueComponent : undefined}
-                /**
-                 * Opts out of Mantine's default condition and always allows adding, as long as not
-                 * an empty query.
-                 */
+                creatable={creatable}
                 shouldCreate={(query) =>
                     query.trim().length > 0 && !values.includes(query)
                 }
                 getCreateLabel={(query) => (
-                    <Group spacing="xxs">
-                        <MantineIcon icon={IconPlus} color="blue" size="sm" />
-                        <Text color="blue">Add "{query}"</Text>
-                    </Group>
+                    <CreateParameterLabel query={query} />
                 )}
                 styles={{
                     item: {
@@ -395,6 +397,21 @@ export const ParameterInput: FC<ParameterInputProps> = ({
             : 'Choose value...';
     }, [parameter]);
 
+    const shouldCreate = useCallback(
+        (query: string) => {
+            return (
+                query.trim().length > 0 &&
+                !(Array.isArray(value) ? value : [value]).includes(query)
+            );
+        },
+        [value],
+    );
+
+    const getCreateLabel = useCallback(
+        (query: string) => <CreateParameterLabel query={query} />,
+        [],
+    );
+
     if (parameter.options_from_dimension && projectUuid) {
         // Create a FilterableItem from parameter.options_from_dimension
         const field: FilterableItem = {
@@ -421,20 +438,30 @@ export const ParameterInput: FC<ParameterInputProps> = ({
                 onChange={(newValue) => onParameterChange(paramKey, newValue)}
                 parameterValues={parameterValues}
                 size={size}
+                creatable={parameter.allow_custom_values}
             />
         );
     }
+
+    const currentValues = value ? (Array.isArray(value) ? value : [value]) : [];
+    const optionsData = parameter.allow_custom_values
+        ? uniq([...(parameter.options ?? []), ...currentValues])
+        : parameter.options ?? [];
+
     if (parameter.multiple) {
         return (
             <MultiSelect
-                data={parameter.options ?? []}
-                value={value ? (Array.isArray(value) ? value : [value]) : []}
+                data={optionsData}
+                value={currentValues}
                 onChange={(newValue) => onParameterChange(paramKey, newValue)}
                 placeholder={placeholder}
                 size={size}
                 searchable
                 clearable
                 disabled={disabled}
+                creatable={parameter.allow_custom_values}
+                shouldCreate={shouldCreate}
+                getCreateLabel={getCreateLabel}
             />
         );
     }
@@ -442,13 +469,16 @@ export const ParameterInput: FC<ParameterInputProps> = ({
     return (
         <Select
             placeholder={placeholder}
-            value={Array.isArray(value) ? value[0] || null : value || null}
+            value={currentValues[0]}
             onChange={(newValue) => onParameterChange(paramKey, newValue)}
-            data={parameter.options ?? []}
+            data={optionsData}
             size={size}
             searchable
             clearable
             disabled={disabled}
+            creatable={parameter.allow_custom_values}
+            shouldCreate={shouldCreate}
+            getCreateLabel={getCreateLabel}
         />
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15995

### Description:
Added support for custom values in project parameters by introducing the `allow_custom_values` property. This allows users to input values beyond the predefined options in parameter dropdowns.

Key changes:
- Added `allow_custom_values` flag to parameter schema in project config
- Updated parameter input components to support custom value entry when enabled
- Ensured both single-select and multi-select parameters support custom values
- Added proper UI for creating new parameter values with a consistent "Add [value]" label
- Updated the Jaffle Shop demo config to demonstrate this functionality

### Demo

With options (multiple=false)

https://github.com/user-attachments/assets/2dadb778-3c9f-4dc7-9d19-a0988b956b96

With options (multiple=true)

https://github.com/user-attachments/assets/870e0b0f-8098-43df-9a43-1a40b0d66c20

With dimension options (multiple=false)

https://github.com/user-attachments/assets/c9e0b266-6f50-43ca-ae0a-d6add0595469

With dimension options (multiple=true)

https://github.com/user-attachments/assets/eb536085-b298-43c3-8772-7878750dd9e9








