### PR TITLE
feat: add full modifiers to get role-scope parity

### DIFF
--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -226,10 +226,6 @@ export const projectMemberAbilities: Record<
         can('manage', 'AiAgent', {
             projectUuid: member.projectUuid,
         });
-        can('manage', 'AiAgentThread', {
-            projectUuid: member.projectUuid,
-            userUuid: member.userUuid,
-        });
     },
     admin(member, { can }) {
         projectMemberAbilities.developer(member, { can });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -12,19 +12,19 @@ const BASE_ROLE_SCOPES = {
     [ProjectMemberRole.VIEWER]: [
         // Basic viewing permissions
         'view:Dashboard',
+        'view:JobStatus@self', // For viewing job status created by user
         'view:SavedChart',
         'view:Space',
         'view:Project',
         'view:PinnedItems',
         'view:DashboardComments',
         'view:Tags',
-        'view:Job', // For viewing job status created by user
         'manage:ExportCsv',
 
         // Enterprise scopes (when available)
         'view:MetricsTree',
         'view:SpotlightTableConfig',
-        'view:AiAgentThread',
+        'view:AiAgentThread@self',
     ],
 
     [ProjectMemberRole.INTERACTIVE_VIEWER]: [
@@ -35,12 +35,12 @@ const BASE_ROLE_SCOPES = {
         'manage:ChangeCsvResults',
         'create:ScheduledDeliveries',
         'create:DashboardComments',
-        'create:Job',
+        'manage:GoogleSheets',
 
         // Space-level content management (requires space admin/editor role)
-        'manage:Dashboard', // Via space access
-        'manage:SavedChart', // Via space access
-        'manage:Space', // Via space access (admin role)
+        'manage:Dashboard@space', // Via space access
+        'manage:SavedChart@space', // Via space access
+        'manage:Space@assigned', // Via space access (admin role)
 
         // Enterprise scopes
         'view:AiAgent',
@@ -50,7 +50,7 @@ const BASE_ROLE_SCOPES = {
     [ProjectMemberRole.EDITOR]: [
         // Editor-specific permissions
         'create:Space',
-        'manage:Space', // For non-private spaces (requires manage:Project)
+        'manage:Space@public', // For non-private spaces
         'manage:Job',
         'manage:PinnedItems',
         'manage:ScheduledDeliveries',
@@ -59,7 +59,7 @@ const BASE_ROLE_SCOPES = {
 
         // Enterprise scopes
         'manage:MetricsTree',
-        'manage:AiAgentThread', // User's own threads
+        'manage:AiAgentThread@self', // User's own threads
     ],
 
     [ProjectMemberRole.DEVELOPER]: [
@@ -70,7 +70,7 @@ const BASE_ROLE_SCOPES = {
         'manage:Validation',
         'manage:CompileProject',
         'create:Project', // Preview projects
-        'delete:Project', // Preview projects created by user
+        'delete:Project@self', // Preview projects created by user
         'update:Project',
         'view:JobStatus', // All jobs in project
 
@@ -78,7 +78,7 @@ const BASE_ROLE_SCOPES = {
         'manage:SpotlightTableConfig',
         'manage:ContentAsCode',
         'manage:AiAgent',
-        'manage:AiAgentThread', // User's own threads
+        'manage:AiAgentThread@self', // User's own threads
     ],
 
     [ProjectMemberRole.ADMIN]: [
@@ -86,6 +86,7 @@ const BASE_ROLE_SCOPES = {
         'delete:Project', // Any project
         'view:Analytics',
         'manage:Dashboard', // All dashboards
+        'manage:Space', // All spaces
         'manage:Project', // Required for managing non-private spaces
         'manage:SavedChart', // All saved charts
         'view:AiAgentThread', // All threads in project

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -1,0 +1,298 @@
+/* eslint-disable no-console */
+import { Ability, AbilityBuilder } from '@casl/ability';
+import { groupBy, isEqual } from 'lodash';
+import { ProjectMemberRole } from '../types/projectMemberRole';
+import { projectMemberAbilities } from './projectMemberAbility';
+import {
+    PROJECT_ADMIN,
+    PROJECT_DEVELOPER,
+    PROJECT_EDITOR,
+    PROJECT_INTERACTIVE_VIEWER,
+    PROJECT_VIEWER,
+} from './projectMemberAbility.mock';
+import { getScopesForRole } from './roleToScopeMapping';
+import { buildAbilityFromScopes } from './scopeAbilityBuilder';
+import { type MemberAbility } from './types';
+
+type CASLRule = {
+    action: string;
+    subject: string;
+    conditions?: Record<string, unknown>;
+    inverted?: boolean;
+    reason?: string;
+};
+
+/**
+ * Normalize a CASL rule for comparison by sorting object keys and handling undefined values
+ */
+const normalizeRule = (rule: CASLRule): CASLRule => ({
+    action: rule.action,
+    subject: rule.subject,
+});
+
+/**
+ * Compare two sets of CASL rules for functional equivalence
+ */
+const compareRuleSets = (
+    roleBasedRules: CASLRule[],
+    scopeBasedRules: CASLRule[],
+    roleName: string,
+): { isEqual: boolean; mismatches: string[] } => {
+    const normalizedRoleRules = roleBasedRules.map(normalizeRule);
+    const normalizedScopeRules = scopeBasedRules.map(normalizeRule);
+
+    const mismatches: string[] = [];
+
+    // Check if rule counts match
+    if (normalizedRoleRules.length !== normalizedScopeRules.length) {
+        mismatches.push(
+            `Rule count mismatch: role-based has ${normalizedRoleRules.length} rules, scope-based has ${normalizedScopeRules.length} rules`,
+        );
+    }
+
+    // Group rules by action+subject for easier comparison
+    const roleRulesGrouped = groupBy(
+        normalizedRoleRules,
+        (rule) => `${rule.action}:${rule.subject}`,
+    );
+    const scopeRulesGrouped = groupBy(
+        normalizedScopeRules,
+        (rule) => `${rule.action}:${rule.subject}`,
+    );
+
+    // Check for missing or extra rule types
+    const roleKeys = new Set(Object.keys(roleRulesGrouped));
+    const scopeKeys = new Set(Object.keys(scopeRulesGrouped));
+
+    const missingInScope = [...roleKeys].filter((key) => !scopeKeys.has(key));
+    const extraInScope = [...scopeKeys].filter((key) => !roleKeys.has(key));
+
+    missingInScope.forEach((key) => {
+        mismatches.push(`Missing in scope-based: ${key}`);
+    });
+
+    extraInScope.forEach((key) => {
+        mismatches.push(`Extra in scope-based: ${key}`);
+    });
+
+    // Compare matching rule groups
+    const commonKeys = [...roleKeys].filter((key) => scopeKeys.has(key));
+
+    commonKeys.forEach((key) => {
+        const roleRulesForKey = roleRulesGrouped[key];
+        const scopeRulesForKey = scopeRulesGrouped[key];
+
+        // For rules with the same action+subject, we need to check if the conditions are equivalent
+        // This is more complex because multiple rules might combine to create the same effective permissions
+        if (roleRulesForKey.length !== scopeRulesForKey.length) {
+            // Different number of rules for same action+subject - this might be OK if conditions are equivalent
+            // For now, we'll flag this as a potential issue but continue checking
+            mismatches.push(
+                `Different rule count for ${key}: role-based has ${roleRulesForKey.length}, scope-based has ${scopeRulesForKey.length}`,
+            );
+        }
+
+        // Check if rule sets contain equivalent conditions
+        const roleConditions = roleRulesForKey
+            .map((r) => r.conditions)
+            .filter(Boolean);
+        const scopeConditions = scopeRulesForKey
+            .map((r) => r.conditions)
+            .filter(Boolean);
+
+        if (!isEqual(roleConditions, scopeConditions)) {
+            mismatches.push(
+                `Condition mismatch on ${roleName} for ${key}:\nRole-based: ${JSON.stringify(
+                    roleConditions,
+                    null,
+                    2,
+                )}\nScope-based: ${JSON.stringify(scopeConditions, null, 2)}`,
+            );
+        }
+    });
+
+    return {
+        isEqual: mismatches.length === 0,
+        mismatches,
+    };
+};
+
+/**
+ * List of enterprise-only subject names that should be filtered in non-enterprise mode
+ */
+const ENTERPRISE_SUBJECTS = new Set([
+    'MetricsTree',
+    'SpotlightTableConfig',
+    'AiAgent',
+    'AiAgentThread',
+    'ContentAsCode',
+]);
+
+/**
+ * Filter enterprise rules from role-based abilities when testing in non-enterprise mode
+ */
+const filterEnterpriseRules = (
+    rules: CASLRule[],
+    isEnterprise: boolean,
+): CASLRule[] => {
+    if (isEnterprise) {
+        return rules;
+    }
+
+    return rules.filter((rule) => !ENTERPRISE_SUBJECTS.has(rule.subject));
+};
+
+/**
+ * Test role-to-scope parity for a specific role
+ */
+const testRoleScopeParity = (
+    role: ProjectMemberRole,
+    isEnterprise: boolean = false,
+): { isEqual: boolean; mismatches: string[] } => {
+    // Get the appropriate mock member profile
+    const memberProfiles = {
+        [ProjectMemberRole.VIEWER]: PROJECT_VIEWER,
+        [ProjectMemberRole.INTERACTIVE_VIEWER]: PROJECT_INTERACTIVE_VIEWER,
+        [ProjectMemberRole.EDITOR]: PROJECT_EDITOR,
+        [ProjectMemberRole.DEVELOPER]: PROJECT_DEVELOPER,
+        [ProjectMemberRole.ADMIN]: PROJECT_ADMIN,
+    };
+
+    const member = memberProfiles[role];
+
+    // Build abilities using role-based approach
+    const roleBuilder = new AbilityBuilder<MemberAbility>(Ability);
+    projectMemberAbilities[role](member, roleBuilder);
+    const roleAbility = roleBuilder.build();
+
+    // Filter enterprise rules from role-based abilities if not enterprise
+    const filteredRoleRules = filterEnterpriseRules(
+        roleAbility.rules as CASLRule[],
+        isEnterprise,
+    );
+
+    // Build abilities using scope-based approach
+    const scopeBuilder = new AbilityBuilder<MemberAbility>(Ability);
+    const scopes = getScopesForRole(role);
+
+    buildAbilityFromScopes(
+        {
+            userUuid: member.userUuid,
+            projectUuid: member.projectUuid,
+            scopes,
+            isEnterprise,
+        },
+        scopeBuilder,
+    );
+    const scopeAbility = scopeBuilder.build();
+
+    // Compare the filtered rule sets
+    const result = compareRuleSets(
+        filteredRoleRules,
+        scopeAbility.rules as CASLRule[],
+        role,
+    );
+
+    return result;
+};
+
+describe('Role to Scope Parity', () => {
+    const systemProjectRoles = [
+        ProjectMemberRole.VIEWER,
+        ProjectMemberRole.INTERACTIVE_VIEWER,
+        ProjectMemberRole.EDITOR,
+        ProjectMemberRole.DEVELOPER,
+        ProjectMemberRole.ADMIN,
+    ];
+
+    describe('Non-Enterprise Environment', () => {
+        it.each(systemProjectRoles)(
+            'should have equivalent permissions for %s role',
+            (role) => {
+                const comparison = testRoleScopeParity(role, false);
+
+                if (!comparison.isEqual) {
+                    console.error(
+                        `\n=== PARITY MISMATCH FOR ${role.toUpperCase()} ROLE ===`,
+                    );
+                    comparison.mismatches.forEach((mismatch) => {
+                        console.error(`❌ ${mismatch}`);
+                    });
+                    console.error('=== END MISMATCH REPORT ===\n');
+                }
+
+                expect(comparison.isEqual).toBe(true);
+            },
+        );
+    });
+
+    describe('Enterprise Environment', () => {
+        it.each(systemProjectRoles)(
+            'should have equivalent permissions for %s role in enterprise',
+            (role) => {
+                const comparison = testRoleScopeParity(role, true);
+
+                if (!comparison.isEqual) {
+                    console.error(
+                        `\n=== ENTERPRISE PARITY MISMATCH FOR ${role.toUpperCase()} ROLE ===`,
+                    );
+                    comparison.mismatches.forEach((mismatch) => {
+                        console.error(`❌ ${mismatch}`);
+                    });
+                    console.error('=== END MISMATCH REPORT ===\n');
+                }
+
+                expect(comparison.isEqual).toBe(true);
+            },
+        );
+    });
+
+    // This is helpful for debugging, but it's not a test
+    describe.skip('Rule Count Analysis', () => {
+        it('should report rule counts for documentation', () => {
+            console.log('\n=== ROLE PERMISSION RULE COUNTS ===');
+
+            systemProjectRoles.forEach((role) => {
+                const member = {
+                    [ProjectMemberRole.VIEWER]: PROJECT_VIEWER,
+                    [ProjectMemberRole.INTERACTIVE_VIEWER]:
+                        PROJECT_INTERACTIVE_VIEWER,
+                    [ProjectMemberRole.EDITOR]: PROJECT_EDITOR,
+                    [ProjectMemberRole.DEVELOPER]: PROJECT_DEVELOPER,
+                    [ProjectMemberRole.ADMIN]: PROJECT_ADMIN,
+                }[role];
+
+                // Count role-based rules
+                const roleBuilder = new AbilityBuilder<MemberAbility>(Ability);
+                projectMemberAbilities[role](member, roleBuilder);
+                const roleRuleCount = roleBuilder.build().rules.length;
+
+                // Count scope-based rules
+                const scopeBuilder = new AbilityBuilder<MemberAbility>(Ability);
+                const scopes = getScopesForRole(role);
+                buildAbilityFromScopes(
+                    {
+                        userUuid: member.userUuid,
+                        projectUuid: member.projectUuid,
+                        scopes,
+                        isEnterprise: false,
+                    },
+                    scopeBuilder,
+                );
+                const scopeRuleCount = scopeBuilder.build().rules.length;
+
+                console.log(
+                    `${role.padEnd(20)}: Role-based: ${roleRuleCount
+                        .toString()
+                        .padStart(3)}, Scope-based: ${scopeRuleCount
+                        .toString()
+                        .padStart(3)}, Scopes: ${scopes.length
+                        .toString()
+                        .padStart(3)}`,
+                );
+            });
+
+            console.log('=== END RULE COUNT ANALYSIS ===\n');
+        });
+    });
+});

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -25,7 +25,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...baseContextWithOrg,
-                    scopes: ['view:organization'],
+                    scopes: ['view:Organization'],
                 },
                 builder,
             );
@@ -57,7 +57,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...baseContext,
-                    scopes: ['view:dashboard'],
+                    scopes: ['view:Dashboard'],
                 },
                 builder,
             );
@@ -98,7 +98,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...contextWithUser,
-                    scopes: ['view:dashboard'],
+                    scopes: ['view:Dashboard'],
                 },
                 builder,
             );
@@ -127,7 +127,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...projectContext,
-                    scopes: ['view:project'],
+                    scopes: ['view:Project'],
                 },
                 builder,
             );
@@ -149,7 +149,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...baseContextWithOrg,
-                    scopes: ['create:project'],
+                    scopes: ['create:Project'],
                 },
                 builder,
             );
