### PR TITLE
feat: enable ai agent user access

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -99,3 +99,22 @@ export type AiAgentGroupAccessTable = Knex.CompositeTableType<
         >
     >
 >;
+
+export const AiAgentUserAccessTableName = 'ai_agent_user_access';
+
+export type DbAiAgentUserAccess = {
+    user_uuid: string;
+    ai_agent_uuid: string;
+    created_at: Date;
+};
+
+export type AiAgentUserAccessTable = Knex.CompositeTableType<
+    // base
+    DbAiAgentUserAccess,
+    // insert
+    Omit<DbAiAgentUserAccess, 'created_at'>,
+    // update
+    Partial<
+        Omit<DbAiAgentUserAccess, 'user_uuid' | 'ai_agent_uuid' | 'created_at'>
+    >
+>;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7057,17 +7057,11 @@ const models: TsoaRoute.Models = {
     PivotIndexColum: {
         dataType: 'refAlias',
         type: {
-            dataType: 'union',
-            subSchemas: [
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        type: { ref: 'VizIndexType', required: true },
-                        reference: { dataType: 'string', required: true },
-                    },
-                },
-                { dataType: 'undefined' },
-            ],
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                type: { ref: 'VizIndexType', required: true },
+                reference: { dataType: 'string', required: true },
+            },
             validators: {},
         },
     },
@@ -7117,20 +7111,23 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSqlRunnerPivotQueryPayload: {
+    SortBy: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'array',
+            array: { dataType: 'refAlias', ref: 'VizSortBy' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PivotConfiguration: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 sortBy: {
                     dataType: 'union',
-                    subSchemas: [
-                        {
-                            dataType: 'array',
-                            array: { dataType: 'refAlias', ref: 'VizSortBy' },
-                        },
-                        { dataType: 'undefined' },
-                    ],
+                    subSchemas: [{ ref: 'SortBy' }, { dataType: 'undefined' }],
                     required: true,
                 },
                 groupByColumns: {
@@ -7152,9 +7149,30 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'ValuesColumn' },
                     required: true,
                 },
-                indexColumn: { ref: 'PivotIndexColum', required: true },
-                savedSqlUuid: { dataType: 'string' },
+                indexColumn: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'PivotIndexColum' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSqlRunnerPivotQueryPayload: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'PivotConfiguration' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: { savedSqlUuid: { dataType: 'string' } },
+                },
+            ],
             validators: {},
         },
     },
@@ -12139,7 +12157,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12149,7 +12167,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12159,7 +12177,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -12172,7 +12190,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -15794,15 +15812,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SortBy: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'array',
-            array: { dataType: 'refAlias', ref: 'VizSortBy' },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ReadyQueryResultsPage: {
         dataType: 'refAlias',
         type: {
@@ -15853,7 +15862,22 @@ const models: TsoaRoute.Models = {
                                             required: true,
                                         },
                                         indexColumn: {
-                                            ref: 'PivotIndexColum',
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            ref: 'PivotIndexColum',
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
+                                                { dataType: 'undefined' },
+                                            ],
                                             required: true,
                                         },
                                         totalColumnCount: {
@@ -16327,45 +16351,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        pivotConfiguration: {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                sortBy: {
-                                    dataType: 'union',
-                                    subSchemas: [
-                                        { ref: 'SortBy' },
-                                        { dataType: 'undefined' },
-                                    ],
-                                    required: true,
-                                },
-                                groupByColumns: {
-                                    dataType: 'union',
-                                    subSchemas: [
-                                        {
-                                            dataType: 'array',
-                                            array: {
-                                                dataType: 'refAlias',
-                                                ref: 'GroupByColumn',
-                                            },
-                                        },
-                                        { dataType: 'undefined' },
-                                    ],
-                                    required: true,
-                                },
-                                valuesColumns: {
-                                    dataType: 'array',
-                                    array: {
-                                        dataType: 'refAlias',
-                                        ref: 'ValuesColumn',
-                                    },
-                                    required: true,
-                                },
-                                indexColumn: {
-                                    ref: 'PivotIndexColum',
-                                    required: true,
-                                },
-                            },
-                        },
+                        pivotConfiguration: { ref: 'PivotConfiguration' },
                         limit: { dataType: 'double' },
                         sql: { dataType: 'string', required: true },
                     },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4481,7 +4481,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_':
