### PR TITLE
refactor: extract normalizeColumnName function for Trino column case handling

### DIFF
--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -143,6 +143,14 @@ const catalogToSchema = (results: string[][][]): WarehouseCatalog => {
     return warehouseCatalog;
 };
 
+/*
+    Force lowercase for Trino column names
+    When using trino and snowflake, some columns can be returned uppercase
+    and we can't enforce "ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;"
+    like we do in snowflake client
+*/
+const normalizeColumnName = (columnName: string) => columnName.toLowerCase();
+
 const resultHandler = (
     schema: { [key: string]: AnyType }[],
     data: AnyType[][],
@@ -151,13 +159,7 @@ const resultHandler = (
     return data.map((i) => {
         const item: { [key: string]: AnyType } = {};
         i.map((column, index) => {
-            /* Force lowercase for Trino column names 
-            When using trino and snowflake, some columns can be returned uppercase 
-            and we can't enforce "ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;"
-            like we do in snowflake client
-            */
-            const name: string = s[index].toLowerCase();
-            item[name] = column;
+            item[normalizeColumnName(s[index])] = column;
             return null;
         });
         return item;
@@ -279,7 +281,7 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
             const fields = schema.reduce(
                 (acc, column) => ({
                     ...acc,
-                    [column.name]: {
+                    [normalizeColumnName(column.name)]: {
                         type: convertDataTypeToDimensionType(
                             column.typeSignature.rawType ?? TrinoTypes.VARCHAR,
                         ),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/16461

### Description:
Refactored the Trino column name normalization logic by extracting it into a dedicated function `normalizeColumnName`. This improves code readability and ensures consistent lowercase handling of column names throughout the TrinoWarehouseClient. The function is now used both in the result handler and when converting schema fields.


#### Before:
<img width="1246" height="912" alt="Screenshot 2025-08-18 at 14 10 34" src="https://github.com/user-attachments/assets/bce48a0c-9aeb-44f7-bfc7-723f701cbb0a" />


#### After:
<img width="1426" height="939" alt="Screenshot 2025-08-18 at 14 32 27" src="https://github.com/user-attachments/assets/4d654e5a-3621-461b-9020-1b96cbcb4dc0" />

