### PR TITLE
feat: add chart URLs to dashboard search results

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findDashboards.ts
+++ b/packages/backend/src/ee/services/ai/tools/findDashboards.ts
@@ -54,9 +54,12 @@ const getDashboardText = (
         }
         <Charts count="${dashboard.charts.length}">
             ${dashboard.charts
-                .map(
-                    (chart) =>
-                        `<Chart>
+                .map((chart) => {
+                    const chartUrl = siteUrl
+                        ? `${siteUrl}/projects/${dashboard.projectUuid}/saved/${chart.uuid}/view#chart-link#chart-type-${chart.chartType}`
+                        : undefined;
+
+                    return `<Chart chartUuid="${chart.uuid}">
                             <Name>${chart.name}</Name>
                             <ChartType>${chart.chartType}</ChartType>
                             ${
@@ -64,9 +67,10 @@ const getDashboardText = (
                                     ? `<Description>${chart.description}</Description>`
                                     : ''
                             }
+                            ${chartUrl ? `<Url>${chartUrl}</Url>` : ''}
                             <ViewsCount>${chart.viewsCount}</ViewsCount>
-                        </Chart>`,
-                )
+                        </Chart>`;
+                })
                 .join('\n            ')}
         </Charts>
         ${

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -293,6 +293,7 @@ export class SearchModel {
         const directChartsQuery = this.database(SavedChartsTableName)
             .select(
                 'dashboard_uuid',
+                { uuid: 'saved_query_uuid' },
                 'name',
                 'description',
                 { chartType: 'last_version_chart_kind' },
@@ -329,6 +330,7 @@ export class SearchModel {
             )
             .select(
                 'dashboards.dashboard_uuid',
+                { uuid: `${SavedChartsTableName}.saved_query_uuid` },
                 `${SavedChartsTableName}.name`,
                 `${SavedChartsTableName}.description`,
                 {
@@ -359,6 +361,7 @@ export class SearchModel {
             Record<
                 string,
                 Array<{
+                    uuid: string;
                     name: string;
                     description: string;
                     chartType: string;
@@ -370,6 +373,7 @@ export class SearchModel {
                 acc[chart.dashboard_uuid] = [];
             }
             acc[chart.dashboard_uuid].push({
+                uuid: chart.uuid,
                 name: chart.name,
                 description: chart.description,
                 chartType: chart.chartType,

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -33,6 +33,7 @@ export type DashboardSearchResult = Pick<
         userUuid: string;
     } | null;
     charts: {
+        uuid: string;
         name: string;
         description?: string;
         chartType: ChartKind;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added chart UUIDs and URLs to dashboard search results to improve AI assistant functionality.

1. Added the chart UUID to the dashboard search results data structure
2. Modified the SQL queries to include the saved_query_uuid in chart results
3. Enhanced the dashboard text representation to include chart URLs with proper linking to the project and chart view