### PR TITLE
chore: upgrade date zoom component to mantine 8

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -20,9 +20,6 @@ import ThirdPartyProvider from './providers/ThirdPartyServicesProvider';
 import TrackingProvider from './providers/Tracking/TrackingProvider';
 import Routes from './Routes';
 
-// Mantine v8 styles
-import '@mantine-8/core/styles.css';
-
 // const isMobile =
 //     /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
 //         navigator.userAgent,

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
@@ -1,0 +1,29 @@
+/* Dashed outline button for adding date zoom */
+.addDateZoomButton {
+    border-style: dashed;
+    border-width: 1px;
+    border-color: var(--mantine-color-gray-4);
+}
+
+/* Positioned close button on date zoom */
+.closeButton {
+    position: absolute;
+    top: -6px;
+    left: -6px;
+    z-index: 1;
+    color: var(--mantine-color-gray-6);
+    background-color: var(--mantine-color-white);
+}
+
+/* Active date zoom button with blue border */
+.activeDateZoomButton {
+    border-color: var(--mantine-color-blue-6);
+}
+
+/* Menu item styling for disabled state */
+.menuItemDisabled {
+    color: white;
+    &:not([data-disabled='false']) {
+        color: var(--mantine-color-gray-6);
+    }
+}

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -1,30 +1,32 @@
 import { DateGranularity } from '@lightdash/common';
 import {
     ActionIcon,
+    Box,
     Button,
     Group,
+    MantineProvider,
     Menu,
-    Text,
-    useMantineTheme,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import {
     IconCalendarSearch,
+    IconCheck,
     IconChevronDown,
     IconChevronUp,
     IconX,
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import styles from './DateZoom.module.css';
 
 type Props = {
     isEditMode: boolean;
 };
 
 export const DateZoom: FC<Props> = ({ isEditMode }) => {
-    const theme = useMantineTheme();
     const [showOpenIcon, setShowOpenIcon] = useState(false);
 
     const dateZoomGranularity = useDashboardContext(
@@ -46,149 +48,136 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
     if (isDateZoomDisabled) {
         if (isEditMode)
             return (
-                <Button
-                    variant="outline"
-                    size="xs"
-                    leftIcon={<MantineIcon icon={IconCalendarSearch} />}
-                    onClick={() => setIsDateZoomDisabled(false)}
-                    sx={(themeStyles) => ({
-                        borderStyle: 'dashed',
-                        borderWidth: '1px',
-                        borderColor: themeStyles.colors.gray[4],
-                    })}
-                >
-                    + Add date zoom
-                </Button>
+                <MantineProvider theme={getMantine8ThemeOverride()}>
+                    <Button
+                        variant="outline"
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconCalendarSearch} />}
+                        onClick={() => setIsDateZoomDisabled(false)}
+                        classNames={{ root: styles.addDateZoomButton }}
+                    >
+                        + Add date zoom
+                    </Button>
+                </MantineProvider>
             );
         return null;
     }
 
     return (
-        <Menu
-            withinPortal
-            withArrow
-            closeOnItemClick
-            closeOnClickOutside
-            offset={-1}
-            position="bottom-end"
-            disabled={isEditMode}
-            onOpen={() => setShowOpenIcon(true)}
-            onClose={() => setShowOpenIcon(false)}
-        >
-            <Menu.Target>
-                <Group spacing={0} sx={{ position: 'relative' }}>
-                    {isEditMode && (
-                        <ActionIcon
+        <MantineProvider theme={getMantine8ThemeOverride()}>
+            <Menu
+                withinPortal
+                withArrow
+                closeOnItemClick
+                closeOnClickOutside
+                offset={-1}
+                position="bottom-end"
+                disabled={isEditMode}
+                onOpen={() => setShowOpenIcon(true)}
+                onClose={() => setShowOpenIcon(false)}
+            >
+                <Menu.Target>
+                    <Group gap={0} pos="relative">
+                        {isEditMode && (
+                            <ActionIcon
+                                size="xs"
+                                variant="subtle"
+                                onClick={() => setIsDateZoomDisabled(true)}
+                                className={styles.closeButton}
+                            >
+                                <MantineIcon icon={IconX} size={12} />
+                            </ActionIcon>
+                        )}
+                        <Button
                             size="xs"
-                            variant="subtle"
-                            onClick={() => setIsDateZoomDisabled(true)}
-                            sx={(themeStyles) => ({
-                                position: 'absolute',
-                                top: -6,
-                                left: -6,
-                                zIndex: 1,
-                                backgroundColor: themeStyles.white,
-                            })}
+                            variant="default"
+                            disabled={isEditMode}
+                            classNames={
+                                dateZoomGranularity
+                                    ? { root: styles.activeDateZoomButton }
+                                    : undefined
+                            }
+                            leftSection={
+                                <MantineIcon icon={IconCalendarSearch} />
+                            }
+                            rightSection={
+                                <MantineIcon
+                                    icon={
+                                        showOpenIcon
+                                            ? IconChevronUp
+                                            : IconChevronDown
+                                    }
+                                />
+                            }
                         >
-                            <MantineIcon icon={IconX} size={12} />
-                        </ActionIcon>
-                    )}
-                    <Button
-                        size="xs"
-                        variant="default"
-                        loaderPosition="center"
-                        disabled={isEditMode}
-                        sx={{
-                            borderColor: dateZoomGranularity
-                                ? theme.colors.blue['6']
-                                : 'default',
-                        }}
-                        leftIcon={<MantineIcon icon={IconCalendarSearch} />}
-                        rightIcon={
-                            <MantineIcon
-                                icon={
-                                    showOpenIcon
-                                        ? IconChevronUp
-                                        : IconChevronDown
-                                }
-                            />
-                        }
-                    >
-                        <Text>
                             Date Zoom
                             {dateZoomGranularity ? `:` : null}{' '}
                             {dateZoomGranularity ? (
-                                <Text span fw={500}>
+                                <Box fw={500} ml="xxs">
                                     {dateZoomGranularity}
-                                </Text>
+                                </Box>
                             ) : null}
-                        </Text>
-                    </Button>
-                </Group>
-            </Menu.Target>
-            <Menu.Dropdown>
-                <Menu.Label fz={10}>Granularity</Menu.Label>
-                <Menu.Item
-                    fz="xs"
-                    onClick={() => {
-                        track({
-                            name: EventName.DATE_ZOOM_CLICKED,
-                            properties: {
-                                granularity: 'default',
-                            },
-                        });
-
-                        setDateZoomGranularity(undefined);
-                    }}
-                    bg={
-                        dateZoomGranularity === undefined
-                            ? theme.colors.blue['6']
-                            : 'white'
-                    }
-                    disabled={dateZoomGranularity === undefined}
-                    sx={{
-                        '&[disabled]': {
-                            color:
-                                dateZoomGranularity === undefined
-                                    ? 'white'
-                                    : 'black',
-                        },
-                    }}
-                >
-                    Default
-                </Menu.Item>
-                {Object.values(DateGranularity).map((granularity) => (
+                        </Button>
+                    </Group>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    <Menu.Label fz={10}>Granularity</Menu.Label>
                     <Menu.Item
                         fz="xs"
-                        key={granularity}
                         onClick={() => {
                             track({
                                 name: EventName.DATE_ZOOM_CLICKED,
                                 properties: {
-                                    granularity,
+                                    granularity: 'default',
                                 },
                             });
-                            setDateZoomGranularity(granularity);
+
+                            setDateZoomGranularity(undefined);
                         }}
-                        disabled={dateZoomGranularity === granularity}
-                        bg={
-                            dateZoomGranularity === granularity
-                                ? theme.colors.blue['6']
-                                : 'white'
+                        disabled={dateZoomGranularity === undefined}
+                        className={
+                            dateZoomGranularity === undefined
+                                ? styles.menuItemDisabled
+                                : ''
                         }
-                        sx={{
-                            '&[disabled]': {
-                                color:
-                                    dateZoomGranularity === granularity
-                                        ? 'white'
-                                        : 'black',
-                            },
-                        }}
+                        rightSection={
+                            dateZoomGranularity === undefined ? (
+                                <MantineIcon icon={IconCheck} size={14} />
+                            ) : null
+                        }
                     >
-                        {granularity}
+                        Default
                     </Menu.Item>
-                ))}
-            </Menu.Dropdown>
-        </Menu>
+                    {Object.values(DateGranularity).map((granularity) => (
+                        <Menu.Item
+                            fz="xs"
+                            key={granularity}
+                            onClick={() => {
+                                track({
+                                    name: EventName.DATE_ZOOM_CLICKED,
+                                    properties: {
+                                        granularity,
+                                    },
+                                });
+                                setDateZoomGranularity(granularity);
+                            }}
+                            disabled={dateZoomGranularity === granularity}
+                            className={
+                                dateZoomGranularity === granularity
+                                    ? styles.menuItemDisabled
+                                    : ''
+                            }
+                            rightSection={
+                                dateZoomGranularity === granularity ? (
+                                    <MantineIcon icon={IconCheck} size={14} />
+                                ) : null
+                            }
+                        >
+                            {granularity}
+                        </Menu.Item>
+                    ))}
+                </Menu.Dropdown>
+            </Menu>
+        </MantineProvider>
     );
 };

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -4,6 +4,9 @@ import { scan } from 'react-scan'; // react-scan has to be imported before react
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
+// Mantine 8 styles
+import '@mantine-8/core/styles.css';
+
 import App from './App';
 
 // Trigger FE tests


### PR DESCRIPTION
### Description:

Upgrades the date zoom component to mantine 8. Why now? It's next to the new parameter component which uses mantine 8. Here's how it looks now:

<img width="347" height="242" alt="Screenshot 2025-08-04 at 15 26 50" src="https://github.com/user-attachments/assets/bbdab0ca-c605-4ad0-abee-b3d31a0c7d1d" />


Before
<img width="381" height="273" alt="Screenshot 2025-08-04 at 15 05 21" src="https://github.com/user-attachments/assets/8c179596-9189-4d57-b1fa-dee492893da7" />


Edit mode before/after
<img width="163" height="55" alt="Screenshot 2025-08-04 at 15 30 46" src="https://github.com/user-attachments/assets/2e610cd8-3196-424d-a5c1-2cced295c5ef" />
<img width="155" height="51" alt="Screenshot 2025-08-04 at 15 32 33" src="https://github.com/user-attachments/assets/33428965-0b61-4dbd-b71d-58264a7ff5bc" />

