### PR TITLE
fix: improve BigQuery error handling

### DIFF
--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -541,6 +541,39 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                     break;
                 }
                 break;
+
+            case 'stopped':
+                return new WarehouseQueryError(
+                    `BigQuery job was stopped. ${
+                        error?.message ||
+                        'This may be due to configuration issues such as maximum bytes billed limit, job timeout, or query cancellation. Please check your connection settings.'
+                    }`,
+                );
+
+            case 'invalid':
+                return new WarehouseQueryError(
+                    `BigQuery configuration is invalid. ${
+                        error?.message ||
+                        'Please verify your connection settings and other advanced options.'
+                    }`,
+                );
+
+            case 'quotaExceeded':
+                return new WarehouseQueryError(
+                    `BigQuery quota exceeded. ${
+                        error?.message ||
+                        'You may have reached your query quota, slots quota, or other BigQuery limits. Please check your BigQuery quotas and usage.'
+                    }`,
+                );
+
+            case 'rateLimitExceeded':
+                return new WarehouseQueryError(
+                    `BigQuery rate limit exceeded. ${
+                        error?.message ||
+                        'Please wait a moment and try again, or consider reducing query frequency.'
+                    }`,
+                );
+
             default:
                 break;
         }
@@ -552,7 +585,9 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             )}`,
         );
         return new WarehouseQueryError(
-            `Bigquery warehouse error: ${error?.reason}`,
+            `Bigquery warehouse error: ${error?.reason}${
+                error?.message ? ` - ${error.message}` : ''
+            }`,
         );
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Improves BigQuery error handling by adding more error messages
- Added detailed error messages for 'stopped', 'invalid', 'quotaExceeded', and 'rateLimitExceeded' states
- Enhanced the default error message to include the error message along with the reason
