### PR TITLE
fix: add projectUuid to Project subject

### DIFF
--- a/packages/frontend/src/components/NavBar/SettingsMenu.tsx
+++ b/packages/frontend/src/components/NavBar/SettingsMenu.tsx
@@ -31,6 +31,7 @@ const SettingsMenu: FC = () => {
         'update',
         subject('Project', {
             organizationUuid: user.organizationUuid,
+            projectUuid: activeProjectUuid,
         }),
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #16524

Before

<img width="439" height="157" alt="image" src="https://github.com/user-attachments/assets/c4fda928-d923-4c78-a1f0-4fb7d3515e2f" />

After

<img width="1745" height="792" alt="image" src="https://github.com/user-attachments/assets/3b77511b-10db-42dc-92f2-88652eec00cd" />

### Description:
Added `projectUuid` to the subject of the 'update' permission check in the SettingsMenu component. This ensures that project-specific permissions are correctly evaluated when accessing project settings.