### PR TITLE
chore: migrate explore header buttons to mantine 8

### DIFF
--- a/packages/common/src/types/timezone.ts
+++ b/packages/common/src/types/timezone.ts
@@ -28,3 +28,6 @@ export enum TimeZone {
     'Pacific/Apia' = 'Pacific/Apia',
     'Pacific/Kiritimati' = 'Pacific/Kiritimati',
 }
+
+export const isTimeZone = (timezone: string): timezone is TimeZone =>
+    Object.values(TimeZone).includes(timezone as TimeZone);

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -478,9 +478,7 @@ describe('Date tests', () => {
 
         // Change date operator
         cy.get('[role="combobox"]').find('input[value="is"]').click();
-        cy.get('[role="listbox"]')
-            .findByRole('option', { name: 'is not' })
-            .click();
+        cy.findByRole('option', { name: 'is not' }).click();
         cy.get('[role="combobox"]')
             .find('input[value="is"]')
             .should('not.exist');

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -1,10 +1,11 @@
 import { getItemId, getMetrics } from '@lightdash/common';
-import { Button, Tooltip } from '@mantine/core';
+import { Button, MantineProvider, Tooltip } from '@mantine-8/core';
 import { IconDeviceFloppy } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useExplore } from '../../../hooks/useExplore';
 import { useAddVersionMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
+import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import MantineIcon from '../../common/MantineIcon';
 import ChartCreateModal from '../../common/modal/ChartCreateModal';
@@ -59,7 +60,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
     };
 
     return (
-        <>
+        <MantineProvider theme={getMantine8ThemeOverride()}>
             <Tooltip
                 label={
                     'A custom metric ID matches an existing table metric. Rename it to avoid conflicts.'
@@ -76,7 +77,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
                     color={isExplorer ? 'blue' : 'green.7'}
                     size="xs"
                     loading={update.isLoading}
-                    leftIcon={
+                    leftSection={
                         isExplorer ? (
                             <MantineIcon icon={IconDeviceFloppy} />
                         ) : undefined
@@ -84,7 +85,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
                     {...(isDisabled && {
                         'data-disabled': true,
                     })}
-                    sx={{
+                    style={{
                         '&[data-disabled="true"]': {
                             pointerEvents: 'all',
                         },
@@ -104,7 +105,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
                     defaultSpaceUuid={spaceUuid ?? undefined}
                 />
             )}
-        </>
+        </MantineProvider>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -1,11 +1,10 @@
 import { getItemId, getMetrics } from '@lightdash/common';
-import { Button, MantineProvider, Tooltip } from '@mantine-8/core';
+import { Button, Tooltip } from '@mantine-8/core';
 import { IconDeviceFloppy } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useExplore } from '../../../hooks/useExplore';
 import { useAddVersionMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import MantineIcon from '../../common/MantineIcon';
 import ChartCreateModal from '../../common/modal/ChartCreateModal';
@@ -60,7 +59,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
     };
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
+        <>
             <Tooltip
                 label={
                     'A custom metric ID matches an existing table metric. Rename it to avoid conflicts.'
@@ -105,7 +104,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
                     defaultSpaceUuid={spaceUuid ?? undefined}
                 />
             )}
-        </MantineProvider>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -5,16 +5,18 @@ import {
     Box,
     Button,
     Group,
+    MantineProvider,
     Popover,
     Text,
     Tooltip,
     type ButtonProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconRefresh } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useProject } from '../../hooks/useProject';
 import { useRefreshServer } from '../../hooks/useRefreshServer';
+import { getMantine8ThemeOverride } from '../../mantine8Theme';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
 import useTracking from '../../providers/Tracking/useTracking';
@@ -23,7 +25,7 @@ import MantineIcon from '../common/MantineIcon';
 
 const RefreshDbtButton: FC<{
     onClick?: () => void;
-    buttonStyles?: ButtonProps['sx'];
+    buttonStyles?: ButtonProps['style'];
     leftIcon?: React.ReactNode;
     defaultTextOverride?: React.ReactNode;
     refreshingTextOverride?: React.ReactNode;
@@ -74,65 +76,67 @@ const RefreshDbtButton: FC<{
             return null;
         }
         return (
-            <Popover withinPortal withArrow width={300}>
-                <Popover.Target>
-                    <Box
-                        sx={{
-                            cursor: 'pointer',
-                        }}
-                    >
-                        <Button
-                            size="xs"
-                            variant="outline"
-                            leftIcon={<MantineIcon icon={IconRefresh} />}
-                            disabled
+            <MantineProvider theme={getMantine8ThemeOverride()}>
+                <Popover withinPortal withArrow width={300}>
+                    <Popover.Target>
+                        <Box
+                            style={{
+                                cursor: 'pointer',
+                            }}
                         >
-                            Refresh dbt
-                        </Button>
-                    </Box>
-                </Popover.Target>
-                <Popover.Dropdown>
-                    <Text>
-                        You're still connected to a dbt project created from the
-                        CLI.
-                        <br />
-                        To keep your Lightdash project in sync with your dbt
-                        project,
-                        <br /> you need to either{' '}
-                        <Anchor
-                            href={
-                                'https://docs.lightdash.com/get-started/setup-lightdash/connect-project#2-import-a-dbt-project'
-                            }
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            change your connection type
-                        </Anchor>
-                        , setup a{' '}
-                        <Anchor
-                            href={
-                                'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action'
-                            }
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            GitHub action
-                        </Anchor>
-                        <br />
-                        or, run{' '}
-                        <Anchor
-                            href={
-                                'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#lightdash-deploy-syncs-the-changes-in-your-dbt-project-to-lightdash'
-                            }
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            lightdash deploy
-                        </Anchor>
-                        ) from your command line.
-                    </Text>
-                </Popover.Dropdown>
-            </Popover>
+                            <Button
+                                size="xs"
+                                variant="outline"
+                                leftSection={<MantineIcon icon={IconRefresh} />}
+                                disabled
+                            >
+                                Refresh dbt
+                            </Button>
+                        </Box>
+                    </Popover.Target>
+                    <Popover.Dropdown>
+                        <Text>
+                            You're still connected to a dbt project created from
+                            the CLI.
+                            <br />
+                            To keep your Lightdash project in sync with your dbt
+                            project,
+                            <br /> you need to either{' '}
+                            <Anchor
+                                href={
+                                    'https://docs.lightdash.com/get-started/setup-lightdash/connect-project#2-import-a-dbt-project'
+                                }
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                change your connection type
+                            </Anchor>
+                            , setup a{' '}
+                            <Anchor
+                                href={
+                                    'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action'
+                                }
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                GitHub action
+                            </Anchor>
+                            <br />
+                            or, run{' '}
+                            <Anchor
+                                href={
+                                    'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#lightdash-deploy-syncs-the-changes-in-your-dbt-project-to-lightdash'
+                                }
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                lightdash deploy
+                            </Anchor>
+                            ) from your command line.
+                        </Text>
+                    </Popover.Dropdown>
+                </Popover>
+            </MantineProvider>
         );
     }
 
@@ -146,38 +150,42 @@ const RefreshDbtButton: FC<{
     };
 
     return (
-        <Group spacing="xs">
-            <Tooltip
-                withinPortal
-                multiline
-                w={320}
-                position="bottom"
-                label="If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button."
-            >
-                <Button
-                    size="xs"
-                    variant="default"
-                    leftIcon={leftIcon ?? <MantineIcon icon={IconRefresh} />}
-                    loading={isLoading}
-                    onClick={handleRefresh}
-                    sx={buttonStyles}
-                >
-                    {!isLoading
-                        ? defaultTextOverride ?? 'Refresh dbt'
-                        : refreshingTextOverride ?? 'Refreshing dbt'}
-                </Button>
-            </Tooltip>
-            {data?.type === ProjectType.PREVIEW && (
+        <MantineProvider theme={getMantine8ThemeOverride()}>
+            <Group gap="xs">
                 <Tooltip
                     withinPortal
-                    label={`Developer previews are temporary Lightdash projects`}
+                    multiline
+                    w={320}
+                    position="bottom"
+                    label="If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button."
                 >
-                    <Badge color="yellow" size="lg" radius="sm">
-                        Developer preview
-                    </Badge>
+                    <Button
+                        size="xs"
+                        variant="default"
+                        leftSection={
+                            leftIcon ?? <MantineIcon icon={IconRefresh} />
+                        }
+                        loading={isLoading}
+                        onClick={handleRefresh}
+                        style={buttonStyles}
+                    >
+                        {!isLoading
+                            ? defaultTextOverride ?? 'Refresh dbt'
+                            : refreshingTextOverride ?? 'Refreshing dbt'}
+                    </Button>
                 </Tooltip>
-            )}
-        </Group>
+                {data?.type === ProjectType.PREVIEW && (
+                    <Tooltip
+                        withinPortal
+                        label={`Developer previews are temporary Lightdash projects`}
+                    >
+                        <Badge color="yellow" size="lg" radius="sm">
+                            Developer preview
+                        </Badge>
+                    </Tooltip>
+                )}
+            </Group>
+        </MantineProvider>
     );
 };
 

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -5,7 +5,6 @@ import {
     Box,
     Button,
     Group,
-    MantineProvider,
     Popover,
     Text,
     Tooltip,
@@ -16,7 +15,6 @@ import { useEffect, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useProject } from '../../hooks/useProject';
 import { useRefreshServer } from '../../hooks/useRefreshServer';
-import { getMantine8ThemeOverride } from '../../mantine8Theme';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
 import useTracking from '../../providers/Tracking/useTracking';
@@ -76,67 +74,65 @@ const RefreshDbtButton: FC<{
             return null;
         }
         return (
-            <MantineProvider theme={getMantine8ThemeOverride()}>
-                <Popover withinPortal withArrow width={300}>
-                    <Popover.Target>
-                        <Box
-                            style={{
-                                cursor: 'pointer',
-                            }}
+            <Popover withinPortal withArrow width={300}>
+                <Popover.Target>
+                    <Box
+                        style={{
+                            cursor: 'pointer',
+                        }}
+                    >
+                        <Button
+                            size="xs"
+                            variant="outline"
+                            leftSection={<MantineIcon icon={IconRefresh} />}
+                            disabled
                         >
-                            <Button
-                                size="xs"
-                                variant="outline"
-                                leftSection={<MantineIcon icon={IconRefresh} />}
-                                disabled
-                            >
-                                Refresh dbt
-                            </Button>
-                        </Box>
-                    </Popover.Target>
-                    <Popover.Dropdown>
-                        <Text>
-                            You're still connected to a dbt project created from
-                            the CLI.
-                            <br />
-                            To keep your Lightdash project in sync with your dbt
-                            project,
-                            <br /> you need to either{' '}
-                            <Anchor
-                                href={
-                                    'https://docs.lightdash.com/get-started/setup-lightdash/connect-project#2-import-a-dbt-project'
-                                }
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                change your connection type
-                            </Anchor>
-                            , setup a{' '}
-                            <Anchor
-                                href={
-                                    'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action'
-                                }
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                GitHub action
-                            </Anchor>
-                            <br />
-                            or, run{' '}
-                            <Anchor
-                                href={
-                                    'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#lightdash-deploy-syncs-the-changes-in-your-dbt-project-to-lightdash'
-                                }
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                lightdash deploy
-                            </Anchor>
-                            ) from your command line.
-                        </Text>
-                    </Popover.Dropdown>
-                </Popover>
-            </MantineProvider>
+                            Refresh dbt
+                        </Button>
+                    </Box>
+                </Popover.Target>
+                <Popover.Dropdown>
+                    <Text>
+                        You're still connected to a dbt project created from the
+                        CLI.
+                        <br />
+                        To keep your Lightdash project in sync with your dbt
+                        project,
+                        <br /> you need to either{' '}
+                        <Anchor
+                            href={
+                                'https://docs.lightdash.com/get-started/setup-lightdash/connect-project#2-import-a-dbt-project'
+                            }
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            change your connection type
+                        </Anchor>
+                        , setup a{' '}
+                        <Anchor
+                            href={
+                                'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#automatically-deploy-your-changes-to-lightdash-using-a-github-action'
+                            }
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            GitHub action
+                        </Anchor>
+                        <br />
+                        or, run{' '}
+                        <Anchor
+                            href={
+                                'https://docs.lightdash.com/guides/cli/how-to-use-lightdash-deploy#lightdash-deploy-syncs-the-changes-in-your-dbt-project-to-lightdash'
+                            }
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            lightdash deploy
+                        </Anchor>
+                        ) from your command line.
+                    </Text>
+                </Popover.Dropdown>
+            </Popover>
         );
     }
 
