### PR TITLE
fix: use getAllCells instead of getVisibleCells for conditional formatting

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -68,7 +68,7 @@ const TableRow: FC<TableRowProps> = ({
     const rowFields = useMemo(
         () =>
             row
-                .getAllCells()
+                .getAllCells() // get all as they can be necessary for conditional formatting
                 .reduce<ConditionalFormattingRowFields>((acc, cell) => {
                     const meta = cell.column.columnDef.meta;
                     if (meta?.item) {

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -68,7 +68,7 @@ const TableRow: FC<TableRowProps> = ({
     const rowFields = useMemo(
         () =>
             row
-                .getVisibleCells()
+                .getAllCells()
                 .reduce<ConditionalFormattingRowFields>((acc, cell) => {
                     const meta = cell.column.columnDef.meta;
                     if (meta?.item) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #14734

### Description:
Changed `getVisibleCells()` to `getAllCells()` in TableBody component to ensure all cells are available for conditional formatting, even if they're not currently visible in the UI.


#### Example condition

<img width="1380" height="789" alt="Screenshot 2025-08-20 at 14 25 06" src="https://github.com/user-attachments/assets/8933330a-4955-42f0-9c79-82dcf2ff53f8" />


#### Before
<img width="1378" height="788" alt="Screenshot 2025-08-20 at 14 25 22" src="https://github.com/user-attachments/assets/daaf03f7-ce00-45b3-b471-d93f4b183f5b" />

#### After
<img width="1378" height="789" alt="Screenshot 2025-08-20 at 14 24 47" src="https://github.com/user-attachments/assets/1d8ca8bd-c57b-46a4-af42-3f3ce33f6917" />

