### PR TITLE
feat: support totals with parameters on the FE

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -286,6 +286,10 @@ const ValidDashboardChartTile: FC<{
             colorPalette={chart.colorPalette}
             setEchartsRef={setEchartsRef}
             computedSeries={computedSeries}
+            parameters={
+                dashboardChartReadyQuery.executeQueryResponse
+                    .usedParametersValues
+            }
         >
             <LightdashVisualization
                 isDashboard
@@ -361,6 +365,10 @@ const ValidDashboardChartTileMinimal: FC<{
             colorPalette={chart.colorPalette}
             setEchartsRef={setEchartsRef}
             computedSeries={computedSeries}
+            parameters={
+                dashboardChartReadyQuery.executeQueryResponse
+                    .usedParametersValues
+            }
         >
             <LightdashVisualization
                 isDashboard

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -194,6 +194,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                 onPivotDimensionsChange={setPivotFields}
                 colorPalette={org?.chartColors ?? ECHARTS_DEFAULT_COLORS}
                 tableCalculationsMetadata={tableCalculationsMetadata}
+                parameters={query.data?.usedParametersValues}
             >
                 <CollapsableCard
                     title="Chart"

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTable.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTable.tsx
@@ -15,6 +15,7 @@ const VisualizationTableConfig: FC<VisualizationTableConfigProps> = ({
     savedChartUuid,
     dashboardFilters,
     invalidateCache,
+    parameters,
 }) => {
     const tableConfig = useTableConfig(
         initialChartConfig,
@@ -26,6 +27,7 @@ const VisualizationTableConfig: FC<VisualizationTableConfigProps> = ({
         savedChartUuid,
         dashboardFilters,
         invalidateCache,
+        parameters,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -8,6 +8,7 @@ import {
     type DashboardFilters,
     type ItemsMap,
     type MetricQuery,
+    type ParametersValuesMap,
     type PivotValue,
     type Series,
     type TableCalculationMetadata,
@@ -53,6 +54,7 @@ export type VisualizationProviderProps = {
         metricQuery?: MetricQuery;
         fields?: ItemsMap;
     };
+    parameters?: ParametersValuesMap;
     isLoading: boolean;
     columnOrder: string[];
     onSeriesContextMenu?: (
@@ -96,6 +98,7 @@ const VisualizationProvider: FC<
     setEchartsRef,
     computedSeries,
     apiErrorDetail,
+    parameters,
 }) => {
     const itemsMap = useMemo(() => {
         return resultsData?.fields;
@@ -416,6 +419,7 @@ const VisualizationProvider: FC<
                     savedChartUuid={savedChartUuid}
                     dashboardFilters={dashboardFilters}
                     invalidateCache={invalidateCache}
+                    parameters={parameters}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -6,6 +6,7 @@ import {
     type ItemsMap,
     type Metric,
     type MetricQuery,
+    type ParametersValuesMap,
     type TableCalculation,
     type TableCalculationMetadata,
 } from '@lightdash/common';
@@ -148,6 +149,7 @@ export type VisualizationTableConfigProps =
         savedChartUuid: string | undefined;
         dashboardFilters: DashboardFilters | undefined;
         invalidateCache: boolean | undefined;
+        parameters?: ParametersValuesMap;
     };
 
 // Treemap

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -87,6 +87,9 @@ export const AiChartVisualization: FC<Props> = ({
             <VisualizationProvider
                 resultsData={resultsData}
                 chartConfig={chartConfig.echartsConfig}
+                parameters={
+                    queryExecutionHandle.data.query.usedParametersValues
+                }
                 columnOrder={[
                     ...metricQuery.dimensions,
                     ...metricQuery.metrics,

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -15,6 +15,7 @@ import {
     type DashboardFilters,
     type ItemsMap,
     type MetricQuery,
+    type ParametersValuesMap,
     type PivotData,
     type TableChart,
 } from '@lightdash/common';
@@ -46,6 +47,7 @@ const useTableConfig = (
     savedChartUuid?: string,
     dashboardFilters?: DashboardFilters,
     invalidateCache?: boolean,
+    parameters?: ParametersValuesMap,
 ) => {
     const { embedToken } = useEmbed();
 
@@ -211,6 +213,7 @@ const useTableConfig = (
                   showColumnCalculation:
                       tableChartConfig?.showColumnCalculation,
                   embedToken,
+                  parameters,
               }
             : {
                   metricQuery: resultsData?.metricQuery,
@@ -221,6 +224,7 @@ const useTableConfig = (
                       tableChartConfig?.showColumnCalculation,
                   // embed token is not necessary here because embeds don't use metricQuery for table calculations
                   embedToken: undefined,
+                  parameters,
               },
     );
 

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -89,6 +89,9 @@ export const useColumns = (): TableColumn[] => {
     const resultsFields = useExplorerContext(
         (context) => context.query.data?.fields,
     );
+    const parameters = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.parameters,
+    );
 
     const { data: exploreData } = useExplore(tableName, {
         refetchOnMount: false,
@@ -158,6 +161,7 @@ export const useColumns = (): TableColumn[] => {
             : undefined,
         itemsMap: activeItemsMap,
         embedToken,
+        parameters,
     });
 
     return useMemo(() => {

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -56,6 +56,7 @@ const MinimalExplorer: FC = () => {
             pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
             savedChartUuid={savedChart.uuid}
             colorPalette={savedChart.colorPalette}
+            parameters={query.data?.usedParametersValues}
         >
             <MantineProvider inherit theme={themeOverride}>
                 <Box mih="inherit" h="100%">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #15996

### Description:
Pass parameters to table visualization components to ensure proper calculation of totals in tables. This fix ensures that parameters are correctly propagated from dashboard contexts, chart visualizations, and explorer views to the underlying table calculation hooks.

The changes add a `parameters` prop to various visualization components and pass it through to the `useCalculateTotal` hook, which now includes these parameters in API requests for total calculations.

## Screenshots
<img width="2546" height="1135" alt="image" src="https://github.com/user-attachments/assets/9d18768d-7a07-4b77-86ea-c917ca87a2e8" />