### PR TITLE
docs: standardize API endpoint JSDoc comments with @summary

### DIFF
--- a/packages/backend/src/controllers/CLAUDE.md
+++ b/packages/backend/src/controllers/CLAUDE.md
@@ -22,8 +22,8 @@ Key patterns:
 @Tags('Projects')
 export class ProjectController extends BaseController {
     /**
+     * Retrieves all charts within a project's spaces
      * @summary List charts
-     * @description Retrieves all charts within a project's spaces
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -44,8 +44,8 @@ export class ProjectController extends BaseController {
     }
 
     /**
+     * Creates a new chart in the specified project
      * @summary Create chart
-     * @description Creates a new chart in the specified project
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @Post('/{projectUuid}/charts')
@@ -88,7 +88,7 @@ export class ProjectController extends BaseController {
 -   Services accessed via `this.services.get{Service}Service()`
 -   Consistent response format: `{status: 'ok', results: T}`
 -   User object available as `req.user!` in authenticated endpoints
--   All endpoints must have JSDoc comments with `@summary` (2-3 words) and `@description`
+-   All endpoints must have JSDoc comments with description first, then `@summary` tag (2-3 words)
 
 **V2 Differences:**
 

--- a/packages/backend/src/controllers/CLAUDE.md
+++ b/packages/backend/src/controllers/CLAUDE.md
@@ -5,24 +5,6 @@ Backend API controllers built with TSOA that handle HTTP requests and generate O
 <howToUse>
 Controllers are automatically registered by TSOA and accessible at their defined routes. All controllers extend BaseController and use dependency injection:
 
-```typescript
-export class MyController extends BaseController {
-    @Route('/api/v1/my-resource')
-    @Tags('MyResource')
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @Get('/{id}')
-    @SuccessResponse('200', 'Success')
-    @Response<ApiErrorPayload>('default', 'Error')
-    async getResource(@Path() id: string): Promise<ApiSuccessEmpty> {
-        const result = await this.services.getMyService().getById(id);
-        return {
-            status: 'ok',
-            results: result,
-        };
-    }
-}
-```
-
 Key patterns:
 
 -   Use `@Middlewares([allowApiKeyAuthentication, isAuthenticated])` for protected endpoints
@@ -36,9 +18,15 @@ Key patterns:
 ```typescript
 // Basic CRUD controller
 @Route('/api/v1/projects')
+@Response<ApiErrorPayload>('default', 'Error')
 @Tags('Projects')
 export class ProjectController extends BaseController {
+    /**
+     * @summary List charts
+     * @description Retrieves all charts within a project's spaces
+     */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
     @Get('/{projectUuid}/charts')
     @OperationId('listCharts')
     async getCharts(
@@ -55,6 +43,10 @@ export class ProjectController extends BaseController {
         };
     }
 
+    /**
+     * @summary Create chart
+     * @description Creates a new chart in the specified project
+     */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @Post('/{projectUuid}/charts')
     @SuccessResponse('201', 'Created')
@@ -96,6 +88,7 @@ export class ProjectController extends BaseController {
 -   Services accessed via `this.services.get{Service}Service()`
 -   Consistent response format: `{status: 'ok', results: T}`
 -   User object available as `req.user!` in authenticated endpoints
+-   All endpoints must have JSDoc comments with `@summary` (2-3 words) and `@description`
 
 **V2 Differences:**
 

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -54,10 +54,8 @@ export type ApiGetAsyncQueryResultsResponse = {
 @Tags('Query')
 export class QueryController extends BaseController {
     /**
-     * Get results from an asynchronous query
-     *
-     * Retrieves paginated results from a previously executed async query using its UUID.
-     * Use this endpoint to fetch query results after the query has completed execution.
+     * @summary Get results
+     * @description Retrieves paginated results from a previously executed async query using its UUID
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -96,10 +94,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Cancel an asynchronous query
-     *
-     * Cancels a running async query. Once cancelled, the query cannot be resumed
-     * and any partial results will be discarded.
+     * @summary Cancel query
+     * @description Cancels a running async query and discards any partial results
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -126,11 +122,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Execute an asynchronous metric query
-     *
-     * Executes a metric query asynchronously against your data warehouse.
-     * Returns a query UUID that can be used to fetch results once the query completes.
-     * Metric queries are built using dimensions, metrics, filters, and sorts from your dbt models.
+     * @summary Execute metric query
+     * @description Executes a metric query asynchronously against your data warehouse using dimensions, metrics, filters, and sorts
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -178,10 +171,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Execute an asynchronous saved chart query
-     *
-     * Executes a saved chart query asynchronously. Saved charts contain pre-configured
-     * metric queries that can be executed with optional parameter overrides.
+     * @summary Execute saved chart
+     * @description Executes a saved chart query asynchronously with optional parameter overrides
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -217,10 +208,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Execute an asynchronous dashboard chart query
-     *
-     * Executes a chart within a dashboard context asynchronously. Dashboard charts
-     * inherit dashboard-level filters and may have additional contextual parameters.
+     * @summary Execute dashboard chart
+     * @description Executes a chart within a dashboard context asynchronously with inherited dashboard filters
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -259,10 +248,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Execute an asynchronous underlying data query
-     *
-     * Executes a query to retrieve the underlying raw data for a specific metric or dimension.
-     * This is useful for drilling down into the data behind aggregated values.
+     * @summary Execute underlying data
+     * @description Executes a query to retrieve underlying raw data for drilling down into aggregated values
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -301,10 +288,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Execute an asynchronous SQL query
-     *
-     * Executes a raw SQL query asynchronously against your data warehouse.
-     * This allows for custom queries beyond the metric layer capabilities.
+     * @summary Execute SQL query
+     * @description Executes a raw SQL query asynchronously against your data warehouse for custom queries
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -339,10 +324,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Execute an asynchronous SQL chart query
-     *
-     * Executes a saved SQL chart query asynchronously. SQL charts are custom visualizations
-     * built from raw SQL queries with optional chart configurations.
+     * @summary Execute SQL chart
+     * @description Executes a saved SQL chart query asynchronously with optional chart configurations
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -378,10 +361,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Execute an asynchronous dashboard SQL chart query
-     *
-     * Executes a SQL chart within a dashboard context asynchronously. Dashboard SQL charts
-     * can inherit dashboard-level filters and contextual parameters.
+     * @summary Execute dashboard SQL chart
+     * @description Executes a SQL chart within a dashboard context asynchronously with inherited filters
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -421,11 +402,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Stream query results
-     *
-     * Streams query results directly from storage as a JSON stream.
-     * Use this endpoint for large result sets to avoid memory issues.
-     * The response is streamed as newline-delimited JSON (NDJSON).
+     * @summary Stream results
+     * @description Streams query results directly from storage as newline-delimited JSON for large result sets
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -461,11 +439,8 @@ export class QueryController extends BaseController {
     }
 
     /**
-     * Download query results
-     *
-     * Downloads query results in various formats (CSV, XLSX, JSON).
-     * Supports custom formatting options like column ordering, hidden fields,
-     * and pivot configurations.
+     * @summary Download results
+     * @description Downloads query results in various formats with custom formatting options
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -54,8 +54,8 @@ export type ApiGetAsyncQueryResultsResponse = {
 @Tags('Query')
 export class QueryController extends BaseController {
     /**
+     * Retrieves paginated results from a previously executed async query using its UUID
      * @summary Get results
-     * @description Retrieves paginated results from a previously executed async query using its UUID
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -94,8 +94,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Cancels a running async query and discards any partial results
      * @summary Cancel query
-     * @description Cancels a running async query and discards any partial results
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -122,8 +122,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Executes a metric query asynchronously against your data warehouse using dimensions, metrics, filters, and sorts
      * @summary Execute metric query
-     * @description Executes a metric query asynchronously against your data warehouse using dimensions, metrics, filters, and sorts
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -171,8 +171,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Executes a saved chart query asynchronously with optional parameter overrides
      * @summary Execute saved chart
-     * @description Executes a saved chart query asynchronously with optional parameter overrides
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -208,8 +208,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Executes a chart within a dashboard context asynchronously with inherited dashboard filters
      * @summary Execute dashboard chart
-     * @description Executes a chart within a dashboard context asynchronously with inherited dashboard filters
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -248,8 +248,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Executes a query to retrieve underlying raw data for drilling down into aggregated values
      * @summary Execute underlying data
-     * @description Executes a query to retrieve underlying raw data for drilling down into aggregated values
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -288,8 +288,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Executes a raw SQL query asynchronously against your data warehouse for custom queries
      * @summary Execute SQL query
-     * @description Executes a raw SQL query asynchronously against your data warehouse for custom queries
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -324,8 +324,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Executes a saved SQL chart query asynchronously with optional chart configurations
      * @summary Execute SQL chart
-     * @description Executes a saved SQL chart query asynchronously with optional chart configurations
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -361,8 +361,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Executes a SQL chart within a dashboard context asynchronously with inherited filters
      * @summary Execute dashboard SQL chart
-     * @description Executes a SQL chart within a dashboard context asynchronously with inherited filters
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -402,8 +402,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Streams query results directly from storage as newline-delimited JSON for large result sets
      * @summary Stream results
-     * @description Streams query results directly from storage as newline-delimited JSON for large result sets
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -439,8 +439,8 @@ export class QueryController extends BaseController {
     }
 
     /**
+     * Downloads query results in various formats with custom formatting options
      * @summary Download results
-     * @description Downloads query results in various formats with custom formatting options
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -28018,6 +28018,7 @@
                         }
                     }
                 },
+                "description": "Retrieves paginated results from a previously executed async query using its UUID",
                 "summary": "Get results",
                 "tags": ["Query"],
                 "security": [],
@@ -28087,6 +28088,7 @@
                         }
                     }
                 },
+                "description": "Cancels a running async query and discards any partial results",
                 "summary": "Cancel query",
                 "tags": ["Query"],
                 "security": [],
@@ -28136,6 +28138,7 @@
                         }
                     }
                 },
+                "description": "Executes a metric query asynchronously against your data warehouse using dimensions, metrics, filters, and sorts",
                 "summary": "Execute metric query",
                 "tags": ["Query"],
                 "security": [],
@@ -28186,6 +28189,7 @@
                         }
                     }
                 },
+                "description": "Executes a saved chart query asynchronously with optional parameter overrides",
                 "summary": "Execute saved chart",
                 "tags": ["Query"],
                 "security": [],
@@ -28236,6 +28240,7 @@
                         }
                     }
                 },
+                "description": "Executes a chart within a dashboard context asynchronously with inherited dashboard filters",
                 "summary": "Execute dashboard chart",
                 "tags": ["Query"],
                 "security": [],
@@ -28286,6 +28291,7 @@
                         }
                     }
                 },
+                "description": "Executes a query to retrieve underlying raw data for drilling down into aggregated values",
                 "summary": "Execute underlying data",
                 "tags": ["Query"],
                 "security": [],
@@ -28336,6 +28342,7 @@
                         }
                     }
                 },
+                "description": "Executes a raw SQL query asynchronously against your data warehouse for custom queries",
                 "summary": "Execute SQL query",
                 "tags": ["Query"],
                 "security": [],
@@ -28386,6 +28393,7 @@
                         }
                     }
                 },
+                "description": "Executes a saved SQL chart query asynchronously with optional chart configurations",
                 "summary": "Execute SQL chart",
                 "tags": ["Query"],
                 "security": [],
@@ -28436,6 +28444,7 @@
                         }
                     }
                 },
+                "description": "Executes a SQL chart within a dashboard context asynchronously with inherited filters",
                 "summary": "Execute dashboard SQL chart",
                 "tags": ["Query"],
                 "security": [],
@@ -28486,6 +28495,7 @@
                         }
                     }
                 },
+                "description": "Downloads query results in various formats with custom formatting options",
                 "summary": "Download results",
                 "tags": ["Query"],
                 "security": [],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -18200,7 +18200,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1876.1",
+        "version": "0.1880.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -28018,7 +28018,7 @@
                         }
                     }
                 },
-                "description": "Get results from an asynchronous query\n\nRetrieves paginated results from a previously executed async query using its UUID.\nUse this endpoint to fetch query results after the query has completed execution.",
+                "summary": "Get results",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28087,7 +28087,7 @@
                         }
                     }
                 },
-                "description": "Cancel an asynchronous query\n\nCancels a running async query. Once cancelled, the query cannot be resumed\nand any partial results will be discarded.",
+                "summary": "Cancel query",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28136,7 +28136,7 @@
                         }
                     }
                 },
-                "description": "Execute an asynchronous metric query\n\nExecutes a metric query asynchronously against your data warehouse.\nReturns a query UUID that can be used to fetch results once the query completes.\nMetric queries are built using dimensions, metrics, filters, and sorts from your dbt models.",
+                "summary": "Execute metric query",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28186,7 +28186,7 @@
                         }
                     }
                 },
-                "description": "Execute an asynchronous saved chart query\n\nExecutes a saved chart query asynchronously. Saved charts contain pre-configured\nmetric queries that can be executed with optional parameter overrides.",
+                "summary": "Execute saved chart",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28236,7 +28236,7 @@
                         }
                     }
                 },
-                "description": "Execute an asynchronous dashboard chart query\n\nExecutes a chart within a dashboard context asynchronously. Dashboard charts\ninherit dashboard-level filters and may have additional contextual parameters.",
+                "summary": "Execute dashboard chart",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28286,7 +28286,7 @@
                         }
                     }
                 },
-                "description": "Execute an asynchronous underlying data query\n\nExecutes a query to retrieve the underlying raw data for a specific metric or dimension.\nThis is useful for drilling down into the data behind aggregated values.",
+                "summary": "Execute underlying data",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28336,7 +28336,7 @@
                         }
                     }
                 },
-                "description": "Execute an asynchronous SQL query\n\nExecutes a raw SQL query asynchronously against your data warehouse.\nThis allows for custom queries beyond the metric layer capabilities.",
+                "summary": "Execute SQL query",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28386,7 +28386,7 @@
                         }
                     }
                 },
-                "description": "Execute an asynchronous SQL chart query\n\nExecutes a saved SQL chart query asynchronously. SQL charts are custom visualizations\nbuilt from raw SQL queries with optional chart configurations.",
+                "summary": "Execute SQL chart",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28436,7 +28436,7 @@
                         }
                     }
                 },
-                "description": "Execute an asynchronous dashboard SQL chart query\n\nExecutes a SQL chart within a dashboard context asynchronously. Dashboard SQL charts\ncan inherit dashboard-level filters and contextual parameters.",
+                "summary": "Execute dashboard SQL chart",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [
@@ -28486,7 +28486,7 @@
                         }
                     }
                 },
-                "description": "Download query results\n\nDownloads query results in various formats (CSV, XLSX, JSON).\nSupports custom formatting options like column ordering, hidden fields,\nand pivot configurations.",
+                "summary": "Download results",
                 "tags": ["Query"],
                 "security": [],
                 "parameters": [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:

### Description:
Standardized API documentation format across controllers by:

1. Simplified controller documentation in CLAUDE.md by removing redundant example code
2. Added requirement for JSDoc comments with `@summary` and `@description` tags
3. Reformatted all QueryController endpoint documentation to follow the new standard:
   - Concise `@summary` (2-3 words)
   - Brief `@description` that explains the endpoint's purpose

These changes make the API documentation more consistent and easier to maintain while improving the generated Swagger documentation.


#### Before
<img width="1424" height="1295" alt="Screenshot 2025-08-06 at 11 54 14" src="https://github.com/user-attachments/assets/5d7d75b3-500a-467a-9142-a83fe79d796e" />


#### After
<img width="1236" height="1295" alt="Screenshot 2025-08-06 at 13 39 42" src="https://github.com/user-attachments/assets/6ef48748-ee21-4236-a239-bb9d43fbc945" />

