### PR TITLE
feat: add find_charts tool to MCP service

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -102,6 +102,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     openIdIdentityModel: models.getOpenIdIdentityModel(),
+                    spaceService: repository.getSpaceService(),
                 }),
             scimService: ({ models, context }) =>
                 new ScimService({
@@ -251,6 +252,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     userAttributesModel: models.getUserAttributesModel(),
                     searchModel: models.getSearchModel(),
                     spaceModel: models.getSpaceModel(),
+                    spaceService: repository.getSpaceService(),
                 }),
         },
         modelProviders: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16266

### Description:

Added a new `filterBySpaceAccess` method to the SpaceService to centralize space access filtering logic. This method is now used by both `AiAgentService` and `McpService` to filter search results based on user permissions.

Also added a new `find_charts` tool to the McpService, allowing AI agents to search for charts with proper space access controls.
