### PR TITLE
feat: add metadata to chart/dashboard search results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,16 @@ pnpm generate-api
 ## Code Style Memories
 
 -   Never use duck typing, don't have parameters that can have different types, make types intentional
+-   **Prefer strict object shapes**: Start with required properties and make them optional only when truly needed
+    -   ✅ Good: `{ charts: Chart[] }` - can be empty array
+    -   ❌ Avoid: `{ charts?: Chart[] }` - unclear if missing or empty
+-   **Use null for absent values**: When a value might not exist, prefer explicit null over optional properties
+    -   ✅ Good: `{ createdBy: User | null }` - explicitly absent
+    -   ❌ Avoid: `{ createdBy?: User }` - ambiguous presence
+-   **When optional properties are acceptable**:
+    -   Backwards compatibility requirements
+    -   API design patterns where omission has semantic meaning
+    -   Configuration objects with sensible defaults
 
 ## Development Troubleshooting
 

--- a/packages/backend/src/ee/services/ai/tools/findCharts.ts
+++ b/packages/backend/src/ee/services/ai/tools/findCharts.ts
@@ -5,6 +5,7 @@ import {
     toolFindChartsArgsSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
+import moment from 'moment';
 import type { FindChartsFn } from '../types/aiAgentDependencies';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 
@@ -34,6 +35,7 @@ const getChartText = (chart: AllChartsSearchResult, siteUrl?: string) => {
         <Name>${chart.name}</Name>
         <SearchRank>${chart.search_rank}</SearchRank>
         <ChartType>${chart.chartType}</ChartType>
+        <ChartSource>${chart.chartSource}</ChartSource>
         ${
             chart.description
                 ? `<Description>${chart.description}</Description>`
@@ -41,6 +43,26 @@ const getChartText = (chart: AllChartsSearchResult, siteUrl?: string) => {
         }
         ${chartUrl ? `<Url>${chartUrl}</Url>` : ''}
         <SpaceUuid>${chart.spaceUuid}</SpaceUuid>
+        <ViewsCount>${chart.viewsCount}</ViewsCount>
+        ${
+            chart.firstViewedAt
+                ? `<FirstViewedAt>${moment(
+                      chart.firstViewedAt,
+                  ).fromNow()}</FirstViewedAt>`
+                : ''
+        }
+        ${
+            chart.lastModified
+                ? `<LastModified>${moment(
+                      chart.lastModified,
+                  ).fromNow()}</LastModified>`
+                : ''
+        }
+        ${
+            chart.createdBy
+                ? `<CreatedBy>${chart.createdBy.firstName} ${chart.createdBy.lastName}</CreatedBy>`
+                : ''
+        }
     </Chart>
     `.trim();
 };

--- a/packages/backend/src/ee/services/ai/tools/findDashboards.ts
+++ b/packages/backend/src/ee/services/ai/tools/findDashboards.ts
@@ -3,6 +3,7 @@ import {
     toolFindDashboardsArgsSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
+import moment from 'moment';
 import type { FindDashboardsFn } from '../types/aiAgentDependencies';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 
@@ -31,6 +32,43 @@ const getDashboardText = (
         }
         ${dashboardUrl ? `<Url>${dashboardUrl}</Url>` : ''}
         <SpaceUuid>${dashboard.spaceUuid}</SpaceUuid>
+        <ViewsCount>${dashboard.viewsCount}</ViewsCount>
+        ${
+            dashboard.firstViewedAt
+                ? `<FirstViewedAt>${moment(
+                      dashboard.firstViewedAt,
+                  ).fromNow()}</FirstViewedAt>`
+                : ''
+        }
+        ${
+            dashboard.lastModified
+                ? `<LastModified>${moment(
+                      dashboard.lastModified,
+                  ).fromNow()}</LastModified>`
+                : ''
+        }
+        ${
+            dashboard.createdBy
+                ? `<CreatedBy>${dashboard.createdBy.firstName} ${dashboard.createdBy.lastName}</CreatedBy>`
+                : ''
+        }
+        <Charts count="${dashboard.charts.length}">
+            ${dashboard.charts
+                .map(
+                    (chart) =>
+                        `<Chart>
+                            <Name>${chart.name}</Name>
+                            <ChartType>${chart.chartType}</ChartType>
+                            ${
+                                chart.description
+                                    ? `<Description>${chart.description}</Description>`
+                                    : ''
+                            }
+                            <ViewsCount>${chart.viewsCount}</ViewsCount>
+                        </Chart>`,
+                )
+                .join('\n            ')}
+        </Charts>
         ${
             dashboard.validationErrors && dashboard.validationErrors.length > 0
                 ? `<ValidationErrors count="${dashboard.validationErrors.length}"/>`

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -24,6 +24,20 @@ export type DashboardSearchResult = Pick<
     validationErrors: {
         validationId: ValidationErrorDashboardResponse['validationId'];
     }[];
+    viewsCount: number;
+    firstViewedAt: string | null;
+    lastModified: string | null;
+    createdBy: {
+        firstName: string;
+        lastName: string;
+        userUuid: string;
+    } | null;
+    charts: {
+        name: string;
+        description?: string;
+        chartType: ChartKind;
+        viewsCount: number;
+    }[];
 } & RankedItem;
 
 export type SavedChartSearchResult = Pick<
@@ -35,6 +49,14 @@ export type SavedChartSearchResult = Pick<
         validationId: ValidationErrorChartResponse['validationId'];
     }[];
     chartSource: 'saved';
+    viewsCount: number;
+    firstViewedAt: string | null;
+    lastModified: string | null;
+    createdBy: {
+        firstName: string;
+        lastName: string;
+        userUuid: string;
+    } | null;
 } & RankedItem;
 
 export type SqlChartSearchResult = Pick<
@@ -46,6 +68,14 @@ export type SqlChartSearchResult = Pick<
     spaceUuid: SqlChart['space']['uuid'];
     projectUuid: SqlChart['project']['projectUuid'];
     chartSource: 'sql';
+    viewsCount: number;
+    firstViewedAt: string | null;
+    lastModified: string | null;
+    createdBy: {
+        firstName: string;
+        lastName: string;
+        userUuid: string;
+    } | null;
 } & RankedItem;
 
 export type AllChartsSearchResult = Pick<
@@ -55,6 +85,14 @@ export type AllChartsSearchResult = Pick<
     Partial<Pick<SqlChartSearchResult, 'slug'>> & {
         chartType: ChartKind;
         chartSource: 'saved' | 'sql';
+        viewsCount: number;
+        firstViewedAt: string | null;
+        lastModified: string | null;
+        createdBy: {
+            firstName: string;
+            lastName: string;
+            userUuid: string;
+        } | null;
     } & RankedItem;
 
 export type TableSearchResult = Pick<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16313

### Description:

Enhances AI tools with richer chart and dashboard metadata

1. Updates `findCharts` and `findDashboards` to include additional metadata:
    - View counts
    - First viewed date
    - Last modified date
    - Creator information
    - For dashboards: embedded chart details