### PR TITLE
feat: add artifact creation to Agent tools, route to retrieve an artifact

### DIFF
--- a/examples/api/ai-agents.http
+++ b/examples/api/ai-agents.http
@@ -13,15 +13,15 @@ Content-Type: application/json
 ### =============================================================================
 
 ### List all AI Agents
-GET http://localhost:8080/api/v1/aiAgents
+GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents
 Content-Type: application/json
 
 ### Get specific AI Agent
-GET http://localhost:8080/api/v1/aiAgents/AGENT_UUID
+GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AGENT_UUID
 Content-Type: application/json
 
 ### Create AI Agent
-POST http://localhost:8080/api/v1/aiAgents
+POST http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents
 Content-Type: application/json
 
 {
@@ -38,7 +38,7 @@ Content-Type: application/json
 }
 
 ### Update AI Agent
-PATCH http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID
+PATCH http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID
 Content-Type: application/json
 
 {
@@ -49,7 +49,7 @@ Content-Type: application/json
 }
 
 ### Delete AI Agent
-DELETE http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID
+DELETE http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID
 Content-Type: application/json
 
 ### =============================================================================
@@ -57,15 +57,15 @@ Content-Type: application/json
 ### =============================================================================
 
 ### List Agent Threads
-GET http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/threads
+GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/threads
 Content-Type: application/json
 
 ### Get specific Agent Thread
-GET http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID
+GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID
 Content-Type: application/json
 
 ### Start new Agent Thread (create thread with first message)
-POST http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/generate
+POST http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/generate
 Content-Type: application/json
 
 {
@@ -73,7 +73,7 @@ Content-Type: application/json
 }
 
 ### Generate response in existing Agent Thread
-POST http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID/generate
+POST http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID/generate
 Content-Type: application/json
 
 {
@@ -81,17 +81,14 @@ Content-Type: application/json
 }
 
 ### Get Agent Thread Message Visualization
-GET http://localhost:8080/api/v1/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID/message/MESSAGE_UUID/viz
+GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/threads/THREAD_UUID/message/MESSAGE_UUID/viz
 Content-Type: application/json
 
-### =============================================================================
-### LEGACY AI ENDPOINTS (for reference)
-### =============================================================================
-
-### Dashboard summary
-POST http://localhost:8080/api/v1/ai/PROJECT_UUID/dashboard/DASHBOARD_UUID/summary
+### Get Artifact
+GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/artifacts/ARTIFACT_UUID
 Content-Type: application/json
 
-{
-    "context": "say something interesting"
-}
+
+### Get Artifact Version
+GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/artifacts/ARTIFACT_UUID?version=2
+Content-Type: application/json

--- a/examples/api/ai-agents.http
+++ b/examples/api/ai-agents.http
@@ -90,5 +90,6 @@ Content-Type: application/json
 
 
 ### Get Artifact Version
-GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/artifacts/ARTIFACT_UUID?version=2
+GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/artifacts/ARTIFACT_UUID/versions/VERSION_UUID
 Content-Type: application/json
