### PR TITLE
feat: add auto run results setting in explore

### DIFF
--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -507,6 +507,10 @@ describe('Date tests', () => {
                 'YYYY',
             )}-${now.format('MM')}-01')`,
         );
+
+        // wait for query to finish
+        cy.findByText('Loading chart').should('not.exist');
+        cy.findByText('Loading results').should('not.exist');
         cy.get('.tabler-icon-x').click({ multiple: true });
 
         // Filter by week
@@ -531,6 +535,10 @@ describe('Date tests', () => {
                 weekDate,
             )}')`,
         );
+
+        // wait for query to finish
+        cy.findByText('Loading chart').should('not.exist');
+        cy.findByText('Loading results').should('not.exist');
         cy.get('.tabler-icon-x').click({ multiple: true });
 
         // Filter by day
@@ -550,6 +558,10 @@ describe('Date tests', () => {
                 todayDate,
             )}')`,
         );
+
+        // wait for query to finish
+        cy.findByText('Loading chart').should('not.exist');
+        cy.findByText('Loading results').should('not.exist');
         cy.get('.tabler-icon-x').click({ multiple: true });
     });
 

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -370,7 +370,7 @@ describe('Date tests', () => {
             `(DATE_TRUNC('YEAR', "customers".created)) = ('2018-01-01')`,
         );
 
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
 
         // Filter by month
         cy.contains('Add filter').click();
@@ -397,7 +397,7 @@ describe('Date tests', () => {
             `(DATE_TRUNC('MONTH', "customers".created)) = ('2018-09-01')`,
         );
 
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
     });
 
     it('Should keep value when changing date operator', () => {
@@ -457,7 +457,7 @@ describe('Date tests', () => {
             )}')`,
         );
 
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
     });
 
     it('Should filter by date on dimension', () => {
@@ -493,7 +493,7 @@ describe('Date tests', () => {
                 'YYYY',
             )}-01-01')`,
         );
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
 
         // Filter by month
         cy.get('[data-testid=tree-single-node-Month]')
@@ -508,10 +508,7 @@ describe('Date tests', () => {
             )}-${now.format('MM')}-01')`,
         );
 
-        // wait for query to finish
-        cy.findByText('Loading chart').should('not.exist');
-        cy.findByText('Loading results').should('not.exist');
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
 
         // Filter by week
         function startOfTheWeek(): Date {
@@ -536,10 +533,7 @@ describe('Date tests', () => {
             )}')`,
         );
 
-        // wait for query to finish
-        cy.findByText('Loading chart').should('not.exist');
-        cy.findByText('Loading results').should('not.exist');
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
 
         // Filter by day
         cy.get('[data-testid=tree-single-node-Day]')
@@ -559,10 +553,7 @@ describe('Date tests', () => {
             )}')`,
         );
 
-        // wait for query to finish
-        cy.findByText('Loading chart').should('not.exist');
-        cy.findByText('Loading results').should('not.exist');
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
     });
 
     it.skip('Should filter by datetime on dimension', () => {
@@ -601,7 +592,7 @@ describe('Date tests', () => {
         cy.get('.bp4-date-input input')
             .should('be.visible')
             .then(($value) => checkDatetime($value, '"events".timestamp_tz'));
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
 
         // Filter by millisecond
         cy.get('span:contains("Millisecond") ~ div').click();
@@ -614,7 +605,7 @@ describe('Date tests', () => {
                     `DATE_TRUNC('MILLISECOND', "events".timestamp_tz)`,
                 ),
             );
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
 
         // Filter by second
         cy.get('span:contains("Second") ~ div').click();
@@ -627,7 +618,7 @@ describe('Date tests', () => {
                     `DATE_TRUNC('SECOND', "events".timestamp_tz)`,
                 ),
             );
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
 
         // Filter by minute
         cy.get('span:contains("Minute") ~ div').click();
@@ -640,7 +631,7 @@ describe('Date tests', () => {
                     `DATE_TRUNC('MINUTE', "events".timestamp_tz)`,
                 ),
             );
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
 
         // Filter by hour
         cy.get('span:contains("Hour") ~ div').click();
@@ -653,6 +644,6 @@ describe('Date tests', () => {
                     `DATE_TRUNC('HOUR', "events".timestamp_tz)`,
                 ),
             );
-        cy.get('.tabler-icon-x').click({ multiple: true });
+        cy.findByTestId('delete-filter-rule-button').click();
     });
 });

