### PR TITLE
feat: include sql charts in find_charts tool

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1730,17 +1730,15 @@ export class AiAgentService {
         };
 
         const findCharts: FindChartsFn = async (args) => {
-            const searchResults = await this.searchModel.searchSavedCharts(
+            const allCharts = await this.searchModel.searchAllCharts(
                 projectUuid,
                 args.chartSearchQuery.label,
-                undefined,
                 'OR',
             );
-            // TODO: also search for sql charts
 
             const filteredResults = await this.spaceService.filterBySpaceAccess(
                 user,
-                searchResults,
+                allCharts,
             );
 
             const totalResults = filteredResults.length;

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -624,7 +624,7 @@ export class McpService extends BaseService {
 
         const findCharts: FindChartsFn = (args) =>
             wrapSentryTransaction('McpService.findCharts', args, async () => {
-                const searchResults = await this.searchModel.searchSavedCharts(
+                const searchResults = await this.searchModel.searchAllCharts(
                     projectUuid,
                     args.chartSearchQuery.label,
                 );

--- a/packages/backend/src/ee/services/ai/tools/findCharts.ts
+++ b/packages/backend/src/ee/services/ai/tools/findCharts.ts
@@ -1,5 +1,7 @@
 import {
-    SavedChartSearchResult,
+    AllChartsSearchResult,
+    isSavedChartSearchResult,
+    isSqlChartSearchResult,
     toolFindChartsArgsSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -12,10 +14,20 @@ type Dependencies = {
     siteUrl?: string;
 };
 
-const getChartText = (chart: SavedChartSearchResult, siteUrl?: string) => {
-    const chartUrl = siteUrl
-        ? `${siteUrl}/projects/${chart.projectUuid}/saved/${chart.uuid}/view#chart-link#chart-type-${chart.chartType}`
-        : undefined;
+const getChartText = (chart: AllChartsSearchResult, siteUrl?: string) => {
+    const isSavedChart = isSavedChartSearchResult(chart);
+    const isSqlChart = isSqlChartSearchResult(chart);
+
+    let chartUrl: string | undefined;
+    if (isSavedChart) {
+        chartUrl = siteUrl
+            ? `${siteUrl}/projects/${chart.projectUuid}/saved/${chart.uuid}/view#chart-link#chart-type-${chart.chartType}`
+            : undefined;
+    } else if (isSqlChart) {
+        chartUrl = siteUrl
+            ? `${siteUrl}/projects/${chart.projectUuid}/sql-runner/${chart.slug}#chart-link#chart-type-${chart.chartType}`
+            : undefined;
+    }
 
     return `
     <Chart chartUuid="${chart.uuid}">

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -1,6 +1,7 @@
 import {
     AiMetricQueryWithFilters,
     AiWebAppPrompt,
+    AllChartsSearchResult,
     AnyType,
     CacheMetadata,
     CatalogField,
@@ -9,7 +10,6 @@ import {
     Explore,
     ItemsMap,
     KnexPaginateArgs,
-    SavedChartSearchResult,
     SlackPrompt,
     ToolFindChartsArgs,
     ToolFindDashboardsArgs,
@@ -67,7 +67,7 @@ export type FindChartsFn = (
         chartSearchQuery: ToolFindChartsArgs['chartSearchQueries'][number];
     },
 ) => Promise<{
-    charts: SavedChartSearchResult[];
+    charts: AllChartsSearchResult[];
     pagination: Pagination | undefined;
 }>;
 

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -34,6 +34,7 @@ export type SavedChartSearchResult = Pick<
     validationErrors: {
         validationId: ValidationErrorChartResponse['validationId'];
     }[];
+    chartSource: 'saved';
 } & RankedItem;
 
 export type SqlChartSearchResult = Pick<
@@ -43,7 +44,18 @@ export type SqlChartSearchResult = Pick<
     uuid: SqlChart['savedSqlUuid'];
     chartType: ChartKind;
     spaceUuid: SqlChart['space']['uuid'];
+    projectUuid: SqlChart['project']['projectUuid'];
+    chartSource: 'sql';
 } & RankedItem;
+
+export type AllChartsSearchResult = Pick<
+    SavedChartSearchResult,
+    'uuid' | 'name' | 'description' | 'spaceUuid' | 'projectUuid'
+> &
+    Partial<Pick<SqlChartSearchResult, 'slug'>> & {
+        chartType: ChartKind;
+        chartSource: 'saved' | 'sql';
+    } & RankedItem;
 
 export type TableSearchResult = Pick<
     Table,
@@ -101,6 +113,7 @@ export type SearchResult =
     | DashboardTabResult
     | SavedChartSearchResult
     | SqlChartSearchResult
+    | AllChartsSearchResult
     | TableErrorSearchResult
     | TableSearchResult
     | FieldSearchResult
@@ -118,6 +131,16 @@ export const isTableErrorSearchResult = (
     value: SearchResult,
 ): value is TableErrorSearchResult =>
     'explore' in value && 'validationErrors' in value;
+
+export const isSavedChartSearchResult = (
+    value: SearchResult,
+): value is SavedChartSearchResult =>
+    'chartSource' in value && value.chartSource === 'saved';
+
+export const isSqlChartSearchResult = (
+    value: SearchResult,
+): value is SqlChartSearchResult =>
+    'chartSource' in value && value.chartSource === 'sql';
 
 export type SearchResults = {
     spaces: SpaceSearchResult[];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #16246 

### Description:

Implemented a unified search function for charts that includes **both** saved charts and SQL charts. This PR:

- Added a new `searchAllCharts` method in the SearchModel that combines results from both saved charts and SQL charts
- Replaced calls to `searchSavedCharts` with `searchAllCharts` in AI agent services
- Created new types to support combined chart search results:
  - Added `AllChartsSearchResult` type
  - Added helper functions `isSavedChartSearchResult` and `isSqlChartSearchResult`
- Updated the chart URL generation in the `findCharts` tool to handle both saved and SQL charts


This change enables AI agents to find and reference both types of charts when responding to user queries ordered by one unified search rank

first chart is a sql chart and is the most relevant based on the search query

![Screenshot 2025-08-07 at 17.44.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/a0cf1f2f-50b6-490b-801e-a928b99600cd.png)

