### PR TITLE
refactor: remove showQueryWarnings feature flag and enable metric deduplication by default

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -21,7 +21,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showQueryWarnings: false,
     },
 };
 
@@ -56,7 +55,6 @@ export const lightdashConfigWithBasicSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showQueryWarnings: false,
     },
 };
 
@@ -79,7 +77,6 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showQueryWarnings: false,
     },
 };
 
@@ -98,7 +95,6 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showQueryWarnings: false,
     },
 };
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -179,7 +179,6 @@ export const lightdashConfigMock: LightdashConfig = {
         defaultLimit: 500,
         csvCellsLimit: 100000,
         timezone: undefined,
-        showQueryWarnings: false,
     },
     ai: {
         copilot: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -680,7 +680,6 @@ export type LightdashConfig = {
         csvCellsLimit: number;
         timezone: string | undefined;
         maxPageSize: number;
-        showQueryWarnings: boolean;
     };
     pivotTable: {
         maxColumnLimit: number;
@@ -1373,8 +1372,6 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_MAX_PAGE_SIZE',
                 ) || 2500, // Defaults to default limit * 5
-            showQueryWarnings:
-                process.env.LIGHTDASH_SHOW_QUERY_WARNINGS === 'true',
         },
         chart: {
             versionHistory: {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1005,7 +1005,6 @@ export class EmbedService extends BaseService {
                 metricQuery,
                 warehouseClient,
                 availableParameters,
-                undefined,
                 combinedParameters,
             );
 

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -34,8 +34,6 @@ export class FeatureFlagModel {
         this.featureFlagHandlers = {
             [FeatureFlags.UserGroupsEnabled]:
                 this.getUserGroupsEnabled.bind(this),
-            [FeatureFlags.ShowQueryWarnings]:
-                this.getShowQueryWarningsEnabled.bind(this),
         };
     }
 
@@ -86,30 +84,6 @@ export class FeatureFlagModel {
                           // nor do we want to wait too long
                           throwOnTimeout: false,
                           timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getShowQueryWarningsEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.query.showQueryWarnings ||
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.ShowQueryWarnings,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
                       },
                   )
                 : false);

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1364,16 +1364,6 @@ export class AsyncQueryService extends ProjectService {
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes({ account });
 
-        const { enabled: useExperimentalMetricCtes } =
-            await this.featureFlagModel.get({
-                user: {
-                    userUuid: account.user.id,
-                    organizationUuid: account.organization.organizationUuid,
-                    organizationName: account.organization.name,
-                },
-                featureFlagId: FeatureFlags.ShowQueryWarnings,
-            });
-
         const availableParameters = await this.getAvailableParameters(
             projectUuid,
             explore,
@@ -1387,7 +1377,6 @@ export class AsyncQueryService extends ProjectService {
             userAttributes,
             timezone: this.lightdashConfig.query.timezone || 'UTC',
             dateZoom,
-            useExperimentalMetricCtes,
             // ! TODO: Should validate the parameters to make sure they are valid from the options
             parameters,
             availableParameters,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -434,7 +434,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         defaultLimit: 500,
         csvCellsLimit: 100,
         timezone: undefined,
-        showQueryWarnings: false,
     },
 };
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1754,7 +1754,6 @@ export class ProjectService extends BaseService {
         userAttributes,
         timezone,
         dateZoom,
-        useExperimentalMetricCtes,
         parameters,
         availableParameters,
     }: {
@@ -1765,7 +1764,6 @@ export class ProjectService extends BaseService {
         userAttributes: UserAttributeValueMap;
         timezone: string;
         dateZoom?: DateZoom;
-        useExperimentalMetricCtes?: boolean;
         parameters?: ParametersValuesMap;
         availableParameters: string[];
     }): Promise<CompiledQuery> {
@@ -1795,10 +1793,8 @@ export class ProjectService extends BaseService {
             availableParameters,
         });
 
-        return wrapSentryTransactionSync(
-            'QueryBuilder.buildQuery',
-            { useExperimentalMetricCtes },
-            () => queryBuilder.compileQuery(useExperimentalMetricCtes),
+        return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>
+            queryBuilder.compileQuery(),
         );
     }
 