--- a/packages/frontend/src/components/AutoFetchResultsButton.tsx
+++ b/packages/frontend/src/components/AutoFetchResultsButton.tsx
@@ -1,0 +1,37 @@
+import { ActionIcon, Tooltip, type MantineSize } from '@mantine/core';
+import { IconRefresh, IconRefreshOff } from '@tabler/icons-react';
+import { memo, type FC } from 'react';
+import useExplorerContext from '../providers/Explorer/useExplorerContext';
+import MantineIcon from './common/MantineIcon';
+
+export const AutoFetchResultsButton: FC<{ size?: MantineSize }> = memo(
+    ({ size }) => {
+        const autoFetchEnabled = useExplorerContext(
+            (context) => context.state.autoFetchEnabled,
+        );
+        const setAutoFetchEnabled = useExplorerContext(
+            (context) => context.actions.setAutoFetchEnabled,
+        );
+
+        return (
+            <Tooltip
+                label={`Auto-fetch results ${
+                    autoFetchEnabled ? 'enabled' : 'disabled'
+                }`}
+                position="bottom"
+                withArrow
+                withinPortal
+            >
+                <ActionIcon
+                    size={size}
+                    variant="default"
+                    onClick={() => setAutoFetchEnabled(!autoFetchEnabled)}
+                >
+                    <MantineIcon
+                        icon={autoFetchEnabled ? IconRefresh : IconRefreshOff}
+                    />
+                </ActionIcon>
+            </Tooltip>
+        );
+    },
+);

