### PR TITLE
fix: remove escape of #... in databricks and bigquery

### DIFF
--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -67,4 +67,37 @@ describe('BigquerySqlBuilder escaping', () => {
         );
         expect(anotherEscaped).toBe("\\' OR \\'1\\'=\\'1");
     });
+
+    test('Should NOT remove # comments from strings', () => {
+        // Test that # symbols are preserved in strings (not treated as comments)
+        const stringWithHash = 'Column name with # symbol';
+        const escaped = bigquerySqlBuilder.escapeString(stringWithHash);
+        expect(escaped).toBe('Column name with # symbol');
+
+        // Test that # at start of line is preserved
+        const hashAtStart = '#important-tag';
+        const escapedHashStart = bigquerySqlBuilder.escapeString(hashAtStart);
+        expect(escapedHashStart).toBe('#important-tag');
+
+        // Test multiple # symbols are preserved
+        const multipleHashes = 'value1#value2#value3';
+        const escapedMultiple = bigquerySqlBuilder.escapeString(multipleHashes);
+        expect(escapedMultiple).toBe('value1#value2#value3');
+    });
+
+    test('Should still remove -- and /* */ comments', () => {
+        // Test that -- comments are still removed
+        const stringWithDashComment = 'test value -- this is a comment';
+        const escapedDash = bigquerySqlBuilder.escapeString(
+            stringWithDashComment,
+        );
+        expect(escapedDash).toBe('test value ');
+
+        // Test that /* */ comments are still removed
+        const stringWithBlockComment = 'test /* block comment */ value';
+        const escapedBlock = bigquerySqlBuilder.escapeString(
+            stringWithBlockComment,
+        );
+        expect(escapedBlock).toBe('test  value');
+    });
 });

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -166,10 +166,9 @@ export class BigquerySqlBuilder extends WarehouseBaseSqlBuilder {
                 .replaceAll('\\', '\\\\')
                 .replaceAll("'", "\\'")
                 .replaceAll('"', '\\"')
-                // Remove SQL comments (BigQuery supports --, /* */, and # comments)
+                // Remove SQL comments (BigQuery supports --, /* */ comments)
                 .replace(/--.*$/gm, '')
                 .replace(/\/\*[\s\S]*?\*\//g, '')
-                .replace(/#.*$/gm, '') // BigQuery also supports # comments
                 // Remove null bytes
                 .replaceAll('\0', '')
         );

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -1,4 +1,7 @@
-import { DatabricksWarehouseClient } from './DatabricksWarehouseClient';
+import {
+    DatabricksSqlBuilder,
+    DatabricksWarehouseClient,
+} from './DatabricksWarehouseClient';
 import { credentials, rows, schema } from './DatabricksWarehouseClient.mock';
 import { expectedFields } from './WarehouseClient.mock';
 
@@ -28,5 +31,63 @@ describe('DatabricksWarehouseClient', () => {
 
         expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(rows[0]);
+    });
+});
+
+describe('DatabricksSqlBuilder escaping', () => {
+    const databricksSqlBuilder = new DatabricksSqlBuilder();
+
+    test('Should escape backslashes and quotes in Databricks', () => {
+        expect(databricksSqlBuilder.escapeString("\\') OR (1=1) --")).toBe(
+            "\\\\\\') OR (1=1) ",
+        );
+    });
+
+    test('Should handle SQL injection attempts', () => {
+        // Test with a typical SQL injection pattern
+        const maliciousInput = "'; DROP TABLE users; --";
+        const escaped = databricksSqlBuilder.escapeString(maliciousInput);
+        expect(escaped).toBe("\\'; DROP TABLE users; ");
+
+        // Test with another common SQL injection pattern
+        const anotherMaliciousInput = "' OR '1'='1";
+        const anotherEscaped = databricksSqlBuilder.escapeString(
+            anotherMaliciousInput,
+        );
+        expect(anotherEscaped).toBe("\\' OR \\'1\\'=\\'1");
+    });
+
+    test('Should NOT remove # comments from strings', () => {
+        // Test that # symbols are preserved in strings (not treated as comments)
+        const stringWithHash = 'Column name with # symbol';
+        const escaped = databricksSqlBuilder.escapeString(stringWithHash);
+        expect(escaped).toBe('Column name with # symbol');
+
+        // Test that # at start of line is preserved
+        const hashAtStart = '#important-tag';
+        const escapedHashStart = databricksSqlBuilder.escapeString(hashAtStart);
+        expect(escapedHashStart).toBe('#important-tag');
+
+        // Test multiple # symbols are preserved
+        const multipleHashes = 'value1#value2#value3';
+        const escapedMultiple =
+            databricksSqlBuilder.escapeString(multipleHashes);
+        expect(escapedMultiple).toBe('value1#value2#value3');
+    });
+
+    test('Should still remove -- and /* */ comments', () => {
+        // Test that -- comments are still removed
+        const stringWithDashComment = 'test value -- this is a comment';
+        const escapedDash = databricksSqlBuilder.escapeString(
+            stringWithDashComment,
+        );
+        expect(escapedDash).toBe('test value ');
+
+        // Test that /* */ comments are still removed
+        const stringWithBlockComment = 'test /* block comment */ value';
+        const escapedBlock = databricksSqlBuilder.escapeString(
+            stringWithBlockComment,
+        );
+        expect(escapedBlock).toBe('test  value');
     });
 });

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -203,10 +203,9 @@ export class DatabricksSqlBuilder extends WarehouseBaseSqlBuilder {
                 .replaceAll('\\', '\\\\')
                 .replaceAll("'", "\\'")
                 .replaceAll('"', '\\"')
-                // Remove SQL comments (Spark SQL supports --, /* */, and # comments)
+                // Remove SQL comments (Spark SQL supports --, /* */ comments)
                 .replace(/--.*$/gm, '')
                 .replace(/\/\*[\s\S]*?\*\//g, '')
-                .replace(/#.*$/gm, '') // Spark SQL also supports # comments
                 // Remove null bytes
                 .replaceAll('\0', '')
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16257
Closes: #16362

### Description:

BigQuery and Databricks SQL builders were incorrectly treating `#` symbols in string values as SQL comments and removing them. This caused issues when column names or data values legitimately contained `#` characters (e.g., hashtags, identifiers, etc.).

test-cli
test-backend
test-frontend