### PR TITLE
feat: add title generation for AI threads

### DIFF
--- a/packages/backend/src/database/migrations/20250821071500_add_title_to_ai_thread.ts
+++ b/packages/backend/src/database/migrations/20250821071500_add_title_to_ai_thread.ts
@@ -1,0 +1,48 @@
+import { Knex } from 'knex';
+
+const AiThreadTableName = 'ai_thread';
+
+export async function up(knex: Knex): Promise<void> {
+    const hasTitle = await knex.schema.hasColumn(AiThreadTableName, 'title');
+    const hasTitleGeneratedAt = await knex.schema.hasColumn(
+        AiThreadTableName,
+        'title_generated_at',
+    );
+
+    if (hasTitle && hasTitleGeneratedAt) {
+        return;
+    }
+
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        if (!hasTitle) {
+            table
+                .string('title', 255)
+                .nullable()
+                .comment(
+                    'Generated title for the thread based on conversation content',
+                );
+        }
+        if (!hasTitleGeneratedAt) {
+            table
+                .timestamp('title_generated_at', { useTz: false })
+                .nullable()
+                .comment('Timestamp when the title was generated');
+        }
+    });
+
+    // Add index on title for future search functionality
+    const hasIndex = await knex.schema.hasColumn(AiThreadTableName, 'title');
+    if (hasIndex) {
+        await knex.schema.alterTable(AiThreadTableName, (table) => {
+            table.index(['title'], 'ai_thread_title_idx');
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.dropIndex(['title'], 'ai_thread_title_idx');
+        table.dropColumn('title_generated_at');
+        table.dropColumn('title');
+    });
+}

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -5,6 +5,8 @@ import {
     ApiAiAgentSummaryResponse,
     ApiAiAgentThreadCreateRequest,
     ApiAiAgentThreadCreateResponse,
+    ApiAiAgentThreadGenerateResponse,
+    ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
@@ -318,6 +320,63 @@ export class AiAgentController extends BaseController {
          * Hack to get the response object from the request
          */
         stream.pipeDataStreamToResponse(req.res!);
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/generate')
+    @OperationId('generateAgentThreadResponse')
+    async generateAgentThreadResponse(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+    ): Promise<ApiAiAgentThreadGenerateResponse> {
+        this.setStatus(200);
+
+        const response =
+            await this.getAiAgentService().generateAgentThreadResponse(
+                req.user!,
+                {
+                    agentUuid,
+                    threadUuid,
+                },
+            );
+
+        return {
+            status: 'ok',
+            results: {
+                response,
+            },
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/generate-title')
+    @OperationId('generateAgentThreadTitle')
+    async generateAgentThreadTitle(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+    ): Promise<ApiAiAgentThreadGenerateTitleResponse> {
+        this.setStatus(200);
+
+        const title = await this.getAiAgentService().generateThreadTitle(
+            req.user!,
+            {
+                agentUuid,
+                threadUuid,
+            },
+        );
+
+        return {
+            status: 'ok',
+            results: {
+                title,
+            },
+        };
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -9,6 +9,8 @@ export type DbAiThread = {
     organization_uuid: string;
     project_uuid: string;
     created_from: string; // slack, web, etc
+    title: string | null;
+    title_generated_at: Date | null;
 };
 
 export type AiThreadTable = Knex.CompositeTableType<
@@ -16,6 +18,12 @@ export type AiThreadTable = Knex.CompositeTableType<
     Pick<
         DbAiThread,
         'organization_uuid' | 'project_uuid' | 'created_from' | 'agent_uuid'
+    >,
+    Partial<
+        Pick<
+            DbAiThread,
+            'agent_uuid' | 'title' | 'title_generated_at' | 'project_uuid'
+        >
     >
 >;
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -701,6 +701,8 @@ export class AiAgentModel {
                     | 'agent_uuid'
                     | 'created_at'
                     | 'created_from'
+                    | 'title'
+                    | 'title_generated_at'
                 > &
                     Pick<DbAiPrompt, 'prompt' | 'ai_prompt_uuid'> &
                     Pick<DbUser, 'user_uuid'> &
@@ -712,6 +714,8 @@ export class AiAgentModel {
                 `${AiThreadTableName}.agent_uuid`,
                 `${AiThreadTableName}.created_at`,
                 `${AiThreadTableName}.created_from`,
+                `${AiThreadTableName}.title`,
+                `${AiThreadTableName}.title_generated_at`,
                 `${AiPromptTableName}.prompt`,
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${UserTableName}.user_uuid`,
@@ -741,6 +745,10 @@ export class AiAgentModel {
             agentUuid: row.agent_uuid!,
             createdAt: row.created_at as unknown as string,
             createdFrom: row.created_from,
+            title: row.title,
+            titleGeneratedAt: row.title_generated_at as unknown as
+                | string
+                | null,
             firstMessage: {
                 uuid: row.ai_prompt_uuid,
                 message: row.prompt,
@@ -1994,5 +2002,20 @@ export class AiAgentModel {
             .orderBy(`${AiArtifactsTableName}.created_at`, 'desc');
 
         return results;
+    }
+
+    async updateThreadTitle({
+        threadUuid,
+        title,
+    }: {
+        threadUuid: string;
+        title: string;
+    }): Promise<void> {
+        await this.database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .update({
+                title,
+                title_generated_at: new Date(),
+            });
     }
 }

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -1,0 +1,50 @@
+import { CoreMessage, generateObject, LanguageModelV1 } from 'ai';
+import { z } from 'zod';
+
+const TitleSchema = z.object({
+    title: z
+        .string()
+        .min(1, 'Title must not be empty')
+        .max(60, 'Title must be 60 characters or less')
+        .describe('A concise, descriptive title for the conversation thread'),
+});
+
+export type GeneratedTitle = z.infer<typeof TitleSchema>;
+
+export async function generateThreadTitle(
+    model: LanguageModelV1,
+    messages: CoreMessage[],
+): Promise<string> {
+    const result = await generateObject({
+        model,
+        schema: TitleSchema,
+        messages: [
+            {
+                role: 'system',
+                content: `You are a helpful assistant that creates short, descriptive titles for conversations.
+
+Generate a concise title (maximum 60 characters) that summarizes the main topic or question being discussed.
+
+Good examples:
+- "Order data analysis"
+- "Sales performance review" 
+- "Customer insights report"
+- "Revenue trends by region"
+- "Dashboard creation help"
+- "Chart formatting issues"
+
+The title should be clear, specific, and helpful for someone browsing a list of conversations.`,
+            },
+            {
+                role: 'user',
+                content:
+                    'Please create a title for this conversation based on the messages.',
+            },
+            ...messages,
+        ],
+        maxTokens: 30,
+        temperature: 0.3,
+    });
+
+    return result.object.title;
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5292,6 +5292,42 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadGenerateResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        response: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadGenerateTitleResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        title: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiResultType: {
         dataType: 'refEnum',
         enums: [
@@ -5565,7 +5601,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 versionCreatedAt: { dataType: 'datetime', required: true },
-                vizConfigOutput: {
+                chartConfig: {
                     dataType: 'union',
                     subSchemas: [
                         { ref: 'Record_string.unknown_' },
@@ -6108,6 +6144,7 @@ const models: TsoaRoute.Models = {
             organizationCreatedAt: { dataType: 'datetime' },
             userId: { dataType: 'double', required: true },
             role: { ref: 'OrganizationMemberRole' },
+            roleUuid: { dataType: 'string' },
             isTrackingAnonymized: { dataType: 'boolean', required: true },
             isMarketingOptedIn: { dataType: 'boolean', required: true },
             isSetupComplete: { dataType: 'boolean', required: true },
@@ -11365,6 +11402,14 @@ const models: TsoaRoute.Models = {
                 lastName: { dataType: 'string', required: true },
                 firstName: { dataType: 'string', required: true },
                 email: { dataType: 'string', required: true },
+                roleUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
                 role: { ref: 'ProjectMemberRole', required: true },
                 projectUuid: { dataType: 'string', required: true },
                 userUuid: { dataType: 'string', required: true },
@@ -13249,6 +13294,14 @@ const models: TsoaRoute.Models = {
                 isPending: { dataType: 'boolean' },
                 isInviteExpired: { dataType: 'boolean' },
                 isActive: { dataType: 'boolean', required: true },
+                roleUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
                 role: { ref: 'OrganizationMemberRole', required: true },
                 organizationUuid: { dataType: 'string', required: true },
                 email: { dataType: 'string', required: true },
@@ -20855,6 +20908,150 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'streamAgentThreadResponse',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_generateAgentThreadResponse: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/generate',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.generateAgentThreadResponse,
+        ),
+
+        async function AiAgentController_generateAgentThreadResponse(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_generateAgentThreadResponse,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'generateAgentThreadResponse',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_generateAgentThreadTitle: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/generate-title',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.generateAgentThreadTitle,
+        ),
+
+        async function AiAgentController_generateAgentThreadTitle(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_generateAgentThreadTitle,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'generateAgentThreadTitle',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5891,6 +5891,46 @@
                 "required": ["prompt"],
                 "type": "object"
             },
+            "ApiAiAgentThreadGenerateResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "response": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["response"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadGenerateTitleResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["title"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "AiResultType": {
                 "enum": [
                     "time_series_chart",
@@ -6168,7 +6208,7 @@
                         "type": "string",
                         "format": "date-time"
                     },
-                    "vizConfigOutput": {
+                    "chartConfig": {
                         "allOf": [
                             {
                                 "$ref": "#/components/schemas/Record_string.unknown_"
@@ -6217,7 +6257,7 @@
                 },
                 "required": [
                     "versionCreatedAt",
-                    "vizConfigOutput",
+                    "chartConfig",
                     "description",
                     "title",
                     "versionUuid",
@@ -6773,6 +6813,9 @@
                     },
                     "role": {
                         "$ref": "#/components/schemas/OrganizationMemberRole"
+                    },
+                    "roleUuid": {
+                        "type": "string"
                     },
                     "isTrackingAnonymized": {
                         "type": "boolean"
@@ -12238,6 +12281,9 @@
                     "email": {
                         "type": "string"
                     },
+                    "roleUuid": {
+                        "type": "string"
+                    },
                     "role": {
                         "$ref": "#/components/schemas/ProjectMemberRole"
                     },
@@ -14069,6 +14115,9 @@
                     "isActive": {
                         "type": "boolean",
                         "description": "Whether the user can login"
+                    },
+                    "roleUuid": {
+                        "type": "string"
                     },
                     "role": {
                         "$ref": "#/components/schemas/OrganizationMemberRole",
@@ -18567,7 +18616,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1936.2",
+        "version": "0.1942.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -140,6 +140,8 @@ export type AiAgentThreadSummary<TUser extends AiAgentUser = AiAgentUser> = {
     agentUuid: string;
     createdAt: string;
     createdFrom: string;
+    title: string | null;
+    titleGeneratedAt: string | null;
     firstMessage: {
         uuid: string;
         message: string;
@@ -224,6 +226,20 @@ export type ApiAiAgentStartThreadResponse = {
     results: {
         jobId: string;
         threadUuid: string;
+    };
+};
+
+export type ApiAiAgentThreadGenerateResponse = {
+    status: 'ok';
+    results: {
+        response: string;
+    };
+};
+
+export type ApiAiAgentThreadGenerateTitleResponse = {
+    status: 'ok';
+    results: {
+        title: string;
     };
 };
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -122,10 +122,12 @@ import { type ValidationResponse } from './types/validation';
 
 import type {
     ApiAiAgentThreadCreateResponse,
+    ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadMessageVizResponse,
     ApiAiAgentThreadResponse,
+    ApiAiAgentThreadSummaryListResponse,
     ApiGetUserAgentPreferencesResponse,
     ApiUpdateUserAgentPreferencesResponse,
     DecodedEmbed,
@@ -939,6 +941,8 @@ type ApiResults =
     | ApiGetProjectParametersListResults
     | ApiAiAgentThreadCreateResponse['results']
     | ApiAiAgentThreadMessageCreateResponse['results']
+    | ApiAiAgentThreadGenerateTitleResponse['results']
+    | ApiAiAgentThreadSummaryListResponse['results']
     | Account;
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
@@ -80,7 +80,8 @@ export const ConversationsList: FC<ConversationsListProps> = ({
                                     }}
                                 >
                                     <Table.Td>
-                                        {thread.firstMessage.message}
+                                        {thread.title ||
+                                            thread.firstMessage.message}
                                     </Table.Td>
                                     <Table.Td>{thread.user.name}</Table.Td>
                                     <Table.Td>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -64,7 +64,7 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
         })}
         label={
             <Text truncate="end" size="sm" c="gray.7">
-                {thread.firstMessage.message}
+                {thread.title || thread.firstMessage.message}
             </Text>
         }
         active={isActive}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -7,6 +7,7 @@ import {
     useAiAgent,
     useAiAgentThread,
     useCreateAgentThreadMessageMutation,
+    useGenerateAgentThreadTitleMutation,
 } from '../../features/aiCopilot/hooks/useOrganizationAiAgents';
 import { useAiAgentThreadStreaming } from '../../features/aiCopilot/streaming/useAiAgentThreadStreamQuery';
 import { type AgentContext } from './AgentPage';
@@ -33,10 +34,15 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         agentUuid,
         threadUuid,
     );
+    const { mutateAsync: generateThreadTitle } =
+        useGenerateAgentThreadTitleMutation(projectUuid!, agentUuid!);
     const isStreaming = useAiAgentThreadStreaming(threadUuid!);
 
     const handleSubmit = (prompt: string) => {
-        void createAgentThreadMessage({ prompt });
+        void Promise.all([
+            createAgentThreadMessage({ prompt }),
+            generateThreadTitle({ threadUuid: threadUuid! }),
+        ]);
     };
 
     if (isLoadingThread || !thread || agentQuery.isLoading) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR adds thread title generation functionality to AI conversations. It includes:

1. A database migration to add `title` and `title_generated_at` columns to the `ai_thread` table
2. A new title generator service that creates concise, descriptive titles (max 60 chars) for conversation threads
3. New API endpoints for generating titles and non-streaming responses
4. Automatic title generation when creating new threads or adding messages
