### PR TITLE
fix: add getJoinedTables function to handle table aliases in joins

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -828,6 +828,9 @@ export const getCustomBinDimensionSql = ({
     };
 };
 
+/*
+ * Returns list of intermediary/extra joined tables based on the current joined tables
+ */
 export const getJoinedTables = (
     explore: Explore,
     tableNames: string[],
@@ -838,11 +841,18 @@ export const getJoinedTables = (
     const allNewReferences = explore.joinedTables.reduce<string[]>(
         (sum, joinedTable) => {
             if (tableNames.includes(joinedTable.table)) {
-                const newReferencesInJoin = parseAllReferences(
-                    joinedTable.sqlOn,
-                    joinedTable.table,
-                ).reduce<string[]>(
-                    (acc, { refTable }) =>
+                const joinTableReferences =
+                    joinedTable.tablesReferences ||
+                    parseAllReferences(
+                        // fallback for old explores, it might be incorrect when the join as an alias
+                        joinedTable.sqlOn,
+                        joinedTable.table,
+                    ).map(({ refTable }) => refTable);
+
+                const newReferencesInJoin = joinTableReferences.reduce<
+                    string[]
+                >(
+                    (acc, refTable) =>
                         !tableNames.includes(refTable)
                             ? [...acc, refTable]
                             : acc,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Improved the `getJoinedTables` function to correctly handle table aliases in SQL joins. The function now uses `tablesReferences` property from joined tables instead of parsing SQL references, which prevents issues when joins use aliases that differ from original table names. Added comprehensive tests to verify the function works correctly with aliased tables and intermediary joins.


Fixes the problem where the join has an alias but SQL references original table.
Example:
```
  - name: payments
    config:
      meta:
        primary_key: payment_id
        joins:
          - join: orders
            alias: 'banana'
            sql_on: ${orders.order_id} = ${payments.order_id}
            relationship: many-to-one
```
<img width="1368" height="1293" alt="Screenshot 2025-08-15 at 13 51 13" src="https://github.com/user-attachments/assets/53d15ce0-64fa-478f-8918-3c3649fee029" />

