### PR TITLE
feat: add AI artifacts model

### DIFF
--- a/packages/backend/src/ee/database/entities/aiArtifacts.ts
+++ b/packages/backend/src/ee/database/entities/aiArtifacts.ts
@@ -6,7 +6,7 @@ export type DbAiArtifact = {
     ai_artifact_uuid: string;
     created_at: Date;
     ai_thread_uuid: string;
-    artifact_type: string;
+    artifact_type: 'chart';
 };
 
 export type AiArtifactsTable = Knex.CompositeTableType<

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -283,3 +283,18 @@ export type AiAgentExploreAccessSummary = {
 export type ApiAiAgentExploreAccessSummaryResponse = ApiSuccess<
     AiAgentExploreAccessSummary[]
 >;
+
+export type AiArtifact = {
+    artifactUuid: string;
+    threadUuid: string;
+    promptUuid: string | null;
+    artifactType: 'chart';
+    savedQueryUuid: string | null;
+    createdAt: Date;
+    versionNumber: number;
+    versionUuid: string;
+    title: string | null;
+    description: string | null;
+    chartConfig: Record<string, unknown> | null;
+    versionCreatedAt: Date;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Adds AI artifact management functionality to support chart artifacts. This PR:

- Restricts `artifact_type` to only accept 'chart' value in the database schema
- Implements CRUD operations for AI artifacts in the `AiAgentModel` class:
  - `createArtifact`: Creates a new artifact with its first version
  - `createArtifactVersion`: Adds a new version to an existing artifact
  - `createOrUpdateArtifact`: Creates or updates an artifact based on thread UUID
  - `getArtifact`: Retrieves an artifact by UUID
  - `getArtifactByPromptUuid`: Retrieves an artifact by prompt UUID
  - `getArtifactByThreadUuid`: Retrieves an artifact by thread UUID
  - `findArtifactByThreadUuid`: Safely finds an artifact by thread UUID (returns null if not found)
- Defines the `AiArtifact` type in the common package to be used across the application