### PR TITLE
feat: enable CORS for OAuth discovery endpoints

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -594,6 +594,17 @@ export default class App {
             ),
         );
 
+        // Always allow CORS for .well-known routes (required for OAuth discovery)
+        expressApp.use(
+            '/.well-known/*',
+            cors({
+                methods: 'OPTIONS, GET, HEAD',
+                allowedHeaders: '*',
+                credentials: false,
+                origin: true, // Allow all origins for .well-known endpoints
+            }),
+        );
+
         // Root-level .well-known endpoints for OAuth discovery (required by many MCP clients)
         // Use the same handlers as the API-level endpoints to ensure consistency
         expressApp.get(

--- a/packages/backend/src/routers/oauthRouter.ts
+++ b/packages/backend/src/routers/oauthRouter.ts
@@ -6,6 +6,7 @@ import {
     OAuthIntrospectResponse,
 } from '@lightdash/common';
 import OAuth2Server from '@node-oauth/oauth2-server';
+import cors from 'cors';
 import express from 'express';
 import Logger from '../logging/logger';
 import { DEFAULT_OAUTH_CLIENT_ID } from '../models/OAuth2Model';
@@ -15,6 +16,17 @@ import {
 } from '../services/OAuthService/OAuthService';
 
 const oauthRouter = express.Router({ mergeParams: true });
+
+// Always allow CORS for .well-known routes (required for OAuth discovery)
+oauthRouter.use(
+    '/.well-known/*',
+    cors({
+        methods: 'OPTIONS, GET, HEAD',
+        allowedHeaders: '*',
+        credentials: false,
+        origin: true, // Allow all origins for .well-known endpoints
+    }),
+);
 
 // Get OAuth service from request
 function getOAuthService(req: express.Request): OAuthService {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added CORS support for OAuth discovery endpoints by configuring the `/.well-known/*` routes to allow cross-origin requests. This enables proper OAuth discovery functionality by allowing all origins to access these endpoints with GET, HEAD, and OPTIONS methods.


This will allow MCP inspector to work:

![CleanShot 2025-08-12 at 17.00.34@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/SRLEqMEevAzoFwvhnfeq/b0563764-5933-4a1c-9198-ee484aed8503.png)

