### PR TITLE
fix: extract limit clause from subquery and add it at the end of the sql

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.mocks.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.mocks.ts
@@ -71,3 +71,16 @@ export const QUERY_WITH_NESTED_FILTERS_SQL =
     'SELECT\n"table"."field1" AS "field1",\n"table"."field2" AS "field2",\n"table"."field3" AS "field3"\nFROM "table"\nWHERE ((\n("table"."field1") IN (\'value1\')\n) AND ((\n("table"."field2") > (10)\n) OR (\n("table"."field3") = true\n)))';
 
 export const QUERY_WITH_EMPTY_SELECT_SQL = 'SELECT\n*\nFROM "test_table"';
+
+// Limit and offset SQL strings
+export const QUERY_WITH_LIMIT_SQL =
+    'SELECT\n"test_table"."test_field" AS "test_field"\nFROM "test_table"\nLIMIT 100';
+
+export const QUERY_WITH_LIMIT_OFFSET_SQL =
+    'SELECT\n"test_table"."test_field" AS "test_field"\nFROM (\nSELECT * FROM source_table WHERE field IS NOT NULL\n) AS "subquery"\nLIMIT 50 OFFSET 10';
+
+export const QUERY_WITH_LIMIT_OFFSET_MIN_SQL =
+    'SELECT\n"test_table"."test_field" AS "test_field"\nFROM (\nSELECT * FROM source_table WHERE field IS NOT NULL\n) AS "subquery"\nLIMIT 30 OFFSET 5';
+
+export const QUERY_WITH_LIMIT_ONLY_LIMIT_SQL =
+    'SELECT\n"test_table"."test_field" AS "test_field"\nFROM (\nSELECT * FROM source_table WHERE field IS NOT NULL\n) AS "subquery"\nLIMIT 75';

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -420,13 +420,13 @@ const restoreStringsFromPlaceholders = (
         (_, p1) => placeholders[Number(p1)],
     );
 
-interface LimitOffsetClause {
+export interface LimitOffsetClause {
     limit: number;
     offset?: number;
 }
 
 // Extract the outer limit and offset clauses from a SQL query
-const extractOuterLimitOffsetFromSQL = (
+export const extractOuterLimitOffsetFromSQL = (
     sql: string,
 ): LimitOffsetClause | undefined => {
     let s = sql.trim();
@@ -459,7 +459,7 @@ const extractOuterLimitOffsetFromSQL = (
 };
 
 // Remove the outermost limit and offset clauses from SQL
-const removeCommentsAndOuterLimitOffset = (sql: string): string => {
+export const removeCommentsAndOuterLimitOffset = (sql: string): string => {
     let s = sql.trim();
     // remove comments
     s = removeComments(s);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #12574

### Description:
Brings back functionality from https://github.com/lightdash/lightdash/pull/12647 which fixed https://github.com/lightdash/lightdash/issues/12574 and was removed in https://github.com/lightdash/lightdash/pull/15986

- Extracts and handles LIMIT/OFFSET clauses from subqueries
- Preserves OFFSET values when present in subqueries
- Uses the minimum value when both the subquery and outer query specify LIMIT values
- Includes comprehensive test cases for various LIMIT/OFFSET scenarios

**Sql Runner Sql**
```sql
SELECT * FROM "SNOWFLAKE_LEARNING_DB"."PUBLIC"."TRACKS_RAW" LIMIT 3;
```

**Before**
```sql
SELECT
    "USER_ID" AS "USER_ID",
    "EVENT_ID" AS "EVENT_ID",
    "EVENT_NAME" AS "EVENT_NAME",
    "EVENT_TIMESTAMP" AS "EVENT_TIMESTAMP"
FROM (
    SELECT * FROM "SNOWFLAKE_LEARNING_DB"."PUBLIC"."TRACKS_RAW" LIMIT 3
) AS "sql_query"
LIMIT 500
```

**After**
```sql
SELECT
    "USER_ID" AS "USER_ID",
    "EVENT_ID" AS "EVENT_ID",
    "EVENT_NAME" AS "EVENT_NAME",
    "EVENT_TIMESTAMP" AS "EVENT_TIMESTAMP"
FROM (
    SELECT * FROM "SNOWFLAKE_LEARNING_DB"."PUBLIC"."TRACKS_RAW"
) AS "sql_query"
LIMIT 3
```

test-frontend
test-backend