--- a/packages/frontend/src/components/AutoFetchResultsButton.tsx
+++ b/packages/frontend/src/components/AutoFetchResultsButton.tsx
@@ -26,8 +26,8 @@ export const AutoFetchResultsButton: FC<{ size?: MantineSize }> = memo(
                     onClick={() => setAutoFetchEnabled(!autoFetchEnabled)}
                     sx={(theme) => ({
                         color: autoFetchEnabled
-                            ? theme.colors.blue['6']
-                            : 'default',
+                            ? theme.colors.blue[6]
+                            : undefined,
                     })}
                 >
                     <MantineIcon

--- a/packages/frontend/src/components/AutoFetchResultsButton.tsx
+++ b/packages/frontend/src/components/AutoFetchResultsButton.tsx
@@ -1,17 +1,15 @@
 import { ActionIcon, Tooltip, type MantineSize } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
 import { IconRefresh, IconRefreshOff } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
-import useExplorerContext from '../providers/Explorer/useExplorerContext';
 import MantineIcon from './common/MantineIcon';
 
 export const AutoFetchResultsButton: FC<{ size?: MantineSize }> = memo(
     ({ size }) => {
-        const autoFetchEnabled = useExplorerContext(
-            (context) => context.state.autoFetchEnabled,
-        );
-        const setAutoFetchEnabled = useExplorerContext(
-            (context) => context.actions.setAutoFetchEnabled,
-        );
+        const [autoFetchEnabled, setAutoFetchEnabled] = useLocalStorage({
+            key: 'lightdash-explorer-auto-fetch-enabled',
+            defaultValue: true,
+        });
 
         return (
             <Tooltip

--- a/packages/frontend/src/components/AutoFetchResultsButton.tsx
+++ b/packages/frontend/src/components/AutoFetchResultsButton.tsx
@@ -24,6 +24,11 @@ export const AutoFetchResultsButton: FC<{ size?: MantineSize }> = memo(
                     size={size}
                     variant="default"
                     onClick={() => setAutoFetchEnabled(!autoFetchEnabled)}
+                    sx={(theme) => ({
+                        color: autoFetchEnabled
+                            ? theme.colors.blue['6']
+                            : 'default',
+                    })}
                 >
                     <MantineIcon
                         icon={autoFetchEnabled ? IconRefresh : IconRefreshOff}

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -12,6 +12,7 @@ import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAc
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
+import { AutoFetchResultsButton } from '../../AutoFetchResultsButton';
 import { RefreshButton } from '../../RefreshButton';
 import RefreshDbtButton from '../../RefreshDbtButton';
 import MantineIcon from '../../common/MantineIcon';
@@ -148,6 +149,7 @@ const ExplorerHeader: FC = memo(() => {
                     />
                 )}
 
+                <AutoFetchResultsButton size="md" />
                 <RefreshButton size="xs" />
 
                 {!savedChart && userCanCreateCharts && (

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -203,18 +203,15 @@ const FiltersCard: FC = memo(() => {
                     data,
                 );
             setHasDefaultFiltersApplied(true);
-            setFilters(
-                {
-                    metrics: undefined,
-                    tableCalculations: undefined,
-                    dimensions: overrideFilterGroupWithFilterRules(
-                        filters.dimensions,
-                        reducedRules,
-                        undefined,
-                    ),
-                },
-                false,
-            );
+            setFilters({
+                metrics: undefined,
+                tableCalculations: undefined,
+                dimensions: overrideFilterGroupWithFilterRules(
+                    filters.dimensions,
+                    reducedRules,
+                    undefined,
+                ),
+            });
         }
     });
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -98,7 +98,7 @@ const CellContextMenu: FC<
                 ? null // Set as null if value is invalid date or undefined
                 : value.raw;
 
-        addFilter(item, filterValue, true);
+        addFilter(item, filterValue);
     }, [track, addFilter, item, value]);
 
     let parseResult: null | object = null;

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -85,7 +85,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             icon={<MantineIcon icon={IconFilter} />}
                             onClick={() => {
                                 track({ name: EventName.ADD_FILTER_CLICKED });
-                                addFilter(item, undefined, false);
+                                addFilter(item, undefined);
                             }}
                         >
                             Filter by{' '}
@@ -164,7 +164,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             icon={<MantineIcon icon={IconFilter} />}
                             onClick={() => {
                                 track({ name: EventName.ADD_FILTER_CLICKED });
-                                addFilter(item, undefined, false);
+                                addFilter(item, undefined);
                             }}
                         >
                             Filter by{' '}
@@ -212,7 +212,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     icon={<MantineIcon icon={IconFilter} />}
                     onClick={() => {
                         track({ name: EventName.ADD_FILTER_CLICKED });
-                        addFilter(item, undefined, false);
+                        addFilter(item, undefined);
                     }}
                 >
                     Filter by{' '}

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -158,6 +158,7 @@ const FilterRuleForm: FC<Props> = ({
                             <ActionIcon
                                 onClick={onDelete}
                                 disabled={isRequired}
+                                data-testid="delete-filter-rule-button"
                             >
                                 <MantineIcon icon={IconX} size="sm" />
                             </ActionIcon>

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -39,7 +39,7 @@ import useFiltersContext from './useFiltersContext';
 
 type Props = {
     filters: Filters;
-    setFilters: (value: Filters, shouldFetchResults: boolean) => void;
+    setFilters: (value: Filters) => void;
     isEditMode: boolean;
 };
 
@@ -68,7 +68,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
 
     const totalFilterRules = getTotalFilterRules(filters);
     const clearAllFilters = useCallback(() => {
-        setFilters({}, false);
+        setFilters({});
     }, [setFilters]);
     const invalidFilterRules = getInvalidFilterRules(fields, totalFilterRules);
     const hasInvalidFilterRules = invalidFilterRules.length > 0;
@@ -79,7 +79,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
     const addFieldRule = useCallback(
         (field: FieldWithSuggestions) => {
             if (isFilterableField(field)) {
-                setFilters(addFilterRule({ filters, field }), false);
+                setFilters(addFilterRule({ filters, field }));
                 toggleFieldInput(false);
             }
         },
@@ -88,7 +88,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
 
     const updateFiltersFromGroup = useCallback(
         (filterGroup: FilterGroup) => {
-            setFilters(getFiltersFromGroup(filterGroup, fields), false);
+            setFilters(getFiltersFromGroup(filterGroup, fields));
         },
         [fields, setFilters],
     );
@@ -198,7 +198,7 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
                                 fields={fields}
                                 isEditMode={isEditMode}
                                 onChange={updateFiltersFromGroup}
-                                onDelete={() => setFilters({}, true)}
+                                onDelete={() => setFilters({})}
                             />
                         )}
                     </>

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -22,7 +22,6 @@ const themeOverride: MantineThemeOverride = {
 const getInitialState = (exploreId: string, savedChart: SavedChart) => ({
     parameters: {},
     autoFetchEnabled: true,
-    shouldFetchResults: true,
     expandedSections: [
         ExplorerSection.FILTERS,
         ExplorerSection.VISUALIZATION,

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -21,6 +21,7 @@ const themeOverride: MantineThemeOverride = {
 
 const getInitialState = (exploreId: string, savedChart: SavedChart) => ({
     parameters: {},
+    autoFetchEnabled: true,
     shouldFetchResults: true,
     expandedSections: [
         ExplorerSection.FILTERS,

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -21,7 +21,6 @@ const themeOverride: MantineThemeOverride = {
 
 const getInitialState = (exploreId: string, savedChart: SavedChart) => ({
     parameters: {},
-    autoFetchEnabled: true,
     expandedSections: [
         ExplorerSection.FILTERS,
         ExplorerSection.VISUALIZATION,

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -226,6 +226,7 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                 };
 
                 return {
+                    autoFetchEnabled: true,
                     shouldFetchResults: true,
                     expandedSections: unsavedChartVersion
                         ? [

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -227,7 +227,6 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
 
                 return {
                     autoFetchEnabled: true,
-                    shouldFetchResults: true,
                     expandedSections: unsavedChartVersion
                         ? [
                               ExplorerSection.VISUALIZATION,

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -226,7 +226,6 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                 };
 
                 return {
-                    autoFetchEnabled: true,
                     expandedSections: unsavedChartVersion
                         ? [
                               ExplorerSection.VISUALIZATION,

--- a/packages/frontend/src/hooks/useFilters.ts
+++ b/packages/frontend/src/hooks/useFilters.ts
@@ -38,11 +38,8 @@ export const useFilters = () => {
     );
 
     const addFilter = useCallback(
-        (field: FilterableField, value: any, shouldFetchResults?: boolean) => {
-            setFilters(
-                addFilterRule({ filters, field, value }),
-                !!shouldFetchResults,
-            );
+        (field: FilterableField, value: any) => {
+            setFilters(addFilterRule({ filters, field, value }));
             if (!filterIsOpen) toggleExpandedSection(ExplorerSection.FILTERS);
 
             window.scrollTo({

--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -255,6 +255,7 @@ const ChartHistory = () => {
                             : undefined
                     }
                     initialState={{
+                        autoFetchEnabled: true,
                         shouldFetchResults: true,
                         previouslyFetchedState: undefined,
                         expandedSections: [ExplorerSection.VISUALIZATION],

--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -256,7 +256,6 @@ const ChartHistory = () => {
                     }
                     initialState={{
                         autoFetchEnabled: true,
-                        shouldFetchResults: true,
                         previouslyFetchedState: undefined,
                         expandedSections: [ExplorerSection.VISUALIZATION],
                         unsavedChartVersion: chartVersionQuery.data.chart,

--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -255,7 +255,6 @@ const ChartHistory = () => {
                             : undefined
                     }
                     initialState={{
-                        autoFetchEnabled: true,
                         previouslyFetchedState: undefined,
                         expandedSections: [ExplorerSection.VISUALIZATION],
                         unsavedChartVersion: chartVersionQuery.data.chart,

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -105,7 +105,6 @@ const MinimalSavedExplorer: FC = () => {
             initialState={
                 data
                     ? {
-                          autoFetchEnabled: true,
                           expandedSections: [ExplorerSection.VISUALIZATION],
                           unsavedChartVersion: {
                               tableName: data.tableName,

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -105,6 +105,7 @@ const MinimalSavedExplorer: FC = () => {
             initialState={
                 data
                     ? {
+                          autoFetchEnabled: true,
                           shouldFetchResults: true,
                           expandedSections: [ExplorerSection.VISUALIZATION],
                           unsavedChartVersion: {

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -106,7 +106,6 @@ const MinimalSavedExplorer: FC = () => {
                 data
                     ? {
                           autoFetchEnabled: true,
-                          shouldFetchResults: true,
                           expandedSections: [ExplorerSection.VISUALIZATION],
                           unsavedChartVersion: {
                               tableName: data.tableName,

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -60,7 +60,6 @@ const SavedExplorer = () => {
             initialState={
                 data
                     ? {
-                          autoFetchEnabled: true,
                           expandedSections: [ExplorerSection.VISUALIZATION],
                           unsavedChartVersion: {
                               tableName: data.tableName,

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -61,7 +61,6 @@ const SavedExplorer = () => {
                 data
                     ? {
                           autoFetchEnabled: true,
-                          shouldFetchResults: true,
                           expandedSections: [ExplorerSection.VISUALIZATION],
                           unsavedChartVersion: {
                               tableName: data.tableName,

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -60,6 +60,7 @@ const SavedExplorer = () => {
             initialState={
                 data
                     ? {
+                          autoFetchEnabled: true,
                           shouldFetchResults: true,
                           expandedSections: [ExplorerSection.VISUALIZATION],
                           unsavedChartVersion: {

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.test.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.test.tsx
@@ -127,51 +127,6 @@ describe('ExplorerProvider reducer', () => {
         });
     });
 
-    describe('SET_FETCH_RESULTS_FALSE', () => {
-        it('sets shouldFetchResults to false', () => {
-            const state = mockExplorerState({ shouldFetchResults: true });
-
-            const newState = reducer(state, {
-                type: ActionType.SET_FETCH_RESULTS_FALSE,
-            });
-
-            expect(newState.shouldFetchResults).toBe(false);
-        });
-
-        it('does not affect other parts of state', () => {
-            const state = mockExplorerState({
-                shouldFetchResults: true,
-                unsavedChartVersion: {
-                    tableName: 'orders',
-                    metricQuery: mockMetricQuery({
-                        dimensions: ['order_id'],
-                    }),
-                    chartConfig: mockCartesianChartConfig,
-                    tableConfig: mockTableConfig,
-                },
-            });
-
-            const newState = reducer(state, {
-                type: ActionType.SET_FETCH_RESULTS_FALSE,
-            });
-
-            expect(newState.unsavedChartVersion.tableName).toBe('orders');
-            expect(newState.unsavedChartVersion.metricQuery.dimensions).toEqual(
-                ['order_id'],
-            );
-        });
-
-        it('does not mutate previous state', () => {
-            const frozen = Object.freeze(
-                mockExplorerState({ shouldFetchResults: true }),
-            );
-
-            expect(() =>
-                reducer(frozen, { type: ActionType.SET_FETCH_RESULTS_FALSE }),
-            ).not.toThrow();
-        });
-    });
-
     describe('SET_PREVIOUSLY_FETCHED_STATE', () => {
         const mockPrevQuery = mockMetricQuery({
             dimensions: ['dimension_1'],
@@ -209,7 +164,6 @@ describe('ExplorerProvider reducer', () => {
 
         it('does not affect other parts of state', () => {
             const state = mockExplorerState({
-                shouldFetchResults: true,
                 unsavedChartVersion: {
                     tableName: 'sales',
                     metricQuery: mockMetricQuery(),
@@ -226,7 +180,6 @@ describe('ExplorerProvider reducer', () => {
             expect(newState.unsavedChartVersion).toEqual(
                 state.unsavedChartVersion,
             );
-            expect(newState.shouldFetchResults).toBe(true);
         });
     });
 
@@ -351,7 +304,6 @@ describe('ExplorerProvider reducer', () => {
 
         it('preserves other parts of the state', () => {
             const state = mockExplorerState({
-                shouldFetchResults: true,
                 previouslyFetchedState: mockMetricQuery(),
             });
 
@@ -360,7 +312,6 @@ describe('ExplorerProvider reducer', () => {
                 payload: 'non_existent_field',
             });
 
-            expect(newState.shouldFetchResults).toBe(true);
             expect(newState.previouslyFetchedState).toEqual(mockMetricQuery());
         });
 
@@ -1073,10 +1024,9 @@ describe('ExplorerProvider reducer', () => {
             expect(newState.unsavedChartVersion.metricQuery.filters).toEqual(
                 filters,
             );
-            expect(newState.shouldFetchResults).toBe(false);
         });
 
-        it('sets filters and enables shouldFetchResults', () => {
+        it('sets filters', () => {
             const filters = {
                 metrics: mockFilterGroup({
                     id: 'metrics-group',
@@ -1095,13 +1045,11 @@ describe('ExplorerProvider reducer', () => {
             const newState = reducer(state, {
                 type: ActionType.SET_FILTERS,
                 payload: filters,
-                options: { shouldFetchResults: true },
             });
 
             expect(newState.unsavedChartVersion.metricQuery.filters).toEqual(
                 filters,
             );
-            expect(newState.shouldFetchResults).toBe(true);
         });
 
         it('preserves other parts of state', () => {

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -829,6 +829,11 @@ export function reducer(
                 draft.isVisualizationConfigOpen = false;
             });
         }
+        case ActionType.SET_AUTO_FETCH_ENABLED: {
+            return produce(state, (draft) => {
+                draft.autoFetchEnabled = action.payload;
+            });
+        }
         default: {
             return assertUnreachable(
                 action,
@@ -1437,10 +1442,10 @@ const ExplorerProvider: FC<
     ]);
 
     useEffect(() => {
-        if (!state.shouldFetchResults) return;
+        if (!state.shouldFetchResults || !reducerState.autoFetchEnabled) return;
         runQuery();
         dispatch({ type: ActionType.SET_FETCH_RESULTS_FALSE });
-    }, [runQuery, state.shouldFetchResults]);
+    }, [runQuery, state.shouldFetchResults, reducerState.autoFetchEnabled]);
 
     const queryClient = useQueryClient();
     const clearExplore = useCallback(async () => {
@@ -1530,8 +1535,16 @@ const ExplorerProvider: FC<
     const openVisualizationConfig = useCallback(() => {
         dispatch({ type: ActionType.OPEN_VISUALIZATION_CONFIG });
     }, []);
+
     const closeVisualizationConfig = useCallback(() => {
         dispatch({ type: ActionType.CLOSE_VISUALIZATION_CONFIG });
+    }, []);
+
+    const setAutoFetchEnabled = useCallback((autoFetchEnabled: boolean) => {
+        dispatch({
+            type: ActionType.SET_AUTO_FETCH_ENABLED,
+            payload: autoFetchEnabled,
+        });
     }, []);
 
     const actions = useMemo(
@@ -1577,6 +1590,7 @@ const ExplorerProvider: FC<
             getDownloadQueryUuid,
             openVisualizationConfig,
             closeVisualizationConfig,
+            setAutoFetchEnabled,
         }),
         [
             clearExplore,
@@ -1620,6 +1634,7 @@ const ExplorerProvider: FC<
             getDownloadQueryUuid,
             openVisualizationConfig,
             closeVisualizationConfig,
+            setAutoFetchEnabled,
         ],
     );
 

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -25,6 +25,7 @@ import {
     type TableCalculation,
     type TimeZone,
 } from '@lightdash/common';
+import { useLocalStorage } from '@mantine/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { produce } from 'immer';
 import cloneDeep from 'lodash/cloneDeep';
@@ -819,11 +820,7 @@ export function reducer(
                 draft.isVisualizationConfigOpen = false;
             });
         }
-        case ActionType.SET_AUTO_FETCH_ENABLED: {
-            return produce(state, (draft) => {
-                draft.autoFetchEnabled = action.payload;
-            });
-        }
+
         default: {
             return assertUnreachable(
                 action,
@@ -857,6 +854,11 @@ const ExplorerProvider: FC<
     dateZoomGranularity,
     projectUuid: propProjectUuid,
 }) => {
+    const [autoFetchEnabled] = useLocalStorage({
+        key: 'lightdash-explorer-auto-fetch-enabled',
+        defaultValue: true,
+    });
+
     const defaultStateWithConfig = useMemo(
         () => ({
             ...defaultState,
@@ -1384,9 +1386,9 @@ const ExplorerProvider: FC<
     ]);
 
     useEffect(() => {
-        if (!reducerState.autoFetchEnabled) return;
+        if (!autoFetchEnabled) return;
         runQuery();
-    }, [runQuery, reducerState.autoFetchEnabled]);
+    }, [runQuery, autoFetchEnabled]);
 
     const queryClient = useQueryClient();
     const clearExplore = useCallback(async () => {
@@ -1481,13 +1483,6 @@ const ExplorerProvider: FC<
         dispatch({ type: ActionType.CLOSE_VISUALIZATION_CONFIG });
     }, []);
 
-    const setAutoFetchEnabled = useCallback((autoFetchEnabled: boolean) => {
-        dispatch({
-            type: ActionType.SET_AUTO_FETCH_ENABLED,
-            payload: autoFetchEnabled,
-        });
-    }, []);
-
     const actions = useMemo(
         () => ({
             clearExplore,
@@ -1531,7 +1526,6 @@ const ExplorerProvider: FC<
             getDownloadQueryUuid,
             openVisualizationConfig,
             closeVisualizationConfig,
-            setAutoFetchEnabled,
         }),
         [
             clearExplore,
@@ -1575,7 +1569,6 @@ const ExplorerProvider: FC<
             getDownloadQueryUuid,
             openVisualizationConfig,
             closeVisualizationConfig,
-            setAutoFetchEnabled,
         ],
     );
 

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -142,13 +142,8 @@ const getTableCalculationsMetadata = (
 // eslint-disable-next-line react-refresh/only-export-components
 export function reducer(
     state: ExplorerReduceState,
-    action: Action & { options?: { shouldFetchResults: boolean } },
+    action: Action,
 ): ExplorerReduceState {
-    state = {
-        ...state,
-        shouldFetchResults:
-            action.options?.shouldFetchResults || state.shouldFetchResults,
-    };
     switch (action.type) {
         case ActionType.RESET: {
             return action.payload;
@@ -158,11 +153,6 @@ export function reducer(
                 draft.unsavedChartVersion.tableName = action.payload;
                 draft.unsavedChartVersion.metricQuery.exploreName =
                     action.payload;
-            });
-        }
-        case ActionType.SET_FETCH_RESULTS_FALSE: {
-            return produce(state, (draft) => {
-                draft.shouldFetchResults = false;
             });
         }
         case ActionType.SET_PREVIOUSLY_FETCHED_STATE: {
@@ -945,9 +935,6 @@ const ExplorerProvider: FC<
         dispatch({
             type: ActionType.REMOVE_FIELD,
             payload: fieldId,
-            options: {
-                shouldFetchResults: true,
-            },
         });
     }, []);
 
@@ -955,9 +942,6 @@ const ExplorerProvider: FC<
         dispatch({
             type: ActionType.TOGGLE_SORT_FIELD,
             payload: fieldId,
-            options: {
-                shouldFetchResults: true,
-            },
         });
     }, []);
 
@@ -965,9 +949,6 @@ const ExplorerProvider: FC<
         dispatch({
             type: ActionType.SET_SORT_FIELDS,
             payload: sortFields,
-            options: {
-                shouldFetchResults: true,
-            },
         });
     }, []);
 
@@ -975,9 +956,6 @@ const ExplorerProvider: FC<
         dispatch({
             type: ActionType.REMOVE_SORT_FIELD,
             payload: fieldId,
-            options: {
-                shouldFetchResults: true,
-            },
         });
     }, []);
 
@@ -986,9 +964,6 @@ const ExplorerProvider: FC<
             dispatch({
                 type: ActionType.MOVE_SORT_FIELDS,
                 payload: { sourceIndex, destinationIndex },
-                options: {
-                    shouldFetchResults: true,
-                },
             });
         },
         [],
@@ -1002,9 +977,6 @@ const ExplorerProvider: FC<
             dispatch({
                 type: ActionType.ADD_SORT_FIELD,
                 payload: { fieldId, ...options },
-                options: {
-                    shouldFetchResults: true,
-                },
             });
         },
         [],
@@ -1014,9 +986,6 @@ const ExplorerProvider: FC<
         dispatch({
             type: ActionType.SET_ROW_LIMIT,
             payload: limit,
-            options: {
-                shouldFetchResults: true,
-            },
         });
     }, []);
 
@@ -1024,24 +993,15 @@ const ExplorerProvider: FC<
         dispatch({
             type: ActionType.SET_TIME_ZONE,
             payload: timezone,
-            options: {
-                shouldFetchResults: true,
-            },
         });
     }, []);
 
-    const setFilters = useCallback(
-        (filters: MetricQuery['filters'], shouldFetchResults: boolean) => {
-            dispatch({
-                type: ActionType.SET_FILTERS,
-                payload: filters,
-                options: {
-                    shouldFetchResults,
-                },
-            });
-        },
-        [],
-    );
+    const setFilters = useCallback((filters: MetricQuery['filters']) => {
+        dispatch({
+            type: ActionType.SET_FILTERS,
+            payload: filters,
+        });
+    }, []);
 
     const setParameter = useCallback(
         (key: string, value: string | string[] | null) => {
@@ -1180,9 +1140,6 @@ const ExplorerProvider: FC<
             dispatch({
                 type: ActionType.ADD_TABLE_CALCULATION,
                 payload: tableCalculation,
-                options: {
-                    shouldFetchResults: true,
-                },
             });
         },
         [unsavedChartVersion],
@@ -1202,9 +1159,6 @@ const ExplorerProvider: FC<
             dispatch({
                 type: ActionType.UPDATE_TABLE_CALCULATION,
                 payload: { oldName, tableCalculation },
-                options: {
-                    shouldFetchResults: true,
-                },
             });
         },
         [unsavedChartVersion],
@@ -1213,9 +1167,6 @@ const ExplorerProvider: FC<
         dispatch({
             type: ActionType.DELETE_TABLE_CALCULATION,
             payload: name,
-            options: {
-                shouldFetchResults: true,
-            },
         });
     }, []);
 
@@ -1224,9 +1175,6 @@ const ExplorerProvider: FC<
             dispatch({
                 type: ActionType.ADD_CUSTOM_DIMENSION,
                 payload: customDimension,
-                options: {
-                    shouldFetchResults: true,
-                },
             });
 
             // TODO: add dispatch toggle
@@ -1242,9 +1190,6 @@ const ExplorerProvider: FC<
             dispatch({
                 type: ActionType.EDIT_CUSTOM_DIMENSION,
                 payload: { customDimension, previousCustomDimensionId },
-                options: {
-                    shouldFetchResults: true,
-                },
             });
             // TODO: add dispatch toggle
         },
@@ -1287,9 +1232,6 @@ const ExplorerProvider: FC<
             dispatch({
                 type: ActionType.UPDATE_METRIC_FORMAT,
                 payload: args,
-                options: {
-                    shouldFetchResults: true,
-                },
             });
         },
         [],
@@ -1442,10 +1384,9 @@ const ExplorerProvider: FC<
     ]);
 
     useEffect(() => {
-        if (!state.shouldFetchResults || !reducerState.autoFetchEnabled) return;
+        if (!reducerState.autoFetchEnabled) return;
         runQuery();
-        dispatch({ type: ActionType.SET_FETCH_RESULTS_FALSE });
-    }, [runQuery, state.shouldFetchResults, reducerState.autoFetchEnabled]);
+    }, [runQuery, reducerState.autoFetchEnabled]);
 
     const queryClient = useQueryClient();
     const clearExplore = useCallback(async () => {

--- a/packages/frontend/src/providers/Explorer/defaultState.ts
+++ b/packages/frontend/src/providers/Explorer/defaultState.ts
@@ -3,6 +3,7 @@ import { EMPTY_CARTESIAN_CHART_CONFIG } from '../../hooks/cartesianChartConfig/u
 import { ExplorerSection, type ExplorerReduceState } from './types';
 
 export const defaultState: ExplorerReduceState = {
+    autoFetchEnabled: true,
     isVisualizationConfigOpen: false,
     shouldFetchResults: false,
     previouslyFetchedState: undefined,

--- a/packages/frontend/src/providers/Explorer/defaultState.ts
+++ b/packages/frontend/src/providers/Explorer/defaultState.ts
@@ -3,7 +3,6 @@ import { EMPTY_CARTESIAN_CHART_CONFIG } from '../../hooks/cartesianChartConfig/u
 import { ExplorerSection, type ExplorerReduceState } from './types';
 
 export const defaultState: ExplorerReduceState = {
-    autoFetchEnabled: true,
     isVisualizationConfigOpen: false,
     previouslyFetchedState: undefined,
     expandedSections: [ExplorerSection.RESULTS, ExplorerSection.PARAMETERS],

--- a/packages/frontend/src/providers/Explorer/defaultState.ts
+++ b/packages/frontend/src/providers/Explorer/defaultState.ts
@@ -5,7 +5,6 @@ import { ExplorerSection, type ExplorerReduceState } from './types';
 export const defaultState: ExplorerReduceState = {
     autoFetchEnabled: true,
     isVisualizationConfigOpen: false,
-    shouldFetchResults: false,
     previouslyFetchedState: undefined,
     expandedSections: [ExplorerSection.RESULTS, ExplorerSection.PARAMETERS],
     unsavedChartVersion: {

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -83,6 +83,7 @@ export enum ActionType {
     REPLACE_FIELDS,
     OPEN_VISUALIZATION_CONFIG,
     CLOSE_VISUALIZATION_CONFIG,
+    SET_AUTO_FETCH_ENABLED,
 }
 
 export type ConfigCacheMap = {
@@ -246,9 +247,14 @@ export type Action =
       }
     | {
           type: ActionType.CLOSE_VISUALIZATION_CONFIG;
+      }
+    | {
+          type: ActionType.SET_AUTO_FETCH_ENABLED;
+          payload: boolean;
       };
 
 export interface ExplorerReduceState {
+    autoFetchEnabled: boolean;
     shouldFetchResults: boolean;
     expandedSections: ExplorerSection[];
     metadata?: {
@@ -369,5 +375,6 @@ export interface ExplorerContextType {
         getDownloadQueryUuid: (limit: number | null) => Promise<string>;
         openVisualizationConfig: () => void;
         closeVisualizationConfig: () => void;
+        setAutoFetchEnabled: (autoFetchEnabled: boolean) => void;
     };
 }

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -82,7 +82,6 @@ export enum ActionType {
     REPLACE_FIELDS,
     OPEN_VISUALIZATION_CONFIG,
     CLOSE_VISUALIZATION_CONFIG,
-    SET_AUTO_FETCH_ENABLED,
 }
 
 export type ConfigCacheMap = {
@@ -245,14 +244,9 @@ export type Action =
       }
     | {
           type: ActionType.CLOSE_VISUALIZATION_CONFIG;
-      }
-    | {
-          type: ActionType.SET_AUTO_FETCH_ENABLED;
-          payload: boolean;
       };
 
 export interface ExplorerReduceState {
-    autoFetchEnabled: boolean;
     expandedSections: ExplorerSection[];
     metadata?: {
         // Temporary state that tracks changes to `table calculations` - keeps track of new name and previous name to ensure these get updated correctly when making changes to the layout & config of a chart
@@ -369,6 +363,5 @@ export interface ExplorerContextType {
         getDownloadQueryUuid: (limit: number | null) => Promise<string>;
         openVisualizationConfig: () => void;
         closeVisualizationConfig: () => void;
-        setAutoFetchEnabled: (autoFetchEnabled: boolean) => void;
     };
 }

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -63,7 +63,6 @@ export enum ActionType {
     ADD_TABLE_CALCULATION,
     UPDATE_TABLE_CALCULATION,
     DELETE_TABLE_CALCULATION,
-    SET_FETCH_RESULTS_FALSE,
     SET_PREVIOUSLY_FETCHED_STATE,
     ADD_ADDITIONAL_METRIC,
     EDIT_ADDITIONAL_METRIC,
@@ -98,7 +97,6 @@ export type ConfigCacheMap = {
 
 export type Action =
     | { type: ActionType.RESET; payload: ExplorerReduceState }
-    | { type: ActionType.SET_FETCH_RESULTS_FALSE }
     | {
           type: ActionType.SET_PREVIOUSLY_FETCHED_STATE;
           payload: MetricQuery;
@@ -255,7 +253,6 @@ export type Action =
 
 export interface ExplorerReduceState {
     autoFetchEnabled: boolean;
-    shouldFetchResults: boolean;
     expandedSections: ExplorerSection[];
     metadata?: {
         // Temporary state that tracks changes to `table calculations` - keeps track of new name and previous name to ensure these get updated correctly when making changes to the layout & config of a chart
@@ -317,10 +314,7 @@ export interface ExplorerContextType {
         moveSortFields: (sourceIndex: number, destinationIndex: number) => void;
         setRowLimit: (limit: number) => void;
         setTimeZone: (timezone: TimeZone) => void;
-        setFilters: (
-            filters: MetricQuery['filters'],
-            syncPristineState: boolean,
-        ) => void;
+        setFilters: (filters: MetricQuery['filters']) => void;
         setParameter: (key: string, value: string | string[] | null) => void;
         clearAllParameters: () => void;
         addAdditionalMetric: (metric: AdditionalMetric) => void;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10080

### Description:
Added an auto-fetch toggle button that allows users to enable/disable automatic query execution when making changes to the explorer. This gives users more control over when queries are run, especially useful for complex or resource-intensive queries.

The auto-fetch button appears in the Explorer header, with a tooltip indicating the current status. When enabled (default), queries run automatically as before. When disabled, users must manually click the refresh button to execute queries.

Auto fetch results setting is saved in the local storage.
Complete removed `shouldFetchResults` boolean from `exploreProvider`

<img width="626" height="59" alt="image" src="https://github.com/user-attachments/assets/57f80672-ca78-4fa2-b654-94b1ea1843ca" />
