### PR TITLE
feat: only show metrics/dimensions overview when focusing on explore

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findExplores.ts
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.ts
@@ -64,8 +64,10 @@ const generateExploreResponse = ({
 `.trim()
             : ''
     }
-
-    <Fields alt="All fields from all tables" totalCount="${
+    ${
+        dimensions && metrics && dimensions.length > 0 && metrics.length > 0
+            ? `
+    <Fields alt="most popular dimensions and metrics" totalCount="${
         (dimensionsPagination?.totalResults ?? 0) +
         (metricsPagination?.totalResults ?? 0)
     }" displayedResults="${dimensions.length + metrics.length}">
@@ -100,7 +102,9 @@ const generateExploreResponse = ({
                 )
                 .join('\n            ')}
         </Metrics>
-    </Fields>
+    </Fields>`.trim()
+            : ''
+    }
 </Explore>`.trim();
 
 export const getFindExplores = ({
@@ -116,7 +120,7 @@ export const getFindExplores = ({
         description: `Tool: findExplores
 
 Purpose:
-Lists available Explores along with their field labels, joined tables, hints for you (Ai Hints), descriptions, and a sample set of dimensions and metrics.
+Lists available Explores along with their field labels, joined tables, hints for you (Ai Hints) and descriptions.
 
 Usage Tips:
 - Use this to understand the structure of an Explore before calling findFields.
@@ -136,7 +140,7 @@ Usage Tips:
                     tableName: args.exploreName,
                     page: args.page ?? 1,
                     pageSize,
-                    includeFields: true,
+                    includeFields: !!args.exploreName,
                     fieldSearchSize,
                     fieldOverviewSearchSize,
                 });

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -31,10 +31,10 @@ export type FindExploresFn = (
 ) => Promise<{
     tablesWithFields: {
         table: CatalogTable;
-        dimensions: CatalogField[];
-        metrics: CatalogField[];
-        dimensionsPagination: Pagination | undefined;
-        metricsPagination: Pagination | undefined;
+        dimensions?: CatalogField[];
+        metrics?: CatalogField[];
+        dimensionsPagination?: Pagination;
+        metricsPagination?: Pagination;
     }[];
     pagination: Pagination | undefined;
 }>;


### PR DESCRIPTION
related to: https://github.com/lightdash/lightdash/issues/16232

### Description:
This PR optimizes the `findExplores` AI tool to only fetch fields when a specific explore is requested. It updates the tool to:

1. Make fields optional in the response type
2. Only include fields in the response when an explore name is provided
3. Only render the Fields section in the response when dimensions and metrics are available
4. Update the tool description to better reflect its behavior

This change improves performance by avoiding unnecessary field fetching when browsing the list of available explores.


CONTEXT: https://lightdash.slack.com/archives/C08S88JT17W/p1754465077895719