### PR TITLE
fix: close visualization config when exiting edit mode

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -130,6 +130,23 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
         (context) => context.actions.closeVisualizationConfig,
     );
 
+    const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+    useLayoutEffect(() => {
+        if (isVisualizationConfigOpen) {
+            const target = document.getElementById(VisualizationConfigPortalId);
+            setPortalTarget(target);
+        } else {
+            setPortalTarget(null);
+        }
+    }, [isVisualizationConfigOpen]);
+
+    useLayoutEffect(() => {
+        if (!isEditMode) {
+            closeVisualizationConfig();
+        }
+    }, [isEditMode, closeVisualizationConfig]);
+
     useLayoutEffect(() => {
         if (!isOpen) {
             closeVisualizationConfig();
@@ -257,7 +274,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                                  * NOTE: not using Portal from mantine-8 because this page lacks MantineProvider from Mantine 8
                                  * TODO: use mantine-8 portal with reuseTargetNode flag to avoid rendering additional divs
                                  */}
-                                {isVisualizationConfigOpen &&
+                                {portalTarget &&
                                     createPortal(
                                         <VisualizationConfig
                                             chartType={
@@ -266,9 +283,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                                             }
                                             onClose={closeVisualizationConfig}
                                         />,
-                                        document.getElementById(
-                                            VisualizationConfigPortalId,
-                                        )!,
+                                        portalTarget,
                                     )}
 
                                 <Can


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/16287

### Description:
Improved the visualization configuration portal handling in the VisualizationCard component by:

1. Adding state management for the portal target element
2. Using a more reliable approach to render the portal only when the target element is available
3. Adding an effect to automatically close the visualization config when exiting edit mode
4. Simplifying the portal creation by directly using the stored target element

This change prevents potential issues with accessing DOM elements that might not exist and ensures proper cleanup when switching between modes.