### PR TITLE
feat: add roles models and services

### DIFF
--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -28,9 +28,12 @@ import { ProjectModel } from './ProjectModel/ProjectModel';
 import { ProjectParametersModel } from './ProjectParametersModel';
 import { QueryHistoryModel } from './QueryHistoryModel/QueryHistoryModel';
 import { ResourceViewItemModel } from './ResourceViewItemModel';
+import { RolesModel } from './RolesModel';
 import { SavedChartModel } from './SavedChartModel';
 import { SavedSqlModel } from './SavedSqlModel';
 import { SchedulerModel } from './SchedulerModel';
+import { ScopedRolesModel } from './ScopedRolesModel';
+import { ScopesModel } from './ScopesModel';
 import { SearchModel } from './SearchModel';
 import { SessionModel } from './SessionModel';
 import { ShareModel } from './ShareModel';
@@ -93,6 +96,9 @@ export type ModelManifest = {
     spotlightTableConfigModel: SpotlightTableConfigModel;
     queryHistoryModel: QueryHistoryModel;
     projectParametersModel: ProjectParametersModel;
+    rolesModel: RolesModel;
+    scopesModel: ScopesModel;
+    scopedRolesModel: ScopedRolesModel;
     /** An implementation signature for these models are not available at this stage */
     aiAgentModel: unknown;
     embedModel: unknown;
@@ -559,6 +565,24 @@ export class ModelRepository
         return this.getModel(
             'projectParametersModel',
             () => new ProjectParametersModel({ database: this.database }),
+        );
+    }
+
+    public getRolesModel(): RolesModel {
+        return this.getModel('rolesModel', () => new RolesModel(this.database));
+    }
+
+    public getScopesModel(): ScopesModel {
+        return this.getModel(
+            'scopesModel',
+            () => new ScopesModel(this.database),
+        );
+    }
+
+    public getScopedRolesModel(): ScopedRolesModel {
+        return this.getModel(
+            'scopedRolesModel',
+            () => new ScopedRolesModel(this.database),
         );
     }
 

--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -1,0 +1,94 @@
+import { NotFoundError, Role } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    DbRole,
+    DbRoleInsert,
+    DbRoleUpdate,
+    RolesTableName,
+} from '../database/entities/roles';
+
+export class RolesModel {
+    private readonly database: Knex;
+
+    constructor(database: Knex) {
+        this.database = database;
+    }
+
+    static mapDbRoleToRole(dbRole: DbRole): Role {
+        return {
+            roleUuid: dbRole.role_uuid,
+            name: dbRole.name,
+            description: dbRole.description,
+            organizationUuid: dbRole.organization_uuid,
+            createdBy: dbRole.created_by,
+            createdAt: dbRole.created_at,
+            updatedAt: dbRole.updated_at,
+        };
+    }
+
+    async listByOrg(organizationUuid: string): Promise<Role[]> {
+        const dbRoles = await this.database(RolesTableName)
+            .where('organization_uuid', organizationUuid)
+            .orderBy('name', 'asc');
+
+        return dbRoles.map(RolesModel.mapDbRoleToRole);
+    }
+
+    async getByUuid(roleUuid: string): Promise<Role> {
+        const dbRole = await this.database(RolesTableName)
+            .where('role_uuid', roleUuid)
+            .first();
+
+        if (!dbRole) {
+            throw new NotFoundError(`Role with UUID ${roleUuid} not found`);
+        }
+
+        return RolesModel.mapDbRoleToRole(dbRole);
+    }
+
+    async create(role: DbRoleInsert): Promise<Role> {
+        const [newRole] = await this.database(RolesTableName)
+            .insert(role)
+            .returning('*');
+
+        return RolesModel.mapDbRoleToRole(newRole);
+    }
+
+    async update(roleUuid: string, updates: DbRoleUpdate): Promise<Role> {
+        const [updatedRole] = await this.database(RolesTableName)
+            .where('role_uuid', roleUuid)
+            .update({
+                ...updates,
+                updated_at: new Date(),
+            })
+            .returning('*');
+
+        if (!updatedRole) {
+            throw new NotFoundError(`Role with UUID ${roleUuid} not found`);
+        }
+
+        return RolesModel.mapDbRoleToRole(updatedRole);
+    }
+
+    async delete(roleUuid: string): Promise<void> {
+        const deletedCount = await this.database(RolesTableName)
+            .where('role_uuid', roleUuid)
+            .delete();
+
+        if (deletedCount === 0) {
+            throw new NotFoundError(`Role with UUID ${roleUuid} not found`);
+        }
+    }
+
+    async findRoleByNameAndOrg(
+        name: string,
+        organizationUuid: string,
+    ): Promise<Role | undefined> {
+        const dbRole = await this.database(RolesTableName)
+            .where('name', name)
+            .where('organization_uuid', organizationUuid)
+            .first();
+
+        return dbRole ? RolesModel.mapDbRoleToRole(dbRole) : undefined;
+    }
+}