@@ -150,42 +146,38 @@ const RefreshDbtButton: FC<{
     };
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Group gap="xs">
+        <Group gap="xs">
+            <Tooltip
+                withinPortal
+                multiline
+                w={320}
+                position="bottom"
+                label="If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button."
+            >
+                <Button
+                    size="xs"
+                    variant="default"
+                    leftSection={leftIcon ?? <MantineIcon icon={IconRefresh} />}
+                    loading={isLoading}
+                    onClick={handleRefresh}
+                    style={buttonStyles}
+                >
+                    {!isLoading
+                        ? defaultTextOverride ?? 'Refresh dbt'
+                        : refreshingTextOverride ?? 'Refreshing dbt'}
+                </Button>
+            </Tooltip>
+            {data?.type === ProjectType.PREVIEW && (
                 <Tooltip
                     withinPortal
-                    multiline
-                    w={320}
-                    position="bottom"
-                    label="If you've updated your YAML files, you can sync your changes to Lightdash by clicking this button."
+                    label={`Developer previews are temporary Lightdash projects`}
                 >
-                    <Button
-                        size="xs"
-                        variant="default"
-                        leftSection={
-                            leftIcon ?? <MantineIcon icon={IconRefresh} />
-                        }
-                        loading={isLoading}
-                        onClick={handleRefresh}
-                        style={buttonStyles}
-                    >
-                        {!isLoading
-                            ? defaultTextOverride ?? 'Refresh dbt'
-                            : refreshingTextOverride ?? 'Refreshing dbt'}
-                    </Button>
+                    <Badge color="yellow" size="lg" radius="sm">
+                        Developer preview
+                    </Badge>
                 </Tooltip>
-                {data?.type === ProjectType.PREVIEW && (
-                    <Tooltip
-                        withinPortal
-                        label={`Developer previews are temporary Lightdash projects`}
-                    >
-                        <Badge color="yellow" size="lg" radius="sm">
-                            Developer preview
-                        </Badge>
-                    </Tooltip>
-                )}
-            </Group>
-        </MantineProvider>
+            )}
+        </Group>
     );
 };
 

