### PR TITLE
refactor: restructure filter schemas with type literals for better validation

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/findFields.ts
@@ -3,6 +3,7 @@ import {
     CatalogField,
     convertToAiHints,
     FieldType,
+    getFilterTypeFromItemType,
     getItemId,
     isEmojiIcon,
     toolFindFieldsArgsSchema,
@@ -40,9 +41,11 @@ const getFieldText = (catalogField: CatalogField) => {
     <${fieldTypeLabel} fieldId="${getItemId({
         name: catalogField.name,
         table: catalogField.tableName,
-    })}" fieldType="${catalogField.fieldValueType}" fieldFilterType="${
-        catalogField.basicType
-    }">
+    })}" fieldType="${
+        catalogField.fieldValueType
+    }" fieldFilterType="${getFilterTypeFromItemType(
+        catalogField.fieldValueType,
+    )}">
         <Name>${catalogField.name}</Name>
         <Label>${catalogField.label}</Label>
         <SearchRank>${catalogField.searchRank}</SearchRank>

--- a/packages/common/src/ee/AiAgent/schemas/fieldType.ts
+++ b/packages/common/src/ee/AiAgent/schemas/fieldType.ts
@@ -1,9 +1,0 @@
-import { z } from 'zod';
-import { DimensionType, MetricType } from '../../../types/field';
-
-const dimensionTypeSchema = z.nativeEnum(DimensionType);
-const metricTypeSchema = z.nativeEnum(MetricType);
-
-const fieldTypeSchema = z.union([dimensionTypeSchema, metricTypeSchema]);
-
-export default fieldTypeSchema;

--- a/packages/common/src/ee/AiAgent/schemas/filters/booleanFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/booleanFilters.ts
@@ -1,14 +1,25 @@
 import { z } from 'zod';
-import { FilterOperator } from '../../../../types/filter';
+import { DimensionType, MetricType } from '../../../../types/field';
+import { FilterOperator, FilterType } from '../../../../types/filter';
+import { getFieldIdSchema } from '../fieldId';
+
+const commonBooleanFilterRuleSchema = z.object({
+    fieldId: getFieldIdSchema({ additionalDescription: null }),
+    fieldType: z.union([
+        z.literal(DimensionType.BOOLEAN),
+        z.literal(MetricType.BOOLEAN),
+    ]),
+    fieldFilterType: z.literal(FilterType.BOOLEAN),
+});
 
 const booleanFilterSchema = z.union([
-    z.object({
+    commonBooleanFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.NULL),
             z.literal(FilterOperator.NOT_NULL),
         ]),
     }),
-    z.object({
+    commonBooleanFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.EQUALS),
             z.literal(FilterOperator.NOT_EQUALS),

--- a/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
@@ -1,26 +1,43 @@
 import { z } from 'zod';
-import { FilterOperator, UnitOfTime } from '../../../../types/filter';
+import { DimensionType, MetricType } from '../../../../types/field';
+import {
+    FilterOperator,
+    FilterType,
+    UnitOfTime,
+} from '../../../../types/filter';
+import { getFieldIdSchema } from '../fieldId';
 
 const dateOrDateTimeSchema = z.union([
     z.string().date(),
     z.string().datetime(),
 ]);
 
+const commonDateFilterRuleSchema = z.object({
+    fieldId: getFieldIdSchema({ additionalDescription: null }),
+    fieldType: z.union([
+        z.literal(DimensionType.DATE),
+        z.literal(DimensionType.TIMESTAMP),
+        z.literal(MetricType.DATE),
+        z.literal(MetricType.TIMESTAMP),
+    ]),
+    fieldFilterType: z.literal(FilterType.DATE),
+});
+
 const dateFilterSchema = z.union([
-    z.object({
+    commonDateFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.NULL),
             z.literal(FilterOperator.NOT_NULL),
         ]),
     }),
-    z.object({
+    commonDateFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.EQUALS),
             z.literal(FilterOperator.NOT_EQUALS),
         ]),
         values: z.array(dateOrDateTimeSchema),
     }),
-    z.object({
+    commonDateFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.IN_THE_PAST),
             z.literal(FilterOperator.NOT_IN_THE_PAST),
@@ -39,7 +56,7 @@ const dateFilterSchema = z.union([
             ]),
         }),
     }),
-    z.object({
+    commonDateFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.IN_THE_CURRENT),
             z.literal(FilterOperator.NOT_IN_THE_CURRENT),
@@ -56,7 +73,7 @@ const dateFilterSchema = z.union([
             ]),
         }),
     }),
