### PR TITLE
feat: refactor Project and Organaization services to enable iframe explores

### DIFF
--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -72,7 +72,7 @@ export class ExploreController extends BaseController {
         const results: ApiExploresResults = await this.services
             .getProjectService()
             .getAllExploresSummary(
-                req.user!,
+                req.account!,
                 projectUuid,
                 req.query.filtered === 'true',
             );

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -172,7 +172,7 @@ export class OrganizationController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getProjects(req.user!),
+                .getProjects(req.account!),
         };
     }
 

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -93,7 +93,7 @@ export class ProjectController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getProject(projectUuid, req.user!),
+                .getProject(projectUuid, req.account!),
         };
     }
 
@@ -671,7 +671,7 @@ export class ProjectController extends BaseController {
         const { schedulerTimezone: oldDefaultProjectTimezone } =
             await this.services
                 .getProjectService()
-                .getProject(projectUuid, req.user!);
+                .getProject(projectUuid, req.account!);
 
         await this.services
             .getProjectService()

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -2090,7 +2090,10 @@ export class AiAgentService {
             throw new ForbiddenError(`Copilot not enabled`);
         }
 
-        const project = await this.projectService.getProject(projectUuid, user);
+        const project = await this.projectService.getProject(
+            projectUuid,
+            fromSession(user),
+        );
         if (project.organizationUuid !== organizationUuid) {
             throw new ForbiddenError(
                 'Project does not belong to this organization',
@@ -2118,7 +2121,10 @@ export class AiAgentService {
             throw new ForbiddenError('Copilot is not enabled');
         }
 
-        const project = await this.projectService.getProject(projectUuid, user);
+        const project = await this.projectService.getProject(
+            projectUuid,
+            fromSession(user),
+        );
         if (project.organizationUuid !== organizationUuid) {
             throw new ForbiddenError(
                 'Project does not belong to this organization',
@@ -2155,7 +2161,10 @@ export class AiAgentService {
             throw new ForbiddenError('Copilot is not enabled');
         }
 
-        const project = await this.projectService.getProject(projectUuid, user);
+        const project = await this.projectService.getProject(
+            projectUuid,
+            fromSession(user),
+        );
         if (project.organizationUuid !== organizationUuid) {
             throw new ForbiddenError(
                 'Project does not belong to this organization',

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -264,7 +264,7 @@ projectRouter.get(
             const results: TablesConfiguration = await req.services
                 .getProjectService()
                 .getTablesConfiguration(
-                    req.user!,
+                    req.account!,
                     getObjectValue(req.params, 'projectUuid'),
                 );
             res.json({

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -7,6 +7,7 @@ import {
     UploadMetricGsheet,
     UploadMetricGsheetPayload,
 } from '@lightdash/common';
+import { fromSession } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -96,7 +97,7 @@ export class GdriveService extends BaseService {
 
         const { organizationUuid } = await this.projectService.getProject(
             gsheetOptions.projectUuid,
-            user,
+            fromSession(user),
         );
 
         const payload: UploadMetricGsheetPayload = {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -1,15 +1,12 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
     AllowedEmailDomains,
-    AllowedEmailDomainsRoles,
     convertProjectRoleToOrganizationRole,
     CreateColorPalette,
     CreateGroup,
     CreateOrganization,
-    CreateProject,
-    DbtVersionOptionLatest,
     ForbiddenError,
-    getOrganizationNameSchema,
     Group,
     GroupWithMembers,
     isUserWithOrg,
@@ -18,8 +15,6 @@ import {
     LightdashMode,
     NotExistsError,
     OnbordingRecord,
-    OpenIdIdentityIssuerType,
-    OpenIdUser,
     Organization,
     OrganizationColorPalette,
     OrganizationColorPaletteWithIsActive,
@@ -29,11 +24,7 @@ import {
     OrganizationMemberRole,
     OrganizationProject,
     ParameterError,
-    ProjectType,
-    RequestMethod,
-    ServiceAccountScope,
     SessionUser,
-    UnexpectedServerError,
     UpdateAllowedEmailDomains,
     UpdateColorPalette,
     UpdateOrganization,
@@ -43,11 +34,7 @@ import {
 import { groupBy } from 'lodash';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
-import { ServiceAccountModel } from '../../ee/models/ServiceAccountModel';
-import { PersonalAccessTokenModel } from '../../models/DashboardModel/PersonalAccessTokenModel';
-import { EmailModel } from '../../models/EmailModel';
 import { GroupsModel } from '../../models/GroupsModel';
-import { InviteLinkModel } from '../../models/InviteLinkModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationAllowedEmailDomainsModel } from '../../models/OrganizationAllowedEmailDomainsModel';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
@@ -55,7 +42,6 @@ import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { UserModel } from '../../models/UserModel';
 import { BaseService } from '../BaseService';
-import { ProjectService } from '../ProjectService/ProjectService';
 
 type OrganizationServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -300,8 +286,8 @@ export class OrganizationService extends BaseService {
         };
     }
 
-    async getProjects(user: SessionUser): Promise<OrganizationProject[]> {
-        const { organizationUuid } = user;
+    async getProjects(account: Account): Promise<OrganizationProject[]> {
+        const { organizationUuid } = account.organization;
         if (organizationUuid === undefined) {
             throw new NotExistsError('Organization not found');
         }
@@ -310,7 +296,7 @@ export class OrganizationService extends BaseService {
         );
 
         return projects.filter((project) =>
-            user.ability.can(
+            account.user.ability.can(
                 'view',
                 subject('Project', {
                     organizationUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -41,6 +41,7 @@ import {
 import { ProjectService } from './ProjectService';
 import {
     allExplores,
+    buildAccount,
     defaultProject,
     expectedAllExploreSummary,
     expectedAllExploreSummaryWithoutErrors,
@@ -148,6 +149,11 @@ const getMockedProjectService = (lightdashConfig: LightdashConfig) =>
         projectParametersModel: {} as ProjectParametersModel,
     });
 
+const account = buildAccount({
+    accountType: 'session',
+    userType: 'registered',
+});
+
 describe('ProjectService', () => {
     const { projectUuid } = defaultProject;
     const service = getMockedProjectService(lightdashConfigMock);
@@ -173,7 +179,10 @@ describe('ProjectService', () => {
         expect(results).toEqual(expectedCatalog);
     });
     test('should get tables configuration', async () => {
-        const result = await service.getTablesConfiguration(user, projectUuid);
+        const result = await service.getTablesConfiguration(
+            account,
+            projectUuid,
+        );
         expect(result).toEqual(tablesConfiguration);
     });
     test('should update tables configuration', async () => {
@@ -225,7 +234,7 @@ describe('ProjectService', () => {
     describe('getAllExploresSummary', () => {
         test('should get all explores summary without filtering', async () => {
             const result = await service.getAllExploresSummary(
-                user,
+                account,
                 projectUuid,
                 false,
             );
@@ -233,7 +242,7 @@ describe('ProjectService', () => {
         });
         test('should get all explores summary with filtering', async () => {
             const result = await service.getAllExploresSummary(
-                user,
+                account,
                 projectUuid,
                 true,
             );
@@ -244,7 +253,7 @@ describe('ProjectService', () => {
                 projectModel.getTablesConfiguration as jest.Mock
             ).mockImplementationOnce(async () => tablesConfigurationWithTags);
             const result = await service.getAllExploresSummary(
-                user,
+                account,
                 projectUuid,
                 true,
             );
@@ -255,7 +264,7 @@ describe('ProjectService', () => {
                 projectModel.getTablesConfiguration as jest.Mock
             ).mockImplementationOnce(async () => tablesConfigurationWithNames);
             const result = await service.getAllExploresSummary(
-                user,
+                account,
                 projectUuid,
                 true,
             );
@@ -263,7 +272,7 @@ describe('ProjectService', () => {
         });
         test('should get all explores summary that do not have errors', async () => {
             const result = await service.getAllExploresSummary(
-                user,
+                account,
                 projectUuid,
                 false,
                 false,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -948,10 +948,10 @@ export class ProjectService extends BaseService {
         });
     }
 
-    async getProject(projectUuid: string, user: SessionUser): Promise<Project> {
+    async getProject(projectUuid: string, account: Account): Promise<Project> {
         const project = await this.projectModel.get(projectUuid);
         if (
-            user.ability.cannot(
+            account.user.ability.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid: project.organizationUuid,
@@ -3857,7 +3857,7 @@ export class ProjectService extends BaseService {
     }
 
     async getAllExploresSummary(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
         filtered: boolean,
         includeErrors: boolean = true,
@@ -3866,7 +3866,7 @@ export class ProjectService extends BaseService {
             projectUuid,
         );
         if (
-            user.ability.cannot(
+            account.user.ability.cannot(
                 'view',
                 subject('Project', { organizationUuid, projectUuid }),
             )
@@ -3882,11 +3882,7 @@ export class ProjectService extends BaseService {
         if (!explores) {
             return [];
         }
-        const userAttributes =
-            await this.userAttributesModel.getAttributeValuesForOrgMember({
-                organizationUuid,
-                userUuid: user.userUuid,
-            });
+        const { userAttributes } = await this.getUserAttributes({ account });
 
         const allExploreSummaries = explores.reduce<SummaryExplore[]>(
             (acc, explore) => {
@@ -3946,7 +3942,7 @@ export class ProjectService extends BaseService {
         if (filtered) {
             const {
                 tableSelection: { type, value },
-            } = await this.getTablesConfiguration(user, projectUuid);
+            } = await this.getTablesConfiguration(account, projectUuid);
             if (type === TableSelectionType.WITH_TAGS) {
                 return allExploreSummaries.filter(
                     (explore) =>
@@ -4322,14 +4318,14 @@ export class ProjectService extends BaseService {
     }
 
     async getTablesConfiguration(
-        user: SessionUser,
+        account: Account,
         projectUuid: string,
     ): Promise<TablesConfiguration> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );
         if (
-            user.ability.cannot(
+            account.user.ability.cannot(
                 'view',
                 subject('Project', { organizationUuid, projectUuid }),
             )


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Pulled out of the [PR](https://github.com/lightdash/lightdash/pull/16118) for enabling explores in embedded iframes 

Refactored authentication to use `req.account` instead of `req.user` in organization and project controllers. 

test-frontend
test-backend