### PR TITLE
chore: index catalog on integration test setup

### DIFF
--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -326,16 +326,7 @@ export class CatalogService<
         return filteredExplores;
     }
 
-    async indexCatalog(
-        projectUuid: string,
-        userUuid: string | undefined,
-        embedderFn?: (
-            documents: {
-                name: string;
-                description: string;
-            }[],
-        ) => Promise<Array<Array<number>>>,
-    ) {
+    async indexCatalog(projectUuid: string, userUuid: string | undefined) {
         const cachedExploresMap =
             await this.projectModel.getAllExploresFromCache(projectUuid);
 

--- a/packages/backend/src/vitest.setup.integration.ts
+++ b/packages/backend/src/vitest.setup.integration.ts
@@ -188,6 +188,13 @@ export const setupIntegrationTest =
             imageUrl: null,
         };
 
+        const catalogService = app.getServiceRepository().getCatalogService();
+
+        await catalogService.indexCatalog(
+            SEED_PROJECT.project_uuid,
+            testUser.userUuid,
+        );
+
         const cleanup = async () => {
             console.info('🧹 Cleaning up test environment...');
 


### PR DESCRIPTION
### Description:
Removed the unused `embedderFn` parameter from the `indexCatalog` method in the `CatalogService` class. Also added catalog indexing during integration test setup to ensure the catalog is properly indexed for tests.