### PR TITLE
fix : long chart titles need to be truncated when viewing editing charts

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -334,7 +334,17 @@ const SavedChartsHeader: FC = () => {
                                     dashboardUuid={savedChart.dashboardUuid}
                                     dashboardName={savedChart.dashboardName}
                                 />
-                                <Title c="dark.6" order={5} fw={600}>
+                                <Title 
+                                    c="dark.6" 
+                                    order={5} 
+                                    fw={600}
+                                    sx={{
+                                        maxWidth: '300px',
+                                        whiteSpace: 'nowrap',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                    }}
+                                >
                                     {savedChart.name}
                                 </Title>
                                 {isEditMode && userCanManageChart && (


### PR DESCRIPTION
Closes : #13176 

### Description:

This PR adds text truncation to the chart title in the SavedChartsHeader component to ensure that long chart names don't break the layout and can fit on the same line as the breadcrumbs.

### Changes Made

File Modified: `packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx`
Added: CSS truncation properties to the chart title

### Preview : 


Before :  (_as you can see, the breadcrumb is hidden and the edit button is nearly inaccessible._)

<img width="1906" height="85" alt="image" src="https://github.com/user-attachments/assets/b1a48dd0-8774-4e12-b090-b955d8fabd06" />


After : 

<img width="1890" height="77" alt="image" src="https://github.com/user-attachments/assets/147dc613-a3b1-493a-816d-a6c7c41e9128" />

