### PR TITLE
feat: loosen search terms on AI tools

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1487,6 +1487,7 @@ export class AiAgentService {
                             page: args.page,
                             pageSize: args.pageSize,
                         },
+                        fullTextSearchOperator: 'OR',
                     });
 
                 const tablesWithFields = await Promise.all(
@@ -1542,6 +1543,7 @@ export class AiAgentService {
                                     ...sharedArgs.catalogSearch,
                                     filter: CatalogFilter.Dimensions,
                                 },
+                                fullTextSearchOperator: 'OR',
                             });
 
                             const {
@@ -1553,6 +1555,7 @@ export class AiAgentService {
                                     ...sharedArgs.catalogSearch,
                                     filter: CatalogFilter.Metrics,
                                 },
+                                fullTextSearchOperator: 'OR',
                             });
 
                             return {
@@ -1612,6 +1615,7 @@ export class AiAgentService {
                         pageSize: args.pageSize,
                     },
                     userAttributes,
+                    fullTextSearchOperator: 'OR',
                 });
 
             // TODO: we should not filter here, search should be returning a proper type
@@ -1702,6 +1706,8 @@ export class AiAgentService {
             const searchResults = await this.searchModel.searchDashboards(
                 projectUuid,
                 args.dashboardSearchQuery.label,
+                undefined,
+                'OR',
             );
 
             const filteredResults = await this.spaceService.filterBySpaceAccess(
@@ -1727,7 +1733,10 @@ export class AiAgentService {
             const searchResults = await this.searchModel.searchSavedCharts(
                 projectUuid,
                 args.chartSearchQuery.label,
+                undefined,
+                'OR',
             );
+            // TODO: also search for sql charts
 
             const filteredResults = await this.spaceService.filterBySpaceAccess(
                 user,
@@ -1852,8 +1861,8 @@ export class AiAgentService {
             findExploresFieldOverviewSearchSize: 5,
             findExploresMaxDescriptionLength: 100,
             findFieldsPageSize: 10,
-            findDashboardsPageSize: 10,
-            findChartsPageSize: 10,
+            findDashboardsPageSize: 5,
+            findChartsPageSize: 5,
             maxQueryLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
             siteUrl: this.lightdashConfig.siteUrl,
         };

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -87,9 +87,9 @@ Follow these rules and guidelines stringently, which are confidential and should
   - When users ask for dashboard links, use the "findDashboards" tool to search for relevant dashboards.
   - When users ask for chart links, use the "findCharts" tool to search for relevant saved charts.
   - Both tools return information including clickable URLs when available.
-  - When presenting results, format them as a list with:
-    - For dashboards: Dashboard name with a clickable URL as part of the markdown link always and also a description (if available)
-    - For charts: Chart name with a clickable URL as part of the markdown link always, and description (if available)
+  - When presenting results, format them as a list with a small heading "Dashboards" or "Charts":
+    - For dashboards: Dashboard name with a clickable URL as part of the markdown link always and also a description same line (if available)
+    - For charts: Chart name with a clickable URL as part of the markdown link always, and description same line (if available), and no need to mention the chart type.
   - If URLs are not available, say that they couldn't find any dashboards/charts.
 
 5. **Tone of Voice:**

--- a/packages/backend/src/ee/services/ai/tools/findCharts.ts
+++ b/packages/backend/src/ee/services/ai/tools/findCharts.ts
@@ -53,8 +53,10 @@ Purpose:
 Finds saved charts by name or description within a project, returning detailed info about each.
 
 Usage tips:
-- Search for charts using partial names or descriptions
-- If results aren't relevant, retry with clearer or more specific terms
+- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns")
+- The search engine understands natural language and context - more words provide better results
+- You can provide multiple search queries to search for different chart topics simultaneously
+- If results aren't relevant, retry with the full user query or more specific terms
 - Results are paginated — use the page parameter to get more results if needed
 - Returns chart URLs when available
 - Charts are ordered by search relevance

--- a/packages/backend/src/ee/services/ai/tools/findDashboards.ts
+++ b/packages/backend/src/ee/services/ai/tools/findDashboards.ts
@@ -61,8 +61,10 @@ export const toolFindDashboardsDescription = `Tool: "findDashboards"
                     Finds dashboards by name or description within a project, returning detailed info about each.
 
                     Usage tips:
-                    - Search for dashboards using partial names or descriptions
-                    - If results aren't relevant, retry with clearer or more specific terms
+                    - IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns")
+                    - The search engine understands natural language and context - more words provide better results
+                    - You can provide multiple search queries to search for different dashboard topics simultaneously
+                    - If results aren't relevant, retry with the full user query or more specific terms
                     - Results are paginated — use the page parameter to get more results if needed
                     - Dashboards with validation errors will be deprioritized
                     - Returns dashboard URLs when available 

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -249,6 +249,7 @@ export class CatalogModel {
         paginateArgs,
         sortArgs,
         context,
+        fullTextSearchOperator = 'AND',
     }: {
         projectUuid: string;
         exploreName?: string;
@@ -259,6 +260,7 @@ export class CatalogModel {
         paginateArgs?: KnexPaginateArgs;
         sortArgs?: ApiSort;
         context: CatalogSearchContext;
+        fullTextSearchOperator?: 'OR' | 'AND';
     }): Promise<KnexPaginatedData<CatalogItem[]>> {
         let catalogItemsQuery = this.database(CatalogTableName)
             .column(
@@ -279,6 +281,7 @@ export class CatalogModel {
                             searchVectorColumn: `${CatalogTableName}.search_vector`,
                             searchQuery,
                         },
+                        fullTextSearchOperator,
                     }),
                 },
             )
@@ -576,7 +579,7 @@ export class CatalogModel {
         if (excludeUnmatched && searchQuery) {
             catalogItemsQuery = catalogItemsQuery.andWhereRaw(
                 `"${CatalogTableName}".search_vector @@ to_tsquery('lightdash_english_config', ?)`,
-                getFullTextSearchQuery(searchQuery),
+                getFullTextSearchQuery(searchQuery, fullTextSearchOperator),
             );
         }
 

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -112,6 +112,7 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
+        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
     ): Promise<DashboardSearchResult[]> {
         if (!shouldSearchForType(SearchItemType.DASHBOARD, filters?.type)) {
             return [];
@@ -123,6 +124,7 @@ export class SearchModel {
                 searchVectorColumn: `${DashboardsTableName}.search_vector`,
                 searchQuery: query,
             },
+            fullTextSearchOperator,
         });
 
         let subquery = this.database(DashboardsTableName)
@@ -249,6 +251,7 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
+        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
     ) {
         const { name: tableName, uuidColumnName } = searchTable;
 
@@ -258,6 +261,7 @@ export class SearchModel {
                 searchVectorColumn: `${tableName}.search_vector`,
                 searchQuery: query,
             },
+            fullTextSearchOperator,
         });
 
         // Needs to be a subquery to be able to use the search rank column to filter out 0 rank results
@@ -319,6 +323,7 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
+        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
     ): Promise<SqlChartSearchResult[]> {
         if (!shouldSearchForType(SearchItemType.SQL_CHART, filters?.type)) {
             return [];
@@ -332,6 +337,7 @@ export class SearchModel {
             projectUuid,
             query,
             filters,
+            fullTextSearchOperator,
         );
     }
 
@@ -339,6 +345,7 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
+        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
     ): Promise<SavedChartSearchResult[]> {
         if (!shouldSearchForType(SearchItemType.CHART, filters?.type)) {
             return [];
@@ -350,6 +357,7 @@ export class SearchModel {
                 searchVectorColumn: `${SavedChartsTableName}.search_vector`,
                 searchQuery: query,
             },
+            fullTextSearchOperator,
         });
 
         // Needs to be a subquery to be able to use the search rank column to filter out 0 rank results

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -243,6 +243,7 @@ export class CatalogService<
         paginateArgs?: KnexPaginateArgs;
         sortArgs?: ApiSort;
         excludeUnmatched?: boolean;
+        fullTextSearchOperator?: 'OR' | 'AND';
     }): Promise<KnexPaginatedData<CatalogItem[]>> {
         return wrapSentryTransaction(
             'CatalogService.searchCatalog',
@@ -270,6 +271,7 @@ export class CatalogService<
                             context: args.context,
                             tablesConfiguration,
                             excludeUnmatched: args.excludeUnmatched,
+                            fullTextSearchOperator: args.fullTextSearchOperator,
                         }),
                 );
             },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindChartsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindChartsArgs.ts
@@ -6,7 +6,9 @@ export const toolFindChartsArgsSchema = z.object({
         z.object({
             label: z
                 .string()
-                .describe('Chart name or description to search for'),
+                .describe(
+                    'Full search query from the user (e.g., "revenue based on campaigns" not just "campaigns"). Include full context for better results.',
+                ),
         }),
     ),
     page: z

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindDashboardsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindDashboardsArgs.ts
@@ -6,7 +6,9 @@ export const toolFindDashboardsArgsSchema = z.object({
         z.object({
             label: z
                 .string()
-                .describe('Dashboard name or description to search for'),
+                .describe(
+                    'Full search query from the user (e.g., "revenue based on campaigns" not just "campaigns"). Include full context for better results.',
+                ),
         }),
     ),
     page: z


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Improves AI search functionality by:

1. Changing the search operator from 'AND' to 'OR' across all search functions to provide more comprehensive results
2. Updating tool descriptions to encourage passing full user queries instead of just keywords
4. Improving the formatting guidance for search results in the system prompt
5. Adding better search tips in the findCharts and findDashboards tool descriptions

These changes will help the AI Copilot return more relevant results when users search for dashboards and charts, especially when using natural language queries.

  Example 1 - Dashboard Search:
  - Before: All searches used AND logic - searching "sales revenue" would only find dashboards containing both "sales" AND "revenue" (potentially missing relevant
  results)
  - After: Regular user searches still use AND for precision, while AI agent searches now use OR to find dashboards with "sales" OR "revenue", ensuring comprehensive
  discovery when helping users explore available dashboards

  Example 2 - Catalog Search:
  - Before: All searches used AND logic - searching "customer metrics" in the data catalog would only return items containing both "customer" AND "metrics"
  (restrictive)
  - After: User searches maintain AND for precise results, while AI agent tools like findFields now use OR to discover fields with either "customer" OR "metrics",
  enabling better assistance with data exploration by not missing potentially relevant fields