### PR TITLE
fix: use useProjectUuid for subtotals

### DIFF
--- a/packages/frontend/src/hooks/useCalculateSubtotals.ts
+++ b/packages/frontend/src/hooks/useCalculateSubtotals.ts
@@ -7,12 +7,12 @@ import {
     type ParametersValuesMap,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import {
     convertDateDashboardFilters,
     convertDateFilters,
 } from '../utils/dateFilter';
+import { useProjectUuid } from './useProjectUuid';
 
 const calculateSubtotalsFromQuery = async (
     projectUuid: string,
@@ -89,7 +89,7 @@ export const useCalculateSubtotals = ({
     embedToken?: string;
     parameters?: ParametersValuesMap;
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     return useQuery<ApiCalculateSubtotalsResponse['results'], ApiError>(
         [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactored `useCalculateSubtotals` hook to use the `useProjectUuid` hook instead of directly using `useParams` from react-router.  This created problems with the SDK because that component doesn't have route params for react-router to parse. We get the projectUuid via props—which are then saved and propagated via EmbedContext. 

[Slack context](https://lightdash.slack.com/archives/C097A5L6MV2/p1753788076866199?thread_ts=1753429757.377389&cid=C097A5L6MV2)