--- a/packages/backend/src/models/ScopedRolesModel.ts
+++ b/packages/backend/src/models/ScopedRolesModel.ts
@@ -1,0 +1,137 @@
+import { NotFoundError, RoleWithScopes } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    RolesTableName,
+    ScopedRolesTableName,
+    ScopesTableName,
+} from '../database/entities/roles';
+
+export class ScopedRolesModel {
+    private readonly database: Knex;
+
+    constructor(database: Knex) {
+        this.database = database;
+    }
+
+    async addScopesToRole(
+        roleUuid: string,
+        scopeUuids: string[],
+        grantedBy: string,
+    ): Promise<void> {
+        if (scopeUuids.length === 0) {
+            return;
+        }
+
+        // Check for existing relationships to avoid duplicates
+        const existing = await this.database(ScopedRolesTableName)
+            .where('role_uuid', roleUuid)
+            .whereIn('scope_uuid', scopeUuids)
+            .select('scope_uuid');
+
+        const existingScopeUuids = existing.map((row) => row.scope_uuid);
+        const newScopeUuids = scopeUuids.filter(
+            (scopeUuid) => !existingScopeUuids.includes(scopeUuid),
+        );
+
+        if (newScopeUuids.length === 0) {
+            return; // All scopes already exist
+        }
+
+        const scopedRolesToInsert = newScopeUuids.map((scopeUuid) => ({
+            role_uuid: roleUuid,
+            scope_uuid: scopeUuid,
+            granted_by: grantedBy,
+        }));
+
+        await this.database.batchInsert(
+            ScopedRolesTableName,
+            scopedRolesToInsert,
+        );
+    }
+
+    async removeScopesFromRole(
+        roleUuid: string,
+        scopeUuids: string[],
+    ): Promise<void> {
+        if (scopeUuids.length === 0) {
+            return;
+        }
+
+        const deletedCount = await this.database(ScopedRolesTableName)
+            .where('role_uuid', roleUuid)
+            .whereIn('scope_uuid', scopeUuids)
+            .delete();
+
+        if (deletedCount === 0) {
+            throw new NotFoundError('No scope assignments found for this role');
+        }
+    }
+
+    async removeAllScopesFromRole(roleUuid: string): Promise<void> {
+        await this.database(ScopedRolesTableName)
+            .where('role_uuid', roleUuid)
+            .delete();
+    }
+
+    async removeAllRolesFromScope(scopeUuid: string): Promise<void> {
+        await this.database(ScopedRolesTableName)
+            .where('scope_uuid', scopeUuid)
+            .delete();
+    }
+
+    async getScopedRole(roleUuid: string): Promise<RoleWithScopes> {
+        // Get the role with its scopes using a join
+        const roleWithScopes = await this.database(RolesTableName)
+            .leftJoin(
+                ScopedRolesTableName,
+                'roles.role_uuid',
+                'scoped_roles.role_uuid',
+            )
+            .leftJoin(
+                ScopesTableName,
+                'scoped_roles.scope_uuid',
+                'scopes.scope_uuid',
+            )
+            .where('roles.role_uuid', roleUuid)
+            .select(
+                'roles.*',
+                'scopes.scope_uuid',
+                'scopes.resource',
+                'scopes.action',
+                'scopes.name as scope_name',
+                'scopes.description as scope_description',
+                'scopes.created_at as scope_created_at',
+            );
+
+        if (roleWithScopes.length === 0) {
+            throw new NotFoundError(`Role with UUID ${roleUuid} not found`);
+        }
+
+        // Extract the role data from the first row
+        const roleData = roleWithScopes[0];
+        const role: RoleWithScopes = {
+            roleUuid: roleData.role_uuid,
+            name: roleData.name,
+            description: roleData.description,
+            organizationUuid: roleData.organization_uuid,
+            createdBy: roleData.created_by,
+            createdAt: roleData.created_at,
+            updatedAt: roleData.updated_at,
+            scopes: [],
+        };
+
+        // Extract scopes from all rows (filtering out null scopes from left join)
+        role.scopes = roleWithScopes
+            .filter((row) => row.scope_uuid !== null)
+            .map((row) => ({
+                scopeUuid: row.scope_uuid,
+                resource: row.resource,
+                action: row.action,
+                name: row.scope_name,
+                description: row.scope_description,
+                createdAt: row.scope_created_at,
+            }));
+
+        return role;
+    }
+}

