### PR TITLE
fix: conditionally load Sentry Spotlight in development

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -43,8 +43,10 @@ export default defineConfig(async () => {
                     disable: true,
                 },
             }),
-            spotlight(),
-            spotlightSidecar(),
+            ...(process.env.SENTRY_SPOTLIGHT === '1' &&
+            process.env.NODE_ENV === 'development'
+                ? [spotlight(), spotlightSidecar()]
+                : []),
         ],
         css: {
             transformer: 'lightningcss',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Make Sentry Spotlight optional in development mode by only enabling it when `SENTRY_SPOTLIGHT=1` environment variable is set.
