### PR TITLE
feat: add orderBy for dashboard tiles for consistent order & update test

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -863,7 +863,11 @@ export class DashboardModel {
             .where(
                 `${DashboardTilesTableName}.dashboard_version_id`,
                 dashboard.dashboard_version_id,
-            );
+            )
+            .orderBy([
+                { column: `${DashboardTilesTableName}.y_offset` },
+                { column: `${DashboardTilesTableName}.x_offset` },
+            ]);
 
         const tabs = await this.database(DashboardTabsTableName)
             .select<DashboardTab[]>(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16139

### Description:
Added sortBy for `[y, x]` columns to preserve the order, which was otherwise randomised for the customer.