### PR TITLE
feat: only reload relevant charts on param change

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -95,6 +95,15 @@ export const useDashboardChartReadyQuery = (
         explore,
     ]);
 
+    const chartParameterValues = useMemo(() => {
+        if (!chartQuery.data?.parameters) return {};
+        return Object.fromEntries(
+            Object.keys(chartQuery.data.parameters)
+                .filter((key) => parameterValues && key in parameterValues)
+                .map((key) => [key, parameterValues[key]]),
+        );
+    }, [parameterValues, chartQuery.data?.parameters]);
+
     setChartsWithDateZoomApplied((prev) => {
         if (hasADateDimension) {
             if (granularity) {
@@ -119,7 +128,7 @@ export const useDashboardChartReadyQuery = (
             autoRefresh,
             hasADateDimension ? granularity : null,
             invalidateCache,
-            parameterValues,
+            chartParameterValues,
         ],
         [
             chartQuery.data?.projectUuid,
@@ -133,7 +142,7 @@ export const useDashboardChartReadyQuery = (
             hasADateDimension,
             granularity,
             invalidateCache,
-            parameterValues,
+            chartParameterValues,
         ],
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15992 

### Description:

Only reload relevant charts when a param changes. 

This works well. I thought there was an issue, but the issue was in the SQL definitions. One thing that is a little strange is that when react query has the old values cached, the charts update, but there is no spinner. I'm not sure if it's worth doing much about that. 

![Kapture 2025-08-01 at 09 57 54](https://github.com/user-attachments/assets/66f19b2e-dc47-4265-953a-2216283d1e2d)