+

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1,4 +1,5 @@
 import {
+    ApiAiAgentArtifactResponse,
     ApiAiAgentExploreAccessSummaryResponse,
     ApiAiAgentResponse,
     ApiAiAgentSummaryResponse,
@@ -444,6 +445,50 @@ export class AiAgentController extends BaseController {
                     projectUuid,
                     body.tags,
                 ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentUuid}/artifacts/{artifactUuid}')
+    @OperationId('getArtifact')
+    async getArtifact(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() artifactUuid: string,
+    ): Promise<ApiAiAgentArtifactResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getArtifact(
+                req.user!,
+                agentUuid,
+                artifactUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentUuid}/artifacts/{artifactUuid}/versions/{versionUuid}')
+    @OperationId('getArtifactVersion')
+    async getArtifactVersion(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() artifactUuid: string,
+        @Path() versionUuid: string,
+    ): Promise<ApiAiAgentArtifactResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getArtifact(
+                req.user!,
+                agentUuid,
+                artifactUuid,
+                versionUuid,
+            ),
         };
     }
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -822,6 +822,11 @@ export class AiAgentModel {
                     Pick<DbAiSlackPrompt, 'slack_user_id'> &
                     Pick<DbAiWebAppPrompt, 'user_uuid'> & {
                         user_name: string;
+                        ai_artifact_uuid: string | null;
+                        version_number: number | null;
+                        ai_artifact_version_uuid: string | null;
+                        title: string | null;
+                        description: string | null;
                     })[]
             >(
                 `${AiPromptTableName}.ai_prompt_uuid`,
@@ -838,6 +843,11 @@ export class AiAgentModel {
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackPromptTableName}.slack_user_id`,
                 `${AiWebAppPromptTableName}.user_uuid`,
+                `${AiArtifactsTableName}.ai_artifact_uuid`,
+                `${AiArtifactVersionsTableName}.version_number`,
+                `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                `${AiArtifactVersionsTableName}.title`,
+                `${AiArtifactVersionsTableName}.description`,
                 this.database.raw(
                     `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
                 ),
@@ -851,6 +861,16 @@ export class AiAgentModel {
                 AiWebAppPromptTableName,
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${AiWebAppPromptTableName}.ai_prompt_uuid`,
+            )
+            .leftJoin(
+                AiArtifactVersionsTableName,
+                `${AiPromptTableName}.ai_prompt_uuid`,
+                `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+            )
+            .leftJoin(
+                AiArtifactsTableName,
+                `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                `${AiArtifactsTableName}.ai_artifact_uuid`,
             )
             .where(`${AiPromptTableName}.ai_thread_uuid`, threadUuid)
             .andWhere(
@@ -894,6 +914,15 @@ export class AiAgentModel {
                     filtersOutput: row.filters_output,
                     metricQuery: row.metric_query,
                     humanScore: row.human_score,
+                    artifact: row.ai_artifact_uuid
+                        ? {
+                              uuid: row.ai_artifact_uuid,
+                              versionNumber: row.version_number ?? 1,
+                              versionUuid: row.ai_artifact_version_uuid!,
+                              title: row.title,
+                              description: row.description,
+                          }
+                        : null,
                     toolCalls: toolCalls
                         .filter(
                             (
@@ -976,6 +1005,11 @@ export class AiAgentModel {
                     Pick<DbAiSlackPrompt, 'slack_user_id'> &
                     Pick<DbAiWebAppPrompt, 'user_uuid'> & {
                         user_name: string;
+                        ai_artifact_uuid: string | null;
+                        version_number: number | null;
+                        ai_artifact_version_uuid: string | null;
+                        title: string | null;
+                        description: string | null;
                     })[]
             >(
                 `${AiPromptTableName}.ai_prompt_uuid`,
@@ -992,6 +1026,11 @@ export class AiAgentModel {
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackPromptTableName}.slack_user_id`,
                 `${AiWebAppPromptTableName}.user_uuid`,
+                `${AiArtifactsTableName}.ai_artifact_uuid`,
+                `${AiArtifactVersionsTableName}.version_number`,
+                `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                `${AiArtifactVersionsTableName}.title`,
+                `${AiArtifactVersionsTableName}.description`,
                 this.database.raw(
                     `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
                 ),
@@ -1015,6 +1054,16 @@ export class AiAgentModel {
                 AiWebAppPromptTableName,
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${AiWebAppPromptTableName}.ai_prompt_uuid`,
+            )
+            .leftJoin(
+                AiArtifactVersionsTableName,
+                `${AiPromptTableName}.ai_prompt_uuid`,
+                `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+            )
+            .leftJoin(
+                AiArtifactsTableName,
+                `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                `${AiArtifactsTableName}.ai_artifact_uuid`,
             )
             .where(`${AiPromptTableName}.ai_thread_uuid`, threadUuid)
             .andWhere(
@@ -1061,6 +1110,15 @@ export class AiAgentModel {
                     filtersOutput: row.filters_output,
                     metricQuery: row.metric_query,
                     humanScore: row.human_score,
+                    artifact: row.ai_artifact_uuid
+                        ? {
+                              uuid: row.ai_artifact_uuid,
+                              versionNumber: row.version_number ?? 1,
+                              versionUuid: row.ai_artifact_version_uuid!,
+                              title: row.title,
+                              description: row.description,
+                          }
+                        : null,
                     toolCalls: toolCalls
                         .filter(
                             (

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1863,6 +1863,9 @@ export class AiAgentService {
             ) => this.aiAgentModel.updateModelResponse(update),
             trackEvent: (event: AiAgentResponseStreamed) =>
                 this.analytics.track(event),
+
+            createOrUpdateArtifact: (data) =>
+                this.aiAgentModel.createOrUpdateArtifact(data),
         };
 
         return stream
@@ -2869,5 +2872,17 @@ export class AiAgentService {
         }));
 
         return exploreAccessSummary;
+    }
+
+    async getArtifact(
+        user: SessionUser,
+        agentUuid: string,
+        artifactUuid: string,
+        versionUuid?: string,
+    ) {
+        // TODO: Add proper permission checking - for now just check user has access to the agent
+        await this.getAgent(user, agentUuid);
+
+        return this.aiAgentModel.getArtifact(artifactUuid, versionUuid);
     }
 }

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -96,6 +96,7 @@ const getAgentTools = (
         getPrompt: dependencies.getPrompt,
         updatePrompt: dependencies.updatePrompt,
         sendFile: dependencies.sendFile,
+        createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
     });
 
@@ -106,6 +107,7 @@ const getAgentTools = (
         getPrompt: dependencies.getPrompt,
         updatePrompt: dependencies.updatePrompt,
         sendFile: dependencies.sendFile,
+        createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
     });
 
@@ -116,6 +118,7 @@ const getAgentTools = (
         getPrompt: dependencies.getPrompt,
         updatePrompt: dependencies.updatePrompt,
         sendFile: dependencies.sendFile,
+        createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
     });
 

--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
+    CreateOrUpdateArtifactFn,
     GetExploreFn,
     GetPromptFn,
     RunMiniMetricQueryFn,
@@ -28,6 +29,7 @@ type Dependencies = {
     getPrompt: GetPromptFn;
     updatePrompt: UpdatePromptFn;
     sendFile: SendFileFn;
+    createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
 };
 
@@ -38,6 +40,7 @@ export const getGenerateBarVizConfig = ({
     getPrompt,
     sendFile,
     updatePrompt,
+    createOrUpdateArtifact,
     maxLimit,
 }: Dependencies) => {
     const schema = toolVerticalBarArgsSchema;
@@ -70,6 +73,17 @@ export const getGenerateBarVizConfig = ({
                 // end of TODO
 
                 const prompt = await getPrompt();
+
+                await createOrUpdateArtifact({
+                    threadUuid: prompt.threadUuid,
+                    promptUuid: prompt.promptUuid,
+                    artifactType: 'chart',
+                    title: toolArgs.title,
+                    description: toolArgs.description,
+                    vizConfig: toolArgs,
+                });
+
+                // TODO :: keeping this for now, until the front-end is under feature-flag
                 await updatePrompt({
                     promptUuid: prompt.promptUuid,
                     vizConfigOutput: toolArgs,

--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -9,6 +9,7 @@ import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
 import { CsvService } from '../../../../services/CsvService/CsvService';
 import type {
+    CreateOrUpdateArtifactFn,
     GetExploreFn,
     GetPromptFn,
     RunMiniMetricQueryFn,
@@ -31,6 +32,7 @@ type Dependencies = {
     getPrompt: GetPromptFn;
     updatePrompt: UpdatePromptFn;
     sendFile: SendFileFn;
+    createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
 };
 export const getGenerateTableVizConfig = ({
@@ -40,6 +42,7 @@ export const getGenerateTableVizConfig = ({
     sendFile,
     updatePrompt,
     updateProgress,
+    createOrUpdateArtifact,
     maxLimit,
 }: Dependencies) => {
     const schema = toolTableVizArgsSchema;
@@ -72,6 +75,18 @@ export const getGenerateTableVizConfig = ({
                 // end of TODO
 
                 const prompt = await getPrompt();
+
+                // Create or update artifact
+                await createOrUpdateArtifact({
+                    threadUuid: prompt.threadUuid,
+                    promptUuid: prompt.promptUuid,
+                    artifactType: 'chart',
+                    title: toolArgs.title,
+                    description: toolArgs.description,
+                    vizConfig: toolArgs,
+                });
+
+                // TODO :: keeping this for now, until the front-end is under feature-flag
                 await updatePrompt({
                     promptUuid: prompt.promptUuid,
                     vizConfigOutput: toolArgs,

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
+    CreateOrUpdateArtifactFn,
     GetExploreFn,
     GetPromptFn,
     RunMiniMetricQueryFn,
@@ -28,6 +29,7 @@ type Dependencies = {
     getPrompt: GetPromptFn;
     updatePrompt: UpdatePromptFn;
     sendFile: SendFileFn;
+    createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
 };
 export const getGenerateTimeSeriesVizConfig = ({
@@ -37,6 +39,7 @@ export const getGenerateTimeSeriesVizConfig = ({
     getPrompt,
     sendFile,
     updatePrompt,
+    createOrUpdateArtifact,
     maxLimit,
 }: Dependencies) => {
     const schema = toolTimeSeriesArgsSchema;
@@ -69,6 +72,18 @@ export const getGenerateTimeSeriesVizConfig = ({
                 // end of TODO
 
                 const prompt = await getPrompt();
+
+                // Create or update artifact
+                await createOrUpdateArtifact({
+                    threadUuid: prompt.threadUuid,
+                    promptUuid: prompt.promptUuid,
+                    artifactType: 'chart',
+                    title: toolArgs.title,
+                    description: toolArgs.description,
+                    vizConfig: toolArgs,
+                });
+
+                // TODO :: keeping this for now, until the front-end is under feature-flag
                 await updatePrompt({
                     promptUuid: prompt.promptUuid,
                     vizConfigOutput: toolArgs,

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -1,6 +1,7 @@
 import { AiAgent } from '@lightdash/common';
 import { CoreMessage, LanguageModelV1 } from 'ai';
 import {
+    CreateOrUpdateArtifactFn,
     FindChartsFn,
     FindDashboardsFn,
     FindExploresFn,
@@ -54,6 +55,7 @@ export type AiAgentDependencies = {
     storeToolCall: StoreToolCallFn;
     storeToolResults: StoreToolResultsFn;
     trackEvent: TrackEventFn;
+    createOrUpdateArtifact: CreateOrUpdateArtifactFn;
 };
 
 export type AiGenerateAgentResponseArgs = AiAgentArgs;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -1,4 +1,5 @@
 import {
+    AiArtifact,
     AiMetricQueryWithFilters,
     AiWebAppPrompt,
     AllChartsSearchResult,
@@ -117,3 +118,12 @@ export type SearchFieldValuesFn = (args: {
     query: string;
     filters?: Filters;
 }) => Promise<string[]>;
+
+export type CreateOrUpdateArtifactFn = (data: {
+    threadUuid: string;
+    promptUuid: string;
+    artifactType: 'chart';
+    title?: string;
+    description?: string;
+    vizConfig: Record<string, unknown>;
+}) => Promise<AiArtifact>;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5081,6 +5081,43 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                artifact: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                description: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                title: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                versionUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                versionNumber: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                uuid: { dataType: 'string', required: true },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 savedQueryUuid: {
                     dataType: 'union',
                     subSchemas: [
@@ -5520,6 +5557,84 @@ const models: TsoaRoute.Models = {
             ref: 'ApiSuccess_AiAgentExploreAccessSummary-Array_',
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiArtifact: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                versionCreatedAt: { dataType: 'datetime', required: true },
+                vizConfigOutput: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'Record_string.unknown_' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                versionUuid: { dataType: 'string', required: true },
+                versionNumber: { dataType: 'double', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                savedQueryUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                artifactType: {
+                    dataType: 'enum',
+                    enums: ['chart'],
+                    required: true,
+                },
+                promptUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                threadUuid: { dataType: 'string', required: true },
+                artifactUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiArtifact_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiArtifact', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentArtifactResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiArtifact_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Role: {
@@ -21153,6 +21268,156 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getAgentExploreAccessSummary',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getArtifact: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        artifactUuid: {
+            in: 'path',
+            name: 'artifactUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/artifacts/:artifactUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getArtifact,
+        ),
+
+        async function AiAgentController_getArtifact(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getArtifact,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getArtifact',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getArtifactVersion: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        artifactUuid: {
+            in: 'path',
+            name: 'artifactUuid',
+            required: true,
+            dataType: 'string',
+        },
+        versionUuid: {
+            in: 'path',
+            name: 'versionUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/artifacts/:artifactUuid/versions/:versionUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getArtifactVersion,
+        ),
+
+        async function AiAgentController_getArtifactVersion(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getArtifactVersion,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getArtifactVersion',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5701,6 +5701,37 @@
             },
             "AiAgentMessageAssistant": {
                 "properties": {
+                    "artifact": {
+                        "properties": {
+                            "description": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "title": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "versionUuid": {
+                                "type": "string"
+                            },
+                            "versionNumber": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "description",
+                            "title",
+                            "versionUuid",
+                            "versionNumber",
+                            "uuid"
+                        ],
+                        "type": "object",
+                        "nullable": true
+                    },
                     "savedQueryUuid": {
                         "type": "string",
                         "nullable": true
@@ -5751,6 +5782,7 @@
                     }
                 },
                 "required": [
+                    "artifact",
                     "savedQueryUuid",
                     "toolCalls",
                     "humanScore",
@@ -6129,6 +6161,92 @@
             },
             "ApiAiAgentExploreAccessSummaryResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentExploreAccessSummary-Array_"
+            },
+            "AiArtifact": {
+                "properties": {
+                    "versionCreatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "vizConfigOutput": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Record_string.unknown_"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "versionUuid": {
+                        "type": "string"
+                    },
+                    "versionNumber": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "savedQueryUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "artifactType": {
+                        "type": "string",
+                        "enum": ["chart"],
+                        "nullable": false
+                    },
+                    "promptUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "artifactUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "versionCreatedAt",
+                    "vizConfigOutput",
+                    "description",
+                    "title",
+                    "versionUuid",
+                    "versionNumber",
+                    "createdAt",
+                    "savedQueryUuid",
+                    "artifactType",
+                    "promptUuid",
+                    "threadUuid",
+                    "artifactUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiArtifact_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiArtifact"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentArtifactResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiArtifact_"
             },
             "Role": {
                 "properties": {
@@ -18449,7 +18567,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1933.1",
+        "version": "0.1936.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -121,6 +121,14 @@ export type AiAgentMessageAssistant = {
 
     toolCalls: AiAgentToolCall[];
     savedQueryUuid: string | null;
+
+    artifact: {
+        uuid: string;
+        versionNumber: number;
+        versionUuid: string;
+        title: string | null;
+        description: string | null;
+    } | null;
 };
 
 export type AiAgentMessage<TUser extends AiAgentUser = AiAgentUser> =
@@ -298,3 +306,5 @@ export type AiArtifact = {
     chartConfig: Record<string, unknown> | null;
     versionCreatedAt: Date;
 };
+
+export type ApiAiAgentArtifactResponse = ApiSuccess<AiArtifact>;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
@@ -269,6 +269,7 @@ const createOptimisticMessages = (
             humanScore: null,
             toolCalls: [],
             savedQueryUuid: null,
+            artifact: null,
         },
     ];
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR adds support for AI agent artifacts, allowing charts generated by AI to be stored and retrieved. It introduces a new endpoint `/api/v1/projects/:projectUuid/aiAgents/:agentUuid/artifacts/:artifactUuid` to fetch artifacts by UUID

The implementation updates the chart generation tools (bar, table, time series) to create artifacts when generating visualizations, storing metadata like title, description, and visualization configuration. This enables persistent storage of AI-generated charts that can be accessed independently of the conversation thread.


⚠️ Change is backwards-compatible so can be tested out from the existing UI
