### PR TITLE
feat: enable table calcs referencing other table calcs

### DIFF
--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -96,3 +96,114 @@ test('Should throw compile error if metric in non existent table', () => {
         }),
     ).toThrowError(CompileError);
 });
+
+test('Should compile table calculations with references to other table calculations', () => {
+    const metricQueryWithTableCalcReferences = {
+        ...METRIC_QUERY_VALID_REFERENCES,
+        tableCalculations: [
+            {
+                name: 'calc_a',
+                displayName: 'Calc A',
+                sql: '${table_3.metric_1} + 70',
+            },
+            {
+                name: 'calc_b',
+                displayName: 'Calc B',
+                sql: '${calc_a} * 2',
+            },
+        ],
+    };
+
+    const result = compileMetricQuery({
+        explore: EXPLORE,
+        metricQuery: metricQueryWithTableCalcReferences,
+        warehouseSqlBuilder: warehouseClientMock,
+        availableParameters: [],
+    });
+
+    // Check that calc_a was compiled correctly
+    const calcA = result.compiledTableCalculations.find(
+        (c) => c.name === 'calc_a',
+    );
+    expect(calcA?.compiledSql).toBe('"table_3_metric_1" + 70');
+
+    // Check that calc_b references calc_a with parentheses
+    const calcB = result.compiledTableCalculations.find(
+        (c) => c.name === 'calc_b',
+    );
+    expect(calcB?.compiledSql).toBe('("table_3_metric_1" + 70) * 2');
+});
+
+test('Should detect circular dependencies in table calculations', () => {
+    const metricQueryWithCircularDeps = {
+        ...METRIC_QUERY_VALID_REFERENCES,
+        tableCalculations: [
+            {
+                name: 'calc_a',
+                displayName: 'Calc A',
+                sql: '${calc_b} + 10',
+            },
+            {
+                name: 'calc_b',
+                displayName: 'Calc B',
+                sql: '${calc_a} * 2',
+            },
+        ],
+    };
+
+    expect(() =>
+        compileMetricQuery({
+            explore: EXPLORE,
+            metricQuery: metricQueryWithCircularDeps,
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        }),
+    ).toThrowError(CompileError);
+});
+
+test('Should handle complex dependency chains', () => {
+    const metricQueryWithChain = {
+        ...METRIC_QUERY_VALID_REFERENCES,
+        tableCalculations: [
+            {
+                name: 'calc_c',
+                displayName: 'Calc C',
+                sql: '(${calc_a} + ${calc_b}) / 2',
+            },
+            {
+                name: 'calc_a',
+                displayName: 'Calc A',
+                sql: '${table_3.metric_1} + 70',
+            },
+            {
+                name: 'calc_b',
+                displayName: 'Calc B',
+                sql: '${table_3.metric_1} * 1.5',
+            },
+        ],
+    };
+
+    const result = compileMetricQuery({
+        explore: EXPLORE,
+        metricQuery: metricQueryWithChain,
+        warehouseSqlBuilder: warehouseClientMock,
+        availableParameters: [],
+    });
+
+    // Check that all calculations are properly compiled in dependency order
+    const calcA = result.compiledTableCalculations.find(
+        (c) => c.name === 'calc_a',
+    );
+    const calcB = result.compiledTableCalculations.find(
+        (c) => c.name === 'calc_b',
+    );
+    const calcC = result.compiledTableCalculations.find(
+        (c) => c.name === 'calc_c',
+    );
+
+    expect(calcA?.compiledSql).toBe('"table_3_metric_1" + 70');
+    expect(calcB?.compiledSql).toBe('"table_3_metric_1" * 1.5');
+    expect(calcC?.compiledSql).toBe(
+        '(("table_3_metric_1" + 70) + ("table_3_metric_1" * 1.5)) / 2',
+    );
+});

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -16,10 +16,127 @@ import {
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
 
+interface TableCalculationDependency {
+    name: string;
+    dependencies: string[];
+}
+
+const getTableCalculationReferences = (sql: string): string[] => {
+    const matches = sql.match(lightdashVariablePattern) || [];
+    return matches.map((match) => match.slice(2, -1)); // Remove ${ and }
+};
+
+const buildTableCalculationDependencyGraph = (
+    tableCalculations: TableCalculation[],
+): TableCalculationDependency[] =>
+    tableCalculations.map((calc) => ({
+        name: calc.name,
+        dependencies: getTableCalculationReferences(calc.sql),
+    }));
+
+const detectCircularDependencies = (
+    dependencies: TableCalculationDependency[],
+): void => {
+    const visited = new Set<string>();
+    const recursionStack = new Set<string>();
+
+    const dfs = (node: string, path: string[]): void => {
+        if (recursionStack.has(node)) {
+            throw new CompileError(
+                `Circular dependency detected in table calculations: ${[
+                    ...path,
+                    node,
+                ].join(' -> ')}`,
+                {},
+            );
+        }
+
+        if (visited.has(node)) {
+            return;
+        }
+
+        visited.add(node);
+        recursionStack.add(node);
+
+        const deps =
+            dependencies.find((d) => d.name === node)?.dependencies || [];
+        for (const dep of deps) {
+            // Only check dependencies that are table calculations
+            if (dependencies.some((d) => d.name === dep)) {
+                dfs(dep, [...path, node]);
+            }
+        }
+
+        recursionStack.delete(node);
+    };
+
+    for (const dep of dependencies) {
+        if (!visited.has(dep.name)) {
+            dfs(dep.name, []);
+        }
+    }
+};
+
+const sortTableCalcs = (
+    dependencyGraph: TableCalculationDependency[],
+): string[] => {
+    const inDegree = new Map<string, number>();
+    const adjList = new Map<string, string[]>();
+
+    // Initialize
+    for (const dep of dependencyGraph) {
+        inDegree.set(dep.name, 0);
+        adjList.set(dep.name, []);
+    }
+
+    // Build adjacency list and in-degree count
+    for (const dep of dependencyGraph) {
+        for (const dependency of dep.dependencies) {
+            // Only consider dependencies that are table calculations
+            if (dependencyGraph.some((d) => d.name === dependency)) {
+                if (!adjList.has(dependency)) {
+                    adjList.set(dependency, []);
+                }
+                adjList.get(dependency)!.push(dep.name);
+                inDegree.set(dep.name, (inDegree.get(dep.name) || 0) + 1);
+            }
+        }
+    }
+
+    // Topological sort using Kahn's algorithm
+    const queue: string[] = [];
+    const result: string[] = [];
+
+    inDegree.forEach((degree, node) => {
+        if (degree === 0) {
+            queue.push(node);
+        }
+    });
+
+    while (queue.length > 0) {
+        const current = queue.shift()!;
+        result.push(current);
+
+        for (const neighbor of adjList.get(current) || []) {
+            const newDegree = inDegree.get(neighbor)! - 1;
+            inDegree.set(neighbor, newDegree);
+            if (newDegree === 0) {
+                queue.push(neighbor);
+            }
+        }
+    }
+
+    return result;
+};
+
 const compileTableCalculation = (
     tableCalculation: TableCalculation,
     validFieldIds: string[],
     quoteChar: string,
+    compiledTableCalculations: Map<
+        string,
+        CompiledTableCalculation
+    > = new Map(),
 ): CompiledTableCalculation => {
     if (validFieldIds.includes(tableCalculation.name)) {
         throw new CompileError(
@@ -27,23 +144,85 @@ const compileTableCalculation = (
             {},
         );
     }
+
     const compiledSql = tableCalculation.sql.replace(
         lightdashVariablePattern,
         (_, p1) => {
+            // Check if this is a reference to another table calculation
+            if (compiledTableCalculations.has(p1)) {
+                const referencedTableCalc = compiledTableCalculations.get(p1)!;
+                // Wrap the referenced table calculation SQL in parentheses to preserve precedence
+                return `(${referencedTableCalc.compiledSql})`;
+            }
+
+            // Otherwise, treat it as a field reference
             const fieldId = convertFieldRefToFieldId(p1);
             if (validFieldIds.includes(fieldId)) {
                 return `${quoteChar}${fieldId}${quoteChar}`;
             }
+
             throw new CompileError(
-                `Table calculation contains a reference ${p1} to a field that isn't included in the query.`,
+                `Table calculation contains a reference "${p1}" to a field or table calculation that isn't included in the query.`,
                 {},
             );
         },
     );
+
     return {
         ...tableCalculation,
         compiledSql,
     };
+};
+
+const compileTableCalculations = (
+    tableCalculations: TableCalculation[],
+    validFieldIds: string[],
+    quoteChar: string,
+): CompiledTableCalculation[] => {
+    // Build dependency graph to check for circular dependencies
+    const dependencyGraph =
+        buildTableCalculationDependencyGraph(tableCalculations);
+    detectCircularDependencies(dependencyGraph);
+
+    const compiledTableCalculations: CompiledTableCalculation[] = [];
+
+    // Create a map to track compiled table calculations. We'll go through the
+    // dependency graph first, then add any table calculations that weren't in it.
+    const compiledTableCalcMap = new Map<string, CompiledTableCalculation>();
+
+    // Sort them so we compile them in the correct order
+    const sortedTableCalcNames = sortTableCalcs(dependencyGraph);
+    for (const calcName of sortedTableCalcNames) {
+        const tableCalculation = tableCalculations.find(
+            (tc) => tc.name === calcName,
+        );
+        if (tableCalculation) {
+            const compiled = compileTableCalculation(
+                tableCalculation,
+                validFieldIds,
+                quoteChar,
+                compiledTableCalcMap,
+            );
+            compiledTableCalcMap.set(calcName, compiled);
+            compiledTableCalculations.push(compiled);
+        }
+    }
+
+    // Add any table calculations that weren't in the dependency graph (no dependencies or references)
+    for (const tableCalculation of tableCalculations) {
+        if (!compiledTableCalcMap.has(tableCalculation.name)) {
+            const compiled = compileTableCalculation(
+                tableCalculation,
+                validFieldIds,
+                quoteChar,
+                compiledTableCalcMap,
+            );
+            compiledTableCalcMap.set(tableCalculation.name, compiled);
+            compiledTableCalculations.push(compiled);
+        }
+    }
+
+    return compiledTableCalculations;
 };
 
 type CompileAdditionalMetricArgs = {
@@ -93,13 +272,12 @@ export const compileMetricQuery = ({
     availableParameters,
 }: CompileMetricQueryArgs): CompiledMetricQuery => {
     const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
-    const compiledTableCalculations = metricQuery.tableCalculations.map(
-        (tableCalculation) =>
-            compileTableCalculation(
-                tableCalculation,
-                [...metricQuery.dimensions, ...metricQuery.metrics],
-                fieldQuoteChar,
-            ),
+    const validFieldIds = [...metricQuery.dimensions, ...metricQuery.metrics];
+
+    const compiledTableCalculations = compileTableCalculations(
+        metricQuery.tableCalculations,
+        validFieldIds,
+        fieldQuoteChar,
     );
     const compiledAdditionalMetrics = (metricQuery.additionalMetrics || []).map(
         (additionalMetric) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #404 

### Description:

Makes it possible for table calculations to reference other table calculations. The approach is:
- Make a dependency graph for TCs
- Look for cycles
- Sort them based on dependencies so we know which to compile first
- Compile them in order by injecting the SQL from upstream calcs into the downstream ones

To test:
- Create a table calc
- Create another one that references the first one
- You can continue to chain them

What this **doesn't** solve:
- Auto complete in the FE (implemented up the stack)
- Issues with TCs getting renamed when edited

Here's what it looks like (the last TC is defined like `${rate_plus_1} + ${rate_plus_1_plus_1}`:
<img width="1166" height="615" alt="Screenshot 2025-08-18 at 15 43 40" src="https://github.com/user-attachments/assets/a491fd55-5216-4d32-a807-0a8d48c8329a" />
