### PR TITLE
fix: charts with default parameters not updating

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -48,6 +48,9 @@ export const useDashboardChartReadyQuery = (
     const addParameterReferences = useDashboardContext(
         (c) => c.addParameterReferences,
     );
+    const tileParameterReferences = useDashboardContext(
+        (c) => c.tileParameterReferences,
+    );
     const dashboardSorts = useMemo(
         () => chartSort[tileUuid] || [],
         [chartSort, tileUuid],
@@ -96,13 +99,14 @@ export const useDashboardChartReadyQuery = (
     ]);
 
     const chartParameterValues = useMemo(() => {
-        if (!chartQuery.data?.parameters) return {};
+        if (!tileParameterReferences || !tileParameterReferences[tileUuid])
+            return {};
         return Object.fromEntries(
-            Object.keys(chartQuery.data.parameters)
-                .filter((key) => parameterValues && key in parameterValues)
-                .map((key) => [key, parameterValues[key]]),
+            Object.entries(parameterValues).filter(([key]) =>
+                tileParameterReferences[tileUuid].includes(key),
+            ),
         );
-    }, [parameterValues, chartQuery.data?.parameters]);
+    }, [parameterValues, tileParameterReferences, tileUuid]);
 
     setChartsWithDateZoomApplied((prev) => {
         if (hasADateDimension) {

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -808,6 +808,7 @@ const DashboardProvider: React.FC<
         clearAllParameters,
         dashboardParameterReferences,
         addParameterReferences,
+        tileParameterReferences,
         areAllChartsLoaded,
     };
     return (

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -103,5 +103,6 @@ export type DashboardContextType = {
     setParameter: (key: string, value: string | string[] | null) => void;
     dashboardParameterReferences: Set<string>;
     addParameterReferences: (tileUuid: string, references: string[]) => void;
+    tileParameterReferences: Record<string, string[]>;
     areAllChartsLoaded: boolean;
 };


### PR DESCRIPTION
### Description

Fix an issue where charts in dashboards that had default values didn't update with parameter changes. They didn't keep track of which parameters were needed. This just uses the tile-based lookup we already had after all the charts run for the first time. 

