### PR TITLE
feat: add find_dashboards tool to MCP service

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -249,6 +249,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     catalogService: repository.getCatalogService(),
                     projectService: repository.getProjectService(),
                     userAttributesModel: models.getUserAttributesModel(),
+                    searchModel: models.getSearchModel(),
+                    spaceModel: models.getSpaceModel(),
                 }),
         },
         modelProviders: {

--- a/packages/backend/src/ee/services/ai/tools/findDashboards.ts
+++ b/packages/backend/src/ee/services/ai/tools/findDashboards.ts
@@ -56,15 +56,7 @@ const getDashboardsText = (
 </SearchResult>
 `.trim();
 
-export const getFindDashboards = ({
-    findDashboards,
-    pageSize,
-    siteUrl,
-}: Dependencies) => {
-    const schema = toolFindDashboardsArgsSchema;
-
-    return tool({
-        description: `Tool: "findDashboards"
+export const toolFindDashboardsDescription = `Tool: "findDashboards"
                     Purpose:
                     Finds dashboards by name or description within a project, returning detailed info about each.
 
@@ -75,8 +67,16 @@ export const getFindDashboards = ({
                     - Dashboards with validation errors will be deprioritized
                     - Returns dashboard URLs when available 
                     - It doesn't provide a dashboard summary yet, so don't suggest this capability
-        `,
-        parameters: schema,
+        `;
+
+export const getFindDashboards = ({
+    findDashboards,
+    pageSize,
+    siteUrl,
+}: Dependencies) =>
+    tool({
+        description: toolFindDashboardsDescription,
+        parameters: toolFindDashboardsArgsSchema,
         execute: async (args) => {
             try {
                 const dashboardSearchQueryResults = await Promise.all(
@@ -109,4 +109,3 @@ export const getFindDashboards = ({
             }
         },
     });
-};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16243

### Description:

Added a new MCP tool for finding dashboards. This tool allows users to search for dashboards by name or description within a project. The implementation includes:

- Added a new `FIND_DASHBOARDS` enum to the McpToolName
- Registered the new dashboard search tool with the MCP server
- Implemented the `getFindDashboardsFunction` to handle dashboard search requests
- Ensured proper access control by filtering results based on user permissions
