### PR TITLE
chore: improve parameter name validation

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -168,7 +168,7 @@ export class ExploreCompiler {
             throw new CompileError(
                 `Failed to compile explore "${name}". Invalid parameter names: ${invalidParameters.join(
                     ', ',
-                )}. Parameter names cannot contain dots.`,
+                )}`,
                 {
                     invalidParameters,
                 },

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -100,13 +100,14 @@ export const getAvailableParametersFromTables = (
 /**
  * Validate parameter names
  * @param parameters - The parameters to validate
- * @returns True if any parameter name contains a dot, false otherwise
+ * @returns True if any parameter name doesn't match the valid pattern, false otherwise
  */
 export const validateParameterNames = (
     parameters: Record<string, LightdashProjectParameter> | undefined,
 ) => {
+    const validNamePattern = /^[a-zA-Z0-9_-]+$/;
     const invalidParameters = Object.keys(parameters || {}).filter(
-        (paramName) => paramName.includes('.'),
+        (paramName) => !validNamePattern.test(paramName),
     );
     return {
         isInvalid: invalidParameters.length > 0,

--- a/packages/common/src/utils/loadLightdashProjectConfig.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.ts
@@ -59,7 +59,7 @@ export const loadLightdashProjectConfig = async (
         throw new LightdashProjectConfigError(
             `Invalid lightdash.config.yml with invalid parameter names: ${invalidParameters.join(
                 ', ',
-            )}. Parameter names cannot contain dots.`,
+            )}`,
             {
                 invalidParameters,
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Enhances parameter name validation to reject more invalid characters beyond just dots. Parameter names must now match the pattern `/^[a-zA-Z0-9_-]+$/`, allowing only alphanumeric characters, underscores, and hyphens.

The PR:
- Updates the validation logic in `validateParameterNames()` to use a regex pattern
- Adds comprehensive tests for parameter name validation
- Updates error messages to be more generic (removes specific mention of dots)

This change helps prevent issues with parameter names that could cause problems in queries or UI rendering.