### PR TITLE
feat: add findFields tool to MCP service

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/findFields.ts
@@ -91,11 +91,7 @@ const getFieldsText = (
 </SearchResult>
 `.trim();
 
-export const getFindFields = ({ findFields, pageSize }: Dependencies) => {
-    const schema = toolFindFieldsArgsSchema;
-
-    return tool({
-        description: `Tool: "findFields"
+export const toolFindFieldsDescription = `Tool: "findFields"
 
 Purpose:
 Finds the most relevant Fields (Metrics & Dimensions) within Explores, returning detailed info about each.
@@ -107,8 +103,12 @@ Usage tips:
 - Fields are sorted by relevance, with a maximum score of 1 and a minimum of 0, so the top results are the most relevant.
 - If results aren't relevant, retry with clearer or more specific terms.
 - Results are paginated — use the next page token to get more results if needed.
-`,
-        parameters: schema,
+`;
+
+export const getFindFields = ({ findFields, pageSize }: Dependencies) =>
+    tool({
+        description: toolFindFieldsDescription,
+        parameters: toolFindFieldsArgsSchema,
         execute: async (args) => {
             try {
                 const fieldSearchQueryResults = await Promise.all(
@@ -140,4 +140,3 @@ Usage tips:
             }
         },
     });
-};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16199

### Description:

Added a new MCP tool for finding fields in explores. This implementation registers a `FIND_FIELDS` tool in the MCP service that allows users to search for fields (metrics and dimensions) within explores. The tool includes functionality to search by field name, filter by table, and supports pagination of results.

The implementation includes:

- New `FIND_FIELDS` enum in McpToolName
- Registration of the tool with proper schema validation
- Implementation of the `getFindFieldsFunction` to handle field search requests
- Reuse of existing field search functionality from the catalog service


![CleanShot 2025-08-05 at 17.49.03@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/0e33e169-393d-47c8-b152-126e4c0ebb13.png)

