### PR TITLE
fix: remove extra space in SQL string generation

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -533,7 +533,7 @@ export const stringFilterRuleMocks = {
         ...emptyStringFilter,
         operator: FilterOperator.NOT_EQUALS,
     },
-    notEqualsFilterWithEmptyStringSQL: `((${stringFilterDimension}) NOT IN ('' ) OR ("customers".first_name) IS NULL)`,
+    notEqualsFilterWithEmptyStringSQL: `((${stringFilterDimension}) NOT IN ('') OR ("customers".first_name) IS NULL)`,
 
     notIncludeFilterWithEmptyString: {
         ...emptyStringFilter,

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -70,7 +70,7 @@ export const renderStringFilterSql = (
             return filter.values && filter.values.length > 0
                 ? `((${dimensionSql}) NOT IN (${filter.values
                       .map((v) => `${stringQuoteChar}${v}${stringQuoteChar}`)
-                      .join(',')} ) OR (${dimensionSql}) IS NULL)`
+                      .join(',')}) OR (${dimensionSql}) IS NULL)`
                 : 'true';
         case FilterOperator.INCLUDE:
             if (nonEmptyFilterValues && nonEmptyFilterValues.length > 0) {


### PR DESCRIPTION
Closes: N/A

### Description:

Fixed spacing in SQL string generation for NOT_EQUALS filter operator. Removed extra space after the closing parenthesis in the SQL template string to ensure consistent formatting.