### PR TITLE
feat(slack): add onReady callback for slack app initialization

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -193,16 +193,24 @@ export class AiAgentService {
     private initSlackListeners() {
         if (!this.lightdashConfig.ai.copilot.enabled) return;
 
-        const { slackApp } = this.slackClient;
-        if (slackApp) {
-            slackApp.event('app_mention', (m) => this.handleAppMention(m));
-            this.handlePromptUpvote(slackApp);
-            this.handlePromptDownvote(slackApp);
-            AiAgentService.handleClickExploreButton(slackApp);
-            AiAgentService.handleClickOAuthButton(slackApp);
-        } else {
-            Logger.warn('Slack app not found');
-        }
+        this.slackClient.onReady((app) => {
+            try {
+                app.event('app_mention', (m) => this.handleAppMention(m));
+                this.handlePromptUpvote(app);
+                this.handlePromptDownvote(app);
+                AiAgentService.handleClickExploreButton(app);
+                AiAgentService.handleClickOAuthButton(app);
+                this.handleExecuteFollowUpTool(app);
+                Logger.info(
+                    'AiAgentService Slack event listeners attached successfully',
+                );
+            } catch (error) {
+                Logger.error(
+                    'Failed to attach AiAgentService Slack event listeners:',
+                    error,
+                );
+            }
+        });
     }
 
     private async getIsCopilotEnabled(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:

Adds a new `onReady` callback system to the SlackClient to ensure Slack event listeners are properly registered. This improves the reliability of Slack integrations by:

1. Adding a callback queue that executes when the Slack app is initialized
2. Refactoring both AiAgentService and UnfurlService to use this new pattern
3. Improving error handling for Slack event registration

Notes: 
  1. Before the refactor: `SlackClient` had `addEventListeners()` method that registered the `link_shared` event handler:
  `app.event('link_shared', (m) => this.unfurlSlackUrls(m, unfurlService));`
  2. After the refactor: The `UnfurlService` constructor calls `initSlackListeners()` but it tries to access `this.slackClient.slackApp` which might not be initialized yet:

This change ensures that Slack event listeners are properly attached even if the Slack app isn't immediately available at service initialization time.

> [!NOTE]
> internal analytics can confirm this issue is more common after merge of https://github.com/lightdash/lightdash/pull/16254/files