### PR TITLE
Fix : two scrollbars in the nested spaces modal

### DIFF
--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -91,10 +91,6 @@ const MantineModal: React.FC<MantineModalProps> = ({
 
                 <Modal.Body
                     p={0}
-                    sx={() => ({
-                        overflow: 'auto',
-                        maxHeight: 'calc(80vh - 130px)',
-                    })}
                     {...modalBodyProps}
                 >
                     <Stack

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -76,7 +76,7 @@ const SpaceSelector = ({
     );
 
     return (
-        <Stack h="600px">
+        <Stack>
             {userCanManageProject ? (
                 <AdminContentViewFilter
                     value={selectedAdminContentType}
@@ -97,10 +97,12 @@ const SpaceSelector = ({
             />
 
             <Paper
-                component={ScrollArea}
                 w="100%"
-                sx={{ flexGrow: 1 }}
                 withBorder
+                sx={{
+                    height: '250px',
+                    overflow: 'auto',
+                }}
             >
                 <Tree
                     withRootSelectable={isRootSelectionEnabled}

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -1,10 +1,10 @@
 import { type CreateSavedChartVersion } from '@lightdash/common';
-import { Group, Modal, Text } from '@mantine/core';
+import { MantineProvider } from '@mantine/core';
 import { IconChartBar } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
-import MantineIcon from '../../MantineIcon';
+import MantineModal from '../../MantineModal';
 import { SaveToDashboard } from './SaveToDashboard';
 import { SaveToSpaceOrDashboard } from './SaveToSpaceOrDashboard';
 import { type ChartMetadata } from './types';
@@ -54,47 +54,44 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     }, [saveMode, editingDashboardInfo]);
 
     return (
-        <Modal
-            opened={isOpen}
-            onClose={onClose}
-            keepMounted={false}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon icon={IconChartBar} size="lg" color="gray.7" />
-                    <Text fw={500}>{getModalTitle()}</Text>
-                </Group>
-            }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.gray[4]}` },
-                body: { padding: 0 },
-            })}
-        >
-            {saveMode === SaveMode.TO_DASHBOARD && (
-                <SaveToDashboard
-                    projectUuid={projectUuid}
-                    dashboardName={editingDashboardInfo.name}
-                    dashboardUuid={editingDashboardInfo.dashboardUuid}
-                    savedData={savedData}
-                    onClose={onClose}
-                    defaults={chartMetadata}
-                />
-            )}
+        <MantineProvider inherit theme={{ colorScheme: 'light' }}>
+            <MantineModal
+                opened={isOpen}
+                onClose={onClose}
+                title={getModalTitle()}
+                icon={IconChartBar}
+                modalBodyProps={{
+                    px: 0,
+                    py: 0,
+                }}
+            >
+                {saveMode === SaveMode.TO_DASHBOARD && (
+                    <SaveToDashboard
+                        projectUuid={projectUuid}
+                        dashboardName={editingDashboardInfo.name}
+                        dashboardUuid={editingDashboardInfo.dashboardUuid}
+                        savedData={savedData}
+                        onClose={onClose}
+                        defaults={chartMetadata}
+                    />
+                )}
 
-            {saveMode === SaveMode.DEFAULT && (
-                <SaveToSpaceOrDashboard
-                    projectUuid={projectUuid}
-                    savedData={savedData}
-                    onConfirm={onConfirm}
-                    onClose={onClose}
-                    defaultSpaceUuid={spaceUuid}
-                    dashboardInfoFromSavedData={{
-                        dashboardName: savedData.dashboardName ?? null,
-                        dashboardUuid: savedData.dashboardUuid ?? null,
-                    }}
-                    chartMetadata={chartMetadata}
-                />
-            )}
-        </Modal>
+                {saveMode === SaveMode.DEFAULT && (
+                    <SaveToSpaceOrDashboard
+                        projectUuid={projectUuid}
+                        savedData={savedData}
+                        onConfirm={onConfirm}
+                        onClose={onClose}
+                        defaultSpaceUuid={spaceUuid}
+                        dashboardInfoFromSavedData={{
+                            dashboardName: savedData.dashboardName ?? null,
+                            dashboardUuid: savedData.dashboardUuid ?? null,
+                        }}
+                        chartMetadata={chartMetadata}
+                    />
+                )}
+            </MantineModal>
+        </MantineProvider>
     );
 };
 


### PR DESCRIPTION
Closes: #14836
Related issue: #14860

### Description
This PR resolves the scroll behavior issue in the "Save Chart" and "Create Dashboard" modals by removing the appearance of two scrollbars within the nested SpaceSelector modal and ensuring the layout remains responsive across different screen sizes.

### Changes Made

**1. MantineModal adjustments**

File: `packages/frontend/src/components/common/MantineModal/index.tsx`
Change: Removed the calculated height that was causing an additional scrollbar to appear. The modal now properly fills the available height without overflow.

**2. Fixed scroll behavior in SpaceSelector**

File: `packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx`
Change: Added a fixed height and enabled scroll functionality specifically for the space selection area to prevent overflow from affecting the entire modal.

**3. Updated Save Chart modal**

File: `packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx`
Change: Replaced the regular Modal component with MantineModal to maintain consistency and proper scroll handling.

### Preveiw

**Create Dashboard Modal**

| Before | After |
|--------|-------|
| ![Create Dashboard - Before](https://github.com/user-attachments/assets/34c5d52a-cf21-4090-9b1e-58bcc8f622de) | ![Create Dashboard - After](https://github.com/user-attachments/assets/794e0012-71c6-40d2-af4a-84c2ab364649) |

---
**Save Chart Modal**

| Before | After |
|--------|-------|
| ![Save Chart - Before](https://github.com/user-attachments/assets/e161f41a-8253-4dba-beec-aa886ac36f03) | ![Save Chart - After](https://github.com/user-attachments/assets/4154820c-9183-48dd-a774-b4e5c0c66339) |


