### PR TITLE
feat: add duplicate tab functionality

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/DuplicateTabModal.tsx
+++ b/packages/frontend/src/components/DashboardTabs/DuplicateTabModal.tsx
@@ -1,0 +1,74 @@
+import { type DashboardTab } from '@lightdash/common';
+import {
+    Button,
+    Group,
+    Modal,
+    Stack,
+    TextInput,
+    Title,
+    type ModalProps,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { type FC } from 'react';
+
+type DuplicateTabModalProps = ModalProps & {
+    tab: DashboardTab;
+    onConfirm: (name: string) => void;
+};
+
+const DuplicateTabModal: FC<DuplicateTabModalProps> = ({
+    tab,
+    onConfirm,
+    onClose,
+    ...modalProps
+}) => {
+    const form = useForm<{ name: string }>();
+
+    const handleConfirm = form.onSubmit(({ name }) => {
+        onConfirm(name);
+        form.reset();
+    });
+
+    const handleClose = () => {
+        form.reset();
+        onClose?.();
+    };
+
+    return (
+        <Modal
+            title={
+                <Group spacing="xs">
+                    <Title order={4}>Duplicate Tab</Title>
+                </Group>
+            }
+            {...modalProps}
+            size="sm"
+            onClose={handleClose}
+        >
+            <form onSubmit={handleConfirm}>
+                <Stack spacing="lg" pt="sm">
+                    <TextInput
+                        label="Tab name"
+                        required
+                        placeholder={`Copy of ${tab.name}`}
+                        defaultValue={`Copy of ${tab.name}`}
+                        data-autofocus
+                        {...form.getInputProps('name')}
+                    />
+
+                    <Group position="right" mt="sm">
+                        <Button variant="outline" onClick={handleClose}>
+                            Cancel
+                        </Button>
+
+                        <Button type="submit" disabled={!form.isValid()}>
+                            Create duplicate
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </Modal>
+    );
+};
+
+export default DuplicateTabModal; 

--- a/packages/frontend/src/components/DashboardTabs/Tab.tsx
+++ b/packages/frontend/src/components/DashboardTabs/Tab.tsx
@@ -2,7 +2,7 @@ import { Draggable } from '@hello-pangea/dnd';
 import type { DashboardTab } from '@lightdash/common';
 import { ActionIcon, Box, Menu, Tabs, Title, Tooltip } from '@mantine/core';
 import { mergeRefs, useHover } from '@mantine/hooks';
-import { IconGripVertical, IconPencil, IconTrash } from '@tabler/icons-react';
+import { IconGripVertical, IconDotsVertical, IconPencil, IconTrash, IconCopy } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import { useIsTruncated } from '../../hooks/useIsTruncated';
 import MantineIcon from '../common/MantineIcon';
@@ -17,6 +17,7 @@ type DraggableTabProps = {
     setEditingTab: Dispatch<SetStateAction<boolean>>;
     setDeletingTab: Dispatch<SetStateAction<boolean>>;
     handleDeleteTab: (tabUuid: string) => void;
+    handleDuplicateTab: (tabUuid: string) => void;
 };
 
 const DraggableTab: FC<DraggableTabProps> = ({
@@ -28,6 +29,7 @@ const DraggableTab: FC<DraggableTabProps> = ({
     isActive,
     setEditingTab,
     handleDeleteTab,
+    handleDuplicateTab,
     setDeletingTab,
 }) => {
     const { hovered: isHovered, ref: hoverRef } = useHover();
@@ -68,7 +70,7 @@ const DraggableTab: FC<DraggableTabProps> = ({
                                     <Menu.Target>
                                         <ActionIcon variant="subtle" size="xs">
                                             <MantineIcon
-                                                icon={IconPencil}
+                                                icon={IconDotsVertical}
                                                 display={
                                                     isHovered ? 'block' : 'none'
                                                 }
@@ -81,6 +83,12 @@ const DraggableTab: FC<DraggableTabProps> = ({
                                             icon={<IconPencil size={14} />}
                                         >
                                             Rename Tab
+                                        </Menu.Item>
+                                        <Menu.Item
+                                            onClick={() => handleDuplicateTab(tab.uuid)}
+                                            icon={<IconCopy size={14} />}
+                                        >
+                                            Duplicate Tab
                                         </Menu.Item>
                                         {sortedTabs.length === 1 ||
                                         !currentTabHasTiles ? (

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -21,6 +21,7 @@ import { LockedDashboardModal } from '../common/modal/LockedDashboardModal';
 import { TabAddModal } from './AddTabModal';
 import { TabDeleteModal } from './DeleteTabModal';
 import { TabEditModal } from './EditTabModal';
+import DuplicateTabModal from './DuplicateTabModal';
 import GridTile from './GridTile';
 import DraggableTab from './Tab';
 import {
@@ -81,10 +82,14 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     const setHaveTabsChanged = useDashboardContext((c) => c.setHaveTabsChanged);
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
+    const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
+    const setHaveTilesChanged = useDashboardContext((c) => c.setHaveTilesChanged);
 
     // tabs state
     const [isEditingTab, setEditingTab] = useState<boolean>(false);
     const [isDeletingTab, setDeletingTab] = useState<boolean>(false);
+    const [isDuplicatingTab, setDuplicatingTab] = useState<boolean>(false);
+    const [tabToDuplicate, setTabToDuplicate] = useState<DashboardTab | null>(null);
 
     const defaultTab = dashboardTabs?.[0];
     // Context: We don't want to show the "tabs mode" if there is only one tab in state
@@ -205,6 +210,53 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             handleBatchDeleteTiles(tilesToDelete);
         }
     };
+
+    const handleDuplicateTab = (tabUuid: string) => {
+        const tab = dashboardTabs.find((tab) => tab.uuid === tabUuid);
+        if (tab) {
+            setTabToDuplicate(tab);
+            setDuplicatingTab(true);
+        }
+    };
+
+    const handleConfirmDuplicateTab = (name: string) => {
+        if (tabToDuplicate) {
+            const lastOrd = dashboardTabs.sort((a, b) => b.order - a.order)[0].order;
+            const newTab = {
+                name: name,
+                uuid: uuid4(),
+                isDefault: false,
+                order: lastOrd + 1,
+            };
+            
+            setDashboardTabs((currentTabs) => [...currentTabs, newTab]);
+            setActiveTab(newTab);
+            setHaveTabsChanged(true);
+
+            // Duplicate tiles from the original tab
+            const tilesToDuplicate = dashboardTiles?.filter(
+                (tile) => tile.tabUuid === tabToDuplicate.uuid,
+            );
+            
+            if (tilesToDuplicate && tilesToDuplicate.length > 0) {
+                const duplicatedTiles = tilesToDuplicate.map((tile) => ({
+                    ...tile,
+                    uuid: uuid4(),
+                    tabUuid: newTab.uuid,
+                }));
+                
+                // Directly add tiles to the dashboard without using handleAddTiles
+                // to avoid automatic assignment to current active tab
+                setDashboardTiles((currentTiles) => [
+                    ...(currentTiles ?? []),
+                    ...duplicatedTiles,
+                ]);
+                setHaveTilesChanged(true);
+            }
+        }
+        setDuplicatingTab(false);
+        setTabToDuplicate(null);
+    };
     const MAGIC_SCROLL_AREA_HEIGHT = 40;
 
     return (
@@ -308,6 +360,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                             }
                                                             handleDeleteTab={
                                                                 handleDeleteTab
+                                                            }
+                                                            handleDuplicateTab={
+                                                                handleDuplicateTab
                                                             }
                                                             setDeletingTab={
                                                                 setDeletingTab
@@ -426,6 +481,17 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                         handleAddTab(name);
                                     }}
                                 />
+                                {tabToDuplicate && (
+                                    <DuplicateTabModal
+                                        tab={tabToDuplicate}
+                                        onClose={() => {
+                                            setDuplicatingTab(false);
+                                            setTabToDuplicate(null);
+                                        }}
+                                        opened={isDuplicatingTab}
+                                        onConfirm={handleConfirmDuplicateTab}
+                                    />
+                                )}
                                 {activeTab && (
                                     <>
                                         <TabEditModal


### PR DESCRIPTION
Closes: #14308 

### Description:

This PR adds the ability to duplicate tabs in the dashboard, allowing users to quickly create copies of existing tabs with all their content (tiles).

Changes Made : 

Files modified : 

- `Tab.tsx`: Updated to use three-dot menu with duplicate option
- `index.tsx`: Added duplicate tab functions and modal state management
- `DuplicateTabModal.tsx`: New modal component for tab duplication

Key Functions Added:

- `handleDuplicateTab()`: Opens the duplicate modal
- `handleConfirmDuplicateTab()`: Processes the duplication with a custom name
- Proper tile duplication with new `UUIDs` and tab assignment

Feature working Preview :

![DuplicateTabs'](https://github.com/user-attachments/assets/9f26f416-f05f-48fb-895f-b80707531ea3)