@@ -188,7 +188,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...editorContext,
-                    scopes: ['manage:dashboard'],
+                    scopes: ['manage:Dashboard'],
                 },
                 builder,
             );
@@ -221,7 +221,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...adminContext,
-                    scopes: ['manage:space'],
+                    scopes: ['manage:Space'],
                 },
                 builder,
             );
@@ -254,7 +254,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...userContext,
-                    scopes: ['view:job_status'],
+                    scopes: ['view:JobStatus@self'],
                 },
                 builder,
             );
@@ -292,7 +292,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...userContext,
-                    scopes: ['manage:ai_agent_thread'],
+                    scopes: ['manage:AiAgentThread@self'],
                 },
                 builder,
             );
@@ -303,7 +303,7 @@ describe('scopeAbilityBuilder', () => {
                 ability.can(
                     'manage',
                     subject('AiAgentThread', {
-                        organizationUuid: 'org-123',
+                        projectUuid: 'project-123',
                         userUuid: 'user-456',
                     }),
                 ),
@@ -314,7 +314,7 @@ describe('scopeAbilityBuilder', () => {
                 ability.can(
                     'manage',
                     subject('AiAgentThread', {
-                        organizationUuid: 'org-123',
+                        projectUuid: 'project-123',
                         userUuid: 'other-user',
                     }),
                 ),
@@ -327,7 +327,7 @@ describe('scopeAbilityBuilder', () => {
             buildAbilityFromScopes(
                 {
                     ...baseContext,
-                    scopes: ['view:analytics', 'manage:tags'],
+                    scopes: ['view:Analytics', 'manage:Tags'],
                 },
                 builder,
             );
@@ -383,11 +383,7 @@ describe('scopeAbilityBuilder', () => {
                 organizationUuid: 'org-123',
                 isEnterprise: false,
                 organizationRole: 'admin',
-                scopes: [
-                    'view:dashboard',
-                    'manage:saved_chart',
-                    'view:project',
-                ],
+                scopes: ['view:Dashboard', 'manage:SavedChart', 'view:Project'],
             };
 
             const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -438,7 +434,7 @@ describe('scopeAbilityBuilder', () => {
                 const contextWithOrgManage = {
                     ...baseContext,
                     userUuid: 'user-456',
-                    scopes: ['manage:organization', 'manage:saved_chart'],
+                    scopes: ['manage:Organization', 'manage:SavedChart'],
                 };
 
                 const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -473,7 +469,7 @@ describe('scopeAbilityBuilder', () => {
                 const contextWithoutOrgManage = {
                     ...baseContext,
                     userUuid: 'user-456',
-                    scopes: ['manage:saved_chart'],
+                    scopes: ['manage:SavedChart@space'],
                 };
 
                 const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -514,7 +510,7 @@ describe('scopeAbilityBuilder', () => {
                 const contextWithProjectManage = {
                     ...baseContext,
                     userUuid: 'user-456',
-                    scopes: ['manage:project', 'manage:space'],
+                    scopes: ['manage:Project', 'manage:Space'],
                 };
 
                 const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -555,13 +551,13 @@ describe('scopeAbilityBuilder', () => {
                 const contextWithOrgManage = {
                     ...baseContext,
                     userUuid: 'user-456',
-                    scopes: ['manage:organization', 'promote:dashboard'],
+                    scopes: ['manage:Organization', 'promote:Dashboard'],
                 };
 
                 const contextWithoutOrgManage = {
                     ...baseContext,
                     userUuid: 'user-456',
-                    scopes: ['promote:dashboard'],
+                    scopes: ['promote:Dashboard@space'],
                 };
 
                 // Test dashboard promotion with organization management
@@ -619,6 +615,136 @@ describe('scopeAbilityBuilder', () => {
             });
         });
 
+        describe('AI agent thread permissions with modifiers', () => {
+            it('should handle view:ai_agent_thread@self permissions', () => {
+                const contextWithUser = {
+                    ...baseContext,
+                    userUuid: 'user-456',
+                    isEnterprise: true,
+                };
+
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...contextWithUser,
+                        scopes: ['view:AiAgentThread@self'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can view own AI agent threads
+                expect(
+                    ability.can(
+                        'view',
+                        subject('AiAgentThread', {
+                            projectUuid: 'project-123',
+                            userUuid: 'user-456',
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Cannot view other users' threads
+                expect(
+                    ability.can(
+                        'view',
+                        subject('AiAgentThread', {
+                            projectUuid: 'project-123',
+                            userUuid: 'other-user',
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle manage:ai_agent_thread@self permissions', () => {
+                const contextWithUser = {
+                    ...baseContext,
+                    userUuid: 'user-456',
+                    isEnterprise: true,
+                };
+
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...contextWithUser,
+                        userUuid: 'user-456',
+                        scopes: ['manage:AiAgentThread@self'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can manage own AI agent threads
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('AiAgentThread', {
+                            projectUuid: 'project-123',
+                            userUuid: 'user-456',
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Cannot manage other users' threads
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('AiAgentThread', {
+                            userUuid: 'other-user',
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle view:ai_agent_thread permissions for all threads', () => {
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...baseContextWithOrg,
+                        isEnterprise: true,
+                        scopes: ['view:AiAgentThread'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can view any AI agent thread
+                expect(
+                    ability.can(
+                        'view',
+                        subject('AiAgentThread', {
+                            organizationUuid: 'org-123',
+                            userUuid: 'any-user',
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should handle manage:ai_agent_thread permissions for all threads', () => {
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...baseContextWithOrg,
+                        isEnterprise: true,
+                        scopes: ['manage:AiAgentThread'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can manage any AI agent thread
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('AiAgentThread', {
+                            organizationUuid: 'org-123',
+                            userUuid: 'any-user',
+                        }),
+                    ),
+                ).toBe(true);
+            });
+        });
+
         describe('edge cases and error handling', () => {
             it('should handle empty scope array', () => {
                 const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -636,7 +762,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...contextWithoutUser,
-                        scopes: ['view:dashboard'],
+                        scopes: ['view:Dashboard'],
                     },
                     builder,
                 );
@@ -672,8 +798,8 @@ describe('scopeAbilityBuilder', () => {
                     {
                         ...baseContext,
                         scopes: [
-                            'view:dashboard',
-                            'view:project',
+                            'view:Dashboard',
+                            'view:Project',
                             'invalid:scope',
                         ],
                     },
@@ -699,9 +825,9 @@ describe('scopeAbilityBuilder', () => {
                     {
                         ...baseContext,
                         scopes: [
-                            'view:dashboard',
-                            'manage:saved_chart',
-                            'view:space',
+                            'view:Dashboard',
+                            'manage:SavedChart',
+                            'view:Space',
                         ],
                     },
                     builder,
@@ -746,7 +872,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['view:saved_chart'],
+                        scopes: ['view:SavedChart'],
                     },
                     builder,
                 );
@@ -777,7 +903,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...contextWithUser,
-                        scopes: ['view:dashboard'],
+                        scopes: ['view:Dashboard'],
                     },
                     builder,
                 );
@@ -840,7 +966,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...contextWithUser,
-                        scopes: ['manage:dashboard'],
+                        scopes: ['manage:Dashboard@space'],
                     },
                     builder,
                 );
@@ -916,7 +1042,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...contextWithUser,
-                        scopes: ['manage:space@assigned'],
+                        scopes: ['manage:Space@assigned'],
                     },
                     builder,
                 );
@@ -975,7 +1101,7 @@ describe('scopeAbilityBuilder', () => {
         });
 
         describe('job and job status permissions', () => {
-            it('should handle view:job permissions', () => {
+            it('should handle view:job@self permissions', () => {
                 const contextWithUser = {
                     ...baseContext,
                     userUuid: 'user-456',
@@ -985,7 +1111,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...contextWithUser,
-                        scopes: ['view:job'],
+                        scopes: ['view:Job@self'],
                     },
                     builder,
                 );
@@ -1012,81 +1138,13 @@ describe('scopeAbilityBuilder', () => {
                 ).toBe(false);
             });
 
-            it('should handle view:job_status permissions for organization context', () => {
+            it('should handle view:job_status@self permissions for user context', () => {
                 const builder = new AbilityBuilder<MemberAbility>(Ability);
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['view:job_status'],
-                    },
-                    builder,
-                );
-                const ability = builder.build();
-
-                // Cannot view job status without user context when no manage:Organization scope
-                expect(
-                    ability.can(
-                        'view',
-                        subject('JobStatus', {
-                            organizationUuid: 'org-123',
-                        }),
-                    ),
-                ).toBe(false);
-
-                // Cannot view job status from another organization
-                expect(
-                    ability.can(
-                        'view',
-                        subject('JobStatus', {
-                            organizationUuid: 'different-org',
-                        }),
-                    ),
-                ).toBe(false);
-            });
-
-            it('should handle view:job_status permissions with manage:Organization scope', () => {
-                const builder = new AbilityBuilder<MemberAbility>(Ability);
-                buildAbilityFromScopes(
-                    {
-                        ...baseContextWithOrg,
-                        scopes: ['view:job_status', 'manage:organization'],
-                    },
-                    builder,
-                );
-                const ability = builder.build();
-
-                // Can view all job status in organization when manage:Organization scope is present
-                expect(
-                    ability.can(
-                        'view',
-                        subject('JobStatus', {
-                            organizationUuid: 'org-123',
-                        }),
-                    ),
-                ).toBe(true);
-
-                // Cannot view job status from another organization
-                expect(
-                    ability.can(
-                        'view',
-                        subject('JobStatus', {
-                            organizationUuid: 'different-org',
-                        }),
-                    ),
-                ).toBe(false);
-            });
-
-            it('should handle view:job_status permissions for user context', () => {
-                const contextWithUser = {
-                    ...baseContext,
-                    userUuid: 'user-456',
-                };
-
-                const builder = new AbilityBuilder<MemberAbility>(Ability);
-                buildAbilityFromScopes(
-                    {
-                        ...contextWithUser,
-                        scopes: ['view:job_status'],
+                        userUuid: 'user-456',
+                        scopes: ['view:JobStatus@self'],
                     },
                     builder,
                 );
@@ -1112,6 +1170,303 @@ describe('scopeAbilityBuilder', () => {
                     ),
                 ).toBe(false);
             });
+
+            it('should handle view:job_status permissions for all job status', () => {
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...baseContextWithOrg,
+                        scopes: ['view:JobStatus'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can view all job status in organization
+                expect(
+                    ability.can(
+                        'view',
+                        subject('JobStatus', {
+                            organizationUuid: 'org-123',
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Cannot view job status from another organization
+                expect(
+                    ability.can(
+                        'view',
+                        subject('JobStatus', {
+                            organizationUuid: 'different-org',
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle view:job permissions for all jobs', () => {
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...baseContext,
+                        scopes: ['view:Job'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can view any job
+                expect(
+                    ability.can(
+                        'view',
+                        subject('Job', {
+                            organizationUuid: 'org-123',
+                            projectUuid: 'project-123',
+                            userUuid: 'any-user',
+                        }),
+                    ),
+                ).toBe(true);
+            });
+        });
+
+        describe('space-based permissions modifiers', () => {
+            it('should handle manage:dashboard@space permissions', () => {
+                const contextWithUser = {
+                    ...baseContextWithOrg,
+                    userUuid: 'user-456',
+                };
+
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...contextWithUser,
+                        scopes: ['manage:Dashboard@space'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can manage dashboard with editor role
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid: 'org-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Can manage dashboard with admin role
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid: 'org-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.ADMIN,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Cannot manage dashboard with viewer role
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid: 'org-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(false);
+
+                // Cannot manage dashboard without access
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('Dashboard', {
+                            organizationUuid: 'org-123',
+                            access: [],
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle manage:saved_chart@space permissions', () => {
+                const contextWithUser = {
+                    ...baseContext,
+                    userUuid: 'user-456',
+                };
+
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...contextWithUser,
+                        scopes: ['manage:SavedChart@space'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can manage saved chart with editor role
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid: 'project-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Can manage saved chart with admin role
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid: 'project-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.ADMIN,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Cannot manage without proper access
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SavedChart', {
+                            projectUuid: 'project-123',
+                            access: [
+                                {
+                                    userUuid: 'other-user',
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle promote:dashboard@space permissions', () => {
+                const contextWithUser = {
+                    ...baseContext,
+                    userUuid: 'user-456',
+                };
+
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...contextWithUser,
+                        scopes: ['promote:Dashboard@space'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can promote dashboard with editor access
+                expect(
+                    ability.can(
+                        'promote',
+                        subject('Dashboard', {
+                            projectUuid: 'project-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Cannot promote without editor access
+                expect(
+                    ability.can(
+                        'promote',
+                        subject('Dashboard', {
+                            projectUuid: 'project-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should handle manage:semantic_viewer@space permissions', () => {
+                const contextWithUser = {
+                    ...baseContextWithOrg,
+                    userUuid: 'user-456',
+                };
+
+                const builder = new AbilityBuilder<MemberAbility>(Ability);
+                buildAbilityFromScopes(
+                    {
+                        ...contextWithUser,
+                        scopes: ['manage:SemanticViewer@space'],
+                    },
+                    builder,
+                );
+                const ability = builder.build();
+
+                // Can manage semantic viewer with editor role
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SemanticViewer', {
+                            organizationUuid: 'org-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.EDITOR,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(true);
+
+                // Cannot manage without editor role
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('SemanticViewer', {
+                            organizationUuid: 'org-123',
+                            access: [
+                                {
+                                    userUuid: 'user-456',
+                                    role: SpaceMemberRole.VIEWER,
+                                },
+                            ],
+                        }),
+                    ),
+                ).toBe(false);
+            });
         });
 
         describe('semantic viewer permissions', () => {
@@ -1120,7 +1475,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['view:semantic_viewer'],
+                        scopes: ['view:SemanticViewer'],
                     },
                     builder,
                 );
@@ -1141,7 +1496,7 @@ describe('scopeAbilityBuilder', () => {
                 const contextWithOrgManage = {
                     ...baseContextWithOrg,
                     userUuid: 'user-456',
-                    scopes: ['manage:organization'],
+                    scopes: ['manage:Organization'],
                 };
 
                 const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -1149,8 +1504,8 @@ describe('scopeAbilityBuilder', () => {
                     {
                         ...contextWithOrgManage,
                         scopes: [
-                            'manage:organization',
-                            'manage:semantic_viewer',
+                            'manage:Organization',
+                            'manage:SemanticViewer',
                         ],
                     },
                     builder,
@@ -1178,7 +1533,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...contextWithUser,
-                        scopes: ['manage:semantic_viewer'],
+                        scopes: ['manage:SemanticViewer@space'],
                     },
                     builder,
                 );
@@ -1224,7 +1579,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['create:space'],
+                        scopes: ['create:Space'],
                     },
                     builder,
                 );
@@ -1248,7 +1603,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['manage:export_csv'],
+                        scopes: ['manage:ExportCsv'],
                     },
                     builder,
                 );
@@ -1270,7 +1625,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['manage:change_csv_results'],
+                        scopes: ['manage:ChangeCsvResults'],
                     },
                     builder,
                 );
@@ -1294,7 +1649,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['view:underlying_data'],
+                        scopes: ['view:UnderlyingData'],
                     },
                     builder,
                 );
@@ -1318,7 +1673,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['manage:sql_runner'],
+                        scopes: ['manage:SqlRunner'],
                     },
                     builder,
                 );
@@ -1340,7 +1695,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['manage:custom_sql'],
+                        scopes: ['manage:CustomSql'],
                     },
                     builder,
                 );
@@ -1365,7 +1720,7 @@ describe('scopeAbilityBuilder', () => {
                     {
                         ...baseContext,
                         userUuid: 'user-456',
-                        scopes: ['delete:project@self'],
+                        scopes: ['delete:Project@self'],
                     },
                     builder,
                 );
@@ -1393,23 +1748,24 @@ describe('scopeAbilityBuilder', () => {
                 ).toBe(false);
             });
 
-            it('should handle delete:project for preview projects', () => {
+            it('should handle delete:project@self for own preview projects', () => {
                 const builder = new AbilityBuilder<MemberAbility>(Ability);
                 buildAbilityFromScopes(
                     {
-                        ...baseContextWithOrg,
-                        scopes: ['delete:project'],
+                        ...baseContext,
+                        userUuid: 'user-456',
+                        scopes: ['delete:Project@self'],
                     },
                     builder,
                 );
                 const ability = builder.build();
 
-                // Can delete preview projects in organization
+                // Can delete preview projects in a project
                 expect(
                     ability.can(
                         'delete',
                         subject('Project', {
-                            organizationUuid: 'org-123',
+                            createdByUserUuid: 'user-456',
                             type: ProjectType.PREVIEW,
                         }),
                     ),
@@ -1420,7 +1776,7 @@ describe('scopeAbilityBuilder', () => {
                     ability.can(
                         'delete',
                         subject('Project', {
-                            organizationUuid: 'org-123',
+                            createdByUserUuid: 'user-456',
                             type: ProjectType.DEFAULT,
                         }),
                     ),
@@ -1434,7 +1790,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['view:pinned_items'],
+                        scopes: ['view:PinnedItems'],
                     },
                     builder,
                 );
@@ -1456,7 +1812,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['manage:pinned_items'],
+                        scopes: ['manage:PinnedItems'],
                     },
                     builder,
                 );
@@ -1480,7 +1836,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['manage:explore'],
+                        scopes: ['manage:Explore'],
                     },
                     builder,
                 );
@@ -1504,7 +1860,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['create:virtual_view'],
+                        scopes: ['create:VirtualView'],
                     },
                     builder,
                 );
@@ -1537,7 +1893,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['delete:virtual_view'],
+                        scopes: ['delete:VirtualView'],
                     },
                     builder,
                 );
@@ -1570,7 +1926,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['manage:virtual_view'],
+                        scopes: ['manage:VirtualView'],
                     },
                     builder,
                 );
@@ -1615,9 +1971,9 @@ describe('scopeAbilityBuilder', () => {
                     {
                         ...baseContextWithOrg,
                         scopes: [
-                            'create:virtual_view',
-                            'delete:virtual_view',
-                            'manage:virtual_view',
+                            'create:VirtualView',
+                            'delete:VirtualView',
+                            'manage:VirtualView',
                         ],
                     },
                     builder,
@@ -1662,9 +2018,9 @@ describe('scopeAbilityBuilder', () => {
                     {
                         ...baseContextWithOrg,
                         scopes: [
-                            'create:virtual_view',
-                            'delete:virtual_view',
-                            'manage:virtual_view',
+                            'create:VirtualView',
+                            'delete:VirtualView',
+                            'manage:VirtualView',
                         ],
                     },
                     builder,
@@ -1711,7 +2067,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContextWithOrg,
-                        scopes: ['view:organization_member_profile'],
+                        scopes: ['view:OrganizationMemberProfile'],
                     },
                     builder,
                 );
@@ -1744,7 +2100,7 @@ describe('scopeAbilityBuilder', () => {
                 buildAbilityFromScopes(
                     {
                         ...baseContext,
-                        scopes: ['manage:organization_member_profile'],
+                        scopes: ['manage:OrganizationMemberProfile'],
                     },
                     builder,
                 );
@@ -1770,7 +2126,7 @@ describe('scopeAbilityBuilder', () => {
                         ...baseContext,
                         isEnterprise: true,
                         organizationRole: 'admin',
-                        scopes: ['manage:personal_access_token'],
+                        scopes: ['manage:PersonalAccessToken'],
                         permissionsConfig: {
                             pat: {
                                 enabled: true,
@@ -1792,7 +2148,7 @@ describe('scopeAbilityBuilder', () => {
                         ...baseContext,
                         isEnterprise: true,
                         organizationRole: 'admin',
-                        scopes: ['manage:personal_access_token'],
+                        scopes: ['manage:PersonalAccessToken'],
                         permissionsConfig: {
                             pat: {
                                 enabled: false,
@@ -1816,7 +2172,7 @@ describe('scopeAbilityBuilder', () => {
                         ...baseContext,
                         isEnterprise: true,
                         organizationRole: 'developer',
-                        scopes: ['manage:personal_access_token'],
+                        scopes: ['manage:PersonalAccessToken'],
                         permissionsConfig: {
                             pat: {
                                 enabled: true,
@@ -1840,7 +2196,7 @@ describe('scopeAbilityBuilder', () => {
                         ...baseContext,
                         isEnterprise: true,
                         organizationRole: 'admin',
-                        scopes: ['manage:personal_access_token'],
+                        scopes: ['manage:PersonalAccessToken'],
                         // No permissionsConfig provided
                     },
                     builder,
@@ -1859,7 +2215,7 @@ describe('scopeAbilityBuilder', () => {
                         ...baseContext,
                         isEnterprise: true,
                         organizationRole: '', // Empty organization role
-                        scopes: ['manage:personal_access_token'],
+                        scopes: ['manage:PersonalAccessToken'],
                         permissionsConfig: {
                             pat: {
                                 enabled: true,

--- a/packages/common/src/authorization/scopeAbilityBuilder.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.ts
@@ -42,14 +42,16 @@ const applyScopeAbilities = (
         if (!scope) return;
 
         const [action, subject] = parseScope(scopeName);
-        const conditionsList = scope.getConditions
-            ? scope.getConditions(context)
-            : [];
+        const conditionsList = scope.getConditions(context);
 
-        // Apply each condition set
-        conditionsList.forEach((conditions) => {
-            builder.can(action, subject, conditions);
-        });
+        // Apply each condition set if there are any
+        if (conditionsList.length === 0) {
+            builder.can(action, subject);
+        } else {
+            conditionsList.forEach((conditions) => {
+                builder.can(action, subject, conditions);
+            });
+        }
     });
 
     handlePatConfigApplication(context, builder);

--- a/packages/common/src/types/scopes.ts
+++ b/packages/common/src/types/scopes.ts
@@ -47,7 +47,7 @@ type ProjectScopeContext = BaseScopeContext & {
  */
 export type ScopeContext = OrganizationScopeContext | ProjectScopeContext;
 
-export type ScopeModifer = 'self' | 'public' | 'assigned';
+export type ScopeModifer = 'self' | 'public' | 'assigned' | 'space';
 type OptionalModifier = `${'' | `@${ScopeModifer}`}`;
 
 /**
@@ -79,5 +79,5 @@ export type Scope = {
     /**
      * Get the conditions to be applied to the CASL ability derived from the scope
      */
-    getConditions?: (context: ScopeContext) => Record<string, unknown>[];
+    getConditions: (context: ScopeContext) => Record<string, unknown>[];
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16522

### Description:

This PR refines the authorization system by implementing a more granular scope-based permission model that aligns with the existing role-based abilities. Key changes include:

1. Added a comprehensive test suite (`roleToScopeParity.test.ts`) to ensure parity between role-based and scope-based permissions. This suite compares the `ability.rules` objects returned by both the role-base ability and the scope-based ability.
2. Standardized scope naming conventions to use PascalCase for subject names—this is really done in the scopeBuilder test file.
3. Introduced more specific scope modifiers (`@self`, `@space`, `@assigned`, `@public`) to better control access levels. This helped improved space-based permissions to clearly differentiate between global access and space-specific access