### PR TITLE
feat: add explore access summary for AI agents

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1,4 +1,5 @@
 import {
+    ApiAiAgentExploreAccessSummaryResponse,
     ApiAiAgentResponse,
     ApiAiAgentSummaryResponse,
     ApiAiAgentThreadCreateRequest,
@@ -464,6 +465,27 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/explore-access-summary')
+    @OperationId('getAgentExploreAccessSummary')
+    async getAgentExploreAccessSummary(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: { tags: string[] | null },
+    ): Promise<ApiAiAgentExploreAccessSummaryResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentService().getAgentExploreAccessSummary(
+                    req.account!,
+                    projectUuid,
+                    body.tags,
+                ),
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -2921,4 +2921,48 @@ export class AiAgentService {
 
         return undefined;
     }
+
+    public async getAgentExploreAccessSummary(
+        account: Account,
+        projectUuid: string,
+        tags: string[] | null,
+    ) {
+        const exploreSummaries =
+            await this.projectService.getAllExploresSummary(
+                account,
+                projectUuid,
+                false,
+            );
+
+        const allExplores = await Promise.all(
+            exploreSummaries.map((explore) =>
+                this.projectService.getExplore(
+                    account,
+                    projectUuid,
+                    explore.name,
+                ),
+            ),
+        );
+
+        const filteredExplores = allExplores
+            .map((explore) =>
+                filterExploreByTags({ availableTags: tags, explore }),
+            )
+            .filter((explore) => explore !== undefined);
+
+        const exploreAccessSummary = filteredExplores.map((explore) => ({
+            exploreName: explore.label,
+            joinedTables: explore.joinedTables.map(
+                (table) => explore.tables[table.table].label,
+            ),
+            dimensions: Object.values(
+                explore.tables[explore.baseTable].dimensions,
+            ).map((dimension) => dimension.label),
+            metrics: Object.values(
+                explore.tables[explore.baseTable].metrics,
+            ).map((metric) => metric.label),
+        }));
+
+        return exploreAccessSummary;
+    }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5547,6 +5547,54 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentExploreAccessSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                exploreName: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiAgentExploreAccessSummary-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentExploreAccessSummary',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentExploreAccessSummaryResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiAgentExploreAccessSummary-Array_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiJobScheduledResponse: {
         dataType: 'refAlias',
         type: {
@@ -12161,7 +12209,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12171,7 +12219,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12181,7 +12229,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -12194,7 +12242,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -16044,6 +16092,7 @@ const models: TsoaRoute.Models = {
             'calculateSubtotal',
             'embed',
             'ai',
+            'mcp',
             'api',
             'cli',
             'metricsExplorer',
@@ -20943,6 +20992,82 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updatePromptFeedback',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getAgentExploreAccessSummary: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                tags: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/explore-access-summary',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getAgentExploreAccessSummary,
+        ),
+
+        async function AiAgentController_getAgentExploreAccessSummary(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getAgentExploreAccessSummary,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAgentExploreAccessSummary',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6169,6 +6169,47 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "AiAgentExploreAccessSummary": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "exploreName": {
+                        "type": "string"
+                    }
+                },
+                "required": ["metrics", "dimensions", "exploreName"],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentExploreAccessSummary-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentExploreAccessSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentExploreAccessSummaryResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentExploreAccessSummary-Array_"
+            },
             "ApiJobScheduledResponse": {
                 "properties": {
                     "results": {
@@ -12973,22 +13014,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -16905,6 +16946,7 @@
                     "calculateSubtotal",
                     "embed",
                     "ai",
+                    "mcp",
                     "api",
                     "cli",
                     "metricsExplorer"
@@ -18223,7 +18265,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1897.1",
+        "version": "0.1901.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -272,3 +272,14 @@ export type AiAgentToolCall = {
     toolName: string; // ToolName zod enum
     toolArgs: object;
 };
+
+export type AiAgentExploreAccessSummary = {
+    exploreName: string;
+    joinedTables: string[];
+    dimensions: string[];
+    metrics: string[];
+};
+
+export type ApiAiAgentExploreAccessSummaryResponse = ApiSuccess<
+    AiAgentExploreAccessSummary[]
+>;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useUserAgentPreferences.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useUserAgentPreferences.ts
@@ -1,4 +1,5 @@
 import {
+    type ApiAiAgentExploreAccessSummaryResponse,
     type ApiError,
     type ApiGetUserAgentPreferencesResponse,
     type ApiSuccessEmpty,
@@ -148,5 +149,33 @@ export const useDeleteUserAgentPreferences = (projectUuid: string) => {
                 apiError: error,
             });
         },
+    });
+};
+
+const getAgentExploreAccessSummary = (
+    projectUuid: string,
+    payload: { tags: string[] | null },
+) =>
+    lightdashApi<ApiAiAgentExploreAccessSummaryResponse['results']>({
+        url: `/projects/${projectUuid}/aiAgents/explore-access-summary`,
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+
+export const useGetAgentExploreAccessSummary = (
+    projectUuid: string,
+    payload: { tags: string[] | null },
+) => {
+    return useQuery<
+        ApiAiAgentExploreAccessSummaryResponse['results'],
+        ApiError
+    >({
+        queryKey: [
+            USER_AGENT_PREFERENCES,
+            projectUuid,
+            'exploreAccessSummary',
+            payload.tags,
+        ],
+        queryFn: () => getAgentExploreAccessSummary(projectUuid, payload),
     });
 };

--- a/packages/frontend/src/ee/pages/AiAgents/AiExploreAccessTree.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiExploreAccessTree.tsx
@@ -1,0 +1,99 @@
+import { type AiAgentExploreAccessSummary } from '@lightdash/common';
+import { Group, Stack, Text, Tree, type TreeNodeData } from '@mantine-8/core';
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+const convertToTree = (exploreAccessSummary: AiAgentExploreAccessSummary[]) => {
+    return exploreAccessSummary.map<TreeNodeData>((e) => ({
+        label: e.exploreName,
+        value: e.exploreName,
+        nodeProps: { uuid: e.exploreName, joinedTables: e.joinedTables },
+        children: [
+            {
+                label: 'Dimensions',
+                value: `${e.exploreName}.dimensions`,
+                nodeProps: { uuid: `${e.exploreName}.dimensions` },
+                children: e.dimensions.map<TreeNodeData>((d) => ({
+                    label: d,
+                    value: `${e.exploreName}.dimensions.${d}`,
+                    nodeProps: { uuid: `${e.exploreName}.dimensions.${d}` },
+                })),
+            },
+            {
+                label: 'Metrics',
+                value: `${e.exploreName}.metrics`,
+                nodeProps: { uuid: `${e.exploreName}.metrics` },
+                children: e.metrics.map<TreeNodeData>((m) => ({
+                    label: m,
+                    value: `${e.exploreName}.metrics.${m}`,
+                    nodeProps: { uuid: `${e.exploreName}.metrics.${m}` },
+                })),
+            },
+        ],
+    }));
+};
+
+type Props = {
+    exploreAccessSummary: AiAgentExploreAccessSummary[];
+};
+
+const AiExploreAccessTree: FC<Props> = ({ exploreAccessSummary }) => {
+    return (
+        <Tree
+            data={convertToTree(exploreAccessSummary)}
+            renderNode={({
+                node,
+                expanded,
+                hasChildren,
+                level,
+                elementProps,
+            }) => (
+                <Stack gap="two">
+                    <Group gap="xxs" {...elementProps}>
+                        {level === 1 || level === 2 ? (
+                            <MantineIcon
+                                color={hasChildren ? 'gray.9' : 'gray.5'}
+                                icon={
+                                    expanded
+                                        ? IconChevronDown
+                                        : IconChevronRight
+                                }
+                                size="sm"
+                            />
+                        ) : null}
+
+                        <Text
+                            size="sm"
+                            fw={level === 1 ? 600 : level === 2 ? 500 : 400}
+                        >
+                            {node.label}{' '}
+                            {level === 1 &&
+                                `(${
+                                    node.children
+                                        ?.flatMap(
+                                            (c) => c.children?.length ?? 0,
+                                        )
+                                        .reduce((a, b) => a + b, 0) ?? 0
+                                })`}
+                            {level === 2 && `(${node.children?.length ?? 0})`}
+                        </Text>
+                    </Group>
+                    {expanded &&
+                    level === 1 &&
+                    node.nodeProps?.joinedTables &&
+                    node.nodeProps?.joinedTables.length > 0 ? (
+                        <Text size="xs" c="dimmed" pl="sm">
+                            Joins{' '}
+                            <Text span fw={500}>
+                                {node.nodeProps?.joinedTables.join(', ')}
+                            </Text>
+                        </Text>
+                    ) : null}
+                </Stack>
+            )}
+        />
+    );
+};
+
+export default AiExploreAccessTree;

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -12,7 +12,9 @@ import {
     Badge,
     Box,
     Button,
+    Card,
     Code,
+    Collapse,
     Container,
     Group,
     HoverCard,
@@ -30,6 +32,7 @@ import {
     type ComboboxItem,
     type ComboboxLikeRenderOptionInput,
 } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import { useForm, zodResolver } from '@mantine/form';
 import {
     IconAdjustmentsAlt,
@@ -69,6 +72,8 @@ import {
     useProjectCreateAiAgentMutation,
     useProjectUpdateAiAgentMutation,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { useGetAgentExploreAccessSummary } from '../../features/aiCopilot/hooks/useUserAgentPreferences';
+import AiExploreAccessTree from './AiExploreAccessTree';
 
 const formSchema: z.ZodType<
     Pick<
@@ -313,6 +318,16 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [agent, isCreateMode]);
 
+    const [isExploreAccessSummaryOpen, { toggle: toggleExploreAccessSummary }] =
+        useDisclosure(false);
+
+    const exploreAccessSummaryQuery = useGetAgentExploreAccessSummary(
+        projectUuid!,
+        {
+            tags: form.values.tags,
+        },
+    );
+
     const slackChannelsConfigured = useMemo(
         () =>
             form.values.integrations.some(
@@ -525,62 +540,123 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                 );
                                             }}
                                         />
-                                        <TagsInput
-                                            variant="subtle"
-                                            label={
-                                                <Group gap="xs">
-                                                    <Text fz="sm" fw={500}>
-                                                        Tags
-                                                    </Text>
-                                                    <HoverCard
-                                                        position="right"
-                                                        withArrow
-                                                    >
-                                                        <HoverCard.Target>
-                                                            <MantineIcon
-                                                                icon={
-                                                                    IconInfoCircle
-                                                                }
-                                                            />
-                                                        </HoverCard.Target>
-                                                        <HoverCard.Dropdown maw="250px">
-                                                            <Text fz="xs">
-                                                                Add tags to
-                                                                control which
-                                                                metrics and
-                                                                dimensions your
-                                                                AI agent can
-                                                                access. See more
-                                                                in our{' '}
+
+                                        <Box>
+                                            <TagsInput
+                                                variant="subtle"
+                                                label={
+                                                    <Group gap="xs">
+                                                        <Text fz="sm" fw={500}>
+                                                            Tags
+                                                        </Text>
+                                                        <HoverCard
+                                                            position="right"
+                                                            withArrow
+                                                        >
+                                                            <HoverCard.Target>
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconInfoCircle
+                                                                    }
+                                                                />
+                                                            </HoverCard.Target>
+                                                            <HoverCard.Dropdown maw="250px">
+                                                                <Text fz="xs">
+                                                                    Add tags to
+                                                                    control
+                                                                    which
+                                                                    metrics and
+                                                                    dimensions
+                                                                    your AI
+                                                                    agent can
+                                                                    access. See
+                                                                    more in our{' '}
+                                                                    <Anchor
+                                                                        fz="xs"
+                                                                        c="dimmed"
+                                                                        underline="always"
+                                                                        href="https://docs.lightdash.com/guides/ai-agents#limiting-access-to-specific-explores-and-fields"
+                                                                        target="_blank"
+                                                                    >
+                                                                        docs
+                                                                    </Anchor>
+                                                                </Text>
+                                                            </HoverCard.Dropdown>
+                                                        </HoverCard>
+                                                    </Group>
+                                                }
+                                                placeholder="Select tags"
+                                                inputWrapperOrder={[
+                                                    'label',
+                                                    'input',
+                                                    'description',
+                                                ]}
+                                                description={
+                                                    exploreAccessSummaryQuery.isSuccess ? (
+                                                        exploreAccessSummaryQuery
+                                                            .data.length ===
+                                                        0 ? (
+                                                            'No explorers are available for this tag selection. Make sure to use the correct tags, or tag the project with the correct tags and redeploy the project.'
+                                                        ) : (
+                                                            <>
+                                                                {
+                                                                    exploreAccessSummaryQuery
+                                                                        .data
+                                                                        .length
+                                                                }{' '}
+                                                                explores will be
+                                                                available to
+                                                                this agent.{' '}
                                                                 <Anchor
-                                                                    fz="xs"
-                                                                    c="dimmed"
-                                                                    underline="always"
-                                                                    href="https://docs.lightdash.com/guides/ai-agents#limiting-access-to-specific-explores-and-fields"
-                                                                    target="_blank"
+                                                                    size="xs"
+                                                                    onClick={
+                                                                        toggleExploreAccessSummary
+                                                                    }
                                                                 >
-                                                                    docs
-                                                                </Anchor>
-                                                            </Text>
-                                                        </HoverCard.Dropdown>
-                                                    </HoverCard>
-                                                </Group>
-                                            }
-                                            placeholder="Select tags"
-                                            {...form.getInputProps('tags')}
-                                            value={
-                                                form.getInputProps('tags')
-                                                    .value ?? []
-                                            }
-                                            onChange={(value) => {
-                                                form.setFieldValue(
-                                                    'tags',
-                                                    value.length > 0
-                                                        ? value
-                                                        : null,
-                                                );
-                                            }}
-                                        />
+                                                                    Click here
+                                                                </Anchor>{' '}
+                                                                to see detailed
+                                                                list with
+                                                                metrics and
+                                                                dimensions.
+                                                            </>
+                                                        )
+                                                    ) : (
+                                                        `Loading AI access information...`
+                                                    )
+                                                }
+                                                {...form.getInputProps('tags')}
+                                                value={
+                                                    form.getInputProps('tags')
+                                                        .value ?? []
+                                                }
+                                                onChange={(value) => {
+                                                    form.setFieldValue(
+                                                        'tags',
+                                                        value.length > 0
+                                                            ? value
+                                                            : null,
+                                                    );
+                                                }}
+                                            />
+
+                                            {exploreAccessSummaryQuery.isSuccess ? (
+                                                <Collapse
+                                                    mt="xs"
+                                                    in={
+                                                        isExploreAccessSummaryOpen
+                                                    }
+                                                >
+                                                    <Card>
+                                                        <AiExploreAccessTree
+                                                            exploreAccessSummary={
+                                                                exploreAccessSummaryQuery.data
+                                                            }
+                                                        />
+                                                    </Card>
+                                                </Collapse>
+                                            ) : null}
+                                        </Box>
 
                                         <MultiSelect
                                             variant="subtle"


### PR DESCRIPTION
Closes: #16314

### Description:
This PR adds a new endpoint and UI for AI agents to view explore access summaries. It allows users to see which explores, dimensions, and metrics an AI agent can access based on selected tags.

The changes include:
- New API endpoint `/explore-access-summary` to retrieve explore access information
- New React component `AiExploreAccessTree` to display the explore data in a tree view
- Integration with the agent edit page to show available explores based on selected tags
- Collapsible UI to show detailed metrics and dimensions for each explore

![AI Agent Explore Access Summary](https://user-images.githubusercontent.com/12345678/example-image.png)