### PR TITLE
chore: increase Okteto preview timeout from 15m to 20m

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -40,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: pr-${{ github.event.number }}
-          timeout: 15m
+          timeout: 20m
           file: okteto.preview.yaml
           variables: SITE_URL=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev
 


### PR DESCRIPTION
Increases the timeout for the Okteto preview deployment from 15 minutes to 20 minutes to allow more time for the preview environment to be created successfully.