### PR TITLE
fix(test): make model number assertions generic

### DIFF
--- a/packages/e2e/cypress/e2e/api/catalog.cy.ts
+++ b/packages/e2e/cypress/e2e/api/catalog.cy.ts
@@ -14,7 +14,7 @@ describe('Lightdash catalog all tables and fields', () => {
             `${apiUrl}/projects/${projectUuid}/dataCatalog?type=table`,
         ).then((resp) => {
             expect(resp.status).to.eq(200);
-            expect(resp.body.results).to.have.length(21);
+            expect(resp.body.results).to.have.length.gt(0);
             const userTable = resp.body.results.find(
                 (table) => table.name === 'users',
             );

--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -169,7 +169,7 @@ const testCompile = (): Cypress.Chainable<string> => {
     cy.contains('Step 2/3', { timeout: 60000 });
     cy.contains('Successfully synced dbt project!', { timeout: 60000 });
 
-    cy.contains('selected 21 models');
+    cy.contains(/selected \d+ models/);
     // Configure
     cy.contains('button', 'Save changes').click();
     cy.url().should('include', '/home', { timeout: 30000 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR makes the E2E tests more resilient by replacing hardcoded expectations with dynamic checks:

1. In the catalog API test, replaced the expectation for exactly 21 tables with a check that there is at least 1 table
2. In the project creation test, updated the model count validation to use a regex pattern that accepts any number of models instead of expecting exactly 21 models

These changes will prevent test failures when the number of models in the test project changes.

test-frontend
test-backend