--- a/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
+++ b/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
@@ -1,9 +1,10 @@
-import { ActionIcon } from '@mantine/core';
+import { ActionIcon, MantineProvider } from '@mantine-8/core';
 import { IconCheck, IconLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useLocation } from 'react-router';
 import { useAsyncClipboard } from '../../../hooks/useAsyncClipboard';
 import { useCreateShareMutation } from '../../../hooks/useShare';
+import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import MantineIcon from '../MantineIcon';
 
 const ShareShortLinkButton: FC<{
@@ -25,17 +26,19 @@ const ShareShortLinkButton: FC<{
     const { handleCopy, copied } = useAsyncClipboard(getSharedUrl);
 
     return (
-        <ActionIcon
-            variant="default"
-            onClick={handleCopy}
-            disabled={isDisabled}
-            color="gray"
-        >
-            <MantineIcon
-                icon={copied ? IconCheck : IconLink}
-                color={copied ? 'green' : undefined}
-            />
-        </ActionIcon>
+        <MantineProvider theme={getMantine8ThemeOverride()}>
+            <ActionIcon
+                variant="default"
+                onClick={handleCopy}
+                disabled={isDisabled}
+                color="gray"
+            >
+                <MantineIcon
+                    icon={copied ? IconCheck : IconLink}
+                    color={copied ? 'green' : undefined}
+                />
+            </ActionIcon>
+        </MantineProvider>
     );
 };
 

--- a/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
+++ b/packages/frontend/src/components/common/ShareShortLinkButton/index.tsx
@@ -1,10 +1,9 @@
-import { ActionIcon, MantineProvider } from '@mantine-8/core';
+import { ActionIcon } from '@mantine-8/core';
 import { IconCheck, IconLink } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useLocation } from 'react-router';
 import { useAsyncClipboard } from '../../../hooks/useAsyncClipboard';
 import { useCreateShareMutation } from '../../../hooks/useShare';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import MantineIcon from '../MantineIcon';
 
 const ShareShortLinkButton: FC<{
@@ -26,19 +25,17 @@ const ShareShortLinkButton: FC<{
     const { handleCopy, copied } = useAsyncClipboard(getSharedUrl);
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <ActionIcon
-                variant="default"
-                onClick={handleCopy}
-                disabled={isDisabled}
-                color="gray"
-            >
-                <MantineIcon
-                    icon={copied ? IconCheck : IconLink}
-                    color={copied ? 'green' : undefined}
-                />
-            </ActionIcon>
-        </MantineProvider>
+        <ActionIcon
+            variant="default"
+            onClick={handleCopy}
+            disabled={isDisabled}
+            color="gray"
+        >
+            <MantineIcon
+                icon={copied ? IconCheck : IconLink}
+                color={copied ? 'green' : undefined}
+            />
+        </ActionIcon>
     );
 };
 

