### PR TITLE
fix: agent generates queries with limits > 1000

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -53,6 +53,7 @@ export const aiCopilotConfigSchema = z
         requiresFeatureFlag: z.boolean(),
         telemetryEnabled: z.boolean(),
         debugLoggingEnabled: z.boolean(),
+        maxQueryLimit: z.number().positive(),
     })
     .refine(
         ({ providers, defaultProvider, enabled }) =>

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -185,6 +185,7 @@ export const lightdashConfigMock: LightdashConfig = {
         copilot: {
             enabled: false,
             debugLoggingEnabled: false,
+            maxQueryLimit: 10000,
             telemetryEnabled: false,
             requiresFeatureFlag: false,
             defaultProvider: 'openai',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1,4 +1,5 @@
 import {
+    AI_DEFAULT_MAX_QUERY_LIMIT,
     ALL_TASK_NAMES,
     AllowedEmailDomainsRole,
     AllowedEmailDomainsRoles,
@@ -1061,6 +1062,9 @@ export const parseConfig = (): LightdashConfig => {
                   }
                 : undefined,
         },
+        maxQueryLimit:
+            getIntegerFromEnvironmentVariable('AI_COPILOT_MAX_QUERY_LIMIT') ||
+            AI_DEFAULT_MAX_QUERY_LIMIT,
     };
 
     const copilotConfigParse =

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1019,7 +1019,7 @@ export class AiAgentService {
 
         const parsedVizConfig = parseVizConfig(
             message.vizConfigOutput,
-            this.lightdashConfig.query.maxLimit,
+            this.lightdashConfig.ai.copilot.maxQueryLimit,
         );
 
         if (!parsedVizConfig) {
@@ -1044,21 +1044,21 @@ export class AiAgentService {
                     runMetricQuery: (q) =>
                         this.runAiMetricQuery(user, projectUuid, q),
                     vizTool: parsedVizConfig.vizTool,
-                    maxLimit: this.lightdashConfig.query.maxLimit,
+                    maxLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
                 });
             case AiResultType.TIME_SERIES_RESULT:
                 return renderTimeSeriesViz({
                     runMetricQuery: (q) =>
                         this.runAiMetricQuery(user, projectUuid, q),
                     vizTool: parsedVizConfig.vizTool,
-                    maxLimit: this.lightdashConfig.query.maxLimit,
+                    maxLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
                 });
             case AiResultType.TABLE_RESULT:
                 return renderTableViz({
                     runMetricQuery: (q) =>
                         this.runAiMetricQuery(user, projectUuid, q),
                     vizTool: parsedVizConfig.vizTool,
-                    maxLimit: this.lightdashConfig.query.maxLimit,
+                    maxLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
                 });
             default:
                 return assertUnreachable(parsedVizConfig, 'Invalid viz type');
@@ -1139,7 +1139,7 @@ export class AiAgentService {
 
         const parsedVizConfig = parseVizConfig(
             message.vizConfigOutput,
-            this.lightdashConfig.query.maxLimit,
+            this.lightdashConfig.ai.copilot.maxQueryLimit,
         );
 
         if (!parsedVizConfig) {
@@ -1659,7 +1659,7 @@ export class AiAgentService {
             threadUuid: prompt.threadUuid,
             promptUuid: prompt.promptUuid,
             messageHistory,
-            maxLimit: this.lightdashConfig.query.maxLimit,
+            maxLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
             organizationId: user.organizationUuid,
             userId: user.userUuid,
             debugLoggingEnabled:
@@ -1951,7 +1951,7 @@ export class AiAgentService {
         const exploreBlocks = getExploreBlocks(
             slackPrompt,
             this.lightdashConfig.siteUrl,
-            this.lightdashConfig.query.maxLimit,
+            this.lightdashConfig.ai.copilot.maxQueryLimit,
         );
         const historyBlocks = getDeepLinkBlocks(
             slackPrompt,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16162

### Description:

We were using `LIGHTDASH_QUERY_MAX_LIMIT` in agents as maxlimit for queries, but we have a different limit `AI_DEFAULT_MAX_QUERY_LIMIT` for viz queries validations. These two were different (10k for ld max limit, 1k  for ai max query) causing errors.
This PR unifies this and introduces a new maxQuery config at config schema level. 