### PR TITLE
fix: add create and delete scopes for VirtualView

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5886,7 +5886,7 @@ export class ProjectService extends BaseService {
 
         if (
             account.user.ability.cannot(
-                'manage',
+                'create',
                 subject('VirtualView', { organizationUuid, projectUuid }),
             )
         ) {
@@ -5953,7 +5953,7 @@ export class ProjectService extends BaseService {
 
         if (
             account.user.ability.cannot(
-                'manage',
+                'create',
                 subject('VirtualView', { organizationUuid, projectUuid }),
             )
         ) {
@@ -6001,7 +6001,7 @@ export class ProjectService extends BaseService {
 
         if (
             user.ability.cannot(
-                'manage',
+                'delete',
                 subject('VirtualView', { organizationUuid, projectUuid }),
             )
         ) {

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -1365,6 +1365,188 @@ describe('scopeAbilityBuilder', () => {
             });
         });
 
+        describe('virtual view permissions', () => {
+            it('should handle create:virtual_view permissions', () => {
+                const ability = buildAbilityFromScopes({
+                    ...baseContext,
+                    scopes: ['create:virtual_view'],
+                });
+
+                expect(
+                    ability.can(
+                        'create',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Should not be able to delete with create scope
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle delete:virtual_view permissions', () => {
+                const ability = buildAbilityFromScopes({
+                    ...baseContext,
+                    scopes: ['delete:virtual_view'],
+                });
+
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Should not be able to create with delete scope
+                expect(
+                    ability.can(
+                        'create',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle manage:virtual_view permissions for both create and delete', () => {
+                const ability = buildAbilityFromScopes({
+                    ...baseContext,
+                    scopes: ['manage:virtual_view'],
+                });
+
+                // Should be able to manage (create and delete)
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Manage scope should allow both create and delete actions
+                expect(
+                    ability.can(
+                        'create',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(true);
+
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should not allow virtual view actions for different organizations', () => {
+                const ability = buildAbilityFromScopes({
+                    ...baseContext,
+                    scopes: [
+                        'create:virtual_view',
+                        'delete:virtual_view',
+                        'manage:virtual_view',
+                    ],
+                });
+
+                // Should not access virtual views from different org
+                expect(
+                    ability.can(
+                        'create',
+                        subject('VirtualView', {
+                            organizationUuid: 'different-org',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(false);
+
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('VirtualView', {
+                            organizationUuid: 'different-org',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(false);
+
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('VirtualView', {
+                            organizationUuid: 'different-org',
+                            projectUuid: 'project-123',
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should allow virtual view actions for different projects within same organization', () => {
+                const ability = buildAbilityFromScopes({
+                    ...baseContext,
+                    scopes: [
+                        'create:virtual_view',
+                        'delete:virtual_view',
+                        'manage:virtual_view',
+                    ],
+                });
+
+                // Virtual view permissions are organization-scoped, not project-scoped
+                // So they should work across different projects within the same org
+                expect(
+                    ability.can(
+                        'create',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'different-project',
+                        }),
+                    ),
+                ).toBe(true);
+
+                expect(
+                    ability.can(
+                        'delete',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'different-project',
+                        }),
+                    ),
+                ).toBe(true);
+
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('VirtualView', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'different-project',
+                        }),
+                    ),
+                ).toBe(true);
+            });
+        });
+
         describe('organization member profile permissions', () => {
             it('should handle view:organization_member_profile permissions', () => {
                 const ability = buildAbilityFromScopes({

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -515,6 +515,20 @@ const scopes: Scope[] = [
         getConditions: addDefaultOrgIdCondition,
     },
     {
+        name: 'create:VirtualView',
+        description: 'Create virtual views',
+        isEnterprise: false,
+        group: ScopeGroup.DATA,
+        getConditions: addDefaultOrgIdCondition,
+    },
+    {
+        name: 'delete:VirtualView',
+        description: 'Delete virtual views',
+        isEnterprise: false,
+        group: ScopeGroup.DATA,
+        getConditions: addDefaultOrgIdCondition,
+    },
+    {
         name: 'manage:VirtualView',
         description: 'Create and manage virtual views',
         isEnterprise: false,

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -28,6 +28,7 @@ import {
     EditVirtualViewModal,
 } from '../../../features/virtualView';
 import { useExplore } from '../../../hooks/useExplore';
+import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -142,14 +143,6 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         chartUuid,
     ]);
 
-    const canManageVirtualViews = user.data?.ability?.can(
-        'manage',
-        subject('VirtualView', {
-            organizationUuid: user.data?.organizationUuid,
-            projectUuid,
-        }),
-    );
-
     const missingFields = useMemo(() => {
         if (explore) {
             const visibleFields = getVisibleFields(explore);
@@ -251,8 +244,14 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
             >
                 <Group position="apart">
                     <PageBreadcrumbs size="md" items={breadcrumbs} />
-                    {canManageVirtualViews &&
-                        explore.type === ExploreType.VIRTUAL && (
+                    {explore.type === ExploreType.VIRTUAL && (
+                        <Can
+                            I="create"
+                            this={subject('VirtualView', {
+                                organizationUuid: user.data?.organizationUuid,
+                                projectUuid,
+                            })}
+                        >
                             <Menu withArrow offset={-2}>
                                 <Menu.Target>
                                     <ActionIcon variant="transparent">
@@ -268,18 +267,30 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                                             Edit virtual view
                                         </Text>
                                     </Menu.Item>
-                                    <Menu.Item
-                                        icon={<MantineIcon icon={IconTrash} />}
-                                        color="red"
-                                        onClick={handleDeleteVirtualView}
+                                    <Can
+                                        I="delete"
+                                        this={subject('VirtualView', {
+                                            organizationUuid:
+                                                user.data?.organizationUuid,
+                                            projectUuid,
+                                        })}
                                     >
-                                        <Text fz="xs" fw={500}>
-                                            Delete
-                                        </Text>
-                                    </Menu.Item>
+                                        <Menu.Item
+                                            icon={
+                                                <MantineIcon icon={IconTrash} />
+                                            }
+                                            color="red"
+                                            onClick={handleDeleteVirtualView}
+                                        >
+                                            <Text fz="xs" fw={500}>
+                                                Delete
+                                            </Text>
+                                        </Menu.Item>
+                                    </Can>
                                 </Menu.Dropdown>
                             </Menu>
-                        )}
+                        </Can>
+                    )}
                 </Group>
 
                 <ItemDetailProvider>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 


We added 2 new scopes : create and delete virtualviews

Existing old roles will keep using manage:virtualView, so they will be able to create or delete virtual views

Tested updating old roles:

With create only (but not delete):

<img width="458" height="232" alt="Screenshot from 2025-08-20 09-43-07" src="https://github.com/user-attachments/assets/699d4dad-ada1-41d5-a17a-4937249bafa9" />

With manage: 
<img width="458" height="232" alt="Screenshot from 2025-08-20 09-35-08" src="https://github.com/user-attachments/assets/9a5b6cd4-7546-421b-bda7-3a56605f2137" />

### Description:
Added two new authorization scopes for virtual views: `create:VirtualView` and `delete:VirtualView`. These granular permissions will allow for more fine-grained access control when working with virtual views, complementing the existing `manage:VirtualView` scope.