### PR TITLE
chore: migrate AboutFooter to mantine 8

### DIFF
--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -8,14 +8,16 @@ import {
     Button,
     Divider,
     Group,
+    MantineProvider,
     Modal,
     Stack,
     Text,
     Title,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconBook, IconInfoCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 
+import { getMantine8ThemeOverride } from '../mantine8Theme';
 import useApp from '../providers/App/useApp';
 import {
     TrackPage,
@@ -43,142 +45,141 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
         healthState.data?.mode === LightdashMode.DEFAULT;
 
     return (
-        <TrackSection name={SectionName.PAGE_FOOTER}>
-            <Box mt={FOOTER_MARGIN} h={FOOTER_HEIGHT} component="footer">
-                <Divider color="gray.2" w="100%" mb="-1px" />
+        <MantineProvider theme={getMantine8ThemeOverride()}>
+            <TrackSection name={SectionName.PAGE_FOOTER}>
+                <Box mt={FOOTER_MARGIN} h={FOOTER_HEIGHT} component="footer">
+                    <Divider color="gray.2" w="100%" mb="-1px" />
 
-                <Group
-                    h="100%"
-                    miw={minimal ? '100%' : maxWidth}
-                    maw={maxWidth}
-                    position="apart"
-                    mx="auto"
-                >
-                    <Button
-                        variant={minimal ? 'subtle' : 'light'}
-                        color="gray.7"
-                        p="xs"
-                        fw="500"
-                        leftIcon={<Logo />}
-                        loading={healthState.isInitialLoading}
-                        onClick={() => setIsOpen(true)}
+                    <Group
+                        h="100%"
+                        miw={minimal ? '100%' : maxWidth}
+                        maw={maxWidth}
+                        justify="space-between"
+                        mx="auto"
                     >
-                        {!minimal && 'Lightdash - '}
-                        {healthState.data && `v${healthState.data.version}`}
-                        {showUpdateBadge && (
-                            <Badge
-                                variant="light"
-                                ml="xs"
-                                radius="xs"
-                                size="xs"
-                            >
-                                New version available!
-                            </Badge>
-                        )}
-                    </Button>
-
-                    {minimal ? (
-                        <Anchor
-                            href="https://docs.lightdash.com/"
-                            target="_blank"
-                        >
-                            <ActionIcon color="gray.7" p="xs" size="lg">
-                                <MantineIcon
-                                    icon={IconBook}
-                                    size="lg"
-                                    color="gray.7"
-                                />
-                            </ActionIcon>
-                        </Anchor>
-                    ) : (
-                        <MantineLinkButton
-                            href="https://docs.lightdash.com/"
-                            target="_blank"
-                            leftIcon={
-                                <MantineIcon
-                                    icon={IconBook}
-                                    size="lg"
-                                    color="gray.7"
-                                />
-                            }
-                            variant="light"
+                        <Button
+                            variant={minimal ? 'subtle' : 'light'}
                             color="gray.7"
-                            fw="500"
                             p="xs"
+                            fw="500"
+                            leftSection={<Logo />}
+                            loading={healthState.isInitialLoading}
+                            onClick={() => setIsOpen(true)}
                         >
-                            Documentation
-                        </MantineLinkButton>
-                    )}
-                </Group>
-            </Box>
+                            {!minimal && 'Lightdash - '}
+                            {healthState.data && `v${healthState.data.version}`}
+                            {showUpdateBadge && (
+                                <Badge
+                                    variant="light"
+                                    ml="xs"
+                                    radius="xs"
+                                    size="xs"
+                                >
+                                    New version available!
+                                </Badge>
+                            )}
+                        </Button>
 
-            <Modal
-                opened={isOpen}
-                onClose={() => setIsOpen(false)}
-                title={
-                    <Group align="center" position="left" spacing="xs">
-                        <IconInfoCircle size={17} color="gray" /> About
-                        Lightdash
-                    </Group>
-                }
-            >
-                <TrackPage
-                    name={PageName.ABOUT_LIGHTDASH}
-                    type={PageType.MODAL}
-                >
-                    <Stack mx="xs">
-                        <Title order={5} fw={500}>
-                            <b>Version:</b>{' '}
-                            {healthState.data
-                                ? `v${healthState.data.version}`
-                                : 'n/a'}
-                        </Title>
-                        {showUpdateBadge && (
-                            <Alert
-                                title="New version available!"
-                                color="blue"
-                                icon={<IconInfoCircle size={17} />}
+                        {minimal ? (
+                            <Anchor
+                                href="https://docs.lightdash.com/"
+                                target="_blank"
                             >
-                                <Text color="blue">
-                                    The version v
-                                    {healthState.data?.latest.version} is now
-                                    available. Please follow the instructions in
-                                    the{' '}
-                                    <Anchor
-                                        href="https://docs.lightdash.com/self-host/update-lightdash"
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        style={{
-                                            textDecoration: 'underline',
-                                        }}
-                                    >
-                                        How to update version
-                                    </Anchor>{' '}
-                                    documentation.
-                                </Text>
-                            </Alert>
-                        )}
-
-                        <Group position="right">
+                                <ActionIcon color="gray.7" p="xs" size="lg">
+                                    <MantineIcon
+                                        icon={IconBook}
+                                        size="lg"
+                                        color="gray.7"
+                                    />
+                                </ActionIcon>
+                            </Anchor>
+                        ) : (
                             <MantineLinkButton
                                 href="https://docs.lightdash.com/"
                                 target="_blank"
-                                variant="default"
+                                leftIcon={
+                                    <MantineIcon
+                                        icon={IconBook}
+                                        size="lg"
+                                        color="gray.7"
+                                    />
+                                }
+                                variant="light"
+                                color="gray.7"
+                                fw="500"
+                                p="xs"
                             >
-                                Docs
+                                Documentation
                             </MantineLinkButton>
-                            <MantineLinkButton
-                                href="https://github.com/lightdash/lightdash"
-                                target="_blank"
-                                variant="default"
-                            >
-                                Github
-                            </MantineLinkButton>
+                        )}
+                    </Group>
+                </Box>
+
+                <Modal
+                    opened={isOpen}
+                    onClose={() => setIsOpen(false)}
+                    title={
+                        <Group align="center" justify="flex-start" gap="xs">
+                            <IconInfoCircle size={17} color="gray" /> About
+                            Lightdash
                         </Group>
-                    </Stack>
-                </TrackPage>
-            </Modal>
-        </TrackSection>
+                    }
+                >
+                    <TrackPage
+                        name={PageName.ABOUT_LIGHTDASH}
+                        type={PageType.MODAL}
+                    >
+                        <Stack mx="xs">
+                            <Title order={5} fw={500}>
+                                <b>Version:</b>{' '}
+                                {healthState.data
+                                    ? `v${healthState.data.version}`
+                                    : 'n/a'}
+                            </Title>
+                            {showUpdateBadge && (
+                                <Alert
+                                    title="New version available!"
+                                    color="blue"
+                                    icon={<IconInfoCircle size={17} />}
+                                >
+                                    <Text c="blue">
+                                        The version v
+                                        {healthState.data?.latest.version} is
+                                        now available. Please follow the
+                                        instructions in the{' '}
+                                        <Anchor
+                                            href="https://docs.lightdash.com/self-host/update-lightdash"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                        >
+                                            How to update version
+                                        </Anchor>{' '}
+                                        documentation.
+                                    </Text>
+                                </Alert>
+                            )}
+
+                            <Group justify="flex-end">
+                                <MantineLinkButton
+                                    href="https://docs.lightdash.com/"
+                                    target="_blank"
+                                    variant="default"
+                                >
+                                    Docs
+                                </MantineLinkButton>
+                                <MantineLinkButton
+                                    href="https://github.com/lightdash/lightdash"
+                                    target="_blank"
+                                    variant="default"
+                                >
+                                    Github
+                                </MantineLinkButton>
+                            </Group>
+                        </Stack>
+                    </TrackPage>
+                </Modal>
+            </TrackSection>
+        </MantineProvider>
     );
 };
 

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -58,7 +58,7 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                         mx="auto"
                     >
                         <Button
-                            variant={minimal ? 'subtle' : 'light'}
+                            variant={minimal ? 'transparent' : 'subtle'}
                             color="gray.7"
                             p="xs"
                             fw="500"
@@ -151,6 +151,7 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                                             href="https://docs.lightdash.com/self-host/update-lightdash"
                                             target="_blank"
                                             rel="noreferrer"
+                                            underline="always" // Required: link isn't differentiated from blue text without underline
                                         >
                                             How to update version
                                         </Anchor>{' '}


### PR DESCRIPTION
one more test of the `STYLE_GUIDE.md` on a more custom component

One-shot was mid successful:

### One-shotted

Component prop name changes (position -> justify, spacing -> gap)

### Needed prompting

- It thought that underline wasn't needed (but mantine anchors only underline on hover)
- The docs button component had a darker grey background - are the greys between mantine 6 and the new theme different? I had to manually change it to a transparent background on the docs button - since that is how it looked before.
- Should it have used CSS modules here? There's lots of inline styling