-    z.object({
+    commonDateFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.LESS_THAN),
             z.literal(FilterOperator.LESS_THAN_OR_EQUAL),
@@ -65,7 +82,7 @@ const dateFilterSchema = z.union([
         ]),
         values: z.array(dateOrDateTimeSchema).length(1),
     }),
-    z.object({
+    commonDateFilterRuleSchema.extend({
         operator: z.literal(FilterOperator.IN_BETWEEN),
         values: z.array(dateOrDateTimeSchema).length(2),
     }),

--- a/packages/common/src/ee/AiAgent/schemas/filters/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/index.ts
@@ -2,53 +2,44 @@ import { v4 as uuid } from 'uuid';
 import { z } from 'zod';
 import type { FilterRule, Filters } from '../../../../types/filter';
 import assertUnreachable from '../../../../utils/assertUnreachable';
-import { getFieldIdSchema } from '../fieldId';
+
 import booleanFilterSchema from './booleanFilters';
 import dateFilterSchema from './dateFilters';
 import numberFilterSchema from './numberFilters';
 import stringFilterSchema from './stringFilters';
 
-const filterRuleTypeSchema = z
-    .enum(['date', 'timestamp', 'number', 'string', 'boolean'])
-    .describe('"fieldFilterType" of the field');
+const filterAndOrSchema = z
+    .union([z.literal('and'), z.literal('or')])
+    .describe('Type of filter group operation');
 
-const filterRuleSchema = z.object({
-    type: z.enum(['or', 'and']).describe('Type of filter group operation'),
-    target: z.object({
-        fieldId: getFieldIdSchema({ additionalDescription: null }),
-        type: filterRuleTypeSchema,
-    }),
-    rule: z
-        .union([
-            booleanFilterSchema.describe('Boolean filter'),
-            stringFilterSchema.describe('String filter'),
-            numberFilterSchema.describe('Number filter'),
-            dateFilterSchema.describe('Date filter'),
-        ])
-        .describe(
-            'Filter rule for the field. You can only select filter rules that match the "fieldFilterType" type specified in the field details.',
-        ),
-});
+const filterRuleSchema = z.union([
+    booleanFilterSchema,
+    stringFilterSchema,
+    numberFilterSchema,
+    dateFilterSchema,
+]);
 
 const filterRuleSchemaTransformed = filterRuleSchema.transform(
     (data): FilterRule => ({
         id: uuid(),
-        target: data.target,
-        operator: data.rule.operator,
-        values: 'values' in data.rule ? data.rule.values : [],
-        ...('settings' in data.rule ? { settings: data.rule.settings } : {}),
+        target: {
+            fieldId: data.fieldId,
+        },
+        operator: data.operator,
+        values: 'values' in data ? data.values : [],
+        ...('settings' in data ? { settings: data.settings } : {}),
     }),
 );
 
 export const filtersSchema = z.object({
-    type: z.enum(['and', 'or']).describe('Type of filter group operation'),
+    type: filterAndOrSchema,
     dimensions: z.array(filterRuleSchema).nullable(),
     metrics: z.array(filterRuleSchema).nullable(),
 });
 
 const filtersSchemaAndFilterRulesTransformed = z
     .object({
-        type: z.enum(['and', 'or']).describe('Type of filter group operation'),
+        type: filterAndOrSchema,
         dimensions: z.array(filterRuleSchemaTransformed).nullable(),
         metrics: z.array(filterRuleSchemaTransformed).nullable(),
     })

--- a/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
@@ -1,21 +1,40 @@
 import { z } from 'zod';
-import { FilterOperator } from '../../../../types/filter';
+import { DimensionType, MetricType } from '../../../../types/field';
+import { FilterOperator, FilterType } from '../../../../types/filter';
+import { getFieldIdSchema } from '../fieldId';
+
+const commonNumberFilterRuleSchema = z.object({
+    fieldId: getFieldIdSchema({ additionalDescription: null }),
+    fieldType: z.union([
+        z.literal(DimensionType.NUMBER),
+        z.literal(MetricType.NUMBER),
+        z.literal(MetricType.PERCENTILE),
+        z.literal(MetricType.MEDIAN),
+        z.literal(MetricType.AVERAGE),
+        z.literal(MetricType.COUNT),
+        z.literal(MetricType.COUNT_DISTINCT),
+        z.literal(MetricType.SUM),
+        z.literal(MetricType.MIN),
+        z.literal(MetricType.MAX),
+    ]),
+    fieldFilterType: z.literal(FilterType.NUMBER),
+});
 
 const numberFilterSchema = z.union([
-    z.object({
+    commonNumberFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.NULL),
             z.literal(FilterOperator.NOT_NULL),
         ]),
     }),
-    z.object({
+    commonNumberFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.EQUALS),
             z.literal(FilterOperator.NOT_EQUALS),
         ]),
         values: z.array(z.number()),
     }),
