### PR TITLE
test: add filters + chart generation eval

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.yml
@@ -3,6 +3,7 @@ models:
   - name: payments
     description: This table has information about individual payments
     config:
+      tags: ["ai"]
       meta:
         primary_key: payment_id
         joins:
@@ -31,6 +32,5 @@ models:
           meta:
             metrics:
               total_revenue:
-                tags: ['ai']
                 type: sum
                 description: Sum of all payments

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -21,7 +21,7 @@ import type {
     AiStreamAgentResponseArgs,
 } from '../types/aiAgent';
 
-const defaultAgentOptions = {
+export const defaultAgentOptions = {
     toolChoice: 'auto',
     maxSteps: 10,
     maxRetries: 3,

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -1,10 +1,14 @@
 import {
     AiAgent,
     AiWebAppPrompt,
+    CatalogType,
     isDateItem,
-    SessionAccount,
+    toolFindFieldsArgsSchema,
+    toolTableVizArgsSchema,
+    toolTimeSeriesArgsSchema,
 } from '@lightdash/common';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { CatalogSearchContext } from '../../../../../models/CatalogModel/CatalogModel';
 import {
     getModels,
     getServices,
@@ -96,8 +100,9 @@ describeOrSkip('agent integration tests', () => {
     };
 
     it(
-        'should be able to find explores and be factual',
+        'should be able to tell the user what data models are available to explore with their agent',
         async () => {
+            const services = getServices(context.app);
             if (!createdAgent) {
                 throw new Error('Agent not created');
             }
@@ -114,11 +119,28 @@ describeOrSkip('agent integration tests', () => {
             expect(toolCalls.length).toBeGreaterThan(0);
             expect(toolCalls[0].tool_name).toBe('findExplores');
 
+            const { data: tables } =
+                await services.catalogService.searchCatalog({
+                    projectUuid: createdAgent.projectUuid!,
+                    catalogSearch: {
+                        type: CatalogType.Table,
+                        yamlTags: context.testAgent.tags ?? undefined,
+                    },
+                    userAttributes: {},
+                    context: CatalogSearchContext.AI_AGENT,
+                    paginateArgs: {
+                        page: 1,
+                        pageSize: 100,
+                    },
+                    tables: null,
+                });
+
+            const tablesText = tables.map((table) => table.name).join(', ');
+
             const factualityEvaluation = await llmAsAJudge({
                 query: promptQueryText,
                 response,
-                expectedAnswer:
-                    'You can explore data models such as Orders, Customers, Payments, Events, Subscriptions, Tracks',
+                expectedAnswer: `You can explore data models such as ${tablesText}`,
                 model,
                 scorerType: 'factuality',
             });
@@ -148,8 +170,19 @@ describeOrSkip('agent integration tests', () => {
             .select('*');
 
         expect(toolCalls.length).toBeGreaterThan(0);
-        expect(toolCalls[0].tool_name).toBe('findExplores');
-        expect(toolCalls[1].tool_name).toBe('findFields');
+
+        const generateTableVizConfigToolCall = toolCalls.find(
+            (call) => call.tool_name === 'generateTableVizConfig',
+        );
+        expect(generateTableVizConfigToolCall).toBeDefined();
+        const generateTableVizConfigToolCallParsed =
+            toolTableVizArgsSchema.safeParse(
+                generateTableVizConfigToolCall?.tool_args,
+            );
+        expect(generateTableVizConfigToolCallParsed.success).toBe(true);
+        expect(generateTableVizConfigToolCallParsed.data?.vizConfig.limit).toBe(
+            1,
+        );
 
         const factualityEvaluation = await llmAsAJudge({
             query: promptQueryText,
@@ -184,21 +217,31 @@ describeOrSkip('agent integration tests', () => {
 
         expect(toolCalls.length).toBeGreaterThan(0);
         expect(toolCalls[0].tool_name).toBe('findExplores');
+
         expect(toolCalls[1].tool_name).toBe('findFields');
+        const findFieldsToolCallParsed = toolFindFieldsArgsSchema.safeParse(
+            toolCalls[1].tool_args,
+        );
+        expect(findFieldsToolCallParsed.success).toBe(true);
+        expect(findFieldsToolCallParsed.data?.table).toBe('payments');
+        findFieldsToolCallParsed.data?.fieldSearchQueries.forEach((field) => {
+            expect(field.label).toMatch(/revenue|month/i);
+        });
+
         expect(toolCalls[2].tool_name).toBe('generateTimeSeriesVizConfig');
 
-        const vizConfig = JSON.stringify(
-            toolCalls.find(
-                (toolCall) =>
-                    toolCall.tool_name === 'generateTimeSeriesVizConfig',
-            )?.tool_args,
-        );
+        const generateTimeSeriesVizConfigToolCallParsed =
+            toolTimeSeriesArgsSchema.safeParse(toolCalls[2].tool_args);
+        expect(generateTimeSeriesVizConfigToolCallParsed.success).toBe(true);
+
+        const vizConfig =
+            generateTimeSeriesVizConfigToolCallParsed.data?.vizConfig;
 
         const factualityEvaluation = await llmAsAJudge({
             query: promptQueryText,
             response,
             expectedAnswer:
-                "I've been able to generate a time-series chart of revenue over time monthly on the orders explore",
+                "I've generated a chart of revenue over time (monthly) with Payments explore, order date month on the x axis and total revenue on the y axis",
             scorerType: 'factuality',
             model,
         });
@@ -210,42 +253,31 @@ describeOrSkip('agent integration tests', () => {
         expect(factualityEvaluation.answer).toBeOneOf(['A', 'B']);
         expect(factualityEvaluation.rationale).toBeDefined();
 
-        const jsonExpected = JSON.stringify({
-            title: 'Monthly Orders over time',
-            filters: null,
-            description:
-                'This is a time-series chart that displays the number of orders aggregated by month, showing trends in orders over time.',
-            followUpTools: ['generate_time_series_viz'],
-            vizConfig: {
-                limit: 1000,
-                sorts: [
-                    { fieldId: 'orders_order_date_month', descending: false },
-                ],
-                yMetrics: ['orders_total_order_amount'],
-                stackBars: null,
-                xAxisType: 'time',
-                xAxisLabel: 'Order Month',
-                xDimension: 'orders_order_date_month',
-                yAxisLabel: 'Total Revenue',
-                exploreName: 'orders',
-                followUpTools: ['generate_time_series_viz'],
-                breakdownByDimension: null,
-            },
-        });
+        const vizConfigExpected = {
+            limit: 1000,
+            sorts: [{ fieldId: 'orders_order_date_month', descending: false }],
+            lineType: 'line',
+            yMetrics: ['payments_total_revenue'],
+            xAxisLabel: 'Order date month',
+            xDimension: 'orders_order_date_month',
+            yAxisLabel: 'Total revenue',
+            exploreName: 'payments',
+            breakdownByDimension: null,
+        };
 
-        const jsonDiffEvaluation = await llmAsAJudge({
+        const vizConfigJsonDiffEvaluation = await llmAsAJudge({
             model,
             query: promptQueryText,
-            response: vizConfig,
-            expectedAnswer: jsonExpected,
+            response: JSON.stringify(vizConfig),
+            expectedAnswer: JSON.stringify(vizConfigExpected),
             scorerType: 'jsonDiff',
         });
 
-        if (!jsonDiffEvaluation) {
+        if (!vizConfigJsonDiffEvaluation) {
             throw new Error('JSON diff evaluation not found');
         }
 
-        expect(jsonDiffEvaluation.score).toBeGreaterThanOrEqual(0.5);
+        expect(vizConfigJsonDiffEvaluation.score).toBeGreaterThanOrEqual(0.9);
     });
 
     it(
@@ -314,6 +346,91 @@ describeOrSkip('agent integration tests', () => {
                 0.7,
             );
             expect(contextRelevancyEvaluation.reason).toBeDefined();
+        },
+        TIMEOUT,
+    );
+
+    it(
+        'should answer "How many orders were there in 2018?" and generate a one line result',
+        async () => {
+            if (!createdAgent) {
+                throw new Error('Agent not created');
+            }
+
+            const promptQueryText = 'How many orders were there in 2018?';
+
+            const { response, prompt } = await promptAgent(promptQueryText);
+
+            const toolCalls = await context
+                .db<DbAiAgentToolCall>('ai_agent_tool_call')
+                .where('ai_prompt_uuid', prompt!.promptUuid)
+                .select('*');
+
+            // Should have exactly 3 tool calls in sequence
+            expect(toolCalls.length).toBe(3);
+
+            // First tool call: findExplores
+            expect(toolCalls[0].tool_name).toBe('findExplores');
+            expect(toolCalls[0].tool_args).toEqual({
+                page: 1,
+                type: 'find_explores',
+            });
+
+            // Second tool call: findFields with specific search for order count and date
+            expect(toolCalls[1].tool_name).toBe('findFields');
+            expect(toolCalls[1].tool_args).toEqual({
+                page: 1,
+                type: 'find_fields',
+                table: 'orders',
+                fieldSearchQueries: [
+                    { label: 'Unique order count' },
+                    { label: 'Order date year' },
+                ],
+            });
+
+            // Third tool call: generateTableVizConfig with 2018 filter
+            expect(toolCalls[2].tool_name).toBe('generateTableVizConfig');
+
+            const tableVizArgsParsed = toolTableVizArgsSchema.safeParse(
+                toolCalls[2].tool_args,
+            );
+
+            if (!tableVizArgsParsed.success) {
+                throw new Error('Failed to parse table viz args');
+            }
+
+            const tableVizArgs = tableVizArgsParsed.data;
+
+            expect(tableVizArgs.filters?.dimensions?.[0]).toMatchObject({
+                rule: { values: ['2018'], operator: 'equals' },
+                type: 'or',
+                target: {
+                    type: 'date',
+                    fieldId: 'orders_order_date_year',
+                },
+            });
+
+            expect(tableVizArgs.vizConfig.metrics).toContain(
+                'orders_unique_order_count',
+            );
+            expect(tableVizArgsParsed.data.vizConfig.exploreName).toBe(
+                'orders',
+            );
+
+            const factualityEvaluation = await llmAsAJudge({
+                query: promptQueryText,
+                response,
+                expectedAnswer: 'There were 99 orders in 2018',
+                scorerType: 'factuality',
+                model,
+            });
+
+            if (!factualityEvaluation) {
+                throw new Error('Factuality evaluation not found');
+            }
+
+            expect(factualityEvaluation.answer).toBeOneOf(['A', 'B']);
+            expect(factualityEvaluation.rationale).toBeDefined();
         },
         TIMEOUT,
     );

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsAJudge.ts
@@ -4,6 +4,7 @@ import { generateObject } from 'ai';
 import { JSONDiff, Score } from 'autoevals';
 import { z } from 'zod';
 import { getOpenaiGptmodel } from '../../../models/openai-gpt';
+import { defaultAgentOptions } from '../../agent';
 
 export const factualityScores = {
     A: 0.4,
@@ -86,6 +87,7 @@ export async function llmAsAJudge({
             }
             const { object } = await generateObject({
                 model,
+                ...defaultAgentOptions,
                 schema: z.object({
                     answer: z
                         .enum(['A', 'B', 'C', 'D', 'E'])

--- a/packages/backend/src/vitest.setup.integration.ts
+++ b/packages/backend/src/vitest.setup.integration.ts
@@ -150,14 +150,13 @@ export const setupIntegrationTest =
             ...testUserData,
             ability: defineUserAbility(testUserData, []),
             isTrackingAnonymized: false,
-            userId: 1,
             abilityRules: [],
         };
 
         const testUserSessionAccount: SessionAccount = {
             user: {
                 ...testUser,
-                id: '1',
+                id: testUser.userUuid,
                 type: 'registered',
             },
             organization: {
@@ -189,7 +188,6 @@ export const setupIntegrationTest =
         };
 
         const catalogService = app.getServiceRepository().getCatalogService();
-
         await catalogService.indexCatalog(
             SEED_PROJECT.project_uuid,
             testUser.userUuid,
@@ -226,6 +224,7 @@ export const getServices = (app: App) => {
     const services = {
         aiAgentService: serviceRepository.getAiAgentService<AiAgentService>(),
         projectService: serviceRepository.getProjectService(),
+        catalogService: serviceRepository.getCatalogService(),
     };
 
     console.info('✅ Services retrieved:', Object.keys(services).join(', '));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Improves AI agent integration tests with more specific assertions and validations:

- Exports `defaultAgentOptions` to make it accessible in tests
- Updates test for exploring available data models to dynamically verify against actual catalog data
- Enhances tool call validation with proper schema parsing
- Adds a new test case for answering "How many orders were there in 2018?"
- Improves factuality evaluations with more precise expected answers
- Fixes user ID consistency in test setup

