### PR TITLE
feat: bump sdk version to match latest release

### DIFF
--- a/packages/frontend/sdk/package.json
+++ b/packages/frontend/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/sdk",
-    "version": "0.1818.0",
+    "version": "0.1855.1",
     "private": false,
     "files": [
         "dist"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15541

### Description:
Bumps the version of `@lightdash/sdk` from `0.1818.0` to `0.1855.1`.