### PR TITLE
fix: only run query after first run even if auto-fetch is enabled

### DIFF
--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1447,9 +1447,11 @@ const ExplorerProvider: FC<
     ]);
 
     useEffect(() => {
-        if (!autoFetchEnabled && isEditMode) return;
+        // If auto-fetch is disabled or the query hasn't been fetched yet, don't run the query
+        // This will stop auto-fetching until the first query is run
+        if ((!autoFetchEnabled || !query.isFetched) && isEditMode) return;
         runQuery();
-    }, [runQuery, autoFetchEnabled, isEditMode]);
+    }, [runQuery, autoFetchEnabled, isEditMode, query.isFetched]);
 
     const queryClient = useQueryClient();
     const clearExplore = useCallback(async () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16205

### Description:
Prevents auto-fetching in edit mode until the first query is run. This change adds a check for `query.isFetched` in the condition that determines whether to run a query automatically, ensuring that auto-fetching only starts after the user has manually run a query at least once.

**With auto-fetch: true (only auto fetches after running query)**

https://github.com/user-attachments/assets/7411a24c-4940-4f0b-ad21-efcff14df864

**With auto-fetch: false (no change)**

https://github.com/user-attachments/assets/34d9331c-3e67-44b4-93da-580f8f084d1e


