### PR TITLE
feat: add global Mantine8Provider to simplify component theming

### DIFF
--- a/packages/frontend/CLAUDE.md
+++ b/packages/frontend/CLAUDE.md
@@ -3,12 +3,11 @@
 **CRITICAL**: Before working on any frontend component, read
 the [Frontend Style Guide](STYLE_GUIDE.md). Key points:
 
-- **Use Mantine v8 only** - Migrate any Mantine v6 components you encounter
-- **Provider setup required** - Wrap v8 components with `MantineProvider` using `getMantine8ThemeOverride()`
-- **Styling hierarchy**: 
-  1. Inline-style component props (≤3 simple layout props like `mt`, `p`, `w`)
-  2. CSS modules (default choice when more than 3 inline-style props are needed or when component props aren't available)
-  3. Theme extensions for reusable styles
-- **NEVER use** `styles`(v8) or `sx`(v6) props or `style`(v6/v8)
-- **Prop changes** - `spacing` → `gap`, `noWrap` → `wrap="nowrap"`, `sx` → `style` (v6)
-- **Component docs** - Props/APIs at `https://mantine.dev/core/[component-name]/` (e.g. select, segmented-control)
+-   **Use Mantine v8 only** - Migrate any Mantine v6 components you encounter
+-   **Styling hierarchy**:
+    1. Inline-style component props (≤3 simple layout props like `mt`, `p`, `w`)
+    2. CSS modules (default choice when more than 3 inline-style props are needed or when component props aren't available)
+    3. Theme extensions for reusable styles
+-   **NEVER use** `styles`(v8) or `sx`(v6) props or `style`(v6/v8)
+-   **Prop changes** - `spacing` → `gap`, `noWrap` → `wrap="nowrap"`, `sx` → `style` (v6)
+-   **Component docs** - Props/APIs at `https://mantine.dev/core/[component-name]/` (e.g. select, segmented-control)

--- a/packages/frontend/STYLE_GUIDE.md
+++ b/packages/frontend/STYLE_GUIDE.md
@@ -8,15 +8,14 @@
 
 When creating/updating components:
 
-- [ ] Use `@mantine-8/core` imports
-- [ ] Wrap top level component with `MantineProvider` and pass the theme provider `getMantine8ThemeOverride()` to its prop: 'theme'
-- [ ] Follow Quick Migration Guide below and then make reasoning in section ###  When to Override Styles
-- [ ] Confirm you know the guidelines in section ### 1. Theme Extensions (For Repeated Patterns) and section ### 2. Context-Specific Overrides (for simple overrides)
-- [ ] No `style` or `styles` or `sx` props
-- [ ] Check Mantine docs/types for available component props
-- [ ] Use inline-style component props for styling when available (and follow <=3 props rule; if more than 3 props, use CSS modules)
-- [ ] Use CSS modules when component props aren't available or when more than 3 inline-style props are needed
-- [ ] Theme values('md', 'lg', 'xl', or 'gray.1', 'gray.2', etc) instead of magic numbers
+-   [ ] Use `@mantine-8/core` imports
+-   [ ] Follow Quick Migration Guide below and then make reasoning in section ### When to Override Styles
+-   [ ] Confirm you know the guidelines in section ### 1. Theme Extensions (For Repeated Patterns) and section ### 2. Context-Specific Overrides (for simple overrides)
+-   [ ] No `style` or `styles` or `sx` props
+-   [ ] Check Mantine docs/types for available component props
+-   [ ] Use inline-style component props for styling when available (and follow <=3 props rule; if more than 3 props, use CSS modules)
+-   [ ] Use CSS modules when component props aren't available or when more than 3 inline-style props are needed
+-   [ ] Theme values('md', 'lg', 'xl', or 'gray.1', 'gray.2', etc) instead of magic numbers
 
 ### Quick Migration Guide
 
@@ -25,27 +24,24 @@ When creating/updating components:
 import { Button, Group } from '@mantine/core';
 
 <Group spacing="xs" noWrap>
-    <Button sx={{mt: 20}}>Click</Button>
-</Group>
+    <Button sx={{ mt: 20 }}>Click</Button>
+</Group>;
 
 // ✅ Mantine 8
-import { Button, Group, MantineProvider } from '@mantine-8/core';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
+import { Button, Group } from '@mantine-8/core';
 
-<MantineProvider theme={getMantine8ThemeOverride()}>
-    <Group gap="xs" wrap="nowrap">
-        <Button mt={20}>Click</Button>
-    </Group>
-</MantineProvider>
+<Group gap="xs" wrap="nowrap">
+    <Button mt={20}>Click</Button>
+</Group>;
 ```
 
 ### Key Prop Changes
 
-- `spacing` → `gap`
-- `noWrap` → `wrap="nowrap"`
-- `sx` → Component props (e.g., `mt`, `w`, `c`) or CSS modules if it's not possible to use component props. Also follow the best practices below in section ### When to Override Styles.
-- `leftIcon` → `leftSection`
-- `rightIcon` → `rightSection`
+-   `spacing` → `gap`
+-   `noWrap` → `wrap="nowrap"`
+-   `sx` → Component props (e.g., `mt`, `w`, `c`) or CSS modules if it's not possible to use component props. Also follow the best practices below in section ### When to Override Styles.
+-   `leftIcon` → `leftSection`
+-   `rightIcon` → `rightSection`
 
 ## Styling Best Practices
 
@@ -86,9 +82,9 @@ Only override styles when there's a clear contextual need:
 
 **❌ NEVER use:**
 
-- `styles` prop (always use CSS modules instead)
-- `sx` prop (it's a v6 prop)
-- `style` prop (inline styles)
+-   `styles` prop (always use CSS modules instead)
+-   `sx` prop (it's a v6 prop)
+-   `style` prop (inline styles)
 
 ### 1. Theme Extensions (For Repeated Patterns)
 
@@ -138,13 +134,13 @@ When hitting more than 3 props, use CSS modules instead.
 
 Common inline-style component props examples:
 
-- Layout: `mt`, `mb`, `ml`, `mr`, `m`, `p`, `pt`, `pb`, `pl`, `pr`
-- Sizing: `w`, `h`, `maw`, `mah`, `miw`, `mih`
-- Colors: `c` (color), `bg` (background)
-- Display: `display`, `pos` (position)
-- Font: `ff` (font family), `fs` (font size), `fw` (font weight)
-- Text: `ta` (text align), `lh` (line height)
-- Shadow: `shadow` (shadow)
+-   Layout: `mt`, `mb`, `ml`, `mr`, `m`, `p`, `pt`, `pb`, `pl`, `pr`
+-   Sizing: `w`, `h`, `maw`, `mah`, `miw`, `mih`
+-   Colors: `c` (color), `bg` (background)
+-   Display: `display`, `pos` (position)
+-   Font: `ff` (font family), `fs` (font size), `fw` (font weight)
+-   Text: `ta` (text align), `lh` (line height)
+-   Shadow: `shadow` (shadow)
 
 #### CSS Modules (complex styles)
 
@@ -167,14 +163,12 @@ Use CSS modules when component props aren't available or for complex styling (wh
 ```tsx
 import styles from './Component.module.css';
 
-<Card className={styles.customCard}>
-    {/* Card content */}
-</Card>
+<Card className={styles.customCard}>{/* Card content */}</Card>;
 ```
 
 Do not include a `<file>.css.d.ts` file for css modules. We are using Vite and don't need them.
 
-In CSS modules, avoid using `!important` where possible. It's better to use the `classNames` API for increased specificity. 
+In CSS modules, avoid using `!important` where possible. It's better to use the `classNames` API for increased specificity.
 
 ### 3. Important Guidelines
 
@@ -197,10 +191,10 @@ Before moving styles to CSS modules, analyze if they're actually needed:
 
 **When to remove styles entirely:**
 
-- The style has no visual effect in its context
-- It's overridden by parent layout (e.g., flex/grid children)
-- It's redundant with the theme
-- It's legacy code from previous v6 implementations
+-   The style has no visual effect in its context
+-   It's overridden by parent layout (e.g., flex/grid children)
+-   It's redundant with the theme
+-   It's legacy code from previous v6 implementations
 
 **Always verify:** Test the component with and without the style to confirm it has no effect before removing.
 
@@ -221,11 +215,10 @@ styles.
 
 Component props and APIs can be found in the official docs:
 
-- **Pattern**: `https://mantine.dev/core/[component-name]/`
-- **Examples**:
-    - Select: https://mantine.dev/core/select/
-    - SegmentedControl: https://mantine.dev/core/segmented-control/
-    - SemiCircleProgress: https://mantine.dev/core/semi-circle-progress/
+-   **Pattern**: `https://mantine.dev/core/[component-name]/`
+-   **Examples**:
+    -   Select: https://mantine.dev/core/select/
+    -   SegmentedControl: https://mantine.dev/core/segmented-control/
+    -   SemiCircleProgress: https://mantine.dev/core/semi-circle-progress/
 
 **Tip**: In your IDE, hover over a component or use Go to Definition to see all available props in the TypeScript interface.
-

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -13,6 +13,7 @@ import AbilityProvider from '../src/providers/Ability/AbilityProvider';
 import ActiveJobProvider from '../src/providers/ActiveJob/ActiveJobProvider';
 import AppProvider from '../src/providers/App/AppProvider';
 import FullscreenProvider from '../src/providers/Fullscreen/FullscreenProvider';
+import Mantine8Provider from '../src/providers/Mantine8Provider';
 import MantineProvider from '../src/providers/MantineProvider';
 import ReactQueryProvider from '../src/providers/ReactQuery/ReactQueryProvider';
 import ThirdPartyServicesProvider from '../src/providers/ThirdPartyServicesProvider';
@@ -68,42 +69,46 @@ const SdkProviders: FC<
         styles?: { backgroundColor?: string; fontFamily?: string };
     }>
 > = ({ children, styles }) => {
+    const themeOverride = {
+        fontFamily: styles?.fontFamily,
+        other: {
+            tableFont: styles?.fontFamily,
+            chartFont: styles?.fontFamily,
+        },
+    };
+
     return (
         <ReactQueryProvider>
             <MantineProvider
                 withGlobalStyles
                 withNormalizeCSS
                 withCSSVariables
-                themeOverride={{
-                    fontFamily: styles?.fontFamily,
-                    other: {
-                        tableFont: styles?.fontFamily,
-                        chartFont: styles?.fontFamily,
-                    },
-                }}
+                themeOverride={themeOverride}
                 notificationsLimit={0}
             >
-                <ModalsProvider>
-                    <AppProvider>
-                        <FullscreenProvider enabled={false}>
-                            <ThirdPartyServicesProvider enabled={false}>
-                                <ErrorBoundary wrapper={{ mt: '4xl' }}>
-                                    <MemoryRouter>
-                                        <TrackingProvider enabled={true}>
-                                            <AbilityProvider>
-                                                <ChartColorMappingContextProvider>
-                                                    <ActiveJobProvider>
-                                                        {children}
-                                                    </ActiveJobProvider>
-                                                </ChartColorMappingContextProvider>
-                                            </AbilityProvider>
-                                        </TrackingProvider>
-                                    </MemoryRouter>
-                                </ErrorBoundary>
-                            </ThirdPartyServicesProvider>
-                        </FullscreenProvider>
-                    </AppProvider>
-                </ModalsProvider>
+                <Mantine8Provider themeOverride={themeOverride}>
+                    <ModalsProvider>
+                        <AppProvider>
+                            <FullscreenProvider enabled={false}>
+                                <ThirdPartyServicesProvider enabled={false}>
+                                    <ErrorBoundary wrapper={{ mt: '4xl' }}>
+                                        <MemoryRouter>
+                                            <TrackingProvider enabled={true}>
+                                                <AbilityProvider>
+                                                    <ChartColorMappingContextProvider>
+                                                        <ActiveJobProvider>
+                                                            {children}
+                                                        </ActiveJobProvider>
+                                                    </ChartColorMappingContextProvider>
+                                                </AbilityProvider>
+                                            </TrackingProvider>
+                                        </MemoryRouter>
+                                    </ErrorBoundary>
+                                </ThirdPartyServicesProvider>
+                            </FullscreenProvider>
+                        </AppProvider>
+                    </ModalsProvider>
+                </Mantine8Provider>
             </MantineProvider>
         </ReactQueryProvider>
     );

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import AbilityProvider from './providers/Ability/AbilityProvider';
 import ActiveJobProvider from './providers/ActiveJob/ActiveJobProvider';
 import AppProvider from './providers/App/AppProvider';
 import FullscreenProvider from './providers/Fullscreen/FullscreenProvider';
+import Mantine8Provider from './providers/Mantine8Provider';
 import MantineProvider from './providers/MantineProvider';
 import ReactQueryProvider from './providers/ReactQuery/ReactQueryProvider';
 import ThirdPartyProvider from './providers/ThirdPartyServicesProvider';
@@ -69,9 +70,11 @@ const App = () => (
 
         <ReactQueryProvider>
             <MantineProvider withGlobalStyles withNormalizeCSS withCSSVariables>
-                <ModalsProvider>
-                    <RouterProvider router={router} />
-                </ModalsProvider>
+                <Mantine8Provider>
+                    <ModalsProvider>
+                        <RouterProvider router={router} />
+                    </ModalsProvider>
+                </Mantine8Provider>
             </MantineProvider>
             <ReactQueryDevtools initialIsOpen={false} />
         </ReactQueryProvider>

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -8,7 +8,6 @@ import {
     Button,
     Divider,
     Group,
-    MantineProvider,
     Modal,
     Stack,
     Text,
@@ -17,7 +16,6 @@ import {
 import { IconBook, IconInfoCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 
-import { getMantine8ThemeOverride } from '../mantine8Theme';
 import useApp from '../providers/App/useApp';
 import {
     TrackPage,
@@ -45,142 +43,140 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
         healthState.data?.mode === LightdashMode.DEFAULT;
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <TrackSection name={SectionName.PAGE_FOOTER}>
-                <Box mt={FOOTER_MARGIN} h={FOOTER_HEIGHT} component="footer">
-                    <Divider color="gray.2" w="100%" mb="-1px" />
+        <TrackSection name={SectionName.PAGE_FOOTER}>
+            <Box mt={FOOTER_MARGIN} h={FOOTER_HEIGHT} component="footer">
+                <Divider color="gray.2" w="100%" mb="-1px" />
 
-                    <Group
-                        h="100%"
-                        miw={minimal ? '100%' : maxWidth}
-                        maw={maxWidth}
-                        justify="space-between"
-                        mx="auto"
+                <Group
+                    h="100%"
+                    miw={minimal ? '100%' : maxWidth}
+                    maw={maxWidth}
+                    justify="space-between"
+                    mx="auto"
+                >
+                    <Button
+                        variant={minimal ? 'transparent' : 'subtle'}
+                        color="gray.7"
+                        p="xs"
+                        fw="500"
+                        leftSection={<Logo />}
+                        loading={healthState.isInitialLoading}
+                        onClick={() => setIsOpen(true)}
                     >
-                        <Button
-                            variant={minimal ? 'transparent' : 'subtle'}
-                            color="gray.7"
-                            p="xs"
-                            fw="500"
-                            leftSection={<Logo />}
-                            loading={healthState.isInitialLoading}
-                            onClick={() => setIsOpen(true)}
-                        >
-                            {!minimal && 'Lightdash - '}
-                            {healthState.data && `v${healthState.data.version}`}
-                            {showUpdateBadge && (
-                                <Badge
-                                    variant="light"
-                                    ml="xs"
-                                    radius="xs"
-                                    size="xs"
-                                >
-                                    New version available!
-                                </Badge>
-                            )}
-                        </Button>
-
-                        {minimal ? (
-                            <Anchor
-                                href="https://docs.lightdash.com/"
-                                target="_blank"
+                        {!minimal && 'Lightdash - '}
+                        {healthState.data && `v${healthState.data.version}`}
+                        {showUpdateBadge && (
+                            <Badge
+                                variant="light"
+                                ml="xs"
+                                radius="xs"
+                                size="xs"
                             >
-                                <ActionIcon color="gray.7" p="xs" size="lg">
-                                    <MantineIcon
-                                        icon={IconBook}
-                                        size="lg"
-                                        color="gray.7"
-                                    />
-                                </ActionIcon>
-                            </Anchor>
-                        ) : (
+                                New version available!
+                            </Badge>
+                        )}
+                    </Button>
+
+                    {minimal ? (
+                        <Anchor
+                            href="https://docs.lightdash.com/"
+                            target="_blank"
+                        >
+                            <ActionIcon color="gray.7" p="xs" size="lg">
+                                <MantineIcon
+                                    icon={IconBook}
+                                    size="lg"
+                                    color="gray.7"
+                                />
+                            </ActionIcon>
+                        </Anchor>
+                    ) : (
+                        <MantineLinkButton
+                            href="https://docs.lightdash.com/"
+                            target="_blank"
+                            leftIcon={
+                                <MantineIcon
+                                    icon={IconBook}
+                                    size="lg"
+                                    color="gray.7"
+                                />
+                            }
+                            variant="light"
+                            color="gray.7"
+                            fw="500"
+                            p="xs"
+                        >
+                            Documentation
+                        </MantineLinkButton>
+                    )}
+                </Group>
+            </Box>
+
+            <Modal
+                opened={isOpen}
+                onClose={() => setIsOpen(false)}
+                title={
+                    <Group align="center" justify="flex-start" gap="xs">
+                        <IconInfoCircle size={17} color="gray" /> About
+                        Lightdash
+                    </Group>
+                }
+            >
+                <TrackPage
+                    name={PageName.ABOUT_LIGHTDASH}
+                    type={PageType.MODAL}
+                >
+                    <Stack mx="xs">
+                        <Title order={5} fw={500}>
+                            <b>Version:</b>{' '}
+                            {healthState.data
+                                ? `v${healthState.data.version}`
+                                : 'n/a'}
+                        </Title>
+                        {showUpdateBadge && (
+                            <Alert
+                                title="New version available!"
+                                color="blue"
+                                icon={<IconInfoCircle size={17} />}
+                            >
+                                <Text c="blue">
+                                    The version v
+                                    {healthState.data?.latest.version} is now
+                                    available. Please follow the instructions in
+                                    the{' '}
+                                    <Anchor
+                                        href="https://docs.lightdash.com/self-host/update-lightdash"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        underline="always" // Required: link isn't differentiated from blue text without underline
+                                    >
+                                        How to update version
+                                    </Anchor>{' '}
+                                    documentation.
+                                </Text>
+                            </Alert>
+                        )}
+
+                        <Group justify="flex-end">
                             <MantineLinkButton
                                 href="https://docs.lightdash.com/"
                                 target="_blank"
-                                leftIcon={
-                                    <MantineIcon
-                                        icon={IconBook}
-                                        size="lg"
-                                        color="gray.7"
-                                    />
-                                }
-                                variant="light"
-                                color="gray.7"
-                                fw="500"
-                                p="xs"
+                                variant="default"
                             >
-                                Documentation
+                                Docs
                             </MantineLinkButton>
-                        )}
-                    </Group>
-                </Box>
-
-                <Modal
-                    opened={isOpen}
-                    onClose={() => setIsOpen(false)}
-                    title={
-                        <Group align="center" justify="flex-start" gap="xs">
-                            <IconInfoCircle size={17} color="gray" /> About
-                            Lightdash
+                            <MantineLinkButton
+                                href="https://github.com/lightdash/lightdash"
+                                target="_blank"
+                                variant="default"
+                            >
+                                Github
+                            </MantineLinkButton>
                         </Group>
-                    }
-                >
-                    <TrackPage
-                        name={PageName.ABOUT_LIGHTDASH}
-                        type={PageType.MODAL}
-                    >
-                        <Stack mx="xs">
-                            <Title order={5} fw={500}>
-                                <b>Version:</b>{' '}
-                                {healthState.data
-                                    ? `v${healthState.data.version}`
-                                    : 'n/a'}
-                            </Title>
-                            {showUpdateBadge && (
-                                <Alert
-                                    title="New version available!"
-                                    color="blue"
-                                    icon={<IconInfoCircle size={17} />}
-                                >
-                                    <Text c="blue">
-                                        The version v
-                                        {healthState.data?.latest.version} is
-                                        now available. Please follow the
-                                        instructions in the{' '}
-                                        <Anchor
-                                            href="https://docs.lightdash.com/self-host/update-lightdash"
-                                            target="_blank"
-                                            rel="noreferrer"
-                                            underline="always" // Required: link isn't differentiated from blue text without underline
-                                        >
-                                            How to update version
-                                        </Anchor>{' '}
-                                        documentation.
-                                    </Text>
-                                </Alert>
-                            )}
-
-                            <Group justify="flex-end">
-                                <MantineLinkButton
-                                    href="https://docs.lightdash.com/"
-                                    target="_blank"
-                                    variant="default"
-                                >
-                                    Docs
-                                </MantineLinkButton>
-                                <MantineLinkButton
-                                    href="https://github.com/lightdash/lightdash"
-                                    target="_blank"
-                                    variant="default"
-                                >
-                                    Github
-                                </MantineLinkButton>
-                            </Group>
-                        </Stack>
-                    </TrackPage>
-                </Modal>
-            </TrackSection>
-        </MantineProvider>
+                    </Stack>
+                </TrackPage>
+            </Modal>
+        </TrackSection>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ParametersCard/ParametersCard.tsx
+++ b/packages/frontend/src/components/Explorer/ParametersCard/ParametersCard.tsx
@@ -1,4 +1,4 @@
-import { Box, MantineProvider } from '@mantine-8/core';
+import { Box } from '@mantine-8/core';
 import { memo, useMemo } from 'react';
 import { useParams } from 'react-router';
 import {
@@ -6,7 +6,6 @@ import {
     useParameters,
 } from '../../../features/parameters';
 import { useExplore } from '../../../hooks/useExplore';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
@@ -89,41 +88,37 @@ const ParametersCard = memo(
         );
 
         return (
-            <MantineProvider theme={getMantine8ThemeOverride()}>
-                <CollapsableCard
-                    isOpen={
-                        paramsIsOpen &&
-                        isProjectParametersFetched &&
-                        isExploreFetched
-                    }
-                    title="Parameters"
-                    disabled={!tableName}
-                    toggleTooltip={!tableName ? 'No model selected' : ''}
-                    onToggle={() =>
-                        toggleExpandedSection(ExplorerSection.PARAMETERS)
-                    }
-                >
-                    <Box m="md">
-                        <ParameterSelection
-                            parameters={parameters}
-                            missingRequiredParameters={
-                                missingRequiredParameters
-                            }
-                            isLoading={
-                                isProjectParametersLoading || isExploreLoading
-                            }
-                            isError={isProjectParametersError || isExploreError}
-                            parameterValues={parameterValues || {}}
-                            onParameterChange={handleParameterChange}
-                            showClearAll={true}
-                            onClearAll={clearAllParameters}
-                            cols={2}
-                            projectUuid={projectUuid}
-                            disabled={!isEditMode}
-                        />
-                    </Box>
-                </CollapsableCard>
-            </MantineProvider>
+            <CollapsableCard
+                isOpen={
+                    paramsIsOpen &&
+                    isProjectParametersFetched &&
+                    isExploreFetched
+                }
+                title="Parameters"
+                disabled={!tableName}
+                toggleTooltip={!tableName ? 'No model selected' : ''}
+                onToggle={() =>
+                    toggleExpandedSection(ExplorerSection.PARAMETERS)
+                }
+            >
+                <Box m="md">
+                    <ParameterSelection
+                        parameters={parameters}
+                        missingRequiredParameters={missingRequiredParameters}
+                        isLoading={
+                            isProjectParametersLoading || isExploreLoading
+                        }
+                        isError={isProjectParametersError || isExploreError}
+                        parameterValues={parameterValues || {}}
+                        onParameterChange={handleParameterChange}
+                        showClearAll={true}
+                        onClearAll={clearAllParameters}
+                        cols={2}
+                        projectUuid={projectUuid}
+                        disabled={!isEditMode}
+                    />
+                </Box>
+            </CollapsableCard>
         );
     },
 );

--- a/packages/frontend/src/components/PinnedParameters.tsx
+++ b/packages/frontend/src/components/PinnedParameters.tsx
@@ -4,13 +4,11 @@ import {
     Button,
     CloseButton,
     Group,
-    MantineProvider,
     Popover,
     Text,
 } from '@mantine-8/core';
 import { useCallback, useMemo, type FC } from 'react';
 import { ParameterInput } from '../features/parameters/components/ParameterInput';
-import { getMantine8ThemeOverride } from '../mantine8Theme';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 
 interface PinnedParameterProps {
@@ -171,22 +169,20 @@ const PinnedParameters: FC<PinnedParametersProps> = ({ isEditMode }) => {
     }
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Group gap="xs">
-                {pinnedParametersList.map(({ key, parameter }) => (
-                    <PinnedParameter
-                        key={key}
-                        parameterKey={key}
-                        parameter={parameter}
-                        value={parameterValues[key] ?? null}
-                        onChange={handleParameterChange}
-                        onUnpin={handleUnpin}
-                        isEditMode={isEditMode}
-                        projectUuid={dashboard?.projectUuid}
-                    />
-                ))}
-            </Group>
-        </MantineProvider>
+        <Group gap="xs">
+            {pinnedParametersList.map(({ key, parameter }) => (
+                <PinnedParameter
+                    key={key}
+                    parameterKey={key}
+                    parameter={parameter}
+                    value={parameterValues[key] ?? null}
+                    onChange={handleParameterChange}
+                    onUnpin={handleUnpin}
+                    isEditMode={isEditMode}
+                    projectUuid={dashboard?.projectUuid}
+                />
+            ))}
+        </Group>
     );
 };
 

--- a/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
+++ b/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
@@ -8,7 +8,6 @@ import {
     Group,
     JsonInput,
     LoadingOverlay,
-    MantineProvider,
     Modal,
     Pagination,
     Paper,
@@ -24,7 +23,6 @@ import { IconEye, IconSearch, IconVariable, IconX } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useTableStyles } from '../../hooks/styles/useTableStyles';
 import { useProjectParametersList } from '../../hooks/useProjectParameters';
-import { getMantine8ThemeOverride } from '../../mantine8Theme';
 import MantineIcon from '../common/MantineIcon';
 import { SettingsCard } from '../common/Settings/SettingsCard';
 import { DEFAULT_PAGE_SIZE } from '../common/Table/constants';
@@ -182,123 +180,117 @@ const ProjectParameters: FC<ProjectParametersProps> = ({ projectUuid }) => {
     }
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Stack>
-                <Text c="dimmed">
-                    Learn more about parameters in our{' '}
-                    <Anchor
-                        role="button"
-                        href="https://docs.lightdash.com/guides/using-parameters#how-to-use-parameters"
-                        target="_blank"
-                        rel="noreferrer"
-                    >
-                        docs
-                    </Anchor>
-                    .
-                </Text>
+        <Stack>
+            <Text c="dimmed">
+                Learn more about parameters in our{' '}
+                <Anchor
+                    role="button"
+                    href="https://docs.lightdash.com/guides/using-parameters#how-to-use-parameters"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    docs
+                </Anchor>
+                .
+            </Text>
 
-                <SettingsCard shadow="none" p={0}>
-                    <Paper p="sm" bd={0}>
-                        <Group gap="md" align="center">
-                            <Title order={5}>Parameters</Title>
-                        </Group>
+            <SettingsCard shadow="none" p={0}>
+                <Paper p="sm" bd={0}>
+                    <Group gap="md" align="center">
+                        <Title order={5}>Parameters</Title>
+                    </Group>
 
-                        <Box mt="sm">
-                            <TextInput
-                                size="xs"
-                                placeholder="Search parameters by name, label, description, or model"
-                                onChange={(e) => setSearch(e.target.value)}
-                                value={search}
-                                w={380}
-                                leftSection={<MantineIcon icon={IconSearch} />}
-                                rightSection={
-                                    search.length > 0 && (
-                                        <ActionIcon
-                                            variant="subtle"
-                                            onClick={() => setSearch('')}
-                                        >
-                                            <MantineIcon icon={IconX} />
-                                        </ActionIcon>
-                                    )
-                                }
-                            />
-                        </Box>
-                    </Paper>
+                    <Box mt="sm">
+                        <TextInput
+                            size="xs"
+                            placeholder="Search parameters by name, label, description, or model"
+                            onChange={(e) => setSearch(e.target.value)}
+                            value={search}
+                            w={380}
+                            leftSection={<MantineIcon icon={IconSearch} />}
+                            rightSection={
+                                search.length > 0 && (
+                                    <ActionIcon
+                                        variant="subtle"
+                                        onClick={() => setSearch('')}
+                                    >
+                                        <MantineIcon icon={IconX} />
+                                    </ActionIcon>
+                                )
+                            }
+                        />
+                    </Box>
+                </Paper>
 
-                    <Table
-                        withRowBorders
-                        className={cx(classes.root, classes.alignLastTdRight)}
-                    >
-                        <Table.Thead>
+                <Table
+                    withRowBorders
+                    className={cx(classes.root, classes.alignLastTdRight)}
+                >
+                    <Table.Thead>
+                        <Table.Tr>
+                            <Table.Th
+                                style={{ cursor: 'pointer' }}
+                                onClick={() => handleSort('name')}
+                            >
+                                <Group gap="xs">
+                                    <Text>Parameter</Text>
+                                    <Text>{getSortIcon('name')}</Text>
+                                </Group>
+                            </Table.Th>
+                            <Table.Th>
+                                <Text ta="left">Source</Text>
+                            </Table.Th>
+                            <Table.Th></Table.Th>
+                        </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody style={{ position: 'relative' }}>
+                        {!isLoading && parameters && parameters.length ? (
+                            tableRows
+                        ) : isLoading ? (
                             <Table.Tr>
-                                <Table.Th
-                                    style={{ cursor: 'pointer' }}
-                                    onClick={() => handleSort('name')}
-                                >
-                                    <Group gap="xs">
-                                        <Text>Parameter</Text>
-                                        <Text>{getSortIcon('name')}</Text>
-                                    </Group>
-                                </Table.Th>
-                                <Table.Th>
-                                    <Text ta="left">Source</Text>
-                                </Table.Th>
-                                <Table.Th></Table.Th>
+                                <Table.Td colSpan={3}>
+                                    <Box py="lg">
+                                        <LoadingOverlay visible={true} />
+                                    </Box>
+                                </Table.Td>
                             </Table.Tr>
-                        </Table.Thead>
-                        <Table.Tbody style={{ position: 'relative' }}>
-                            {!isLoading && parameters && parameters.length ? (
-                                tableRows
-                            ) : isLoading ? (
-                                <Table.Tr>
-                                    <Table.Td colSpan={3}>
-                                        <Box py="lg">
-                                            <LoadingOverlay visible={true} />
-                                        </Box>
-                                    </Table.Td>
-                                </Table.Tr>
-                            ) : (
-                                <Table.Tr>
-                                    <Table.Td colSpan={3}>
-                                        <Text
-                                            c="gray.6"
-                                            fs="italic"
-                                            ta="center"
-                                        >
-                                            {debouncedSearch
-                                                ? 'No parameters found matching your search'
-                                                : 'No parameters configured for this project'}
-                                        </Text>
-                                    </Table.Td>
-                                </Table.Tr>
-                            )}
-                        </Table.Tbody>
-                    </Table>
+                        ) : (
+                            <Table.Tr>
+                                <Table.Td colSpan={3}>
+                                    <Text c="gray.6" fs="italic" ta="center">
+                                        {debouncedSearch
+                                            ? 'No parameters found matching your search'
+                                            : 'No parameters configured for this project'}
+                                    </Text>
+                                </Table.Td>
+                            </Table.Tr>
+                        )}
+                    </Table.Tbody>
+                </Table>
 
-                    {pagination && pagination.totalPageCount > 1 && (
-                        <Paper p="sm">
-                            <Group justify="center">
-                                <Pagination
-                                    value={page}
-                                    onChange={setPage}
-                                    total={pagination.totalPageCount}
-                                    size="sm"
-                                />
-                            </Group>
-                        </Paper>
-                    )}
-                </SettingsCard>
-
-                {selectedParameter && (
-                    <ConfigModal
-                        parameterName={selectedParameter.name}
-                        config={selectedParameter.config}
-                        opened={configModal}
-                        onClose={configModalHandlers.close}
-                    />
+                {pagination && pagination.totalPageCount > 1 && (
+                    <Paper p="sm">
+                        <Group justify="center">
+                            <Pagination
+                                value={page}
+                                onChange={setPage}
+                                total={pagination.totalPageCount}
+                                size="sm"
+                            />
+                        </Group>
+                    </Paper>
                 )}
-            </Stack>
-        </MantineProvider>
+            </SettingsCard>
+
+            {selectedParameter && (
+                <ConfigModal
+                    parameterName={selectedParameter.name}
+                    config={selectedParameter.config}
+                    opened={configModal}
+                    onClose={configModalHandlers.close}
+                />
+            )}
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -2,7 +2,6 @@ import {
     Button,
     Group,
     Kbd,
-    MantineProvider,
     Text,
     Tooltip,
     rgba,
@@ -12,7 +11,6 @@ import { useHotkeys, useOs } from '@mantine-8/hooks';
 import { IconPlayerPlay, IconX } from '@tabler/icons-react';
 import { memo, useCallback, useTransition, type FC } from 'react';
 import useHealth from '../hooks/health/useHealth';
-import { getMantine8ThemeOverride } from '../mantine8Theme';
 import useExplorerContext from '../providers/Explorer/useExplorerContext';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
@@ -65,85 +63,83 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     useHotkeys([['mod + enter', onClick, { preventDefault: true }]]);
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Button.Group>
+        <Button.Group>
+            <Tooltip
+                label={
+                    <Group gap="xxs">
+                        <Kbd fw={600}>
+                            {os === 'macos' || os === 'ios' ? '⌘' : 'ctrl'}
+                        </Kbd>
+
+                        <Text fw={600}>+</Text>
+
+                        <Kbd fw={600}>Enter</Kbd>
+                    </Group>
+                }
+                position="bottom"
+                withArrow
+                withinPortal
+                disabled={isLoading || !isValidQuery}
+            >
+                <Button
+                    size={size}
+                    pr={limit ? 'xs' : undefined}
+                    disabled={!isValidQuery}
+                    leftSection={<MantineIcon icon={IconPlayerPlay} />}
+                    loading={isLoading}
+                    onClick={onClick}
+                    style={(theme) => ({
+                        flex: 1,
+                        borderRight: isValidQuery
+                            ? `1px solid ${rgba(theme.colors.gray[5], 0.6)}`
+                            : undefined,
+                        borderTopRightRadius: 0,
+                        borderBottomRightRadius: 0,
+                    })}
+                >
+                    Run query ({limit})
+                </Button>
+            </Tooltip>
+
+            {isLoading ? (
                 <Tooltip
-                    label={
-                        <Group gap="xxs">
-                            <Kbd fw={600}>
-                                {os === 'macos' || os === 'ios' ? '⌘' : 'ctrl'}
-                            </Kbd>
-
-                            <Text fw={600}>+</Text>
-
-                            <Kbd fw={600}>Enter</Kbd>
-                        </Group>
-                    }
+                    label={'Cancel query'}
                     position="bottom"
                     withArrow
                     withinPortal
-                    disabled={isLoading || !isValidQuery}
                 >
                     <Button
                         size={size}
-                        pr={limit ? 'xs' : undefined}
-                        disabled={!isValidQuery}
-                        leftSection={<MantineIcon icon={IconPlayerPlay} />}
-                        loading={isLoading}
-                        onClick={onClick}
-                        style={(theme) => ({
-                            flex: 1,
-                            borderRight: isValidQuery
-                                ? `1px solid ${rgba(theme.colors.gray[5], 0.6)}`
-                                : undefined,
-                            borderTopRightRadius: 0,
-                            borderBottomRightRadius: 0,
-                        })}
+                        p="xs"
+                        onClick={() =>
+                            startTransition(() => {
+                                cancelQuery();
+                            })
+                        }
+                        style={{
+                            borderTopLeftRadius: 0,
+                            borderBottomLeftRadius: 0,
+                        }}
                     >
-                        Run query ({limit})
+                        <MantineIcon icon={IconX} size="sm" />
                     </Button>
                 </Tooltip>
-
-                {isLoading ? (
-                    <Tooltip
-                        label={'Cancel query'}
-                        position="bottom"
-                        withArrow
-                        withinPortal
-                    >
-                        <Button
-                            size={size}
-                            p="xs"
-                            onClick={() =>
-                                startTransition(() => {
-                                    cancelQuery();
-                                })
-                            }
-                            style={{
-                                borderTopLeftRadius: 0,
-                                borderBottomLeftRadius: 0,
-                            }}
-                        >
-                            <MantineIcon icon={IconX} size="sm" />
-                        </Button>
-                    </Tooltip>
-                ) : (
-                    <RunQuerySettings
-                        disabled={!isValidQuery}
-                        size={size}
-                        maxLimit={maxLimit}
-                        limit={limit}
-                        onLimitChange={setRowLimit}
-                        showAutoFetchSetting
-                        targetProps={{
-                            style: {
-                                borderTopLeftRadius: 0,
-                                borderBottomLeftRadius: 0,
-                            },
-                        }}
-                    />
-                )}
-            </Button.Group>
-        </MantineProvider>
+            ) : (
+                <RunQuerySettings
+                    disabled={!isValidQuery}
+                    size={size}
+                    maxLimit={maxLimit}
+                    limit={limit}
+                    onLimitChange={setRowLimit}
+                    showAutoFetchSetting
+                    targetProps={{
+                        style: {
+                            borderTopLeftRadius: 0,
+                            borderBottomLeftRadius: 0,
+                        },
+                    }}
+                />
+            )}
+        </Button.Group>
     );
 });

--- a/packages/frontend/src/components/SqlRunner/RunSqlQueryButton.tsx
+++ b/packages/frontend/src/components/SqlRunner/RunSqlQueryButton.tsx
@@ -1,17 +1,8 @@
-import {
-    Button,
-    Group,
-    Kbd,
-    MantineProvider,
-    rgba,
-    Text,
-    Tooltip,
-} from '@mantine-8/core';
+import { Button, Group, Kbd, rgba, Text, Tooltip } from '@mantine-8/core';
 import { useOs } from '@mantine-8/hooks';
 import { IconPlayerPlay } from '@tabler/icons-react';
 import { type FC } from 'react';
 import useHealth from '../../hooks/health/useHealth';
-import { getMantine8ThemeOverride } from '../../mantine8Theme';
 import RunQuerySettings from '../RunQuerySettings';
 import MantineIcon from '../common/MantineIcon';
 
@@ -27,64 +18,62 @@ const RunSqlQueryButton: FC<{
 
     const os = useOs();
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Button.Group>
-                <Tooltip
-                    label={
-                        <Group gap="xxs">
-                            <Kbd fw={600}>
-                                {os === 'macos' || os === 'ios' ? '⌘' : 'ctrl'}
-                            </Kbd>
+        <Button.Group>
+            <Tooltip
+                label={
+                    <Group gap="xxs">
+                        <Kbd fw={600}>
+                            {os === 'macos' || os === 'ios' ? '⌘' : 'ctrl'}
+                        </Kbd>
 
-                            <Text fw={600}>+</Text>
+                        <Text fw={600}>+</Text>
 
-                            <Kbd fw={600}>Enter</Kbd>
-                        </Group>
-                    }
-                    position="bottom"
-                    withArrow
-                    withinPortal
-                    disabled={isLoading}
+                        <Kbd fw={600}>Enter</Kbd>
+                    </Group>
+                }
+                position="bottom"
+                withArrow
+                withinPortal
+                disabled={isLoading}
+            >
+                <Button
+                    size="xs"
+                    pr={limit ? 'xs' : undefined}
+                    leftSection={<MantineIcon icon={IconPlayerPlay} />}
+                    onClick={onSubmit}
+                    loading={isLoading}
+                    disabled={disabled}
+                    style={(theme) => ({
+                        flex: 1,
+                        borderRight: !disabled
+                            ? `1px solid ${rgba(theme.colors.gray[5], 0.6)}`
+                            : undefined,
+
+                        ...(onLimitChange !== undefined && {
+                            borderTopRightRadius: 0,
+                            borderBottomRightRadius: 0,
+                        }),
+                    })}
                 >
-                    <Button
-                        size="xs"
-                        pr={limit ? 'xs' : undefined}
-                        leftSection={<MantineIcon icon={IconPlayerPlay} />}
-                        onClick={onSubmit}
-                        loading={isLoading}
-                        disabled={disabled}
-                        style={(theme) => ({
-                            flex: 1,
-                            borderRight: !disabled
-                                ? `1px solid ${rgba(theme.colors.gray[5], 0.6)}`
-                                : undefined,
-
-                            ...(onLimitChange !== undefined && {
-                                borderTopRightRadius: 0,
-                                borderBottomRightRadius: 0,
-                            }),
-                        })}
-                    >
-                        {`Run query ${limit ? `(${limit})` : ''}`}
-                    </Button>
-                </Tooltip>
-                {onLimitChange !== undefined && (
-                    <RunQuerySettings
-                        disabled={disabled}
-                        size="xs"
-                        maxLimit={maxLimit}
-                        limit={limit || 500}
-                        onLimitChange={onLimitChange}
-                        targetProps={{
-                            style: {
-                                borderTopLeftRadius: 0,
-                                borderBottomLeftRadius: 0,
-                            },
-                        }}
-                    />
-                )}
-            </Button.Group>
-        </MantineProvider>
+                    {`Run query ${limit ? `(${limit})` : ''}`}
+                </Button>
+            </Tooltip>
+            {onLimitChange !== undefined && (
+                <RunQuerySettings
+                    disabled={disabled}
+                    size="xs"
+                    maxLimit={maxLimit}
+                    limit={limit || 500}
+                    onLimitChange={onLimitChange}
+                    targetProps={{
+                        style: {
+                            borderTopLeftRadius: 0,
+                            borderBottomLeftRadius: 0,
+                        },
+                    }}
+                />
+            )}
+        </Button.Group>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -3,7 +3,6 @@ import {
     Anchor,
     Button,
     Flex,
-    MantineProvider,
     Stack,
     Text,
     TextInput,
@@ -19,7 +18,6 @@ import {
     useOneTimePassword,
 } from '../../../hooks/useEmailVerification';
 import { useUserUpdateMutation } from '../../../hooks/user/useUserUpdateMutation';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import { VerifyEmailModal } from '../../../pages/VerifyEmail';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
@@ -108,107 +106,102 @@ const ProfilePanel: FC = () => {
     const isLoading = isLoadingUser || isUpdatingUser || !form.initialized;
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <form onSubmit={handleOnSubmit}>
-                <Stack mt="md">
-                    <TextInput
-                        placeholder="First name"
-                        label="First name"
-                        type="text"
-                        required
-                        disabled={isLoading}
-                        {...form.getInputProps('firstName')}
-                    />
+        <form onSubmit={handleOnSubmit}>
+            <Stack mt="md">
+                <TextInput
+                    placeholder="First name"
+                    label="First name"
+                    type="text"
+                    required
+                    disabled={isLoading}
+                    {...form.getInputProps('firstName')}
+                />
 
-                    <TextInput
-                        placeholder="Last name"
-                        label="Last name"
-                        type="text"
-                        required
-                        disabled={isLoading}
-                        {...form.getInputProps('lastName')}
-                    />
+                <TextInput
+                    placeholder="Last name"
+                    label="Last name"
+                    type="text"
+                    required
+                    disabled={isLoading}
+                    {...form.getInputProps('lastName')}
+                />
 
-                    <TextInput
-                        placeholder="Email"
-                        label="Email"
-                        type="email"
-                        required
-                        disabled={isLoading}
-                        inputWrapperOrder={[
-                            'label',
-                            'input',
-                            'error',
-                            'description',
-                        ]}
-                        {...form.getInputProps('email')}
-                        rightSection={
-                            isEmailServerConfigured && data?.isVerified ? (
-                                <Tooltip label="This e-mail has been verified">
-                                    <MantineIcon
-                                        size="lg"
-                                        icon={IconCircleCheck}
-                                        color="green.6"
-                                    />
-                                </Tooltip>
-                            ) : (
+                <TextInput
+                    placeholder="Email"
+                    label="Email"
+                    type="email"
+                    required
+                    disabled={isLoading}
+                    inputWrapperOrder={[
+                        'label',
+                        'input',
+                        'error',
+                        'description',
+                    ]}
+                    {...form.getInputProps('email')}
+                    rightSection={
+                        isEmailServerConfigured && data?.isVerified ? (
+                            <Tooltip label="This e-mail has been verified">
                                 <MantineIcon
                                     size="lg"
-                                    icon={IconAlertCircle}
-                                    color="gray.6"
+                                    icon={IconCircleCheck}
+                                    color="green.6"
                                 />
-                            )
-                        }
-                        descriptionProps={{ mt: 'xs' }}
-                        description={
-                            isEmailServerConfigured && !data?.isVerified ? (
-                                <Text c="dimmed">
-                                    This email has not been verified.{' '}
-                                    <Anchor
-                                        component="span"
-                                        onClick={() => {
-                                            if (!data?.otp) {
-                                                sendVerificationEmail();
-                                            }
-                                            setShowVerifyEmailModal(true);
-                                        }}
-                                    >
-                                        Click here to verify it
-                                    </Anchor>
-                                    .
-                                </Text>
-                            ) : null
-                        }
-                    />
+                            </Tooltip>
+                        ) : (
+                            <MantineIcon
+                                size="lg"
+                                icon={IconAlertCircle}
+                                color="gray.6"
+                            />
+                        )
+                    }
+                    descriptionProps={{ mt: 'xs' }}
+                    description={
+                        isEmailServerConfigured && !data?.isVerified ? (
+                            <Text c="dimmed">
+                                This email has not been verified.{' '}
+                                <Anchor
+                                    component="span"
+                                    onClick={() => {
+                                        if (!data?.otp) {
+                                            sendVerificationEmail();
+                                        }
+                                        setShowVerifyEmailModal(true);
+                                    }}
+                                >
+                                    Click here to verify it
+                                </Anchor>
+                                .
+                            </Text>
+                        ) : null
+                    }
+                />
 
-                    <Flex justify="flex-end" gap="sm">
-                        {form.isDirty() && !isUpdatingUser && (
-                            <Button
-                                variant="outline"
-                                onClick={() => form.reset()}
-                            >
-                                Cancel
-                            </Button>
-                        )}
-                        <Button
-                            type="submit"
-                            loading={isLoading}
-                            disabled={!form.isDirty()}
-                        >
-                            Update
+                <Flex justify="flex-end" gap="sm">
+                    {form.isDirty() && !isUpdatingUser && (
+                        <Button variant="outline" onClick={() => form.reset()}>
+                            Cancel
                         </Button>
-                    </Flex>
+                    )}
+                    <Button
+                        type="submit"
+                        loading={isLoading}
+                        disabled={!form.isDirty()}
+                    >
+                        Update
+                    </Button>
+                </Flex>
 
-                    <VerifyEmailModal
-                        opened={showVerifyEmailModal}
-                        onClose={() => {
-                            setShowVerifyEmailModal(false);
-                        }}
-                        isLoading={statusLoading || emailLoading}
-                    />
-                </Stack>
-            </form>
-        </MantineProvider>
+                <VerifyEmailModal
+                    opened={showVerifyEmailModal}
+                    onClose={() => {
+                        setShowVerifyEmailModal(false);
+                    }}
+                    isLoading={statusLoading || emailLoading}
+                />
+            </Stack>
+        </form>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/InvitesModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/InvitesModal.tsx
@@ -6,7 +6,6 @@ import {
 import {
     Button,
     Group,
-    MantineProvider,
     Modal,
     Select,
     TextInput,
@@ -17,7 +16,6 @@ import { IconUser } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import { z } from 'zod';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import useApp from '../../../providers/App/useApp';
 import { TrackPage } from '../../../providers/Tracking/TrackingProvider';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -63,78 +61,73 @@ const InvitesModal: FC<{
     };
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Modal
-                opened={opened}
-                onClose={onClose}
-                title={
-                    <Group gap="xs">
-                        <MantineIcon size="lg" icon={IconUser} />
-                        <Title order={4}>Add user</Title>
-                    </Group>
-                }
-                size="lg"
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            title={
+                <Group gap="xs">
+                    <MantineIcon size="lg" icon={IconUser} />
+                    <Title order={4}>Add user</Title>
+                </Group>
+            }
+            size="lg"
+        >
+            <TrackPage
+                name={PageName.INVITE_MANAGEMENT_SETTINGS}
+                type={PageType.MODAL}
+                category={CategoryName.SETTINGS}
             >
-                <TrackPage
-                    name={PageName.INVITE_MANAGEMENT_SETTINGS}
-                    type={PageType.MODAL}
-                    category={CategoryName.SETTINGS}
+                <form
+                    name="invite_user"
+                    onSubmit={form.onSubmit((values: SendInviteFormProps) =>
+                        handleSubmit(values),
+                    )}
                 >
-                    <form
-                        name="invite_user"
-                        onSubmit={form.onSubmit((values: SendInviteFormProps) =>
-                            handleSubmit(values),
-                        )}
-                    >
-                        <Group gap="xs" align="start" wrap="nowrap">
-                            <TextInput
-                                name="email"
-                                label="Enter user email address"
-                                placeholder="example@gmail.com"
-                                required
-                                disabled={isLoading}
-                                style={{ flex: 1 }}
-                                {...form.getInputProps('email')}
-                            />
-                            {user.data?.ability?.can(
-                                'manage',
-                                'Organization',
-                            ) && (
-                                <Select
-                                    data={Object.values(
-                                        OrganizationMemberRole,
-                                    ).map((orgMemberRole) => ({
+                    <Group gap="xs" align="start" wrap="nowrap">
+                        <TextInput
+                            name="email"
+                            label="Enter user email address"
+                            placeholder="example@gmail.com"
+                            required
+                            disabled={isLoading}
+                            style={{ flex: 1 }}
+                            {...form.getInputProps('email')}
+                        />
+                        {user.data?.ability?.can('manage', 'Organization') && (
+                            <Select
+                                data={Object.values(OrganizationMemberRole).map(
+                                    (orgMemberRole) => ({
                                         value: orgMemberRole,
                                         label: orgMemberRole.replace('_', ' '),
-                                    }))}
-                                    disabled={isLoading}
-                                    required
-                                    placeholder="Select role"
-                                    comboboxProps={{
-                                        position: 'bottom',
-                                        withinPortal: true,
-                                    }}
-                                    style={{ marginTop: 20, width: 180 }}
-                                    {...form.getInputProps('role')}
-                                />
-                            )}
-                            <Button
+                                    }),
+                                )}
                                 disabled={isLoading}
-                                type="submit"
-                                style={{ marginTop: 20 }}
-                            >
-                                {health.data?.hasEmailClient
-                                    ? 'Send invite'
-                                    : 'Generate invite'}
-                            </Button>
-                        </Group>
-                    </form>
-                    {inviteLink && (
-                        <InviteSuccess invite={inviteLink} hasMarginTop />
-                    )}
-                </TrackPage>
-            </Modal>
-        </MantineProvider>
+                                required
+                                placeholder="Select role"
+                                comboboxProps={{
+                                    position: 'bottom',
+                                    withinPortal: true,
+                                }}
+                                style={{ marginTop: 20, width: 180 }}
+                                {...form.getInputProps('role')}
+                            />
+                        )}
+                        <Button
+                            disabled={isLoading}
+                            type="submit"
+                            style={{ marginTop: 20 }}
+                        >
+                            {health.data?.hasEmailClient
+                                ? 'Send invite'
+                                : 'Generate invite'}
+                        </Button>
+                    </Group>
+                </form>
+                {inviteLink && (
+                    <InviteSuccess invite={inviteLink} hasMarginTop />
+                )}
+            </TrackPage>
+        </Modal>
     );
 };
 

--- a/packages/frontend/src/components/common/Tree/Tree.tsx
+++ b/packages/frontend/src/components/common/Tree/Tree.tsx
@@ -1,10 +1,4 @@
-import {
-    Box,
-    MantineProvider,
-    Tree as MantineTree,
-    rem,
-    useTree,
-} from '@mantine-8/core';
+import { Box, Tree as MantineTree, rem, useTree } from '@mantine-8/core';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { type FuzzyMatches } from '../../../hooks/useFuzzySearch';
@@ -102,76 +96,74 @@ const Tree: React.FC<Props> = ({
     }, [withRootSelectable, tree]);
 
     return (
-        <MantineProvider>
-            <Box px="sm" py="xs">
-                <TreeItem
-                    withRootSelectable={withRootSelectable}
-                    selected={!value}
-                    label={topLevelLabel}
-                    isRoot={true}
-                    onClick={handleSelectTopLevel}
+        <Box px="sm" py="xs">
+            <TreeItem
+                withRootSelectable={withRootSelectable}
+                selected={!value}
+                label={topLevelLabel}
+                isRoot={true}
+                onClick={handleSelectTopLevel}
+            />
+
+            <Box ml={rem(6)} pl={rem(13.5)}>
+                <MantineTree
+                    data={treeData}
+                    tree={tree}
+                    levelOffset={rem(23)}
+                    renderNode={({
+                        node,
+                        selected,
+                        expanded,
+                        hasChildren,
+                        elementProps,
+                        tree: nTree,
+                    }) => {
+                        const nodeItem = data.find(
+                            (i) => i.path === node.value,
+                        );
+
+                        if (!nodeItem) {
+                            throw new Error(
+                                `Item with uuid ${node.value} not found`,
+                            );
+                        }
+
+                        const highlights =
+                            '_fuzzyMatches' in nodeItem
+                                ? nodeItem._fuzzyMatches
+                                : [];
+
+                        return (
+                            <div {...elementProps}>
+                                <TreeItem
+                                    expanded={expanded}
+                                    selected={selected}
+                                    label={node.label}
+                                    matchHighlights={highlights}
+                                    hasChildren={hasChildren}
+                                    onClick={() =>
+                                        nTree.toggleSelected(node.value)
+                                    }
+                                    onClickExpand={() =>
+                                        nTree.toggleExpanded(node.value)
+                                    }
+                                />
+                            </div>
+                        );
+                    }}
+                    allowRangeSelection={false}
+                    checkOnSpace={false}
+                    clearSelectionOnOutsideClick={false}
+                    expandOnClick={false}
+                    expandOnSpace={false}
+                    selectOnClick={false}
+                    classNames={{
+                        node: classes.node,
+                        label: classes.label,
+                    }}
                 />
-
-                <Box ml={rem(6)} pl={rem(13.5)}>
-                    <MantineTree
-                        data={treeData}
-                        tree={tree}
-                        levelOffset={rem(23)}
-                        renderNode={({
-                            node,
-                            selected,
-                            expanded,
-                            hasChildren,
-                            elementProps,
-                            tree: nTree,
-                        }) => {
-                            const nodeItem = data.find(
-                                (i) => i.path === node.value,
-                            );
-
-                            if (!nodeItem) {
-                                throw new Error(
-                                    `Item with uuid ${node.value} not found`,
-                                );
-                            }
-
-                            const highlights =
-                                '_fuzzyMatches' in nodeItem
-                                    ? nodeItem._fuzzyMatches
-                                    : [];
-
-                            return (
-                                <div {...elementProps}>
-                                    <TreeItem
-                                        expanded={expanded}
-                                        selected={selected}
-                                        label={node.label}
-                                        matchHighlights={highlights}
-                                        hasChildren={hasChildren}
-                                        onClick={() =>
-                                            nTree.toggleSelected(node.value)
-                                        }
-                                        onClickExpand={() =>
-                                            nTree.toggleExpanded(node.value)
-                                        }
-                                    />
-                                </div>
-                            );
-                        }}
-                        allowRangeSelection={false}
-                        checkOnSpace={false}
-                        clearSelectionOnOutsideClick={false}
-                        expandOnClick={false}
-                        expandOnSpace={false}
-                        selectOnClick={false}
-                        classNames={{
-                            node: classes.node,
-                            label: classes.label,
-                        }}
-                    />
-                </Box>
             </Box>
-        </MantineProvider>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/components/common/Tree/TreeItem.tsx
+++ b/packages/frontend/src/components/common/Tree/TreeItem.tsx
@@ -65,6 +65,8 @@ const TreeItem: React.FC<Props> = ({
             pl={withPadding ? rem(4) : undefined}
             pr={withPadding ? 'xs' : undefined}
             radius="sm"
+            withBorder={false}
+            shadow="none"
             wrap="nowrap"
             onClick={onClick}
         >

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -1,8 +1,6 @@
-import { MantineProvider } from '@mantine-8/core';
 import { Navigate, Outlet, type RouteObject } from 'react-router';
 import NavBar from '../components/NavBar';
 import PrivateRoute from '../components/PrivateRoute';
-import { getMantine8ThemeOverride } from '../mantine8Theme';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
 import { AiAgentThreadStreamStoreProvider } from './features/aiCopilot/streaming/AiAgentThreadStreamStoreProvider';
@@ -57,11 +55,9 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
         element: (
             <PrivateRoute>
                 <NavBar />
-                <MantineProvider theme={getMantine8ThemeOverride()}>
-                    <AiAgentThreadStreamStoreProvider>
-                        <Outlet />
-                    </AiAgentThreadStreamStoreProvider>
-                </MantineProvider>
+                <AiAgentThreadStreamStoreProvider>
+                    <Outlet />
+                </AiAgentThreadStreamStoreProvider>
             </PrivateRoute>
         ),
         children: [

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -1,12 +1,5 @@
 import { DateGranularity } from '@lightdash/common';
-import {
-    ActionIcon,
-    Box,
-    Button,
-    Group,
-    MantineProvider,
-    Menu,
-} from '@mantine-8/core';
+import { ActionIcon, Box, Button, Group, Menu } from '@mantine-8/core';
 import {
     IconCalendarSearch,
     IconCheck,
@@ -16,7 +9,6 @@ import {
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -48,136 +40,130 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
     if (isDateZoomDisabled) {
         if (isEditMode)
             return (
-                <MantineProvider theme={getMantine8ThemeOverride()}>
-                    <Button
-                        variant="outline"
-                        size="xs"
-                        leftSection={<MantineIcon icon={IconCalendarSearch} />}
-                        onClick={() => setIsDateZoomDisabled(false)}
-                        classNames={{ root: styles.addDateZoomButton }}
-                    >
-                        + Add date zoom
-                    </Button>
-                </MantineProvider>
+                <Button
+                    variant="outline"
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconCalendarSearch} />}
+                    onClick={() => setIsDateZoomDisabled(false)}
+                    classNames={{ root: styles.addDateZoomButton }}
+                >
+                    + Add date zoom
+                </Button>
             );
         return null;
     }
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Menu
-                withinPortal
-                withArrow
-                closeOnItemClick
-                closeOnClickOutside
-                offset={-1}
-                position="bottom-end"
-                disabled={isEditMode}
-                onOpen={() => setShowOpenIcon(true)}
-                onClose={() => setShowOpenIcon(false)}
-            >
-                <Menu.Target>
-                    <Group gap={0} pos="relative">
-                        {isEditMode && (
-                            <ActionIcon
-                                size="xs"
-                                variant="subtle"
-                                onClick={() => setIsDateZoomDisabled(true)}
-                                className={styles.closeButton}
-                            >
-                                <MantineIcon icon={IconX} size={12} />
-                            </ActionIcon>
-                        )}
-                        <Button
+        <Menu
+            withinPortal
+            withArrow
+            closeOnItemClick
+            closeOnClickOutside
+            offset={-1}
+            position="bottom-end"
+            disabled={isEditMode}
+            onOpen={() => setShowOpenIcon(true)}
+            onClose={() => setShowOpenIcon(false)}
+        >
+            <Menu.Target>
+                <Group gap={0} pos="relative">
+                    {isEditMode && (
+                        <ActionIcon
                             size="xs"
-                            variant="default"
-                            disabled={isEditMode}
-                            classNames={
-                                dateZoomGranularity
-                                    ? { root: styles.activeDateZoomButton }
-                                    : undefined
-                            }
-                            leftSection={
-                                <MantineIcon icon={IconCalendarSearch} />
-                            }
-                            rightSection={
-                                <MantineIcon
-                                    icon={
-                                        showOpenIcon
-                                            ? IconChevronUp
-                                            : IconChevronDown
-                                    }
-                                />
-                            }
+                            variant="subtle"
+                            onClick={() => setIsDateZoomDisabled(true)}
+                            className={styles.closeButton}
                         >
-                            Date Zoom
-                            {dateZoomGranularity ? `:` : null}{' '}
-                            {dateZoomGranularity ? (
-                                <Box fw={500} ml="xxs">
-                                    {dateZoomGranularity}
-                                </Box>
-                            ) : null}
-                        </Button>
-                    </Group>
-                </Menu.Target>
-                <Menu.Dropdown>
-                    <Menu.Label fz={10}>Granularity</Menu.Label>
+                            <MantineIcon icon={IconX} size={12} />
+                        </ActionIcon>
+                    )}
+                    <Button
+                        size="xs"
+                        variant="default"
+                        disabled={isEditMode}
+                        classNames={
+                            dateZoomGranularity
+                                ? { root: styles.activeDateZoomButton }
+                                : undefined
+                        }
+                        leftSection={<MantineIcon icon={IconCalendarSearch} />}
+                        rightSection={
+                            <MantineIcon
+                                icon={
+                                    showOpenIcon
+                                        ? IconChevronUp
+                                        : IconChevronDown
+                                }
+                            />
+                        }
+                    >
+                        Date Zoom
+                        {dateZoomGranularity ? `:` : null}{' '}
+                        {dateZoomGranularity ? (
+                            <Box fw={500} ml="xxs">
+                                {dateZoomGranularity}
+                            </Box>
+                        ) : null}
+                    </Button>
+                </Group>
+            </Menu.Target>
+            <Menu.Dropdown>
+                <Menu.Label fz={10}>Granularity</Menu.Label>
+                <Menu.Item
+                    fz="xs"
+                    onClick={() => {
+                        track({
+                            name: EventName.DATE_ZOOM_CLICKED,
+                            properties: {
+                                granularity: 'default',
+                            },
+                        });
+
+                        setDateZoomGranularity(undefined);
+                    }}
+                    disabled={dateZoomGranularity === undefined}
+                    className={
+                        dateZoomGranularity === undefined
+                            ? styles.menuItemDisabled
+                            : ''
+                    }
+                    rightSection={
+                        dateZoomGranularity === undefined ? (
+                            <MantineIcon icon={IconCheck} size={14} />
+                        ) : null
+                    }
+                >
+                    Default
+                </Menu.Item>
+                {Object.values(DateGranularity).map((granularity) => (
                     <Menu.Item
                         fz="xs"
+                        key={granularity}
                         onClick={() => {
                             track({
                                 name: EventName.DATE_ZOOM_CLICKED,
                                 properties: {
-                                    granularity: 'default',
+                                    granularity,
                                 },
                             });
-
-                            setDateZoomGranularity(undefined);
+                            setDateZoomGranularity(granularity);
                         }}
-                        disabled={dateZoomGranularity === undefined}
+                        disabled={dateZoomGranularity === granularity}
                         className={
-                            dateZoomGranularity === undefined
+                            dateZoomGranularity === granularity
                                 ? styles.menuItemDisabled
                                 : ''
                         }
                         rightSection={
-                            dateZoomGranularity === undefined ? (
+                            dateZoomGranularity === granularity ? (
                                 <MantineIcon icon={IconCheck} size={14} />
                             ) : null
                         }
                     >
-                        Default
+                        {granularity}
                     </Menu.Item>
-                    {Object.values(DateGranularity).map((granularity) => (
-                        <Menu.Item
-                            fz="xs"
-                            key={granularity}
-                            onClick={() => {
-                                track({
-                                    name: EventName.DATE_ZOOM_CLICKED,
-                                    properties: {
-                                        granularity,
-                                    },
-                                });
-                                setDateZoomGranularity(granularity);
-                            }}
-                            disabled={dateZoomGranularity === granularity}
-                            className={
-                                dateZoomGranularity === granularity
-                                    ? styles.menuItemDisabled
-                                    : ''
-                            }
-                            rightSection={
-                                dateZoomGranularity === granularity ? (
-                                    <MantineIcon icon={IconCheck} size={14} />
-                                ) : null
-                            }
-                        >
-                            {granularity}
-                        </Menu.Item>
-                    ))}
-                </Menu.Dropdown>
-            </Menu>
-        </MantineProvider>
+                ))}
+            </Menu.Dropdown>
+        </Menu>
     );
 };

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -2,7 +2,7 @@ import {
     type ParameterDefinitions,
     type ParametersValuesMap,
 } from '@lightdash/common';
-import { Box, Button, MantineProvider, Menu } from '@mantine-8/core';
+import { Box, Button, Menu } from '@mantine-8/core';
 import {
     IconChevronDown,
     IconChevronUp,
@@ -11,7 +11,6 @@ import {
 import { useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import { ParameterSelection } from '../index';
 import styles from './Parameters.module.css';
 
@@ -60,66 +59,60 @@ export const Parameters: FC<Props> = ({
         .join(' ');
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
-            <Menu
-                withinPortal
-                withArrow
-                arrowOffset={100}
-                closeOnItemClick={false}
-                closeOnClickOutside
-                offset={-1}
-                position="bottom-end"
-                disabled={isLoading}
-                onOpen={() => setShowOpenIcon(true)}
-                onClose={() => setShowOpenIcon(false)}
-            >
-                <Menu.Target>
-                    <Button
-                        size="xs"
-                        variant="default"
-                        loading={isLoading}
-                        disabled={isLoading}
-                        className={buttonClasses}
-                        leftSection={<MantineIcon icon={IconVariable} />}
-                        rightSection={
-                            <MantineIcon
-                                icon={
-                                    showOpenIcon
-                                        ? IconChevronUp
-                                        : IconChevronDown
-                                }
-                            />
-                        }
-                    >
-                        Parameters
-                        {selectedParametersCount > 0
-                            ? ` (${selectedParametersCount})`
-                            : ''}
-                    </Button>
-                </Menu.Target>
-                <Menu.Dropdown>
-                    <Menu.Label fz={10}>Parameters</Menu.Label>
-                    <Box p="sm" miw={200}>
-                        <ParameterSelection
-                            parameters={parameters}
-                            isLoading={isLoading}
-                            isError={isError}
-                            parameterValues={parameterValues}
-                            onParameterChange={onParameterChange}
-                            size="xs"
-                            showClearAll={selectedParametersCount > 0}
-                            onClearAll={onClearAll}
-                            projectUuid={projectUuid}
-                            missingRequiredParameters={
-                                missingRequiredParameters
+        <Menu
+            withinPortal
+            withArrow
+            arrowOffset={100}
+            closeOnItemClick={false}
+            closeOnClickOutside
+            offset={-1}
+            position="bottom-end"
+            disabled={isLoading}
+            onOpen={() => setShowOpenIcon(true)}
+            onClose={() => setShowOpenIcon(false)}
+        >
+            <Menu.Target>
+                <Button
+                    size="xs"
+                    variant="default"
+                    loading={isLoading}
+                    disabled={isLoading}
+                    className={buttonClasses}
+                    leftSection={<MantineIcon icon={IconVariable} />}
+                    rightSection={
+                        <MantineIcon
+                            icon={
+                                showOpenIcon ? IconChevronUp : IconChevronDown
                             }
-                            isEditMode={isEditMode}
-                            pinnedParameters={pinnedParameters}
-                            onParameterPin={onParameterPin}
                         />
-                    </Box>
-                </Menu.Dropdown>
-            </Menu>
-        </MantineProvider>
+                    }
+                >
+                    Parameters
+                    {selectedParametersCount > 0
+                        ? ` (${selectedParametersCount})`
+                        : ''}
+                </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+                <Menu.Label fz={10}>Parameters</Menu.Label>
+                <Box p="sm" miw={200}>
+                    <ParameterSelection
+                        parameters={parameters}
+                        isLoading={isLoading}
+                        isError={isError}
+                        parameterValues={parameterValues}
+                        onParameterChange={onParameterChange}
+                        size="xs"
+                        showClearAll={selectedParametersCount > 0}
+                        onClearAll={onClearAll}
+                        projectUuid={projectUuid}
+                        missingRequiredParameters={missingRequiredParameters}
+                        isEditMode={isEditMode}
+                        pinnedParameters={pinnedParameters}
+                        onParameterPin={onParameterPin}
+                    />
+                </Box>
+            </Menu.Dropdown>
+        </Menu>
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerParameters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerParameters.tsx
@@ -4,7 +4,6 @@ import {
     type ParameterDefinitions,
     type ParametersValuesMap,
 } from '@lightdash/common';
-import { MantineProvider } from '@mantine-8/core';
 import {
     ActionIcon,
     Center,
@@ -18,7 +17,6 @@ import { IconPencil, IconRotate2 } from '@tabler/icons-react';
 import { isEqual } from 'lodash';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { getMantine8ThemeOverride } from '../../../mantine8Theme';
 import { ParameterInput } from '../../parameters/components/ParameterInput';
 
 type SchedulerParameterItemProps = {
@@ -211,37 +209,34 @@ const SchedulerParameters: FC<SchedulerParametersProps> = ({
 
     return (
         <Stack>
-            <MantineProvider theme={getMantine8ThemeOverride()}>
-                {Object.entries(availableParameters).map(
-                    ([paramKey, parameter]) => {
-                        const schedulerValue =
-                            schedulerParameterValues?.[paramKey];
-                        // Use actual dashboard parameter value, fallback to default if not set
-                        const dashboardValue =
-                            currentParameterValues?.[paramKey] ??
-                            parameter.default ??
-                            null;
+            {Object.entries(availableParameters).map(
+                ([paramKey, parameter]) => {
+                    const schedulerValue = schedulerParameterValues?.[paramKey];
+                    // Use actual dashboard parameter value, fallback to default if not set
+                    const dashboardValue =
+                        currentParameterValues?.[paramKey] ??
+                        parameter.default ??
+                        null;
 
-                        return (
-                            <ParameterItem
-                                key={paramKey}
-                                paramKey={paramKey}
-                                parameter={parameter}
-                                dashboardValue={dashboardValue}
-                                schedulerValue={schedulerValue}
-                                onChange={handleParameterChange}
-                                onRevert={() => handleRevertParameter(paramKey)}
-                                hasChanged={hasParameterChanged(paramKey)}
-                                projectUuid={dashboard?.projectUuid || ''}
-                                parameterValues={{
-                                    ...currentParameterValues,
-                                    ...schedulerParameterValues,
-                                }}
-                            />
-                        );
-                    },
-                )}
-            </MantineProvider>
+                    return (
+                        <ParameterItem
+                            key={paramKey}
+                            paramKey={paramKey}
+                            parameter={parameter}
+                            dashboardValue={dashboardValue}
+                            schedulerValue={schedulerValue}
+                            onChange={handleParameterChange}
+                            onRevert={() => handleRevertParameter(paramKey)}
+                            hasChanged={hasParameterChanged(paramKey)}
+                            projectUuid={dashboard?.projectUuid || ''}
+                            parameterValues={{
+                                ...currentParameterValues,
+                                ...schedulerParameterValues,
+                            }}
+                        />
+                    );
+                },
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -4,7 +4,6 @@ import {
     type DashboardTile,
     type Dashboard as IDashboard,
 } from '@lightdash/common';
-import { MantineProvider } from '@mantine-8/core';
 import { Box, Button, Flex, Group, Modal, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { captureException, useProfiler } from '@sentry/react';
@@ -35,7 +34,6 @@ import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
 import { useSpaceSummaries } from '../hooks/useSpaces';
-import { getMantine8ThemeOverride } from '../mantine8Theme';
 import useApp from '../providers/App/useApp';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
@@ -579,7 +577,7 @@ const Dashboard: FC = () => {
     }
 
     return (
-        <MantineProvider theme={getMantine8ThemeOverride()}>
+        <>
             {blocker.state === 'blocked' && (
                 <Modal
                     opened
@@ -796,7 +794,7 @@ const Dashboard: FC = () => {
                     />
                 )}
             </Page>
-        </MantineProvider>
+        </>
     );
 };
 

--- a/packages/frontend/src/providers/Mantine8Provider.tsx
+++ b/packages/frontend/src/providers/Mantine8Provider.tsx
@@ -1,0 +1,31 @@
+import {
+    MantineProvider as MantineProviderBase,
+    type MantineThemeOverride,
+} from '@mantine-8/core';
+import { type FC } from 'react';
+
+import { getMantine8ThemeOverride } from '../mantine8Theme';
+
+type Props = {
+    theme?: MantineThemeOverride;
+    themeOverride?: MantineThemeOverride;
+    notificationsLimit?: number;
+};
+
+const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
+    children,
+    theme = getMantine8ThemeOverride(),
+    themeOverride = {},
+}) => {
+    return (
+        <MantineProviderBase
+            theme={{ ...theme, ...themeOverride }}
+            forceColorScheme="light"
+            classNamesPrefix="mantine-8"
+        >
+            {children}
+        </MantineProviderBase>
+    );
+};
+
+export default Mantine8Provider;


### PR DESCRIPTION
### Description:

Centralized Mantine v8 theme provider implementation by creating a global `Mantine8Provider` component that wraps the application. This eliminates the need to wrap individual components with `MantineProvider` and pass the theme override in multiple places.

Key changes:

- Created a new `Mantine8Provider` component that uses the global theme from `getMantine8ThemeOverride()`
- Added the provider to the main App and SDK entry points
- Removed redundant `MantineProvider` wrappers from individual components
- Updated style guide documentation to remove the requirement for wrapping components with `MantineProvider`

This change improves code maintainability by centralizing theme management and reduces boilerplate code throughout the application.