### PR TITLE
fix: remove Group from embedded tabbed dashboard

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -366,19 +366,16 @@ const EmbedDashboard: FC<{
                             </Tabs.Tab>
                         ))}
                     </Tabs.List>
-                    <Group style={{ position: 'relative' }}>
-                        {/* div container required to respect the position inside the Embed SDK */}
-                        <EmbedDashboardGrid
-                            filteredTiles={filteredTiles}
-                            layouts={layouts}
-                            dashboard={dashboard}
-                            projectUuid={projectUuid}
-                            hasRequiredDashboardFiltersToSet={
-                                hasRequiredDashboardFiltersToSet
-                            }
-                            isTabEmpty={isTabEmpty}
-                        />
-                    </Group>
+                    <EmbedDashboardGrid
+                        filteredTiles={filteredTiles}
+                        layouts={layouts}
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                        hasRequiredDashboardFiltersToSet={
+                            hasRequiredDashboardFiltersToSet
+                        }
+                        isTabEmpty={isTabEmpty}
+                    />
                 </Tabs>
             ) : (
                 <EmbedDashboardGrid


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16384

### Description:
Removed `Group` wrapper around `EmbedDashboardGrid` component in the embedded dashboard view. The comment indicated the wrapper was for respecting position inside the Embed SDK, but it appears to have been causing width calculation problems with the Grid component. 

The first tab rendered would be collapsed without any width. After switching tabs, we'd get a wider canvas, but still narrower than it should be. 

### Before

![Screen Cast 2025-08-13 at 10 03 40 AM](https://github.com/user-attachments/assets/bc73b07b-6aed-46f0-8187-ccb388810bb3)

### After

![Screen Cast 2025-08-13 at 5 20 25 PM](https://github.com/user-attachments/assets/82107e0c-aee2-4c50-9e53-0e01a1fd1abf)
