### PR TITLE
fix: use embed permissions rather than space access for saved charts

### DIFF
--- a/packages/backend/src/auth/account/account.mock.ts
+++ b/packages/backend/src/auth/account/account.mock.ts
@@ -89,7 +89,19 @@ export function buildAccount({
     }
     return fromJwt({
         decodedToken: defaultJwtToken,
-        organization: defaultOrganization,
+        embed: {
+            organization: defaultOrganization,
+            projectUuid: 'test-project-uuid',
+            dashboardUuids: ['test-dashboard-uuid'],
+            allowAllDashboards: false,
+            createdAt: '2024-01-01',
+            encodedSecret: 'test-encoded-secret',
+            user: {
+                userUuid: defaultUserId,
+                firstName: 'Test',
+                lastName: 'User',
+            },
+        },
         source: 'test-jwt-token',
         dashboardUuid: 'test-dashboard-uuid',
         userAttributes: defaultUserAttributes,

--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -46,7 +46,19 @@ describe('account', () => {
         it('should create an ExternalAccount from JWT with user externalId', () => {
             const result = fromJwt({
                 decodedToken: mockDecodedToken,
-                organization: mockOrganization,
+                embed: {
+                    organization: mockOrganization,
+                    projectUuid: 'test-project-uuid',
+                    dashboardUuids: ['test-dashboard-uuid'],
+                    allowAllDashboards: false,
+                    createdAt: '2024-01-01',
+                    encodedSecret: 'test-encoded-secret',
+                    user: {
+                        userUuid: 'test-user-uuid',
+                        firstName: 'Test',
+                        lastName: 'User',
+                    },
+                },
                 source: 'test-jwt-token',
                 dashboardUuid: 'test-dashboard-uuid',
                 userAttributes: mockUserAttributes,
@@ -94,7 +106,19 @@ describe('account', () => {
 
             const result = fromJwt({
                 decodedToken: tokenWithoutExternalId,
-                organization: mockOrganization,
+                embed: {
+                    organization: mockOrganization,
+                    projectUuid: 'test-project-uuid',
+                    dashboardUuids: ['test-dashboard-uuid'],
+                    allowAllDashboards: false,
+                    createdAt: '2024-01-01',
+                    encodedSecret: 'test-encoded-secret',
+                    user: {
+                        userUuid: 'test-user-uuid',
+                        firstName: 'Test',
+                        lastName: 'User',
+                    },
+                },
                 source: 'anonymous-jwt-token',
                 dashboardUuid: 'test-dashboard-uuid',
                 userAttributes: mockUserAttributes,
@@ -121,7 +145,19 @@ describe('account', () => {
 
             const result = fromJwt({
                 decodedToken: tokenWithoutUser,
-                organization: mockOrganization,
+                embed: {
+                    organization: mockOrganization,
+                    projectUuid: 'test-project-uuid',
+                    dashboardUuids: ['test-dashboard-uuid'],
+                    allowAllDashboards: false,
+                    createdAt: '2024-01-01',
+                    encodedSecret: 'test-encoded-secret',
+                    user: {
+                        userUuid: 'test-user-uuid',
+                        firstName: 'Test',
+                        lastName: 'User',
+                    },
+                },
                 source: 'no-user-jwt-token',
                 dashboardUuid: 'test-dashboard-uuid',
                 userAttributes: mockUserAttributes,
@@ -142,7 +178,19 @@ describe('account', () => {
 
             const result = fromJwt({
                 decodedToken: mockDecodedToken,
-                organization: mockOrganization,
+                embed: {
+                    organization: mockOrganization,
+                    projectUuid: 'test-project-uuid',
+                    dashboardUuids: ['test-dashboard-uuid'],
+                    allowAllDashboards: false,
+                    createdAt: '2024-01-01',
+                    encodedSecret: 'test-encoded-secret',
+                    user: {
+                        userUuid: 'test-user-uuid',
+                        firstName: 'Test',
+                        lastName: 'User',
+                    },
+                },
                 source: 'test-jwt-token',
                 dashboardUuid: 'test-dashboard-uuid',
                 userAttributes: emptyUserAttributes,

--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -10,11 +10,11 @@ import {
     applyEmbeddedAbility,
     buildAccountHelpers,
     CreateEmbedJwt,
-    Embed,
     ForbiddenError,
     MemberAbility,
     OauthAccount,
     Organization,
+    OssEmbed,
     ServiceAcctAccount,
     SessionAccount,
     SessionUser,
@@ -74,19 +74,24 @@ const extractOrganizationFromUser = (
 
 export const fromJwt = ({
     decodedToken,
-    organization,
+    embed,
     source,
     dashboardUuid,
     userAttributes,
 }: {
     decodedToken: CreateEmbedJwt;
-    organization: Embed['organization'];
+    embed: OssEmbed;
     source: string;
     dashboardUuid: string;
     userAttributes: UserAccessControls;
 }): AnonymousAccount => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
-    applyEmbeddedAbility(decodedToken, dashboardUuid, organization, builder);
+    applyEmbeddedAbility(
+        decodedToken,
+        dashboardUuid,
+        embed.organization,
+        builder,
+    );
     const abilities = builder.build();
 
     return createAccount({
@@ -95,7 +100,8 @@ export const fromJwt = ({
             data: decodedToken,
             source,
         },
-        organization,
+        organization: embed.organization,
+        embed,
         access: {
             dashboardId: dashboardUuid,
             filtering: decodedToken.content.dashboardFiltersInteractivity,
@@ -103,7 +109,7 @@ export const fromJwt = ({
         },
         // Create the fields we're able to set from the JWT
         user: {
-            id: getExternalId(decodedToken, source, organization),
+            id: getExternalId(decodedToken, source, embed.organization),
             type: 'anonymous',
             ability: abilities,
             abilityRules: abilities.rules,

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -244,6 +244,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectParametersModel: models.getProjectParametersModel(),
                     pivotTableService: repository.getPivotTableService(),
                     prometheusMetrics,
+                    permissionsService: repository.getPermissionsService(),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
@@ -1,11 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 // This rule is failing in CI but passes locally
-import {
-    ForbiddenError,
-    JWT_HEADER_NAME,
-    NotFoundError,
-    ParameterError,
-} from '@lightdash/common';
+import { JWT_HEADER_NAME, NotFoundError } from '@lightdash/common';
 import { NextFunction, Request, Response } from 'express';
 import { fromJwt } from '../../auth/account';
 import { decodeLightdashJwt } from '../../auth/lightdashJwt';
@@ -87,11 +82,13 @@ export async function jwtAuthMiddleware(
         }
 
         // Get embed configuration from database
-        const { encodedSecret, organization } =
-            await embedService.getEmbeddingByProjectId(projectUuid);
-        const decodedToken = decodeLightdashJwt(embedToken, encodedSecret);
+        const embed = await embedService.getEmbeddingByProjectId(projectUuid);
+        const decodedToken = decodeLightdashJwt(
+            embedToken,
+            embed.encodedSecret,
+        );
         const userAttributesPromise = embedService.getEmbedUserAttributes(
-            organization.organizationUuid,
+            embed.organization.organizationUuid,
             decodedToken,
         );
         const dashboardUuidPromise = embedService.getDashboardUuidFromJwt(
@@ -114,7 +111,7 @@ export async function jwtAuthMiddleware(
         req.account = fromJwt({
             decodedToken,
             source: embedToken,
-            organization,
+            embed,
             dashboardUuid,
             userAttributes,
         });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -48,6 +48,7 @@ import type { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CacheHitCacheResult, MissCacheResult } from '../CacheService/types';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
 import {
     allExplores,
@@ -187,6 +188,7 @@ const getMockedAsyncQueryService = (
             s3Client: {} as S3Client,
             downloadFileModel: {} as DownloadFileModel,
         }),
+        permissionsService: {} as PermissionsService,
         ...overrides,
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -48,6 +48,7 @@ import {
     isCustomSqlDimension,
     isDateItem,
     isField,
+    isJwtUser,
     isMetric,
     isVizTableConfig,
     ItemsMap,
@@ -102,6 +103,7 @@ import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
 import { ExcelService } from '../ExcelService/ExcelService';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
 import { getDashboardParametersValuesMap } from '../ProjectService/parameters';
 import {
@@ -140,6 +142,7 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     storageClient: S3ResultsFileStorageClient;
     pivotTableService: PivotTableService;
     prometheusMetrics?: PrometheusMetrics;
+    permissionsService: PermissionsService;
 };
 
 export class AsyncQueryService extends ProjectService {
@@ -157,6 +160,8 @@ export class AsyncQueryService extends ProjectService {
 
     prometheusMetrics?: PrometheusMetrics;
 
+    permissionsService: PermissionsService;
+
     constructor(args: AsyncQueryServiceArguments) {
         super(args);
         this.queryHistoryModel = args.queryHistoryModel;
@@ -166,6 +171,7 @@ export class AsyncQueryService extends ProjectService {
         this.storageClient = args.storageClient;
         this.pivotTableService = args.pivotTableService;
         this.prometheusMetrics = args.prometheusMetrics;
+        this.permissionsService = args.permissionsService;
     }
 
     // ! Duplicate of SavedSqlService.hasAccess
@@ -1951,6 +1957,51 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    private async checkQueryPermissions(
+        account: Account,
+        projectUuid: string,
+        savedChartUuid: string,
+        space: Omit<SpaceSummary, 'userAccess'>,
+    ) {
+        if (isJwtUser(account)) {
+            await this.permissionsService.checkEmbedPermissions(
+                account,
+                savedChartUuid,
+            );
+        } else {
+            const access = await this.spaceModel.getUserSpaceAccess(
+                account.user.id,
+                space.uuid,
+            );
+
+            if (
+                account.user.ability.cannot(
+                    'view',
+                    subject('SavedChart', {
+                        organizationUuid: space.organizationUuid,
+                        projectUuid,
+                        isPrivate: space.isPrivate,
+                        access,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
+        }
+
+        if (
+            account.user.ability.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid: space.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
     async executeAsyncDashboardChartQuery({
         account,
         projectUuid,
@@ -1984,37 +2035,12 @@ export class AsyncQueryService extends ProjectService {
             ),
         ]);
 
-        // Anonymous users cannot be assigned to a space,
-        // so they can only access public, `isPrivate: false` charts
-        const savedChartSubject = {
-            organizationUuid,
+        await this.checkQueryPermissions(
+            account,
             projectUuid,
-            isPrivate: space.isPrivate,
-            ...(account.isRegisteredUser()
-                ? {
-                      access: await this.spaceModel.getUserSpaceAccess(
-                          account.user.id,
-                          space.uuid,
-                      ),
-                  }
-                : {}),
-        };
-
-        if (
-            account.user.ability.cannot(
-                'view',
-                subject('SavedChart', savedChartSubject),
-            ) ||
-            account.user.ability.cannot(
-                'view',
-                subject('Project', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
+            savedChart.uuid,
+            space,
+        );
 
         await this.analyticsModel.addChartViewEvent(
             savedChart.uuid,

--- a/packages/backend/src/services/PermissionsService/PermissionsService.ts
+++ b/packages/backend/src/services/PermissionsService/PermissionsService.ts
@@ -1,0 +1,49 @@
+import { AnonymousAccount, ForbiddenError } from '@lightdash/common';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { BaseService } from '../BaseService';
+
+type PermissionsServiceArguments = {
+    dashboardModel: DashboardModel;
+};
+
+export class PermissionsService extends BaseService {
+    private readonly dashboardModel: DashboardModel;
+
+    constructor(args: PermissionsServiceArguments) {
+        super();
+        this.dashboardModel = args.dashboardModel;
+    }
+
+    async checkEmbedPermissions(
+        account: AnonymousAccount,
+        savedChartUuid: string,
+    ) {
+        const { projectUuid, dashboardUuids, allowAllDashboards } =
+            account.embed;
+        const dashboardUuid = account.access.dashboardId;
+
+        if (!projectUuid) {
+            throw new ForbiddenError(
+                'Project UUID is required to check embed permissions',
+            );
+        }
+
+        if (!allowAllDashboards && !dashboardUuids.includes(dashboardUuid)) {
+            throw new ForbiddenError(
+                `Dashboard ${dashboardUuid} is not embedded`,
+            );
+        }
+
+        const chartInDashboards = await this.dashboardModel.getAllByProject(
+            projectUuid,
+            savedChartUuid,
+        );
+
+        const chartInDashboardUuids = chartInDashboards.map((d) => d.uuid);
+        if (!chartInDashboardUuids.includes(dashboardUuid)) {
+            throw new ForbiddenError(
+                `This chart does not belong to dashboard ${dashboardUuid}`,
+            );
+        }
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -26,6 +26,7 @@ import { MetricsExplorerService } from './MetricsExplorerService/MetricsExplorer
 import { NotificationsService } from './NotificationsService/NotificationsService';
 import { OAuthService } from './OAuthService/OAuthService';
 import { OrganizationService } from './OrganizationService/OrganizationService';
+import { PermissionsService } from './PermissionsService/PermissionsService';
 import { PersonalAccessTokenService } from './PersonalAccessTokenService';
 import { PinningService } from './PinningService/PinningService';
 import { PivotTableService } from './PivotTableService/PivotTableService';
@@ -93,6 +94,7 @@ interface ServiceManifest {
     asyncQueryService: AsyncQueryService;
     renameService: RenameService;
     projectParametersService: ProjectParametersService;
+    permissionsService: PermissionsService;
     /** An implementation signature for these services are not available at this stage */
     embedService: unknown;
     aiService: unknown;
@@ -438,6 +440,16 @@ export class ServiceRepository
         );
     }
 
+    public getPermissionsService(): PermissionsService {
+        return this.getService(
+            'permissionsService',
+            () =>
+                new PermissionsService({
+                    dashboardModel: this.models.getDashboardModel(),
+                }),
+        );
+    }
+
     public getPersonalAccessTokenService(): PersonalAccessTokenService {
         return this.getService(
             'personalAccessTokenService',
@@ -558,6 +570,7 @@ export class ServiceRepository
                         this.models.getProjectParametersModel(),
                     pivotTableService: this.getPivotTableService(),
                     prometheusMetrics: this.prometheusMetrics,
+                    permissionsService: this.getPermissionsService(),
                 }),
         );
     }
@@ -578,6 +591,7 @@ export class ServiceRepository
                     slackClient: this.clients.getSlackClient(),
                     dashboardModel: this.models.getDashboardModel(),
                     catalogModel: this.models.getCatalogModel(),
+                    permissionsService: this.getPermissionsService(),
                 }),
         );
     }

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -1,17 +1,9 @@
 import { z } from 'zod';
-import { type Organization } from '../../types/organization';
-import { type LightdashUser } from '../../types/user';
+import type { OssEmbed } from '../../types/auth';
 import assertUnreachable from '../../utils/assertUnreachable';
 
-export type Embed = {
-    projectUuid: string;
-    organization: Pick<Organization, 'organizationUuid' | 'name' | 'createdAt'>;
-    encodedSecret: string;
-    dashboardUuids: string[];
-    allowAllDashboards: boolean;
-    createdAt: string;
-    user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'>;
-};
+/** @deprecated Use OssEmbed instead */
+export type Embed = OssEmbed;
 
 export type DecodedEmbed = Omit<Embed, 'encodedSecret'> & {
     encodedSecret: undefined;

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -4,11 +4,12 @@ import {
 } from '../ee';
 import { ForbiddenError } from './errors';
 import { type Organization } from './organization';
-import {
-    type AccountUser,
-    type ExternalUser,
-    type IntrinsicUserAttributes,
-    type LightdashSessionUser,
+import type {
+    AccountUser,
+    ExternalUser,
+    IntrinsicUserAttributes,
+    LightdashSessionUser,
+    LightdashUser,
 } from './user';
 import { type UserAttributeValueMap } from './userAttributes';
 
@@ -119,6 +120,16 @@ export type SessionAccount = BaseAccountWithHelpers & {
     user: LightdashSessionUser;
 };
 
+export type OssEmbed = {
+    projectUuid: string;
+    organization: Pick<Organization, 'organizationUuid' | 'name' | 'createdAt'>;
+    encodedSecret: string;
+    dashboardUuids: string[];
+    allowAllDashboards: boolean;
+    createdAt: string;
+    user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'>;
+};
+
 /**
  * Account for anonymous users with JWT authentication (embeds)
  */
@@ -127,6 +138,8 @@ export type AnonymousAccount = BaseAccountWithHelpers & {
     user: ExternalUser;
     /** The access permissions the account has */
     access: DashboardAccess;
+    /** The embed configuration associated with the JWT */
+    embed: OssEmbed;
 };
 
 export type ApiKeyAccount = BaseAccountWithHelpers & {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Context
[Slack](https://lightdash.slack.com/archives/C02GQKJK84Q/p1755507975305269?thread_ts=1755504091.015969&cid=C02GQKJK84Q)

### Description:
Reverts the [earlier change](https://github.com/lightdash/lightdash/pull/16203/files#diff-25f79f87865d422eb5f578ae799c0764ba6389d73bb68c7f59a9fae896b2dcc6R775-R793) consolidating embed/registered user permissions when fetching a saved chart. 

Adds permission checking for embedded charts in SavedChartService that mirrors checks being done for similar queries in EmbedService.
