### PR TITLE
fix: handle empty string location in BigQuery client config

### DIFF
--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -184,7 +184,8 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         try {
             this.client = new BigQuery({
                 projectId: credentials.executionProject || credentials.project,
-                location: credentials.location,
+                // empty string is not a valid value for location
+                location: credentials.location || undefined,
                 maxRetries: credentials.retries,
                 credentials: credentials.keyfileContents,
             });


### PR DESCRIPTION


### Description:
Fix BigQuery client initialization by handling empty location strings. When the `location` credential is an empty string, it's now treated as `undefined` to avoid invalid value errors from the BigQuery client.