### PR TITLE
style: make ai content links less prominent

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
@@ -5,21 +5,13 @@
     gap: var(--mantine-spacing-xxs);
     padding: var(--mantine-spacing-two) var(--mantine-spacing-xs);
     border-radius: var(--mantine-radius-md);
+    border: 1px solid var(--mantine-color-gray-3);
     cursor: pointer;
-}
-
-.chartContentLink {
     transition: all 0.2s ease;
-    border: 1px solid var(--mantine-color-blue-3);
+    position: relative;
+    vertical-align: middle;
+    margin-right: var(--mantine-spacing-two);
     &:hover {
-        background-color: var(--mantine-color-blue-1) !important;
-    }
-}
-
-.dashboardContentLink {
-    transition: all 0.2s ease;
-    border: 1px solid var(--mantine-color-green-3);
-    &:hover {
-        background-color: var(--mantine-color-green-1) !important;
+        background-color: var(--mantine-color-gray-1) !important;
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -17,8 +17,8 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { clsx } from '@mantine/core';
 import {
+    IconArrowRight,
     IconCheck,
     IconCopy,
     IconExclamationCircle,
@@ -102,28 +102,35 @@ const AssistantBubbleContent: FC<{
                                 <Anchor
                                     {...props}
                                     target="_blank"
-                                    fz="xs"
+                                    fz="sm"
                                     fw={500}
-                                    bg="green.0"
-                                    c="green.7"
+                                    bg="gray.0"
+                                    c="gray.7"
                                     td="none"
                                     classNames={{
-                                        root: clsx(
-                                            styles.dashboardContentLink,
-                                            styles.contentLink,
-                                        ),
+                                        root: styles.contentLink,
                                     }}
                                 >
                                     <MantineIcon
                                         icon={IconLayoutDashboard}
-                                        size={12}
+                                        size="md"
                                         color="green.7"
                                         fill="green.6"
-                                        fillOpacity={0.3}
-                                        strokeWidth={1.8}
+                                        fillOpacity={0.2}
+                                        strokeWidth={1.9}
                                     />
 
-                                    {children}
+                                    {/* margin is added by md package */}
+                                    <Text fz="sm" fw={500} m={0}>
+                                        {children}
+                                    </Text>
+
+                                    <MantineIcon
+                                        icon={IconArrowRight}
+                                        color="gray.7"
+                                        size="sm"
+                                        strokeWidth={2.0}
+                                    />
                                 </Anchor>
                             );
                         } else if (contentType === 'chart-link') {
@@ -138,30 +145,37 @@ const AssistantBubbleContent: FC<{
                                 <Anchor
                                     {...props}
                                     target="_blank"
-                                    fz="xs"
+                                    fz="sm"
                                     fw={500}
-                                    bg="blue.0"
-                                    c="blue.7"
+                                    bg="gray.0"
+                                    c="gray.7"
                                     td="none"
                                     classNames={{
-                                        root: clsx(
-                                            styles.chartContentLink,
-                                            styles.contentLink,
-                                        ),
+                                        root: styles.contentLink,
                                     }}
                                 >
                                     {chartTypeKind && (
                                         <MantineIcon
                                             icon={getChartIcon(chartTypeKind)}
-                                            size="sm"
+                                            size="md"
                                             color="blue.7"
                                             fill="blue.4"
-                                            fillOpacity={0.3}
-                                            strokeWidth={1.8}
+                                            fillOpacity={0.2}
+                                            strokeWidth={1.9}
                                         />
                                     )}
 
-                                    {children}
+                                    {/* margin is added by md package */}
+                                    <Text fz="sm" fw={500} m={0}>
+                                        {children}
+                                    </Text>
+
+                                    <MantineIcon
+                                        icon={IconArrowRight}
+                                        color="gray.7"
+                                        size="sm"
+                                        strokeWidth={2.0}
+                                    />
                                 </Anchor>
                             );
                         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Quick tweaks to make the content links less prominent
Added arrow to indicate it's a link

[new-version-links.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/DJhzIQbRJqTJiKN3mUjT/d4d6a464-975e-4dd2-9446-e6b24ac13573.mov" />](https://app.graphite.dev/media/video/DJhzIQbRJqTJiKN3mUjT/d4d6a464-975e-4dd2-9446-e6b24ac13573.mov)

