### PR TITLE
fix: error states in explorer

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -62,7 +62,9 @@ export const ExplorerResults = memo(() => {
         }
     });
 
-    const apiError = useExplorerContext((context) => context.query.error);
+    const apiError = useExplorerContext(
+        (context) => context.query.error ?? context.queryResults.error,
+    );
 
     const setColumnOrder = useExplorerContext(
         (context) => context.actions.setColumnOrder,

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -11,12 +11,12 @@ import {
     IconLayoutSidebarLeftExpand,
 } from '@tabler/icons-react';
 import {
-    type FC,
     memo,
     useCallback,
     useLayoutEffect,
     useMemo,
     useState,
+    type FC,
 } from 'react';
 import { createPortal } from 'react-dom';
 import ErrorBoundary from '../../../features/errorBoundary/ErrorBoundary';
@@ -185,7 +185,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                     unsavedChartVersion.pivotConfig?.columns
                 }
                 resultsData={resultsData}
-                apiErrorDetail={query.error?.error}
+                apiErrorDetail={query.error?.error ?? queryResults.error?.error}
                 isLoading={isLoadingQueryResults}
                 columnOrder={unsavedChartVersion.tableConfig.columnOrder}
                 onSeriesContextMenu={onSeriesContextMenu}

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -39,7 +39,17 @@ const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
         if (apiErrorDetail) {
             return (
                 <EmptyState
-                    icon={<MantineIcon icon={IconChartBarOff} />}
+                    icon={
+                        // Icon consistent with SuboptimalState in charts
+                        <MantineIcon
+                            color="gray.5"
+                            size="xxl"
+                            icon={IconChartBarOff}
+                        />
+                    }
+                    h="100%"
+                    w="100%"
+                    justify="center"
                     title="Unable to load visualization"
                     description={
                         <Fragment>

--- a/packages/frontend/src/components/common/EmptyState/index.tsx
+++ b/packages/frontend/src/components/common/EmptyState/index.tsx
@@ -3,6 +3,7 @@ import {
     Text,
     Title,
     type DefaultProps,
+    type StackProps,
     type TextProps,
     type TitleProps,
 } from '@mantine/core';
@@ -14,6 +15,7 @@ type EmptyStateProps = DefaultProps & {
     titleProps?: TitleProps;
     description?: ReactNode;
     descriptionProps?: TextProps;
+    justify?: StackProps['justify'];
 };
 
 export const EmptyState: FC<React.PropsWithChildren<EmptyStateProps>> = ({
@@ -24,9 +26,9 @@ export const EmptyState: FC<React.PropsWithChildren<EmptyStateProps>> = ({
     descriptionProps,
     children,
     maw = 400,
-    ...defaultMantineProps
+    ...defaultMantinePropsWithJustify
 }) => (
-    <Stack align="center" pt="4xl" pb="5xl" {...defaultMantineProps}>
+    <Stack align="center" pt="4xl" pb="5xl" {...defaultMantinePropsWithJustify}>
         {icon}
 
         {title ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR fixes error handling in the Explorer by displaying errors from both the query and queryResults contexts. Previously, errors from queryResults were not being shown to users. Additionally, it removes the default value for the "subscription_status" parameter in the Jaffle Shop demo configuration.

The changes ensure that users will see appropriate error messages when either the query execution or the results processing encounters an issue, improving the overall error visibility in the Explorer interface.

**Before**
<img width="1171" height="1242" alt="image" src="https://github.com/user-attachments/assets/7eb24f78-87d7-447a-a4d4-32ab26e0e379" />

**After**

<img width="1163" height="1168" alt="image" src="https://github.com/user-attachments/assets/bd8632a8-8d5c-4a7e-92eb-d62e5c536502" />

