### PR TITLE
feat: refactor AI agent with configurable search parameters

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -59,11 +59,16 @@ const getAgentTools = (
     }
 
     const findExplores = getFindExplores({
+        maxDescriptionLength: args.findExploresMaxDescriptionLength,
+        pageSize: args.findExploresPageSize,
+        fieldSearchSize: args.findExploresFieldSearchSize,
+        fieldOverviewSearchSize: args.findExploresFieldOverviewSearchSize,
         findExplores: dependencies.findExplores,
     });
 
     const findFields = getFindFields({
         findFields: dependencies.findFields,
+        pageSize: args.findFieldsPageSize,
     });
 
     const generateBarVizConfig = getGenerateBarVizConfig({
@@ -73,7 +78,7 @@ const getAgentTools = (
         getPrompt: dependencies.getPrompt,
         updatePrompt: dependencies.updatePrompt,
         sendFile: dependencies.sendFile,
-        maxLimit: args.maxLimit,
+        maxLimit: args.maxQueryLimit,
     });
 
     const generateTimeSeriesVizConfig = getGenerateTimeSeriesVizConfig({
@@ -83,7 +88,7 @@ const getAgentTools = (
         getPrompt: dependencies.getPrompt,
         updatePrompt: dependencies.updatePrompt,
         sendFile: dependencies.sendFile,
-        maxLimit: args.maxLimit,
+        maxLimit: args.maxQueryLimit,
     });
 
     const generateTableVizConfig = getGenerateTableVizConfig({
@@ -93,7 +98,7 @@ const getAgentTools = (
         getPrompt: dependencies.getPrompt,
         updatePrompt: dependencies.updatePrompt,
         sendFile: dependencies.sendFile,
-        maxLimit: args.maxLimit,
+        maxLimit: args.maxQueryLimit,
     });
 
     const tools = {

--- a/packages/backend/src/ee/services/ai/tools/findFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/findFields.ts
@@ -5,7 +5,6 @@ import {
     FieldType,
     getItemId,
     isEmojiIcon,
-    KnexPaginateArgs,
     toolFindFieldsArgsSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -14,6 +13,7 @@ import { toolErrorHandler } from '../utils/toolErrorHandler';
 
 type Dependencies = {
     findFields: FindFieldFn;
+    pageSize: number;
 };
 
 const fieldKindLabel = (fieldType: FieldType) => {
@@ -75,16 +75,9 @@ const getFieldText = (catalogField: CatalogField) => {
     `.trim();
 };
 
-const getFieldsText = (args: {
-    searchQuery: string;
-    fields: CatalogField[];
-    pagination:
-        | (KnexPaginateArgs & {
-              totalPageCount: number;
-              totalResults: number;
-          })
-        | undefined;
-}) =>
+const getFieldsText = (
+    args: Awaited<ReturnType<FindFieldFn>> & { searchQuery: string },
+) =>
     `
 <SearchResults searchQuery="${args.searchQuery}" page="${
         args.pagination?.page
@@ -95,7 +88,7 @@ const getFieldsText = (args: {
 </SearchResults>
 `.trim();
 
-export const getFindFields = ({ findFields }: Dependencies) => {
+export const getFindFields = ({ findFields, pageSize }: Dependencies) => {
     const schema = toolFindFieldsArgsSchema;
 
     return tool({
@@ -122,7 +115,7 @@ Usage tips:
                             table: args.table,
                             fieldSearchQuery,
                             page: args.page ?? 1,
-                            pageSize: 10,
+                            pageSize,
                         })),
                     })),
                 );

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -20,10 +20,15 @@ export type AiAgentArgs = {
     messageHistory: CoreMessage[];
     promptUuid: string;
     threadUuid: string;
-    maxLimit: number;
     organizationId: string;
     userId: string;
     debugLoggingEnabled: boolean;
+    findExploresPageSize: number;
+    findExploresFieldOverviewSearchSize: number;
+    findExploresFieldSearchSize: number;
+    findExploresMaxDescriptionLength: number;
+    findFieldsPageSize: number;
+    maxQueryLimit: number;
 };
 
 export type AiAgentDependencies = {

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -22,7 +22,11 @@ type Pagination = KnexPaginateArgs & {
 };
 
 export type FindExploresFn = (
-    args: { tableName: string | null } & KnexPaginateArgs,
+    args: {
+        tableName: string | null;
+        fieldOverviewSearchSize: number;
+        fieldSearchSize: number;
+    } & KnexPaginateArgs,
 ) => Promise<{
     tablesWithFields: {
         table: CatalogTable;


### PR DESCRIPTION
### Description:
Refactored AI agent configuration to use explicit parameters instead of hardcoded values. This change:

- Added configurable parameters for search result sizes in AI agent tools
- Created proper type definitions for AI agent arguments and dependencies
- Replaced hardcoded values with configurable parameters for:
  - Field search sizes
  - Page sizes for explore and field searches
  - Maximum description length
  - Query limits

This makes the AI agent behavior more configurable and removes TODOs that were previously in the code.