### PR TITLE
feat: add controller for roles

### DIFF
--- a/packages/backend/src/controllers/RolesController.ts
+++ b/packages/backend/src/controllers/RolesController.ts
@@ -1,0 +1,231 @@
+import {
+    AddScopeToRole,
+    ApiAddScopeToRoleResponse,
+    ApiCreateRoleResponse,
+    ApiDeleteRoleResponse,
+    ApiErrorPayload,
+    ApiGetRoleResponse,
+    ApiGetRolesResponse,
+    ApiGetScopesResponse,
+    ApiRemoveScopeFromRoleResponse,
+    ApiRemoveScopesFromRoleResponse,
+    ApiUpdateRoleResponse,
+    CreateRole,
+    RemoveScopesFromRole,
+    UpdateRole,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Patch,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
+import { BaseController } from './baseController';
+
+@Route('/api/v1/organizations/{organizationUuid}/roles')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Roles')
+@Middlewares([allowApiKeyAuthentication, isAuthenticated])
+export class RolesController extends BaseController {
+    /**
+     * Get all roles for an organization
+     * @summary List organization roles
+     */
+
+    @SuccessResponse('200', 'Success')
+    @Get()
+    @OperationId('getOrganizationRoles')
+    async getRoles(
+        @Path() organizationUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiGetRolesResponse> {
+        const roles = await this.services
+            .getRolesService()
+            .listRolesByOrganization(req.account!, organizationUuid);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: roles,
+        };
+    }
+
+    /**
+     * Create a new role in an organization
+     * @summary Create role
+     */
+    @SuccessResponse('201', 'Created')
+    @Post()
+    @OperationId('createOrganizationRole')
+    async createRole(
+        @Path() organizationUuid: string,
+        @Body() body: CreateRole,
+        @Request() req: express.Request,
+    ): Promise<ApiCreateRoleResponse> {
+        const role = await this.services
+            .getRolesService()
+            .createRole(req.account!, organizationUuid, body);
+
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: role,
+        };
+    }
+
+    /**
+     * Get all available scopes
+     * @summary List all scopes
+     */
+    @SuccessResponse('200', 'Success')
+    @Get('/scopes')
+    @OperationId('getAllScopes')
+    async getAllScopes(
+        @Path() organizationUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiGetScopesResponse> {
+        const scopes = await this.services
+            .getRolesService()
+            .getAllScopes(req.account!);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: scopes,
+        };
+    }
+
+    /**
+     * Get a specific role with its scopes
+     * @summary Get role details
+     */
+    @SuccessResponse('200', 'Success')
+    @Get('{roleUuid}')
+    @OperationId('getOrganizationRole')
+    async getRole(
+        @Path() organizationUuid: string,
+        @Path() roleUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiGetRoleResponse> {
+        const role = await this.services
+            .getRolesService()
+            .getRoleWithScopes(req.account!, organizationUuid, roleUuid);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: role,
+        };
+    }
+
+    /**
+     * Update a role's details
+     * @summary Update role
+     */
+    @SuccessResponse('200', 'Success')
+    @Patch('{roleUuid}')
+    @OperationId('updateOrganizationRole')
+    async updateRole(
+        @Path() organizationUuid: string,
+        @Path() roleUuid: string,
+        @Body() body: UpdateRole,
+        @Request() req: express.Request,
+    ): Promise<ApiUpdateRoleResponse> {
+        const role = await this.services
+            .getRolesService()
+            .updateRole(req.account!, organizationUuid, roleUuid, body);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: role,
+        };
+    }
+
+    /**
+     * Delete a role from an organization
+     * @summary Delete role
+     */
+    @SuccessResponse('200', 'Success')
+    @Delete('{roleUuid}')
+    @OperationId('deleteOrganizationRole')
+    async deleteRole(
+        @Path() organizationUuid: string,
+        @Path() roleUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiDeleteRoleResponse> {
+        await this.services
+            .getRolesService()
+            .deleteRole(req.account!, organizationUuid, roleUuid);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Add scopes to a role
+     * @summary Add scopes to role
+     */
+    @SuccessResponse('201', 'Created')
+    @Post('{roleUuid}/scopes')
+    @OperationId('addScopesToRole')
+    async addScopesToRole(
+        @Path() organizationUuid: string,
+        @Path() roleUuid: string,
+        @Body() body: AddScopeToRole,
+        @Request() req: express.Request,
+    ): Promise<ApiAddScopeToRoleResponse> {
+        const scopes = await this.services
+            .getRolesService()
+            .addScopesToRole(req.account!, organizationUuid, roleUuid, body);
+
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: scopes,
+        };
+    }
+
+    /**
+     * Remove multiple scopes from a role
+     * @summary Remove scopes from role
+     */
+    @SuccessResponse('200', 'Success')
+    @Delete('{roleUuid}/scopes')
+    @OperationId('removeScopesFromRole')
+    async removeScopesFromRole(
+        @Path() organizationUuid: string,
+        @Path() roleUuid: string,
+        @Body() body: RemoveScopesFromRole,
+        @Request() req: express.Request,
+    ): Promise<ApiRemoveScopesFromRoleResponse> {
+        await this.services
+            .getRolesService()
+            .removeScopesFromRole(
+                req.account!,
+                organizationUuid,
+                roleUuid,
+                body,
+            );
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -86,6 +86,8 @@ import { CatalogController } from './../controllers/catalogController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { BigquerySSOController } from './../controllers/bigquerySSOController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { RolesController } from './../controllers/RolesController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { QueryController } from './../controllers/v2/QueryController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ParametersController } from './../controllers/v2/ParametersController';
@@ -15666,6 +15668,284 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Role: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                createdBy: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                roleUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetRolesResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'Role' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCreateRoleResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Role', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: { dataType: 'string' },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CaslSubjectNames: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['AiAgent'] },
+                { dataType: 'enum', enums: ['AiAgentThread'] },
+                { dataType: 'enum', enums: ['Analytics'] },
+                { dataType: 'enum', enums: ['ChangeCsvResults'] },
+                { dataType: 'enum', enums: ['CompileProject'] },
+                { dataType: 'enum', enums: ['ContentAsCode'] },
+                { dataType: 'enum', enums: ['CustomSql'] },
+                { dataType: 'enum', enums: ['Dashboard'] },
+                { dataType: 'enum', enums: ['DashboardComments'] },
+                { dataType: 'enum', enums: ['Explore'] },
+                { dataType: 'enum', enums: ['ExportCsv'] },
+                { dataType: 'enum', enums: ['Group'] },
+                { dataType: 'enum', enums: ['InviteLink'] },
+                { dataType: 'enum', enums: ['Job'] },
+                { dataType: 'enum', enums: ['JobStatus'] },
+                { dataType: 'enum', enums: ['MetricsTree'] },
+                { dataType: 'enum', enums: ['Organization'] },
+                { dataType: 'enum', enums: ['OrganizationMemberProfile'] },
+                { dataType: 'enum', enums: ['PersonalAccessToken'] },
+                { dataType: 'enum', enums: ['PinnedItems'] },
+                { dataType: 'enum', enums: ['Project'] },
+                { dataType: 'enum', enums: ['SavedChart'] },
+                { dataType: 'enum', enums: ['ScheduledDeliveries'] },
+                { dataType: 'enum', enums: ['SemanticViewer'] },
+                { dataType: 'enum', enums: ['Space'] },
+                { dataType: 'enum', enums: ['SpotlightTableConfig'] },
+                { dataType: 'enum', enums: ['SqlRunner'] },
+                { dataType: 'enum', enums: ['Tags'] },
+                { dataType: 'enum', enums: ['UnderlyingData'] },
+                { dataType: 'enum', enums: ['Validation'] },
+                { dataType: 'enum', enums: ['VirtualView'] },
+                { dataType: 'enum', enums: ['Export'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AbilityAction: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['create'] },
+                { dataType: 'enum', enums: ['delete'] },
+                { dataType: 'enum', enums: ['export'] },
+                { dataType: 'enum', enums: ['manage'] },
+                { dataType: 'enum', enums: ['promote'] },
+                { dataType: 'enum', enums: ['update'] },
+                { dataType: 'enum', enums: ['view'] },
+                { dataType: 'enum', enums: ['csv'] },
+                { dataType: 'enum', enums: ['image'] },
+                { dataType: 'enum', enums: ['pdf'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Scope: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                createdAt: { dataType: 'datetime', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                action: { ref: 'AbilityAction', required: true },
+                resource: { ref: 'CaslSubjectNames', required: true },
+                scopeUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetScopesResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'Scope' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RoleWithScopes: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Role' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        scopes: {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'Scope' },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetRoleResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'RoleWithScopes', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateRoleResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'Role', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: { dataType: 'string' },
+                name: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDeleteRoleResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccessEmpty', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAddScopeToRoleResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'Scope' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AddScopeToRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                scopeUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiRemoveScopesFromRoleResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccessEmpty', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RemoveScopesFromRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                scopeUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
             },
             validators: {},
         },
@@ -33832,6 +34112,526 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'get',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRolesController_getRoles: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        organizationUuid: {
+            in: 'path',
+            name: 'organizationUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/organizations/:organizationUuid/roles',
+        ...fetchMiddlewares<RequestHandler>(RolesController),
+        ...fetchMiddlewares<RequestHandler>(RolesController.prototype.getRoles),
+
+        async function RolesController_getRoles(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRolesController_getRoles,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<RolesController>(
+                    RolesController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getRoles',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRolesController_createRole: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        organizationUuid: {
+            in: 'path',
+            name: 'organizationUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: { in: 'body', name: 'body', required: true, ref: 'CreateRole' },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v1/organizations/:organizationUuid/roles',
+        ...fetchMiddlewares<RequestHandler>(RolesController),
+        ...fetchMiddlewares<RequestHandler>(
+            RolesController.prototype.createRole,
+        ),
+
+        async function RolesController_createRole(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRolesController_createRole,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<RolesController>(
+                    RolesController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createRole',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRolesController_getAllScopes: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        organizationUuid: {
+            in: 'path',
+            name: 'organizationUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/organizations/:organizationUuid/roles/scopes',
+        ...fetchMiddlewares<RequestHandler>(RolesController),
+        ...fetchMiddlewares<RequestHandler>(
+            RolesController.prototype.getAllScopes,
+        ),
+
+        async function RolesController_getAllScopes(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRolesController_getAllScopes,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<RolesController>(
+                    RolesController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAllScopes',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRolesController_getRole: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        organizationUuid: {
+            in: 'path',
+            name: 'organizationUuid',
+            required: true,
+            dataType: 'string',
+        },
+        roleUuid: {
+            in: 'path',
+            name: 'roleUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/organizations/:organizationUuid/roles/:roleUuid',
+        ...fetchMiddlewares<RequestHandler>(RolesController),
+        ...fetchMiddlewares<RequestHandler>(RolesController.prototype.getRole),
+
+        async function RolesController_getRole(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRolesController_getRole,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<RolesController>(
+                    RolesController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getRole',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRolesController_updateRole: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        organizationUuid: {
+            in: 'path',
+            name: 'organizationUuid',
+            required: true,
+            dataType: 'string',
+        },
+        roleUuid: {
+            in: 'path',
+            name: 'roleUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: { in: 'body', name: 'body', required: true, ref: 'UpdateRole' },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.patch(
+        '/api/v1/organizations/:organizationUuid/roles/:roleUuid',
+        ...fetchMiddlewares<RequestHandler>(RolesController),
+        ...fetchMiddlewares<RequestHandler>(
+            RolesController.prototype.updateRole,
+        ),
+
+        async function RolesController_updateRole(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRolesController_updateRole,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<RolesController>(
+                    RolesController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateRole',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRolesController_deleteRole: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        organizationUuid: {
+            in: 'path',
+            name: 'organizationUuid',
+            required: true,
+            dataType: 'string',
+        },
+        roleUuid: {
+            in: 'path',
+            name: 'roleUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.delete(
+        '/api/v1/organizations/:organizationUuid/roles/:roleUuid',
+        ...fetchMiddlewares<RequestHandler>(RolesController),
+        ...fetchMiddlewares<RequestHandler>(
+            RolesController.prototype.deleteRole,
+        ),
+
+        async function RolesController_deleteRole(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRolesController_deleteRole,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<RolesController>(
+                    RolesController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteRole',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRolesController_addScopesToRole: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        organizationUuid: {
+            in: 'path',
+            name: 'organizationUuid',
+            required: true,
+            dataType: 'string',
+        },
+        roleUuid: {
+            in: 'path',
+            name: 'roleUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'AddScopeToRole',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v1/organizations/:organizationUuid/roles/:roleUuid/scopes',
+        ...fetchMiddlewares<RequestHandler>(RolesController),
+        ...fetchMiddlewares<RequestHandler>(
+            RolesController.prototype.addScopesToRole,
+        ),
+
+        async function RolesController_addScopesToRole(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRolesController_addScopesToRole,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<RolesController>(
+                    RolesController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'addScopesToRole',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRolesController_removeScopesFromRole: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        organizationUuid: {
+            in: 'path',
+            name: 'organizationUuid',
+            required: true,
+            dataType: 'string',
+        },
+        roleUuid: {
+            in: 'path',
+            name: 'roleUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'RemoveScopesFromRole',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.delete(
+        '/api/v1/organizations/:organizationUuid/roles/:roleUuid/scopes',
+        ...fetchMiddlewares<RequestHandler>(RolesController),
+        ...fetchMiddlewares<RequestHandler>(
+            RolesController.prototype.removeScopesFromRole,
+        ),
+
+        async function RolesController_removeScopesFromRole(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRolesController_removeScopesFromRole,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<RolesController>(
+                    RolesController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'removeScopesFromRole',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16569,6 +16569,294 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "Role": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdBy": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "roleUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "createdBy",
+                    "organizationUuid",
+                    "description",
+                    "name",
+                    "roleUuid"
+                ],
+                "type": "object"
+            },
+            "ApiGetRolesResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/Role"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiCreateRoleResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Role"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "CreateRole": {
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name"],
+                "type": "object"
+            },
+            "CaslSubjectNames": {
+                "type": "string",
+                "enum": [
+                    "AiAgent",
+                    "AiAgentThread",
+                    "Analytics",
+                    "ChangeCsvResults",
+                    "CompileProject",
+                    "ContentAsCode",
+                    "CustomSql",
+                    "Dashboard",
+                    "DashboardComments",
+                    "Explore",
+                    "ExportCsv",
+                    "Group",
+                    "InviteLink",
+                    "Job",
+                    "JobStatus",
+                    "MetricsTree",
+                    "Organization",
+                    "OrganizationMemberProfile",
+                    "PersonalAccessToken",
+                    "PinnedItems",
+                    "Project",
+                    "SavedChart",
+                    "ScheduledDeliveries",
+                    "SemanticViewer",
+                    "Space",
+                    "SpotlightTableConfig",
+                    "SqlRunner",
+                    "Tags",
+                    "UnderlyingData",
+                    "Validation",
+                    "VirtualView",
+                    "Export"
+                ]
+            },
+            "AbilityAction": {
+                "type": "string",
+                "enum": [
+                    "create",
+                    "delete",
+                    "export",
+                    "manage",
+                    "promote",
+                    "update",
+                    "view",
+                    "csv",
+                    "image",
+                    "pdf"
+                ]
+            },
+            "Scope": {
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "action": {
+                        "$ref": "#/components/schemas/AbilityAction"
+                    },
+                    "resource": {
+                        "$ref": "#/components/schemas/CaslSubjectNames"
+                    },
+                    "scopeUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "createdAt",
+                    "description",
+                    "name",
+                    "action",
+                    "resource",
+                    "scopeUuid"
+                ],
+                "type": "object"
+            },
+            "ApiGetScopesResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/Scope"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "RoleWithScopes": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Role"
+                    },
+                    {
+                        "properties": {
+                            "scopes": {
+                                "items": {
+                                    "$ref": "#/components/schemas/Scope"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["scopes"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiGetRoleResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/RoleWithScopes"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiUpdateRoleResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/Role"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "UpdateRole": {
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "ApiDeleteRoleResponse": {
+                "$ref": "#/components/schemas/ApiSuccessEmpty"
+            },
+            "ApiAddScopeToRoleResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/Scope"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "AddScopeToRole": {
+                "properties": {
+                    "scopeUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["scopeUuids"],
+                "type": "object"
+            },
+            "ApiRemoveScopesFromRoleResponse": {
+                "$ref": "#/components/schemas/ApiSuccessEmpty"
+            },
+            "RemoveScopesFromRole": {
+                "properties": {
+                    "scopeUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["scopeUuids"],
+                "type": "object"
+            },
             "ResultsPaginationMetadata_ResultRow_": {
                 "allOf": [
                     {
@@ -18200,7 +18488,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1880.0",
+        "version": "0.1888.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -27991,6 +28279,406 @@
                 "tags": ["Projects"],
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v1/organizations/{organizationUuid}/roles": {
+            "get": {
+                "operationId": "getOrganizationRoles",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGetRolesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get all roles for an organization",
+                "summary": "List organization roles",
+                "tags": ["Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "createOrganizationRole",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiCreateRoleResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Create a new role in an organization",
+                "summary": "Create role",
+                "tags": ["Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateRole"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/organizations/{organizationUuid}/roles/scopes": {
+            "get": {
+                "operationId": "getAllScopes",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGetScopesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get all available scopes",
+                "summary": "List all scopes",
+                "tags": ["Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/organizations/{organizationUuid}/roles/{roleUuid}": {
+            "get": {
+                "operationId": "getOrganizationRole",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGetRoleResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a specific role with its scopes",
+                "summary": "Get role details",
+                "tags": ["Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "roleUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "updateOrganizationRole",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUpdateRoleResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update a role's details",
+                "summary": "Update role",
+                "tags": ["Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "roleUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateRole"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteOrganizationRole",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDeleteRoleResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete a role from an organization",
+                "summary": "Delete role",
+                "tags": ["Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "roleUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/organizations/{organizationUuid}/roles/{roleUuid}/scopes": {
+            "post": {
+                "operationId": "addScopesToRole",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAddScopeToRoleResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Add scopes to a role",
+                "summary": "Add scopes to role",
+                "tags": ["Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "roleUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AddScopeToRole"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "removeScopesFromRole",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRemoveScopesFromRoleResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Remove multiple scopes from a role",
+                "summary": "Remove scopes from role",
+                "tags": ["Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organizationUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "roleUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RemoveScopesFromRole"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v2/projects/{projectUuid}/query/{queryUuid}": {

--- a/packages/e2e/cypress/e2e/api/roles.cy.ts
+++ b/packages/e2e/cypress/e2e/api/roles.cy.ts
@@ -1,0 +1,560 @@
+import { Role, SEED_ORG_1, SEED_ORG_2 } from '@lightdash/common';
+
+describe('Roles API', () => {
+    const deleteRole = (roleUuid: string) => {
+        cy.request({
+            url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${roleUuid}`,
+            method: 'DELETE',
+        }).then((resp) => {
+            expect(resp.status).to.eq(200);
+        });
+    };
+
+    const createRole = (name: string, description?: string) => {
+        const roleName = `${name} ${new Date().getTime()}`;
+        return cy
+            .request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles`,
+                method: 'POST',
+                body: {
+                    name: roleName,
+                    ...(description && { description }),
+                },
+            })
+            .then((resp) => {
+                expect(resp.status).to.eq(201);
+                expect(resp.body).to.have.property('status', 'ok');
+                expect(resp.body.results).to.have.property('roleUuid');
+                return resp.body.results.roleUuid;
+            });
+    };
+
+    const getFirstScope = () =>
+        cy
+            .request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/scopes`,
+                method: 'GET',
+            })
+            .then((resp) => {
+                expect(resp.status).to.eq(200);
+                expect(resp.body.results).to.be.an('array');
+                expect(resp.body.results.length).to.be.greaterThan(0);
+                return resp.body.results[0].scopeUuid;
+            });
+
+    const addScopeToRole = (roleUuid: string, scopeUuid: string) =>
+        cy
+            .request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${roleUuid}/scopes`,
+                method: 'POST',
+                body: {
+                    scopeUuids: [scopeUuid],
+                },
+            })
+            .then((resp) => {
+                expect(resp.status).to.eq(201);
+                expect(resp.body).to.have.property('status', 'ok');
+                expect(resp.body.results).to.be.an('array');
+                return resp.body.results;
+            });
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    describe('GET /api/v1/organizations/{orgUuid}/roles/scopes', () => {
+        it('should return all available scopes', () => {
+            cy.request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/scopes`,
+                method: 'GET',
+            }).then((resp) => {
+                expect(resp.status).to.eq(200);
+                expect(resp.body).to.have.property('status', 'ok');
+                expect(resp.body.results).to.be.an('array');
+            });
+        });
+
+        it('should forbid scopes access to unauthenticated users', () => {
+            cy.logout();
+
+            cy.request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/scopes`,
+                method: 'GET',
+                headers: {
+                    Authorization: 'Bearer invalid-token',
+                },
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(401);
+            });
+        });
+    });
+
+    describe('POST /api/v1/organizations/{orgUuid}/roles', () => {
+        it('should create a new role', () => {
+            const roleName = `Test Role ${new Date().getTime()}`;
+            cy.request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles`,
+                method: 'POST',
+                body: {
+                    name: roleName,
+                    description: 'Test role description',
+                },
+            })
+                .then((resp) => {
+                    expect(resp.status).to.eq(201);
+                    expect(resp.body).to.have.property('status', 'ok');
+                    expect(resp.body.results).to.have.property(
+                        'name',
+                        roleName,
+                    );
+                    expect(resp.body.results).to.have.property(
+                        'description',
+                        'Test role description',
+                    );
+                    expect(resp.body.results).to.have.property('roleUuid');
+                    expect(resp.body.results).to.have.property(
+                        'organizationUuid',
+                        SEED_ORG_1.organization_uuid,
+                    );
+
+                    return resp.body.results.roleUuid;
+                })
+                .then(deleteRole);
+        });
+
+        it('should not allow duplicate role names in same organization', () => {
+            const roleName = `Duplicate Test ${new Date().getTime()}`;
+
+            // Create first role
+            let firstRoleUuid: string;
+            cy.request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles`,
+                method: 'POST',
+                body: {
+                    name: roleName,
+                },
+            }).then((createResp) => {
+                firstRoleUuid = createResp.body.results.roleUuid;
+
+                // Try to create duplicate
+                cy.request({
+                    url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles`,
+                    method: 'POST',
+                    body: {
+                        name: roleName,
+                    },
+                    failOnStatusCode: false,
+                })
+                    .then((resp) => {
+                        expect(resp.status).to.eq(409);
+                    })
+                    .then(() => {
+                        // Clean up the created role
+                        deleteRole(firstRoleUuid);
+                    });
+            });
+        });
+
+        it('should forbid role creation from another organization', () => {
+            cy.anotherLogin();
+            cy.request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles`,
+                method: 'POST',
+                body: {
+                    name: 'Unauthorized Role',
+                },
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(403);
+            });
+        });
+    });
+
+    describe('GET /api/v1/organizations/{orgUuid}/roles', () => {
+        it('should return organization roles without scopes', () => {
+            // Create a role first to test with
+            createRole('Test Role for List').then((createdRoleUuid) => {
+                cy.request({
+                    url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles`,
+                    method: 'GET',
+                }).then((resp) => {
+                    expect(resp.status).to.eq(200);
+                    expect(resp.body).to.have.property('status', 'ok');
+                    expect(resp.body.results).to.be.an('array');
+
+                    // Check that the created role is in the list
+                    const foundRole = resp.body.results.find(
+                        (role: Role) => role.roleUuid === createdRoleUuid,
+                    );
+                    expect(foundRole).to.not.equal(undefined);
+
+                    // Roles list should not include scopes
+                    resp.body.results.forEach((role: Role) => {
+                        expect(role).to.not.have.property('scopes');
+                    });
+
+                    // Clean up
+                    deleteRole(createdRoleUuid);
+                });
+            });
+        });
+
+        it('should not return roles from another organization', () => {
+            // Create a role in org 1
+            createRole('Org1 Role').then((org1RoleUuid) => {
+                cy.anotherLogin();
+                cy.request({
+                    url: `api/v1/organizations/${SEED_ORG_2.organization_uuid}/roles`,
+                    method: 'GET',
+                })
+                    .then((resp) => {
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body.results).to.be.an('array');
+
+                        // Should not contain the role created in SEED_ORG_1
+                        const foundRole = resp.body.results.find(
+                            (role: Role) => role.roleUuid === org1RoleUuid,
+                        );
+                        expect(foundRole).to.equal(undefined);
+                    })
+                    .then(() => {
+                        // Clean up
+                        cy.login();
+                        deleteRole(org1RoleUuid);
+                    });
+            });
+        });
+    });
+
+    describe('GET /api/v1/organizations/{orgUuid}/roles/{roleUuid}', () => {
+        it('should return a specific role with its scopes', () => {
+            createRole('Test Role for Get').then((createdRoleUuid) => {
+                cy.request({
+                    url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${createdRoleUuid}`,
+                    method: 'GET',
+                })
+                    .then((resp) => {
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body).to.have.property('status', 'ok');
+                        expect(resp.body.results).to.have.property(
+                            'roleUuid',
+                            createdRoleUuid,
+                        );
+                        expect(resp.body.results).to.have.property('scopes');
+                        expect(resp.body.results.scopes).to.be.an('array');
+                    })
+                    .then(() => {
+                        deleteRole(createdRoleUuid);
+                    });
+            });
+        });
+
+        it('should return 404 when getting a non-existent role', () => {
+            cy.request({
+                url: `api/v1/organizations/${
+                    SEED_ORG_1.organization_uuid
+                }/roles/${window.crypto.randomUUID()}`,
+                method: 'GET',
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(404);
+            });
+        });
+
+        it('should forbid access to role from another organization', () => {
+            // Create a role in org 1
+            createRole('Org1 Role for Access Test').then((org1RoleUuid) => {
+                cy.anotherLogin();
+                cy.request({
+                    url: `api/v1/organizations/${SEED_ORG_2.organization_uuid}/roles/${org1RoleUuid}`,
+                    method: 'GET',
+                    failOnStatusCode: false,
+                })
+                    .then((resp) => {
+                        expect(resp.status).to.eq(404);
+                    })
+                    .then(() => {
+                        // Clean up
+                        cy.login();
+                        deleteRole(org1RoleUuid);
+                    });
+            });
+        });
+    });
+
+    describe('PATCH /api/v1/organizations/{orgUuid}/roles/{roleUuid}', () => {
+        it('should update role name and description', () => {
+            createRole('Test Role for Update').then((createdRoleUuid) => {
+                const updatedName = `Updated Role ${new Date().getTime()}`;
+                const updatedDescription = 'Updated description';
+
+                cy.request({
+                    url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${createdRoleUuid}`,
+                    method: 'PATCH',
+                    body: {
+                        name: updatedName,
+                        description: updatedDescription,
+                    },
+                })
+                    .then((resp) => {
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body.results).to.have.property(
+                            'name',
+                            updatedName,
+                        );
+                        expect(resp.body.results).to.have.property(
+                            'description',
+                            updatedDescription,
+                        );
+                    })
+                    .then(() => {
+                        deleteRole(createdRoleUuid);
+                    });
+            });
+        });
+
+        it('should update only role description', () => {
+            createRole('Test Role for Description Update').then(
+                (createdRoleUuid) => {
+                    const newDescription = 'Another description update';
+
+                    cy.request({
+                        url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${createdRoleUuid}`,
+                        method: 'PATCH',
+                        body: {
+                            description: newDescription,
+                        },
+                    })
+                        .then((resp) => {
+                            expect(resp.status).to.eq(200);
+                            expect(resp.body.results).to.have.property(
+                                'description',
+                                newDescription,
+                            );
+                        })
+                        .then(() => {
+                            deleteRole(createdRoleUuid);
+                        });
+                },
+            );
+        });
+
+        it('should not allow updating to duplicate name', () => {
+            const duplicateName = `Duplicate Update ${new Date().getTime()}`;
+            let duplicateRoleUuid: string;
+
+            // Create a role with this name
+            cy.request({
+                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles`,
+                method: 'POST',
+                body: {
+                    name: duplicateName,
+                },
+            })
+                .then((createResp) => {
+                    duplicateRoleUuid = createResp.body.results.roleUuid;
+
+                    // Create another role to try to update
+                    return createRole('Role to Update');
+                })
+                .then((roleToUpdateUuid) => {
+                    // Try to update another role to this name
+                    cy.request({
+                        url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${roleToUpdateUuid}`,
+                        method: 'PATCH',
+                        body: {
+                            name: duplicateName,
+                        },
+                        failOnStatusCode: false,
+                    })
+                        .then((resp) => {
+                            expect(resp.status).to.eq(409);
+                        })
+                        .then(() => {
+                            // Clean up both created roles
+                            deleteRole(duplicateRoleUuid);
+                            deleteRole(roleToUpdateUuid);
+                        });
+                });
+        });
+    });
+
+    describe('POST /api/v1/organizations/{orgUuid}/roles/{roleUuid}/scopes', () => {
+        it('should add a scope to a role', () => {
+            // Create a role and get a scope
+            createRole('Test Role for Scope').then((createdRoleUuid) => {
+                getFirstScope().then((scopeUuid) => {
+                    addScopeToRole(createdRoleUuid, scopeUuid).then(() => {
+                        deleteRole(createdRoleUuid);
+                    });
+                });
+            });
+        });
+
+        it('should not allow adding the same scope twice', () => {
+            createRole('Test Role for Duplicate Scope').then(
+                (createdRoleUuid) => {
+                    getFirstScope().then((scopeUuid) => {
+                        // Add scope first time
+                        addScopeToRole(createdRoleUuid, scopeUuid).then(() => {
+                            // Try to add the same scope again
+                            cy.request({
+                                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${createdRoleUuid}/scopes`,
+                                method: 'POST',
+                                body: {
+                                    scopeUuids: [scopeUuid],
+                                },
+                                failOnStatusCode: false,
+                            })
+                                .then((resp) => {
+                                    expect(resp.status).to.eq(409);
+                                })
+                                .then(() => {
+                                    deleteRole(createdRoleUuid);
+                                });
+                        });
+                    });
+                },
+            );
+        });
+
+        it('should return 404 when adding non-existent scope', () => {
+            createRole('Test Role for Invalid Scope').then(
+                (createdRoleUuid) => {
+                    cy.request({
+                        url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${createdRoleUuid}/scopes`,
+                        method: 'POST',
+                        body: {
+                            scopeUuids: [window.crypto.randomUUID()],
+                        },
+                        failOnStatusCode: false,
+                    })
+                        .then((resp) => {
+                            expect(resp.status).to.eq(404);
+                        })
+                        .then(() => {
+                            deleteRole(createdRoleUuid);
+                        });
+                },
+            );
+        });
+    });
+
+    describe('DELETE /api/v1/organizations/{orgUuid}/roles/{roleUuid}/scopes', () => {
+        it('should remove a scope from a role', () => {
+            createRole('Test Role for Scope Removal').then(
+                (createdRoleUuid) => {
+                    getFirstScope().then((scopeUuid) => {
+                        // Add scope first
+                        addScopeToRole(createdRoleUuid, scopeUuid).then(() => {
+                            // Remove the scope using the bulk route
+                            cy.request({
+                                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${createdRoleUuid}/scopes`,
+                                method: 'DELETE',
+                                body: {
+                                    scopeUuids: [scopeUuid],
+                                },
+                            })
+                                .then((resp) => {
+                                    expect(resp.status).to.eq(200);
+                                    expect(resp.body).to.have.property(
+                                        'status',
+                                        'ok',
+                                    );
+                                })
+                                .then(() => {
+                                    deleteRole(createdRoleUuid);
+                                });
+                        });
+                    });
+                },
+            );
+        });
+
+        it('should return 404 when trying to remove non-existent scope assignment', () => {
+            createRole('Test Role for Invalid Scope Removal').then(
+                (createdRoleUuid) => {
+                    getFirstScope().then((scopeUuid) => {
+                        cy.request({
+                            url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${createdRoleUuid}/scopes`,
+                            method: 'DELETE',
+                            body: {
+                                scopeUuids: [scopeUuid],
+                            },
+                            failOnStatusCode: false,
+                        })
+                            .then((resp) => {
+                                expect(resp.status).to.eq(404);
+                            })
+                            .then(() => {
+                                deleteRole(createdRoleUuid);
+                            });
+                    });
+                },
+            );
+        });
+    });
+
+    describe('DELETE /api/v1/organizations/{orgUuid}/roles/{roleUuid}', () => {
+        it('should delete a role with all its scope associations', () => {
+            // Create a role to delete
+            createRole('Role to Delete').then((roleToDeleteUuid) => {
+                getFirstScope().then((scopeUuid) => {
+                    // Add a scope to the role
+                    addScopeToRole(roleToDeleteUuid, scopeUuid).then(() => {
+                        // Delete the role
+                        cy.request({
+                            url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${roleToDeleteUuid}`,
+                            method: 'DELETE',
+                        }).then((resp) => {
+                            expect(resp.status).to.eq(200);
+
+                            // Verify the role is deleted
+                            cy.request({
+                                url: `api/v1/organizations/${SEED_ORG_1.organization_uuid}/roles/${roleToDeleteUuid}`,
+                                method: 'GET',
+                                failOnStatusCode: false,
+                            }).then((getResp) => {
+                                expect(getResp.status).to.eq(404);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should return 404 for deleting a non-existent role', () => {
+            cy.request({
+                url: `api/v1/organizations/${
+                    SEED_ORG_1.organization_uuid
+                }/roles/${window.crypto.randomUUID()}`,
+                method: 'DELETE',
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(404);
+            });
+        });
+
+        it('should forbid deleting role from another organization', () => {
+            // Create a role in org 1
+            createRole('Org1 Role for Delete Test').then((org1RoleUuid) => {
+                // Try to delete from org 2
+                cy.anotherLogin();
+                cy.request({
+                    url: `api/v1/organizations/${SEED_ORG_2.organization_uuid}/roles/${org1RoleUuid}`,
+                    method: 'DELETE',
+                    failOnStatusCode: false,
+                })
+                    .then((resp) => {
+                        expect(resp.status).to.eq(404);
+                    })
+                    .then(() => {
+                        // Clean up the created role
+                        cy.login();
+                        deleteRole(org1RoleUuid);
+                    });
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Added a new RolesController to manage organization roles and permissions through the API. This controller provides endpoints for:

- Creating, updating, and deleting roles
- Listing all available roles in an organization
- Getting details of a specific role with its scopes
- Adding and removing permission scopes from roles
- Listing all available permission scopes

The implementation includes comprehensive e2e tests that verify all endpoints function correctly, including proper authorization checks and error handling.