### PR TITLE
chore: refactor embed provider and hooks for iframe explores

### DIFF
--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -6,6 +6,7 @@ import { getMantine8ThemeOverride } from '../mantine8Theme';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
 import { AiAgentThreadStreamStoreProvider } from './features/aiCopilot/streaming/AiAgentThreadStreamStoreProvider';
+import EmbeddedApp from './features/embed/EmbeddedApp';
 import AgentPage from './pages/AiAgents/AgentPage';
 import AgentsRedirect from './pages/AiAgents/AgentsRedirect';
 import AgentsWelcome from './pages/AiAgents/AgentsWelcome';
@@ -16,16 +17,11 @@ import ProjectAiAgentEditPage from './pages/AiAgents/ProjectAiAgentEditPage';
 import AiConversationsPage from './pages/AiConversations';
 import EmbedDashboard from './pages/EmbedDashboard';
 import { SlackAuthSuccess } from './pages/SlackAuthSuccess';
-import EmbedProvider from './providers/Embed/EmbedProvider';
 
 const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
     {
         path: '/embed',
-        element: (
-            <EmbedProvider>
-                <Outlet />
-            </EmbedProvider>
-        ),
+        element: <EmbeddedApp />,
         children: [
             {
                 path: '/embed/:projectUuid',

--- a/packages/frontend/src/ee/features/embed/EmbeddedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbeddedApp.tsx
@@ -1,0 +1,38 @@
+import { type SavedChart } from '@lightdash/common';
+import { type FC, useState } from 'react';
+import { Outlet, useNavigate, useParams } from 'react-router';
+import EmbedProvider from '../../providers/Embed/EmbedProvider';
+
+/**
+ * A wrapping app around the Embed Context Provider. This allows better management of
+ * the embedded iframe experience.
+ */
+const EmbeddedApp: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const [savedChart, setSavedChart] = useState<SavedChart>();
+    const navigate = useNavigate();
+
+    const handleExplore = (options: { chart: SavedChart }) => {
+        setSavedChart(options.chart);
+        void navigate(
+            `/embed/${projectUuid}/explore/${options.chart.tableName}`,
+        );
+    };
+
+    const handleBackToDashboard = async () => {
+        await navigate(`/embed/${projectUuid}`);
+    };
+
+    return (
+        <EmbedProvider
+            savedChart={savedChart}
+            projectUuid={projectUuid}
+            onExplore={handleExplore}
+            onBackToDashboard={handleBackToDashboard}
+        >
+            <Outlet />
+        </EmbedProvider>
+    );
+};
+
+export default EmbeddedApp;

--- a/packages/frontend/src/ee/pages/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/pages/EmbedExplore.tsx
@@ -9,8 +9,13 @@ const EmbedExplorePage: FC<{
     containerStyles?: React.CSSProperties;
     exploreId?: string;
     savedChart?: SavedChart;
-}> = ({ containerStyles, exploreId, savedChart }) => {
-    const { embedToken } = useEmbed();
+}> = ({
+    containerStyles,
+    exploreId: exploreIdProps,
+    savedChart: savedChartProps,
+}) => {
+    const { embedToken, savedChart: savedChartEmbed } = useEmbed();
+    const savedChart = savedChartEmbed || savedChartProps;
 
     if (!embedToken) {
         return (
@@ -18,17 +23,6 @@ const EmbedExplorePage: FC<{
                 <SuboptimalState
                     icon={IconUnlink}
                     title="This embed link is not valid"
-                />
-            </div>
-        );
-    }
-
-    if (!exploreId) {
-        return (
-            <div style={{ marginTop: '20px' }}>
-                <SuboptimalState
-                    title="Missing explore ID"
-                    description="No explore ID provided"
                 />
             </div>
         );
@@ -44,6 +38,8 @@ const EmbedExplorePage: FC<{
             </div>
         );
     }
+
+    const exploreId = exploreIdProps || savedChart?.tableName;
 
     return (
         <EmbedExplore

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -18,6 +18,8 @@ type Props = {
     contentOverrides?: LanguageMap;
     embedHeaders?: Record<string, string>;
     onExplore?: (options: { chart: SavedChart }) => void;
+    onBackToDashboard?: () => void;
+    savedChart?: SavedChart;
 };
 
 const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
@@ -27,6 +29,8 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     projectUuid,
     contentOverrides,
     onExplore,
+    onBackToDashboard,
+    savedChart,
 }) => {
     const [isInitialized, setIsInitialized] = useState(false);
     const embed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
@@ -59,6 +63,8 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             projectUuid: embed?.projectUuid || projectUuid,
             languageMap: contentOverrides,
             onExplore,
+            savedChart,
+            onBackToDashboard,
         };
     }, [
         embed?.projectUuid,
@@ -68,6 +74,8 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         projectUuid,
         contentOverrides,
         onExplore,
+        savedChart,
+        onBackToDashboard,
     ]);
 
     return (

--- a/packages/frontend/src/ee/providers/Embed/context.ts
+++ b/packages/frontend/src/ee/providers/Embed/context.ts
@@ -9,6 +9,8 @@ const EmbedProviderContext = createContext<EmbedContext>({
     languageMap: undefined,
     t: (_input: string) => undefined,
     onExplore: (_options: { chart: SavedChart }) => {},
+    savedChart: undefined,
+    onBackToDashboard: undefined,
 });
 
 export default EmbedProviderContext;

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -9,10 +9,20 @@ export type InMemoryEmbed = {
 };
 
 export interface EmbedContext {
+    // The JWT token used to authenticate the user
     embedToken?: string;
+    // Dashboard filters available to the JWT user
     filters?: SdkFilter[];
+    // The project UUID of the project the JWT user is embedded in
     projectUuid?: string;
+    // Powers localization of the dashboard
     languageMap?: LanguageMap;
+    // The function to call when the user clicks "Explore from here"
     onExplore?: (options: { chart: SavedChart }) => void;
+    // Localization function
     t: (input: string) => string | undefined;
+    // The function to call when the user clicks "Back to dashboard" from an Explore
+    onBackToDashboard?: () => void;
+    // The chart that the user is exploring
+    savedChart?: SavedChart;
 }

--- a/packages/frontend/src/hooks/gitIntegration/useGitIntegration.ts
+++ b/packages/frontend/src/hooks/gitIntegration/useGitIntegration.ts
@@ -1,6 +1,7 @@
 import type { ApiError, GitIntegrationConfiguration } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
+import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 
 const getGitIntegration = async () =>
     lightdashApi<any>({
@@ -9,9 +10,13 @@ const getGitIntegration = async () =>
         body: undefined,
     });
 
-export const useGitIntegration = () =>
-    useQuery<GitIntegrationConfiguration, ApiError>({
+export const useGitIntegration = () => {
+    const ability = useAbilityContext();
+
+    return useQuery<GitIntegrationConfiguration, ApiError>({
         queryKey: ['git-integration'],
         queryFn: () => getGitIntegration(),
         retry: false,
+        enabled: ability?.can('manage', 'Explore'),
     });
+};

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -13,7 +13,7 @@ import {
 } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import useToaster from './toaster/useToaster';
-import useUser from './user/useUser';
+import { useAccount } from './user/useAccount';
 
 const getSpaceSummaries = async (projectUuid: string) => {
     return lightdashApi<SpaceSummary[]>({
@@ -35,7 +35,7 @@ export const useSpaceSummaries = (
     includePrivateSpaces: boolean = false,
     queryOptions?: UseQueryOptions<SpaceSummary[], ApiError>,
 ) => {
-    const { data: user } = useUser(true);
+    const { data: account } = useAccount();
     return useQuery<SpaceSummary[], ApiError>(
         ['projects', projectUuid, 'spaces'],
         () => getSpaceSummaries(projectUuid!),
@@ -46,10 +46,10 @@ export const useSpaceSummaries = (
                     ? data
                     : data.filter(
                           (space) =>
-                              !!user &&
-                              hasDirectAccessToSpace(space, user.userUuid),
+                              !!account?.user &&
+                              hasDirectAccessToSpace(space, account.user.id),
                       ),
-            enabled: !!projectUuid,
+            enabled: !!projectUuid && account?.isRegisteredUser(),
             ...queryOptions,
         },
     );

--- a/packages/frontend/src/hooks/user/useUser.ts
+++ b/packages/frontend/src/hooks/user/useUser.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
+import { useAccount } from './useAccount';
 
 export type UserWithAbility = LightdashUserWithAbilityRules & {
     ability: Ability;
@@ -24,10 +25,12 @@ const getUserState = async (): Promise<UserWithAbility> => {
 };
 
 const useUser = (isAuthenticated: boolean) => {
+    const { data: account } = useAccount();
+
     return useQuery<UserWithAbility, ApiError>({
         queryKey: ['user'],
         queryFn: getUserState,
-        enabled: isAuthenticated,
+        enabled: isAuthenticated && account?.isRegisteredUser(),
         retry: false,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactored the embedded app experience to prepare for embed iframe explores. Created a new `EmbeddedApp` component that wraps the `EmbedProvider` and handles navigation between dashboard and explore views. This will let us add a new route that can facilitate navigation between Dashboard and what will be the iframe Explore. 

Some hooks were tweaked to disable if we're in an embedded context because we know those requests will fail—and they're not needed for the embedded experience.