### PR TITLE
fix: prevent duplicate metrics in cross-table metric references

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -860,16 +860,38 @@ export class MetricQueryBuilder {
                         metricObject.table,
                     );
                     metricReferences.forEach((metricReference) => {
-                        acc.push(
-                            getMetricFromId(
+                        const isInMetricsObjects = metricsObjects.some(
+                            (metric) =>
+                                getItemId(metric) ===
                                 getItemId({
                                     table: metricReference.refTable,
                                     name: metricReference.refName,
                                 }),
-                                explore,
-                                compiledMetricQuery,
-                            ),
                         );
+                        const isInReferencedMetricObjects = acc.some(
+                            (metric) =>
+                                getItemId(metric) ===
+                                getItemId({
+                                    table: metricReference.refTable,
+                                    name: metricReference.refName,
+                                }),
+                        );
+                        // Only add if doesn't exist in metricsObjects or referencedMetricObjects
+                        if (
+                            !isInMetricsObjects &&
+                            !isInReferencedMetricObjects
+                        ) {
+                            acc.push(
+                                getMetricFromId(
+                                    getItemId({
+                                        table: metricReference.refTable,
+                                        name: metricReference.refName,
+                                    }),
+                                    explore,
+                                    compiledMetricQuery,
+                                ),
+                            );
+                        }
                     });
                 }
                 return acc;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Fixed an issue where metrics referencing other metrics would duplicate the referenced metrics in the query when those base metrics were also explicitly selected. The fix ensures that referenced metrics are only added once to the query, preventing redundant calculations and potential SQL errors.

The PR adds a test case that verifies metrics referencing other metrics work correctly when the base metrics are also selected in the query.