--- a/packages/frontend/src/components/common/TimeZonePicker/index.tsx
+++ b/packages/frontend/src/components/common/TimeZonePicker/index.tsx
@@ -1,7 +1,8 @@
 import { getTimezoneLabel, TimeZone } from '@lightdash/common';
-import { Select, type SelectProps } from '@mantine/core';
+import { MantineProvider, Select, type SelectProps } from '@mantine-8/core';
 import dayjs from 'dayjs';
 import { useMemo, type FC } from 'react';
+import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 
 export interface TimeZonePickerProps extends Omit<SelectProps, 'data'> {}
 
@@ -24,14 +25,16 @@ const TimeZonePicker: FC<TimeZonePickerProps> = (props) => {
     );
 
     return (
-        <Select
-            variant="filled"
-            maw={190}
-            size="xs"
-            placeholder="Select timezone"
-            data={timeZoneOptions}
-            {...props}
-        />
+        <MantineProvider theme={getMantine8ThemeOverride()}>
+            <Select
+                variant="filled"
+                maw={190}
+                size="xs"
+                placeholder="Select timezone"
+                data={timeZoneOptions}
+                {...props}
+            />
+        </MantineProvider>
     );
 };
 

--- a/packages/frontend/src/components/common/TimeZonePicker/index.tsx
+++ b/packages/frontend/src/components/common/TimeZonePicker/index.tsx
@@ -1,8 +1,7 @@
 import { getTimezoneLabel, TimeZone } from '@lightdash/common';
