### PR TITLE
fix: table calcs changing names when edited

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -139,8 +139,25 @@ const TableCalculationModal: FC<Props> = ({
             return;
         }
         try {
+            // Determine the final name - only run uniqueness check if name changed or it's a new calculation
+            const isNewCalculation = !tableCalculation;
+            const nameChanged =
+                tableCalculation && tableCalculation.displayName !== name;
+
+            let finalName: string;
+            if (isNewCalculation || nameChanged) {
+                finalName = getUniqueTableCalculationName(
+                    name,
+                    tableCalculations,
+                    tableCalculation,
+                );
+            } else {
+                // Name unchanged - keep the original name
+                finalName = tableCalculation.name;
+            }
+
             onSave({
-                name: getUniqueTableCalculationName(name, tableCalculations),
+                name: finalName,
                 displayName: name,
                 sql,
                 format: data.format,

--- a/packages/frontend/src/features/tableCalculation/utils/index.ts
+++ b/packages/frontend/src/features/tableCalculation/utils/index.ts
@@ -3,15 +3,21 @@ import { snakeCaseName, type TableCalculation } from '@lightdash/common';
 export const getUniqueTableCalculationName = (
     name: string,
     tableCalculations: TableCalculation[],
+    excludeTableCalc?: TableCalculation,
 ): string => {
     const snakeName = snakeCaseName(name);
     const suffixes = Array.from(Array(100).keys());
     const getCalcName = (suffix: number) =>
         suffix === 0 ? snakeName : `${snakeName}_${suffix}`;
 
+    // Filter out the table calculation we're currently editing
+    const otherTableCalculations = excludeTableCalc
+        ? tableCalculations.filter((tc) => tc.name !== excludeTableCalc.name)
+        : tableCalculations;
+
     const validSuffix = suffixes.find(
         (suffix) =>
-            tableCalculations.findIndex(
+            otherTableCalculations.findIndex(
                 ({ name: tableCalcName }) =>
                     tableCalcName === getCalcName(suffix),
             ) === -1,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16474 
### Description:

Fixes an issue where table calculations would change ids when edited. If I had `a` and edited it, the id in code would be changed to `a_1`. This will cause problems now that we are allowing chaining table calcs together. 

This simple fix seems to solves the main issue here. Note that calculation names and IDs are stored separately, but there is no way to edit them separately at the moment. In the future we could enhance this to keep the ID static even if the name is changed, but that will cause other problems. We'd probably have to make them both editable. 

To test:
- Create a TC, check the name in the SQL
- Edit the TC
- The id used in SQL should still match the name

**Old behavior - sql changes**
![Kapture 2025-08-20 at 14 15 07](https://github.com/user-attachments/assets/ddb68f28-4849-411c-a01f-2b2b3da2d5a2)

**Fixed - this PR**
![after](https://github.com/user-attachments/assets/3f9c8556-60f0-4036-9b0b-83c068667727)

