### PR TITLE
feat: add migration for custom roles

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -127,8 +127,8 @@ import {
     CatalogTableName,
     CatalogTagsTable,
     CatalogTagsTableName,
-    MetricsTreeEdgesTableName,
     type MetricsTreeEdgesTable,
+    MetricsTreeEdgesTableName,
 } from '../database/entities/catalog';
 import {
     DashboardTileCommentsTable,
@@ -177,6 +177,12 @@ import {
     QueryHistoryTable,
     QueryHistoryTableName,
 } from '../database/entities/queryHistory';
+import {
+    RolesTableName,
+    RoleTable,
+    ScopedRolesTableName,
+    ScopedRoleTable,
+} from '../database/entities/roles';
 import {
     SavedSqlTable,
     SavedSqlTableName,
@@ -366,5 +372,7 @@ declare module 'knex/types/tables' {
         [OrganizationColorPaletteTableName]: OrganizationColorPaletteTable;
         [QueryHistoryTableName]: QueryHistoryTable;
         [ProjectParametersTableName]: ProjectParametersTable;
+        [RolesTableName]: RoleTable;
+        [ScopedRolesTableName]: ScopedRoleTable;
     }
 }

--- a/packages/backend/src/database/entities/roles.ts
+++ b/packages/backend/src/database/entities/roles.ts
@@ -1,0 +1,49 @@
+import { Knex } from 'knex';
+
+export const RolesTableName = 'roles';
+export const ScopedRolesTableName = 'scoped_roles';
+
+export type DbRole = {
+    role_uuid: string;
+    name: string;
+    description: string | null;
+    organization_uuid: string;
+    created_by: string | null;
+    owner_type: 'user' | 'system';
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbRoleInsert = Pick<
+    DbRole,
+    'name' | 'description' | 'organization_uuid'
+> & {
+    created_by: string; // Required on insert, but can become null later
+};
+
+export type DbRoleUpdate = Partial<
+    Pick<DbRole, 'name' | 'description' | 'updated_at'>
+>;
+
+export type RoleTable = Knex.CompositeTableType<
+    DbRole,
+    DbRoleInsert,
+    DbRoleUpdate
+>;
+
+export type DbScopedRole = {
+    role_uuid: string;
+    scope_name: string;
+    granted_at: Date;
+    granted_by: string;
+};
+
+export type DbScopedRoleInsert = Pick<
+    DbScopedRole,
+    'role_uuid' | 'scope_name' | 'granted_by'
+>;
+
+export type ScopedRoleTable = Knex.CompositeTableType<
+    DbScopedRole,
+    DbScopedRoleInsert
+>;

--- a/packages/backend/src/database/migrations/20250807212731_add_custom_roles.ts
+++ b/packages/backend/src/database/migrations/20250807212731_add_custom_roles.ts
@@ -1,0 +1,109 @@
+import { Knex } from 'knex';
+
+const RolesTableName = 'roles';
+const ScopedRolesTableName = 'scoped_roles';
+const OrgMembershipsTableName = 'organization_memberships';
+const ProjectMembershipsTableName = 'project_memberships';
+const ProjectGroupAccessTableName = 'project_group_access';
+
+const addRoleUuidTo = async (knex: Knex, tableName: string) => {
+    if (!(await knex.schema.hasColumn(tableName, 'role_uuid'))) {
+        await knex.schema.alterTable(tableName, (table) => {
+            table
+                .uuid('role_uuid')
+                .nullable()
+                .references('role_uuid')
+                .inTable('roles')
+                // Prevent deleting a role if assigned to a user
+                .onDelete('RESTRICT');
+        });
+    }
+};
+
+export async function up(knex: Knex): Promise<void> {
+    // Create roles table
+    await knex.schema.createTable(RolesTableName, (rolesTable) => {
+        rolesTable
+            .uuid('role_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        rolesTable.string('name').notNullable();
+        rolesTable.text('description').nullable();
+        rolesTable
+            .uuid('organization_uuid')
+            .nullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+
+        rolesTable
+            .uuid('created_by')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+        rolesTable.string('owner_type').notNullable().defaultTo('user');
+        rolesTable.timestamp('created_at').defaultTo(knex.fn.now());
+        rolesTable.timestamp('updated_at').defaultTo(knex.fn.now());
+
+        rolesTable.unique(['name', 'organization_uuid']);
+        rolesTable.index('organization_uuid');
+    });
+
+    // 'user' roles must have an organization_uuid, 'system' roles defined by Lightdash must not
+    await knex.raw(`
+        ALTER TABLE roles
+            ADD CONSTRAINT user_roles_need_org
+                CHECK (
+                    (owner_type = 'user' AND organization_uuid IS NOT NULL) OR
+                    (owner_type = 'system' AND organization_uuid IS NULL)
+                )
+    `);
+
+    await Promise.all([
+        addRoleUuidTo(knex, OrgMembershipsTableName),
+        addRoleUuidTo(knex, ProjectMembershipsTableName),
+        addRoleUuidTo(knex, ProjectGroupAccessTableName),
+    ]);
+
+    // Create scoped_roles join table
+    await knex.schema.createTable(ScopedRolesTableName, (scopedRolesTable) => {
+        scopedRolesTable
+            .uuid('role_uuid')
+            .notNullable()
+            .references('role_uuid')
+            .inTable('roles')
+            .onDelete('CASCADE');
+        scopedRolesTable.string('scope_name').notNullable();
+        scopedRolesTable.timestamp('granted_at').defaultTo(knex.fn.now());
+        scopedRolesTable
+            .uuid('granted_by')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+
+        scopedRolesTable.primary(['role_uuid', 'scope_name']);
+        scopedRolesTable.index('role_uuid');
+        scopedRolesTable.index('scope_name');
+    });
+}
+
+const removeRoleUuidFrom = async (knex: Knex, tableName: string) => {
+    if (await knex.schema.hasColumn(tableName, 'role_uuid')) {
+        await knex.schema.alterTable(tableName, (table) => {
+            table.dropColumn('role_uuid');
+        });
+    }
+};
+
+export async function down(knex: Knex): Promise<void> {
+    await Promise.all([
+        removeRoleUuidFrom(knex, OrgMembershipsTableName),
+        removeRoleUuidFrom(knex, ProjectMembershipsTableName),
+        removeRoleUuidFrom(knex, ProjectGroupAccessTableName),
+    ]);
+
+    await knex.schema.dropTableIfExists(ScopedRolesTableName);
+    await knex.schema.dropTableIfExists(RolesTableName);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -259,6 +259,7 @@ export * from './types/queryHistory';
 export * from './types/rename';
 export * from './types/resourceViewItem';
 export * from './types/results';
+export * from './types/roles';
 export * from './types/savedCharts';
 export * from './types/scheduler';
 export * from './types/schedulerLog';

--- a/packages/common/src/types/roles.ts
+++ b/packages/common/src/types/roles.ts
@@ -1,0 +1,52 @@
+import type { ApiSuccessEmpty } from './api/success';
+
+export type Role = {
+    roleUuid: string;
+    name: string;
+    description: string | null;
+    organizationUuid: string;
+    ownerType: 'user' | 'system';
+    createdBy: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type RoleWithScopes = Role & {
+    scopes: string[];
+};
+
+export type CreateRole = {
+    name: string;
+    description?: string;
+};
+
+export type UpdateRole = {
+    name?: string;
+    description?: string;
+};
+
+export type AddScopesToRole = {
+    scopeNames: string[];
+};
+
+// API Response Types
+export type ApiGetRolesResponse = {
+    status: 'ok';
+    results: Role[];
+};
+
+export type ApiRoleWithScopesResponse = {
+    status: 'ok';
+    results: RoleWithScopes;
+};
+
+export type ApiDefaultRoleResponse = {
+    status: 'ok';
+    results: Role;
+};
+
+export type ApiDeleteRoleResponse = ApiSuccessEmpty;
+
+export type ApiRemoveScopeFromRoleResponse = ApiSuccessEmpty;
+
+export type ApiUnassignRoleFromUserResponse = ApiSuccessEmpty;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16280 (The parent issue has the related sub-issues that will be a part of this stack)

### Description:
Adds database schema for custom roles and permissions system with three new tables:

1. `roles` - Stores organization-specific roles with name and description
2. `scopes` - Defines available permissions (resource + action combinations)
3. `scoped_roles` - Join table linking roles to their granted permissions

The migration initializes the system with common permission scopes for organization management, projects, dashboards, charts, spaces, exports, and AI agents.

This is the first go at adding roles. We'll have a subsequent migration as well to add more roles, as well as an update to the seed the database correctly for e2e tests. 

I move scope definitions out to a separate PR: https://github.com/lightdash/lightdash/pull/16353

[Context](https://www.notion.so/lightdash/Custom-roles-permission-233a63207a7a8027a6d4d68a4b210045)