### PR TITLE
fix: move Mantine styles import to entry points

### DIFF
--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -1,3 +1,5 @@
+import '@mantine-8/core/styles.css';
+
 import { type LanguageMap, type SavedChart } from '@lightdash/common';
 import { type FC, type PropsWithChildren, useEffect, useState } from 'react';
 import { MemoryRouter } from 'react-router';

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -1,3 +1,5 @@
+import '@mantine-8/core/styles.css';
+
 // eslint-disable-next-line import/order
 import { scan } from 'react-scan'; // react-scan has to be imported before react
 

--- a/packages/frontend/src/providers/MantineProvider.tsx
+++ b/packages/frontend/src/providers/MantineProvider.tsx
@@ -1,5 +1,3 @@
-import '@mantine-8/core/styles.css';
-
 import {
     MantineProvider as MantineProviderBase,
     type MantineThemeOverride,


### PR DESCRIPTION
Moved the Mantine CSS import from the MantineProvider component to the entry points of the application. This ensures that the styles are loaded at the root level in both the main application and the SDK.