### PR TITLE
feat: add find_explores tool to MCP service

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -237,9 +237,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig: context.lightdashConfig,
                     storageClient: clients.getResultsFileStorageClient(),
                 }),
-            mcpService: ({ context }) =>
+            mcpService: ({ context, repository, models }) =>
                 new McpService({
                     lightdashConfig: context.lightdashConfig,
+                    catalogService: repository.getCatalogService(),
+                    projectService: repository.getProjectService(),
+                    userAttributesModel: models.getUserAttributesModel(),
                 }),
         },
         modelProviders: {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1,25 +1,46 @@
 import {
+    AnyType,
+    CatalogFilter,
+    CatalogType,
     ForbiddenError,
     MissingConfigError,
     OauthAccount,
     SessionUser,
+    ToolFindExploresArgs,
+    toolFindExploresArgsSchema,
 } from '@lightdash/common';
 // eslint-disable-next-line import/extensions
+import { subject } from '@casl/ability';
 // eslint-disable-next-line import/extensions
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 // eslint-disable-next-line import/extensions
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 import { LightdashConfig } from '../../../config/parseConfig';
+import { CatalogSearchContext } from '../../../models/CatalogModel/CatalogModel';
+import { UserAttributesModel } from '../../../models/UserAttributesModel';
 import { BaseService } from '../../../services/BaseService';
+import { CatalogService } from '../../../services/CatalogService/CatalogService';
 import { OAuthScope } from '../../../services/OAuthService/OAuthService';
+import { ProjectService } from '../../../services/ProjectService/ProjectService';
+import { wrapSentryTransaction } from '../../../utils';
 import { VERSION } from '../../../version';
+import {
+    getFindExplores,
+    toolFindExploresDescription,
+} from '../ai/tools/findExplores';
+import { FindExploresFn } from '../ai/types/aiAgentDependencies';
 
 export enum McpToolName {
     GET_LIGHTDASH_VERSION = 'get_lightdash_version',
+    FIND_EXPLORES = 'find_explores',
 }
 
 type McpServiceArguments = {
     lightdashConfig: LightdashConfig;
+    catalogService: CatalogService;
+    projectService: ProjectService;
+    userAttributesModel: UserAttributesModel;
 };
 
 export type ExtraContext = { user: SessionUser; account: OauthAccount };
@@ -32,11 +53,25 @@ type McpContext = {
 export class McpService extends BaseService {
     private lightdashConfig: LightdashConfig;
 
+    private catalogService: CatalogService;
+
+    private projectService: ProjectService;
+
+    private userAttributesModel: UserAttributesModel;
+
     private mcpServer: McpServer;
 
-    constructor({ lightdashConfig }: McpServiceArguments) {
+    constructor({
+        lightdashConfig,
+        catalogService,
+        projectService,
+        userAttributesModel,
+    }: McpServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
+        this.catalogService = catalogService;
+        this.projectService = projectService;
+        this.userAttributesModel = userAttributesModel;
         try {
             this.mcpServer = new McpServer({
                 name: 'Lightdash MCP Server',
@@ -49,14 +84,14 @@ export class McpService extends BaseService {
         }
     }
 
-    private setupHandlers(): void {
+    setupHandlers(): void {
         this.mcpServer.registerTool(
             McpToolName.GET_LIGHTDASH_VERSION,
             {
                 description: 'Get the current Lightdash version',
                 inputSchema: {},
             },
-            async (args, context) => ({
+            async (_args, context) => ({
                 content: [
                     {
                         type: 'text',
@@ -65,6 +100,196 @@ export class McpService extends BaseService {
                 ],
             }),
         );
+
+        this.mcpServer.registerTool(
+            McpToolName.FIND_EXPLORES,
+            {
+                description: toolFindExploresDescription,
+                inputSchema: {
+                    // Cast to AnyType to avoid slow TypeScript compilation
+                    ...(toolFindExploresArgsSchema.shape as AnyType),
+                    projectUuid: z.string(),
+                },
+            },
+            async (_args, context) => {
+                const args = _args as ToolFindExploresArgs & {
+                    projectUuid: string;
+                };
+
+                const findExplores: FindExploresFn =
+                    await this.getFindExploresFunction(
+                        args,
+                        context as McpContext,
+                    );
+
+                const findExploresTool = getFindExplores({
+                    findExplores,
+                    pageSize: 15,
+                    maxDescriptionLength: 100,
+                    fieldSearchSize: 200,
+                    fieldOverviewSearchSize: 5,
+                });
+                const result = await findExploresTool.execute(args, {
+                    toolCallId: '',
+                    messages: [],
+                });
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: result,
+                        },
+                    ],
+                };
+            },
+        );
+    }
+
+    async getFindExploresFunction(
+        toolArgs: ToolFindExploresArgs & { projectUuid: string },
+        context: McpContext,
+    ): Promise<FindExploresFn> {
+        const { user, account } = context.authInfo!.extra;
+        const { organizationUuid } = user;
+        const { projectUuid } = toolArgs;
+
+        if (!user || !organizationUuid || !account) {
+            throw new ForbiddenError();
+        }
+
+        const project = await this.projectService.getProject(
+            projectUuid,
+            account,
+        );
+
+        if (
+            user.ability.cannot(
+                'view',
+                subject('Project', {
+                    projectUuid,
+                    organizationUuid: project.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const findExplores: FindExploresFn = (args) =>
+            wrapSentryTransaction('McpService.findExplores', args, async () => {
+                const userAttributes =
+                    await this.userAttributesModel.getAttributeValuesForOrgMember(
+                        {
+                            organizationUuid,
+                            userUuid: user.userUuid,
+                        },
+                    );
+
+                const { data: tables, pagination } =
+                    await this.catalogService.searchCatalog({
+                        projectUuid,
+                        catalogSearch: {
+                            type: CatalogType.Table,
+                            yamlTags: undefined,
+                            tables: args.tableName
+                                ? [args.tableName]
+                                : undefined,
+                        },
+                        userAttributes,
+                        context: CatalogSearchContext.MCP,
+                        paginateArgs: {
+                            page: args.page,
+                            pageSize: args.pageSize,
+                        },
+                    });
+
+                const tablesWithFields = await Promise.all(
+                    tables
+                        .filter((table) => table.type === CatalogType.Table)
+                        .map(async (table) => {
+                            if (!args.includeFields) {
+                                return {
+                                    table,
+                                    dimensions: [],
+                                    metrics: [],
+                                    dimensionsPagination: undefined,
+                                    metricsPagination: undefined,
+                                };
+                            }
+
+                            if (
+                                !args.fieldSearchSize ||
+                                !args.fieldOverviewSearchSize
+                            ) {
+                                throw new Error(
+                                    'fieldSearchSize and fieldOverviewSearchSize are required when includeFields is true',
+                                );
+                            }
+
+                            const sharedArgs = {
+                                projectUuid,
+                                catalogSearch: {
+                                    type: CatalogType.Field,
+                                    yamlTags: undefined,
+                                    tables: [table.name],
+                                },
+                                userAttributes,
+                                context: CatalogSearchContext.MCP,
+                                paginateArgs: {
+                                    page: 1,
+                                    pageSize: args.tableName
+                                        ? args.fieldSearchSize
+                                        : args.fieldOverviewSearchSize,
+                                },
+                                sortArgs: {
+                                    sort: 'chartUsage',
+                                    order: 'desc' as const,
+                                },
+                            };
+
+                            const {
+                                data: dimensions,
+                                pagination: dimensionsPagination,
+                            } = await this.catalogService.searchCatalog({
+                                ...sharedArgs,
+                                catalogSearch: {
+                                    ...sharedArgs.catalogSearch,
+                                    filter: CatalogFilter.Dimensions,
+                                },
+                            });
+
+                            const {
+                                data: metrics,
+                                pagination: metricsPagination,
+                            } = await this.catalogService.searchCatalog({
+                                ...sharedArgs,
+                                catalogSearch: {
+                                    ...sharedArgs.catalogSearch,
+                                    filter: CatalogFilter.Metrics,
+                                },
+                            });
+
+                            return {
+                                table,
+                                dimensions: dimensions.filter(
+                                    (d) => d.type === CatalogType.Field,
+                                ),
+                                metrics: metrics.filter(
+                                    (m) => m.type === CatalogType.Field,
+                                ),
+                                dimensionsPagination,
+                                metricsPagination,
+                            };
+                        }),
+                );
+
+                return {
+                    tablesWithFields,
+                    pagination,
+                };
+            });
+
+        return findExplores;
     }
 
     public getServer(): McpServer {

--- a/packages/backend/src/ee/services/ai/tools/findExplores.ts
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.ts
@@ -107,17 +107,7 @@ const generateExploreResponse = ({
     }
 </Explore>`.trim();
 
-export const getFindExplores = ({
-    findExplores,
-    pageSize,
-    maxDescriptionLength,
-    fieldSearchSize,
-    fieldOverviewSearchSize,
-}: Dependencies) => {
-    const schema = toolFindExploresArgsSchema;
-
-    return tool({
-        description: `Tool: findExplores
+export const toolFindExploresDescription = `Tool: findExplores
 
 Purpose:
 Lists available Explores along with their field labels, joined tables, hints for you (Ai Hints) and descriptions.
@@ -128,8 +118,18 @@ Usage Tips:
 - Results are paginated — use the next page token to retrieve additional pages.
 - It's advised to look for tables first and then use the exploreName parameter to narrow results to a specific Explore.
 - When using the exploreName parameter, all fields and full description are returned for that explore.
-`,
-        parameters: schema,
+`;
+
+export const getFindExplores = ({
+    findExplores,
+    pageSize,
+    maxDescriptionLength,
+    fieldSearchSize,
+    fieldOverviewSearchSize,
+}: Dependencies) =>
+    tool({
+        description: toolFindExploresDescription,
+        parameters: toolFindExploresArgsSchema,
         execute: async (args) => {
             try {
                 if (args.page && args.page < 1) {
@@ -169,4 +169,3 @@ ${exploreResponses}
             }
         },
     });
-};

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -58,6 +58,7 @@ export enum CatalogSearchContext {
     CATALOG = 'catalog',
     METRICS_EXPLORER = 'metricsExplorer',
     AI_AGENT = 'aiAgent',
+    MCP = 'mcp',
 }
 
 export type CatalogModelArguments = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #16199

### Description:

Adds support for the `find_explores` tool to the Model Context Protocol (MCP) service. This tool allows MCP clients to search for explores and their fields in Lightdash projects.

The implementation:

- Adds necessary dependencies to the McpService constructor
- Implements the `setupHandlers` method to register the find_explores tool
- Creates a `getFindExploresFunction` method that leverages the catalog service to search for tables and fields
- Adds a new `MCP` context type to the CatalogSearchContext enum

![CleanShot 2025-08-05 at 17.50.10@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/6e78435c-5892-4b9a-9837-eb8d8982a803.png)

