### PR TITLE
chore: add helpful text on ai agent tags' input

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -6,6 +6,7 @@ import {
     Button,
     Code,
     Group,
+    HoverCard,
     LoadingOverlay,
     MultiSelect,
     Paper,
@@ -434,7 +435,45 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                         />
                                         <TagsInput
                                             variant="subtle"
-                                            label="Tags"
+                                            label={
+                                                <Group gap="xs">
+                                                    <Text fz="sm" fw={500}>
+                                                        Tags
+                                                    </Text>
+                                                    <HoverCard
+                                                        position="right"
+                                                        withArrow
+                                                    >
+                                                        <HoverCard.Target>
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconInfoCircle
+                                                                }
+                                                            />
+                                                        </HoverCard.Target>
+                                                        <HoverCard.Dropdown maw="250px">
+                                                            <Text fz="xs">
+                                                                Add tags to
+                                                                control which
+                                                                metrics and
+                                                                dimensions your
+                                                                AI agent can
+                                                                access. See more
+                                                                in our{' '}
+                                                                <Anchor
+                                                                    fz="xs"
+                                                                    c="dimmed"
+                                                                    underline="always"
+                                                                    href="https://docs.lightdash.com/guides/ai-agents#limiting-access-to-specific-explores-and-fields"
+                                                                    target="_blank"
+                                                                >
+                                                                    docs
+                                                                </Anchor>
+                                                            </Text>
+                                                        </HoverCard.Dropdown>
+                                                    </HoverCard>
+                                                </Group>
+                                            }
                                             placeholder="Select tags"
                                             {...form.getInputProps('tags')}
                                             value={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #

### Description:

Added an info tooltip to the Tags field in the AI Agent edit page. The tooltip explains that tags can be used to control which metrics and dimensions the AI agent can access, with a link to the documentation for more details.

![Screenshot 2025-07-28 at 16.27.58.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/419a7686-4f8a-47ce-9dbc-e9bdbe765d1f.png)

