### PR TITLE
feat: add file attachment option to scheduler emails

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5565,7 +5565,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 versionCreatedAt: { dataType: 'datetime', required: true },
-                vizConfigOutput: {
+                chartConfig: {
                     dataType: 'union',
                     subSchemas: [
                         { ref: 'Record_string.unknown_' },
@@ -6108,6 +6108,7 @@ const models: TsoaRoute.Models = {
             organizationCreatedAt: { dataType: 'datetime' },
             userId: { dataType: 'double', required: true },
             role: { ref: 'OrganizationMemberRole' },
+            roleUuid: { dataType: 'string' },
             isTrackingAnonymized: { dataType: 'boolean', required: true },
             isMarketingOptedIn: { dataType: 'boolean', required: true },
             isSetupComplete: { dataType: 'boolean', required: true },
@@ -9104,6 +9105,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                attachFiles: { dataType: 'boolean' },
                 limit: {
                     dataType: 'union',
                     subSchemas: [
@@ -11365,6 +11367,14 @@ const models: TsoaRoute.Models = {
                 lastName: { dataType: 'string', required: true },
                 firstName: { dataType: 'string', required: true },
                 email: { dataType: 'string', required: true },
+                roleUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
                 role: { ref: 'ProjectMemberRole', required: true },
                 projectUuid: { dataType: 'string', required: true },
                 userUuid: { dataType: 'string', required: true },
@@ -13249,6 +13259,14 @@ const models: TsoaRoute.Models = {
                 isPending: { dataType: 'boolean' },
                 isInviteExpired: { dataType: 'boolean' },
                 isActive: { dataType: 'boolean', required: true },
+                roleUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
                 role: { ref: 'OrganizationMemberRole', required: true },
                 organizationUuid: { dataType: 'string', required: true },
                 email: { dataType: 'string', required: true },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6168,7 +6168,7 @@
                         "type": "string",
                         "format": "date-time"
                     },
-                    "vizConfigOutput": {
+                    "chartConfig": {
                         "allOf": [
                             {
                                 "$ref": "#/components/schemas/Record_string.unknown_"
@@ -6217,7 +6217,7 @@
                 },
                 "required": [
                     "versionCreatedAt",
-                    "vizConfigOutput",
+                    "chartConfig",
                     "description",
                     "title",
                     "versionUuid",
@@ -6773,6 +6773,9 @@
                     },
                     "role": {
                         "$ref": "#/components/schemas/OrganizationMemberRole"
+                    },
+                    "roleUuid": {
+                        "type": "string"
                     },
                     "isTrackingAnonymized": {
                         "type": "boolean"
@@ -9833,6 +9836,9 @@
             },
             "SchedulerCsvOptions": {
                 "properties": {
+                    "attachFiles": {
+                        "type": "boolean"
+                    },
                     "limit": {
                         "anyOf": [
                             {
@@ -12238,6 +12244,9 @@
                     "email": {
                         "type": "string"
                     },
+                    "roleUuid": {
+                        "type": "string"
+                    },
                     "role": {
                         "$ref": "#/components/schemas/ProjectMemberRole"
                     },
@@ -14069,6 +14078,9 @@
                     "isActive": {
                         "type": "boolean",
                         "description": "Whether the user can login"
+                    },
+                    "roleUuid": {
+                        "type": "string"
                     },
                     "role": {
                         "$ref": "#/components/schemas/OrganizationMemberRole",
@@ -18567,7 +18579,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1936.2",
+        "version": "0.1942.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2039,6 +2039,7 @@ export default class SchedulerTask {
                 name,
                 thresholds,
                 includeLinks,
+                options,
             } = scheduler;
 
             await this.schedulerService.logSchedulerJob({
@@ -2152,6 +2153,9 @@ export default class SchedulerTask {
                 if (csvUrl === undefined) {
                     throw new Error('Missing CSV URL');
                 }
+                const attachFiles = isSchedulerCsvOptions(options)
+                    ? options.attachFiles || false
+                    : false;
                 await this.emailClient.sendChartCsvNotificationEmail(
                     recipient,
                     name,
@@ -2168,12 +2172,16 @@ export default class SchedulerTask {
                     schedulerUrl,
                     includeLinks,
                     this.s3Client.getExpirationWarning()?.days,
+                    attachFiles,
+                    format,
                 );
             } else if (dashboardUuid) {
                 if (csvUrls === undefined) {
                     throw new Error('Missing CSV URLS');
                 }
-
+                const attachFiles = isSchedulerCsvOptions(options)
+                    ? options.attachFiles || false
+                    : false;
                 await this.emailClient.sendDashboardCsvNotificationEmail(
                     recipient,
                     name,
@@ -2190,6 +2198,8 @@ export default class SchedulerTask {
                     schedulerUrl,
                     includeLinks,
                     this.s3Client.getExpirationWarning()?.days,
+                    attachFiles,
+                    format,
                 );
             } else {
                 throw new Error('Not implemented');

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -13,6 +13,7 @@ import { type ValidationTarget } from './validation';
 export type SchedulerCsvOptions = {
     formatted: boolean;
     limit: 'table' | 'all' | number;
+    attachFiles?: boolean;
 };
 
 export type SchedulerImageOptions = {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -98,6 +98,7 @@ const DEFAULT_VALUES = {
         limit: Limit.TABLE,
         customLimit: 1,
         withPdf: false,
+        attachFiles: false,
     },
     emailTargets: [] as string[],
     slackTargets: [] as string[],
@@ -168,6 +169,7 @@ const getFormValuesFromScheduler = (schedulerData: SchedulerAndTargets) => {
         if (formOptions.limit === Limit.CUSTOM) {
             formOptions.customLimit = options.limit as number;
         }
+        formOptions.attachFiles = options.attachFiles || false;
     } else if (isSchedulerImageOptions(options)) {
         formOptions.withPdf = options.withPdf || false;
     }
@@ -415,6 +417,7 @@ const SchedulerForm: FC<Props> = ({
                         values.options.limit === Limit.CUSTOM
                             ? values.options.customLimit
                             : values.options.limit,
+                    attachFiles: values.options.attachFiles,
                 };
             } else if (values.format === SchedulerFormat.IMAGE) {
                 options = {
@@ -861,8 +864,30 @@ const SchedulerForm: FC<Props> = ({
                                             },
                                         )}
                                     />
-                                ) : (
+                                ) : [
+                                      SchedulerFormat.CSV,
+                                      SchedulerFormat.XLSX,
+                                  ].includes(
+                                      form.getInputProps('format').value,
+                                  ) ? (
                                     <Stack spacing="xs">
+                                        <Checkbox
+                                            label={`Also include ${
+                                                form.getInputProps('format')
+                                                    .value ===
+                                                SchedulerFormat.CSV
+                                                    ? 'CSV'
+                                                    : 'Excel'
+                                            } as email attachment`}
+                                            labelPosition="left"
+                                            {...form.getInputProps(
+                                                'options.attachFiles',
+                                                {
+                                                    type: 'checkbox',
+                                                },
+                                            )}
+                                        />
+
                                         <Button
                                             variant="subtle"
                                             compact
@@ -977,7 +1002,7 @@ const SchedulerForm: FC<Props> = ({
                                             </Group>
                                         </Collapse>
                                     </Stack>
-                                )}
+                                ) : null}
                             </Stack>
                         )}
 


### PR DESCRIPTION
Closes: #16258

### Description:

This PR adds the ability to include CSV and Excel files as email attachments in scheduled deliveries. Users can now opt to have their scheduled reports attached directly to the email, in addition to the existing option of including links to download the files.

The implementation includes:

- Adding an `attachFiles` option to the scheduler form UI
- Updating the EmailClient to handle file attachments with proper content types
- Supporting attachments for both chart and dashboard CSV notifications
- Adding appropriate type definitions and route updates