### PR TITLE
fix: unlock csv file attachment

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -86,11 +86,7 @@ export const getGenerateTableVizConfig = ({
 
                 isOneRow = results.rows.length === 1;
 
-                if (isOneRow) {
-                    return `Here's the result:
-${serializeData(csv, 'csv')}`;
-                }
-
+                // Always send CSV file to Slack if it's a Slack prompt, regardless of row count
                 if (isSlackPrompt(prompt)) {
                     await sendFile({
                         channelId: prompt.slackChannelId,
@@ -101,6 +97,11 @@ ${serializeData(csv, 'csv')}`;
                         filename: 'lightdash-query-results.csv',
                         file: Buffer.from(csv, 'utf8'),
                     });
+                }
+
+                if (isOneRow) {
+                    return `Here's the result:
+                    ${serializeData(csv, 'csv')}`;
                 }
 
                 return `Success.`;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Reordered the logic in `generateTableVizConfig.ts` to ensure CSV files are always sent to Slack when it's a Slack prompt, regardless of row count. Previously, the single row check would return early before the Slack file sending logic could execute.

This fix ensures that Slack users will receive the CSV file attachment for all query results that require a table 