--- a/packages/backend/src/models/ScopesModel.ts
+++ b/packages/backend/src/models/ScopesModel.ts
@@ -1,0 +1,62 @@
+import { NotFoundError, Scope } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    DbScope,
+    DbScopeInsert,
+    ScopesTableName,
+} from '../database/entities/roles';
+
+export class ScopesModel {
+    private readonly database: Knex;
+
+    constructor(database: Knex) {
+        this.database = database;
+    }
+
+    static mapDbScopeToScope(dbScope: DbScope): Scope {
+        return {
+            scopeUuid: dbScope.scope_uuid,
+            resource: dbScope.resource,
+            action: dbScope.action,
+            name: dbScope.name,
+            description: dbScope.description,
+            createdAt: dbScope.created_at,
+        };
+    }
+
+    /**
+     * List scopes, optionally filtered by scope UUIDs
+     * @param scopeUuids - Optional array of scope UUIDs to filter by
+     * @returns Array of scopes
+     */
+    async list(scopeUuids?: string[]): Promise<Scope[]> {
+        const query = this.database(ScopesTableName);
+
+        if (scopeUuids) {
+            void query.whereIn('scope_uuid', scopeUuids);
+        }
+
+        const scopes = await query.orderBy('resource', 'asc');
+        return scopes.map(ScopesModel.mapDbScopeToScope);
+    }
+
+    async getByUuid(scopeUuid: string): Promise<Scope> {
+        const dbScope = await this.database(ScopesTableName)
+            .where('scope_uuid', scopeUuid)
+            .first();
+
+        if (!dbScope) {
+            throw new NotFoundError(`Scope with UUID ${scopeUuid} not found`);
+        }
+
+        return ScopesModel.mapDbScopeToScope(dbScope);
+    }
+
+    async create(scope: DbScopeInsert): Promise<Scope> {
+        const [newScope] = await this.database(ScopesTableName)
+            .insert(scope)
+            .returning('*');
+
+        return ScopesModel.mapDbScopeToScope(newScope);
+    }
+}

