### PR TITLE
feat: jit provision JWT users

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -99,7 +99,7 @@ export type CreateUserEvent = BaseTrack & {
         context: string; // context on where/why this user was created
         createdUserId: string;
         organizationId: string | undefined; // undefined because they can join an org later
-        userConnectionType: 'password' | OpenIdIdentityIssuerType;
+        userConnectionType: 'password' | 'embed' | OpenIdIdentityIssuerType;
     };
 };
 

--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -193,6 +193,7 @@ export class OrganizationModel {
     ): Organization {
         return {
             organizationUuid: data.organization_uuid,
+            organizationId: data.organization_id,
             name: data.organization_name,
             chartColors: palette ?? undefined,
             defaultProjectUuid: data.default_project_uuid

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -58,16 +58,19 @@ export const InteractivityOptionsSchema = z.object({
     canExportPagePdf: z.boolean().optional(),
     canDateZoom: z.boolean().optional(),
     canExplore: z.boolean().optional(),
+    canEdit: z.boolean().optional(),
 });
 
 export type InteractivityOptions = z.infer<typeof InteractivityOptionsSchema>;
 
+// This is our enforceable schema for the embed JWT. We use this to validate advanced embed features.
+// In the future we may lean on a combination of this schema and the 'jsonwebtoken' library to validate the JWT.
 export const EmbedJwtSchema = z
     .object({
         userAttributes: z.record(z.unknown()).optional(),
         user: z
             .object({
-                externalId: z.string().optional(),
+                externalId: z.string(),
                 email: z.string().optional(),
             })
             .optional(),
@@ -89,7 +92,7 @@ export const EmbedJwtSchema = z
                 })
                 .merge(InteractivityOptionsSchema),
         ]),
