### PR TITLE
fix: invalidate parameters queries after job refresh

### DIFF
--- a/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
@@ -38,6 +38,7 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                             'defaultProject',
                         ]);
                     }
+                    await queryClient.invalidateQueries(['parameters']);
                     showToastSuccess({
                         key: TOAST_KEY_FOR_REFRESH_JOB,
                         title: toastTitle,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Invalidate parameters query cache when refreshing a job. This ensures that any parameter changes made during job execution are properly reflected in the UI after a refresh.


https://github.com/user-attachments/assets/c0bf30cb-ec41-499a-a04d-375c34e859e0

