### PR TITLE
feat: use projectUuid in embed for JWT abilities

### DIFF
--- a/packages/backend/src/auth/account/account.mock.ts
+++ b/packages/backend/src/auth/account/account.mock.ts
@@ -4,6 +4,7 @@ import {
     CreateEmbedJwt,
     Embed,
     OrganizationMemberRole,
+    OssEmbed,
     PossibleAbilities,
     SessionAccount,
     SessionUser,
@@ -87,9 +88,23 @@ export function buildAccount({
     if (accountType === 'session') {
         return fromSession(defaultSessionUser, 'session-cookie');
     }
+    const embed: OssEmbed = {
+        organization: defaultOrganization,
+        projectUuid: 'test-project-uuid',
+        encodedSecret: 'test-encoded-secret',
+        dashboardUuids: ['test-dashboard-uuid'],
+        allowAllDashboards: false,
+        createdAt: '2021-01-01',
+        user: {
+            userUuid: 'test-user-uuid',
+            firstName: 'Test',
+            lastName: 'User',
+        },
+    };
+
     return fromJwt({
         decodedToken: defaultJwtToken,
-        organization: defaultOrganization,
+        embed,
         source: 'test-jwt-token',
         dashboardUuid: 'test-dashboard-uuid',
         userAttributes: defaultUserAttributes,

--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -10,11 +10,11 @@ import {
     applyEmbeddedAbility,
     buildAccountHelpers,
     CreateEmbedJwt,
-    Embed,
     ForbiddenError,
     MemberAbility,
     OauthAccount,
     Organization,
+    OssEmbed,
     ServiceAcctAccount,
     SessionAccount,
     SessionUser,
@@ -74,19 +74,19 @@ const extractOrganizationFromUser = (
 
 export const fromJwt = ({
     decodedToken,
-    organization,
+    embed,
     source,
     dashboardUuid,
     userAttributes,
 }: {
     decodedToken: CreateEmbedJwt;
-    organization: Embed['organization'];
+    embed: OssEmbed;
     source: string;
     dashboardUuid: string;
     userAttributes: UserAccessControls;
 }): AnonymousAccount => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
-    applyEmbeddedAbility(decodedToken, dashboardUuid, organization, builder);
+    applyEmbeddedAbility(decodedToken, dashboardUuid, embed, builder);
     const abilities = builder.build();
 
     return createAccount({
@@ -95,7 +95,8 @@ export const fromJwt = ({
             data: decodedToken,
             source,
         },
-        organization,
+        organization: embed.organization,
+        embed,
         access: {
             dashboardId: dashboardUuid,
             filtering: decodedToken.content.dashboardFiltersInteractivity,
@@ -103,7 +104,7 @@ export const fromJwt = ({
         },
         // Create the fields we're able to set from the JWT
         user: {
-            id: getExternalId(decodedToken, source, organization),
+            id: getExternalId(decodedToken, source, embed.organization),
             type: 'anonymous',
             ability: abilities,
             abilityRules: abilities.rules,

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
@@ -87,11 +87,13 @@ export async function jwtAuthMiddleware(
         }
 
         // Get embed configuration from database
-        const { encodedSecret, organization } =
-            await embedService.getEmbeddingByProjectId(projectUuid);
-        const decodedToken = decodeLightdashJwt(embedToken, encodedSecret);
+        const embed = await embedService.getEmbeddingByProjectId(projectUuid);
+        const decodedToken = decodeLightdashJwt(
+            embedToken,
+            embed.encodedSecret,
+        );
         const userAttributesPromise = embedService.getEmbedUserAttributes(
-            organization.organizationUuid,
+            embed.organization.organizationUuid,
             decodedToken,
         );
         const dashboardUuidPromise = embedService.getDashboardUuidFromJwt(
@@ -114,7 +116,7 @@ export async function jwtAuthMiddleware(
         req.account = fromJwt({
             decodedToken,
             source: embedToken,
-            organization,
+            embed,
             dashboardUuid,
             userAttributes,
         });

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -1,17 +1,8 @@
 import { z } from 'zod';
-import { type Organization } from '../../types/organization';
-import { type LightdashUser } from '../../types/user';
+import { type OssEmbed } from '../../types/auth';
 import assertUnreachable from '../../utils/assertUnreachable';
 
-export type Embed = {
-    projectUuid: string;
-    organization: Pick<Organization, 'organizationUuid' | 'name' | 'createdAt'>;
-    encodedSecret: string;
-    dashboardUuids: string[];
-    allowAllDashboards: boolean;
-    createdAt: string;
-    user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'>;
-};
+export type Embed = OssEmbed;
 
 export type DecodedEmbed = Omit<Embed, 'encodedSecret'> & {
     encodedSecret: undefined;

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -9,6 +9,7 @@ import {
     type ExternalUser,
     type IntrinsicUserAttributes,
     type LightdashSessionUser,
+    type LightdashUser,
 } from './user';
 import { type UserAttributeValueMap } from './userAttributes';
 
@@ -54,6 +55,16 @@ export type OauthAuth = {
     scopes: string[];
     expiresAt?: number;
     resource?: URL;
+};
+
+export type OssEmbed = {
+    projectUuid: string;
+    organization: Pick<Organization, 'organizationUuid' | 'name' | 'createdAt'>;
+    encodedSecret: string;
+    dashboardUuids: string[];
+    allowAllDashboards: boolean;
+    createdAt: string;
+    user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'>;
 };
 
 export type Authentication =
@@ -127,6 +138,8 @@ export type AnonymousAccount = BaseAccountWithHelpers & {
     user: ExternalUser;
     /** The access permissions the account has */
     access: DashboardAccess;
+    /** The embed configuration associated with the JWT */
+    embed: OssEmbed;
 };
 
 export type ApiKeyAccount = BaseAccountWithHelpers & {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Part of follow-ups to the [Embedded AuthZ Incident](https://www.notion.so/lightdash/Authorization-error-on-embedded-dashboards-255a63207a7a80a59b70ef3075833b48)

@ZeRego suggested that customers may not be sending a proper JWT with all the claims we expect. This seems correct. I made an assumption that `projectUuid` would always be a claim in the JWT, but we don't enforce the JWT schema for embeds. The theory is that customers that were affected do not mint tokens with `projectUuid`.

We use `projectUuid` when applying CASL abilities. This would then make sense because we have authenticated users that get 403 Forbidden errors when accessing resources we expect to be available.

The error occurred because "View Underlying Data" moved embedded dashboards to use endpoints outside of the Embed Controller. This meant that permissions are more important, because they're checked in those services—but not in EmbedService. If `projectUuid` is missing, we don't apply the correct abilities when resolving the identity.

This change uses `projectUuid` from the embed record we get back from the database rather than the `projectUuid` from the JWT. That will give us a guaranteed `projectUuid` and not rely on the token. We only check the JWT for claims related to granting permissions (ex. canExplore, canDateZoom, etc.)