### PR TITLE
feat: support subtotals with parameters on the FE

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTreemap.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTreemap.tsx
@@ -16,6 +16,7 @@ const VisualizationConfigTreemap: FC<VisualizationConfigTreemapProps> = ({
     onChartConfigChange,
     tableCalculationsMetadata,
     children,
+    parameters,
 }) => {
     const { dimensions, numericMetrics } = useMemo(() => {
         const metrics = getMetricsFromItemsMap(itemsMap ?? {}, isNumericItem);
@@ -33,6 +34,7 @@ const VisualizationConfigTreemap: FC<VisualizationConfigTreemapProps> = ({
         dimensions,
         numericMetrics,
         tableCalculationsMetadata,
+        parameters,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -396,6 +396,7 @@ const VisualizationProvider: FC<
                     resultsData={lastValidResultsData}
                     initialChartConfig={chartConfig.config}
                     onChartConfigChange={handleChartConfigChange}
+                    parameters={parameters}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -171,6 +171,7 @@ export type VisualizationConfigTreemapProps =
     VisualizationConfigCommon<VisualizationConfigTreemap> & {
         itemsMap: ItemsMap | undefined;
         tableCalculationsMetadata?: TableCalculationMetadata[];
+        parameters?: ParametersValuesMap;
     };
 
 // Custom

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -246,6 +246,7 @@ const useTableConfig = (
                   columnOrder,
                   pivotDimensions,
                   embedToken: undefined,
+                  parameters,
               },
     );
 

--- a/packages/frontend/src/hooks/useCalculateSubtotals.ts
+++ b/packages/frontend/src/hooks/useCalculateSubtotals.ts
@@ -4,6 +4,7 @@ import {
     type CalculateSubtotalsFromQuery,
     type DashboardFilters,
     type MetricQuery,
+    type ParametersValuesMap,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router';
@@ -19,6 +20,7 @@ const calculateSubtotalsFromQuery = async (
     metricQuery: MetricQuery,
     columnOrder: string[],
     pivotDimensions?: string[],
+    parameters?: ParametersValuesMap,
 ): Promise<ApiCalculateSubtotalsResponse['results']> => {
     const timezoneFixPayload: CalculateSubtotalsFromQuery = {
         explore: explore,
@@ -28,6 +30,7 @@ const calculateSubtotalsFromQuery = async (
         },
         columnOrder,
         pivotDimensions,
+        parameters,
     };
     return lightdashApi<ApiCalculateSubtotalsResponse['results']>({
         url: `/projects/${projectUuid}/calculate-subtotals`,
@@ -73,6 +76,7 @@ export const useCalculateSubtotals = ({
     dashboardFilters,
     invalidateCache,
     embedToken,
+    parameters,
 }: {
     metricQuery?: MetricQuery;
     explore?: string;
@@ -83,6 +87,7 @@ export const useCalculateSubtotals = ({
     dashboardFilters?: DashboardFilters;
     invalidateCache?: boolean;
     embedToken?: string;
+    parameters?: ParametersValuesMap;
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
 
@@ -98,6 +103,7 @@ export const useCalculateSubtotals = ({
             dashboardFilters,
             invalidateCache,
             embedToken,
+            parameters,
         ],
         () =>
             embedToken && projectUuid && savedChartUuid && columnOrder
@@ -117,6 +123,7 @@ export const useCalculateSubtotals = ({
                       metricQuery,
                       columnOrder,
                       pivotDimensions,
+                      parameters,
                   )
                 : Promise.reject(),
         {

--- a/packages/frontend/src/hooks/useTreemapChartConfig.ts
+++ b/packages/frontend/src/hooks/useTreemapChartConfig.ts
@@ -6,6 +6,7 @@ import type {
     ItemsMap,
     Metric,
     MetricQuery,
+    ParametersValuesMap,
     TableCalculation,
     TableCalculationMetadata,
     TreemapChart,
@@ -75,6 +76,7 @@ export type TreemapChartConfigFn = (
     dimensions: Record<string, CustomDimension | Dimension>,
     numericMetrics: Record<string, Metric | TableCalculation>,
     tableCalculationsMetadata?: TableCalculationMetadata[],
+    parameters?: ParametersValuesMap,
 ) => TreemapChartConfig;
 
 const useTreemapChartConfig: TreemapChartConfigFn = (
@@ -84,6 +86,7 @@ const useTreemapChartConfig: TreemapChartConfigFn = (
     dimensions,
     numericMetrics,
     tableCalculationsMetadata,
+    parameters,
 ) => {
     const [visibleMin, setVisibleMin] = useState(
         treemapConfig?.visibleMin ?? 100,
@@ -216,6 +219,7 @@ const useTreemapChartConfig: TreemapChartConfigFn = (
         showSubtotals: true,
         columnOrder: groupFieldIds,
         pivotDimensions: undefined,
+        parameters,
     });
 
     const data = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15996

### Description:
Added support for parameters in subtotals requests. This includes the new TreeMap viz.

The changes include:
- Added parameters prop to VisualizationConfigTreemap component
- Passed parameters from VisualizationProvider to the treemap config
- Updated useTreemapChartConfig hook to accept parameters
- Modified useCalculateSubtotals to include parameters in API requests

**Table**
<img width="2547" height="592" alt="image" src="https://github.com/user-attachments/assets/ef73fef2-0b8b-4967-a368-529942de8621" />

**Treemap**
<img width="2552" height="1090" alt="image" src="https://github.com/user-attachments/assets/1301a21d-11b2-4bc4-96ec-d457c5b1756a" />

