### PR TITLE
refactor: update SDK package exports and CSS imports

### DIFF
--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -18,6 +18,8 @@ import TrackingProvider from '../src/providers/Tracking/TrackingProvider';
 const LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY =
     '__lightdash_sdk_instance_url';
 
+import '@mantine-8/core/styles.css';
+
 type Props = {
     instanceUrl: string;
     token: Promise<string> | string;

--- a/packages/frontend/sdk/package.json
+++ b/packages/frontend/sdk/package.json
@@ -9,13 +9,13 @@
         ".": {
             "types": "./dist/sdk.d.ts",
             "require": "./dist/sdk.cjs.js",
-            "import": "./dist/sdk.es.js"
+            "import": "./dist/sdk.es.js",
+            "default": "./dist/sdk.cjs.js"
         },
-        "./style.css": "./dist/style.css"
+        "./sdk.css": {
+            "default": "./dist/sdk.css"
+        }
     },
-    "main": "./dist/sdk.cjs.js",
-    "module": "./dist/sdk.es.js",
-    "types": "./dist/sdk.d.ts",
     "peerDependencies": {
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -1,5 +1,5 @@
 import { type DashboardMarkdownTile } from '@lightdash/common';
-import { Menu, Text } from '@mantine/core';
+import { Menu, Text, useMantineTheme } from '@mantine/core';
 import { IconCopy } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import React, { useCallback, useMemo, useState, type FC } from 'react';
@@ -20,6 +20,8 @@ export type Props = Pick<
 };
 
 const MarkdownTile: FC<Props> = (props) => {
+    const theme = useMantineTheme();
+
     const {
         tile: {
             properties: { title, content },
@@ -108,13 +110,15 @@ const MarkdownTile: FC<Props> = (props) => {
                     },
                 }}
             >
-                <MarkdownPreview
-                    className="markdown-tile"
-                    source={content}
-                    rehypePlugins={[
-                        [rehypeExternalLinks, { target: '_blank' }],
-                    ]}
-                />
+                <div data-color-mode={theme.colorScheme}>
+                    <MarkdownPreview
+                        className="markdown-tile"
+                        source={content}
+                        rehypePlugins={[
+                            [rehypeExternalLinks, { target: '_blank' }],
+                        ]}
+                    />
+                </div>
             </Text>
         </TileBase>
     );

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -4,9 +4,6 @@ import { scan } from 'react-scan'; // react-scan has to be imported before react
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-// Mantine 8 styles
-import '@mantine-8/core/styles.css';
-
 import App from './App';
 
 // Trigger FE tests

--- a/packages/sdk-next-test-app/package.json
+++ b/packages/sdk-next-test-app/package.json
@@ -18,6 +18,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "postcss": "^8.4.49",
         "typescript": "^5"
     }
 }

--- a/packages/sdk-next-test-app/postcss.config.json
+++ b/packages/sdk-next-test-app/postcss.config.json
@@ -1,0 +1,3 @@
+{
+    "plugins": ["postcss-preset-env"]
+}

--- a/packages/sdk-next-test-app/src/app/dashboard/yourCustomDashboardOne.tsx
+++ b/packages/sdk-next-test-app/src/app/dashboard/yourCustomDashboardOne.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import '@lightdash/sdk/sdk.css';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import { SavedChart } from '../../../../common/src';

--- a/packages/sdk-test-app/src/App.tsx
+++ b/packages/sdk-test-app/src/App.tsx
@@ -1,5 +1,5 @@
 import Lightdash from '@lightdash/sdk';
-import '@mantine/core/styles.css';
+import '@lightdash/sdk/sdk.css';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SavedChart } from '../../common/src';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1237,6 +1237,9 @@ importers:
       '@types/react-dom':
         specifier: 19.0.2
         version: 19.0.2(@types/react@19.0.2)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.3
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -8004,6 +8007,7 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
+    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -8436,11 +8440,6 @@ packages:
   browser-request@0.3.3:
     resolution: {integrity: sha512-YyNI4qJJ+piQG6MMEuo7J3Bzaqssufx04zpEKYfSrl/1Op59HWali9zMtBpXnkmqMcOuWJPZvudrm9wISmnCbg==}
     engines: {'0': node}
-
-  browserslist@4.24.3:
-    resolution: {integrity: sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.24.4:
     resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
@@ -9678,9 +9677,6 @@ packages:
 
   electron-to-chromium@1.5.140:
     resolution: {integrity: sha512-o82Rj+ONp4Ip7Cl1r7lrqx/pXhbp/lh9DpKcMNscFJdh8ebyRofnc7Sh01B4jx403RI0oqTBvlZ7OBIZLMr2+Q==}
-
-  electron-to-chromium@1.5.77:
-    resolution: {integrity: sha512-AnJSrt5JpRVgY6dgd5yccguLc5A7oMSF0Kt3fcW+Hp5WTuFbl5upeSFZbMZYy2o7jhmIhU8Ekrd82GhyXUqUUg==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -15915,12 +15911,6 @@ packages:
   unzipper@0.10.14:
     resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
 
-  update-browserslist-db@1.1.1:
-    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
@@ -18330,7 +18320,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.26.3
       '@babel/helper-validator-option': 7.25.9
-      browserslist: 4.24.3
+      browserslist: 4.24.4
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -26602,13 +26592,6 @@ snapshots:
 
   browser-request@0.3.3: {}
 
-  browserslist@4.24.3:
-    dependencies:
-      caniuse-lite: 1.0.30001690
-      electron-to-chromium: 1.5.77
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.1(browserslist@4.24.3)
-
   browserslist@4.24.4:
     dependencies:
       caniuse-lite: 1.0.30001715
@@ -27979,8 +27962,6 @@ snapshots:
   efrt@2.7.0: {}
 
   electron-to-chromium@1.5.140: {}
-
-  electron-to-chromium@1.5.77: {}
 
   emittery@0.13.1: {}
 
@@ -33096,7 +33077,7 @@ snapshots:
 
   postcss@8.4.47:
     dependencies:
-      nanoid: 3.3.8
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -35806,12 +35787,6 @@ snapshots:
       listenercount: 1.0.1
       readable-stream: 2.3.8
       setimmediate: 1.0.5
-
-  update-browserslist-db@1.1.1(browserslist@4.24.3):
-    dependencies:
-      browserslist: 4.24.3
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.1.3(browserslist@4.24.4):
     dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Updates the SDK package.json exports configuration to include a default export and properly expose CSS styles through a dedicated path. Moves Mantine 8 styles import to the main SDK index file. Updates the SDK test app to import styles from the new SDK CSS path.