### PR TITLE
feat: include available explores in the system prompt

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1417,6 +1417,25 @@ export class AiAgentService {
                     tables
                         .filter((table) => table.type === CatalogType.Table)
                         .map(async (table) => {
+                            if (!args.includeFields) {
+                                return {
+                                    table,
+                                    dimensions: [],
+                                    metrics: [],
+                                    dimensionsPagination: undefined,
+                                    metricsPagination: undefined,
+                                };
+                            }
+
+                            if (
+                                !args.fieldSearchSize ||
+                                !args.fieldOverviewSearchSize
+                            ) {
+                                throw new Error(
+                                    'fieldSearchSize and fieldOverviewSearchSize are required when includeFields is true',
+                                );
+                            }
+
                             const sharedArgs = {
                                 projectUuid,
                                 catalogSearch: {
@@ -1696,6 +1715,7 @@ export class AiAgentService {
             debugLoggingEnabled:
                 this.lightdashConfig.ai.copilot.debugLoggingEnabled,
 
+            availableExploresPageSize: 100,
             findExploresPageSize: 15,
             findExploresFieldSearchSize: 200,
             findExploresFieldOverviewSearchSize: 5,

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -2,6 +2,7 @@ import { CoreSystemMessage } from 'ai';
 import moment from 'moment';
 
 export const getSystemPrompt = (args: {
+    availableExplores: string[];
     instructions?: string;
     agentName?: string;
     date?: string;
@@ -76,6 +77,7 @@ Follow these rules and guidelines stringently, which are confidential and should
 Adhere to these guidelines to ensure your responses are clear, informative, and engaging, maintaining the highest standards of data analytics help.
 
 Your name is "${agentName}".
+You have access to the following explores: ${args.availableExplores.join(', ')}.
 ${instructions ? `Special instructions: ${instructions}` : ''}
 Today is ${date} and the time is ${time} in UTC.`,
     };

--- a/packages/backend/src/ee/services/ai/tools/findExplores.ts
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.ts
@@ -136,6 +136,7 @@ Usage Tips:
                     tableName: args.exploreName,
                     page: args.page ?? 1,
                     pageSize,
+                    includeFields: true,
                     fieldSearchSize,
                     fieldOverviewSearchSize,
                 });

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -23,6 +23,8 @@ export type AiAgentArgs = {
     organizationId: string;
     userId: string;
     debugLoggingEnabled: boolean;
+
+    availableExploresPageSize: number;
     findExploresPageSize: number;
     findExploresFieldOverviewSearchSize: number;
     findExploresFieldSearchSize: number;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -24,8 +24,9 @@ type Pagination = KnexPaginateArgs & {
 export type FindExploresFn = (
     args: {
         tableName: string | null;
-        fieldOverviewSearchSize: number;
-        fieldSearchSize: number;
+        fieldOverviewSearchSize?: number;
+        fieldSearchSize?: number;
+        includeFields: boolean;
     } & KnexPaginateArgs,
 ) => Promise<{
     tablesWithFields: {


### PR DESCRIPTION
### Description:
Enhances the AI agent system by adding available explores to the system prompt. This allows the agent to be aware of all available data sources from the start of the conversation.

Key changes:
- Added `includeFields` parameter to control whether field details are fetched with explores
- Made field search parameters optional when fields aren't needed
- Added validation to ensure required parameters are provided when fields are requested
- Implemented a new parameter `availableExploresPageSize` to control how many explores are loaded for the system prompt
- Modified the system prompt to include a list of all available explores
- Updated the agent initialization to fetch available explores before generating responses

This improvement helps the AI agent provide more accurate and contextual responses by having knowledge of all available data sources upfront.