### PR TITLE
feat: support subtotals with parameters in backend

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11087,6 +11087,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        parameters: { ref: 'ParametersValuesMap' },
                         pivotDimensions: {
                             dataType: 'array',
                             array: { dataType: 'string' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11943,6 +11943,9 @@
                     },
                     {
                         "properties": {
+                            "parameters": {
+                                "$ref": "#/components/schemas/ParametersValuesMap"
+                            },
                             "pivotDimensions": {
                                 "items": {
                                     "type": "string"

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2606,6 +2606,7 @@ export class ProjectService extends BaseService {
         explore: loadedExplore,
         dateZoom,
         chartUuid,
+        parameters,
     }: {
         account: Account;
         metricQuery: MetricQuery;
@@ -2618,6 +2619,7 @@ export class ProjectService extends BaseService {
         explore?: Explore;
         dateZoom?: DateZoom;
         chartUuid: string | undefined; // for analytics
+        parameters?: ParametersValuesMap;
     }): Promise<{
         rows: Record<string, AnyType>[];
         cacheMetadata: CacheMetadata;
@@ -2685,6 +2687,8 @@ export class ProjectService extends BaseService {
                         userAttributes,
                         this.lightdashConfig.query.timezone || 'UTC',
                         dateZoom,
+                        undefined,
+                        parameters,
                     );
 
                     const { query } = fullQuery;
@@ -5433,6 +5437,7 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         data: CalculateSubtotalsFromQuery,
         organizationUuid: string,
+        parameters?: ParametersValuesMap,
     ) {
         const {
             explore: exploreName,
@@ -5489,6 +5494,7 @@ export class ProjectService extends BaseService {
                 context: QueryExecutionContext.CALCULATE_SUBTOTAL,
                 csvLimit: null,
                 chartUuid: undefined,
+                parameters,
             });
 
             return formatRawRows(rows, fields);
@@ -5557,12 +5563,18 @@ export class ProjectService extends BaseService {
             throw new CustomSqlQueryForbiddenError();
         }
 
+        const combinedParameters = await this.combineParameters(
+            projectUuid,
+            data.parameters,
+        );
+
         // Reuse the _calculateTotal method by passing the explore, metricQuery, and organizationUuid
         return this._calculateSubtotals(
             account,
             projectUuid,
             data,
             organizationUuid,
+            combinedParameters,
         );
     }
 

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -758,6 +758,7 @@ export type ApiCalculateTotalResponse = {
 export type CalculateSubtotalsFromQuery = CalculateTotalFromQuery & {
     columnOrder: string[];
     pivotDimensions?: string[];
+    parameters?: ParametersValuesMap;
 };
 
 export type ApiCalculateSubtotalsResponse = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #15996

### Description:
Added support for parameters in subtotal calculations. This enhancement allows passing parameters to the `calculateSubtotals` endpoint, enabling parameter-based filtering in pivot tables with subtotals.

The implementation includes:
- Adding a `parameters` field to the `CalculateSubtotalsFromQuery` type
- Updating the ProjectService to handle parameters in subtotal calculations
- Passing parameters through the API routes and service methods