-    z.object({
+    commonNumberFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.LESS_THAN),
             z.literal(FilterOperator.LESS_THAN_OR_EQUAL),
@@ -24,7 +43,7 @@ const numberFilterSchema = z.union([
         ]),
         values: z.array(z.number()).length(1),
     }),
-    z.object({
+    commonNumberFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.IN_BETWEEN),
             z.literal(FilterOperator.NOT_IN_BETWEEN),

--- a/packages/common/src/ee/AiAgent/schemas/filters/stringFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/stringFilters.ts
@@ -1,14 +1,25 @@
 import { z } from 'zod';
-import { FilterOperator } from '../../../../types/filter';
+import { DimensionType, MetricType } from '../../../../types/field';
+import { FilterOperator, FilterType } from '../../../../types/filter';
+import { getFieldIdSchema } from '../fieldId';
+
+const commonStringFilterRuleSchema = z.object({
+    fieldId: getFieldIdSchema({ additionalDescription: null }),
+    fieldType: z.union([
+        z.literal(DimensionType.STRING),
+        z.literal(MetricType.STRING),
+    ]),
+    fieldFilterType: z.literal(FilterType.STRING),
+});
 
 const stringFilterSchema = z.union([
-    z.object({
+    commonStringFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.NULL),
             z.literal(FilterOperator.NOT_NULL),
         ]),
     }),
-    z.object({
+    commonStringFilterRuleSchema.extend({
         operator: z.union([
             z.literal(FilterOperator.EQUALS),
             z.literal(FilterOperator.NOT_EQUALS),

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -8,6 +8,7 @@ import {
     type Dimension,
     type Field,
     type FieldType,
+    type Metric,
 } from './field';
 import type { KnexPaginatedData } from './knex-paginate';
 import { type ChartSummary } from './savedCharts';
@@ -68,7 +69,7 @@ export type CatalogField = Pick<
         catalogSearchUuid: string;
         type: CatalogType.Field;
         basicType: 'string' | 'number' | 'date' | 'timestamp' | 'boolean';
-        fieldValueType: Field['type'];
+        fieldValueType: Metric['type'] | Dimension['type'];
         tableName: string;
         tableGroupLabel?: string;
         tags?: string[]; // Tags from table, for filtering

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationFilters.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationFilters.tsx
@@ -6,7 +6,9 @@ import {
     getItemLabel,
     getItemLabelWithoutTableName,
     isAndFilterGroup,
+    isDimension,
     isField,
+    isMetric,
     isOrFilterGroup,
     type DimensionType,
     type FieldTarget,
@@ -25,12 +27,7 @@ import { getConditionalRuleLabel } from '../../../../../components/common/Filter
 import classes from './AgentVisualizationFilters.module.css';
 
 const FilterRuleDisplay: FC<{
-    rule: FilterRule<
-        FilterOperator,
-        FieldTarget & {
-            type: DimensionType | MetricType | TableCalculationType;
-        }
-    >;
+    rule: FilterRule<FilterOperator, FieldTarget>;
     fieldsMap: ItemsMap;
     showTablePrefix: boolean;
     compact?: boolean;
@@ -41,8 +38,14 @@ const FilterRuleDisplay: FC<{
             ? getItemLabel(field)
             : getItemLabelWithoutTableName(field)
         : friendlyName(rule.target.fieldId);
-    const filterType = getFilterTypeFromItemType(rule.target.type);
 
+    if (!isDimension(field) && !isMetric(field)) {
+        throw new Error(
+            `Field ${rule.target.fieldId} is not a dimension or metric`,
+        );
+    }
+
+    const filterType = getFilterTypeFromItemType(field.type);
     const ruleLabels = getConditionalRuleLabel(rule, filterType, displayName);
 
     return (


### PR DESCRIPTION
### Description:
Refactored filter schemas to include type information directly in the schema objects rather than in a separate target object. This simplifies the filter rule structure by:

1. Adding a `type` field to each filter schema (boolean, date, number, string)
2. Flattening the filter rule structure by removing the nested `target` and `rule` objects
3. Moving `fieldId` to the top level of the filter rule
4. Restructuring the schema transformation to match the new flattened structure

This change makes the filter schemas more consistent and easier to work with while maintaining the same validation capabilities.