### PR TITLE
refactor: update AI agent API routes to use a single consistent router

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -44,7 +44,7 @@ import {
 import { BaseController } from '../../controllers/baseController';
 import { type AiAgentService } from '../services/AiAgentService';
 
-@Route('/api/v1/aiAgents')
+@Route('/api/v1/projects/{projectUuid}/aiAgents')
 @Hidden()
 @Response<ApiErrorPayload>('default', 'Error')
 export class AiAgentController extends BaseController {
@@ -54,14 +54,119 @@ export class AiAgentController extends BaseController {
     @OperationId('listAgents')
     async listAgents(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
     ): Promise<ApiAiAgentSummaryResponse> {
         this.setStatus(200);
 
         return {
             status: 'ok',
-            results: await this.getAiAgentService().listAgents(req.user!),
+            results: await this.getAiAgentService().listAgents(
+                req.user!,
+                projectUuid,
+            ),
         };
     }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/preferences')
+    @OperationId('getUserAgentPreferences')
+    async getUserAgentPreferences(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiGetUserAgentPreferencesResponse> {
+        this.setStatus(200);
+
+        const userPreferences =
+            await this.getAiAgentService().getUserAgentPreferences(
+                req.user!,
+                projectUuid,
+            );
+        return {
+            status: 'ok',
+            results: userPreferences ?? undefined,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/preferences')
+    @OperationId('updateUserAgentPreferences')
+    async setUserDefaultAgent(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: ApiUpdateUserAgentPreferences,
+    ): Promise<ApiUpdateUserAgentPreferencesResponse> {
+        this.setStatus(200);
+        await this.getAiAgentService().updateUserAgentPreferences(
+            req.user!,
+            projectUuid,
+            body,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('/preferences')
+    @OperationId('deleteUserAgentPreferences')
+    async deleteUserAgentPreferences(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        await this.getAiAgentService().deleteUserAgentPreferences(
+            req.user!,
+            projectUuid,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    // Legacy routes
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/conversations')
+    @OperationId('getAiAgentConversations')
+    async getAiAgentConversations(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiAiConversations> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getConversations(
+                req.user!,
+                projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/conversations/:aiThreadUuid/messages')
+    @OperationId('getAiAgentConversationMessages')
+    async getAiAgentConversationMessages(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() aiThreadUuid: string,
+    ): Promise<ApiAiConversationMessages> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getConversationMessages(
+                req.user!,
+                projectUuid,
+                aiThreadUuid,
+            ),
+        };
+    }
+    // End of legacy routes
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -69,12 +174,14 @@ export class AiAgentController extends BaseController {
     @OperationId('getAgent')
     async getAgent(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
     ): Promise<ApiAiAgentResponse> {
         this.setStatus(200);
         const agent = await this.getAiAgentService().getAgent(
             req.user!,
             agentUuid,
+            projectUuid,
         );
         return {
             status: 'ok',
@@ -88,13 +195,14 @@ export class AiAgentController extends BaseController {
     @OperationId('createAgent')
     async createAgent(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Body() body: ApiCreateAiAgent,
     ): Promise<ApiCreateAiAgentResponse> {
         this.setStatus(201);
-        const agent = await this.getAiAgentService().createAgent(
-            req.user!,
-            body,
-        );
+        const agent = await this.getAiAgentService().createAgent(req.user!, {
+            ...body,
+            projectUuid,
+        });
         return {
             status: 'ok',
             results: agent,
@@ -107,6 +215,7 @@ export class AiAgentController extends BaseController {
     @OperationId('updateAgent')
     async updateAgent(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Body() body: ApiUpdateAiAgent,
     ): Promise<ApiAiAgentResponse> {
@@ -114,7 +223,7 @@ export class AiAgentController extends BaseController {
         const agent = await this.getAiAgentService().updateAgent(
             req.user!,
             agentUuid,
-            body,
+            { ...body, projectUuid },
         );
         return {
             status: 'ok',
@@ -128,6 +237,7 @@ export class AiAgentController extends BaseController {
     @OperationId('deleteAgent')
     async deleteAgent(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
@@ -145,6 +255,7 @@ export class AiAgentController extends BaseController {
     @OperationId('listAgentThreads')
     async listAgentThreads(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Query() allUsers?: boolean,
     ): Promise<ApiAiAgentThreadSummaryListResponse> {
@@ -165,6 +276,7 @@ export class AiAgentController extends BaseController {
     @OperationId('getAgentThread')
     async getAgentThread(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Path() threadUuid: string,
     ): Promise<ApiAiAgentThreadResponse> {
@@ -185,6 +297,7 @@ export class AiAgentController extends BaseController {
     @OperationId('createAgentThread')
     async createAgentThread(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Body() body: ApiAiAgentThreadCreateRequest,
     ): Promise<ApiAiAgentThreadCreateResponse> {
@@ -205,6 +318,7 @@ export class AiAgentController extends BaseController {
     @OperationId('createAgentThreadMessage')
     async createAgentThreadMessage(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Path() threadUuid: string,
         @Body() body: ApiAiAgentThreadMessageCreateRequest,
@@ -227,6 +341,7 @@ export class AiAgentController extends BaseController {
     @OperationId('streamAgentThreadResponse')
     async streamAgentThreadResponse(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Path() threadUuid: string,
     ): Promise<void> {
@@ -251,6 +366,7 @@ export class AiAgentController extends BaseController {
     @OperationId('getAgentThreadMessageViz')
     async getAgentThreadMessageViz(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Path() threadUuid: string,
         @Path() messageUuid: string,
@@ -277,6 +393,7 @@ export class AiAgentController extends BaseController {
     @OperationId('getAgentThreadMessageVizQuery')
     async getAgentThreadMessageVizQuery(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Path() threadUuid: string,
         @Path() messageUuid: string,
@@ -299,33 +416,13 @@ export class AiAgentController extends BaseController {
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Patch('/messages/{messageUuid}/feedback')
-    @OperationId('updatePromptFeedback')
-    async updatePromptFeedback(
-        @Request() req: express.Request,
-        @Path() messageUuid: string,
-        @Body() body: { humanScore: number },
-    ): Promise<ApiSuccessEmpty> {
-        this.setStatus(200);
-        await this.getAiAgentService().updateHumanScoreForMessage(
-            req.user!,
-            messageUuid,
-            body.humanScore,
-        );
-        return {
-            status: 'ok',
-            results: undefined,
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
     @Patch(
         '/{agentUuid}/threads/{threadUuid}/messages/{messageUuid}/savedQuery',
     )
     @OperationId('updateAgentThreadMessageSavedQuery')
     async updateAgentThreadMessageSavedQuery(
         @Request() req: express.Request,
+        @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Path() threadUuid: string,
         @Path() messageUuid: string,
@@ -348,200 +445,25 @@ export class AiAgentController extends BaseController {
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('/projects/{projectUuid}/conversations')
-    @OperationId('getAiAgentConversations')
-    async getAiAgentConversations(
+    @Patch('/{agentUuid}/threads/{threadUuid}/messages/{messageUuid}/feedback')
+    @OperationId('updatePromptFeedback')
+    async updatePromptFeedback(
         @Request() req: express.Request,
         @Path() projectUuid: string,
-    ): Promise<ApiAiConversations> {
-        this.setStatus(200);
-        return {
-            status: 'ok',
-            results: await this.getAiAgentService().getConversations(
-                req.user!,
-                projectUuid,
-            ),
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Get('/projects/{projectUuid}/conversations/:aiThreadUuid/messages')
-    @OperationId('getAiAgentConversationMessages')
-    async getAiAgentConversationMessages(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
-        @Path() aiThreadUuid: string,
-    ): Promise<ApiAiConversationMessages> {
-        this.setStatus(200);
-        return {
-            status: 'ok',
-            results: await this.getAiAgentService().getConversationMessages(
-                req.user!,
-                projectUuid,
-                aiThreadUuid,
-            ),
-        };
-    }
-
-    protected getAiAgentService() {
-        return this.services.getAiAgentService<AiAgentService>();
-    }
-}
-
-@Route('/api/v1/projects/{projectUuid}/aiAgents/preferences')
-@Hidden()
-@Response<ApiErrorPayload>('default', 'Error')
-export class AiAgentUserPreferencesController extends BaseController {
-    protected getAiAgentService() {
-        return this.services.getAiAgentService<AiAgentService>();
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Get()
-    @OperationId('getUserAgentPreferences')
-    async getUserAgentPreferences(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
-    ): Promise<ApiGetUserAgentPreferencesResponse> {
-        this.setStatus(200);
-
-        const userPreferences =
-            await this.getAiAgentService().getUserAgentPreferences(
-                req.user!,
-                projectUuid,
-            );
-        return {
-            status: 'ok',
-            results: userPreferences ?? undefined,
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Post()
-    @OperationId('updateUserAgentPreferences')
-    async setUserDefaultAgent(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
-        @Body() body: ApiUpdateUserAgentPreferences,
-    ): Promise<ApiUpdateUserAgentPreferencesResponse> {
-        this.setStatus(200);
-        await this.getAiAgentService().updateUserAgentPreferences(
-            req.user!,
-            projectUuid,
-            body,
-        );
-        return {
-            status: 'ok',
-            results: undefined,
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Delete()
-    @OperationId('deleteUserAgentPreferences')
-    async deleteUserAgentPreferences(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Path() messageUuid: string,
+        @Body() body: { humanScore: number },
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await this.getAiAgentService().deleteUserAgentPreferences(
+        await this.getAiAgentService().updateHumanScoreForMessage(
             req.user!,
-            projectUuid,
+            messageUuid,
+            body.humanScore,
         );
         return {
             status: 'ok',
             results: undefined,
-        };
-    }
-}
-
-@Route('/api/v1/projects/{projectUuid}/aiAgents')
-@Hidden()
-@Response<ApiErrorPayload>('default', 'Error')
-export class ProjectAiAgentController extends BaseController {
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Get('/')
-    @OperationId('listProjectAgents')
-    async listProjectAgents(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
-    ): Promise<ApiAiAgentSummaryResponse> {
-        this.setStatus(200);
-
-        return {
-            status: 'ok',
-            results: await this.getAiAgentService().listAgents(
-                req.user!,
-                projectUuid,
-            ),
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Get('/{agentUuid}')
-    @OperationId('getProjectAgent')
-    async getProjectAgent(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
-        @Path() agentUuid: string,
-    ): Promise<ApiAiAgentResponse> {
-        this.setStatus(200);
-        const agent = await this.getAiAgentService().getAgent(
-            req.user!,
-            agentUuid,
-            projectUuid,
-        );
-        return {
-            status: 'ok',
-            results: agent,
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('201', 'Created')
-    @Post('/')
-    @OperationId('createProjectAgent')
-    async createProjectAgent(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
-        @Body() body: ApiCreateAiAgent,
-    ): Promise<ApiCreateAiAgentResponse> {
-        this.setStatus(201);
-        const agent = await this.getAiAgentService().createAgent(req.user!, {
-            ...body,
-            projectUuid,
-        });
-        return {
-            status: 'ok',
-            results: agent,
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Patch('/{agentUuid}')
-    @OperationId('updateProjectAgent')
-    async updateProjectAgent(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
-        @Path() agentUuid: string,
-        @Body() body: ApiUpdateAiAgent,
-    ): Promise<ApiAiAgentResponse> {
-        this.setStatus(200);
-        const agent = await this.getAiAgentService().updateAgent(
-            req.user!,
-            agentUuid,
-            { ...body, projectUuid },
-        );
-        return {
-            status: 'ok',
-            results: agent,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -24,10 +24,6 @@ import { AiController } from './../ee/controllers/aiController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiAgentController } from './../ee/controllers/aiAgentController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { AiAgentUserPreferencesController } from './../ee/controllers/aiAgentController';
-// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { ProjectAiAgentController } from './../ee/controllers/aiAgentController';
-// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ValidationController } from './../controllers/validationController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../controllers/userController';
@@ -4577,6 +4573,184 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentUserPreferences: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                defaultAgentUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiAgentUserPreferences_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentUserPreferences', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetUserAgentPreferencesResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'ApiSuccess_AiAgentUserPreferences_' },
+                { ref: 'ApiSuccessEmpty' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateUserAgentPreferencesResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccessEmpty', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateUserAgentPreferences: {
+        dataType: 'refAlias',
+        type: { ref: 'AiAgentUserPreferences', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiConversation: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                user: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                firstMessage: { dataType: 'string', required: true },
+                createdFrom: { dataType: 'string', required: true },
+                createdAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'datetime' },
+                    ],
+                    required: true,
+                },
+                threadUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiConversations: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiConversation' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiConversationMessageIncomplete: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                user: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                createdAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'datetime' },
+                    ],
+                    required: true,
+                },
+                message: { dataType: 'string', required: true },
+                promptUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiConversationComplete: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'AiConversationMessageIncomplete' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        humanScore: { dataType: 'double' },
+                        metricQuery: { dataType: 'object' },
+                        filtersOutput: { dataType: 'object' },
+                        vizConfigOutput: { dataType: 'object' },
+                        respondedAt: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'datetime' },
+                            ],
+                            required: true,
+                        },
+                        response: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiConversationMessage: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'AiConversationMessageIncomplete' },
+                { ref: 'AiConversationComplete' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiConversationMessages: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiConversationMessage',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_':
         {
             dataType: 'refAlias',
@@ -5371,184 +5545,6 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiConversation: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                user: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                firstMessage: { dataType: 'string', required: true },
-                createdFrom: { dataType: 'string', required: true },
-                createdAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'datetime' },
-                    ],
-                    required: true,
-                },
-                threadUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiAiConversations: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'AiConversation' },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiConversationMessageIncomplete: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                user: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                createdAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'datetime' },
-                    ],
-                    required: true,
-                },
-                message: { dataType: 'string', required: true },
-                promptUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiConversationComplete: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'AiConversationMessageIncomplete' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        humanScore: { dataType: 'double' },
-                        metricQuery: { dataType: 'object' },
-                        filtersOutput: { dataType: 'object' },
-                        vizConfigOutput: { dataType: 'object' },
-                        respondedAt: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'datetime' },
-                            ],
-                            required: true,
-                        },
-                        response: { dataType: 'string', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiConversationMessage: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'AiConversationMessageIncomplete' },
-                { ref: 'AiConversationComplete' },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiAiConversationMessages: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'AiConversationMessage',
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiAgentUserPreferences: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                defaultAgentUuid: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSuccess_AiAgentUserPreferences_: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'AiAgentUserPreferences', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGetUserAgentPreferencesResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'ApiSuccess_AiAgentUserPreferences_' },
-                { ref: 'ApiSuccessEmpty' },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiUpdateUserAgentPreferencesResponse: {
-        dataType: 'refAlias',
-        type: { ref: 'ApiSuccessEmpty', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiUpdateUserAgentPreferences: {
-        dataType: 'refAlias',
-        type: { ref: 'AiAgentUserPreferences', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiJobScheduledResponse: {
@@ -19608,9 +19604,15 @@ export function RegisterRoutes(app: Router) {
         TsoaRoute.ParameterSchema
     > = {
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
     };
     app.get(
-        '/api/v1/aiAgents',
+        '/api/v1/projects/:projectUuid/aiAgents',
         ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
             AiAgentController.prototype.listAgents,
@@ -19657,26 +19659,26 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_getAgent: Record<
+    const argsAiAgentController_getUserAgentPreferences: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
+        projectUuid: {
             in: 'path',
-            name: 'agentUuid',
+            name: 'projectUuid',
             required: true,
             dataType: 'string',
         },
     };
     app.get(
-        '/api/v1/aiAgents/:agentUuid',
+        '/api/v1/projects/:projectUuid/aiAgents/preferences',
         ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.getAgent,
+            AiAgentController.prototype.getUserAgentPreferences,
         ),
 
-        async function AiAgentController_getAgent(
+        async function AiAgentController_getUserAgentPreferences(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -19686,7 +19688,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_getAgent,
+                    args: argsAiAgentController_getUserAgentPreferences,
                     request,
                     response,
                 });
@@ -19704,7 +19706,7 @@ export function RegisterRoutes(app: Router) {
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'getAgent',
+                    methodName: 'getUserAgentPreferences',
                     controller,
                     response,
                     next,
@@ -19717,74 +19719,14 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_createAgent: Record<
+    const argsAiAgentController_setUserDefaultAgent: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'ApiCreateAiAgent',
-        },
-    };
-    app.post(
-        '/api/v1/aiAgents',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.createAgent,
-        ),
-
-        async function AiAgentController_createAgent(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_createAgent,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'createAgent',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 201,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_updateAgent: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
+        projectUuid: {
             in: 'path',
-            name: 'agentUuid',
+            name: 'projectUuid',
             required: true,
             dataType: 'string',
         },
@@ -19792,17 +19734,17 @@ export function RegisterRoutes(app: Router) {
             in: 'body',
             name: 'body',
             required: true,
-            ref: 'ApiUpdateAiAgent',
+            ref: 'ApiUpdateUserAgentPreferences',
         },
     };
-    app.patch(
-        '/api/v1/aiAgents/:agentUuid',
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/preferences',
         ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.updateAgent,
+            AiAgentController.prototype.setUserDefaultAgent,
         ),
 
-        async function AiAgentController_updateAgent(
+        async function AiAgentController_setUserDefaultAgent(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -19812,7 +19754,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_updateAgent,
+                    args: argsAiAgentController_setUserDefaultAgent,
                     request,
                     response,
                 });
@@ -19830,7 +19772,7 @@ export function RegisterRoutes(app: Router) {
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'updateAgent',
+                    methodName: 'setUserDefaultAgent',
                     controller,
                     response,
                     next,
@@ -19843,26 +19785,26 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_deleteAgent: Record<
+    const argsAiAgentController_deleteUserAgentPreferences: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
+        projectUuid: {
             in: 'path',
-            name: 'agentUuid',
+            name: 'projectUuid',
             required: true,
             dataType: 'string',
         },
     };
     app.delete(
-        '/api/v1/aiAgents/:agentUuid',
+        '/api/v1/projects/:projectUuid/aiAgents/preferences',
         ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.deleteAgent,
+            AiAgentController.prototype.deleteUserAgentPreferences,
         ),
 
-        async function AiAgentController_deleteAgent(
+        async function AiAgentController_deleteUserAgentPreferences(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -19872,7 +19814,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_deleteAgent,
+                    args: argsAiAgentController_deleteUserAgentPreferences,
                     request,
                     response,
                 });
@@ -19890,639 +19832,7 @@ export function RegisterRoutes(app: Router) {
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'deleteAgent',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_listAgentThreads: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        allUsers: { in: 'query', name: 'allUsers', dataType: 'boolean' },
-    };
-    app.get(
-        '/api/v1/aiAgents/:agentUuid/threads',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.listAgentThreads,
-        ),
-
-        async function AiAgentController_listAgentThreads(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_listAgentThreads,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'listAgentThreads',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_getAgentThread: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        threadUuid: {
-            in: 'path',
-            name: 'threadUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.get(
-        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.getAgentThread,
-        ),
-
-        async function AiAgentController_getAgentThread(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_getAgentThread,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getAgentThread',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_createAgentThread: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'ApiAiAgentThreadCreateRequest',
-        },
-    };
-    app.post(
-        '/api/v1/aiAgents/:agentUuid/threads',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.createAgentThread,
-        ),
-
-        async function AiAgentController_createAgentThread(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_createAgentThread,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'createAgentThread',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_createAgentThreadMessage: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        threadUuid: {
-            in: 'path',
-            name: 'threadUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'ApiAiAgentThreadMessageCreateRequest',
-        },
-    };
-    app.post(
-        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/messages',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.createAgentThreadMessage,
-        ),
-
-        async function AiAgentController_createAgentThreadMessage(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_createAgentThreadMessage,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'createAgentThreadMessage',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_streamAgentThreadResponse: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        threadUuid: {
-            in: 'path',
-            name: 'threadUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.post(
-        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/stream',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.streamAgentThreadResponse,
-        ),
-
-        async function AiAgentController_streamAgentThreadResponse(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_streamAgentThreadResponse,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'streamAgentThreadResponse',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_getAgentThreadMessageViz: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        threadUuid: {
-            in: 'path',
-            name: 'threadUuid',
-            required: true,
-            dataType: 'string',
-        },
-        messageUuid: {
-            in: 'path',
-            name: 'messageUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.get(
-        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/message/:messageUuid/viz',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.getAgentThreadMessageViz,
-        ),
-
-        async function AiAgentController_getAgentThreadMessageViz(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_getAgentThreadMessageViz,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getAgentThreadMessageViz',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_getAgentThreadMessageVizQuery: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        threadUuid: {
-            in: 'path',
-            name: 'threadUuid',
-            required: true,
-            dataType: 'string',
-        },
-        messageUuid: {
-            in: 'path',
-            name: 'messageUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.get(
-        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/message/:messageUuid/viz-query',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.getAgentThreadMessageVizQuery,
-        ),
-
-        async function AiAgentController_getAgentThreadMessageVizQuery(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_getAgentThreadMessageVizQuery,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getAgentThreadMessageVizQuery',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_updatePromptFeedback: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        messageUuid: {
-            in: 'path',
-            name: 'messageUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                humanScore: { dataType: 'double', required: true },
-            },
-        },
-    };
-    app.patch(
-        '/api/v1/aiAgents/messages/:messageUuid/feedback',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.updatePromptFeedback,
-        ),
-
-        async function AiAgentController_updatePromptFeedback(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_updatePromptFeedback,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'updatePromptFeedback',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_updateAgentThreadMessageSavedQuery: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        threadUuid: {
-            in: 'path',
-            name: 'threadUuid',
-            required: true,
-            dataType: 'string',
-        },
-        messageUuid: {
-            in: 'path',
-            name: 'messageUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                savedQueryUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-            },
-        },
-    };
-    app.patch(
-        '/api/v1/aiAgents/:agentUuid/threads/:threadUuid/messages/:messageUuid/savedQuery',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.updateAgentThreadMessageSavedQuery,
-        ),
-
-        async function AiAgentController_updateAgentThreadMessageSavedQuery(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_updateAgentThreadMessageSavedQuery,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'updateAgentThreadMessageSavedQuery',
+                    methodName: 'deleteUserAgentPreferences',
                     controller,
                     response,
                     next,
@@ -20548,7 +19858,7 @@ export function RegisterRoutes(app: Router) {
         },
     };
     app.get(
-        '/api/v1/aiAgents/projects/:projectUuid/conversations',
+        '/api/v1/projects/:projectUuid/aiAgents/conversations',
         ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
             AiAgentController.prototype.getAiAgentConversations,
@@ -20614,7 +19924,7 @@ export function RegisterRoutes(app: Router) {
         },
     };
     app.get(
-        '/api/v1/aiAgents/projects/:projectUuid/conversations/:aiThreadUuid/messages',
+        '/api/v1/projects/:projectUuid/aiAgents/conversations/:aiThreadUuid/messages',
         ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
             AiAgentController.prototype.getAiAgentConversationMessages,
@@ -20661,258 +19971,7 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentUserPreferencesController_getUserAgentPreferences: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.get(
-        '/api/v1/projects/:projectUuid/aiAgents/preferences',
-        ...fetchMiddlewares<RequestHandler>(AiAgentUserPreferencesController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentUserPreferencesController.prototype.getUserAgentPreferences,
-        ),
-
-        async function AiAgentUserPreferencesController_getUserAgentPreferences(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentUserPreferencesController_getUserAgentPreferences,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<AiAgentUserPreferencesController>(
-                        AiAgentUserPreferencesController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getUserAgentPreferences',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentUserPreferencesController_setUserDefaultAgent: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'ApiUpdateUserAgentPreferences',
-        },
-    };
-    app.post(
-        '/api/v1/projects/:projectUuid/aiAgents/preferences',
-        ...fetchMiddlewares<RequestHandler>(AiAgentUserPreferencesController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentUserPreferencesController.prototype.setUserDefaultAgent,
-        ),
-
-        async function AiAgentUserPreferencesController_setUserDefaultAgent(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentUserPreferencesController_setUserDefaultAgent,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<AiAgentUserPreferencesController>(
-                        AiAgentUserPreferencesController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'setUserDefaultAgent',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentUserPreferencesController_deleteUserAgentPreferences: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.delete(
-        '/api/v1/projects/:projectUuid/aiAgents/preferences',
-        ...fetchMiddlewares<RequestHandler>(AiAgentUserPreferencesController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentUserPreferencesController.prototype
-                .deleteUserAgentPreferences,
-        ),
-
-        async function AiAgentUserPreferencesController_deleteUserAgentPreferences(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentUserPreferencesController_deleteUserAgentPreferences,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<AiAgentUserPreferencesController>(
-                        AiAgentUserPreferencesController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'deleteUserAgentPreferences',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsProjectAiAgentController_listProjectAgents: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.get(
-        '/api/v1/projects/:projectUuid/aiAgents',
-        ...fetchMiddlewares<RequestHandler>(ProjectAiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            ProjectAiAgentController.prototype.listProjectAgents,
-        ),
-
-        async function ProjectAiAgentController_listProjectAgents(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsProjectAiAgentController_listProjectAgents,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<ProjectAiAgentController>(
-                        ProjectAiAgentController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'listProjectAgents',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsProjectAiAgentController_getProjectAgent: Record<
+    const argsAiAgentController_getAgent: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
@@ -20932,12 +19991,12 @@ export function RegisterRoutes(app: Router) {
     };
     app.get(
         '/api/v1/projects/:projectUuid/aiAgents/:agentUuid',
-        ...fetchMiddlewares<RequestHandler>(ProjectAiAgentController),
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
-            ProjectAiAgentController.prototype.getProjectAgent,
+            AiAgentController.prototype.getAgent,
         ),
 
-        async function ProjectAiAgentController_getProjectAgent(
+        async function AiAgentController_getAgent(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -20947,7 +20006,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsProjectAiAgentController_getProjectAgent,
+                    args: argsAiAgentController_getAgent,
                     request,
                     response,
                 });
@@ -20957,16 +20016,15 @@ export function RegisterRoutes(app: Router) {
                         ? (iocContainer as IocContainerFactory)(request)
                         : iocContainer;
 
-                const controller: any =
-                    await container.get<ProjectAiAgentController>(
-                        ProjectAiAgentController,
-                    );
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
                 if (typeof controller['setStatus'] === 'function') {
                     controller.setStatus(undefined);
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'getProjectAgent',
+                    methodName: 'getAgent',
                     controller,
                     response,
                     next,
@@ -20979,7 +20037,7 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsProjectAiAgentController_createProjectAgent: Record<
+    const argsAiAgentController_createAgent: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
@@ -20999,12 +20057,12 @@ export function RegisterRoutes(app: Router) {
     };
     app.post(
         '/api/v1/projects/:projectUuid/aiAgents',
-        ...fetchMiddlewares<RequestHandler>(ProjectAiAgentController),
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
-            ProjectAiAgentController.prototype.createProjectAgent,
+            AiAgentController.prototype.createAgent,
         ),
 
-        async function ProjectAiAgentController_createProjectAgent(
+        async function AiAgentController_createAgent(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -21014,7 +20072,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsProjectAiAgentController_createProjectAgent,
+                    args: argsAiAgentController_createAgent,
                     request,
                     response,
                 });
@@ -21024,16 +20082,15 @@ export function RegisterRoutes(app: Router) {
                         ? (iocContainer as IocContainerFactory)(request)
                         : iocContainer;
 
-                const controller: any =
-                    await container.get<ProjectAiAgentController>(
-                        ProjectAiAgentController,
-                    );
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
                 if (typeof controller['setStatus'] === 'function') {
                     controller.setStatus(undefined);
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'createProjectAgent',
+                    methodName: 'createAgent',
                     controller,
                     response,
                     next,
@@ -21046,7 +20103,7 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsProjectAiAgentController_updateProjectAgent: Record<
+    const argsAiAgentController_updateAgent: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
@@ -21072,12 +20129,12 @@ export function RegisterRoutes(app: Router) {
     };
     app.patch(
         '/api/v1/projects/:projectUuid/aiAgents/:agentUuid',
-        ...fetchMiddlewares<RequestHandler>(ProjectAiAgentController),
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
         ...fetchMiddlewares<RequestHandler>(
-            ProjectAiAgentController.prototype.updateProjectAgent,
+            AiAgentController.prototype.updateAgent,
         ),
 
-        async function ProjectAiAgentController_updateProjectAgent(
+        async function AiAgentController_updateAgent(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -21087,7 +20144,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsProjectAiAgentController_updateProjectAgent,
+                    args: argsAiAgentController_updateAgent,
                     request,
                     response,
                 });
@@ -21097,16 +20154,779 @@ export function RegisterRoutes(app: Router) {
                         ? (iocContainer as IocContainerFactory)(request)
                         : iocContainer;
 
-                const controller: any =
-                    await container.get<ProjectAiAgentController>(
-                        ProjectAiAgentController,
-                    );
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
                 if (typeof controller['setStatus'] === 'function') {
                     controller.setStatus(undefined);
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'updateProjectAgent',
+                    methodName: 'updateAgent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_deleteAgent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.delete(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.deleteAgent,
+        ),
+
+        async function AiAgentController_deleteAgent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_deleteAgent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteAgent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_listAgentThreads: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        allUsers: { in: 'query', name: 'allUsers', dataType: 'boolean' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.listAgentThreads,
+        ),
+
+        async function AiAgentController_listAgentThreads(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_listAgentThreads,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listAgentThreads',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getAgentThread: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getAgentThread,
+        ),
+
+        async function AiAgentController_getAgentThread(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getAgentThread,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAgentThread',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_createAgentThread: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiAiAgentThreadCreateRequest',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.createAgentThread,
+        ),
+
+        async function AiAgentController_createAgentThread(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_createAgentThread,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createAgentThread',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_createAgentThreadMessage: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiAiAgentThreadMessageCreateRequest',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/messages',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.createAgentThreadMessage,
+        ),
+
+        async function AiAgentController_createAgentThreadMessage(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_createAgentThreadMessage,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createAgentThreadMessage',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_streamAgentThreadResponse: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/stream',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.streamAgentThreadResponse,
+        ),
+
+        async function AiAgentController_streamAgentThreadResponse(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_streamAgentThreadResponse,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'streamAgentThreadResponse',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getAgentThreadMessageViz: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        messageUuid: {
+            in: 'path',
+            name: 'messageUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/message/:messageUuid/viz',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getAgentThreadMessageViz,
+        ),
+
+        async function AiAgentController_getAgentThreadMessageViz(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getAgentThreadMessageViz,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAgentThreadMessageViz',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getAgentThreadMessageVizQuery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        messageUuid: {
+            in: 'path',
+            name: 'messageUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/message/:messageUuid/viz-query',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getAgentThreadMessageVizQuery,
+        ),
+
+        async function AiAgentController_getAgentThreadMessageVizQuery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getAgentThreadMessageVizQuery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAgentThreadMessageVizQuery',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_updateAgentThreadMessageSavedQuery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        messageUuid: {
+            in: 'path',
+            name: 'messageUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                savedQueryUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/messages/:messageUuid/savedQuery',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.updateAgentThreadMessageSavedQuery,
+        ),
+
+        async function AiAgentController_updateAgentThreadMessageSavedQuery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_updateAgentThreadMessageSavedQuery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateAgentThreadMessageSavedQuery',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_updatePromptFeedback: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        messageUuid: {
+            in: 'path',
+            name: 'messageUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                humanScore: { dataType: 'double', required: true },
+            },
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/messages/:messageUuid/feedback',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.updatePromptFeedback,
+        ),
+
+        async function AiAgentController_updatePromptFeedback(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_updatePromptFeedback,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updatePromptFeedback',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5154,6 +5154,211 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "AiAgentUserPreferences": {
+                "properties": {
+                    "defaultAgentUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["defaultAgentUuid"],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentUserPreferences_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentUserPreferences"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiGetUserAgentPreferencesResponse": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/ApiSuccess_AiAgentUserPreferences_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ApiSuccessEmpty"
+                    }
+                ]
+            },
+            "ApiUpdateUserAgentPreferencesResponse": {
+                "$ref": "#/components/schemas/ApiSuccessEmpty"
+            },
+            "ApiUpdateUserAgentPreferences": {
+                "$ref": "#/components/schemas/AiAgentUserPreferences"
+            },
+            "AiConversation": {
+                "properties": {
+                    "user": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name", "uuid"],
+                        "type": "object"
+                    },
+                    "firstMessage": {
+                        "type": "string"
+                    },
+                    "createdFrom": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        ]
+                    },
+                    "threadUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "user",
+                    "firstMessage",
+                    "createdFrom",
+                    "createdAt",
+                    "threadUuid"
+                ],
+                "type": "object"
+            },
+            "ApiAiConversations": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiConversation"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "AiConversationMessageIncomplete": {
+                "properties": {
+                    "user": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name", "uuid"],
+                        "type": "object"
+                    },
+                    "createdAt": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        ]
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["user", "createdAt", "message", "promptUuid"],
+                "type": "object"
+            },
+            "AiConversationComplete": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AiConversationMessageIncomplete"
+                    },
+                    {
+                        "properties": {
+                            "humanScore": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "metricQuery": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            "filtersOutput": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            "vizConfigOutput": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            "respondedAt": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    }
+                                ]
+                            },
+                            "response": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["respondedAt", "response"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiConversationMessage": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/AiConversationMessageIncomplete"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AiConversationComplete"
+                    }
+                ]
+            },
+            "ApiAiConversationMessages": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiConversationMessage"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess_": {
                 "properties": {
                     "name": {
@@ -5963,211 +6168,6 @@
                 },
                 "required": ["results", "status"],
                 "type": "object"
-            },
-            "AiConversation": {
-                "properties": {
-                    "user": {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["name", "uuid"],
-                        "type": "object"
-                    },
-                    "firstMessage": {
-                        "type": "string"
-                    },
-                    "createdFrom": {
-                        "type": "string"
-                    },
-                    "createdAt": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            }
-                        ]
-                    },
-                    "threadUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "user",
-                    "firstMessage",
-                    "createdFrom",
-                    "createdAt",
-                    "threadUuid"
-                ],
-                "type": "object"
-            },
-            "ApiAiConversations": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/AiConversation"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "AiConversationMessageIncomplete": {
-                "properties": {
-                    "user": {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["name", "uuid"],
-                        "type": "object"
-                    },
-                    "createdAt": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            }
-                        ]
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "promptUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["user", "createdAt", "message", "promptUuid"],
-                "type": "object"
-            },
-            "AiConversationComplete": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/AiConversationMessageIncomplete"
-                    },
-                    {
-                        "properties": {
-                            "humanScore": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "metricQuery": {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            "filtersOutput": {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            "vizConfigOutput": {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            "respondedAt": {
-                                "anyOf": [
-                                    {
-                                        "type": "string"
-                                    },
-                                    {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    }
-                                ]
-                            },
-                            "response": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["respondedAt", "response"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "AiConversationMessage": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/AiConversationMessageIncomplete"
-                    },
-                    {
-                        "$ref": "#/components/schemas/AiConversationComplete"
-                    }
-                ]
-            },
-            "ApiAiConversationMessages": {
-                "properties": {
-                    "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/AiConversationMessage"
-                        },
-                        "type": "array"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "AiAgentUserPreferences": {
-                "properties": {
-                    "defaultAgentUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["defaultAgentUuid"],
-                "type": "object"
-            },
-            "ApiSuccess_AiAgentUserPreferences_": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/AiAgentUserPreferences"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiGetUserAgentPreferencesResponse": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/ApiSuccess_AiAgentUserPreferences_"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ApiSuccessEmpty"
-                    }
-                ]
-            },
-            "ApiUpdateUserAgentPreferencesResponse": {
-                "$ref": "#/components/schemas/ApiSuccessEmpty"
-            },
-            "ApiUpdateUserAgentPreferences": {
-                "$ref": "#/components/schemas/AiAgentUserPreferences"
             },
             "ApiJobScheduledResponse": {
                 "properties": {
@@ -18200,7 +18200,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1880.0",
+        "version": "0.1885.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -72,11 +72,18 @@ const AssistantBubbleContent: FC<{
 
     const handleRetry = useCallback(() => {
         void streamMessage({
+            projectUuid,
             agentUuid,
             threadUuid: message.threadUuid,
             messageUuid: message.uuid,
         });
-    }, [streamMessage, agentUuid, message.threadUuid, message.uuid]);
+    }, [
+        streamMessage,
+        agentUuid,
+        message.threadUuid,
+        message.uuid,
+        projectUuid,
+    ]);
 
     return (
         <>
@@ -295,6 +302,7 @@ export const AssistantBubble: FC<{
     const isQueryError = queryExecutionHandle.isError || queryResults.error;
 
     const updateFeedbackMutation = useUpdatePromptFeedbackMutation(
+        projectUuid,
         agentUuid,
         message.threadUuid,
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -50,6 +50,7 @@ export const AiChartQuickOptions = ({
         pivotDimensions,
     } = useVisualizationContext();
     const { mutate: savePromptQuery } = useSavePromptQuery(
+        projectUuid,
         agentUuid!,
         message.threadUuid,
         message.uuid,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ScrollToBottom.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ScrollToBottom.tsx
@@ -53,12 +53,12 @@ const ThreadScrollToBottom = ({
 }: {
     scrollAreaRef: React.RefObject<HTMLDivElement | null>;
 }) => {
-    const { agentUuid, threadUuid } = useParams();
-    if (!agentUuid || !threadUuid)
-        throw new Error('Agent and thread UUIDs are required');
+    const { agentUuid, threadUuid, projectUuid } = useParams();
+    if (!agentUuid || !threadUuid || !projectUuid)
+        throw new Error('Agent, thread and project UUIDs are required');
 
     const streamingState = useAiAgentThreadStreamQuery(threadUuid);
-    const thread = useAiAgentThread(agentUuid, threadUuid);
+    const thread = useAiAgentThread(projectUuid, agentUuid, threadUuid);
 
     const { messagesEndRef, scrollToBottom } = useAutoScroll(scrollAreaRef);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
@@ -1,5 +1,6 @@
 import { Badge, Loader, Paper, Stack, Table, Text } from '@mantine-8/core';
 import { useState, type FC } from 'react';
+import { useParams } from 'react-router';
 import { useAiAgentThreads } from '../hooks/useOrganizationAiAgents';
 import { ThreadDetailsModal } from './ThreadDetailsModal';
 
@@ -14,7 +15,12 @@ export const ConversationsList: FC<ConversationsListProps> = ({
     agentName,
     allUsers = false,
 }) => {
-    const { data: threads, isLoading } = useAiAgentThreads(agentUuid, allUsers);
+    const { projectUuid } = useParams();
+    const { data: threads, isLoading } = useAiAgentThreads(
+        projectUuid!,
+        agentUuid,
+        allUsers,
+    );
     const [selectedThreadUuid, setSelectedThreadUuid] = useState<string | null>(
         null,
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadDetailsModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadDetailsModal.tsx
@@ -33,7 +33,11 @@ export const ThreadDetailsModal: FC<ThreadDetailsModalProps> = ({
 }) => {
     const { user } = useApp();
     const { projectUuid } = useParams();
-    const { data: thread, isLoading } = useAiAgentThread(agentUuid, threadUuid);
+    const { data: thread, isLoading } = useAiAgentThread(
+        projectUuid!,
+        agentUuid,
+        threadUuid,
+    );
 
     // Format date function since date-fns is not available
     const formatDate = (dateString: string) => {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
@@ -34,23 +34,29 @@ const AI_AGENTS_KEY = 'aiAgents';
 // API calls
 
 const getAgent = async (
+    projectUuid: string,
     agentUuid: string,
-): Promise<ApiAiAgentResponse['results']> =>
-    lightdashApi<ApiAiAgentResponse['results']>({
+): Promise<ApiAiAgentResponse['results']> => {
+    return lightdashApi<ApiAiAgentResponse['results']>({
         version: 'v1',
-        url: `/aiAgents/${agentUuid}`,
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}`,
         method: 'GET',
         body: undefined,
     });
+};
 
-const listAgentThreads = async (agentUuid: string, allUsers?: boolean) => {
+const listAgentThreads = async (
+    projectUuid: string,
+    agentUuid: string,
+    allUsers?: boolean,
+) => {
     const searchParams = new URLSearchParams();
     if (allUsers) {
         searchParams.set('allUsers', 'true');
     }
 
     const queryString = searchParams.toString();
-    const url = `/aiAgents/${agentUuid}/threads${
+    const url = `/projects/${projectUuid}/aiAgents/${agentUuid}/threads${
         queryString ? `?${queryString}` : ''
     }`;
 
@@ -61,36 +67,40 @@ const listAgentThreads = async (agentUuid: string, allUsers?: boolean) => {
     });
 };
 
-const getAgentThread = async (agentUuid: string, threadUuid: string) =>
+const getAgentThread = async (
+    projectUuid: string,
+    agentUuid: string,
+    threadUuid: string,
+) =>
     lightdashApi<ApiAiAgentThreadResponse['results']>({
-        url: `/aiAgents/${agentUuid}/threads/${threadUuid}`,
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}`,
         method: 'GET',
         body: undefined,
     });
 
 const getAgentThreadMessageVizQuery = async (args: {
+    projectUuid: string;
     agentUuid: string;
     threadUuid: string;
     messageUuid: string;
 }) =>
     lightdashApi<ApiAiAgentThreadMessageVizQuery>({
-        url: `/aiAgents/${args.agentUuid}/threads/${args.threadUuid}/message/${args.messageUuid}/viz-query`,
+        url: `/projects/${args.projectUuid}/aiAgents/${args.agentUuid}/threads/${args.threadUuid}/message/${args.messageUuid}/viz-query`,
         method: 'GET',
         body: undefined,
     });
 
-export const useAiAgent = (agentUuid: string | undefined) => {
+export const useAiAgent = (projectUuid: string, agentUuid: string) => {
     const { showToastApiError } = useToaster();
-    const { data: activeProjectUuid } = useActiveProject();
     const navigate = useNavigate();
 
     return useQuery<ApiAiAgentResponse['results'], ApiError>({
-        queryKey: [AI_AGENTS_KEY, agentUuid],
-        queryFn: () => getAgent(agentUuid!),
+        queryKey: [AI_AGENTS_KEY, projectUuid, agentUuid],
+        queryFn: () => getAgent(projectUuid, agentUuid!),
         onError: (error) => {
             if (error.error?.statusCode === 403) {
                 void navigate(
-                    `/projects/${activeProjectUuid}/ai-agents/not-authorized`,
+                    `/projects/${projectUuid}/ai-agents/not-authorized`,
                 );
             } else {
                 showToastApiError({
@@ -103,22 +113,21 @@ export const useAiAgent = (agentUuid: string | undefined) => {
     });
 };
 
-const deleteAgent = async (agentUuid: string) =>
+const deleteAgent = async (projectUuid: string, agentUuid: string) =>
     lightdashApi<ApiSuccessEmpty>({
         version: 'v1',
-        url: `/aiAgents/${agentUuid}`,
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}`,
         method: 'DELETE',
         body: undefined,
     });
 
-export const useDeleteAiAgentMutation = () => {
-    const { data: activeProjectUuid } = useActiveProject();
+export const useDeleteAiAgentMutation = (projectUuid: string) => {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const { showToastApiError, showToastSuccess } = useToaster();
 
     return useMutation<ApiSuccessEmpty, ApiError, string>({
-        mutationFn: (agentUuid) => deleteAgent(agentUuid),
+        mutationFn: (agentUuid) => deleteAgent(projectUuid, agentUuid),
         onSuccess: async () => {
             showToastSuccess({
                 title: 'AI agent deleted successfully',
@@ -126,11 +135,11 @@ export const useDeleteAiAgentMutation = () => {
             await Promise.all(
                 [
                     // Invalidates Project queries
-                    [PROJECT_AI_AGENTS_KEY, activeProjectUuid],
-                    // Invalidates Organization queries
-                    [AI_AGENTS_KEY],
+                    [PROJECT_AI_AGENTS_KEY, projectUuid],
+                    // Invalidates AI Agent queries for this project
+                    [AI_AGENTS_KEY, projectUuid],
                     // Invalidates User Preferences queries
-                    [USER_AGENT_PREFERENCES, activeProjectUuid],
+                    [USER_AGENT_PREFERENCES, projectUuid],
                 ].map((queryKey) =>
                     queryClient.invalidateQueries({
                         queryKey,
@@ -141,10 +150,10 @@ export const useDeleteAiAgentMutation = () => {
             // Not sure why this is needed, the invalidation is performed as a new request is triggered,
             // but the hook is still returning stale data
             await queryClient.refetchQueries({
-                queryKey: [USER_AGENT_PREFERENCES, activeProjectUuid],
+                queryKey: [USER_AGENT_PREFERENCES, projectUuid],
                 exact: true,
             });
-            void navigate(`/projects/${activeProjectUuid}/ai-agents`);
+            void navigate(`/projects/${projectUuid}/ai-agents`);
         },
         onError: ({ error }) => {
             showToastApiError({
@@ -156,25 +165,26 @@ export const useDeleteAiAgentMutation = () => {
 };
 
 export const useAiAgentThreads = (
-    agentUuid: string | undefined,
+    projectUuid: string,
+    agentUuid: string,
     allUsers?: boolean,
 ) => {
-    const { data: activeProjectUuid } = useActiveProject();
     const navigate = useNavigate();
     const { showToastApiError } = useToaster();
 
     return useQuery<ApiAiAgentThreadSummaryListResponse['results'], ApiError>({
         queryKey: [
             AI_AGENTS_KEY,
+            projectUuid,
             agentUuid,
             'threads',
             allUsers ? 'all' : 'user',
         ],
-        queryFn: () => listAgentThreads(agentUuid!, allUsers),
+        queryFn: () => listAgentThreads(projectUuid, agentUuid, allUsers),
         onError: (error) => {
             if (error.error?.statusCode === 403) {
                 void navigate(
-                    `/projects/${activeProjectUuid}/ai-agents/not-authorized`,
+                    `/projects/${projectUuid}/ai-agents/not-authorized`,
                 );
             }
             // Don't show error toast for permission errors - let the UI handle it gracefully
@@ -190,20 +200,28 @@ export const useAiAgentThreads = (
 };
 
 export const useAiAgentThread = (
+    projectUuid: string,
     agentUuid: string | undefined,
     threadUuid: string | null | undefined,
 ) => {
     const { showToastApiError } = useToaster();
-    const { data: activeProjectUuid } = useActiveProject();
     const navigate = useNavigate();
 
     return useQuery<ApiAiAgentThreadResponse['results'], ApiError>({
-        queryKey: [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
-        queryFn: () => getAgentThread(agentUuid!, threadUuid!),
+        queryKey: [
+            AI_AGENTS_KEY,
+            projectUuid,
+            agentUuid,
+            'threads',
+            threadUuid,
+        ],
+        queryFn: () => {
+            return getAgentThread(projectUuid, agentUuid!, threadUuid!);
+        },
         onError: (error) => {
             if (error.error?.statusCode === 403) {
                 void navigate(
-                    `/projects/${activeProjectUuid}/ai-agents/not-authorized`,
+                    `/projects/${projectUuid}/ai-agents/not-authorized`,
                 );
             } else {
                 showToastApiError({
@@ -256,18 +274,19 @@ const createOptimisticMessages = (
 };
 
 const createAgentThread = async (
+    projectUuid: string,
     agentUuid: string | undefined,
     data: ApiAiAgentThreadCreateRequest,
 ) =>
     lightdashApi<ApiAiAgentThreadCreateResponse['results']>({
-        url: `/aiAgents/${agentUuid}/threads`,
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads`,
         method: 'POST',
         body: JSON.stringify(data),
     });
 
 export const useCreateAgentThreadMutation = (
     agentUuid: string | undefined,
-    projectUuid: string | undefined,
+    projectUuid: string,
 ) => {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
@@ -282,15 +301,17 @@ export const useCreateAgentThreadMutation = (
         ApiAiAgentThreadCreateRequest
     >({
         mutationFn: (data) =>
-            agentUuid ? createAgentThread(agentUuid, data) : Promise.reject(),
+            agentUuid
+                ? createAgentThread(projectUuid, agentUuid, data)
+                : Promise.reject(),
         onSuccess: async (thread) => {
             // Invalidate both user-specific and all-users thread queries
             await queryClient.invalidateQueries({
-                queryKey: [AI_AGENTS_KEY, agentUuid, 'threads'],
+                queryKey: [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads'],
             });
 
             queryClient.setQueryData(
-                [AI_AGENTS_KEY, agentUuid, 'threads', thread.uuid],
+                [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', thread.uuid],
                 () => {
                     if (!agentUuid) {
                         return undefined;
@@ -318,6 +339,7 @@ export const useCreateAgentThreadMutation = (
             );
 
             void streamMessage({
+                projectUuid,
                 agentUuid: thread.agentUuid,
                 threadUuid: thread.uuid,
                 messageUuid: thread.firstMessage.uuid,
@@ -325,6 +347,7 @@ export const useCreateAgentThreadMutation = (
                     queryClient.invalidateQueries({
                         queryKey: [
                             AI_AGENTS_KEY,
+                            projectUuid,
                             agentUuid,
                             'threads',
                             thread.uuid,
@@ -355,18 +378,19 @@ export const useCreateAgentThreadMutation = (
 };
 
 const createAgentThreadMessage = async (
+    projectUuid: string,
     agentUuid: string,
     threadUuid: string,
     data: ApiAiAgentThreadMessageCreateRequest,
 ) =>
     lightdashApi<ApiAiAgentThreadMessageCreateResponse['results']>({
-        url: `/aiAgents/${agentUuid}/threads/${threadUuid}/messages`,
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/messages`,
         method: 'POST',
         body: JSON.stringify(data),
     });
 
 export const useCreateAgentThreadMessageMutation = (
-    projectUuid: string | undefined,
+    projectUuid: string,
     agentUuid: string | undefined,
     threadUuid: string | undefined,
 ) => {
@@ -385,14 +409,19 @@ export const useCreateAgentThreadMessageMutation = (
     >({
         mutationFn: (data) =>
             agentUuid && threadUuid
-                ? createAgentThreadMessage(agentUuid, threadUuid, data)
+                ? createAgentThreadMessage(
+                      projectUuid,
+                      agentUuid,
+                      threadUuid,
+                      data,
+                  )
                 : Promise.reject(),
         onMutate: (data) => {
             // Temporary uuid for optimistic messages
             const messageUuid = nanoid();
 
             queryClient.setQueryData(
-                [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
+                [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', threadUuid],
                 (
                     currentData:
                         | ApiAiAgentThreadResponse['results']
@@ -422,7 +451,7 @@ export const useCreateAgentThreadMessageMutation = (
         },
         onSuccess: (data, _vars, context) => {
             queryClient.setQueryData(
-                [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
+                [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', threadUuid],
                 (
                     currentData:
                         | ApiAiAgentThreadResponse['results']
@@ -447,12 +476,14 @@ export const useCreateAgentThreadMessageMutation = (
             );
 
             void streamMessage({
+                projectUuid,
                 agentUuid: agentUuid!,
                 threadUuid: threadUuid!,
                 messageUuid: data.uuid,
                 onFinish: () =>
                     queryClient.invalidateQueries([
                         AI_AGENTS_KEY,
+                        projectUuid,
                         agentUuid,
                         'threads',
                         threadUuid,
@@ -476,8 +507,7 @@ export const useCreateAgentThreadMessageMutation = (
 
 export const useAiAgentThreadMessageVizQuery = (
     {
-        // request should be scoped to a project
-        projectUuid: _projectUuid,
+        projectUuid,
         agentUuid,
         threadUuid,
         messageUuid,
@@ -501,7 +531,8 @@ export const useAiAgentThreadMessageVizQuery = (
     return useQuery<ApiAiAgentThreadMessageVizQuery, ApiError>({
         queryKey: [
             AI_AGENTS_KEY,
-            'viz-query',
+            'viz-query', // this is on top to avoid invalidating an expensive viz-query
+            projectUuid,
             agentUuid,
             'threads',
             threadUuid,
@@ -511,6 +542,7 @@ export const useAiAgentThreadMessageVizQuery = (
         ...useQueryOptions,
         queryFn: () => {
             return getAgentThreadMessageVizQuery({
+                projectUuid: projectUuid,
                 agentUuid,
                 threadUuid,
                 messageUuid,
@@ -533,21 +565,27 @@ export const useAiAgentThreadMessageVizQuery = (
     });
 };
 
-const updatePromptFeedback = async (messageUuid: string, humanScore: number) =>
+const updatePromptFeedback = async (
+    projectUuid: string,
+    agentUuid: string,
+    threadUuid: string,
+    messageUuid: string,
+    humanScore: number,
+) =>
     lightdashApi<ApiSuccessEmpty>({
-        url: `/aiAgents/messages/${messageUuid}/feedback`,
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/messages/${messageUuid}/feedback`,
         method: 'PATCH',
         body: JSON.stringify({ humanScore }),
     });
 
 export const useUpdatePromptFeedbackMutation = (
-    agentUuid: string | undefined,
+    projectUuid: string,
+    agentUuid: string,
     threadUuid: string,
 ) => {
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
     const navigate = useNavigate();
-    const { data: activeProjectUuid } = useActiveProject();
 
     return useMutation<
         ApiSuccessEmpty,
@@ -555,10 +593,16 @@ export const useUpdatePromptFeedbackMutation = (
         { messageUuid: string; humanScore: number }
     >({
         mutationFn: ({ messageUuid, humanScore }) =>
-            updatePromptFeedback(messageUuid, humanScore),
+            updatePromptFeedback(
+                projectUuid,
+                agentUuid,
+                threadUuid,
+                messageUuid,
+                humanScore,
+            ),
         onMutate: ({ messageUuid, humanScore }) => {
             queryClient.setQueryData(
-                [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
+                [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', threadUuid],
                 (
                     currentData:
                         | ApiAiAgentThreadResponse['results']
@@ -583,7 +627,7 @@ export const useUpdatePromptFeedbackMutation = (
         onError: ({ error }) => {
             if (error?.statusCode === 403) {
                 void navigate(
-                    `/projects/${activeProjectUuid}/ai-agents/not-authorized`,
+                    `/projects/${projectUuid}/ai-agents/not-authorized`,
                 );
             } else {
                 showToastApiError({
@@ -596,18 +640,20 @@ export const useUpdatePromptFeedbackMutation = (
 };
 
 const savePromptQuery = async ({
+    projectUuid,
     agentUuid,
     threadUuid,
     messageUuid,
     savedQueryUuid,
 }: {
+    projectUuid: string;
     agentUuid: string;
     threadUuid: string;
     messageUuid: string;
     savedQueryUuid: string | null;
 }) =>
     lightdashApi<ApiSuccessEmpty>({
-        url: `/aiAgents/${agentUuid}/threads/${threadUuid}/messages/${messageUuid}/savedQuery`,
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/messages/${messageUuid}/savedQuery`,
         method: `PATCH`,
         body: JSON.stringify({
             savedQueryUuid,
@@ -615,6 +661,7 @@ const savePromptQuery = async ({
     });
 
 export const useSavePromptQuery = (
+    projectUuid: string,
     agentUuid: string,
     threadUuid: string,
     messageUuid: string,
@@ -622,29 +669,36 @@ export const useSavePromptQuery = (
     const queryClient = useQueryClient();
     const navigate = useNavigate();
     const { showToastApiError } = useToaster();
-    const { data: activeProjectUuid } = useActiveProject();
 
     return useMutation<
         ApiSuccessEmpty,
         ApiError,
         { savedQueryUuid: string | null }
     >({
-        mutationFn: ({ savedQueryUuid }) =>
-            savePromptQuery({
+        mutationFn: ({ savedQueryUuid }) => {
+            return savePromptQuery({
+                projectUuid,
                 agentUuid,
                 threadUuid,
                 messageUuid,
                 savedQueryUuid,
-            }),
+            });
+        },
         onSuccess: () => {
             void queryClient.invalidateQueries({
-                queryKey: [AI_AGENTS_KEY, agentUuid, 'threads', threadUuid],
+                queryKey: [
+                    AI_AGENTS_KEY,
+                    projectUuid,
+                    agentUuid,
+                    'threads',
+                    threadUuid,
+                ],
             });
         },
         onError: ({ error }) => {
             if (error?.statusCode === 403) {
                 void navigate(
-                    `/projects/${activeProjectUuid}/ai-agents/not-authorized`,
+                    `/projects/${projectUuid}/ai-agents/not-authorized`,
                 );
             } else {
                 showToastApiError({

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -15,6 +15,7 @@ import {
 } from './AiAgentThreadStreamStore';
 
 export interface AiAgentThreadStreamOptions {
+    projectUuid: string;
     agentUuid: string;
     threadUuid: string;
     messageUuid: string;
@@ -23,12 +24,13 @@ export interface AiAgentThreadStreamOptions {
 }
 
 const streamAgentThreadResponse = async (
+    projectUuid: string,
     agentUuid: string,
     threadUuid: string,
     { signal }: { signal: AbortSignal },
 ) =>
     lightdashApiStream({
-        url: `/aiAgents/${agentUuid}/threads/${threadUuid}/stream`,
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/stream`,
         method: 'POST',
         body: JSON.stringify({ threadUuid }),
         signal,
@@ -41,6 +43,7 @@ export function useAiAgentThreadStreamMutation() {
 
     const streamMessage = useCallback(
         async ({
+            projectUuid,
             agentUuid,
             threadUuid,
             messageUuid,
@@ -54,6 +57,7 @@ export function useAiAgentThreadStreamMutation() {
                 dispatch(startStreaming({ threadUuid, messageUuid }));
 
                 const response = await streamAgentThreadResponse(
+                    projectUuid,
                     agentUuid,
                     threadUuid,
                     {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -77,7 +77,7 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
 );
 const AgentPage = () => {
     const { agentUuid, threadUuid, projectUuid } = useParams();
-    const { data: threads } = useAiAgentThreads(agentUuid);
+    const { data: threads } = useAiAgentThreads(projectUuid!, agentUuid!);
     const canManageAgents = useAiAgentPermission({
         action: 'manage',
         projectUuid,
@@ -88,7 +88,10 @@ const AgentPage = () => {
         redirectOnUnauthorized: true,
     });
 
-    const { data: agent, isLoading: isLoadingAgent } = useAiAgent(agentUuid);
+    const { data: agent, isLoading: isLoadingAgent } = useAiAgent(
+        projectUuid!,
+        agentUuid!,
+    );
 
     const [showMaxItems, setShowMaxItems] = useState(INITIAL_MAX_THREADS);
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -15,19 +15,24 @@ const AiAgentThreadPage = () => {
     const { agentUuid, threadUuid, projectUuid } = useParams();
     const { user } = useApp();
     const { data: thread, isLoading: isLoadingThread } = useAiAgentThread(
+        projectUuid!,
         agentUuid,
         threadUuid,
     );
 
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
 
-    const agentQuery = useAiAgent(agentUuid);
+    const agentQuery = useAiAgent(projectUuid!, agentUuid!);
     const { agent } = useOutletContext<AgentContext>();
 
     const {
         mutateAsync: createAgentThreadMessage,
         isLoading: isCreatingMessage,
-    } = useCreateAgentThreadMessageMutation(projectUuid, agentUuid, threadUuid);
+    } = useCreateAgentThreadMessageMutation(
+        projectUuid!,
+        agentUuid,
+        threadUuid,
+    );
     const isStreaming = useAiAgentThreadStreaming(threadUuid!);
 
     const handleSubmit = (prompt: string) => {

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -22,7 +22,7 @@ import { type AgentContext } from './AgentPage';
 const AiAgentNewThreadPage = () => {
     const { agentUuid, projectUuid } = useParams();
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
-        useCreateAgentThreadMutation(agentUuid, projectUuid);
+        useCreateAgentThreadMutation(agentUuid, projectUuid!);
     const { agent } = useOutletContext<AgentContext>();
 
     const onSubmit = (prompt: string) => {

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -118,7 +118,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
         useProjectCreateAiAgentMutation(projectUuid!);
     const { mutateAsync: updateAgent, isLoading: isUpdating } =
         useProjectUpdateAiAgentMutation(projectUuid!);
-    const { mutateAsync: deleteAgent } = useDeleteAiAgentMutation();
+    const { mutateAsync: deleteAgent } = useDeleteAiAgentMutation(projectUuid!);
 
     const actualAgentUuid = !isCreateMode && agentUuid ? agentUuid : undefined;
 

--- a/packages/frontend/src/ee/pages/AiConversations.tsx
+++ b/packages/frontend/src/ee/pages/AiConversations.tsx
@@ -32,7 +32,7 @@ import slackSvg from '../../svgs/slack.svg';
 
 const getAiAgentConversations = async (projectUuid: string) => {
     const data = await lightdashApi<AiConversation[]>({
-        url: `/aiAgents/projects/${projectUuid}/conversations`,
+        url: `/projects/${projectUuid}/aiAgents/conversations`,
         method: 'GET',
         body: null,
     });
@@ -57,7 +57,7 @@ const getAiAgentConversationMessages = async (
     aiThreadUuid: string,
 ) => {
     const data = await lightdashApi<AiConversationMessage[]>({
-        url: `/aiAgents/projects/${projectUuid}/conversations/${aiThreadUuid}/messages`,
+        url: `/projects/${projectUuid}/aiAgents/conversations/${aiThreadUuid}/messages`,
         method: 'GET',
         body: null,
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Refactored AI Agent API routes to be project-scoped by moving all endpoints under `/api/v1/projects/{projectUuid}/aiAgents`. This consolidates previously separate controllers (AiAgentController, AiAgentUserPreferencesController, ProjectAiAgentController) into a single controller with consistent URL patterns.

The changes include:

- Updated all API endpoints to include projectUuid in the path
- Consolidated user preferences endpoints under the main controller
- Moved feedback endpoints to be thread-specific
- Updated frontend hooks and components to use the new API structure
