### PR TITLE
chore: add logging for account edges

### DIFF
--- a/packages/backend/src/auth/account/warnAccountExists.ts
+++ b/packages/backend/src/auth/account/warnAccountExists.ts
@@ -1,0 +1,6 @@
+/**
+ * Common util for warning about an account already being authenticated.
+ * Centralizes messages to enable creating metrics for this case.
+ */
+export const buildAccountExistsWarning = (message: string) =>
+    `${message} Account is already authenticated`;

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -10,6 +10,8 @@ import {
 } from '@lightdash/common';
 import { RequestHandler } from 'express';
 import { fromServiceAccount } from '../../auth/account/account';
+import { buildAccountExistsWarning } from '../../auth/account/warnAccountExists';
+import Logger from '../../logging/logger';
 import { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
 
 const getRoleForScopes = (scopes: ServiceAccountScope[]) => {
@@ -154,7 +156,15 @@ export const authenticateServiceAccount: RequestHandler = async (
             createdAt: serviceAccount.createdAt,
             updatedAt: serviceAccount.createdAt,
         };
+
+        if (req?.account?.isAuthenticated()) {
+            Logger.warn(
+                buildAccountExistsWarning('ServiceAccount'),
+                req.account?.authentication?.type,
+            );
+        }
         req.account = fromServiceAccount(req.user!, token);
+
         next();
     } catch (error) {
         next(new AuthorizationError(getErrorMessage(error)));

--- a/packages/backend/src/middlewares/accountMiddleware/sessionAccountMiddleware.ts
+++ b/packages/backend/src/middlewares/accountMiddleware/sessionAccountMiddleware.ts
@@ -2,6 +2,7 @@
 // This rule is failing in CI but passes locally
 import { NextFunction, Request, Response } from 'express';
 import * as Account from '../../auth/account';
+import Logger from '../../logging/logger';
 
 /**
  * Middleware to attach the account to the request.
@@ -12,6 +13,14 @@ export function sessionAccountMiddleware(
     res: Response,
     next: NextFunction,
 ) {
+    // This means we already have a session user with an account, which should not happen.
+    if (req.user && req.account) {
+        Logger.warn(
+            'User with Session Account is already authenticated',
+            req.account.authentication.type,
+        );
+    }
+
     // Nothing to do if there's no user or the account is already set
     if (!req.user || req.account) {
         next();

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
@@ -1,13 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 // This rule is failing in CI but passes locally
-import {
-    ForbiddenError,
-    JWT_HEADER_NAME,
-    NotFoundError,
-    ParameterError,
-} from '@lightdash/common';
+import { JWT_HEADER_NAME, NotFoundError } from '@lightdash/common';
 import { NextFunction, Request, Response } from 'express';
 import { fromJwt } from '../../auth/account';
+import { buildAccountExistsWarning } from '../../auth/account/warnAccountExists';
 import { decodeLightdashJwt } from '../../auth/lightdashJwt';
 import { EmbedService } from '../../ee/services/EmbedService/EmbedService';
 import Logger from '../../logging/logger';
@@ -52,6 +48,10 @@ export async function jwtAuthMiddleware(
         // There are some situations where we'll already have a user and need to still create a
         // JWT account. One example is when an admin is previewing an embed URL.
         if (req.account?.isAuthenticated()) {
+            Logger.warn(
+                buildAccountExistsWarning('JWT Middleware'),
+                req.account?.authentication?.type,
+            );
             next();
             return;
         }

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -160,7 +160,9 @@ export function assertEmbeddedAuth(
     account: Account | undefined,
 ): asserts account is AnonymousAccount {
     if (account?.authentication.type !== 'jwt') {
-        throw new ForbiddenError('Account is not an embedded account');
+        throw new ForbiddenError(
+            `${account?.authentication.type} Account is not jwt auth`,
+        );
     }
 }
 
@@ -168,7 +170,9 @@ export function assertSessionAuth(
     account: Account | undefined,
 ): asserts account is SessionAccount {
     if (account?.authentication.type !== 'session') {
-        throw new ForbiddenError('Account is not a session account');
+        throw new ForbiddenError(
+            `${account?.authentication.type} Account is not session auth`,
+        );
     }
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Part of a series of follow-ups to the [Embedded AuthZ Incident ](https://www.notion.so/lightdash/Authorization-error-on-embedded-dashboards-255a63207a7a80a59b70ef3075833b48)

Prevents multiple authentication methods from overriding each other by adding checks to ensure an account is not already authenticated before setting a new authentication method. Added warning logs when an account is already authenticated via OAuth, API key, service account, or session to help debug authentication issues. 