### PR TITLE
feat: AI Tool schema compatibility layer

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -54,6 +54,7 @@
         "@lightdash/warehouses": "workspace:*",
         "@mastra/core": "^0.11.1",
         "@mastra/evals": "^0.10.7",
+        "@mastra/schema-compat": "^0.10.7",
         "@modelcontextprotocol/sdk": "^1.17.0",
         "@node-oauth/oauth2-server": "^5.2.0",
         "@octokit/app": "^14.0.2",

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -22,6 +22,7 @@ import {
     toolRunMetricQueryArgsSchema,
     ToolSearchFieldValuesArgs,
     toolSearchFieldValuesArgsSchema,
+    type SchemaTarget,
 } from '@lightdash/common';
 // eslint-disable-next-line import/extensions
 import { subject } from '@casl/ability';
@@ -100,6 +101,13 @@ type McpProtocolContext = {
     authInfo?: AuthInfo & {
         extra: ExtraContext;
     };
+};
+
+// MCP always uses Claude/Anthropic models - hardcode the target for schema compatibility
+const MCP_MODEL_TARGET: SchemaTarget = {
+    provider: 'anthropic',
+    modelId: 'claude-4-opus-20250514',
+    supportsStructuredOutputs: false,
 };
 
 export class McpService extends BaseService {
@@ -217,6 +225,7 @@ export class McpService extends BaseService {
                     maxDescriptionLength: 100,
                     fieldSearchSize: 200,
                     fieldOverviewSearchSize: 5,
+                    modelTarget: MCP_MODEL_TARGET,
                 });
                 const result = await findExploresTool.execute(argsWithProject, {
                     toolCallId: '',
@@ -263,6 +272,7 @@ export class McpService extends BaseService {
                 const findFieldsTool = getFindFields({
                     findFields,
                     pageSize: 15,
+                    modelTarget: MCP_MODEL_TARGET,
                 });
                 const result = await findFieldsTool.execute(argsWithProject, {
                     toolCallId: '',
@@ -310,6 +320,7 @@ export class McpService extends BaseService {
                     findDashboards,
                     pageSize: 10,
                     siteUrl: this.lightdashConfig.siteUrl,
+                    modelTarget: MCP_MODEL_TARGET,
                 });
                 const result = await findDashboardsTool.execute(
                     argsWithProject,
@@ -360,6 +371,7 @@ export class McpService extends BaseService {
                     findCharts,
                     pageSize: 10,
                     siteUrl: this.lightdashConfig.siteUrl,
+                    modelTarget: MCP_MODEL_TARGET,
                 });
                 const result = await findChartsTool.execute(argsWithProject, {
                     toolCallId: '',
@@ -571,6 +583,7 @@ export class McpService extends BaseService {
                     getExplore,
                     runMiniMetricQuery,
                     maxLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
+                    modelTarget: MCP_MODEL_TARGET,
                 });
 
                 const result = await runMetricQueryTool.execute(
@@ -620,6 +633,7 @@ export class McpService extends BaseService {
 
                 const searchFieldValuesTool = getSearchFieldValues({
                     searchFieldValues,
+                    modelTarget: MCP_MODEL_TARGET,
                 });
                 const result = await searchFieldValuesTool.execute(
                     argsWithProject,

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -64,29 +64,40 @@ const getAgentTools = (
         );
     }
 
+    const modelTarget = {
+        provider: args.model.provider,
+        modelId: args.model.modelId,
+        supportsStructuredOutputs:
+            args.model.supportsStructuredOutputs ?? false,
+    };
+
     const findExplores = getFindExplores({
         maxDescriptionLength: args.findExploresMaxDescriptionLength,
         pageSize: args.findExploresPageSize,
         fieldSearchSize: args.findExploresFieldSearchSize,
         fieldOverviewSearchSize: args.findExploresFieldOverviewSearchSize,
         findExplores: dependencies.findExplores,
+        modelTarget,
     });
 
     const findFields = getFindFields({
         findFields: dependencies.findFields,
         pageSize: args.findFieldsPageSize,
+        modelTarget,
     });
 
     const findDashboards = getFindDashboards({
         findDashboards: dependencies.findDashboards,
         pageSize: args.findDashboardsPageSize,
         siteUrl: args.siteUrl,
+        modelTarget,
     });
 
     const findCharts = getFindCharts({
         findCharts: dependencies.findCharts,
         pageSize: args.findChartsPageSize,
         siteUrl: args.siteUrl,
+        modelTarget,
     });
 
     const generateBarVizConfig = getGenerateBarVizConfig({
@@ -98,6 +109,7 @@ const getAgentTools = (
         sendFile: dependencies.sendFile,
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
+        modelTarget,
     });
 
     const generateTimeSeriesVizConfig = getGenerateTimeSeriesVizConfig({
@@ -109,6 +121,7 @@ const getAgentTools = (
         sendFile: dependencies.sendFile,
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
+        modelTarget,
     });
 
     const generateTableVizConfig = getGenerateTableVizConfig({
@@ -120,6 +133,7 @@ const getAgentTools = (
         sendFile: dependencies.sendFile,
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
+        modelTarget,
     });
 
     const tools = {

--- a/packages/backend/src/ee/services/ai/tools/findCharts.ts
+++ b/packages/backend/src/ee/services/ai/tools/findCharts.ts
@@ -2,7 +2,9 @@ import {
     AllChartsSearchResult,
     isSavedChartSearchResult,
     isSqlChartSearchResult,
+    SchemaCompatibilityManager,
     toolFindChartsArgsSchema,
+    type SchemaTarget,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import moment from 'moment';
@@ -13,6 +15,7 @@ type Dependencies = {
     findCharts: FindChartsFn;
     pageSize: number;
     siteUrl?: string;
+    modelTarget: SchemaTarget;
 };
 
 const getChartText = (chart: AllChartsSearchResult, siteUrl?: string) => {
@@ -90,10 +93,16 @@ export const getFindCharts = ({
     findCharts,
     pageSize,
     siteUrl,
-}: Dependencies) =>
-    tool({
+    modelTarget,
+}: Dependencies) => {
+    const schema = SchemaCompatibilityManager.transformSchema(
+        toolFindChartsArgsSchema,
+        modelTarget,
+    );
+
+    return tool({
         description: toolFindChartsArgsSchema.description,
-        parameters: toolFindChartsArgsSchema,
+        parameters: schema,
         execute: async (args) => {
             try {
                 const chartSearchQueryResults = await Promise.all(
@@ -124,3 +133,4 @@ export const getFindCharts = ({
             }
         },
     });
+};

--- a/packages/backend/src/ee/services/ai/tools/findDashboards.ts
+++ b/packages/backend/src/ee/services/ai/tools/findDashboards.ts
@@ -1,6 +1,8 @@
 import {
     DashboardSearchResult,
+    SchemaCompatibilityManager,
     toolFindDashboardsArgsSchema,
+    type SchemaTarget,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import moment from 'moment';
@@ -11,6 +13,7 @@ type Dependencies = {
     findDashboards: FindDashboardsFn;
     pageSize: number;
     siteUrl?: string;
+    modelTarget: SchemaTarget;
 };
 
 const getDashboardText = (
@@ -107,10 +110,16 @@ export const getFindDashboards = ({
     findDashboards,
     pageSize,
     siteUrl,
-}: Dependencies) =>
-    tool({
+    modelTarget,
+}: Dependencies) => {
+    const schema = SchemaCompatibilityManager.transformSchema(
+        toolFindDashboardsArgsSchema,
+        modelTarget,
+    );
+
+    return tool({
         description: toolFindDashboardsArgsSchema.description,
-        parameters: toolFindDashboardsArgsSchema,
+        parameters: schema,
         execute: async (args) => {
             try {
                 const dashboardSearchQueryResults = await Promise.all(
@@ -143,3 +152,4 @@ export const getFindDashboards = ({
             }
         },
     });
+};

--- a/packages/backend/src/ee/services/ai/tools/findFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/findFields.ts
@@ -6,7 +6,9 @@ import {
     getFilterTypeFromItemType,
     getItemId,
     isEmojiIcon,
+    SchemaCompatibilityManager,
     toolFindFieldsArgsSchema,
+    type SchemaTarget,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type { FindFieldFn } from '../types/aiAgentDependencies';
@@ -15,6 +17,7 @@ import { toolErrorHandler } from '../utils/toolErrorHandler';
 type Dependencies = {
     findFields: FindFieldFn;
     pageSize: number;
+    modelTarget: SchemaTarget;
 };
 
 const fieldKindLabel = (fieldType: FieldType) => {
@@ -91,10 +94,19 @@ const getFieldsText = (
 </SearchResult>
 `.trim();
 
-export const getFindFields = ({ findFields, pageSize }: Dependencies) =>
-    tool({
+export const getFindFields = ({
+    findFields,
+    pageSize,
+    modelTarget,
+}: Dependencies) => {
+    const schema = SchemaCompatibilityManager.transformSchema(
+        toolFindFieldsArgsSchema,
+        modelTarget,
+    );
+
+    return tool({
         description: toolFindFieldsArgsSchema.description,
-        parameters: toolFindFieldsArgsSchema,
+        parameters: schema,
         execute: async (args) => {
             try {
                 const fieldSearchQueryResults = await Promise.all(
@@ -126,3 +138,4 @@ export const getFindFields = ({ findFields, pageSize }: Dependencies) =>
             }
         },
     });
+};

--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -1,8 +1,10 @@
 import {
     getTotalFilterRules,
     isSlackPrompt,
+    SchemaCompatibilityManager,
     toolVerticalBarArgsSchema,
     toolVerticalBarArgsSchemaTransformed,
+    type SchemaTarget,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
@@ -31,6 +33,7 @@ type Dependencies = {
     sendFile: SendFileFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
+    modelTarget: SchemaTarget;
 };
 
 export const getGenerateBarVizConfig = ({
@@ -42,8 +45,12 @@ export const getGenerateBarVizConfig = ({
     updatePrompt,
     createOrUpdateArtifact,
     maxLimit,
+    modelTarget,
 }: Dependencies) => {
-    const schema = toolVerticalBarArgsSchema;
+    const schema = SchemaCompatibilityManager.transformSchema(
+        toolVerticalBarArgsSchema,
+        modelTarget,
+    );
 
     return tool({
         description: toolVerticalBarArgsSchema.description,

--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -2,8 +2,10 @@ import {
     getTotalFilterRules,
     isSlackPrompt,
     metricQueryTableViz,
+    SchemaCompatibilityManager,
     toolTableVizArgsSchema,
     toolTableVizArgsSchemaTransformed,
+    type SchemaTarget,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
@@ -34,6 +36,7 @@ type Dependencies = {
     sendFile: SendFileFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
+    modelTarget: SchemaTarget;
 };
 export const getGenerateTableVizConfig = ({
     getExplore,
@@ -44,8 +47,12 @@ export const getGenerateTableVizConfig = ({
     updateProgress,
     createOrUpdateArtifact,
     maxLimit,
+    modelTarget,
 }: Dependencies) => {
-    const schema = toolTableVizArgsSchema;
+    const schema = SchemaCompatibilityManager.transformSchema(
+        toolTableVizArgsSchema,
+        modelTarget,
+    );
 
     return tool({
         description: toolTableVizArgsSchema.description,

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -1,8 +1,10 @@
 import {
     getTotalFilterRules,
     isSlackPrompt,
+    SchemaCompatibilityManager,
     toolTimeSeriesArgsSchema,
     toolTimeSeriesArgsSchemaTransformed,
+    type SchemaTarget,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
@@ -31,6 +33,7 @@ type Dependencies = {
     sendFile: SendFileFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
+    modelTarget: SchemaTarget;
 };
 export const getGenerateTimeSeriesVizConfig = ({
     getExplore,
@@ -41,8 +44,12 @@ export const getGenerateTimeSeriesVizConfig = ({
     updatePrompt,
     createOrUpdateArtifact,
     maxLimit,
+    modelTarget,
 }: Dependencies) => {
-    const schema = toolTimeSeriesArgsSchema;
+    const schema = SchemaCompatibilityManager.transformSchema(
+        toolTimeSeriesArgsSchema,
+        modelTarget,
+    );
 
     return tool({
         description: toolTimeSeriesArgsSchema.description,

--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -2,8 +2,10 @@ import {
     getItemLabelWithoutTableName,
     getTotalFilterRules,
     metricQueryTableViz,
+    SchemaCompatibilityManager,
     toolRunMetricQueryArgsSchema,
     toolRunMetricQueryArgsSchemaTransformed,
+    type SchemaTarget,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
@@ -23,16 +25,23 @@ type Dependencies = {
     getExplore: GetExploreFn;
     runMiniMetricQuery: RunMiniMetricQueryFn;
     maxLimit: number;
+    modelTarget: SchemaTarget;
 };
 
 export const getRunMetricQuery = ({
     getExplore,
     runMiniMetricQuery,
     maxLimit,
-}: Dependencies) =>
-    tool({
+    modelTarget,
+}: Dependencies) => {
+    const schema = SchemaCompatibilityManager.transformSchema(
+        toolRunMetricQueryArgsSchema,
+        modelTarget,
+    );
+
+    return tool({
         description: toolRunMetricQueryArgsSchema.description,
-        parameters: toolRunMetricQueryArgsSchema,
+        parameters: schema,
         execute: async (toolArgs) => {
             try {
                 const vizTool =
@@ -94,3 +103,4 @@ export const getRunMetricQuery = ({
             }
         },
     });
+};

--- a/packages/backend/src/ee/services/ai/tools/searchFieldValues.ts
+++ b/packages/backend/src/ee/services/ai/tools/searchFieldValues.ts
@@ -1,6 +1,8 @@
 import {
+    SchemaCompatibilityManager,
     toolSearchFieldValuesArgsSchema,
     toolSearchFieldValuesArgsSchemaTransformed,
+    type SchemaTarget,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type { SearchFieldValuesFn } from '../types/aiAgentDependencies';
@@ -9,12 +11,21 @@ import { toolErrorHandler } from '../utils/toolErrorHandler';
 
 type Dependencies = {
     searchFieldValues: SearchFieldValuesFn;
+    modelTarget: SchemaTarget;
 };
 
-export const getSearchFieldValues = ({ searchFieldValues }: Dependencies) =>
-    tool({
+export const getSearchFieldValues = ({
+    searchFieldValues,
+    modelTarget,
+}: Dependencies) => {
+    const schema = SchemaCompatibilityManager.transformSchema(
+        toolSearchFieldValuesArgsSchema,
+        modelTarget,
+    );
+
+    return tool({
         description: toolSearchFieldValuesArgsSchema.description,
-        parameters: toolSearchFieldValuesArgsSchema,
+        parameters: schema,
         execute: async (toolArgs) => {
             try {
                 const args =
@@ -28,3 +39,4 @@ export const getSearchFieldValues = ({ searchFieldValues }: Dependencies) =>
             }
         },
     });
+};

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -26,15 +26,20 @@ import { serializeData } from './serializeData';
  */
 export function validateSelectedFieldsExistence(
     explore: Explore,
-    selectedFieldIds: string[],
+    selectedFieldIds: (string | undefined)[],
 ) {
     const exploreFieldIds = getFields(explore).map(getItemId);
     const nonExploreFields = selectedFieldIds.filter(
-        (f) => !exploreFieldIds.includes(f),
+        (f) =>
+            typeof f === 'string' &&
+            f.length > 0 &&
+            !exploreFieldIds.includes(f),
     );
 
     if (nonExploreFields.length) {
-        const errorMessage = `The following fields do not exist in the selected explore.
+        const errorMessage = `The following fields do not exist in explore: ${
+            explore.name
+        }.
 
 Fields:
 \`\`\`json

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@casl/ability": "^5.4.3",
+        "@mastra/schema-compat": "^0.10.7",
         "@types/lodash": "^4.14.202",
         "ajv": "^8.3.0",
         "ajv-errors": "^3.0.0",

--- a/packages/common/src/ee/AiAgent/schemas/filters/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/index.ts
@@ -51,18 +51,18 @@ const filterRuleSchemaTransformed = filterRuleSchema.transform(
 
 export const filtersSchema = z.object({
     type: filterAndOrSchema,
-    dimensions: z.array(filterRuleSchema).nullable(),
-    metrics: z.array(filterRuleSchema).nullable(),
+    dimensions: z.array(filterRuleSchema).optional(),
+    metrics: z.array(filterRuleSchema).optional(),
 });
 
 const filtersSchemaAndFilterRulesTransformed = z
     .object({
         type: filterAndOrSchema,
-        dimensions: z.array(filterRuleSchemaTransformed).nullable(),
-        metrics: z.array(filterRuleSchemaTransformed).nullable(),
+        dimensions: z.array(filterRuleSchemaTransformed).optional(),
+        metrics: z.array(filterRuleSchemaTransformed).optional(),
     })
-    // Filters can be null
-    .nullable();
+    // Filters can be optional
+    .optional();
 
 export const filtersSchemaTransformed =
     filtersSchemaAndFilterRulesTransformed.transform((data): Filters => {

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -10,6 +10,7 @@ import {
 } from './tools';
 
 export * from './filters';
+export * from './schemaCompatibility';
 export * from './tools';
 export * from './visualizations';
 

--- a/packages/common/src/ee/AiAgent/schemas/schemaCompatibility.ts
+++ b/packages/common/src/ee/AiAgent/schemas/schemaCompatibility.ts
@@ -1,0 +1,30 @@
+import {
+    AnthropicSchemaCompatLayer,
+    applyCompatLayer,
+    OpenAIReasoningSchemaCompatLayer,
+} from '@mastra/schema-compat';
+import type { ZodSchema } from 'zod';
+
+export interface SchemaTarget {
+    provider: string;
+    modelId: string;
+    supportsStructuredOutputs: boolean;
+}
+
+export class SchemaCompatibilityManager {
+    static transformSchema<T extends ZodSchema>(
+        schema: T,
+        target: SchemaTarget,
+    ): T {
+        const compatLayers = [
+            new OpenAIReasoningSchemaCompatLayer(target),
+            new AnthropicSchemaCompatLayer(target),
+        ];
+
+        return applyCompatLayer({
+            schema,
+            compatLayers,
+            mode: 'aiSdkSchema',
+        }) as unknown as T;
+    }
+}

--- a/packages/common/src/ee/AiAgent/schemas/sortField.ts
+++ b/packages/common/src/ee/AiAgent/schemas/sortField.ts
@@ -13,7 +13,7 @@ const sortFieldSchema = z.object({
         .describe(
             'If true sorts nulls first, if false sorts nulls last, if null then sorts by warehouse default',
         )
-        .nullable(),
+        .optional(),
 });
 
 export default sortFieldSchema;

--- a/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
@@ -5,7 +5,7 @@ type ToolSchemaBuilder<$Schema extends z.ZodRawShape = z.ZodRawShape> = {
         fields: $Fields,
     ) => ToolSchemaBuilder<$Schema & $Fields>;
     withPagination: () => ToolSchemaBuilder<
-        $Schema & { page: z.ZodNullable<z.ZodNumber> }
+        $Schema & { page: z.ZodOptional<z.ZodNumber> }
     >;
     build: () => z.ZodObject<$Schema>;
     schema: z.ZodObject<$Schema>;
@@ -32,10 +32,10 @@ const toolSchemaBuilder = <$Schema extends z.ZodRawShape>(
                 page: z.coerce
                     .number()
                     .positive()
-                    .nullable()
+                    .optional()
                     .describe('Use this to paginate through the results'),
             }),
-        ) as ToolSchemaBuilder<$Schema & { page: z.ZodNullable<z.ZodNumber> }>,
+        ) as ToolSchemaBuilder<$Schema & { page: z.ZodOptional<z.ZodNumber> }>,
 
     /**
      * Builds the schema

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindChartsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindChartsArgs.ts
@@ -34,6 +34,12 @@ export const toolFindChartsArgsSchema = createToolSchema(
 
 export type ToolFindChartsArgs = z.infer<typeof toolFindChartsArgsSchema>;
 
-export const toolFindChartsArgsSchemaTransformed = toolFindChartsArgsSchema;
+export const toolFindChartsArgsSchemaTransformed =
+    toolFindChartsArgsSchema.transform((args) => ({
+        ...args,
+        page: args.page ?? null,
+    }));
 
-export type ToolFindChartsArgsTransformed = ToolFindChartsArgs;
+export type ToolFindChartsArgsTransformed = z.infer<
+    typeof toolFindChartsArgsSchemaTransformed
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindDashboardsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindDashboardsArgs.ts
@@ -39,6 +39,11 @@ export type ToolFindDashboardsArgs = z.infer<
 >;
 
 export const toolFindDashboardsArgsSchemaTransformed =
-    toolFindDashboardsArgsSchema;
+    toolFindDashboardsArgsSchema.transform((args) => ({
+        ...args,
+        page: args.page ?? null,
+    }));
 
-export type ToolFindDashboardsArgsTransformed = ToolFindDashboardsArgs;
+export type ToolFindDashboardsArgsTransformed = z.infer<
+    typeof toolFindDashboardsArgsSchemaTransformed
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -21,7 +21,7 @@ export const toolFindExploresArgsSchema = createToolSchema(
     .extend({
         exploreName: z
             .string()
-            .nullable()
+            .optional()
             .describe(
                 'Name of the table to focus on. If omitted, all tables are returned. For a single table, all dimensions, metrics, and full descriptions are loaded',
             ),
@@ -31,5 +31,12 @@ export const toolFindExploresArgsSchema = createToolSchema(
 
 export type ToolFindExploresArgs = z.infer<typeof toolFindExploresArgsSchema>;
 
-export const toolFindExploresArgsSchemaTransformed = toolFindExploresArgsSchema;
-export type ToolFindExploresArgsTransformed = ToolFindExploresArgs;
+export const toolFindExploresArgsSchemaTransformed =
+    toolFindExploresArgsSchema.transform((args) => ({
+        ...args,
+        exploreName: args.exploreName ?? null,
+        page: args.page ?? null,
+    }));
+export type ToolFindExploresArgsTransformed = z.infer<
+    typeof toolFindExploresArgsSchemaTransformed
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
@@ -32,6 +32,12 @@ export const toolFindFieldsArgsSchema = createToolSchema(
 
 export type ToolFindFieldsArgs = z.infer<typeof toolFindFieldsArgsSchema>;
 
-export const toolFindFieldsArgsSchemaTransformed = toolFindFieldsArgsSchema;
+export const toolFindFieldsArgsSchemaTransformed =
+    toolFindFieldsArgsSchema.transform((args) => ({
+        ...args,
+        page: args.page ?? null,
+    }));
 
-export type ToolFindFieldsArgsTransformed = ToolFindFieldsArgs;
+export type ToolFindFieldsArgsTransformed = z.infer<
+    typeof toolFindFieldsArgsSchemaTransformed
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
@@ -29,9 +29,9 @@ export const toolSearchFieldValuesArgsSchema = createToolSchema(
             .describe(
                 'Query string to filter field values. Optional, pass `null` to get all values',
             )
-            .nullable(),
+            .optional(),
         filters: filtersSchema
-            .nullable()
+            .optional()
             .describe('Filters to apply when searching for field values'),
     })
     .build();

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -16,7 +16,7 @@ export const toolTableVizArgsSchema = createToolSchema(
         ...visualizationMetadataSchema.shape,
         vizConfig: tableVizConfigSchema,
         filters: filtersSchema
-            .nullable()
+            .optional()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore.',
             ),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -16,7 +16,7 @@ export const toolTimeSeriesArgsSchema = createToolSchema(
         ...visualizationMetadataSchema.shape,
         vizConfig: timeSeriesMetricVizConfigSchema,
         filters: filtersSchema
-            .nullable()
+            .optional()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore.',
             ),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -16,7 +16,7 @@ export const toolVerticalBarArgsSchema = createToolSchema(
         ...visualizationMetadataSchema.shape,
         vizConfig: verticalBarMetricVizConfigSchema,
         filters: filtersSchema
-            .nullable()
+            .optional()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore.',
             ),

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -30,7 +30,7 @@ export const tableVizConfigSchema = z
 
         limit: z
             .number()
-            .nullable()
+            .optional()
             .describe('The maximum number of rows in the table.'),
     })
     .describe(
@@ -51,6 +51,6 @@ export const metricQueryTableViz = (
         ...sort,
         nullsFirst: sort.nullsFirst ?? undefined,
     })),
-    limit: getValidAiQueryLimit(vizConfig.limit, maxLimit),
+    limit: getValidAiQueryLimit(vizConfig.limit ?? null, maxLimit),
     filters,
 });

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
@@ -30,7 +30,7 @@ export const timeSeriesMetricVizConfigSchema = z.object({
     breakdownByDimension: getFieldIdSchema({
         additionalDescription:
             'The field id of the dimension used to split the metrics into series for each dimension value. For example if you wanted to split a metric into multiple series based on City you would use the City dimension field id here. If this is not provided then the metric will be displayed as a single series.',
-    }).nullable(),
+    }).optional(),
     lineType: z
         .union([z.literal('line'), z.literal('area')])
         .describe(
@@ -39,15 +39,15 @@ export const timeSeriesMetricVizConfigSchema = z.object({
     limit: z
         .number()
         .max(AI_DEFAULT_MAX_QUERY_LIMIT)
-        .nullable()
+        .optional()
         .describe(`The total number of data points allowed on the chart.`),
     xAxisLabel: z
         .string()
-        .nullable()
+        .optional()
         .describe('A helpful label to explain the x-axis'),
     yAxisLabel: z
         .string()
-        .nullable()
+        .optional()
         .describe('A helpful label to explain the y-axis'),
 });
 
@@ -72,7 +72,7 @@ export const metricQueryTimeSeriesViz = (
     return {
         metrics,
         dimensions,
-        limit: getValidAiQueryLimit(limit, maxLimit),
+        limit: getValidAiQueryLimit(limit ?? null, maxLimit),
         sorts: sorts.map((sort) => ({
             ...sort,
             nullsFirst: sort.nullsFirst ?? undefined,

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
@@ -30,17 +30,17 @@ export const verticalBarMetricVizConfigSchema = z.object({
     limit: z
         .number()
         .max(AI_DEFAULT_MAX_QUERY_LIMIT)
-        .nullable()
+        .optional()
         .describe(
             `The total number of data points / bars allowed on the chart.`,
         ),
     breakdownByDimension: getFieldIdSchema({
         additionalDescription:
             'The field id of the dimension used to split the metrics into groups along the x-axis. If stacking is false then this will create multiple bars around each x value, if stacking is true then this will create multiple bars for each metric stacked on top of each other',
-    }).nullable(),
+    }).optional(),
     stackBars: z
         .boolean()
-        .nullable()
+        .optional()
         .describe(
             'If using breakdownByDimension then this will stack the bars on top of each other instead of side by side.',
         ),
@@ -51,11 +51,11 @@ export const verticalBarMetricVizConfigSchema = z.object({
         ),
     xAxisLabel: z
         .string()
-        .nullable()
+        .optional()
         .describe('A helpful label to explain the x-axis'),
     yAxisLabel: z
         .string()
-        .nullable()
+        .optional()
         .describe('A helpful label to explain the y-axis'),
 });
 
@@ -79,7 +79,7 @@ export const metricQueryVerticalBarViz = (
     return {
         metrics,
         dimensions,
-        limit: getValidAiQueryLimit(limit, maxLimit),
+        limit: getValidAiQueryLimit(limit ?? null, maxLimit),
         sorts: sorts.map((sort) => ({
             ...sort,
             nullsFirst: sort.nullsFirst ?? undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@mastra/evals':
         specifier: ^0.10.7
         version: 0.10.7(@mastra/core@0.11.1(encoding@0.1.13)(openapi-types@12.1.3)(react@19.0.0)(zod@3.25.55))(ai@4.3.16(react@19.0.0)(zod@3.25.55))
+      '@mastra/schema-compat':
+        specifier: ^0.10.7
+        version: 0.10.7(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.0
         version: 1.17.0
@@ -643,6 +646,9 @@ importers:
       '@casl/ability':
         specifier: ^5.4.3
         version: 5.4.4
+      '@mastra/schema-compat':
+        specifier: ^0.10.7
+        version: 0.10.7(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
@@ -3611,6 +3617,12 @@ packages:
 
   '@mastra/schema-compat@0.10.5':
     resolution: {integrity: sha512-Qhz8W4Hz7b9tNoVW306NMzotVy11bya1OjiTN+pthj00HZoaH7nmK8SWBiX4drS+PyhIqA16X5AenELe2QgZag==}
+    peerDependencies:
+      ai: ^4.0.0
+      zod: ^3.0.0
+
+  '@mastra/schema-compat@0.10.7':
+    resolution: {integrity: sha512-lY1V57fHfCRVafNuwmDEmQJNncVZI+wdOdvL/WbgYWLQmL3YjBl3CrM+7yTOM/gG/GPKm8BRxmqnHLhS1rD1zg==}
     peerDependencies:
       ai: ^4.0.0
       zod: ^3.0.0
@@ -8015,6 +8027,7 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
+    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -20261,6 +20274,14 @@ snapshots:
       - supports-color
 
   '@mastra/schema-compat@0.10.5(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)':
+    dependencies:
+      ai: 4.3.16(react@19.0.0)(zod@3.25.55)
+      json-schema: 0.4.0
+      zod: 3.25.55
+      zod-from-json-schema: 0.0.5
+      zod-to-json-schema: 3.24.6(zod@3.25.55)
+
+  '@mastra/schema-compat@0.10.7(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)':
     dependencies:
       ai: 4.3.16(react@19.0.0)(zod@3.25.55)
       json-schema: 0.4.0


### PR DESCRIPTION
# Add Schema Compatibility Layer for AI Tools

This PR adds the `@mastra/schema-compat` package to ensure our AI tools work correctly with different LLM providers. The implementation:

- Adds a schema compatibility manager that transforms Zod schemas based on the target model
- Converts `nullable` fields to `optional` that way they're easier to reason about and work out of the box for anthropic/mcp
- Adds a hardcoded model target for MCP (Claude/Anthropic) to ensure proper schema transformation
- Passes model target information to all AI tools to enable schema compatibility
- Updates all tool implementations to use the transformed schemas

This change ensures our AI tools work consistently across different LLM providers by adapting schemas to each provider's specific requirements.