### PR TITLE
chore: hide temporary query results endpoint from API docs

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -27,6 +27,7 @@ import {
 import {
     Body,
     Get,
+    Hidden,
     Middlewares,
     OperationId,
     Path,
@@ -367,6 +368,7 @@ export class QueryController extends BaseController {
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/{queryUuid}/results')
+    @Hidden() // This endpoint is temporary while we migrate SQL runner to use pagination. Should not be part of API docs.
     @OperationId('getResultsStream')
     async getResultsStream(
         @Path() projectUuid: string,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -18186,7 +18186,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1874.0",
+        "version": "0.1875.5",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -28432,54 +28432,6 @@
                         }
                     }
                 }
-            }
-        },
-        "/api/v2/projects/{projectUuid}/query/{queryUuid}/results": {
-            "get": {
-                "operationId": "getResultsStream",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AnyType"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Stream results from S3",
-                "tags": ["v2", "Query"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "projectUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "path",
-                        "name": "queryUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
             }
         },
         "/api/v2/projects/{projectUuid}/query/{queryUuid}/download": {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:

### Description:
Hide the `/api/v2/projects/{projectUuid}/query/{queryUuid}/results` endpoint from API documentation while we migrate SQL runner to use pagination. This endpoint is temporary and should not be part of the public API docs.