### PR TITLE
feat: add AI artifacts and versions database schema

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -263,6 +263,12 @@ import {
     AiAgentUserPreferencesTableName,
 } from '../ee/database/entities/aiAgentUserPreferences';
 import {
+    AiArtifactsTable,
+    AiArtifactsTableName,
+    AiArtifactVersionsTable,
+    AiArtifactVersionsTableName,
+} from '../ee/database/entities/aiArtifacts';
+import {
     DashboardSummariesTable,
     DashboardSummariesTableName,
 } from '../ee/database/entities/dashboardSummaries';
@@ -348,6 +354,8 @@ declare module 'knex/types/tables' {
         [AiThreadTableName]: AiThreadTable;
         [AiSlackThreadTableName]: AiSlackThreadTable;
         [AiPromptTableName]: AiPromptTable;
+        [AiArtifactsTableName]: AiArtifactsTable;
+        [AiArtifactVersionsTableName]: AiArtifactVersionsTable;
         [AiSlackPromptTableName]: AiSlackPromptTable;
         [AiWebAppPromptTableName]: AiWebAppPromptTable;
         [AiAgentTableName]: AiAgentTable;

--- a/packages/backend/src/database/entities/CLAUDE.md
+++ b/packages/backend/src/database/entities/CLAUDE.md
@@ -56,6 +56,16 @@ declare module 'knex/types/tables' {
 }
 ```
 
+Instead do this:
+
+```typescript
+declare module 'knex/types/tables' {
+    interface Tables {
+        [MyTableName]: ExampleTable; // Correct - using table type
+    }
+}
+```
+
 ## Type Guidelines
 
 -   Use `null` instead of `undefined` or optional types (`?`) for nullable database fields since databases don't have the concept of undefined

--- a/packages/backend/src/ee/database/entities/aiArtifacts.ts
+++ b/packages/backend/src/ee/database/entities/aiArtifacts.ts
@@ -1,0 +1,42 @@
+import { Knex } from 'knex';
+
+export const AiArtifactsTableName = 'ai_artifacts';
+
+export type DbAiArtifact = {
+    ai_artifact_uuid: string;
+    created_at: Date;
+    ai_thread_uuid: string;
+    artifact_type: string;
+    saved_query_uuid: string | null;
+};
+
+export type AiArtifactsTable = Knex.CompositeTableType<
+    DbAiArtifact,
+    Pick<DbAiArtifact, 'ai_thread_uuid' | 'artifact_type' | 'saved_query_uuid'>
+>;
+
+export const AiArtifactVersionsTableName = 'ai_artifact_versions';
+
+export type DbAiArtifactVersion = {
+    ai_artifact_version_uuid: string;
+    ai_artifact_uuid: string;
+    ai_prompt_uuid: string | null;
+    created_at: Date;
+    version_number: number;
+    title: string | null;
+    description: string | null;
+    viz_config_output: Record<string, unknown> | null;
+};
+
+export type AiArtifactVersionsTable = Knex.CompositeTableType<
+    DbAiArtifactVersion,
+    Pick<
+        DbAiArtifactVersion,
+        | 'ai_artifact_uuid'
+        | 'ai_prompt_uuid'
+        | 'version_number'
+        | 'title'
+        | 'description'
+        | 'viz_config_output'
+    >
+>;

--- a/packages/backend/src/ee/database/migrations/20250819073029_ai_artifacts_and_versions.ts
+++ b/packages/backend/src/ee/database/migrations/20250819073029_ai_artifacts_and_versions.ts
@@ -1,0 +1,71 @@
+import { Knex } from 'knex';
+
+const AiArtifactsTable = 'ai_artifacts';
+const AiArtifactVersionsTable = 'ai_artifact_versions';
+const AiPromptTable = 'ai_prompt';
+const AiThreadTable = 'ai_thread';
+const SavedQueriesTable = 'saved_queries';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiArtifactsTable, (table) => {
+        table
+            .uuid('ai_artifact_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table
+            .uuid('ai_thread_uuid')
+            .notNullable()
+            .references('ai_thread_uuid')
+            .inTable(AiThreadTable)
+            .onDelete('CASCADE');
+        table.text('artifact_type').notNullable().defaultTo('chart');
+        table
+            .uuid('saved_query_uuid')
+            .nullable()
+            .references('saved_query_uuid')
+            .inTable(SavedQueriesTable)
+            .onDelete('SET NULL');
+
+        table.index('ai_thread_uuid');
+        table.index('saved_query_uuid');
+        table.index('created_at');
+    });
+
+    await knex.schema.createTable(AiArtifactVersionsTable, (table) => {
+        table
+            .uuid('ai_artifact_version_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_artifact_uuid')
+            .notNullable()
+            .references('ai_artifact_uuid')
+            .inTable(AiArtifactsTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('ai_prompt_uuid')
+            .nullable()
+            .references('ai_prompt_uuid')
+            .inTable(AiPromptTable)
+            .onDelete('SET NULL');
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+
+        table.integer('version_number').notNullable();
+        table.text('title').nullable();
+        table.text('description').nullable();
+        table.jsonb('viz_config_output').nullable();
+
+        table.unique(['ai_artifact_uuid', 'version_number']);
+
+        table.index('ai_artifact_uuid');
+        table.index('ai_prompt_uuid');
+        table.index('created_at');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // Drop tables in reverse order due to foreign key constraints
+    await knex.schema.dropTableIfExists(AiArtifactVersionsTable);
+    await knex.schema.dropTableIfExists(AiArtifactsTable);
+}

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -121,6 +121,13 @@ export type AiAgentMessageAssistant = {
 
     toolCalls: AiAgentToolCall[];
     savedQueryUuid: string | null;
+
+    artifact: {
+        uuid: string;
+        versionNumber: number;
+        title: string | null;
+        description: string | null;
+    } | null;
 };
 
 export type AiAgentMessage<TUser extends AiAgentUser = AiAgentUser> =
@@ -283,3 +290,19 @@ export type AiAgentExploreAccessSummary = {
 export type ApiAiAgentExploreAccessSummaryResponse = ApiSuccess<
     AiAgentExploreAccessSummary[]
 >;
+
+export type AiArtifact = {
+    artifactUuid: string;
+    threadUuid: string;
+    promptUuid: string | null;
+    artifactType: 'chart';
+    savedQueryUuid: string | null;
+    createdAt: Date;
+    versionNumber: number;
+    title: string | null;
+    description: string | null;
+    vizConfigOutput: Record<string, unknown> | null;
+    versionCreatedAt: Date;
+};
+
+export type ApiAiAgentArtifactResponse = ApiSuccess<AiArtifact>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Created database schema for AI artifacts and versions to store AI-generated visualizations. This PR:

- Added new database tables: `ai_artifacts` and `ai_artifact_versions`
- Created TypeScript entity definitions for the new tables
- Added the tables to the Knex type definitions
- Defined common types for AI artifacts in the frontend
