### PR TITLE
fix: duplicate scheduler jobs when there are errors generating daily jobs

### DIFF
--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -576,3 +576,31 @@ export class OauthAuthenticationError extends LightdashError {
         });
     }
 }
+
+export class GenerateDailySchedulerJobError extends LightdashError {
+    schedulerUuid: string;
+
+    constructor(
+        message: string,
+        schedulerUuid: string,
+        originalError?: unknown,
+    ) {
+        super({
+            message,
+            name: 'GenerateDailySchedulerJobError',
+            statusCode: 500,
+            data: {
+                schedulerUuid,
+                originalError:
+                    originalError instanceof Error
+                        ? originalError.message
+                        : String(originalError),
+            },
+        });
+        this.schedulerUuid = schedulerUuid;
+        if (originalError instanceof Error) {
+            this.stack = originalError.stack;
+            this.cause = originalError;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16251

### Description:
Improves the reliability of scheduled jobs by:

1. Adding a new method to delete overlapping scheduled jobs before creating new ones, preventing duplicates if the `generateDailyJobs` task runs multiple times or retries
2. Enhancing error handling in the scheduler worker to:
   - Continue processing other schedulers even if one fails
   - Log detailed error information for each failed scheduler
   - Only throw an exception if all schedulers fail
3. Creating a new `GenerateDailySchedulerJobError` class to provide better error context

This change makes the scheduler more resilient by ensuring jobs aren't duplicated and allowing partial success when some schedulers encounter issues.

Sample error when it fails:
<img width="1660" height="183" alt="image" src="https://github.com/user-attachments/assets/74ee7bf2-a29e-4492-88f7-607541cab502" />


