### PR TITLE
feat: improve UX for unavailable filters in dashboards

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -11,7 +11,7 @@ import {
     type MultiSelectProps,
     type MultiSelectValueProps,
 } from '@mantine/core';
-import { IconPlus } from '@tabler/icons-react';
+import { IconAlertCircle, IconPlus } from '@tabler/icons-react';
 import uniq from 'lodash/uniq';
 import {
     useCallback,
@@ -96,6 +96,8 @@ const FilterStringAutoComplete: FC<Props> = ({
         results: resultsSet,
         refreshedAt,
         refetch,
+        error,
+        isError,
     } = useFieldValues(
         search,
         initialSuggestionData,
@@ -332,7 +334,18 @@ const FilterStringAutoComplete: FC<Props> = ({
                     isInitialLoading ? 'Loading...' : 'No results found'
                 }
                 rightSection={
-                    isInitialLoading ? <Loader size="xs" color="gray" /> : null
+                    isInitialLoading ? (
+                        <Loader size="xs" color="gray" />
+                    ) : isError ? (
+                        <Tooltip
+                            label={
+                                error?.error?.message || 'Filter not available'
+                            }
+                            withinPortal
+                        >
+                            <MantineIcon icon={IconAlertCircle} color="red" />
+                        </Tooltip>
+                    ) : null
                 }
                 dropdownComponent={DropdownComponentOverride}
                 itemComponent={({ label, ...others }) =>


### PR DESCRIPTION

### Description:
Added error handling to `FilterStringAutoComplete`. When a field value query fails, the component now displays a red alert icon with a tooltip showing the error message.

Related to #16000

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/b98440e6-9921-4e59-82ea-2c5c7be68a07.png)

