### PR TITLE
feat: enable useOrgs to work with accounts

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -69,7 +69,7 @@ export class OrganizationController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .get(req.user!),
+                .get(req.account!),
         };
     }
 

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -1,5 +1,6 @@
 import { LightdashInstallType } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { buildAccount } from '../../auth/account/account.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { GroupsModel } from '../../models/GroupsModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
@@ -43,16 +44,18 @@ describe('organization service', () => {
     });
 
     it('Should return needsProject false if there are projects in DB', async () => {
-        expect(await organizationService.get(user)).toEqual({
+        const account = buildAccount({ accountType: 'session' });
+        expect(await organizationService.get(account)).toEqual({
             ...organization,
             needsProject: false,
         });
     });
     it('Should return needsProject true if there are no projects in DB', async () => {
+        const account = buildAccount({ accountType: 'session' });
         (projectModel.hasProjects as jest.Mock).mockImplementationOnce(
             async () => false,
         );
-        expect(await organizationService.get(user)).toEqual({
+        expect(await organizationService.get(account)).toEqual({
             ...organization,
             needsProject: true,
         });

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     Account,
     AllowedEmailDomains,
+    assertIsAccountWithOrg,
     convertProjectRoleToOrganizationRole,
     CreateColorPalette,
     CreateGroup,
@@ -98,16 +99,15 @@ export class OrganizationService extends BaseService {
         this.groupsModel = groupsModel;
     }
 
-    async get(user: SessionUser): Promise<Organization> {
-        if (!isUserWithOrg(user)) {
-            throw new ForbiddenError('User is not part of an organization');
-        }
+    async get(account: Account): Promise<Organization> {
+        assertIsAccountWithOrg(account);
+
         const needsProject = !(await this.projectModel.hasProjects(
-            user.organizationUuid,
+            account.organization.organizationUuid,
         ));
 
         const organization = await this.organizationModel.get(
-            user.organizationUuid,
+            account.organization.organizationUuid,
         );
         return {
             ...organization,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Refactored the organization controller and service to use `account` instead of `user` for consistency. Updated the `get` method in `OrganizationService` to accept an `Account` type parameter and use the `assertIsAccountWithOrg` helper function for validation instead of the previous `isUserWithOrg` check.