-        iat: z.number().optional(),
+        iat: z.number(),
         exp: z.number(),
     })
     .describe(
@@ -112,6 +115,7 @@ type CommonEmbedJwtContent = {
     canDateZoom?: boolean;
     canExportPagePdf?: boolean;
     canExplore?: boolean;
+    canEdit?: boolean;
 };
 
 type EmbedJwtContentDashboardUuid = CommonEmbedJwtContent & {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -285,6 +285,7 @@ export * from './utils/accessors';
 export * from './utils/additionalMetrics';
 export * from './utils/api';
 export { default as assertUnreachable } from './utils/assertUnreachable';
+export * from './utils/buildEmbedUserUuid';
 export * from './utils/catalogMetricsTree';
 export * from './utils/charts';
 export * from './utils/colors';

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -111,7 +111,17 @@ export type SessionAccount = BaseAccountWithHelpers & {
  */
 export type AnonymousAccount = BaseAccountWithHelpers & {
     authentication: JwtAuth;
-    user: ExternalUser;
+    user: ExternalUser<'anonymous'>;
+    /** The access permissions the account has */
+    access: DashboardAccess;
+};
+
+/**
+ * Account for registered embed users with JWT authentication (embeds with canEdit)
+ */
+export type RegisteredEmbedAccount = BaseAccountWithHelpers & {
+    authentication: JwtAuth;
+    user: ExternalUser<'registered'>;
     /** The access permissions the account has */
     access: DashboardAccess;
 };
@@ -129,6 +139,7 @@ export type ServiceAcctAccount = BaseAccountWithHelpers & {
 export type Account =
     | SessionAccount
     | AnonymousAccount
+    | RegisteredEmbedAccount
     | ApiKeyAccount
     | ServiceAcctAccount;
 
@@ -139,7 +150,7 @@ export type AccountWithoutHelpers<T extends Account> = Omit<
 
 export function assertEmbeddedAuth(
     account: Account | undefined,
-): asserts account is AnonymousAccount {
+): asserts account is AnonymousAccount | RegisteredEmbedAccount {
     if (account?.authentication.type !== 'jwt') {
         throw new ForbiddenError('Account is not an embedded account');
     }

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -13,6 +13,11 @@ export type Organization = {
      */
     organizationUuid: string;
     /**
+     * The incrementing id of the organization. Used for joining users to organizations.
+     * @deprecated Use organizationUuid instead if you can.
+     */
+    organizationId: number;
+    /**
      * The name of the organization
      */
     name: string;

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -54,8 +54,9 @@ export interface LightdashSessionUser extends AccountUser {
     isPending?: boolean;
 }
 
-export interface ExternalUser extends AccountUser {
-    type: 'anonymous';
+export interface ExternalUser<T extends 'anonymous' | 'registered'>
+    extends AccountUser {
+    type: T;
 }
 
 export type LightdashUserWithOrg = Required<LightdashUser>;

--- a/packages/common/src/utils/buildEmbedUserUuid.test.ts
+++ b/packages/common/src/utils/buildEmbedUserUuid.test.ts
@@ -1,0 +1,82 @@
+import { validate as isValidUuid } from 'uuid';
+import { buildEmbedUserUuid } from './buildEmbedUserUuid';
+
+describe('buildEmbedUserUuid', () => {
+    describe('Deterministic behavior', () => {
+        it('should generate different UUIDs for different external IDs', () => {
+            const uuid1 = buildEmbedUserUuid('user123');
+            const uuid2 = buildEmbedUserUuid('user456');
+
+            expect(uuid1).not.toBe(uuid2);
+        });
+
+        it('should generate consistent UUIDs for various input types', () => {
+            const testCases = [
+                'simple-user',
+                'user-with-dashes',
+                'user_with_underscores',
+                'user123',
+                'USER123',
+                'user@domain.com',
+                'user+tag@domain.com',
+                'user with spaces',
+                'user\twith\ttabs',
+                'user\nwith\nnewlines',
+            ];
+
+            testCases.forEach((externalId) => {
+                const uuid1 = buildEmbedUserUuid(externalId);
+                const uuid2 = buildEmbedUserUuid(externalId);
+
+                expect(uuid1).toBe(uuid2);
+                expect(isValidUuid(uuid1)).toBe(true);
+            });
+        });
+    });
+
+    describe('UUID format validation', () => {
+        it('should generate a valid UUID-like format (8-4-4-4-12 characters)', () => {
+            const uuid = buildEmbedUserUuid('test-user');
+
+            expect(isValidUuid(uuid)).toBe(true);
+        });
+    });
+
+    describe('MD5 hash verification', () => {
+        it('should generate UUID based on MD5 hash of external ID', () => {
+            const uuid = buildEmbedUserUuid('test-user');
+            expect(uuid).toBe('42b27efc-1480-44fe-8d7e-aa5eec47424d');
+        });
+
+        it('should throw an error for empty string input', () => {
+            expect(() => buildEmbedUserUuid('')).toThrow(
+                'External ID is required to build an embed user UUID',
+            );
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('should handle special characters in external ID', () => {
+            const uuid1 = buildEmbedUserUuid('user@example.com');
+            const uuid2 = buildEmbedUserUuid('user@example.com');
+
+            expect(uuid1).toBe(uuid2);
+            expect(isValidUuid(uuid1)).toBe(true);
+        });
+
+        it('should handle unicode characters', () => {
+            const uuid1 = buildEmbedUserUuid('用户123');
+            const uuid2 = buildEmbedUserUuid('用户123');
+
+            expect(uuid1).toBe(uuid2);
+            expect(isValidUuid(uuid1)).toBe(true);
+        });
+
+        it('should handle very long external IDs', () => {
+            const longId = 'a'.repeat(1000);
+            const uuid = buildEmbedUserUuid(longId);
+
+            expect(isValidUuid(uuid)).toBe(true);
+        });
+    });
+});

--- a/packages/common/src/utils/buildEmbedUserUuid.ts
+++ b/packages/common/src/utils/buildEmbedUserUuid.ts
@@ -1,0 +1,25 @@
+import crypto from 'crypto';
+
+/**
+ * Generate deterministic UUID from external ID using MD5 hash
+ * Conforms to UUID v4 format: [0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}
+ * @see {@link packages/common/src/types/api/uuid.ts}
+ * @see {@link [RFC 4112](https://tools.ietf.org/html/rfc4122)}
+ */
+export const buildEmbedUserUuid = (externalId: string): string => {
+    if (!externalId) {
+        throw new Error('External ID is required to build an embed user UUID');
+    }
+
+    const hash = crypto.createHash('md5').update(externalId).digest('hex');
+
+    return [
+        hash.substring(0, 8),
+        hash.substring(8, 12),
+        // Force '4' as first character
+        `4${hash.substring(13, 16)}`,
+        // Force '8' as first character (valid UUID v4 variant)
+        `8${hash.substring(17, 20)}`,
+        hash.substring(20, 32),
+    ].join('-');
+};

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -1,3 +1,4 @@
+import { buildEmbedUserUuid } from '@lightdash/common';
 import { defineConfig } from 'cypress';
 import cypressSplit from 'cypress-split';
 import { unlinkSync } from 'fs';
@@ -63,6 +64,12 @@ export default defineConfig({
                         unlinkSync(results.video);
                     }
                 }
+            });
+
+            on('task', {
+                buildEmbedUserUuid: (externalId: string) => {
+                    return buildEmbedUserUuid(externalId);
+                },
             });
 
             // IMPORTANT: return the config object

--- a/packages/e2e/cypress/e2e/api/jwt-provisioning.cy.ts
+++ b/packages/e2e/cypress/e2e/api/jwt-provisioning.cy.ts
@@ -1,0 +1,250 @@
+import { SEED_PROJECT } from '@lightdash/common';
+
+const apiUrl = '/api/v1';
+
+describe('JWT Authentication Middleware - User Provisioning', () => {
+    const projectUuid = SEED_PROJECT.project_uuid;
+
+    const wrapRequest =
+        (jwt?: string) => (options: Partial<Cypress.RequestOptions>) => {
+            // Prepare headers with optional JWT token
+            const headers: Record<string, string> = {
+                'Content-type': 'application/json',
+            };
+            if (jwt) {
+                headers['lightdash-embed-token'] = jwt;
+            }
+
+            return cy.request({
+                ...options,
+                headers: {
+                    ...options.headers,
+                    ...headers,
+                },
+            });
+        };
+
+    const findUserByExternalId = (externalId: string) =>
+        cy
+            .task('buildEmbedUserUuid', `external::${externalId}`)
+            .then((userUuid) =>
+                cy.request({
+                    url: `${apiUrl}/org/users/${userUuid}`,
+                    method: 'GET',
+                    failOnStatusCode: false,
+                }),
+            );
+
+    const findUsers = () =>
+        cy.request({
+            url: `${apiUrl}/org/users`,
+            method: 'GET',
+            failOnStatusCode: false,
+        });
+
+    const deleteProvisionedUser = (externalId: string) => {
+        // First login as admin to get access to user management
+        // cy.login();
+
+        cy.task('buildEmbedUserUuid', `external::${externalId}`)
+            .as('userUuid')
+            .then((userUuid) => {
+                cy.log(
+                    `Generated UUID for external ID ${externalId}: ${userUuid}`,
+                );
+
+                // Try to delete the user directly by UUID
+                cy.request({
+                    url: `api/v1/org/user/${userUuid}`,
+                    method: 'DELETE',
+                    failOnStatusCode: false,
+                }).then((deleteResponse) => {
+                    if (deleteResponse.status === 200) {
+                        cy.log(
+                            `Successfully deleted user with UUID: ${userUuid}`,
+                        );
+                    } else {
+                        cy.log(
+                            `Failed to delete user with UUID: ${userUuid}, status: ${deleteResponse.status}`,
+                        );
+                    }
+                });
+
+                // Logout to clean up session
+
+                // cy.logout();
+            });
+    };
+
+    describe('Anonymous JWT Users', () => {
+        it('should create anonymous account for JWT without canEdit', () => {
+            const now = Date.now();
+            const userExternalId = `anon-user-${now}`;
+            const userEmail = `anon-${now}@example.com`;
+
+            cy.getJwtToken(projectUuid, {
+                userExternalId,
+                userEmail,
+                canEdit: false,
+                canExplore: true,
+            }).then((jwt) => {
+                const wrappedRequest = wrapRequest(jwt);
+
+                // Try to access an embed endpoint
+                wrappedRequest({
+                    url: `${apiUrl}/embed/${projectUuid}/dashboard`,
+                    method: 'GET',
+                    failOnStatusCode: false,
+                }).then((response) => {
+                    // Should succeed with anonymous account
+                    expect(response.status).to.equal(200);
+                });
+
+                cy.login();
+
+                findUserByExternalId(userExternalId).then((response) => {
+                    expect(response.status).to.equal(404);
+                });
+            });
+        });
+    });
+
+    describe('Registered Embed Users with canEdit', () => {
+        it('should create a new registered user for JWT with canEdit claim', () => {
+            const userExternalId = `embed-user-${Date.now()}`;
+            const userEmail = `embed-${Date.now()}@example.com`;
+
+            cy.getJwtToken(projectUuid, {
+                userExternalId,
+                userEmail,
+                canEdit: true,
+                canExplore: true,
+            }).then((jwt) => {
+                const wrappedRequest = wrapRequest(jwt);
+
+                // Test that the user can access endpoints requiring registered user
+                wrappedRequest({
+                    url: `${apiUrl}/embed/${projectUuid}/dashboard`,
+                    method: 'GET',
+                    failOnStatusCode: false,
+                }).then((response) => {
+                    // Should succeed with registered embed account
+                    expect(response.status).to.equal(200);
+                });
+
+                cy.login();
+
+                findUserByExternalId(userExternalId).then((response) => {
+                    expect(response.status).to.equal(200);
+                });
+
+                deleteProvisionedUser(userExternalId);
+            });
+        });
+
+        it('should find existing registered user on subsequent requests', () => {
+            const userExternalId = `existing-embed-user-${Date.now()}`;
+            const userEmail = `existing-embed-${Date.now()}@example.com`;
+
+            cy.login();
+
+            // Get the current user count to assert later
+            findUsers().then((response) => {
+                cy.wrap(response.body.results.data.length).as('userCount');
+            });
+
+            cy.logout();
+
+            // First request should create the user
+            cy.getJwtToken(projectUuid, {
+                userExternalId,
+                userEmail,
+                canEdit: true,
+                canExplore: true,
+            }).then((firstJwt) => {
+                const firstRequest = wrapRequest(firstJwt);
+
+                firstRequest({
+                    url: `${apiUrl}/embed/${projectUuid}/dashboard`,
+                    method: 'GET',
+                    failOnStatusCode: false,
+                }).then((firstResponse) => {
+                    expect(firstResponse.status).to.be.oneOf([200, 404]);
+
+                    cy.login();
+
+                    // Assert that the user count has increased by 1
+                    findUsers().then((response) => {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        cy.get('@userCount').then((userCount: any) => {
+                            const userCountWithProvisioned = userCount + 1;
+                            expect(response.body.results.data.length).to.equal(
+                                userCountWithProvisioned,
+                            );
+
+                            cy.wrap(userCountWithProvisioned).as(
+                                'userCountWithProvisioned',
+                            );
+                        });
+                    });
+
+                    cy.logout();
+
+                    // Second request with same external ID should find existing user
+                    cy.getJwtToken(projectUuid, {
+                        userExternalId, // Same external ID
+                        userEmail,
+                        canEdit: true,
+                        canExplore: true,
+                    }).then((secondJwt) => {
+                        const secondRequest = wrapRequest(secondJwt);
+
+                        secondRequest({
+                            url: `${apiUrl}/embed/${projectUuid}/dashboard`,
+                            method: 'GET',
+                            failOnStatusCode: false,
+                        }).then((secondResponse) => {
+                            expect(secondResponse.status).to.be.oneOf([
+                                200, 404,
+                            ]);
+                        });
+                    });
+
+                    cy.login();
+
+                    // Assert that the user count has not changed
+                    findUsers().then((response) => {
+                        cy.get('@userCountWithProvisioned').then(
+                            (userCount) => {
+                                expect(
+                                    response.body.results.data.length,
+                                ).to.equal(userCount);
+                            },
+                        );
+                    });
+
+                    deleteProvisionedUser(userExternalId);
+                });
+            });
+        });
+
+        it('should require externalId for canEdit users', () => {
+            cy.getJwtToken(projectUuid, {
+                userExternalId: null, // No external ID
+                canEdit: true,
+                canExplore: true,
+            }).then((jwt) => {
+                const wrappedRequest = wrapRequest(jwt);
+
+                wrappedRequest({
+                    url: `${apiUrl}/embed/${projectUuid}/dashboard`,
+                    method: 'GET',
+                    failOnStatusCode: false,
+                }).then((response) => {
+                    // Should work as anonymous user since no externalId provided
+                    expect(response.status).to.equal(400);
+                });
+            });
+        });
+    });
+});

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -116,6 +116,7 @@ declare global {
                     canExportPagePdf?: boolean;
                     canDateZoom?: boolean;
                     canExplore?: boolean;
+                    canEdit?: boolean;
                 },
             ): Chainable<string>;
         }
@@ -667,6 +668,7 @@ Cypress.Commands.add(
             canExportPagePdf?: boolean;
             canDateZoom?: boolean;
             canExplore?: boolean;
+            canEdit?: boolean;
         } = {},
     ) => {
         const {
@@ -677,6 +679,7 @@ Cypress.Commands.add(
             canExportPagePdf = false,
             canDateZoom = false,
             canExplore = false,
+            canEdit = false,
         } = options;
 
         // First login to get embed configuration and dashboard UUID
@@ -713,6 +716,7 @@ Cypress.Commands.add(
                         canExportPagePdf,
                         canDateZoom,
                         canExplore,
+                        canEdit,
                     },
                     userAttributes: {
                         email: userEmail,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16050

### Description:
This adds support for provisioning registered users through embed tokens with the `canEdit` claim. When a JWT token includes `canEdit: true`, the system will now:

1. Lookup the user by externalId (required for editing) and return them if they exist. 
2. Create a new registered user account with a deterministic UUID based on the external ID if they don't exist
3. Associate the user with the organization

The implementation includes:
- A new `RegisteredEmbedAccount` type to distinguish from anonymous embed users
- A utility function `buildEmbedUserUuid` to generate deterministic UUIDs from external IDs (UUID-like since we're not encoding time)
- JWT schema validation to ensure required fields are present for edit access. We currently ignore Zod validation errors. They're enforced for this flow with registering embed users. 
- User provisioning logic in the UserService
- E2E tests to verify the provisioning workflow