### PR TITLE
chore: bump sdk version

### DIFF
--- a/packages/frontend/sdk/package.json
+++ b/packages/frontend/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/sdk",
-    "version": "0.1855.1",
+    "version": "0.1903.0",
     "private": false,
     "files": [
         "dist"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Bumps the version of `@lightdash/sdk` from 0.1855.1 to 0.1903.0.