-import { MantineProvider, Select, type SelectProps } from '@mantine-8/core';
+import { Select, type SelectProps } from '@mantine-8/core';
 import dayjs from 'dayjs';
 import { useMemo, type FC } from 'react';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 
 export interface TimeZonePickerProps extends Omit<SelectProps, 'data'> {}
 
@@ -25,16 +24,14 @@ const TimeZonePicker: FC<TimeZonePickerProps> = (props) => {
     );
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Select
-                variant="filled"
-                maw={190}
-                size="xs"
-                placeholder="Select timezone"
-                data={timeZoneOptions}
-                {...props}
-            />
-        </MantineProvider>
+        <Select
+            variant="filled"
+            maw={190}
+            size="xs"
+            placeholder="Select timezone"
+            data={timeZoneOptions}
+            {...props}
+        />
     );
 };
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -45,7 +45,7 @@ import { MetricsTable } from './MetricsTable';
 
 const LOCAL_STORAGE_KEY = 'metrics-catalog-learn-more-popover-closed';
 
-const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['sx'] }> = ({
+const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['style'] }> = ({
     buttonStyles,
 }) => {
     const [opened, { close, open }] = useDisclosure(false);
@@ -88,7 +88,7 @@ const LearnMorePopover: FC<{ buttonStyles?: ButtonProps['sx'] }> = ({
                     size="xs"
                     variant="default"
                     leftIcon={<MantineIcon icon={IconSparkles} />}
-                    sx={buttonStyles}
+                    style={buttonStyles}
                     onClick={opened ? handleClose : open}
                 >
                     Learn more
@@ -377,7 +377,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
         [tableName, metricName, dispatch],
     );
 
-    const headerButtonStyles: ButtonProps['sx'] = {
+    const headerButtonStyles: ButtonProps['style'] = {
         borderRadius: theme.radius.md,
         backgroundColor: '#FAFAFA',
         border: `1px solid ${theme.colors.gray[2]}`,
@@ -446,7 +446,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
                                 />
                             }
                             loading={true}
-                            sx={headerButtonStyles}
+                            style={headerButtonStyles}
                         >
                             Refreshing catalog
                         </Button>

--- a/packages/frontend/src/features/sync/components/SyncModalForm.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalForm.tsx
@@ -203,7 +203,9 @@ export const SyncModalForm: FC<{ chartUuid: string }> = ({ chartUuid }) => {
                             searchable
                             clearable
                             variant="default"
-                            withinPortal
+                            comboboxProps={{
+                                withinPortal: true,
+                            }}
                             {...methods.register('timezone')}
                             onChange={(value) => {
                                 methods.setValue(

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -5,6 +5,7 @@ import {
     deepEqual,
     getFieldRef,
     getItemId,
+    isTimeZone,
     lightdashVariablePattern,
     maybeReplaceFieldsInChartVersion,
     removeEmptyProperties,
@@ -23,7 +24,6 @@ import {
     type SavedChart,
     type SortField,
     type TableCalculation,
-    type TimeZone,
 } from '@lightdash/common';
 import { useLocalStorage } from '@mantine/hooks';
 import { useQueryClient } from '@tanstack/react-query';
@@ -1001,11 +1001,13 @@ const ExplorerProvider: FC<
         });
     }, []);
 
-    const setTimeZone = useCallback((timezone: TimeZone) => {
-        dispatch({
-            type: ActionType.SET_TIME_ZONE,
-            payload: timezone,
-        });
+    const setTimeZone = useCallback((timezone: string | null) => {
+        if (timezone && isTimeZone(timezone)) {
+            dispatch({
+                type: ActionType.SET_TIME_ZONE,
+                payload: timezone,
+            });
+        }
     }, []);
 
     const setFilters = useCallback((filters: MetricQuery['filters']) => {

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -321,7 +321,7 @@ export interface ExplorerContextType {
         removeSortField: (fieldId: FieldId) => void;
         moveSortFields: (sourceIndex: number, destinationIndex: number) => void;
         setRowLimit: (limit: number) => void;
-        setTimeZone: (timezone: TimeZone) => void;
+        setTimeZone: (timezone: string | null) => void;
         setFilters: (filters: MetricQuery['filters']) => void;
         setParameter: (key: string, value: string | string[] | null) => void;
         clearAllParameters: () => void;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Migrated several components to use Mantine 8 by:
- Updated imports from `@mantine/core` to `@mantine-8/core`
- Added `MantineProvider` with theme override to components
- Changed `leftIcon` prop to `leftSection`
- Replaced `sx` prop with `style` prop
- Updated styling syntax to match Mantine 8 requirements

**Before**

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NymtOECmPxzpCcYh2n9e/199e95e0-b3a2-4333-9439-c6aa5cdd5686.png)

**After**

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NymtOECmPxzpCcYh2n9e/1022541d-2b63-424a-84cf-243fbb05aeb8.png)

