### PR TITLE
chore: add parameters to dashboard creation

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -2,6 +2,7 @@ import {
     DashboardConfig,
     DashboardFilters,
     DashboardTileTypes,
+    type DashboardParameters,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
@@ -43,6 +44,7 @@ type DbDashboardView = {
     created_at: Date;
     name: string;
     filters: DashboardFilters;
+    parameters: DashboardParameters | null;
 };
 
 type DbCreateDashboardTile = {
@@ -89,7 +91,10 @@ export type DashboardVersionTable = Knex.CompositeTableType<
 
 export type DashboardViewTable = Knex.CompositeTableType<
     DbDashboardView,
-    Pick<DbDashboardView, 'dashboard_version_id' | 'name' | 'filters'>
+    Pick<
+        DbDashboardView,
+        'dashboard_version_id' | 'name' | 'filters' | 'parameters'
+    >
 >;
 
 export type DashboardTileTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20250728131510_add-parameters-to-dashboards.ts
+++ b/packages/backend/src/database/migrations/20250728131510_add-parameters-to-dashboards.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const DashboardViewsTableName = 'dashboard_views';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DashboardViewsTableName, (table) => {
+        table.jsonb('parameters').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DashboardViewsTableName, (table) => {
+        table.dropColumn('parameters');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1351,6 +1351,40 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardParameterValue: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                value: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'array', array: { dataType: 'string' } },
+                    ],
+                    required: true,
+                },
+                parameterName: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.DashboardParameterValue_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { ref: 'DashboardParameterValue' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardParameters: {
+        dataType: 'refAlias',
+        type: { ref: 'Record_string.DashboardParameterValue_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdatedByUser: {
         dataType: 'refObject',
         properties: {
@@ -1511,6 +1545,7 @@ const models: TsoaRoute.Models = {
                 spaceName: { dataType: 'string', required: true },
                 spaceUuid: { dataType: 'string', required: true },
                 updatedByUser: { ref: 'UpdatedByUser' },
+                parameters: { ref: 'DashboardParameters' },
                 filters: { ref: 'DashboardFilters', required: true },
                 tiles: {
                     dataType: 'array',
@@ -9676,6 +9711,13 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
+                parameters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DashboardParameters' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 dashboardVersionId: { dataType: 'double', required: true },
                 tiles: {
                     dataType: 'array',
@@ -11328,6 +11370,7 @@ const models: TsoaRoute.Models = {
                 },
                 spaceUuid: { dataType: 'string' },
                 updatedByUser: { ref: 'Pick_UpdatedByUser.userUuid_' },
+                parameters: { ref: 'DashboardParameters' },
                 filters: { ref: 'DashboardFilters' },
                 tiles: {
                     dataType: 'array',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1329,6 +1329,39 @@
                 "required": ["tableCalculations", "metrics", "dimensions"],
                 "type": "object"
             },
+            "DashboardParameterValue": {
+                "properties": {
+                    "value": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        ]
+                    },
+                    "parameterName": {
+                        "type": "string"
+                    }
+                },
+                "required": ["value", "parameterName"],
+                "type": "object"
+            },
+            "Record_string.DashboardParameterValue_": {
+                "properties": {},
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/DashboardParameterValue"
+                },
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "DashboardParameters": {
+                "$ref": "#/components/schemas/Record_string.DashboardParameterValue_"
+            },
             "UpdatedByUser": {
                 "properties": {
                     "userUuid": {
@@ -1506,6 +1539,9 @@
                     },
                     "updatedByUser": {
                         "$ref": "#/components/schemas/UpdatedByUser"
+                    },
+                    "parameters": {
+                        "$ref": "#/components/schemas/DashboardParameters"
                     },
                     "filters": {
                         "$ref": "#/components/schemas/DashboardFilters"
@@ -10528,6 +10564,9 @@
                         ],
                         "nullable": true
                     },
+                    "parameters": {
+                        "$ref": "#/components/schemas/DashboardParameters"
+                    },
                     "dashboardVersionId": {
                         "type": "number",
                         "format": "double"
@@ -12195,6 +12234,9 @@
                     },
                     "updatedByUser": {
                         "$ref": "#/components/schemas/Pick_UpdatedByUser.userUuid_"
+                    },
+                    "parameters": {
+                        "$ref": "#/components/schemas/DashboardParameters"
                     },
                     "filters": {
                         "$ref": "#/components/schemas/DashboardFilters"
@@ -18055,7 +18097,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1853.0",
+        "version": "0.1855.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -186,6 +186,7 @@ export const dashboardViewEntry: DashboardViewTable['base'] = {
         metrics: [],
         tableCalculations: [],
     },
+    parameters: {},
 };
 
 export const dashboardWithVersionEntry: GetDashboardQuery = {
@@ -303,6 +304,7 @@ export const expectedDashboard: DashboardDAO = {
         metrics: [],
         tableCalculations: [],
     },
+    parameters: {},
     spaceUuid: 'spaceUuid',
     spaceName: 'space name',
     updatedByUser: {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -8,6 +8,7 @@ import {
     DashboardDAO,
     DashboardLoomTile,
     DashboardMarkdownTile,
+    DashboardParameterValue,
     DashboardSqlChartTile,
     DashboardTab,
     DashboardTileTypes,
@@ -28,6 +29,7 @@ import {
     sanitizeHtml,
     type DashboardBasicDetailsWithTileTypes,
     type DashboardFilters,
+    type DashboardParameters,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { v4 as uuidv4 } from 'uuid';
@@ -145,6 +147,7 @@ export class DashboardModel {
                 metrics: [],
                 tableCalculations: [],
             },
+            parameters: version.parameters || null,
         });
 
         if (version.tabs.length > 0) {
@@ -299,6 +302,7 @@ export class DashboardModel {
                                 : undefined,
                         })) ?? [],
                 },
+                parameters: version.parameters || null,
             })
             .where({ dashboard_version_id: versionId.dashboard_version_id });
     }
@@ -499,6 +503,7 @@ export class DashboardModel {
             dashboardUuid: string;
             name: string;
             filters: DashboardFilters;
+            parameters: DashboardParameters | null;
             chartUuids: string[];
         }>
     > {
@@ -541,6 +546,7 @@ export class DashboardModel {
                     dashboardUuid: `${cteName}.dashboard_uuid`,
                     name: `${cteName}.name`,
                     filters: `${DashboardViewsTableName}.filters`,
+                    parameters: `${DashboardViewsTableName}.parameters`,
                     chartUuids: this.database.raw(
                         "COALESCE(ARRAY_AGG(DISTINCT saved_queries.saved_query_uuid) FILTER (WHERE saved_queries.saved_query_uuid IS NOT NULL), '{}')",
                     ),
@@ -561,7 +567,7 @@ export class DashboardModel {
                     `${DashboardTileChartTableName}.saved_chart_id`,
                     `${SavedChartsTableName}.saved_query_id`,
                 )
-                .groupBy(1, 2, 3)
+                .groupBy(1, 2, 3, 4)
         );
     }
 
@@ -975,6 +981,7 @@ export class DashboardModel {
                 metrics: [],
                 tableCalculations: [],
             },
+            parameters: view?.parameters || undefined,
             spaceUuid: dashboard.space_uuid,
             spaceName: dashboard.space_name,
             views: dashboard.views_count,

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,5 +1,6 @@
 import { type FilterableDimension } from './field';
 import { type DashboardFilters } from './filter';
+import { type DashboardParameters } from './parameters';
 import { type ChartKind, type SavedChartType } from './savedCharts';
 import { type SpaceShare } from './space';
 import { type UpdatedByUser } from './user';
@@ -94,6 +95,7 @@ export type CreateDashboard = {
         | CreateDashboardSqlChartTile
     >;
     filters?: DashboardFilters;
+    parameters?: DashboardParameters;
     updatedByUser?: Pick<UpdatedByUser, 'userUuid'>;
     spaceUuid?: string;
     tabs: DashboardTab[];
@@ -150,6 +152,7 @@ export type Dashboard = {
     updatedAt: Date;
     tiles: Array<DashboardTile>;
     filters: DashboardFilters;
+    parameters?: DashboardParameters;
     updatedByUser?: UpdatedByUser;
     spaceUuid: string;
     spaceName: string;
@@ -211,7 +214,7 @@ export type DashboardUnversionedFields = Pick<
 
 export type DashboardVersionedFields = Pick<
     CreateDashboard,
-    'tiles' | 'filters' | 'updatedByUser' | 'tabs' | 'config'
+    'tiles' | 'filters' | 'parameters' | 'updatedByUser' | 'tabs' | 'config'
 >;
 
 export type UpdateDashboardDetails = Pick<Dashboard, 'name' | 'description'>;

--- a/packages/common/src/types/parameters.ts
+++ b/packages/common/src/types/parameters.ts
@@ -1,1 +1,8 @@
 export type ParametersValuesMap = Record<string, string | string[]>;
+
+export type DashboardParameterValue = {
+    parameterName: string;
+    value: string | string[];
+};
+
+export type DashboardParameters = Record<string, DashboardParameterValue>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #16021 

### Description:

Adds the ability to save parameter values with dashboards. This adds a dashboard parameters type and a column to the `dashboard_views` table to follow the pattern we have with filters. 
