### PR TITLE
chore: remove redundant state from AI agent thread streaming

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/streaming/AiAgentThreadStreamStore.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/AiAgentThreadStreamStore.ts
@@ -18,7 +18,6 @@ export interface StreamingState {
     isStreaming: boolean;
     toolCalls: ToolCall[];
     error?: string;
-    justCompleted?: boolean;
 }
 
 type State = Record<string, StreamingState>;
@@ -73,7 +72,6 @@ const threadStreamSlice = createSlice({
             const streamingThread = state[threadUuid];
             if (streamingThread) {
                 streamingThread.isStreaming = false;
-                streamingThread.justCompleted = true;
             }
         },
         addToolCall: (
@@ -115,16 +113,6 @@ const threadStreamSlice = createSlice({
                 streamingThread.error = error;
             }
         },
-        clearJustCompleted: (
-            state,
-            action: PayloadAction<{ threadUuid: string }>,
-        ) => {
-            const { threadUuid } = action.payload;
-            const streamingThread = state[threadUuid];
-            if (streamingThread) {
-                streamingThread.justCompleted = false;
-            }
-        },
     },
 });
 
@@ -134,7 +122,6 @@ export const {
     stopStreaming,
     setError,
     addToolCall,
-    clearJustCompleted,
 } = threadStreamSlice.actions;
 
 export const store = configureStore({

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -9,7 +9,6 @@ import {
     addToolCall,
     type AiAgentThreadStreamDispatch,
     appendToMessage,
-    clearJustCompleted,
     setError,
     startStreaming,
     stopStreaming,
@@ -136,16 +135,8 @@ export function useAiAgentThreadStreamMutation() {
         [abort],
     );
 
-    const clearMessageJustCompleted = useCallback(
-        (threadUuid: string) => {
-            dispatch(clearJustCompleted({ threadUuid }));
-        },
-        [dispatch],
-    );
-
     return {
         streamMessage,
         cancelMessageStream,
-        clearMessageJustCompleted,
     };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removed the `justCompleted` flag from the AI Agent Thread Stream Store. This includes:

- Removing the `justCompleted` property from the `StreamingState` interface
- Removing the `justCompleted` flag setting in the `stopStreaming` reducer
- Removing the `clearJustCompleted` action and reducer
- Removing the `clearMessageJustCompleted` function from `useAiAgentThreadStreamMutation`
- Removing the `useAiAgentThreadMessageJustCompleted` hook entirely

This simplifies the streaming state management by eliminating the temporary completion state tracking.
