### PR TITLE
fix: stop escaping SQL LIKE wildcards in string values

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.test.ts
@@ -864,47 +864,6 @@ describe('Escaping in postgres', () => {
         ).toContain(replaceWhitespace(`WHERE (( ("table1".dim1) IN (999) ))`));
     });
 
-    test('Should not escape regular characters in postgres', () => {
-        expect(postgresClientWithReplace.escapeString('%')).toBe('%');
-        expect(postgresClientWithReplace.escapeString('_')).toBe('_');
-        expect(postgresClientWithReplace.escapeString('?')).toBe('?');
-        expect(postgresClientWithReplace.escapeString('!')).toBe('!');
-        expect(postgresClientWithReplace.escapeString('credit_card')).toBe(
-            'credit_card',
-        );
-
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: {
-                        ...METRIC_QUERY,
-                        filters: {
-                            dimensions: {
-                                id: '7e750e7c-8098-4a90-b364-4e935ad7a7e9',
-                                and: [
-                                    {
-                                        id: 'd69d3ba0-6ff5-4437-9ef3-4ed69006ea2e',
-                                        target: { fieldId: 'table1_shared' },
-                                        operator: FilterOperator.EQUALS,
-                                        values: ['credit_card'],
-                                    },
-                                ],
-                            },
-                        },
-                    },
-                    warehouseSqlBuilder: postgresClientWithReplace,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toContain(
-            replaceWhitespace(
-                `WHERE (( ("table1".shared) IN ('credit_card') ))`,
-            ),
-        );
-    });
-
     test('Should throw when invalid number is provided', () => {
         expect(() =>
             replaceWhitespace(
@@ -1045,6 +1004,47 @@ describe('Escaping in postgres', () => {
         ).toContain(
             replaceWhitespace(
                 `WHERE (( ("table1".shared) IN ('\\\\\\') OR (1=1) ') ))`,
+            ),
+        );
+    });
+
+    test('Should not escape regular characters in postgres', () => {
+        expect(postgresClientWithReplace.escapeString('%')).toBe('%');
+        expect(postgresClientWithReplace.escapeString('_')).toBe('_');
+        expect(postgresClientWithReplace.escapeString('?')).toBe('?');
+        expect(postgresClientWithReplace.escapeString('!')).toBe('!');
+        expect(postgresClientWithReplace.escapeString('credit_card')).toBe(
+            'credit_card',
+        );
+
+        expect(
+            replaceWhitespace(
+                buildQuery({
+                    explore: EXPLORE,
+                    compiledMetricQuery: {
+                        ...METRIC_QUERY,
+                        filters: {
+                            dimensions: {
+                                id: '7e750e7c-8098-4a90-b364-4e935ad7a7e9',
+                                and: [
+                                    {
+                                        id: 'd69d3ba0-6ff5-4437-9ef3-4ed69006ea2e',
+                                        target: { fieldId: 'table1_shared' },
+                                        operator: FilterOperator.EQUALS,
+                                        values: ['credit_card'],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                    warehouseSqlBuilder: postgresClientWithReplace,
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                }).query,
+            ),
+        ).toContain(
+            replaceWhitespace(
+                `WHERE (( ("table1".shared) IN ('credit_card') ))`,
             ),
         );
     });

--- a/packages/backend/src/utils/QueryBuilder/queryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/queryBuilder.test.ts
@@ -864,8 +864,49 @@ describe('Escaping in postgres', () => {
         ).toContain(replaceWhitespace(`WHERE (( ("table1".dim1) IN (999) ))`));
     });
 
-    test('Should return valid SQL filter with for an invalid number', () => {
+    test('Should not escape regular characters in postgres', () => {
+        expect(postgresClientWithReplace.escapeString('%')).toBe('%');
+        expect(postgresClientWithReplace.escapeString('_')).toBe('_');
+        expect(postgresClientWithReplace.escapeString('?')).toBe('?');
+        expect(postgresClientWithReplace.escapeString('!')).toBe('!');
+        expect(postgresClientWithReplace.escapeString('credit_card')).toBe(
+            'credit_card',
+        );
+
         expect(
+            replaceWhitespace(
+                buildQuery({
+                    explore: EXPLORE,
+                    compiledMetricQuery: {
+                        ...METRIC_QUERY,
+                        filters: {
+                            dimensions: {
+                                id: '7e750e7c-8098-4a90-b364-4e935ad7a7e9',
+                                and: [
+                                    {
+                                        id: 'd69d3ba0-6ff5-4437-9ef3-4ed69006ea2e',
+                                        target: { fieldId: 'table1_shared' },
+                                        operator: FilterOperator.EQUALS,
+                                        values: ['credit_card'],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                    warehouseSqlBuilder: postgresClientWithReplace,
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                }).query,
+            ),
+        ).toContain(
+            replaceWhitespace(
+                `WHERE (( ("table1".shared) IN ('credit_card') ))`,
+            ),
+        );
+    });
+
+    test('Should throw when invalid number is provided', () => {
+        expect(() =>
             replaceWhitespace(
                 buildQuery({
                     explore: EXPLORE,
@@ -890,8 +931,8 @@ describe('Escaping in postgres', () => {
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
             ),
-        ).toContain(
-            replaceWhitespace(`WHERE (( ("table1".dim1) IN (99) OR (1=1) )`),
+        ).toThrow(
+            'Invalid number value in filter: "99) OR (1=1) ". Expected a valid number.',
         );
     });
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -166,12 +166,6 @@ export class BigquerySqlBuilder extends WarehouseBaseSqlBuilder {
                 .replaceAll('\\', '\\\\')
                 .replaceAll("'", "\\'")
                 .replaceAll('"', '\\"')
-                .replaceAll('\n', '\\n')
-                .replaceAll('\r', '\\r')
-                .replaceAll('\t', '\\t')
-                // Escape LIKE pattern wildcards
-                .replaceAll('%', '\\%')
-                .replaceAll('_', '\\_')
                 // Remove SQL comments (BigQuery supports --, /* */, and # comments)
                 .replace(/--.*$/gm, '')
                 .replace(/\/\*[\s\S]*?\*\//g, '')

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -203,12 +203,6 @@ export class DatabricksSqlBuilder extends WarehouseBaseSqlBuilder {
                 .replaceAll('\\', '\\\\')
                 .replaceAll("'", "\\'")
                 .replaceAll('"', '\\"')
-                .replaceAll('\n', '\\n')
-                .replaceAll('\r', '\\r')
-                .replaceAll('\t', '\\t')
-                // Escape LIKE pattern wildcards
-                .replaceAll('%', '\\%')
-                .replaceAll('_', '\\_')
                 // Remove SQL comments (Spark SQL supports --, /* */, and # comments)
                 .replace(/--.*$/gm, '')
                 .replace(/\/\*[\s\S]*?\*\//g, '')

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -160,8 +160,6 @@ export class PostgresSqlBuilder extends WarehouseBaseSqlBuilder {
                 .replaceAll("'", "''")
                 // PostgreSQL LIKE wildcards need to be escaped with backslashes
                 .replaceAll('\\', '\\\\') // Escape backslashes first
-                .replaceAll('%', '\\%') // Escape % wildcard
-                .replaceAll('_', '\\_') // Escape _ wildcard
                 // Remove SQL comments (-- and /* */)
                 .replace(/--.*$/gm, '')
                 .replace(/\/\*[\s\S]*?\*\//g, '')

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -171,9 +171,6 @@ export class SnowflakeSqlBuilder extends WarehouseBaseSqlBuilder {
                 .replaceAll("'", "''")
                 // Escape backslashes first (before LIKE wildcards)
                 .replaceAll('\\', '\\\\')
-                // Escape LIKE pattern wildcards
-                .replaceAll('%', '\\%')
-                .replaceAll('_', '\\_')
                 // Remove SQL comments (-- and /* */)
                 .replace(/--.*$/gm, '')
                 .replace(/\/\*[\s\S]*?\*\//g, '')

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -199,9 +199,6 @@ export class TrinoSqlBuilder extends WarehouseBaseSqlBuilder {
                 .replaceAll("'", "''")
                 // Escape backslashes first (before LIKE wildcards)
                 .replaceAll('\\', '\\\\')
-                // Escape LIKE pattern wildcards
-                .replaceAll('%', '\\%')
-                .replaceAll('_', '\\_')
                 // Remove SQL comments (-- and /* */)
                 .replace(/--.*$/gm, '')
                 .replace(/\/\*[\s\S]*?\*\//g, '')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Removed unnecessary escaping of special characters like `%`, `_` in SQL string escaping functions across all warehouse clients (PostgreSQL, BigQuery, Databricks, Snowflake, and Trino). These characters should not be escaped in regular SQL queries as they are only special in LIKE patterns.

Added tests to verify that regular characters are not escaped in PostgreSQL, ensuring that strings like "credit_card" remain unchanged when used in queries.

test-frontend
test-backend