### PR TITLE
fix: empty selected tabs when scheduling dashboard delivery

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9202,8 +9202,15 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         selectedTabs: {
-                            dataType: 'array',
-                            array: { dataType: 'string' },
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'array',
+                                    array: { dataType: 'string' },
+                                },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
                         },
                         customViewportWidth: { dataType: 'double' },
                         parameters: { ref: 'ParametersValuesMap' },
@@ -12419,7 +12426,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12429,7 +12436,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12439,7 +12446,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -12452,7 +12459,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9950,7 +9950,8 @@
                                 "items": {
                                     "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "nullable": true
                             },
                             "customViewportWidth": {
                                 "type": "number",
@@ -9974,7 +9975,11 @@
                                 "nullable": true
                             }
                         },
-                        "required": ["dashboardUuid", "savedChartUuid"],
+                        "required": [
+                            "selectedTabs",
+                            "dashboardUuid",
+                            "savedChartUuid"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -13211,22 +13216,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -228,7 +228,7 @@ export default class SchedulerTask {
         sendNowSchedulerFilters: DashboardFilterRule[] | undefined,
         sendNowSchedulerParameters: ParametersValuesMap | undefined,
         context: DownloadCsv['properties']['context'],
-        selectedTabs: string[] | undefined,
+        selectedTabs: string[] | null,
     ) {
         if (chartUuid) {
             const chart =
@@ -327,7 +327,7 @@ export default class SchedulerTask {
 
         const selectedTabs = isDashboardScheduler(scheduler)
             ? scheduler.selectedTabs
-            : undefined;
+            : null;
 
         const context =
             scheduler.thresholds === undefined ||
@@ -381,6 +381,7 @@ export default class SchedulerTask {
                                 : undefined,
                         context: ScreenshotContext.SCHEDULED_DELIVERY,
                         contextId: jobId,
+                        selectedTabs,
                     });
                     if (unfurlImage.imageUrl === undefined) {
                         throw new Error('Unable to unfurl image');

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -35,6 +35,7 @@ import {
     ItemsMap,
     MetricQuery,
     MissingConfigError,
+    ParameterError,
     ParametersValuesMap,
     PivotConfig,
     pivotResultsAsCsv,
@@ -43,6 +44,7 @@ import {
     SchedulerCsvOptions,
     SchedulerFormat,
     SessionUser,
+    validateSelectedTabs,
     type RunQueryTags,
 } from '@lightdash/common';
 import archiver from 'archiver';
@@ -901,7 +903,7 @@ export class CsvService extends BaseService {
         options: SchedulerCsvOptions | undefined;
         jobId?: string;
         schedulerFilters?: DashboardFilterRule[];
-        selectedTabs?: string[] | undefined;
+        selectedTabs: string[] | null;
         overrideDashboardFilters?: DashboardFilters;
         dateZoomGranularity?: DateGranularity;
         invalidateCache?: boolean;
@@ -910,6 +912,8 @@ export class CsvService extends BaseService {
         const dashboard = await this.dashboardModel.getById(dashboardUuid);
 
         const dashboardFilters = overrideDashboardFilters || dashboard.filters;
+
+        validateSelectedTabs(selectedTabs, dashboard.tiles);
 
         if (schedulerFilters) {
             dashboardFilters.dimensions = applyDimensionOverrides(
@@ -1405,6 +1409,7 @@ export class CsvService extends BaseService {
             options,
             overrideDashboardFilters: dashboardFilters,
             dateZoomGranularity,
+            selectedTabs: null,
         }).then((urls) => urls.filter((url) => url.path !== '#no-results'));
 
         this.logger.info(

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -131,7 +131,7 @@ export type DashboardScheduler = SchedulerBase & {
     filters?: DashboardFilterRule[];
     parameters?: ParametersValuesMap;
     customViewportWidth?: number;
-    selectedTabs?: string[];
+    selectedTabs: string[] | null;
 };
 
 export type Scheduler = ChartScheduler | DashboardScheduler;

--- a/packages/common/src/utils/dashboard.test.ts
+++ b/packages/common/src/utils/dashboard.test.ts
@@ -1,0 +1,54 @@
+import { type DashboardTile } from '../types/dashboard';
+import { ParameterError } from '../types/errors';
+import { validateSelectedTabs } from './dashboard';
+
+describe('validateSelectedTabs', () => {
+    // Simple mock that focuses on just the tabUuid property
+    const mockTiles = [
+        { tabUuid: 'tab1' },
+        { tabUuid: 'tab2' },
+        { tabUuid: null },
+        { tabUuid: undefined },
+    ] as DashboardTile[];
+
+    it('should not throw when selectedTabs is null', () => {
+        expect(() => validateSelectedTabs(null, mockTiles)).not.toThrow();
+    });
+
+    it('should not throw when selectedTabs is empty array', () => {
+        expect(() => validateSelectedTabs([], mockTiles)).not.toThrow();
+    });
+
+    it('should not throw when selectedTabs contains valid tab UUIDs', () => {
+        expect(() => validateSelectedTabs(['tab1'], mockTiles)).not.toThrow();
+        expect(() =>
+            validateSelectedTabs(['tab1', 'tab2'], mockTiles),
+        ).not.toThrow();
+    });
+
+    it('should throw ParameterError when none of selectedTabs exist in dashboard', () => {
+        expect(() =>
+            validateSelectedTabs(['nonexistent-tab'], mockTiles),
+        ).toThrow(ParameterError);
+        expect(() =>
+            validateSelectedTabs(['tab1', 'nonexistent-tab'], mockTiles),
+        ).not.toThrow(); // Should pass because tab1 exists
+    });
+
+    it('should throw ParameterError with informative message', () => {
+        expect(() =>
+            validateSelectedTabs(['nonexistent-tab'], mockTiles),
+        ).toThrow('None of the selected tabs exist in the dashboard');
+    });
+
+    it('should handle tiles without tabUuid', () => {
+        const tilesWithoutTabUuid = [
+            { tabUuid: undefined },
+            { tabUuid: null },
+        ] as DashboardTile[];
+
+        expect(() =>
+            validateSelectedTabs(['any-tab'], tilesWithoutTabUuid),
+        ).toThrow('None of the selected tabs exist in the dashboard');
+    });
+});

--- a/packages/common/src/utils/dashboard.ts
+++ b/packages/common/src/utils/dashboard.ts
@@ -1,5 +1,6 @@
 import { ChartSourceType } from '../types/content';
-import { DashboardTileTypes } from '../types/dashboard';
+import { type DashboardTile, DashboardTileTypes } from '../types/dashboard';
+import { ParameterError } from '../types/errors';
 import assertUnreachable from './assertUnreachable';
 
 export const convertChartSourceTypeToDashboardTileType = (
@@ -15,5 +16,34 @@ export const convertChartSourceTypeToDashboardTileType = (
                 sourceType,
                 `Unknown source type: ${sourceType}`,
             );
+    }
+};
+
+/**
+ * Validates that selected tabs exist in the dashboard tiles.
+ * If selectedTabs is provided and not empty, ensures at least one selected tab exists in dashboard tabs.
+ * @param selectedTabs - Array of selected tab UUIDs or null
+ * @param dashboardTiles - Array of dashboard tiles
+ * @throws ParameterError if none of the selected tabs exist in the dashboard
+ */
+export const validateSelectedTabs = (
+    selectedTabs: string[] | null,
+    dashboardTiles: DashboardTile[],
+): void => {
+    // If selectedTabs is provided and not empty, validate that at least one exists in dashboard tabs
+    if (selectedTabs && selectedTabs.length > 0) {
+        const availableTabs = dashboardTiles
+            .map((tile) => tile.tabUuid)
+            .filter((tabUuid): tabUuid is string => !!tabUuid)
+            .filter((tabUuid, index, self) => self.indexOf(tabUuid) === index);
+
+        const validSelectedTabs = selectedTabs.filter((tabUuid) =>
+            availableTabs.includes(tabUuid),
+        );
+        if (validSelectedTabs.length === 0) {
+            throw new ParameterError(
+                `None of the selected tabs exist in the dashboard`,
+            );
+        }
     }
 };

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -441,6 +441,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                             tab={activeTab}
                                             dashboardTiles={dashboardTiles}
                                             dashboardTabs={dashboardTabs}
+                                            dashboardUuid={dashboardUuid!}
                                             onClose={() =>
                                                 setDeletingTab(false)
                                             }

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -148,9 +148,11 @@ const ImageExport: FC<Props & Pick<ModalProps, 'onClose'>> = ({
             gridWidth: undefined,
             queryFilters: `?${queryParams.toString()}`,
             selectedTabs:
-                isDashboardTabsAvailable && !allTabsSelected
+                isDashboardTabsAvailable &&
+                !allTabsSelected &&
+                selectedTabs.length > 0
                     ? selectedTabs
-                    : undefined,
+                    : null,
         });
     }, [
         previewChoice,
@@ -173,9 +175,11 @@ const ImageExport: FC<Props & Pick<ModalProps, 'onClose'>> = ({
             queryFilters: `?${queryParams.toString()}`,
             isPreview: true,
             selectedTabs:
-                isDashboardTabsAvailable && !allTabsSelected
+                isDashboardTabsAvailable &&
+                !allTabsSelected &&
+                selectedTabs.length > 0
                     ? selectedTabs
-                    : undefined,
+                    : null,
         });
 
         // Store the preview with the proper key
@@ -235,9 +239,11 @@ const ImageExport: FC<Props & Pick<ModalProps, 'onClose'>> = ({
                                         ) || [],
                                     );
                                 } else {
-                                    setSelectedTabs([
-                                        dashboard?.tabs?.[0]?.uuid,
-                                    ]);
+                                    const firstTabUuid =
+                                        dashboard?.tabs?.[0]?.uuid;
+                                    setSelectedTabs(
+                                        firstTabUuid ? [firstTabUuid] : [],
+                                    );
                                 }
                             }}
                         />

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -32,6 +32,7 @@ type PreviewAndCustomizeScreenshotProps = {
             gridWidth: number | undefined;
             queryFilters: string;
             isPreview?: boolean | undefined;
+            selectedTabs: string[] | null;
         }
     >;
     previewChoice: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined;

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -106,7 +106,7 @@ const DEFAULT_VALUES = {
     filters: [] as DashboardFilterRule[],
     parameters: undefined,
     customViewportWidth: undefined,
-    selectedTabs: undefined,
+    selectedTabs: null,
     thresholds: [],
     includeLinks: true,
 };
@@ -146,7 +146,7 @@ const getSelectedTabsForDashboardScheduler = (
                       schedulerData.selectedTabs,
                       dashboard?.tabs.map((tab) => tab.uuid),
                   )
-                : undefined, // remove tabs that have been deleted
+                : null, // remove tabs that have been deleted
         }
     );
 };
@@ -339,7 +339,7 @@ const SchedulerForm: FC<Props> = ({
     });
 
     const isDashboardTabsAvailable =
-        dashboard?.tabs !== undefined && dashboard.tabs.length > 0;
+        dashboard?.tabs !== undefined && dashboard.tabs.length > 1;
 
     const { activeProjectUuid } = useActiveProjectUuid();
     const { data: project } = useProject(activeProjectUuid);
@@ -364,7 +364,7 @@ const SchedulerForm: FC<Props> = ({
                       ...DEFAULT_VALUES,
                       selectedTabs: isDashboardTabsAvailable
                           ? dashboard?.tabs.map((tab) => tab.uuid)
-                          : undefined,
+                          : null,
                       parameters:
                           isDashboard &&
                           Object.keys(dashboardParameterValues).length > 0
@@ -401,6 +401,12 @@ const SchedulerForm: FC<Props> = ({
                 return isInvalidCronExpression('Cron expression')(
                     cronExpression,
                 );
+            },
+            selectedTabs: (value: string[] | null) => {
+                if (value && value.length === 0) {
+                    return 'Selected tabs should not be empty';
+                }
+                return null;
             },
         },
 
@@ -1053,18 +1059,22 @@ const SchedulerForm: FC<Props> = ({
                                         setAllTabsSelected((old) => !old);
                                         form.setFieldValue(
                                             'selectedTabs',
-                                            e.target.checked
-                                                ? dashboard?.tabs.map(
-                                                      (tab) => tab.uuid,
-                                                  )
-                                                : [],
+                                            e.target.checked ? null : [],
                                         );
                                     }}
                                 />
                                 {!allTabsSelected && (
                                     <MultiSelect
                                         placeholder="Select tabs to include in the delivery"
-                                        value={form.values.selectedTabs}
+                                        value={
+                                            form.values.selectedTabs ??
+                                            undefined
+                                        }
+                                        error={
+                                            form.errors.selectedTabs
+                                                ? 'Selected tabs should not be empty'
+                                                : undefined
+                                        }
                                         data={(dashboard?.tabs || []).map(
                                             (tab) => ({
                                                 value: tab.uuid,

--- a/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerPreview.tsx
@@ -56,6 +56,7 @@ export const SchedulerPreview: FC<Props> = ({
             gridWidth: previewChoice ? parseInt(previewChoice) : undefined,
             queryFilters: getSchedulerFilterOverridesQueryString(),
             isPreview: true,
+            selectedTabs: null,
         });
         if (url) {
             setCurrentPreview(url);

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -87,7 +87,7 @@ const exportDashboard = async (
     id: string,
     gridWidth: number | undefined,
     queryFilters: string,
-    selectedTabs?: string[],
+    selectedTabs: string[] | null,
 ) =>
     lightdashApi<string>({
         url: `/dashboards/${id}/export`,
@@ -139,7 +139,7 @@ export const useExportDashboard = () => {
             gridWidth: number | undefined;
             queryFilters: string;
             isPreview?: boolean;
-            selectedTabs?: string[];
+            selectedTabs: string[] | null;
         }
     >(
         (data) =>


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/16447

### Description

Allow `null` for `selectedTabs` in dashboard schedulers to represent "all tabs selected" and add validation to ensure selected tabs exist in the dashboard.

### What changed?

- Changed `selectedTabs` type from `string[] | undefined` to `string[] | null` where `null` represents "all tabs selected"
- Added validation to ensure that when `selectedTabs` is provided, at least one tab exists in the dashboard
- Updated the scheduler form UI to handle the new `null` value for "all tabs selected"
- Added warnings in the tab deletion modal when a tab is used in scheduled deliveries
- Fixed the order of properties in dashboard tile type definitions