### PR TITLE
fix: Allow empty value for BigQuery maximunBytesBilled

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -574,10 +574,10 @@ const BigQueryForm: FC<{
                                     >
                                         dbt documentation
                                     </Anchor>
-                                    .
+                                    . Leaving this field empty or with a 0 value
+                                    means no limit.
                                 </p>
                             }
-                            required
                             disabled={disabled}
                         />
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -250,10 +250,9 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             query,
             params: options?.values,
             useLegacySql: false,
-            maximumBytesBilled:
-                this.credentials.maximumBytesBilled === undefined
-                    ? undefined
-                    : `${this.credentials.maximumBytesBilled}`,
+            maximumBytesBilled: this.credentials.maximumBytesBilled
+                ? `${this.credentials.maximumBytesBilled}`
+                : undefined,
             priority: this.credentials.priority,
             jobTimeoutMs:
                 this.credentials.timeoutSeconds &&


### PR DESCRIPTION
### Description:
Makes the `maximumBytesBilled` field optional in the BigQuery form by removing the `required` attribute. Updates the help text to clarify that leaving the field empty or with a value of 0 means no limit will be applied. Also simplifies the logic in the BigqueryWarehouseClient to handle empty or zero values properly.