### PR TITLE
fix: handle empty string values in SQL filter generation

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -515,7 +515,7 @@ export const stringFilterRuleMocks = {
         ...emptyStringFilter,
         operator: FilterOperator.EQUALS,
     },
-    equalsFilterWithEmptyStringSQL: 'true',
+    equalsFilterWithEmptyStringSQL: `(${stringFilterDimension}) IN ('')`,
 
     startsWithFilterWithEmptyString: {
         ...emptyStringFilter,
@@ -533,7 +533,7 @@ export const stringFilterRuleMocks = {
         ...emptyStringFilter,
         operator: FilterOperator.NOT_EQUALS,
     },
-    notEqualsFilterWithEmptyStringSQL: 'true',
+    notEqualsFilterWithEmptyStringSQL: `((${stringFilterDimension}) NOT IN ('' ) OR ("customers".first_name) IS NULL)`,
 
     notIncludeFilterWithEmptyString: {
         ...emptyStringFilter,

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -732,7 +732,7 @@ describe('Filter SQL', () => {
         ).toBe(stringFilterRuleMocks.includeFilterWithMixedEmptyStringsSQL);
     });
 
-    test('should return true when equals filter has empty string value', () => {
+    test('should return empty string filter sql when equals filter has empty string value', () => {
         expect(
             renderStringFilterSql(
                 stringFilterDimension,


### PR DESCRIPTION
Regression PR: <https://github.com/lightdash/lightdash/pull/16151>

Closes: <https://github.com/lightdash/lightdash/issues/16428>

### Description:

Fixed string filter SQL generation for empty string values. Previously, when a filter had empty string values, it would return 'true' for EQUALS and NOT_EQUALS operators. Now it properly generates SQL that includes the empty string in the filter condition.

The changes ensure that:

- EQUALS operator with empty string now generates `(dimension) IN ('')` instead of 'true'
- NOT_EQUALS operator with empty string now generates proper SQL with NOT IN and NULL check
- Improved variable naming to distinguish between all filter values and non-empty filter values
- Updated test description to match the new behavior