### PR TITLE
fix: implement missing LESS_THAN_OR_EQUAL and GREATER_THAN_OR_EQUAL operators for conditional formatting

### DIFF
--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -1,0 +1,173 @@
+import { DimensionType, FieldType } from '../types/field';
+import { FilterOperator } from '../types/filter';
+import {
+    createConditionalFormattingConfigWithSingleColor,
+    createConditionalFormattingRuleWithValues,
+    hasMatchingConditionalRules,
+} from './conditionalFormatting';
+
+// Mock field for testing
+const mockNumericField = {
+    name: 'test_field',
+    table: 'test_table',
+    type: DimensionType.NUMBER,
+    fieldType: FieldType.DIMENSION,
+    sql: 'test_sql',
+    tableLabel: 'Test Table',
+    label: 'Test Field',
+    hidden: false,
+};
+
+describe('hasMatchingConditionalRules', () => {
+    describe('LESS_THAN_OR_EQUAL operator', () => {
+        it('should return true when field value is less than rule value', () => {
+            const config =
+                createConditionalFormattingConfigWithSingleColor('#ff0000');
+            const rule = createConditionalFormattingRuleWithValues();
+            rule.operator = FilterOperator.LESS_THAN_OR_EQUAL;
+            rule.values = [10];
+            config.rules = [rule];
+
+            const result = hasMatchingConditionalRules(
+                mockNumericField,
+                5, // less than 10
+                {},
+                config,
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it('should return true when field value equals rule value', () => {
+            const config =
+                createConditionalFormattingConfigWithSingleColor('#ff0000');
+            const rule = createConditionalFormattingRuleWithValues();
+            rule.operator = FilterOperator.LESS_THAN_OR_EQUAL;
+            rule.values = [10];
+            config.rules = [rule];
+
+            const result = hasMatchingConditionalRules(
+                mockNumericField,
+                10, // equals 10
+                {},
+                config,
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it('should return false when field value is greater than rule value', () => {
+            const config =
+                createConditionalFormattingConfigWithSingleColor('#ff0000');
+            const rule = createConditionalFormattingRuleWithValues();
+            rule.operator = FilterOperator.LESS_THAN_OR_EQUAL;
+            rule.values = [10];
+            config.rules = [rule];
+
+            const result = hasMatchingConditionalRules(
+                mockNumericField,
+                15, // greater than 10
+                {},
+                config,
+            );
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('GREATER_THAN_OR_EQUAL operator', () => {
+        it('should return true when field value is greater than rule value', () => {
+            const config =
+                createConditionalFormattingConfigWithSingleColor('#ff0000');
+            const rule = createConditionalFormattingRuleWithValues();
+            rule.operator = FilterOperator.GREATER_THAN_OR_EQUAL;
+            rule.values = [10];
+            config.rules = [rule];
+
+            const result = hasMatchingConditionalRules(
+                mockNumericField,
+                15, // greater than 10
+                {},
+                config,
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it('should return true when field value equals rule value', () => {
+            const config =
+                createConditionalFormattingConfigWithSingleColor('#ff0000');
+            const rule = createConditionalFormattingRuleWithValues();
+            rule.operator = FilterOperator.GREATER_THAN_OR_EQUAL;
+            rule.values = [10];
+            config.rules = [rule];
+
+            const result = hasMatchingConditionalRules(
+                mockNumericField,
+                10, // equals 10
+                {},
+                config,
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it('should return false when field value is less than rule value', () => {
+            const config =
+                createConditionalFormattingConfigWithSingleColor('#ff0000');
+            const rule = createConditionalFormattingRuleWithValues();
+            rule.operator = FilterOperator.GREATER_THAN_OR_EQUAL;
+            rule.values = [10];
+            config.rules = [rule];
+
+            const result = hasMatchingConditionalRules(
+                mockNumericField,
+                5, // less than 10
+                {},
+                config,
+            );
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('should handle multiple values with LESS_THAN_OR_EQUAL', () => {
+            const config =
+                createConditionalFormattingConfigWithSingleColor('#ff0000');
+            const rule = createConditionalFormattingRuleWithValues();
+            rule.operator = FilterOperator.LESS_THAN_OR_EQUAL;
+            rule.values = [5, 15];
+            config.rules = [rule];
+
+            // Should match if value is <= any of the rule values
+            const result = hasMatchingConditionalRules(
+                mockNumericField,
+                10, // <= 15 (second value)
+                {},
+                config,
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it('should handle multiple values with GREATER_THAN_OR_EQUAL', () => {
+            const config =
+                createConditionalFormattingConfigWithSingleColor('#ff0000');
+            const rule = createConditionalFormattingRuleWithValues();
+            rule.operator = FilterOperator.GREATER_THAN_OR_EQUAL;
+            rule.values = [5, 15];
+            config.rules = [rule];
+
+            // Should match if value is >= any of the rule values
+            const result = hasMatchingConditionalRules(
+                mockNumericField,
+                10, // >= 5 (first value)
+                {},
+                config,
+            );
+
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -402,9 +402,71 @@ export const hasMatchingConditionalRules = (
                     // should never happen
                     return false;
 
-                case FilterOperator.NOT_INCLUDE:
                 case FilterOperator.LESS_THAN_OR_EQUAL:
+                    if (shouldCompareFieldToValue) {
+                        return rule.values.some(
+                            (v) =>
+                                isNumericItem(field) &&
+                                typeof v === 'number' &&
+                                typeof convertedValue === 'number' &&
+                                convertedValue <= v,
+                        );
+                    }
+
+                    if (shouldCompareFieldToTarget) {
+                        return (
+                            isNumericItem(field) &&
+                            isNumericItem(compareField) &&
+                            typeof convertedCompareValue === 'number' &&
+                            typeof convertedValue === 'number' &&
+                            convertedValue <= convertedCompareValue
+                        );
+                    }
+
+                    if (shouldCompareTargetToValue) {
+                        return rule.values.some(
+                            (v) =>
+                                isNumericItem(compareField) &&
+                                typeof v === 'number' &&
+                                typeof convertedCompareValue === 'number' &&
+                                convertedCompareValue <= v,
+                        );
+                    }
+
+                    throw new NotImplementedError();
                 case FilterOperator.GREATER_THAN_OR_EQUAL:
+                    if (shouldCompareFieldToValue) {
+                        return rule.values.some(
+                            (v) =>
+                                isNumericItem(field) &&
+                                typeof v === 'number' &&
+                                typeof convertedValue === 'number' &&
+                                convertedValue >= v,
+                        );
+                    }
+
+                    if (shouldCompareFieldToTarget) {
+                        return (
+                            isNumericItem(field) &&
+                            isNumericItem(compareField) &&
+                            typeof convertedCompareValue === 'number' &&
+                            typeof convertedValue === 'number' &&
+                            convertedValue >= convertedCompareValue
+                        );
+                    }
+
+                    if (shouldCompareTargetToValue) {
+                        return rule.values.some(
+                            (v) =>
+                                isNumericItem(compareField) &&
+                                typeof v === 'number' &&
+                                typeof convertedCompareValue === 'number' &&
+                                convertedCompareValue >= v,
+                        );
+                    }
+
+                    throw new NotImplementedError();
+                case FilterOperator.NOT_INCLUDE:
                 case FilterOperator.IN_THE_PAST:
                 case FilterOperator.NOT_IN_THE_PAST:
                 case FilterOperator.IN_THE_NEXT:

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -434,6 +434,7 @@ export const hasMatchingConditionalRules = (
                     }
 
                     throw new NotImplementedError();
+
                 case FilterOperator.GREATER_THAN_OR_EQUAL:
                     if (shouldCompareFieldToValue) {
                         return rule.values.some(
@@ -466,6 +467,7 @@ export const hasMatchingConditionalRules = (
                     }
 
                     throw new NotImplementedError();
+
                 case FilterOperator.NOT_INCLUDE:
                 case FilterOperator.IN_THE_PAST:
                 case FilterOperator.NOT_IN_THE_PAST:


### PR DESCRIPTION
Closes: [#16045](https://github.com/lightdash/lightdash/issues/16045) 

### Description:
The PR adds missing conditional formatting filter operators `LESS_THAN_OR_EQUAL` and `GREATER_THAN_OR_EQUAL` in the
   conditional formatting system. Previously these operators were unimplemented and would fall through to other cases.
Also got Claude to add tests for these. Maybe they are not needed. 

Here is a [loom](https://www.loom.com/share/7870101ac9a14842b6b6e7f5e4a69509) showing the problem and the fix in dev