@@ -1876,16 +1872,6 @@ export class ProjectService extends BaseService {
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes({ account });
 
-        const { enabled: useExperimentalMetricCtes } =
-            await this.featureFlagModel.get({
-                user: {
-                    userUuid: account.user.id,
-                    organizationUuid: account.organization.organizationUuid,
-                    organizationName: account.organization.name,
-                },
-                featureFlagId: FeatureFlags.ShowQueryWarnings,
-            });
-
         const availableParameters = await this.getAvailableParameters(
             projectUuid,
             explore,
@@ -1898,7 +1884,6 @@ export class ProjectService extends BaseService {
             intrinsicUserAttributes,
             userAttributes,
             timezone: this.lightdashConfig.query.timezone || 'UTC',
-            useExperimentalMetricCtes,
             parameters,
             availableParameters,
         });
@@ -5219,7 +5204,6 @@ export class ProjectService extends BaseService {
         metricQuery: MetricQuery,
         warehouseClient: WarehouseClient,
         availableParameters: string[],
-        useExperimentalMetricCtes?: boolean,
         parameters?: ParametersValuesMap,
     ) {
         const totalQuery: MetricQuery = {
@@ -5240,7 +5224,6 @@ export class ProjectService extends BaseService {
             intrinsicUserAttributes,
             userAttributes,
             timezone: this.lightdashConfig.query.timezone || 'UTC',
-            useExperimentalMetricCtes,
             parameters,
             availableParameters,
         });
@@ -5272,16 +5255,6 @@ export class ProjectService extends BaseService {
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes({ account });
 
-        const { enabled: useExperimentalMetricCtes } =
-            await this.featureFlagModel.get({
-                user: {
-                    userUuid: account.user.id,
-                    organizationName: account.organization.name,
-                    organizationUuid: account.organization.organizationUuid,
-                },
-                featureFlagId: FeatureFlags.ShowQueryWarnings,
-            });
-
         const availableParameters = await this.getAvailableParameters(
             projectUuid,
             explore,
@@ -5294,7 +5267,6 @@ export class ProjectService extends BaseService {
             metricQuery,
             warehouseClient,
             availableParameters,
-            useExperimentalMetricCtes,
             parameters,
         );
 
@@ -5348,7 +5320,6 @@ export class ProjectService extends BaseService {
             metricQuery,
             warehouseClient,
             availableParameters,
-            undefined,
             parameters,
         );
 

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -49,12 +49,6 @@ export enum FeatureFlags {
     BigquerySSO = 'bigquery-sso',
 
     /**
-     * Generate new experimental CTE and show query warnings in explore page
-     * This feature flag is temporary while we work on the new query warnings for metric inflation.
-     */
-    ShowQueryWarnings = 'show-query-warnings',
-
-    /**
      * Use workers for async query execution
      */
     WorkerQueryExecution = 'worker-query-execution',

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -8,7 +8,6 @@ import { useParams } from 'react-router';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
@@ -101,10 +100,6 @@ const ExplorerHeader: FC = memo(() => {
         'CompileProject',
     );
 
-    const { data: showQueryWarningsEnabled } = useFeatureFlag(
-        FeatureFlags.ShowQueryWarnings,
-    );
-
     return (
         <Group position="apart">
             {typeof onBackToDashboard === 'function' && (
@@ -147,7 +142,6 @@ const ExplorerHeader: FC = memo(() => {
                 )}
 
                 {userCanManageCompileProject &&
-                    showQueryWarningsEnabled?.enabled &&
                     queryWarnings &&
                     queryWarnings.length > 0 && (
                         <QueryWarnings queryWarnings={queryWarnings} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#16473](https://github.com/lightdash/lightdash/issues/16473)
Closes: [#16471](https://github.com/lightdash/lightdash/issues/16471)

### Description:
Removes the experimental `showQueryWarnings` feature flag and makes metric deduplication with CTEs the default behavior. This change:

1. Removes the `showQueryWarnings` configuration option from the LightdashConfig
2. Removes the `ShowQueryWarnings` feature flag
3. Makes the CTE-based metric deduplication approach the default in MetricQueryBuilder
4. Updates the query building process to always check for and display query warnings
5. Removes the conditional display of query warnings in the Explorer UI

This change improves query accuracy by default by preventing metric inflation due to join relationships.

**Also fixes the issue with wrong totals in saved charts and embeds because it was not using the feature flag.**

#### Before

Note totals different between chart and results table.

<img width="1371" height="1230" alt="Screenshot 2025-08-19 at 14 45 37" src="https://github.com/user-attachments/assets/8b0fafb7-05f6-450e-9af8-d1e58ea9847f" />

<img width="1372" height="526" alt="Screenshot 2025-08-19 at 14 44 25" src="https://github.com/user-attachments/assets/c2f914e9-3aa2-4956-9d9c-834b1dc32db0" />


#### After

<img width="1575" height="1236" alt="Screenshot 2025-08-19 at 14 49 51" src="https://github.com/user-attachments/assets/770db92e-0fe6-4b50-bb2e-6899bec56b36" />

<img width="1576" height="516" alt="Screenshot 2025-08-19 at 14 51 06" src="https://github.com/user-attachments/assets/f84039c0-46dd-4e0e-ac63-41111cc2a4ed" />
