### PR TITLE
feat: table calcs can reference custom dimesions

### DIFF
--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -108,7 +108,12 @@ const compileTableCalculation = (
                 return `${quoteChar}${p1}${quoteChar}`;
             }
 
-            // Otherwise, treat it as a field reference
+            // If the field is already valid, return it
+            if (validFieldIds.includes(p1)) {
+                return `${quoteChar}${p1}${quoteChar}`;
+            }
+
+            // Otherwise, try to convert it as a field reference (table.field format)
             const fieldId = convertFieldRefToFieldId(p1);
             if (validFieldIds.includes(fieldId)) {
                 return `${quoteChar}${fieldId}${quoteChar}`;
@@ -206,11 +211,6 @@ export const compileMetricQuery = ({
     const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
     const validFieldIds = [...metricQuery.dimensions, ...metricQuery.metrics];
 
-    const compiledTableCalculations = compileTableCalculations(
-        metricQuery.tableCalculations,
-        validFieldIds,
-        fieldQuoteChar,
-    );
     const compiledAdditionalMetrics = (metricQuery.additionalMetrics || []).map(
         (additionalMetric) =>
             compileAdditionalMetric({
@@ -229,6 +229,12 @@ export const compileMetricQuery = ({
                 explore.tables,
                 availableParameters,
             ),
+    );
+
+    const compiledTableCalculations = compileTableCalculations(
+        metricQuery.tableCalculations,
+        validFieldIds,
+        fieldQuoteChar,
     );
 
     return {


### PR DESCRIPTION
Closes: #10145 

### Description:

Makes it possible to reference custom dimensions in table calculations. 

This was basically just a bug. We were throwing an error if a reference wasn't qualified with a table name, but custom dimensions don't have to be. All this really does is check that the reference is valid on it's own. 

To test:
Create a custom dimension
Add a table calculation that refers to it

