### PR TITLE
fix: allow MCP clients to pass pagination `page` param as a string and coerce to number server-side

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findCharts.ts
+++ b/packages/backend/src/ee/services/ai/tools/findCharts.ts
@@ -47,31 +47,14 @@ const getChartsText = (
 </SearchResult>
 `.trim();
 
-export const toolFindChartsDescription = `Tool: findCharts
-
-Purpose:
-Finds saved charts by name or description within a project, returning detailed info about each.
-
-Usage tips:
-- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns")
-- The search engine understands natural language and context - more words provide better results
-- You can provide multiple search queries to search for different chart topics simultaneously
-- If results aren't relevant, retry with the full user query or more specific terms
-- Results are paginated — use the page parameter to get more results if needed
-- Returns chart URLs when available
-- Charts are ordered by search relevance
-`;
-
 export const getFindCharts = ({
     findCharts,
     pageSize,
     siteUrl,
-}: Dependencies) => {
-    const schema = toolFindChartsArgsSchema;
-
-    return tool({
-        description: toolFindChartsDescription,
-        parameters: schema,
+}: Dependencies) =>
+    tool({
+        description: toolFindChartsArgsSchema.description,
+        parameters: toolFindChartsArgsSchema,
         execute: async (args) => {
             try {
                 const chartSearchQueryResults = await Promise.all(
@@ -102,4 +85,3 @@ export const getFindCharts = ({
             }
         },
     });
-};

--- a/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
@@ -28,7 +28,8 @@ const toolSchemaBuilder = <$Schema extends z.ZodRawShape>(
     withPagination: () =>
         toolSchemaBuilder(
             schema.extend({
-                page: z
+                // We need to coerce because LLMs were passing strings instead of numbers quite often (via MCP)
+                page: z.coerce
                     .number()
                     .positive()
                     .nullable()

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindChartsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindChartsArgs.ts
@@ -1,22 +1,36 @@
 import { z } from 'zod';
+import { createToolSchema } from '../toolSchemaBuilder';
 
-export const toolFindChartsArgsSchema = z.object({
-    type: z.literal('find_charts'),
-    chartSearchQueries: z.array(
-        z.object({
-            label: z
-                .string()
-                .describe(
-                    'Full search query from the user (e.g., "revenue based on campaigns" not just "campaigns"). Include full context for better results.',
-                ),
-        }),
-    ),
-    page: z
-        .number()
-        .positive()
-        .nullable()
-        .describe('Use this to paginate through the results'),
-});
+export const TOOL_FIND_CHARTS_DESCRIPTION = `Tool: "findCharts"
+Purpose:
+Finds charts by name or description within a project, returning detailed info about each.
+
+Usage tips:
+- IMPORTANT: Pass the user's full query or relevant portion directly (e.g., "revenue based on campaigns" instead of just "campaigns")
+- The search engine understands natural language and context - more words provide better results
+- You can provide multiple search queries to search for different chart topics simultaneously
+- If results aren't relevant, retry with the full user query or more specific terms
+- Results are paginated — use the page parameter to get more results if needed
+- Returns chart URLs when available
+`;
+
+export const toolFindChartsArgsSchema = createToolSchema(
+    'find_charts',
+    TOOL_FIND_CHARTS_DESCRIPTION,
+)
+    .extend({
+        chartSearchQueries: z.array(
+            z.object({
+                label: z
+                    .string()
+                    .describe(
+                        'Full search query from the user (e.g., "revenue based on campaigns" not just "campaigns"). Include full context for better results.',
+                    ),
+            }),
+        ),
+    })
+    .withPagination()
+    .build();
 
 export type ToolFindChartsArgs = z.infer<typeof toolFindChartsArgsSchema>;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

- Added coercion to the page parameter to handle LLMs passing strings instead of numbers
- Refactored the findCharts AI tool to use a more consistent schema pattern


Inconsistent tool calls will success now due to auto string-to-number coercion:

![CleanShot 2025-08-11 at 16.37.24@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/18607551-05c8-4398-9a1d-e1d6f19991e8.png)

