### PR TITLE
feat: validate filter type against field type

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -1,12 +1,18 @@
 import {
-    AI_DEFAULT_MAX_QUERY_LIMIT,
+    assertUnreachable,
+    booleanFilterSchema,
     CompiledField,
+    dateFilterSchema,
     Explore,
     FilterRule,
+    FilterType,
     getErrorMessage,
     getFields,
+    getFilterTypeFromItemType,
     getItemId,
+    numberFilterSchema,
     renderFilterRuleSqlFromField,
+    stringFilterSchema,
     SupportedDbtAdapter,
     WeekDay,
 } from '@lightdash/common';
@@ -44,6 +50,77 @@ ${nonExploreFields.join('\n')}
 }
 
 function validateFilterRule(filterRule: FilterRule, field: CompiledField) {
+    const filterType = getFilterTypeFromItemType(field.type);
+
+    switch (filterType) {
+        case FilterType.BOOLEAN:
+            const parsedBooleanFilterRule = booleanFilterSchema.safeParse({
+                fieldId: filterRule.target.fieldId,
+                fieldType: field.type,
+                fieldFilterType: 'boolean',
+                operator: filterRule.operator,
+                values: filterRule.values,
+            });
+
+            if (!parsedBooleanFilterRule.success) {
+                throw new Error(
+                    `Expected boolean filter rule for field ${filterRule.target.fieldId}. Error: ${parsedBooleanFilterRule.error.message}`,
+                );
+            }
+
+            break;
+        case FilterType.DATE:
+            const parsedDateFilterRule = dateFilterSchema.safeParse({
+                fieldId: filterRule.target.fieldId,
+                fieldType: field.type,
+                fieldFilterType: 'date',
+                operator: filterRule.operator,
+                values: filterRule.values,
+            });
+
+            if (!parsedDateFilterRule.success) {
+                throw new Error(
+                    `Expected date filter rule for field ${filterRule.target.fieldId}. Error: ${parsedDateFilterRule.error.message}`,
+                );
+            }
+
+            break;
+        case FilterType.NUMBER:
+            const parsedNumberFilterRule = numberFilterSchema.safeParse({
+                fieldId: filterRule.target.fieldId,
+                fieldType: field.type,
+                fieldFilterType: 'number',
+                operator: filterRule.operator,
+                values: filterRule.values,
+            });
+
+            if (!parsedNumberFilterRule.success) {
+                throw new Error(
+                    `Expected number filter rule for field ${filterRule.target.fieldId}. Error: ${parsedNumberFilterRule.error.message}`,
+                );
+            }
+
+            break;
+        case FilterType.STRING:
+            const parsedStringFilterRule = stringFilterSchema.safeParse({
+                fieldId: filterRule.target.fieldId,
+                fieldType: field.type,
+                fieldFilterType: 'string',
+                operator: filterRule.operator,
+                values: filterRule.values,
+            });
+
+            if (!parsedStringFilterRule.success) {
+                throw new Error(
+                    `Expected string filter rule for field ${filterRule.target.fieldId}. Error: ${parsedStringFilterRule.error.message}`,
+                );
+            }
+
+            break;
+        default:
+            assertUnreachable(filterType, `Invalid field type: ${filterType}`);
+    }
+
     try {
         renderFilterRuleSqlFromField(
             filterRule,

--- a/packages/common/src/ee/AiAgent/schemas/filters/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/index.ts
@@ -8,6 +8,13 @@ import dateFilterSchema from './dateFilters';
 import numberFilterSchema from './numberFilters';
 import stringFilterSchema from './stringFilters';
 
+export {
+    booleanFilterSchema,
+    dateFilterSchema,
+    numberFilterSchema,
+    stringFilterSchema,
+};
+
 const filterAndOrSchema = z
     .union([z.literal('and'), z.literal('or')])
     .describe('Type of filter group operation');


### PR DESCRIPTION
Closes: #16188

### Description:
Enhanced filter validation in AI services by implementing type-specific validation for filter rules. The PR adds validation logic for boolean, date, timestamp, number, and string filter types, ensuring that filter rules match the expected field type before attempting to render SQL. Additionally, exports filter schema objects from the common package to make them accessible for validation purposes.