+    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_':
         {
             dataType: 'refAlias',
             type: {
@@ -4543,6 +4543,11 @@ const models: TsoaRoute.Models = {
                         array: { dataType: 'string' },
                         required: true,
                     },
+                    userAccess: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4551,7 +4556,7 @@ const models: TsoaRoute.Models = {
     AiAgentSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_',
+            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_',
             validators: {},
         },
     },
@@ -4572,7 +4577,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_':
         {
             dataType: 'refAlias',
             type: {
@@ -4634,6 +4639,11 @@ const models: TsoaRoute.Models = {
                         array: { dataType: 'string' },
                         required: true,
                     },
+                    userAccess: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4642,7 +4652,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_',
             validators: {},
         },
     },
@@ -4671,7 +4681,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess_':
+    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_':
         {
             dataType: 'refAlias',
             type: {
@@ -4729,6 +4739,11 @@ const models: TsoaRoute.Models = {
                         array: { dataType: 'string' },
                         required: true,
                     },
+                    userAccess: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
                 },
                 validators: {},
             },
@@ -4737,12 +4752,12 @@ const models: TsoaRoute.Models = {
     ApiCreateAiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess_',
+            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess__':
         {
             dataType: 'refAlias',
             type: {
@@ -4822,6 +4837,16 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    userAccess: {
+                        dataType: 'union',
+                        subSchemas: [
+                            {
+                                dataType: 'array',
+                                array: { dataType: 'string' },
+                            },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                 },
                 validators: {},
             },
@@ -4833,7 +4858,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -7495,7 +7520,6 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 name: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
-                isPrivate: { dataType: 'boolean', required: true },
                 userAccess: {
                     dataType: 'union',
                     subSchemas: [
@@ -7504,6 +7528,7 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
+                isPrivate: { dataType: 'boolean', required: true },
             },
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5050,7 +5050,7 @@
             "ItemsMap": {
                 "$ref": "#/components/schemas/Record_string.Field-or-TableCalculation-or-CustomDimension-or-Metric_"
             },
-            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_": {
+            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5109,6 +5109,12 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "userAccess": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -5122,13 +5128,14 @@
                     "updatedAt",
                     "instruction",
                     "imageUrl",
-                    "groupAccess"
+                    "groupAccess",
+                    "userAccess"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgentSummary": {
-                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_"
+                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_"
             },
             "ApiAiAgentSummaryResponse": {
                 "properties": {
@@ -5147,7 +5154,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5206,6 +5213,12 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "userAccess": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -5219,13 +5232,14 @@
                     "updatedAt",
                     "instruction",
                     "imageUrl",
-                    "groupAccess"
+                    "groupAccess",
+                    "userAccess"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -5255,7 +5269,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess_": {
+            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5296,6 +5310,12 @@
                         "nullable": true
                     },
                     "groupAccess": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "userAccess": {
                         "items": {
                             "type": "string"
                         },
@@ -5309,15 +5329,16 @@
                     "tags",
                     "instruction",
                     "imageUrl",
-                    "groupAccess"
+                    "groupAccess",
+                    "userAccess"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ApiCreateAiAgent": {
-                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess_"
+                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_"
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5362,6 +5383,12 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "userAccess": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "type": "object",
@@ -5370,7 +5397,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess__"
                     },
                     {
                         "properties": {
@@ -8152,11 +8179,11 @@
                     "uuid": {
                         "type": "string"
                     },
-                    "isPrivate": {
-                        "type": "boolean"
-                    },
                     "userAccess": {
                         "$ref": "#/components/schemas/SpaceShare"
+                    },
+                    "isPrivate": {
+                        "type": "boolean"
                     }
                 },
                 "required": ["name", "uuid", "isPrivate"],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7824,13 +7824,16 @@
                 "required": ["direction", "reference"],
                 "type": "object"
             },
-            "ApiSqlRunnerPivotQueryPayload": {
+            "SortBy": {
+                "items": {
+                    "$ref": "#/components/schemas/VizSortBy"
+                },
+                "type": "array"
+            },
+            "PivotConfiguration": {
                 "properties": {
                     "sortBy": {
-                        "items": {
-                            "$ref": "#/components/schemas/VizSortBy"
-                        },
-                        "type": "array"
+                        "$ref": "#/components/schemas/SortBy"
                     },
                     "groupByColumns": {
                         "items": {
@@ -7846,13 +7849,25 @@
                     },
                     "indexColumn": {
                         "$ref": "#/components/schemas/PivotIndexColum"
-                    },
-                    "savedSqlUuid": {
-                        "type": "string"
                     }
                 },
-                "required": ["valuesColumns", "indexColumn"],
+                "required": ["valuesColumns"],
                 "type": "object"
+            },
+            "ApiSqlRunnerPivotQueryPayload": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/PivotConfiguration"
+                    },
+                    {
+                        "properties": {
+                            "savedSqlUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
             },
             "SqlRunnerPivotQueryBody": {
                 "allOf": [
@@ -12945,22 +12960,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -16681,12 +16696,6 @@
                 ],
                 "type": "object"
             },
-            "SortBy": {
-                "items": {
-                    "$ref": "#/components/schemas/VizSortBy"
-                },
-                "type": "array"
-            },
             "ReadyQueryResultsPage": {
                 "allOf": [
                     {
@@ -16726,7 +16735,6 @@
                                 "required": [
                                     "originalColumns",
                                     "valuesColumns",
-                                    "indexColumn",
                                     "totalColumnCount"
                                 ],
                                 "type": "object",
@@ -17176,28 +17184,7 @@
                     {
                         "properties": {
                             "pivotConfiguration": {
-                                "properties": {
-                                    "sortBy": {
-                                        "$ref": "#/components/schemas/SortBy"
-                                    },
-                                    "groupByColumns": {
-                                        "items": {
-                                            "$ref": "#/components/schemas/GroupByColumn"
-                                        },
-                                        "type": "array"
-                                    },
-                                    "valuesColumns": {
-                                        "items": {
-                                            "$ref": "#/components/schemas/ValuesColumn"
-                                        },
-                                        "type": "array"
-                                    },
-                                    "indexColumn": {
-                                        "$ref": "#/components/schemas/PivotIndexColum"
-                                    }
-                                },
-                                "required": ["valuesColumns", "indexColumn"],
-                                "type": "object"
+                                "$ref": "#/components/schemas/PivotConfiguration"
                             },
                             "limit": {
                                 "type": "number",
@@ -18213,7 +18200,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1875.5",
+        "version": "0.1876.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/vitest.setup.integration.ts
+++ b/packages/backend/src/vitest.setup.integration.ts
@@ -185,6 +185,7 @@ export const setupIntegrationTest =
             integrations: [],
             instruction: 'You are a helpful AI assistant for testing purposes.',
             groupAccess: [],
+            userAccess: [],
             imageUrl: null,
         };
 

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -51,6 +51,7 @@ export const baseAgentSchema = z.object({
     provider: z.string(),
     model: z.string(),
     groupAccess: z.array(z.string()),
+    userAccess: z.array(z.string()),
 });
 
 export type BaseAiAgent = z.infer<typeof baseAgentSchema>;
@@ -68,6 +69,7 @@ export type AiAgent = Pick<
     | 'instruction'
     | 'imageUrl'
     | 'groupAccess'
+    | 'userAccess'
 >;
 
 export type AiAgentSummary = Pick<
@@ -83,6 +85,7 @@ export type AiAgentSummary = Pick<
     | 'instruction'
     | 'imageUrl'
     | 'groupAccess'
+    | 'userAccess'
 >;
 
 export type AiAgentUser = {
@@ -160,6 +163,7 @@ export type ApiCreateAiAgent = Pick<
     | 'instruction'
     | 'imageUrl'
     | 'groupAccess'
+    | 'userAccess'
 >;
 
 export type ApiUpdateAiAgent = Partial<
@@ -172,6 +176,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'instruction'
         | 'imageUrl'
         | 'groupAccess'
+        | 'userAccess'
     >
 > & {
     uuid: string;

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -1,24 +1,10 @@
 import { subject } from '@casl/ability';
-import {
-    FeatureFlags,
-    ProjectMemberRole,
-    convertOrganizationRoleToProjectRole,
-    convertProjectRoleToOrganizationRole,
-    getHighestProjectRole,
-    isGroupWithMembers,
-    type InheritedRoles,
-    type OrganizationMemberRole,
-} from '@lightdash/common';
 import { ActionIcon, Paper, Table, TextInput } from '@mantine/core';
 import { IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
-import { useProjectGroupAccessList } from '../../features/projectGroupAccess/hooks/useProjectGroupAccess';
 import { useTableStyles } from '../../hooks/styles/useTableStyles';
-import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
-import { useOrganizationGroups } from '../../hooks/useOrganizationGroups';
-import { useOrganizationUsers } from '../../hooks/useOrganizationUsers';
-import { useProjectAccess } from '../../hooks/useProjectAccess';
+import { useProjectUsersWithRoles } from '../../hooks/useProjectUsersWithRoles';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useApp from '../../providers/App/useApp';
 import LoadingState from '../common/LoadingState';
@@ -40,99 +26,14 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
 }) => {
     const { user } = useApp();
 
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
-        FeatureFlags.UserGroupsEnabled,
-    );
     const ability = useAbilityContext();
 
     const { cx, classes } = useTableStyles();
 
     const [search, setSearch] = useState('');
 
-    const {
-        data: organizationUsers,
-        isInitialLoading: isOrganizationUsersLoading,
-    } = useOrganizationUsers();
-
-    const { data: groups } = useOrganizationGroups(
-        { includeMembers: 5 },
-        {
-            enabled:
-                userGroupsFeatureFlagQuery.isSuccess &&
-                userGroupsFeatureFlagQuery.data.enabled,
-        },
-    );
-
-    const { data: projectAccess, isInitialLoading: isProjectAccessLoading } =
-        useProjectAccess(projectUuid);
-
-    const { data: projectGroupAccess } = useProjectGroupAccessList(projectUuid);
-
-    const orgRoles = useMemo(() => {
-        if (!organizationUsers || !projectAccess) return undefined;
-
-        return organizationUsers.reduce<Record<string, OrganizationMemberRole>>(
-            (acc, orgUser) => {
-                return {
-                    ...acc,
-                    [orgUser.userUuid]: orgUser.role,
-                };
-            },
-            {},
-        );
-    }, [organizationUsers, projectAccess]);
-
-    const groupRoles = useMemo(() => {
-        if (!organizationUsers) return {};
-        if (!projectGroupAccess) return {};
-        if (!groups) return {};
-
-        return organizationUsers.reduce<Record<string, ProjectMemberRole>>(
-            (aggregatedRoles, orgUser) => {
-                const userGroupRoles = projectGroupAccess.reduce<
-                    ProjectMemberRole[]
-                >((userRoles, groupAccess) => {
-                    const group = groups.find(
-                        (g) => g.uuid === groupAccess.groupUuid,
-                    );
-                    if (!group || !isGroupWithMembers(group)) return userRoles;
-                    if (!group.memberUuids.includes(orgUser.userUuid))
-                        return userRoles;
-
-                    return [...userRoles, groupAccess.role];
-                }, []);
-
-                const highestRole = getHighestProjectRole(
-                    userGroupRoles.map((role) => ({
-                        type: 'group',
-                        role,
-                    })),
-                );
-
-                if (!highestRole) return aggregatedRoles;
-
-                return {
-                    ...aggregatedRoles,
-                    [orgUser.userUuid]: highestRole.role,
-                };
-            },
-            {},
-        );
-    }, [organizationUsers, projectGroupAccess, groups]);
-
-    const projectRoles = useMemo(() => {
-        if (!projectAccess) return {};
-
-        return projectAccess.reduce<Record<string, ProjectMemberRole>>(
-            (acc, projectMember) => {
-                return {
-                    ...acc,
-                    [projectMember.userUuid]: projectMember.role,
-                };
-            },
-            {},
-        );
-    }, [projectAccess]);
+    const { usersWithProjectRole, isLoading, inheritedRoles } =
+        useProjectUsersWithRoles(projectUuid);
 
     const canManageProjectAccess = ability.can(
         'manage',
@@ -141,59 +42,6 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
             projectUuid,
         }),
     );
-
-    const inheritedRoles = useMemo(() => {
-        // Organization users and org roles are not always available, and we don't want to show the user access page if they are not available
-        if (!organizationUsers || !orgRoles) return undefined;
-        return organizationUsers.reduce<Record<string, InheritedRoles>>(
-            (acc, orgUser) => {
-                return {
-                    ...acc,
-                    [orgUser.userUuid]: [
-                        {
-                            type: 'organization',
-                            role: convertOrganizationRoleToProjectRole(
-                                orgRoles[orgUser.userUuid],
-                            ),
-                        },
-                        {
-                            type: 'group',
-                            role: groupRoles[orgUser.userUuid],
-                        },
-                        {
-                            type: 'project',
-                            role: projectRoles[orgUser.userUuid],
-                        },
-                    ],
-                };
-            },
-            {},
-        );
-    }, [organizationUsers, orgRoles, groupRoles, projectRoles]);
-
-    const usersWithProjectRole = useMemo(() => {
-        if (!organizationUsers || !inheritedRoles) return [];
-
-        return organizationUsers.map((orgUser) => {
-            const highestRole = getHighestProjectRole(
-                inheritedRoles[orgUser.userUuid],
-            );
-            const hasProjectRole = !!projectRoles[orgUser.userUuid];
-            const inheritedRole = highestRole?.role
-                ? convertProjectRoleToOrganizationRole(highestRole.role)
-                : orgUser.role;
-            return {
-                ...orgUser,
-                finalRole: hasProjectRole
-                    ? convertProjectRoleToOrganizationRole(
-                          projectRoles[orgUser.userUuid] ||
-                              ProjectMemberRole.VIEWER,
-                      )
-                    : inheritedRole,
-                inheritedRole: inheritedRoles?.[orgUser.userUuid],
-            };
-        });
-    }, [organizationUsers, projectRoles, inheritedRoles]);
 
     const filteredUsers = useMemo(() => {
         if (search && usersWithProjectRole) {
@@ -211,7 +59,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
         return usersWithProjectRole;
     }, [usersWithProjectRole, search, inheritedRoles]);
 
-    if (isProjectAccessLoading || isOrganizationUsersLoading) {
+    if (isLoading) {
         return <LoadingState title="Loading user access" />;
     }
 

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccessRow.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccessRow.tsx
@@ -3,7 +3,6 @@ import {
     ProjectMemberRoleLabels,
     getHighestProjectRole,
     type InheritedRoles,
-    type OrganizationMemberProfile,
     type ProjectRole,
 } from '@lightdash/common';
 import {
@@ -23,13 +22,14 @@ import {
     useRevokeProjectAccessMutation,
     useUpdateProjectAccessMutation,
 } from '../../hooks/useProjectAccess';
+import { type ProjectUserWithRole } from '../../hooks/useProjectUsersWithRoles';
 import MantineIcon from '../common/MantineIcon';
 import RemoveProjectAccessModal from './RemoveProjectAccessModal';
 
 type Props = {
     projectUuid: string;
     canManageProjectAccess: boolean;
-    user: OrganizationMemberProfile;
+    user: ProjectUserWithRole;
     inheritedRoles: InheritedRoles | undefined;
 };
 

--- a/packages/frontend/src/components/ProjectAccess/RemoveProjectAccessModal.tsx
+++ b/packages/frontend/src/components/ProjectAccess/RemoveProjectAccessModal.tsx
@@ -1,11 +1,11 @@
-import { type OrganizationMemberProfile } from '@lightdash/common';
 import { Button, Group, Modal, Text, Title } from '@mantine/core';
 import { IconKey } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { type ProjectUserWithRole } from '../../hooks/useProjectUsersWithRoles';
 import MantineIcon from '../common/MantineIcon';
 
 type Props = {
-    user: OrganizationMemberProfile;
+    user: ProjectUserWithRole;
     onDelete: () => void;
     onClose: () => void;
 };

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -629,8 +629,8 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                 isLoadingProjectUsers
                                                     ? 'Loading users...'
                                                     : userOptions.length === 0
-                                                      ? 'No users available'
-                                                      : 'Select users'
+                                                    ? 'No users available'
+                                                    : 'Select users'
                                             }
                                             data={userOptions}
                                             disabled={
@@ -695,9 +695,9 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                         isLoadingGroups
                                                             ? 'Loading groups...'
                                                             : groupOptions.length ===
-                                                                0
-                                                              ? 'No groups available'
-                                                              : 'Select groups or leave empty for all users'
+                                                              0
+                                                            ? 'No groups available'
+                                                            : 'Select groups or leave empty for all users'
                                                     }
                                                     data={groupOptions}
                                                     disabled={
@@ -871,8 +871,8 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                     {!slackInstallation?.organizationUuid
                                                         ? 'Disabled'
                                                         : !slackChannelsConfigured
-                                                          ? 'Channels not configured'
-                                                          : 'Enabled'}
+                                                        ? 'Channels not configured'
+                                                        : 'Enabled'}
                                                 </Text>
                                             </Group>
                                         </Group>
@@ -986,7 +986,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                                             type: 'slack',
                                                                             channelId:
                                                                                 v,
-                                                                        }) as const,
+                                                                        } as const),
                                                                 ),
                                                             );
                                                         }}

--- a/packages/frontend/src/hooks/useProjectUsersWithRoles.ts
+++ b/packages/frontend/src/hooks/useProjectUsersWithRoles.ts
@@ -1,0 +1,188 @@
+import {
+    FeatureFlags,
+    ProjectMemberRole,
+    convertOrganizationRoleToProjectRole,
+    convertProjectRoleToOrganizationRole,
+    getHighestProjectRole,
+    isGroupWithMembers,
+    type InheritedRoles,
+    type OrganizationMemberProfile,
+    type OrganizationMemberRole,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import { useProjectGroupAccessList } from '../features/projectGroupAccess/hooks/useProjectGroupAccess';
+import { useFeatureFlag } from './useFeatureFlagEnabled';
+import { useOrganizationGroups } from './useOrganizationGroups';
+import { useOrganizationUsers } from './useOrganizationUsers';
+import { useProjectAccess } from './useProjectAccess';
+
+export type ProjectUserWithRole = Omit<OrganizationMemberProfile, 'role'> & {
+    inheritedRole: InheritedRoles | undefined;
+    finalRole: OrganizationMemberRole;
+    projectUuid: string;
+    role: ProjectMemberRole;
+};
+
+export const useProjectUsersWithRoles = (projectUuid: string) => {
+    const userGroupsFeatureFlagQuery = useFeatureFlag(
+        FeatureFlags.UserGroupsEnabled,
+    );
+
+    const organizationUsersQuery = useOrganizationUsers();
+
+    const groupsQuery = useOrganizationGroups(
+        { includeMembers: 5 },
+        {
+            enabled:
+                userGroupsFeatureFlagQuery.isSuccess &&
+                userGroupsFeatureFlagQuery.data.enabled,
+        },
+    );
+
+    const projectAccessQuery = useProjectAccess(projectUuid);
+
+    const projectGroupAccessQuery = useProjectGroupAccessList(projectUuid);
+
+    const orgRoles = useMemo(() => {
+        if (!organizationUsersQuery.isSuccess || !projectAccessQuery.isSuccess)
+            return undefined;
+
+        return organizationUsersQuery.data.reduce<
+            Record<string, OrganizationMemberRole>
+        >((acc, orgUser) => {
+            return {
+                ...acc,
+                [orgUser.userUuid]: orgUser.role,
+            };
+        }, {});
+    }, [organizationUsersQuery, projectAccessQuery]);
+
+    const groupRoles = useMemo(() => {
+        if (
+            !organizationUsersQuery.isSuccess ||
+            !projectGroupAccessQuery.isSuccess ||
+            !groupsQuery.isSuccess
+        )
+            return {};
+
+        return organizationUsersQuery.data.reduce<
+            Record<string, ProjectMemberRole>
+        >((aggregatedRoles, orgUser) => {
+            const userGroupRoles = projectGroupAccessQuery.data.reduce<
+                ProjectMemberRole[]
+            >((userRoles, groupAccess) => {
+                const group = groupsQuery.data.find(
+                    (g) => g.uuid === groupAccess.groupUuid,
+                );
+                if (!group || !isGroupWithMembers(group)) return userRoles;
+                if (!group.memberUuids.includes(orgUser.userUuid))
+                    return userRoles;
+
+                return [...userRoles, groupAccess.role];
+            }, []);
+
+            const highestRole = getHighestProjectRole(
+                userGroupRoles.map((role) => ({
+                    type: 'group',
+                    role,
+                })),
+            );
+
+            if (!highestRole) return aggregatedRoles;
+
+            return {
+                ...aggregatedRoles,
+                [orgUser.userUuid]: highestRole.role,
+            };
+        }, {});
+    }, [organizationUsersQuery, projectGroupAccessQuery, groupsQuery]);
+
+    const projectRoles = useMemo(() => {
+        if (!projectAccessQuery.isSuccess) return {};
+
+        return projectAccessQuery.data.reduce<
+            Record<string, ProjectMemberRole>
+        >((acc, projectMember) => {
+            return {
+                ...acc,
+                [projectMember.userUuid]: projectMember.role,
+            };
+        }, {});
+    }, [projectAccessQuery]);
+
+    const inheritedRoles = useMemo(() => {
+        // Organization users and org roles are not always available, and we don't want to show the user access page if they are not available
+        if (!organizationUsersQuery.isSuccess || !orgRoles) return undefined;
+        return organizationUsersQuery.data.reduce<
+            Record<string, InheritedRoles>
+        >((acc, orgUser) => {
+            return {
+                ...acc,
+                [orgUser.userUuid]: [
+                    {
+                        type: 'organization',
+                        role: convertOrganizationRoleToProjectRole(
+                            orgRoles[orgUser.userUuid],
+                        ),
+                    },
+                    {
+                        type: 'group',
+                        role: groupRoles[orgUser.userUuid],
+                    },
+                    {
+                        type: 'project',
+                        role: projectRoles[orgUser.userUuid],
+                    },
+                ],
+            };
+        }, {});
+    }, [organizationUsersQuery, orgRoles, groupRoles, projectRoles]);
+
+    const usersWithProjectRole: ProjectUserWithRole[] = useMemo(() => {
+        if (!organizationUsersQuery.isSuccess || !inheritedRoles) return [];
+
+        return organizationUsersQuery.data.map((orgUser) => {
+            const highestRole = getHighestProjectRole(
+                inheritedRoles[orgUser.userUuid],
+            );
+            const hasProjectRole = !!projectRoles[orgUser.userUuid];
+            const inheritedRole = highestRole?.role
+                ? convertProjectRoleToOrganizationRole(highestRole.role)
+                : orgUser.role;
+            return {
+                ...orgUser,
+                role:
+                    projectRoles[orgUser.userUuid] || ProjectMemberRole.VIEWER,
+                finalRole: hasProjectRole
+                    ? convertProjectRoleToOrganizationRole(
+                          projectRoles[orgUser.userUuid] ||
+                              ProjectMemberRole.VIEWER,
+                      )
+                    : inheritedRole,
+                inheritedRole: inheritedRoles?.[orgUser.userUuid],
+                projectUuid,
+            };
+        });
+    }, [organizationUsersQuery, projectRoles, inheritedRoles, projectUuid]);
+
+    const usersDictionary = useMemo(() => {
+        if (!usersWithProjectRole) return {};
+
+        return usersWithProjectRole.reduce<Record<string, ProjectUserWithRole>>(
+            (acc, user) => ({
+                ...acc,
+                [user.userUuid]: user,
+            }),
+            {},
+        );
+    }, [usersWithProjectRole]);
+
+    return {
+        usersWithProjectRole,
+        usersDictionary,
+        isLoading:
+            projectAccessQuery.isInitialLoading ||
+            organizationUsersQuery.isInitialLoading,
+        inheritedRoles,
+    };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10245

### Description:
This PR adds user-level access control for AI Agents, allowing specific users to be granted access to an agent regardless of their group membership. The implementation includes:


1. Updated the AI Agent model to include user access in queries and CRUD operations
2. Enhanced the access check logic in `AiAgentService` to verify user access alongside group access
3. Updated the frontend to allow selecting specific users when creating or editing an AI agent

> [!NOTE]
> Created a reusable hook to get the _final_ role a user has. For example, a user might be org editor but downgraded to project viewer - the highest role is respected!

This provides more granular control over who can access AI agents, especially useful for giving access to specific users who may not be in groups with access.

[demo-user-access.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/70017ea6-3f4d-449a-a42c-d3eb83593b9f.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/70017ea6-3f4d-449a-a42c-d3eb83593b9f.mov)

