### PR TITLE
fix: meta block overriding completely any meta properties

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1,3 +1,4 @@
+import { merge } from 'lodash';
 import {
     SupportedDbtAdapter,
     buildModelGraph,
@@ -111,10 +112,8 @@ const convertDimension = (
     startOfWeek?: WeekDay | null,
     isAdditionalDimension?: boolean,
 ): Dimension => {
-    const meta = {
-        ...(column.meta || {}),
-        ...(column.config?.meta || {}),
-    };
+    // Config block takes priority, then meta block
+    const meta = merge({}, column.meta, column.config?.meta);
     let type = meta.dimension?.type || column.data_type || DimensionType.STRING;
     if (!Object.values(DimensionType).includes(type)) {
         throw new MissingCatalogEntryError(
@@ -340,10 +339,8 @@ export const convertTable = (
     spotlightConfig: LightdashProjectConfig['spotlight'],
     startOfWeek?: WeekDay | null,
 ): Omit<Table, 'lineageGraph'> => {
-    const meta = {
-        ...(model.meta || {}),
-        ...(model.config?.meta || {}),
-    }; // Config block takes priority, then meta block
+    // Config block takes priority, then meta block
+    const meta = merge({}, model.meta, model.config?.meta);
     const tableLabel = meta.label || friendlyName(model.name);
 
     const [dimensions, metrics]: [
@@ -361,10 +358,9 @@ export const convertTable = (
                 undefined,
                 startOfWeek,
             );
-            const columnMeta = {
-                ...(column.meta || {}),
-                ...(column.config?.meta || {}),
-            };
+
+            // Config block takes priority, then meta block
+            const columnMeta = merge({}, column.meta, column.config?.meta);
 
             const processIntervalDimension = (
                 dim: Dimension,
@@ -669,10 +665,8 @@ export const convertExplores = async (
     const tableLineage = translateDbtModelsToTableLineage(models);
     const [tables, exploreErrors] = models.reduce(
         ([accTables, accErrors], model) => {
-            const meta = {
-                ...(model.meta || {}),
-                ...(model.config?.meta || {}), // Config block takes priority, then meta block
-            };
+            // Config block takes priority, then meta block
+            const meta = merge({}, model.meta, model.config?.meta);
 
             // model.config.tags has type string[] | string | undefined - normalise it to string[]
             const configTags =
@@ -742,10 +736,9 @@ export const convertExplores = async (
     const explores: (Explore | ExploreError)[] = validModels.reduce<
         (Explore | ExploreError)[]
     >((acc, model) => {
-        const meta = {
-            ...(model.meta || {}),
-            ...(model.config?.meta || {}), // Config block takes priority, then meta block
-        };
+        // Config block takes priority, then meta block
+        const meta = merge({}, model.meta, model.config?.meta);
+
         const configTags =
             typeof model.config?.tags === 'string'
                 ? [model.config.tags]


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Refactored meta object creation in the translator module to use lodash's `merge` function. This ensures that config block metadata properly takes priority over meta block data, fixing inconsistencies in how metadata was being combined. The change affects dimension conversion, table conversion, and explore conversion functions.

**Steps to test:**
1. In `subscriptions.yml` add an `additional dimension` to the `meta` block of `subscription_status`
2. Click `refresh_dbt`
3. See that the newly added `additional_dimension` sql is incorrect

```yaml
# example subscription status column
      - name: subscription_status
        description: Current subscription status (Current, Expired, Cancelled)
        config:
          meta:
            dimension:
              type: string
              colors:
                "Current": "#00FF00"
                "Expired": "#FFA500"
                "Cancelled": "#FF0000"
            metrics:
              current_subscriptions:
                type: count_distinct
                label: Current Subscriptions
                description: Number of current/active subscriptions
                sql: CASE WHEN subscription_status = 'Current' THEN subscription_id ELSE NULL END
              expired_subscriptions:
                type: count_distinct
                label: Expired Subscriptions
                description: Number of expired subscriptions
                sql: CASE WHEN subscription_status = 'Expired' THEN subscription_id ELSE NULL END
              cancelled_subscriptions:
                type: count_distinct
                label: Cancelled Subscriptions
                description: Number of cancelled subscriptions
                sql: CASE WHEN subscription_status = 'Cancelled' THEN subscription_id ELSE NULL END
        meta:
          additional_dimensions:
            test_dim:
              type: string
              description: "Test dimension"
              sql: |
                CASE
                  WHEN ${ld.parameters.subscription_status} = 'all' THEN 'all' ELSE 'not all'
                END
```

**Before**
```sql
SELECT
  "subscriptions".test_dim AS "subscriptions_test_dim",
  SUM("subscriptions".monthly_mrr) AS "subscriptions_total_monthly_mrr"
FROM "postgres"."jaffle"."subscriptions" AS "subscriptions"

GROUP BY 1
ORDER BY "subscriptions_total_monthly_mrr" DESC
LIMIT 500
```

**Error**: `column subscriptions.test_dim does not exist`

**After SQL**
```sql
SELECT
  CASE
  WHEN 'all' = 'all' THEN 'all' ELSE 'not all'
END AS "subscriptions_test_dim",
  SUM("subscriptions".monthly_mrr) AS "subscriptions_total_monthly_mrr"
FROM "postgres"."jaffle"."subscriptions" AS "subscriptions"

GROUP BY 1
ORDER BY "subscriptions_total_monthly_mrr" DESC
LIMIT 500
```