### PR TITLE
fix: document icon in settings not visible until hover 

### DIFF
--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -82,7 +82,12 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                             href="https://docs.lightdash.com/"
                             target="_blank"
                         >
-                            <ActionIcon color="gray.7" p="xs" size="lg">
+                            <ActionIcon
+                                color="gray.7"
+                                p="xs"
+                                size="lg"
+                                variant="subtle"
+                            >
                                 <MantineIcon
                                     icon={IconBook}
                                     size="lg"


### PR DESCRIPTION
Closes: #16180

### Description:

The PR fixes the documentation icon visibility issue in the footer, where the book icon was only visible on hover due to poor contrast.

### Changes made

File: `packages/frontend/src/components/AboutFooter.tsx`: Updated icon color and button variants
change: Removed custom hover styles in favor of consistent light variant behavior

### Preview

| Before | After |
|--------|-------|
| <img width="480" height="100" alt="Before" src="https://github.com/user-attachments/assets/e057bce0-2aea-4f99-8607-01b662adb794" /> | <img width="480" height="100" alt="After" src="https://github.com/user-attachments/assets/59b0df47-64ab-4d00-bc7b-73c1441f046c" /> |

