### PR TITLE
chore: import m8 styles earlier

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -20,9 +20,6 @@ import ThirdPartyProvider from './providers/ThirdPartyServicesProvider';
 import TrackingProvider from './providers/Tracking/TrackingProvider';
 import Routes from './Routes';
 
-// Mantine v8 styles
-import '@mantine-8/core/styles.css';
-
 // const isMobile =
 //     /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
 //         navigator.userAgent,

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -4,6 +4,9 @@ import { scan } from 'react-scan'; // react-scan has to be imported before react
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
+// Mantine 8 styles
+import '@mantine-8/core/styles.css';
+
 import App from './App';
 
 // Trigger FE tests


### PR DESCRIPTION
Import Mantine 8 styles earlier so we can override them. 

Article here: https://help.mantine.dev/q/styles-order

This was all @joaoviana 😄 
