### PR TITLE
fix: table stuck in loading state on explore from here

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -34,8 +34,13 @@ const SimpleTable: FC<SimpleTableProps> = ({
     minimal = false,
     ...rest
 }) => {
-    const { columnOrder, itemsMap, visualizationConfig, resultsData } =
-        useVisualizationContext();
+    const {
+        columnOrder,
+        itemsMap,
+        visualizationConfig,
+        resultsData,
+        isLoading,
+    } = useVisualizationContext();
 
     const shouldPaginateResults = useMemo(() => {
         return Boolean(
@@ -52,6 +57,14 @@ const SimpleTable: FC<SimpleTableProps> = ({
             return 'loading';
         }
 
+        if (
+            !isLoading &&
+            resultsData.rows.length === 0 &&
+            !resultsData.hasFetchedAllRows
+        ) {
+            return 'idle';
+        }
+
         // When paginated, it's success as soon as there are rows
         // When not paginated, it's success as soon as all rows have been fetched
         const isSuccess = shouldPaginateResults
@@ -59,7 +72,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
             : resultsData.hasFetchedAllRows;
 
         return isSuccess ? 'success' : 'loading';
-    }, [resultsData, shouldPaginateResults]);
+    }, [resultsData, shouldPaginateResults, isLoading]);
 
     const showColumnCalculation = useMemo(() => {
         if (!isTableVisualizationConfig(visualizationConfig)) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16411

### Description:

Clicking explore from here on a table in a dashboard was showing an infinite loading state in the explore. 

This was partly due to the infinitely loading logic, which made the loader logic different for tables than other charts, and partly do to the new logic about when to auto-load queries. The current behavior for *all* charts is to not auto-run the query on explore from here. But most charts show a no data message. 

This just makes the table chart also show a no-data message instead of an incorrect loading message. 

To test: 
- explore from here from a table on a dashboard
- the viz should show a no-data message until you manually run the query
