### PR TITLE
fix: add explore to combine parameters

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -850,6 +850,7 @@ export class EmbedService extends BaseService {
         // No parameters are passed in embed requests, just combine the saved parameters
         const combinedParameters = await this.projectService.combineParameters(
             projectUuid,
+            explore,
             {},
             dashboardParameters,
         );
@@ -986,6 +987,7 @@ export class EmbedService extends BaseService {
         // No parameters are passed in embed requests, just combine the saved parameters
         const combinedParameters = await this.projectService.combineParameters(
             projectUuid,
+            explore,
             {},
             dashboardParameters,
         );
@@ -1064,6 +1066,7 @@ export class EmbedService extends BaseService {
         // No parameters are passed in embed requests, just combine the saved parameters
         const combinedParameters = await this.projectService.combineParameters(
             projectUuid,
+            explore,
             {},
             dashboardParameters,
         );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1754,6 +1754,7 @@ export class AsyncQueryService extends ProjectService {
         // Combine default parameter values with request parameters first
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            explore,
             parameters,
         );
 
@@ -1913,6 +1914,7 @@ export class AsyncQueryService extends ProjectService {
         // Combine default parameter values, saved chart parameters, and request parameters first
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            explore,
             parameters,
             savedChartParameters,
         );
@@ -2157,6 +2159,7 @@ export class AsyncQueryService extends ProjectService {
         // Combine default parameter values, dashboard parameters, and request parameters first
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            explore,
             parameters,
             dashboardParameters,
         );
@@ -2345,6 +2348,7 @@ export class AsyncQueryService extends ProjectService {
         // Combine default parameter values with request parameters first
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            explore,
             parameters,
         );
 
@@ -2423,6 +2427,7 @@ export class AsyncQueryService extends ProjectService {
         // Combine default parameter values with request parameters first
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            undefined,
             parameters,
         );
 
@@ -2724,6 +2729,7 @@ export class AsyncQueryService extends ProjectService {
         // Combine default parameter values with request parameters first
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            undefined,
             args.parameters,
         );
 
@@ -2821,6 +2827,7 @@ export class AsyncQueryService extends ProjectService {
         // Combine default parameter values, dashboard parameters, and request parameters first
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            undefined,
             args.parameters,
             dashboardParameters,
         );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -66,6 +66,7 @@ import {
     formatRawRows,
     formatRows,
     getAggregatedField,
+    getAvailableParametersFromTables,
     getDashboardFilterRulesForTables,
     getDateDimension,
     getDimensions,
@@ -5250,18 +5251,11 @@ export class ProjectService extends BaseService {
     async _calculateTotal(
         account: Account,
         projectUuid: string,
-        exploreName: string,
+        explore: Explore,
         metricQuery: MetricQuery,
         organizationUuid: string,
         parameters?: ParametersValuesMap,
     ) {
-        const explore = await this.getExplore(
-            account,
-            projectUuid,
-            exploreName,
-            organizationUuid,
-        );
-
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
             projectUuid,
             await this.getWarehouseCredentials({
@@ -5308,7 +5302,7 @@ export class ProjectService extends BaseService {
             ...this.getUserQueryTags(account),
             organization_uuid: account.organization.organizationUuid,
             project_uuid: projectUuid,
-            explore_name: exploreName,
+            explore_name: explore.name,
             query_context: QueryExecutionContext.CALCULATE_TOTAL,
         };
 
@@ -5458,6 +5452,7 @@ export class ProjectService extends BaseService {
 
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            explore,
             parameters,
             savedChart.parameters,
         );
@@ -5504,15 +5499,23 @@ export class ProjectService extends BaseService {
             throw new CustomSqlQueryForbiddenError();
         }
 
+        const explore = await this.getExplore(
+            account,
+            projectUuid,
+            data.explore,
+            organizationUuid,
+        );
+
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            explore,
             data.parameters,
         );
 
         const results = await this._calculateTotal(
             account,
             projectUuid,
-            data.explore,
+            explore,
             data.metricQuery,
             organizationUuid,
             combinedParameters,
@@ -5524,6 +5527,7 @@ export class ProjectService extends BaseService {
         account: Account,
         projectUuid: string,
         data: CalculateSubtotalsFromQuery,
+        explore: Explore,
         organizationUuid: string,
         parameters?: ParametersValuesMap,
     ) {
@@ -5533,13 +5537,6 @@ export class ProjectService extends BaseService {
             columnOrder,
             pivotDimensions,
         } = data;
-
-        const explore = await this.getExplore(
-            account,
-            projectUuid,
-            exploreName,
-            organizationUuid,
-        );
 
         // Use the shared utility to prepare dimension groups
         const { dimensionGroupsToSubtotal, analyticsData } =
@@ -5651,8 +5648,16 @@ export class ProjectService extends BaseService {
             throw new CustomSqlQueryForbiddenError();
         }
 
+        const explore = await this.getExplore(
+            account,
+            projectUuid,
+            data.explore,
+            organizationUuid,
+        );
+
         const combinedParameters = await this.combineParameters(
             projectUuid,
+            explore,
             data.parameters,
         );
 
@@ -5661,6 +5666,7 @@ export class ProjectService extends BaseService {
             account,
             projectUuid,
             data,
+            explore,
             organizationUuid,
             combinedParameters,
         );
@@ -6547,15 +6553,18 @@ export class ProjectService extends BaseService {
      * Combines parameter values from multiple sources in order of priority:
      * 1. Request parameters (highest priority)
      * 2. Saved chart/dashboard parameters
-     * 3. Default parameter values (lowest priority)
+     * 3. Default explore parameters values
+     * 4. Default project parameters values(lowest priority)
      */
     public async combineParameters(
         projectUuid: string,
+        explore?: Explore,
         requestParameters?: ParametersValuesMap,
         savedParameters?: ParametersValuesMap,
     ): Promise<ParametersValuesMap> {
         // Get default values for parameters
-        const defaultParameters: ParametersValuesMap = {};
+        const projectDefaultParameterValues: ParametersValuesMap = {};
+
         // Fetch all parameters
         const parameterConfigs = await this.projectParametersModel.find(
             projectUuid,
@@ -6563,14 +6572,25 @@ export class ProjectService extends BaseService {
 
         for (const paramConfig of parameterConfigs) {
             if (paramConfig.config.default !== undefined) {
-                defaultParameters[paramConfig.name] =
+                projectDefaultParameterValues[paramConfig.name] =
                     paramConfig.config.default;
             }
         }
 
-        // Combine in order of priority: defaults < saved chart < dashboard < request
+        const exploreParameters = explore
+            ? getAvailableParametersFromTables(Object.values(explore.tables))
+            : [];
+
+        const exploreDefaultParameterValues = Object.fromEntries(
+            Object.entries(exploreParameters)
+                .map(([key, value]) => [key, value.default])
+                .filter(([key, value]) => value !== undefined),
+        );
+
+        // Combine in order of priority: defaults (project / explore) < saved parameters (chart/dashboard) < request
         return {
-            ...defaultParameters,
+            ...projectDefaultParameterValues,
+            ...exploreDefaultParameterValues,
             ...(savedParameters || {}),
             ...(requestParameters || {}),
         };

--- a/packages/backend/src/services/ProjectService/parameters.ts
+++ b/packages/backend/src/services/ProjectService/parameters.ts
@@ -6,6 +6,11 @@ import {
 } from '@lightdash/common';
 import type { DbProjectParameter } from '../../database/entities/projectParameters';
 
+/**
+ * Convert dashboard parameters to ParametersValuesMap format
+ * @param dashboard - The dashboard
+ * @returns The dashboard parameters in ParametersValuesMap format
+ */
 export const getDashboardParametersValuesMap = (
     dashboard: DashboardDAO,
 ): ParametersValuesMap | undefined => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR adds support for explore-specific default parameter values. Now when combining parameters, the system considers values from multiple sources in order of priority:

1. Request parameters (highest priority)
2. Saved chart/dashboard parameters
3. Default explore parameters values
4. Default project parameters values (lowest priority)

The `combineParameters` method now accepts an optional `explore` parameter, which is used to extract default parameter values from the explore's tables. This ensures that explore-specific parameter defaults are properly applied when executing queries.

**Before**
<img width="2549" height="1255" alt="image" src="https://github.com/user-attachments/assets/09bea90b-6eaa-41cd-bfbb-3516b6962fbc" />


**After**
<img width="1039" height="719" alt="image" src="https://github.com/user-attachments/assets/10785bc2-214b-4097-aab3-d15cfd27f2a9" />
