### PR TITLE
chore: improve group access copy

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -464,10 +464,11 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                                 Group Access
                                                             </Text>
                                                             <Tooltip
-                                                                label="Select groups that can access this agent. If no groups are selected, the agent will be visible to all users in the organization."
+                                                                label="Admins and developers will always have access to this agent."
                                                                 withArrow
                                                                 withinPortal
                                                                 multiline
+                                                                position="right"
                                                                 maw="250px"
                                                             >
                                                                 <MantineIcon
@@ -478,6 +479,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                             </Tooltip>
                                                         </Group>
                                                     }
+                                                    description="Select groups that can access this agent. If no groups are selected, the agent will be visible to all users in the org"
                                                     placeholder={
                                                         isLoadingGroups
                                                             ? 'Loading groups...'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Updated the tooltip text for Group Access in the AI Agent edit page to clarify that admins and developers will always have access to the agent, regardless of group selection.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/effc85db-d3d6-4632-ac26-de810cb6f6e1.png)



