### PR TITLE
fix: return valid XML from find fields tool call

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/findFields.ts
@@ -82,13 +82,13 @@ const getFieldsText = (
     args: Awaited<ReturnType<FindFieldFn>> & { searchQuery: string },
 ) =>
     `
-<SearchResults searchQuery="${args.searchQuery}" page="${
+<SearchResult searchQuery="${args.searchQuery}" page="${
         args.pagination?.page
     }" pageSize="${args.pagination?.pageSize}" totalPageCount="${
         args.pagination?.totalPageCount
     }" totalResults="${args.pagination?.totalResults}">
     ${args.fields.map((field) => getFieldText(field)).join('\n\n')}
-</SearchResults>
+</SearchResult>
 `.trim();
 
 export const getFindFields = ({ findFields, pageSize }: Dependencies) => {
@@ -129,7 +129,7 @@ Usage tips:
                     )
                     .join('\n\n');
 
-                return fieldsText;
+                return `<SearchResults>${fieldsText}</SearchResults>`;
             } catch (error) {
                 return toolErrorHandler(
                     error,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the return value of Find fields tool call. Changed the outer tag from `<SearchResults>` to `<SearchResult>` in the `getFieldsText` function, and added a wrapping `<SearchResults>` tag around the returned fields text in the `getFindFields` function. This ensures consistent XML structure for field search results.
