### PR TITLE
fix: add frontend SDK to release process

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -31,6 +31,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
             - name: Semantic Release
+              # Config is on release.config.js
               id: semantic
               uses: cycjimmy/semantic-release-action@v4
               env:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "private": true,
     "workspaces": [
-        "packages/*"
+        "packages/*",
+        "packages/frontend/sdk"
     ],
     "resolutions": {
         "react-is": "19.0.0",
@@ -112,8 +113,8 @@
         "test": "pnpm -r --stream --sequential -F common -F warehouses -F backend -F frontend -F e2e -F cli test",
         "dev": "pnpm -r --stream --parallel -F common -F warehouses -F backend -F frontend run dev",
         "build": "pnpm -r --stream --sequential -F common -F warehouses -F backend -F frontend build",
-        "build-published-packages": "pnpm -r --stream --sequential -F common -F warehouses -F cli build",
-        "release-packages": "pnpm -r --stream --sequential -F common -F warehouses -F cli release",
+        "build-published-packages": "pnpm -r --stream --sequential -F common -F warehouses -F cli build && pnpm frontend-build-sdk",
+        "release-packages": "pnpm -r --stream --sequential -F common -F warehouses -F cli -F frontend release",
         "start": "pnpm run backend-start",
         "prepare": "husky || true",
         "load:env": "dotenv -c -e .env.development.local",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,8 @@
         "fix-format": "pnpm run formatter ./src --write",
         "unused-exports": "ts-unused-exports ./tsconfig.json --allowUnusedEnums --allowUnusedTypes --showLineNumber --ignoreFiles='build/.*' --ignoreFiles='sdk/dist/.*' --ignoreFiles='.*/__mocks__/.*' --ignoreFiles='src/stories/.*'",
         "storybook": "storybook dev -p 6006 --no-open",
-        "build-storybook": "storybook build"
+        "build-storybook": "storybook build",
+        "release": "(cd sdk && pnpm publish --no-git-checks)"
     },
     "dependencies": {
         "@casl/ability": "^5.4.4",

--- a/release.config.js
+++ b/release.config.js
@@ -48,6 +48,7 @@ module.exports = {
                     'packages/e2e/package.json',
                     'packages/frontend/package.json',
                     'packages/warehouses/package.json',
+                    'packages/frontend/sdk/package.json',
                 ],
                 message:
                     'chore(release): ${nextRelease.version} \n\n${nextRelease.notes}',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

<img width="803" height="426" alt="image" src="https://github.com/user-attachments/assets/84702bf2-6f51-4752-b3bf-71e10cb836a9" />

<img width="850" height="64" alt="image" src="https://github.com/user-attachments/assets/87fbbc80-cd57-4799-bd9e-eb0a4ffdbbd4" />

Tested semantic release in Alpha branch https://github.com/lightdash/lightdash/pull/16358

### Description:
Add frontend SDK to the release process by including it in the build and release scripts. The changes include:

1. Adding a comment in the release workflow to indicate that configuration is in release.config.js
2. Updating the build-published-packages script to also build the frontend SDK
3. Adding the frontend package to the release-packages script
4. Creating a release script in the frontend package.json for SDK publishing
5. Including the frontend SDK package.json in the release configuration

These changes ensure that the frontend SDK is properly built and published as part of the release process.