### PR TITLE
fix: improve AI explore search with field type filtering and joined tables

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/tracks.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/tracks.yml
@@ -2,7 +2,7 @@ version: 2
 models:
   - name: tracks
     config:
-      tags: ['ai']
+      tags: ['another-ai-tag']
     meta:
       primary_key: id
       required_filters: 

--- a/packages/backend/src/ee/services/ai/tools/findExplores.ts
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.ts
@@ -1,7 +1,7 @@
 import {
     CatalogField,
     CatalogTable,
-    CatalogType,
+    FieldType,
     getItemId,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -13,26 +13,21 @@ type Dependencies = {
     findExplores: FindExploresFn;
 };
 
-const DESCRIPTION_MAX_LENGTH = 300;
 const PAGE_SIZE = 15;
 
 const generateExploreResponse = (
     table: CatalogTable,
     fields: CatalogField[],
-    descriptionMaxLength: number = DESCRIPTION_MAX_LENGTH,
 ) => {
-    const allTableNames = [
-        table.name,
-        ...(table.joinedTables?.map((t) => t.table) ?? []),
-    ];
+    const allTableNames = [table.name, ...(table.joinedTables ?? [])];
 
     const dimensions = fields
-        .filter((field) => field.type === CatalogType.Field)
+        .filter((field) => field.fieldType === FieldType.DIMENSION)
         .filter((field) => allTableNames.includes(field.tableName))
         .sort((a, b) => (b.chartUsage ?? 0) - (a.chartUsage ?? 0));
 
     const metrics = fields
-        .filter((field) => field.type === CatalogType.Field)
+        .filter((field) => field.fieldType === FieldType.METRIC)
         .filter((field) => allTableNames.includes(field.tableName))
         .sort((a, b) => (b.chartUsage ?? 0) - (a.chartUsage ?? 0));
 
@@ -63,7 +58,7 @@ const generateExploreResponse = (
         ${table.joinedTables
             .map(
                 (joinedTable) =>
-                    `<JoinedTable id="${joinedTable.table}">${joinedTable.table}</JoinedTable>`,
+                    `<JoinedTable id="${joinedTable}">${joinedTable}</JoinedTable>`,
             )
             .join('\n\n')}
     </JoinedTables>

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -266,6 +266,7 @@ export class CatalogModel {
                 `${CachedExploreTableName}.explore`,
                 `required_attributes`,
                 `chart_usage`,
+                `${CatalogTableName}.joined_tables`,
                 `icon`,
                 {
                     search_rank: getFullTextSearchRankCalcSql({
@@ -461,45 +462,52 @@ export class CatalogModel {
                 function yamlTagsFiltering() {
                     void this
                         // Condition 1: The item itself has a matching tag.
-                        // This correctly includes any tagged field or table.
+                        // This is the highest priority rule. It includes any
+                        // field or table that is explicitly tagged.
                         .whereRaw(
                             `${CatalogTableName}.yaml_tags && ?::text[]`,
                             [yamlTags],
                         )
 
-                        // Condition 2: The item is part of an explore where ONLY the explore-level
-                        // table is tagged, making all items in that explore visible.
+                        // Condition 2: The item is part of an explore where ONLY the explore's
+                        // base table is tagged, making all items in that explore visible.
+                        // This handles the "show all fields" scenario.
                         .orWhere(function exploreTaggedButFieldsAreNot() {
-                            void this.whereExists(function exploreIsTagged() {
-                                void this.select('name')
-                                    .from(
-                                        `${CatalogTableName} as explore_table`,
-                                    )
-                                    .whereRaw(
-                                        `explore_table.cached_explore_uuid = ${CatalogTableName}.cached_explore_uuid`,
-                                    )
-                                    .andWhere('explore_table.type', 'table')
-                                    .andWhereRaw(
-                                        `explore_table.yaml_tags && ?::text[]`,
-                                        [yamlTags],
-                                    );
-                            }).whereNotExists(function anyFieldIsTagged() {
-                                void this.select('name')
-                                    .from(
-                                        `${CatalogTableName} as any_field_in_explore`,
-                                    )
-                                    .whereRaw(
-                                        `any_field_in_explore.cached_explore_uuid = ${CatalogTableName}.cached_explore_uuid`,
-                                    )
-                                    .andWhereNot(
-                                        'any_field_in_explore.type',
-                                        'table',
-                                    )
-                                    .andWhereRaw(
-                                        `any_field_in_explore.yaml_tags && ?::text[]`,
-                                        [yamlTags],
-                                    );
-                            });
+                            void this
+                                // Check that the explore's base table has a matching tag.
+                                .whereExists(function exploreIsTagged() {
+                                    void this.select('name')
+                                        .from(
+                                            `${CatalogTableName} as explore_table`,
+                                        )
+                                        .whereRaw(
+                                            `explore_table.cached_explore_uuid = ${CatalogTableName}.cached_explore_uuid`,
+                                        )
+                                        .andWhere('explore_table.type', 'table')
+                                        .andWhereRaw(
+                                            `explore_table.yaml_tags && ?::text[]`,
+                                            [yamlTags],
+                                        );
+                                })
+                                // AND crucially, check that NO fields within that same explore have any tags.
+                                // This enforces the precedence rule.
+                                .whereNotExists(function anyFieldIsTagged() {
+                                    void this.select('name')
+                                        .from(
+                                            `${CatalogTableName} as any_field_in_explore`,
+                                        )
+                                        .whereRaw(
+                                            `any_field_in_explore.cached_explore_uuid = ${CatalogTableName}.cached_explore_uuid`,
+                                        )
+                                        .andWhereNot(
+                                            'any_field_in_explore.type',
+                                            'table',
+                                        )
+                                        .andWhereRaw(
+                                            `any_field_in_explore.yaml_tags && ?::text[]`,
+                                            [yamlTags],
+                                        );
+                                });
                         })
 
                         // Condition 3: The item is a table, and at least one of its

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -96,6 +96,7 @@ export const parseCatalog = (
             chartUsage: dbCatalog.chart_usage ?? undefined,
             icon: dbCatalog.icon ?? null,
             aiHints: convertToAiHints(dbCatalog.explore.aiHint) ?? null,
+            joinedTables: dbCatalog.joined_tables ?? null,
         };
     }
 

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -190,7 +190,9 @@ export class CatalogService<
                             explore.baseTable &&
                             explore.tables?.[explore.baseTable]?.description,
                         type: CatalogType.Table,
-                        joinedTables: explore.joinedTables,
+                        joinedTables:
+                            explore.joinedTables?.map((join) => join.table) ??
+                            null,
                         chartUsage: undefined,
                         // ! since we're not pulling from the catalog search table these do not exist (keep compatibility with data catalog)
                         catalogSearchUuid: '',
@@ -216,7 +218,9 @@ export class CatalogService<
                             explore.tables[explore.baseTable].description,
                         type: CatalogType.Table,
                         groupLabel: explore.groupLabel,
-                        joinedTables: explore.joinedTables,
+                        joinedTables:
+                            explore.joinedTables?.map((join) => join.table) ??
+                            null,
                         tags: explore.tags,
                         chartUsage: undefined,
                         // ! since we're not pulling from the catalog search table these do not exist (keep compatibility with data catalog)

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -1,5 +1,5 @@
 import assertUnreachable from '../utils/assertUnreachable';
-import { type CompiledExploreJoin, type InlineError } from './explore';
+import { type InlineError } from './explore';
 import {
     DimensionType,
     MetricType,
@@ -85,10 +85,10 @@ export type CatalogTable = Pick<
     groupLabel?: string;
     tags?: string[];
     categories: Pick<Tag, 'name' | 'color' | 'tagUuid' | 'yamlReference'>[]; // Tags manually added by the user in the catalog
-    joinedTables?: CompiledExploreJoin[]; // Matched type in explore
     chartUsage: number | undefined;
     icon: CatalogItemIcon | null;
     aiHints: string[] | null;
+    joinedTables: string[] | null;
 };
 
 export type CatalogItem = CatalogField | CatalogTable;


### PR DESCRIPTION
### Description:
This PR improves AI tag filtering and explore data handling in the catalog:

1. Updates the `findExplores.ts` tool to:
   - Filter dimensions and metrics by their field type
   - Simplify joined tables handling

2. Enhances the catalog model with:
   - Better YAML tag filtering with clearer precedence rules
   - Improved SQL query to include joined_tables data
   - More detailed comments explaining the tag filtering logic

3. Simplifies the `CatalogTable` type by:
   - Changing `joinedTables` from `CompiledExploreJoin[]` to `string[] | null`
   - Updating related code to handle this simpler structure

4. Updates the demo tag in tracks.yml from 'ai' to 'another-ai-tag'