### PR TITLE
fix: remove organizationName from user completion mutation

### DIFF
--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -108,7 +108,6 @@ const UserCompletionModal: FC = () => {
             !user.data.isSetupComplete
         ) {
             mutate({
-                organizationName: user.data.organizationName,
                 jobTitle: 'Other',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16527

### Description:
Removed the `organizationName` parameter from the user completion mutation in the UserCompletionModal component. This parameter is no longer needed when completing the user setup process.

Before:

https://github.com/user-attachments/assets/a28fcb82-9caa-48f0-9c2a-3ca57989bce8


After:

https://github.com/user-attachments/assets/e7e0d336-16e3-4e30-bea3-1473cad1952a

