### PR TITLE
feat: add GIN index on yaml_tags in catalog_search table

### DIFF
--- a/packages/backend/src/database/migrations/20250728120551_add_index_on_yaml_tags_in_catalog_search.ts
+++ b/packages/backend/src/database/migrations/20250728120551_add_index_on_yaml_tags_in_catalog_search.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('catalog_search', (table) => {
+        table.index('yaml_tags', 'catalog_search_yaml_tags_index', 'GIN');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('catalog_search', (table) => {
+        table.dropIndex(['yaml_tags']);
+    });
+}


### PR DESCRIPTION
### Description:
Added a GIN index on the `yaml_tags` column in the `catalog_search` table to improve query performance when filtering by tags. This migration creates the index in the `up` function and removes it in the `down` function for rollback capability.