--- a/packages/backend/src/services/RolesService.ts
+++ b/packages/backend/src/services/RolesService.ts
@@ -1,0 +1,366 @@
+import { subject } from '@casl/ability';
+import {
+    Account,
+    AddScopeToRole,
+    AlreadyExistsError,
+    assertIsAccountWithOrg,
+    CreateRole,
+    ForbiddenError,
+    NotFoundError,
+    RemoveScopesFromRole,
+    Role,
+    RoleWithScopes,
+    Scope,
+    UpdateRole,
+} from '@lightdash/common';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import { RolesModel } from '../models/RolesModel';
+import { ScopedRolesModel } from '../models/ScopedRolesModel';
+import { ScopesModel } from '../models/ScopesModel';
+import { BaseService } from './BaseService';
+
+type RolesServiceArguments = {
+    analytics: LightdashAnalytics;
+    rolesModel: RolesModel;
+    scopesModel: ScopesModel;
+    scopedRolesModel: ScopedRolesModel;
+};
+
+export class RolesService extends BaseService {
+    private readonly analytics: LightdashAnalytics;
+
+    private readonly rolesModel: RolesModel;
+
+    private readonly scopesModel: ScopesModel;
+
+    private readonly scopedRolesModel: ScopedRolesModel;
+
+    constructor(args: RolesServiceArguments) {
+        super();
+        this.analytics = args.analytics;
+        this.rolesModel = args.rolesModel;
+        this.scopesModel = args.scopesModel;
+        this.scopedRolesModel = args.scopedRolesModel;
+    }
+
+    async listRolesByOrganization(
+        account: Account,
+        organizationUuid: string,
+    ): Promise<Role[]> {
+        assertIsAccountWithOrg(account);
+
+        if (
+            account.user.ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage roles in this organization',
+            );
+        }
+
+        return this.rolesModel.listByOrg(organizationUuid);
+    }
+
+    async getRoleWithScopes(
+        account: Account,
+        organizationUuid: string,
+        roleUuid: string,
+    ): Promise<RoleWithScopes> {
+        assertIsAccountWithOrg(account);
+
+        if (
+            account.user.ability.cannot(
+                'view',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage roles in this organization',
+            );
+        }
+
+        const role = await this.scopedRolesModel.getScopedRole(roleUuid);
+        if (!role) {
+            throw new NotFoundError(`Role not found`);
+        }
+
+        if (role.organizationUuid !== organizationUuid) {
+            throw new NotFoundError(`Role not found`);
+        }
+
+        return role;
+    }
+
+    async createRole(
+        account: Account,
+        organizationUuid: string,
+        createRole: CreateRole,
+    ): Promise<Role> {
+        assertIsAccountWithOrg(account);
+
+        if (
+            account.user.ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage roles in this organization',
+            );
+        }
+
+        const existingRole = await this.rolesModel.findRoleByNameAndOrg(
+            createRole.name,
+            organizationUuid,
+        );
+
+        if (existingRole) {
+            throw new AlreadyExistsError(
+                `Role with name "${createRole.name}" already exists`,
+            );
+        }
+
+        const role = await this.rolesModel.create({
+            name: createRole.name,
+            description: createRole.description || null,
+            organization_uuid: organizationUuid,
+            created_by: account.user.id,
+        });
+
+        this.analytics.track({
+            userId: account.user.id,
+            event: 'role.created',
+            properties: {
+                organizationId: organizationUuid,
+                roleId: role.roleUuid,
+                roleName: role.name,
+            },
+        });
+
+        return role;
+    }
+
+    async updateRole(
+        account: Account,
+        organizationUuid: string,
+        roleUuid: string,
+        updateRole: UpdateRole,
+    ): Promise<Role> {
+        assertIsAccountWithOrg(account);
+
+        if (
+            account.user.ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage roles in this organization',
+            );
+        }
+
+        const existingRole = await this.rolesModel.getByUuid(roleUuid);
+        if (existingRole.organizationUuid !== organizationUuid) {
+            throw new NotFoundError(`Role not found`);
+        }
+
+        // If name is being updated, check for duplicates
+        if (updateRole.name && updateRole.name !== existingRole.name) {
+            const duplicateRole = await this.rolesModel.findRoleByNameAndOrg(
+                updateRole.name,
+                organizationUuid,
+            );
+
+            if (duplicateRole) {
+                throw new AlreadyExistsError(
+                    `Role with name "${updateRole.name}" already exists`,
+                );
+            }
+        }
+
+        const role = await this.rolesModel.update(roleUuid, {
+            name: updateRole.name,
+            description: updateRole.description,
+        });
+
+        this.analytics.track({
+            userId: account.user.id,
+            event: 'role.updated',
+            properties: {
+                organizationId: organizationUuid,
+                roleId: role.roleUuid,
+                roleName: role.name,
+            },
+        });
+
+        return role;
+    }
+
+    async deleteRole(
+        account: Account,
+        organizationUuid: string,
+        roleUuid: string,
+    ): Promise<void> {
+        assertIsAccountWithOrg(account);
+
+        if (
+            account.user.ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage roles in this organization',
+            );
+        }
+
+        const existingRole = await this.rolesModel.getByUuid(roleUuid);
+        if (existingRole.organizationUuid !== organizationUuid) {
+            throw new NotFoundError(`Role not found`);
+        }
+
+        await this.scopedRolesModel.removeAllScopesFromRole(roleUuid);
+        await this.rolesModel.delete(roleUuid);
+
+        this.analytics.track({
+            userId: account.user.id,
+            event: 'role.deleted',
+            properties: {
+                organizationId: organizationUuid,
+                roleId: roleUuid,
+                roleName: existingRole.name,
+            },
+        });
+    }
+
+    private async assertValidScopesToAdd(
+        roleUuid: string,
+        scopeUuids: string[],
+    ): Promise<Scope[]> {
+        const scopes = await this.scopesModel.list(scopeUuids);
+        if (scopes.length !== scopeUuids.length) {
+            const foundScopeUuids = scopes.map((s) => s.scopeUuid);
+            const missingScopeUuids = scopeUuids.filter(
+                (uuid) => !foundScopeUuids.includes(uuid),
+            );
+            throw new NotFoundError(
+                `Scopes not found: ${missingScopeUuids.join(', ')}`,
+            );
+        }
+
+        // Check for existing relationships to detect duplicates
+        const existing = await this.scopedRolesModel.getScopedRole(roleUuid);
+        const existingScopeUuids = existing.scopes.map((s) => s.scopeUuid);
+        const duplicateScopeUuids = scopeUuids.filter((uuid) =>
+            existingScopeUuids.includes(uuid),
+        );
+
+        if (duplicateScopeUuids.length > 0) {
+            throw new AlreadyExistsError(
+                `Scopes already assigned to role: ${duplicateScopeUuids.join(
+                    ', ',
+                )}`,
+            );
+        }
+
+        return scopes;
+    }
+
+    async addScopesToRole(
+        account: Account,
+        organizationUuid: string,
+        roleUuid: string,
+        addScope: AddScopeToRole,
+    ): Promise<Scope[]> {
+        assertIsAccountWithOrg(account);
+
+        if (
+            account.user.ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage roles',
+            );
+        }
+
+        const existingRole = await this.rolesModel.getByUuid(roleUuid);
+        if (existingRole.organizationUuid !== organizationUuid) {
+            throw new NotFoundError(`Role not found`);
+        }
+
+        const scopes = await this.assertValidScopesToAdd(
+            roleUuid,
+            addScope.scopeUuids,
+        );
+
+        // Add scopes to role using batch insert
+        await this.scopedRolesModel.addScopesToRole(
+            roleUuid,
+            addScope.scopeUuids,
+            account.user.id,
+        );
+
+        this.analytics.track({
+            userId: account.user.id,
+            event: 'role.scopes_added',
+            properties: {
+                organizationId: organizationUuid,
+                roleId: roleUuid,
+                scopesNames: scopes.map((s) => s.name),
+            },
+        });
+
+        return scopes;
+    }
+
+    async removeScopesFromRole(
+        account: Account,
+        organizationUuid: string,
+        roleUuid: string,
+        removeScopes: RemoveScopesFromRole,
+    ): Promise<void> {
+        assertIsAccountWithOrg(account);
+
+        if (
+            account.user.ability.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage roles in this organization',
+            );
+        }
+
+        const existingRole = await this.rolesModel.getByUuid(roleUuid);
+        if (existingRole.organizationUuid !== organizationUuid) {
+            throw new NotFoundError(`Role not found`);
+        }
+
+        const scopes = await this.scopesModel.list(removeScopes.scopeUuids);
+        await this.scopedRolesModel.removeScopesFromRole(
+            roleUuid,
+            removeScopes.scopeUuids,
+        );
+
+        this.analytics.track({
+            userId: account.user.id,
+            event: 'role.scopes_removed',
+            properties: {
+                organizationId: organizationUuid,
+                roleId: roleUuid,
+                scopesNames: scopes.map((s) => s.name),
+            },
+        });
+    }
+
+    async getAllScopes(account: Account): Promise<Scope[]> {
+        assertIsAccountWithOrg(account);
+
+        return this.scopesModel.list();
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -33,6 +33,7 @@ import { ProjectParametersService } from './ProjectParametersService';
 import { ProjectService } from './ProjectService/ProjectService';
 import { PromoteService } from './PromoteService/PromoteService';
 import { RenameService } from './RenameService/RenameService';
+import { RolesService } from './RolesService';
 import { SavedChartService } from './SavedChartsService/SavedChartService';
 import { SavedSqlService } from './SavedSqlService/SavedSqlService';
 import { SchedulerService } from './SchedulerService/SchedulerService';
@@ -93,6 +94,7 @@ interface ServiceManifest {
     asyncQueryService: AsyncQueryService;
     renameService: RenameService;
     projectParametersService: ProjectParametersService;
+    rolesService: RolesService;
     /** An implementation signature for these services are not available at this stage */
     embedService: unknown;
     aiService: unknown;
@@ -937,6 +939,19 @@ export class ServiceRepository
                     analytics: this.context.lightdashAnalytics,
                     projectParametersModel:
                         this.models.getProjectParametersModel(),
+                }),
+        );
+    }
+
+    public getRolesService(): RolesService {
+        return this.getService(
+            'rolesService',
+            () =>
+                new RolesService({
+                    analytics: this.context.lightdashAnalytics,
+                    rolesModel: this.models.getRolesModel(),
+                    scopesModel: this.models.getScopesModel(),
+                    scopedRolesModel: this.models.getScopedRolesModel(),
                 }),
         );
     }

