### PR TITLE
feat: enable 'viewUnderlyingData' for iframe and SDK embeds

### DIFF
--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -587,15 +587,6 @@ describe('Embedded dashboard abilities', () => {
                     }),
                 ),
             ).toBe(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', {
-                        organizationUuid: organization.organizationUuid,
-                        projectUuid,
-                    }),
-                ),
-            ).toBe(false);
         });
 
         it('should not allow viewing Explore domains when canExplore is undefined', () => {
@@ -608,15 +599,6 @@ describe('Embedded dashboard abilities', () => {
                 ability.can(
                     'view',
                     subject('Explore', {
-                        organizationUuid: organization.organizationUuid,
-                        projectUuid,
-                    }),
-                ),
-            ).toBe(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', {
                         organizationUuid: organization.organizationUuid,
                         projectUuid,
                     }),
@@ -693,15 +675,6 @@ describe('Embedded dashboard abilities', () => {
                     }),
                 ),
             ).toBe(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', {
-                        organizationUuid: organization.organizationUuid,
-                        projectUuid,
-                    }),
-                ),
-            ).toBe(false);
         });
 
         it('should not allow viewing Explore domains when canExplore is undefined', () => {
@@ -714,15 +687,6 @@ describe('Embedded dashboard abilities', () => {
                 ability.can(
                     'view',
                     subject('Explore', {
-                        organizationUuid: organization.organizationUuid,
-                        projectUuid,
-                    }),
-                ),
-            ).toBe(false);
-            expect(
-                ability.can(
-                    'view',
-                    subject('Project', {
                         organizationUuid: organization.organizationUuid,
                         projectUuid,
                     }),

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -33,6 +33,17 @@ const dashboardAbilities: EmbeddedAbilityBuilder = ({
         });
     }
 
+    can('view', 'SavedChart', {
+        organizationUuid: organization.organizationUuid,
+        projectUuid: embedUser.content.projectUuid,
+        isPrivate: false,
+    });
+
+    can('view', 'Project', {
+        organizationUuid: organization.organizationUuid,
+        projectUuid: embedUser.content.projectUuid,
+    });
+
     return { embedUser, dashboardUuid, organization, builder };
 };
 
@@ -49,17 +60,6 @@ const exploreAbilities: EmbeddedAbilityBuilder = ({
         can('view', 'UnderlyingData', {
             organizationUuid: organization.organizationUuid,
             projectUuid: content.projectUuid,
-        });
-
-        can('view', 'Project', {
-            organizationUuid: organization.organizationUuid,
-            projectUuid: content.projectUuid,
-        });
-
-        can('view', 'SavedChart', {
-            organizationUuid: organization.organizationUuid,
-            projectUuid: content.projectUuid,
-            isPrivate: false,
         });
     }
 

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -172,6 +172,12 @@ export function assertSessionAuth(
     }
 }
 
+export function isJwtUser(account?: Account): account is AnonymousAccount {
+    if (!account) return false;
+
+    return account.isJwtUser();
+}
+
 export const assertIsAccountWithOrg = (
     account: Account,
 ): asserts account is Account & {

--- a/packages/e2e/cypress/e2e/app/embed.cy.ts
+++ b/packages/e2e/cypress/e2e/app/embed.cy.ts
@@ -37,6 +37,7 @@ describe('Embedded dashboard', () => {
                         dashboardFiltersInteractivity: {
                             enabled: FilterInteractivityValues.all,
                         },
+                        projectUuid: SEED_PROJECT.project_uuid,
                         canExportCsv: true,
                         canExportImages: true,
                         canDateZoom: true,
@@ -55,7 +56,7 @@ describe('Embedded dashboard', () => {
                         'Lightdash is an open source analytics for your dbt project.',
                     ); // markdown
 
-                    cy.contains('855'); // big number
+                    cy.contains('Payments total revenue'); // big number tile
 
                     cy.contains(`What's the average spend per customer?`); // bar chart
                     cy.contains('Average order size'); // bar chart

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -17,6 +17,8 @@ import MantineProvider from '../src/providers/MantineProvider';
 import ReactQueryProvider from '../src/providers/ReactQuery/ReactQueryProvider';
 import ThirdPartyServicesProvider from '../src/providers/ThirdPartyServicesProvider';
 import TrackingProvider from '../src/providers/Tracking/TrackingProvider';
+
+import { ModalsProvider } from '@mantine/modals';
 const LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY =
     '__lightdash_sdk_instance_url';
 
@@ -69,6 +71,9 @@ const SdkProviders: FC<
     return (
         <ReactQueryProvider>
             <MantineProvider
+                withGlobalStyles
+                withNormalizeCSS
+                withCSSVariables
                 themeOverride={{
                     fontFamily: styles?.fontFamily,
                     other: {
@@ -78,25 +83,27 @@ const SdkProviders: FC<
                 }}
                 notificationsLimit={0}
             >
-                <AppProvider>
-                    <FullscreenProvider enabled={false}>
-                        <ThirdPartyServicesProvider enabled={false}>
-                            <ErrorBoundary wrapper={{ mt: '4xl' }}>
-                                <MemoryRouter>
-                                    <TrackingProvider enabled={true}>
-                                        <AbilityProvider>
-                                            <ChartColorMappingContextProvider>
-                                                <ActiveJobProvider>
-                                                    {children}
-                                                </ActiveJobProvider>
-                                            </ChartColorMappingContextProvider>
-                                        </AbilityProvider>
-                                    </TrackingProvider>
-                                </MemoryRouter>
-                            </ErrorBoundary>
-                        </ThirdPartyServicesProvider>
-                    </FullscreenProvider>
-                </AppProvider>
+                <ModalsProvider>
+                    <AppProvider>
+                        <FullscreenProvider enabled={false}>
+                            <ThirdPartyServicesProvider enabled={false}>
+                                <ErrorBoundary wrapper={{ mt: '4xl' }}>
+                                    <MemoryRouter>
+                                        <TrackingProvider enabled={true}>
+                                            <AbilityProvider>
+                                                <ChartColorMappingContextProvider>
+                                                    <ActiveJobProvider>
+                                                        {children}
+                                                    </ActiveJobProvider>
+                                                </ChartColorMappingContextProvider>
+                                            </AbilityProvider>
+                                        </TrackingProvider>
+                                    </MemoryRouter>
+                                </ErrorBoundary>
+                            </ThirdPartyServicesProvider>
+                        </FullscreenProvider>
+                    </AppProvider>
+                </ModalsProvider>
             </MantineProvider>
         </ReactQueryProvider>
     );

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -97,6 +97,7 @@ import {
 } from '../../hooks/useQueryResults';
 import { useDuplicateChartMutation } from '../../hooks/useSavedQuery';
 import { useCreateShareMutation } from '../../hooks/useShare';
+import { useAccount } from '../../hooks/user/useAccount';
 import { Can } from '../../providers/Ability';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useApp from '../../providers/App/useApp';
@@ -122,6 +123,7 @@ import { DashboardMinimalDownloadCsv } from './DashboardMinimalDownloadCsv';
 import EditChartMenuItem from './EditChartMenuItem';
 import ExportDataModal from './ExportDataModal';
 import TileBase from './TileBase/index';
+import { UnderlyingDataMenuItem } from './UnderlyingDataMenuItem';
 
 interface ExportGoogleSheetProps {
     savedChart: SavedChart;
@@ -307,6 +309,10 @@ const ValidDashboardChartTileMinimal: FC<{
     title: string;
     chart: SavedChart;
     dashboardChartReadyQuery: DashboardChartReadyQuery;
+    onSeriesContextMenu?: (
+        e: EchartSeriesClickEvent,
+        series: EChartSeries[],
+    ) => void;
     resultsData: InfiniteQueryResults;
     setEchartsRef?: (ref: RefObject<EChartsReact | null> | undefined) => void;
 }> = ({
@@ -315,6 +321,7 @@ const ValidDashboardChartTileMinimal: FC<{
     dashboardChartReadyQuery,
     resultsData,
     isTitleHidden = false,
+    onSeriesContextMenu,
     setEchartsRef,
 }) => {
     const { health } = useApp();
@@ -359,6 +366,7 @@ const ValidDashboardChartTileMinimal: FC<{
             initialPivotDimensions={chart.pivotConfig?.columns}
             resultsData={resultsDataWithQueryData}
             isLoading={resultsData.isFetchingRows}
+            onSeriesContextMenu={onSeriesContextMenu}
             columnOrder={chart.tableConfig.columnOrder}
             pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
             savedChartUuid={chart.uuid}
@@ -400,7 +408,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const { showToastSuccess } = useToaster();
     const clipboard = useClipboard({ timeout: 200 });
     const { track } = useTracking();
-    const { user } = useApp();
+    const ability = useAbilityContext();
+    const { data: account } = useAccount();
+    const { organizationUuid } = account?.organization || {};
 
     const showExecutionTime = useFeatureFlagEnabled(
         FeatureFlags.ShowExecutionTime,
@@ -433,10 +443,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
 
     const { rows, initialQueryExecutionMs } = resultsData;
 
-    const { projectUuid, dashboardUuid } = useParams<{
-        projectUuid: string;
-        dashboardUuid: string;
-    }>();
+    const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const addDimensionDashboardFilter = useDashboardContext(
         (c) => c.addDimensionDashboardFilter,
@@ -467,13 +475,13 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
             !hasTrackedLoadEvent.current &&
             !resultsData.isInitialLoading &&
             dashboardChartReadyQuery &&
-            user.data &&
+            account?.user &&
             dashboardUuid
         ) {
             track({
                 name: EventName.DASHBOARD_CHART_LOADED,
                 properties: {
-                    userId: user.data.userUuid,
+                    userId: account.user.id,
                     organizationId: chart.organizationUuid,
                     projectId: chart.projectUuid,
                     dashboardId: dashboardUuid,
@@ -496,31 +504,31 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         dashboardChartReadyQuery,
         resultsData,
         track,
-        user.data,
+        account?.user,
         chart.organizationUuid,
         chart.projectUuid,
         chart.uuid,
     ]);
 
-    const userCanManageChart = user.data?.ability?.can(
+    const userCanManageChart = ability.can(
         'manage',
         subject('SavedChart', chart),
     );
-    const userCanManageExplore = user.data?.ability?.can(
-        'manage',
+    const userCanViewExplore = ability?.can(
+        'view',
         subject('Explore', {
             organizationUuid: chart.organizationUuid,
             projectUuid: chart.projectUuid,
         }),
     );
-    const userCanExportData = user.data?.ability.can(
+    const userCanExportData = ability.can(
         'manage',
         subject('ExportCsv', {
             organizationUuid: chart.organizationUuid,
             projectUuid: chart.projectUuid,
         }),
     );
-    const userCanRunCustomSql = user.data?.ability.can(
+    const userCanRunCustomSql = ability.can(
         'manage',
         subject('CustomSql', {
             organizationUuid: chart.organizationUuid,
@@ -572,8 +580,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         track({
             name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
             properties: {
-                organizationId: user?.data?.organizationUuid,
-                userId: user?.data?.userUuid,
+                organizationId: organizationUuid,
+                userId: account?.user?.id,
                 projectId: projectUuid,
             },
         });
@@ -582,8 +590,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         dateZoomGranularity,
         openUnderlyingDataModal,
         track,
-        user?.data?.organizationUuid,
-        user?.data?.userUuid,
+        organizationUuid,
+        account?.user?.id,
         projectUuid,
         metricQuery?.metadata?.hasADateDimension,
         savedChartUuid,
@@ -806,7 +814,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     );
 
     const editButtonTooltipLabel = useMemo(() => {
-        const canManageChartSpace = user.data?.ability?.can(
+        const canManageChartSpace = ability?.can(
             'manage',
             subject('Space', {
                 organizationUuid: chart.organizationUuid,
@@ -832,7 +840,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         chart.projectUuid,
         chart.spaceName,
         chart.spaceUuid,
-        user.data?.ability,
+        ability,
     ]);
 
     // Use the custom hook for dashboard chart downloads
@@ -1058,7 +1066,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 belongsToDashboard={belongsToDashboard}
                 extraMenuItems={
                     savedChartUuid !== null &&
-                    (userCanManageExplore ||
+                    (userCanViewExplore ||
                         userCanManageChart ||
                         userCanExportData) && (
                         <>
@@ -1087,7 +1095,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                         </Box>
                                     </Tooltip>
 
-                                    {userCanManageExplore && chartPathname && (
+                                    {userCanViewExplore && chartPathname && (
                                         <Tooltip
                                             label={
                                                 'This chart contains custom dimensions, you will not be able to run custom SQL on explore.'
@@ -1246,8 +1254,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                             <Can
                                 I="view"
                                 this={subject('UnderlyingData', {
-                                    organizationUuid:
-                                        user.data?.organizationUuid,
+                                    organizationUuid,
                                     projectUuid: projectUuid,
                                 })}
                             >
@@ -1264,17 +1271,15 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                             <Can
                                 I="manage"
                                 this={subject('Explore', {
-                                    organizationUuid:
-                                        user.data?.organizationUuid,
+                                    organizationUuid,
                                     projectUuid: projectUuid,
                                 })}
                             >
                                 <DrillDownMenuItem
                                     {...viewUnderlyingDataOptions}
                                     trackingData={{
-                                        organizationId:
-                                            user.data?.organizationUuid,
-                                        userId: user.data?.userUuid,
+                                        organizationId: organizationUuid,
+                                        userId: account?.user?.id,
                                         projectId: projectUuid,
                                     }}
                                 />
@@ -1351,6 +1356,12 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
 };
 
 const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
+    const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
+    const [contextMenuTargetOffset, setContextMenuTargetOffset] = useState<{
+        left: number;
+        top: number;
+    }>();
+
     const {
         tile: {
             uuid: tileUuid,
@@ -1366,7 +1377,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
     const {
         chart,
         explore,
-        executeQueryResponse: { fields },
+        executeQueryResponse: { fields, metricQuery },
     } = dashboardChartReadyQuery;
     const projectUuid = useProjectUuid();
     const ability = useAbilityContext();
@@ -1391,6 +1402,87 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
             organizationUuid: chart.organizationUuid,
             projectUuid,
         }),
+    );
+
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+    const chartsWithDateZoomApplied = useDashboardContext(
+        (c) => c.chartsWithDateZoomApplied,
+    );
+
+    const { openUnderlyingDataModal } = useMetricQueryDataContext();
+
+    const [viewUnderlyingDataOptions, setViewUnderlyingDataOptions] = useState<{
+        item: ItemsMap[string] | undefined;
+        value: ResultValue;
+        fieldValues: Record<string, ResultValue>;
+        dimensions: string[];
+        pivotReference?: PivotReference;
+    }>();
+
+    const handleViewUnderlyingData = useCallback(() => {
+        if (!viewUnderlyingDataOptions) return;
+
+        const applyDateZoom =
+            metricQuery?.metadata?.hasADateDimension &&
+            savedChartUuid &&
+            dateZoomGranularity &&
+            chartsWithDateZoomApplied?.has(savedChartUuid);
+
+        openUnderlyingDataModal({
+            ...viewUnderlyingDataOptions,
+            ...(applyDateZoom && {
+                dateZoom: {
+                    granularity: dateZoomGranularity,
+                    xAxisFieldId: `${metricQuery?.metadata?.hasADateDimension.table}_${metricQuery?.metadata?.hasADateDimension.name}`,
+                },
+            }),
+        });
+    }, [
+        viewUnderlyingDataOptions,
+        dateZoomGranularity,
+        openUnderlyingDataModal,
+        metricQuery?.metadata?.hasADateDimension,
+        savedChartUuid,
+        chartsWithDateZoomApplied,
+    ]);
+
+    const handleCancelContextMenu = useCallback(
+        (e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(),
+        [],
+    );
+
+    const onSeriesContextMenu = useCallback(
+        (e: EchartSeriesClickEvent, series: EChartSeries[]) => {
+            if (explore === undefined) {
+                return;
+            }
+
+            setContextMenuIsOpen(true);
+            setContextMenuTargetOffset({
+                left: e.event.event.pageX,
+                top: e.event.event.pageY,
+            });
+
+            const allItemsMap = getItemMap(
+                explore,
+                chart.metricQuery.additionalMetrics,
+                chart.metricQuery.tableCalculations,
+            );
+
+            const underlyingData = getDataFromChartClick(
+                e,
+                allItemsMap,
+                series,
+            );
+            const queryDimensions = chart.metricQuery.dimensions || [];
+            setViewUnderlyingDataOptions({
+                ...underlyingData,
+                dimensions: queryDimensions,
+            });
+        },
+        [explore, chart],
     );
 
     const isEmbeddedExploreEnabled =
@@ -1438,15 +1530,51 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
             }
             {...props}
         >
-            <ValidDashboardChartTileMinimal
-                tileUuid={tileUuid}
-                isTitleHidden={hideTitle}
-                chart={chart}
-                dashboardChartReadyQuery={dashboardChartReadyQuery}
-                resultsData={resultsData}
-                title={title || chart.name}
-                setEchartsRef={setEchartRef}
-            />
+            <>
+                <Menu
+                    opened={contextMenuIsOpen}
+                    onClose={() => setContextMenuIsOpen(false)}
+                    withinPortal
+                    closeOnItemClick
+                    closeOnEscape
+                    shadow="md"
+                    radius={0}
+                    position="bottom-start"
+                    offset={{
+                        crossAxis: 0,
+                        mainAxis: 0,
+                    }}
+                >
+                    <Portal>
+                        <Menu.Target>
+                            <div
+                                onContextMenu={handleCancelContextMenu}
+                                style={{
+                                    position: 'absolute',
+                                    ...contextMenuTargetOffset,
+                                }}
+                            />
+                        </Menu.Target>
+                    </Portal>
+
+                    <Menu.Dropdown>
+                        <UnderlyingDataMenuItem
+                            metricQuery={metricQuery}
+                            onViewUnderlyingData={handleViewUnderlyingData}
+                        />
+                    </Menu.Dropdown>
+                </Menu>
+                <ValidDashboardChartTileMinimal
+                    tileUuid={tileUuid}
+                    isTitleHidden={hideTitle}
+                    chart={chart}
+                    dashboardChartReadyQuery={dashboardChartReadyQuery}
+                    onSeriesContextMenu={onSeriesContextMenu}
+                    resultsData={resultsData}
+                    title={title || chart.name}
+                    setEchartsRef={setEchartRef}
+                />
+            </>
         </TileBase>
     );
 };

--- a/packages/frontend/src/components/DashboardTiles/UnderlyingDataMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/UnderlyingDataMenuItem.tsx
@@ -1,0 +1,86 @@
+import { subject } from '@casl/ability';
+import { hasCustomBinDimension, type MetricQuery } from '@lightdash/common';
+import { Menu } from '@mantine/core';
+import { IconStack } from '@tabler/icons-react';
+import { type FC, useCallback } from 'react';
+import { useLocation } from 'react-router';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
+import { useAccount } from '../../hooks/user/useAccount';
+import { Can } from '../../providers/Ability';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
+import MantineIcon from '../common/MantineIcon';
+
+type Props = {
+    onViewUnderlyingData: () => void;
+    metricQuery: MetricQuery;
+};
+
+const TrackedItem: FC<{ onClick: () => void }> = ({ onClick }) => {
+    const { track } = useTracking();
+    const { data: account } = useAccount();
+    const { organizationUuid } = account?.organization || {};
+    const projectUuid = useProjectUuid();
+
+    const handleClick = useCallback(() => {
+        onClick();
+
+        const identity = account?.isRegisteredUser
+            ? { accountId: account?.user?.id }
+            : { anonymousId: 'embed', externalId: account?.user?.id };
+        track({
+            name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
+            properties: {
+                ...identity,
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+            },
+        });
+    }, [onClick, account, organizationUuid, projectUuid, track]);
+
+    return (
+        <Menu.Item
+            icon={<MantineIcon icon={IconStack} />}
+            onClick={handleClick}
+        >
+            View underlying data
+        </Menu.Item>
+    );
+};
+
+export const UnderlyingDataMenuItem: FC<Props> = ({
+    metricQuery,
+    onViewUnderlyingData,
+}) => {
+    const { data: account } = useAccount();
+    const { organizationUuid } = account?.organization || {};
+    const projectUuid = useProjectUuid();
+    const { pathname } = useLocation();
+
+    if (hasCustomBinDimension(metricQuery)) {
+        return null;
+    }
+
+    const canTrack = !pathname.includes('/minimal');
+
+    return (
+        <Can
+            I="view"
+            this={subject('UnderlyingData', {
+                organizationUuid,
+                projectUuid: projectUuid,
+            })}
+        >
+            {canTrack ? (
+                <TrackedItem onClick={onViewUnderlyingData} />
+            ) : (
+                <Menu.Item
+                    icon={<MantineIcon icon={IconStack} />}
+                    onClick={onViewUnderlyingData}
+                >
+                    View underlying data
+                </Menu.Item>
+            )}
+        </Can>
+    );
+};

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/api.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/api.ts
@@ -1,11 +1,4 @@
-import type {
-    ApiChartAndResults,
-    Dashboard,
-    DashboardFilters,
-    DateGranularity,
-    InteractivityOptions,
-    SortField,
-} from '@lightdash/common';
+import type { Dashboard, InteractivityOptions } from '@lightdash/common';
 import { lightdashApi } from '../../../../api';
 
 export const postEmbedDashboard = (projectUuid: string) => {
@@ -13,24 +6,5 @@ export const postEmbedDashboard = (projectUuid: string) => {
         url: `/embed/${projectUuid}/dashboard`,
         method: 'POST',
         body: undefined,
-    });
-};
-
-export const postEmbedChartAndResults = (
-    projectUuid: string,
-    tileUuid: string,
-    dashboardFilters: DashboardFilters,
-    dateZoomGranularity: DateGranularity | undefined,
-    dashboardSorts: SortField[],
-) => {
-    return lightdashApi<ApiChartAndResults>({
-        url: `/embed/${projectUuid}/chart-and-results`,
-        method: 'POST',
-        body: JSON.stringify({
-            tileUuid,
-            dashboardFilters,
-            dateZoomGranularity,
-            dashboardSorts,
-        }),
     });
 };

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
@@ -1,51 +1,15 @@
 import type {
-    ApiChartAndResults,
     ApiError,
     Dashboard,
     InteractivityOptions,
-    SortField,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import useDashboardFiltersForTile from '../../../../hooks/dashboard/useDashboardFiltersForTile';
-import useDashboardContext from '../../../../providers/Dashboard/useDashboardContext';
-import { postEmbedChartAndResults, postEmbedDashboard } from './api';
+import { postEmbedDashboard } from './api';
 
 export const useEmbedDashboard = (projectUuid: string | undefined) => {
     return useQuery<Dashboard & InteractivityOptions, ApiError>({
         queryKey: ['embed-dashboard'],
         queryFn: () => postEmbedDashboard(projectUuid!),
-        enabled: !!projectUuid,
-        retry: false,
-    });
-};
-
-export const useEmbedChartAndResults = (
-    projectUuid: string,
-    tileUuid: string,
-) => {
-    const dashboardFilters = useDashboardFiltersForTile(tileUuid);
-    const dateZoomGranularity = useDashboardContext(
-        (c) => c.dateZoomGranularity,
-    );
-    const chartSort = useDashboardContext((c) => c.chartSort);
-    const dashboardSorts: SortField[] | undefined = chartSort[tileUuid];
-    return useQuery<ApiChartAndResults, ApiError>({
-        queryKey: [
-            'embed-chart-and-results',
-            projectUuid,
-            tileUuid,
-            dashboardFilters,
-            dateZoomGranularity,
-            dashboardSorts,
-        ],
-        queryFn: async () =>
-            postEmbedChartAndResults(
-                projectUuid,
-                tileUuid,
-                dashboardFilters,
-                dateZoomGranularity,
-                dashboardSorts,
-            ),
         enabled: !!projectUuid,
         retry: false,
     });

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -6,9 +6,12 @@ import {
 } from '@lightdash/common';
 import { Tabs } from '@mantine/core';
 import { Prism } from '@mantine/prism';
-import React, { useCallback, type FC } from 'react';
+import { useCallback, type FC } from 'react';
 import useToaster from '../../../../hooks/toaster/useToaster';
 
+// Not sure why lint-staged is removing the value of this enum.
+// prettier-ignore
+// eslint-disable-next-line
 enum SnippetLanguage {
     NODE = 'node',
     PYTHON = 'python',
@@ -33,6 +36,7 @@ const data = {
         canExportPagePdf: {{canExportPagePdf}},
         canDateZoom: {{canDateZoom}},
         canExplore: {{canExploreEnabled}},
+        canViewUnderlyingData: {{canViewUnderlyingData}},
     },
     user: {
         externalId: {{externalId}},
@@ -65,6 +69,7 @@ data = {
         "canExportPagePdf": {{canExportPagePdfPython}},
         "canDateZoom": {{canDateZoomPython}},
         "canExplore": {{canExploreEnabledPython}},
+        "canViewUnderlyingData": {{canViewUnderlyingDataPython}},
     },
     "user": {
         "externalId": {{externalIdPython}},
@@ -107,6 +112,7 @@ func main() {
             CanExportPagePdf bool \`json:"canExportPagePdf"\`
             CanDateZoom bool \`json:"canDateZoom"\`
             CanExplore bool \`json:"canExplore"\`
+            CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
         } \`json:"content"\`
         UserAttributes map[string]string \`json:"userAttributes"\`
         jwt.StandardClaims
@@ -131,6 +137,7 @@ func main() {
             CanExportPagePdf bool \`json:"canExportPagePdf"\`
             CanDateZoom bool \`json:"canDateZoom"\`
             CanExplore bool \`json:"canExplore"\`
+            CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
         }{
             Type:          "dashboard",
             ProjectUuid:   projectUuid,
@@ -147,6 +154,7 @@ func main() {
             CanExportPagePdf: {{canExportPagePdf}},
             CanDateZoom: {{canDateZoom}},
             CanExplore: {{canExploreEnabled}},
+            CanViewUnderlyingData: {{canViewUnderlyingData}},
         },
         User: &struct {
             ExternalId *string \`json:"externalId,omitempty"\`
@@ -246,6 +254,10 @@ const getCodeSnippet = (
             data.content.canExportPagePdf ? 'true' : 'false',
         )
         .replace(
+            '{{canViewUnderlyingData}}',
+            data.content.canViewUnderlyingData ? 'true' : 'false',
+        )
+        .replace(
             '{{canExportCsvEnabled}}',
             data.content.canExportCsv ? 'true' : 'false',
         )
@@ -260,6 +272,10 @@ const getCodeSnippet = (
         .replace(
             '{{canExportPagePdfPython}}',
             data.content.canExportPagePdf ? 'True' : 'False',
+        )
+        .replace(
+            '{{canViewUnderlyingDataPython}}',
+            data.content.canViewUnderlyingData ? 'True' : 'False',
         )
         .replace(
             '{{canExportImagesEnabled}}',

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedUrlForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedUrlForm.tsx
@@ -69,6 +69,7 @@ type FormValues = {
     canExportPagePdf?: boolean;
     canDateZoom?: boolean;
     canExplore?: boolean;
+    canViewUnderlyingData?: boolean;
 } & IntrinsicUserAttributes;
 
 const EmbedUrlForm: FC<{
@@ -98,6 +99,7 @@ const EmbedUrlForm: FC<{
             canDateZoom: false,
             canExportPagePdf: true,
             canExplore: false,
+            canViewUnderlyingData: false,
         },
         validate: {
             dashboardUuid: (value: undefined | string) => {
@@ -134,6 +136,7 @@ const EmbedUrlForm: FC<{
                     canDateZoom: values.canDateZoom,
                     canExportPagePdf: values.canExportPagePdf ?? true,
                     canExplore: values.canExplore,
+                    canViewUnderlyingData: values.canViewUnderlyingData,
                 },
                 userAttributes: values.userAttributes.reduce(
                     (acc, item) => ({
@@ -312,6 +315,11 @@ const EmbedUrlForm: FC<{
                     {...form.getInputProps(`canExplore`)}
                     labelPosition="left"
                     label={`Can explore charts`}
+                />
+                <Switch
+                    {...form.getInputProps(`canViewUnderlyingData`)}
+                    labelPosition="left"
+                    label={`Can view underlying data`}
                 />
                 <Flex justify="flex-end" gap="sm">
                     <Button

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -54,7 +54,10 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     // this initialization in a useEffect, we will not have the hash token in the URL by the time
     // the effect runs.
     if (!isInitialized) {
-        setToInMemoryStorage(EMBED_KEY, { projectUuid, token: embedToken });
+        setToInMemoryStorage(EMBED_KEY, {
+            projectUuid,
+            token: embedToken,
+        });
         setIsInitialized(true);
     }
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -39,6 +39,7 @@ export type DashboardChartReadyQuery = {
 export const useDashboardChartReadyQuery = (
     tileUuid: string,
     chartUuid: string | null,
+    contextOverride?: QueryExecutionContext,
 ) => {
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const invalidateCache = useDashboardContext((c) => c.invalidateCache);
@@ -137,7 +138,7 @@ export const useDashboardChartReadyQuery = (
             timezoneFixFilters,
             dashboardSorts,
             sortKey,
-            context,
+            contextOverride || context,
             autoRefresh,
             hasADateDimension ? granularity : null,
             invalidateCache,
@@ -150,6 +151,7 @@ export const useDashboardChartReadyQuery = (
             timezoneFixFilters,
             dashboardSorts,
             sortKey,
+            contextOverride,
             context,
             autoRefresh,
             hasADateDimension,
@@ -171,7 +173,9 @@ export const useDashboardChartReadyQuery = (
                 {
                     context: autoRefresh
                         ? QueryExecutionContext.AUTOREFRESHED_DASHBOARD
-                        : context || QueryExecutionContext.DASHBOARD,
+                        : contextOverride ||
+                          context ||
+                          QueryExecutionContext.DASHBOARD,
                     chartUuid: chartUuid!,
                     dashboardUuid: dashboardUuid!,
                     dashboardFilters: timezoneFixFilters,

--- a/packages/frontend/src/hooks/useUnderlyingDataResults.ts
+++ b/packages/frontend/src/hooks/useUnderlyingDataResults.ts
@@ -13,9 +13,9 @@ import {
     sleep,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import { convertDateFilters } from '../utils/dateFilter';
+import { useProjectUuid } from './useProjectUuid';
 
 type UnderlyingDataResults = ApiQueryResults & {
     queryUuid: string;
@@ -136,7 +136,7 @@ export const useUnderlyingDataResults = (
     underlyingDataItemId?: string,
     dateZoom?: DateZoom,
 ) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     return useQuery<UnderlyingDataResults, ApiError>({
         queryKey: [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #9605

### Description:
This PR enables "View underlying data" for SDK and iframe embeds. It begins the process of moving Dashboards to use async-queries rather than embed endpoints for querying data.

![Screen Cast 2025-08-04 at 6 52 31 PM](https://github.com/user-attachments/assets/ab1b7f81-6b61-4d13-b3eb-785aaae76be6)


### Testing

#### SDK

1. Create a new JWT with the claim
2. Startup the SDK test app
3. Use the token
4. Change localizations

#### iframe

1. Create the JWT with the claim
2. Test in preview mode
3. Test with generating a URL in a separate window to not use session cookies