### PR TITLE
fix: add Google Sheets permission controls

### DIFF
--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -81,6 +81,18 @@ export class GdriveService extends BaseService {
         }
 
         if (
+            user.ability.cannot(
+                'manage',
+                subject('GoogleSheets', {
+                    organizationUuid: projectSummary.organizationUuid,
+                    projectUuid: projectSummary.projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (
             gsheetOptions.metricQuery.customDimensions?.some(
                 isCustomSqlDimension,
             ) &&

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -152,6 +152,22 @@ export class SchedulerService extends BaseService {
                 projectUuid,
             }),
         );
+
+        const canManageGoogleSheets = user.ability.can(
+            'manage',
+            subject('GoogleSheets', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+
+        if (
+            !canManageGoogleSheets &&
+            scheduler.format === SchedulerFormat.GSHEETS
+        ) {
+            throw new ForbiddenError();
+        }
+
         const isDeliveryOwner = scheduler.createdBy === user.userUuid;
 
         if (canManageDeliveries || (canCreateDeliveries && isDeliveryOwner)) {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -115,6 +115,10 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('create', 'ScheduledDeliveries', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'GoogleSheets', {
+            organizationUuid: member.organizationUuid,
+        });
+
         can('create', 'DashboardComments', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -90,6 +90,9 @@ export const projectMemberAbilities: Record<
         can('create', 'ScheduledDeliveries', {
             projectUuid: member.projectUuid,
         });
+        can('manage', 'GoogleSheets', {
+            projectUuid: member.projectUuid,
+        });
         can('create', 'DashboardComments', {
             projectUuid: member.projectUuid,
         });
@@ -163,6 +166,7 @@ export const projectMemberAbilities: Record<
         can('manage', 'ScheduledDeliveries', {
             projectUuid: member.projectUuid,
         });
+
         can('manage', 'DashboardComments', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -358,6 +358,13 @@ const scopes: Scope[] = [
         getConditions: addDefaultOrgIdCondition,
     },
     {
+        name: 'manage:GoogleSheets',
+        description: 'Manage google sheets',
+        isEnterprise: false,
+        group: ScopeGroup.PROJECT_MANAGEMENT,
+        getConditions: addDefaultOrgIdCondition,
+    },
+    {
         name: 'view:Analytics',
         description: 'View usage analytics',
         isEnterprise: false,

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -34,6 +34,7 @@ export type CaslSubjectNames =
     | 'DashboardPdf'
     | 'Explore'
     | 'ExportCsv'
+    | 'GoogleSheets'
     | 'Group'
     | 'InviteLink'
     | 'Job'

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -62,6 +62,7 @@ import { useProject } from '../../../hooks/useProject';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
+import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
@@ -631,20 +632,32 @@ const SavedChartsHeader: FC = () => {
                                         Alerts
                                     </Menu.Item>
                                 )}
-                                {userCanManageChart && hasGoogleDriveEnabled ? (
-                                    <Menu.Item
-                                        icon={
-                                            <MantineIcon
-                                                icon={IconCirclesRelation}
-                                            />
-                                        }
-                                        onClick={
-                                            syncWithGoogleSheetsModalHandlers.open
-                                        }
-                                    >
-                                        Google Sheets Sync
-                                    </Menu.Item>
-                                ) : null}
+                                {userCanManageChart &&
+                                    hasGoogleDriveEnabled && (
+                                        <Can
+                                            I="manage"
+                                            this={subject('GoogleSheets', {
+                                                organizationUuid:
+                                                    user.data?.organizationUuid,
+                                                projectUuid,
+                                            })}
+                                        >
+                                            <Menu.Item
+                                                icon={
+                                                    <MantineIcon
+                                                        icon={
+                                                            IconCirclesRelation
+                                                        }
+                                                    />
+                                                }
+                                                onClick={
+                                                    syncWithGoogleSheetsModalHandlers.open
+                                                }
+                                            >
+                                                Google Sheets Sync
+                                            </Menu.Item>
+                                        </Can>
+                                    )}
 
                                 {userCanManageChart && (
                                     <>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Added permission checks for Google Sheets integration to ensure only authorized users can access this feature. This PR introduces a new 'GoogleSheets' subject in the authorization system with 'manage' permissions that are granted to organization members and project members.

The changes include:
- Added permission checks in GdriveService to verify user can manage Google Sheets
- Added permission validation in SchedulerService for Google Sheets format
- Created new 'manage:GoogleSheets' scope in the authorization system
- Updated organization and project member abilities to include Google Sheets permissions
- Added UI checks to hide Google Sheets export options for unauthorized users