--- a/packages/common/src/types/roles.ts
+++ b/packages/common/src/types/roles.ts
@@ -41,7 +41,11 @@ export type CreateScope = {
 };
 
 export type AddScopeToRole = {
-    scopeUuid: string;
+    scopeUuids: string[];
+};
+
+export type RemoveScopesFromRole = {
+    scopeUuids: string[];
 };
 
 // API Response Types
@@ -69,10 +73,12 @@ export type ApiDeleteRoleResponse = ApiSuccessEmpty;
 
 export type ApiAddScopeToRoleResponse = {
     status: 'ok';
-    results: Scope;
+    results: Scope[];
 };
 
 export type ApiRemoveScopeFromRoleResponse = ApiSuccessEmpty;
+
+export type ApiRemoveScopesFromRoleResponse = ApiSuccessEmpty;
 
 export type ApiGetScopesResponse = {
     status: 'ok';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16282

### Description:
Adds models and service for role-based access control:

- Created `RolesModel`, `ScopesModel`, and `ScopedRolesModel` to manage roles and permissions
- Implemented `RolesService` with methods for creating, updating, and deleting roles
- Added functionality to assign and remove scopes (permissions) from roles

This implementation provides the foundation the API in the next PR

[Context](https://www.notion.so/lightdash/Custom-roles-permission-233a63207a7a8027a6d4d68a4b210045)