### PR TITLE
refactor: move string escape tests to warehouse package

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -22,7 +22,6 @@ import {
     WarehouseTables,
     WarehouseTypes,
 } from '@lightdash/common';
-import { BigquerySqlBuilder, PostgresSqlBuilder } from '@lightdash/warehouses';
 
 export const warehouseClientMock: WarehouseClient = {
     credentials: {
@@ -109,7 +108,17 @@ export const warehouseClientMock: WarehouseClient = {
     parseError: (error: Error) => {
         throw error;
     },
-    escapeString: (value) => value, // Initializing PostgresSqlBuilder here will cause issues on ProjectService.test.ts
+    escapeString: (value) => {
+        if (typeof value !== 'string') {
+            return value;
+        }
+
+        return value
+            .replaceAll("'", "''")
+            .replaceAll('\\', '\\\\')
+            .replace(/--.*$/gm, '')
+            .replace(/\/\*[\s\S]*?\*\//g, '');
+    },
 };
 
 export const bigqueryClientMock: WarehouseClient = {

--- a/packages/backend/src/utils/QueryBuilder/parameters.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.test.ts
@@ -1,11 +1,11 @@
-import { SnowflakeSqlBuilder } from '@lightdash/warehouses';
+import { warehouseClientMock } from './MetricQueryBuilder.mock';
 import {
     replaceParameters,
     replaceParametersAsString,
     unsafeReplaceParametersAsRaw,
 } from './parameters';
 
-const mockSqlBuilder = new SnowflakeSqlBuilder();
+const mockSqlBuilder = warehouseClientMock;
 
 describe('replaceParameters', () => {
     it('should replace lightdash parameter placeholders with values', () => {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -1,6 +1,9 @@
 import * as pg from 'pg';
 import { PassThrough } from 'stream';
-import { PostgresWarehouseClient } from './PostgresWarehouseClient';
+import {
+    PostgresSqlBuilder,
+    PostgresWarehouseClient,
+} from './PostgresWarehouseClient';
 import {
     columns,
     credentials,
@@ -108,5 +111,51 @@ describe('PostgresWarehouseClient', () => {
     it('expect empty catalog when dbt project has no references', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
         expect(await warehouse.getCatalog([])).toEqual({});
+    });
+});
+
+describe('PostgresSqlBuilder escaping', () => {
+    const postgresSqlBuilder = new PostgresSqlBuilder();
+
+    test('Should not escape regular characters', () => {
+        expect(postgresSqlBuilder.escapeString('%')).toBe('%');
+        expect(postgresSqlBuilder.escapeString('_')).toBe('_');
+        expect(postgresSqlBuilder.escapeString('?')).toBe('?');
+        expect(postgresSqlBuilder.escapeString('!')).toBe('!');
+        expect(postgresSqlBuilder.escapeString('credit_card')).toBe(
+            'credit_card',
+        );
+    });
+
+    test('Should escape single quotes in postgres', () => {
+        expect(postgresSqlBuilder.escapeString("single'quote")).toBe(
+            "single''quote",
+        );
+    });
+
+    test('Should escape unicode characters in postgres', () => {
+        expect(postgresSqlBuilder.escapeString('single\u2019quote')).toBe(
+            "single''quote",
+        );
+    });
+
+    test('Should escape backslashes and quotes in postgres', () => {
+        expect(postgresSqlBuilder.escapeString("\\') OR (1=1) --")).toBe(
+            "\\\\'') OR (1=1) ",
+        );
+    });
+
+    test('Should handle SQL injection attempts', () => {
+        // Test with a typical SQL injection pattern
+        const maliciousInput = "'; DROP TABLE users; --";
+        const escaped = postgresSqlBuilder.escapeString(maliciousInput);
+        expect(escaped).toBe("''; DROP TABLE users; ");
+
+        // Test with another common SQL injection pattern
+        const anotherMaliciousInput = "' OR '1'='1";
+        const anotherEscaped = postgresSqlBuilder.escapeString(
+            anotherMaliciousInput,
+        );
+        expect(anotherEscaped).toBe("'' OR ''1''=''1");
     });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

This will make it easier to move the query builder classes to the common package.

### Description:

- Move string escaping unit tests to the warehouse package where the escape logic is defined
- Remove '@lightdash/warehouses' dependencies from backend unit tests

