### PR TITLE
fix: Empty filters apply placeholder values

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -395,7 +395,7 @@ describe('ProjectService', () => {
             expect(replaceWhitespace(runQueryMock.mock.calls[0][0])).toEqual(
                 replaceWhitespace(`SELECT AS "a_dim1"
                                    FROM test.table AS "a"
-                                   WHERE (( LOWER() LIKE LOWER('%%') ) AND ( () IS NOT NULL ))
+                                   WHERE (( true ) AND ( () IS NOT NULL ))
                                    GROUP BY 1
                                    ORDER BY "a_dim1"
                                    LIMIT 10`),
@@ -453,7 +453,7 @@ describe('ProjectService', () => {
                 replaceWhitespace(`SELECT AS "a_dim1"
                                         FROM test.table AS "a"
                                         LEFT OUTER JOIN public.b AS "b" ON ("a".dim1) = ("b".dim1)
-                                        WHERE (( LOWER() LIKE LOWER('%%') ) AND ( () IS NOT NULL ) AND ( () IN ('test') ) AND ( () IN ('test') ))
+                                        WHERE (( true ) AND ( () IS NOT NULL ) AND ( () IN ('test') ) AND ( () IN ('test') ))
                                         GROUP BY 1
                                         ORDER BY "a_dim1"
                                         LIMIT 10`),

--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -24,6 +24,11 @@ export const NumberFilterBaseWithMultiValues = {
     ...NumberFilterBase,
     values: [1, 2],
 };
+
+export const NumberFilterBaseWithEmptyValues = {
+    ...NumberFilterBase,
+    values: [],
+};
 export const NumberOperatorsWithMultipleValues = [
     FilterOperator.IN_BETWEEN,
     FilterOperator.NOT_IN_BETWEEN,
@@ -405,6 +410,18 @@ const stringMultiUnescapedValueFilter = {
     values: ["Bob's", "Tom's"],
 };
 
+const emptyStringFilter = {
+    id: '701b6520-1b19-4051-a553-7615aee0b03d',
+    target: { fieldId: 'customers_first_name' },
+    values: [''],
+};
+
+const mixedEmptyStringFilter = {
+    id: '701b6520-1b19-4051-a553-7615aee0b03d',
+    target: { fieldId: 'customers_first_name' },
+    values: ['', "Bob's", '', "Tom's"],
+};
+
 export const stringFilterDimension = '"customers".first_name';
 
 export const stringFilterRuleMocks = {
@@ -481,6 +498,48 @@ export const stringFilterRuleMocks = {
         ...stringMultiUnescapedValueFilter,
         operator: FilterOperator.EQUALS,
     },
+
+    includeFilterWithEmptyString: {
+        ...emptyStringFilter,
+        operator: FilterOperator.INCLUDE,
+    },
+    includeFilterWithEmptyStringSQL: 'true',
+
+    includeFilterWithMixedEmptyStrings: {
+        ...mixedEmptyStringFilter,
+        operator: FilterOperator.INCLUDE,
+    },
+    includeFilterWithMixedEmptyStringsSQL: `(LOWER(${stringFilterDimension}) LIKE LOWER('%Bob's%')\n  OR\n  LOWER(${stringFilterDimension}) LIKE LOWER('%Tom's%'))`,
+
+    equalsFilterWithEmptyString: {
+        ...emptyStringFilter,
+        operator: FilterOperator.EQUALS,
+    },
+    equalsFilterWithEmptyStringSQL: 'true',
+
+    startsWithFilterWithEmptyString: {
+        ...emptyStringFilter,
+        operator: FilterOperator.STARTS_WITH,
+    },
+    startsWithFilterWithEmptyStringSQL: 'true',
+
+    endsWithFilterWithEmptyString: {
+        ...emptyStringFilter,
+        operator: FilterOperator.ENDS_WITH,
+    },
+    endsWithFilterWithEmptyStringSQL: 'true',
+
+    notEqualsFilterWithEmptyString: {
+        ...emptyStringFilter,
+        operator: FilterOperator.NOT_EQUALS,
+    },
+    notEqualsFilterWithEmptyStringSQL: 'true',
+
+    notIncludeFilterWithEmptyString: {
+        ...emptyStringFilter,
+        operator: FilterOperator.NOT_INCLUDE,
+    },
+    notIncludeFilterWithEmptyStringSQL: 'true',
 };
 
 type RenderFilterRuleSqlParams = Parameters<

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -712,6 +712,76 @@ describe('Filter SQL', () => {
         ).toBe(stringFilterRuleMocks.notIncludeFilterWithNoValSQL);
     });
 
+    test('should return true when includes filter has empty string value', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.includeFilterWithEmptyString,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.includeFilterWithEmptyStringSQL);
+    });
+
+    test('should filter out empty strings and process valid values in mixed array', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.includeFilterWithMixedEmptyStrings,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.includeFilterWithMixedEmptyStringsSQL);
+    });
+
+    test('should return true when equals filter has empty string value', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.equalsFilterWithEmptyString,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.equalsFilterWithEmptyStringSQL);
+    });
+
+    test('should return true when starts with filter has empty string value', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.startsWithFilterWithEmptyString,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.startsWithFilterWithEmptyStringSQL);
+    });
+
+    test('should return true when ends with filter has empty string value', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.endsWithFilterWithEmptyString,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.endsWithFilterWithEmptyStringSQL);
+    });
+
+    test('should return true when not equals filter has empty string value', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.notEqualsFilterWithEmptyString,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.notEqualsFilterWithEmptyStringSQL);
+    });
+
+    test('should return true when not include filter has empty string value', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.notIncludeFilterWithEmptyString,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.notIncludeFilterWithEmptyStringSQL);
+    });
+
     test('should return single value in startsWith filter sql', () => {
         expect(
             renderStringFilterSql(
@@ -1196,6 +1266,62 @@ describe('Number Filter SQL Injection Prevention', () => {
             expect(renderNumberFilterSql(dimensionSql, filter)).toBe(
                 '(("table"."customer_id")) IN (1000,0.00025)',
             );
+        });
+
+        it('should return true for comparison operators with empty values', () => {
+            const comparisonOperators = [
+                FilterOperator.GREATER_THAN,
+                FilterOperator.GREATER_THAN_OR_EQUAL,
+                FilterOperator.LESS_THAN,
+                FilterOperator.LESS_THAN_OR_EQUAL,
+            ];
+
+            comparisonOperators.forEach((operator) => {
+                const filter = {
+                    ...baseFilter,
+                    operator,
+                    values: [],
+                };
+                expect(renderNumberFilterSql(dimensionSql, filter)).toBe(
+                    'true',
+                );
+            });
+        });
+
+        it('should return true for IN_BETWEEN operator with empty values', () => {
+            const filter = {
+                ...baseFilter,
+                operator: FilterOperator.IN_BETWEEN,
+                values: [],
+            };
+            expect(renderNumberFilterSql(dimensionSql, filter)).toBe('true');
+        });
+
+        it('should return true for IN_BETWEEN operator with only one value', () => {
+            const filter = {
+                ...baseFilter,
+                operator: FilterOperator.IN_BETWEEN,
+                values: [5],
+            };
+            expect(renderNumberFilterSql(dimensionSql, filter)).toBe('true');
+        });
+
+        it('should return true for NOT_IN_BETWEEN operator with empty values', () => {
+            const filter = {
+                ...baseFilter,
+                operator: FilterOperator.NOT_IN_BETWEEN,
+                values: [],
+            };
+            expect(renderNumberFilterSql(dimensionSql, filter)).toBe('true');
+        });
+
+        it('should return true for NOT_IN_BETWEEN operator with only one value', () => {
+            const filter = {
+                ...baseFilter,
+                operator: FilterOperator.NOT_IN_BETWEEN,
+                values: [5],
+            };
+            expect(renderNumberFilterSql(dimensionSql, filter)).toBe('true');
         });
     });
 });

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -120,7 +120,6 @@ const FilterRuleForm: FC<Props> = ({
                 data={filterOperatorOptions}
                 onChange={(value) => {
                     if (!value) return;
-
                     onChange(
                         getFilterRuleFromFieldWithDefaultValue(
                             activeField,
@@ -128,9 +127,7 @@ const FilterRuleForm: FC<Props> = ({
                                 ...filterRule,
                                 operator: value as FilterRule['operator'],
                             },
-                            (filterRule.values?.length || 0) > 0
-                                ? filterRule.values
-                                : [1],
+                            filterRule.values ?? [],
                         ),
                     );
                 }}


### PR DESCRIPTION
Closes: #16043, #7083

### Description:
Improved handling of empty filter values in SQL generation. 

1. String filters with empty values now return `true` instead of generating invalid SQL
2. String filters with mixed empty and non-empty values properly filter out the empty strings
3. Number filters with empty or insufficient values (e.g., only one value for IN_BETWEEN) now return `true`

~~todo: Validate correct usage of `''` strings, as it can be a valid filter~~ We don't support filter by empty strings atm

| Before | After |
|--------|--------|
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/50060d71-220c-4be6-a902-f7c33f66e5e9.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HorFj8gm8QUuuIDE2vgk/e4ebdc92-07dc-4e15-820f-8e6f923220a4.png) |
| <img width="899" height="766" alt="image" src="https://github.com/user-attachments/assets/f5980da7-d77e-4d72-bc55-52349d9d54cb" /> | <img width="899" height="886" alt="image" src="https://github.com/user-attachments/assets/dc1864e3-ef74-4bfb-bbf7-6583e50f08c4" /> |


Follow-up: #16152 tackling range input improvements







