### PR TITLE
fix: get screenshot on preview and size tab

### DIFF
--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -1,5 +1,6 @@
 import { type ApiError, type Dashboard } from '@lightdash/common';
 import {
+    ActionIcon,
     Box,
     Button,
     Card,
@@ -11,7 +12,11 @@ import {
     Stack,
     Text,
 } from '@mantine/core';
-import { IconEye, IconEyeClosed } from '@tabler/icons-react';
+import {
+    IconArrowsDiagonal,
+    IconEye,
+    IconEyeClosed,
+} from '@tabler/icons-react';
 import { type UseMutationResult } from '@tanstack/react-query';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -89,38 +94,58 @@ export const PreviewAndCustomizeScreenshot: FC<
 
                     <Stack>
                         <Card withBorder p={0}>
-                            <Image
-                                src={currentPreview}
-                                onClick={() => {
-                                    if (currentPreview)
-                                        setIsImageModalOpen(true);
-                                }}
-                                width={350}
-                                height={350}
-                                styles={{
-                                    root: {
-                                        objectPosition: 'top',
-                                        cursor: currentPreview
-                                            ? 'pointer'
-                                            : 'default',
-                                    },
-                                }}
-                                withPlaceholder
-                                placeholder={
-                                    <Flex
-                                        gap="md"
-                                        align="center"
-                                        direction="column"
+                            <Box pos="relative">
+                                <Image
+                                    src={currentPreview}
+                                    onClick={() => {
+                                        if (currentPreview)
+                                            setIsImageModalOpen(true);
+                                    }}
+                                    width={350}
+                                    height={350}
+                                    styles={{
+                                        root: {
+                                            objectPosition: 'top',
+                                            cursor: currentPreview
+                                                ? 'pointer'
+                                                : 'default',
+                                        },
+                                    }}
+                                    withPlaceholder
+                                    placeholder={
+                                        <Flex
+                                            gap="md"
+                                            align="center"
+                                            direction="column"
+                                        >
+                                            <MantineIcon
+                                                icon={IconEyeClosed}
+                                                size={30}
+                                            />
+
+                                            <Text>No preview yet</Text>
+                                        </Flex>
+                                    }
+                                />
+                                {currentPreview && (
+                                    <ActionIcon
+                                        pos="absolute"
+                                        top={5}
+                                        right={5}
+                                        variant="light"
+                                        color="blue"
+                                        size="sm"
+                                        onClick={() => {
+                                            if (currentPreview)
+                                                setIsImageModalOpen(true);
+                                        }}
                                     >
                                         <MantineIcon
-                                            icon={IconEyeClosed}
-                                            size={30}
+                                            icon={IconArrowsDiagonal}
                                         />
-
-                                        <Text>No preview yet</Text>
-                                    </Flex>
-                                }
-                            />
+                                    </ActionIcon>
+                                )}
+                            </Box>
                         </Card>
                         <Button
                             mx="auto"

--- a/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
@@ -28,6 +28,7 @@ export const SchedulerPreview: FC<Props> = ({
     const [previewChoice, setPreviewChoice] = useState<
         typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined
     >(customViewportWidth?.toString() ?? CUSTOM_WIDTH_OPTIONS[1].value);
+    const [currentPreview, setCurrentPreview] = useState<string | undefined>();
     const exportDashboardMutation = useExportDashboard();
 
     const getSchedulerFilterOverridesQueryString = useCallback(() => {
@@ -50,12 +51,15 @@ export const SchedulerPreview: FC<Props> = ({
     }, [dashboard.filters, schedulerFilters]);
 
     const handlePreviewClick = useCallback(async () => {
-        await exportDashboardMutation.mutateAsync({
+        const url = await exportDashboardMutation.mutateAsync({
             dashboard,
             gridWidth: previewChoice ? parseInt(previewChoice) : undefined,
             queryFilters: getSchedulerFilterOverridesQueryString(),
             isPreview: true,
         });
+        if (url) {
+            setCurrentPreview(url);
+        }
     }, [
         dashboard,
         exportDashboardMutation,
@@ -93,6 +97,7 @@ export const SchedulerPreview: FC<Props> = ({
                     });
                 }}
                 onPreviewClick={handlePreviewClick}
+                currentPreview={currentPreview}
             />
         </Stack>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16322

### Description:
Added the ability to display the current preview in the Scheduler Preview component. The component now maintains the current preview URL in its state and passes it to the child components, enabling users to see their scheduled dashboard preview.

## Changes:
- Added state to track the current preview URL
- Updated the preview click handler to store the returned URL
- Passed the current preview URL to child components for display

To test here: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/DJhzIQbRJqTJiKN3mUjT/1316a25e-0aa7-448e-a3ee-c15776f88b38.png)

> [!NOTE]
> Added top right button to show full screen mode. user can still click anywhere on the image to do the same

<img width="800" height="593" alt="Screenshot 2025-08-11 at 11 56 59" src="https://github.com/user-attachments/assets/783ea15e-1b31-4a68-9fb0-0c451e980f45" />
 

