### PR TITLE
chore: update subscriptions with multiple and custom params

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
+++ b/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
@@ -15,6 +15,7 @@ parameters:
     label: "Subscription Status"
     description: "Filter subscriptions by their current status"
     default: "all"
+    multiple: true
     options:
       - "all"
       - "Current"
@@ -24,6 +25,7 @@ parameters:
     label: "Minimum Duration (Months)"
     description: "Filter subscriptions by minimum duration in months"
     default: "0"
+    allow_custom_values: true
     options:
       - "0"
       - "1"
@@ -34,6 +36,7 @@ parameters:
     label: "Plan Type"
     description: "Filter by subscription plan"
     default: "all"
+    multiple: true
     options:
       - "all"
       - "free"

--- a/examples/full-jaffle-shop-demo/dbt/models/subscriptions.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/subscriptions.yml
@@ -55,8 +55,8 @@ models:
             metrics:
               subscriptions_by_plan:
                 type: count_distinct
-                label: Subscriptions by Plan
-                description: Count of subscriptions, use with plan dimension for breakdown
+                label: Distinct subscriptions by Plan
+                description: Count of subscriptions, use with plan dimension for breakdown (no parameters)
                 sql: subscription_id
       
       - name: plan_name
@@ -220,7 +220,7 @@ models:
               filtered_by_plan:
                 type: count_distinct
                 label: Subscriptions by Plan
-                description: Count of subscriptions for specific plan type
+                description: Count of subscriptions for specific plan type (uses plan_type)
                 sql: |
                   CASE 
                     WHEN ${ld.parameters.plan_type} = 'all' THEN subscription_id


### PR DESCRIPTION
### Description:

Update Subscriptions model with params that have `multiple` and `allow_custom_values` props. We supported these, but they weren't in the demo data. So this if for testing and using those features.

Not that there is currently a bug where one of these doesn't show up: #16191 
