### PR TITLE
fix: catch error in sql formatter

### DIFF
--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -50,7 +50,7 @@ export const RenderedSql = () => {
                 language: getLanguage(project?.warehouseConnection?.type),
             });
         } catch (e) {
-            console.error(e);
+            console.error('Error rendering SQL:', e.message || 'Unknown error occurred');
             return data.query;
         }
     }, [data?.query, project?.warehouseConnection?.type]);

--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -43,6 +43,18 @@ export const RenderedSql = () => {
         [language],
     );
 
+    const formattedSql = useMemo(() => {
+        if (!data?.query) return '';
+        try {
+            return format(data.query, {
+                language: getLanguage(project?.warehouseConnection?.type),
+            });
+        } catch (e) {
+            console.error(e);
+            return data.query;
+        }
+    }, [data?.query, project?.warehouseConnection?.type]);
+
     if (isInitialLoading) {
         return (
             <Stack my="xs" align="center">
@@ -94,9 +106,7 @@ export const RenderedSql = () => {
             loading={<Loader color="gray" size="xs" />}
             language={language}
             beforeMount={beforeMount}
-            value={format(data?.query || '', {
-                language: getLanguage(project?.warehouseConnection?.type),
-            })}
+            value={formattedSql}
             options={MONACO_READ_ONLY}
             theme="lightdash"
         />

--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -50,7 +50,10 @@ export const RenderedSql = () => {
                 language: getLanguage(project?.warehouseConnection?.type),
             });
         } catch (e) {
-            console.error('Error rendering SQL:', e.message || 'Unknown error occurred');
+            console.error(
+                'Error rendering SQL:',
+                e instanceof Error ? e.message : 'Unknown error occurred',
+            );
             return data.query;
         }
     }, [data?.query, project?.warehouseConnection?.type]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16371 

### Description:

Formatting fails with invalid (not normal) SQL. One way to cause this is to have a Parameter in your query. We are also seeing it in user reports. This just catches the error on formatting and returns the original error. 

To test
- Select Subscriptions model
- Select 'Filtered Subscriptions'
- Open SQL card
- On main it will error

<img width="588" height="231" alt="Screenshot 2025-08-13 at 07 59 58" src="https://github.com/user-attachments/assets/2b372dc4-55ba-46ad-97e8-a657efbcc81f" />
