### PR TITLE
chore: add workingDirectories to vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,27 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "cssVariables.lookupFiles": [
-    "**/*.css",
-    "**/*.scss",
-    "**/*.sass",
-    "**/*.less",
-    "packages/frontend/node_modules/@mantine-8/core/styles.css"
-  ],
-  "yaml.schemas": {
-    "https://raw.githubusercontent.com/okteto/okteto/master/schema.json": [
-      "okteto.yaml",
-      "okteto.preview.yaml",
-      "okteto.dev.yaml"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "cssVariables.lookupFiles": [
+        "**/*.css",
+        "**/*.scss",
+        "**/*.sass",
+        "**/*.less",
+        "packages/frontend/node_modules/@mantine-8/core/styles.css"
+    ],
+    "yaml.schemas": {
+        "https://raw.githubusercontent.com/okteto/okteto/master/schema.json": [
+            "okteto.yaml",
+            "okteto.preview.yaml",
+            "okteto.dev.yaml"
+        ]
+    },
+    "eslint.workingDirectories": [
+        "./packages/common",
+        "./packages/warehouses",
+        "./packages/cli",
+        "./packages/backend",
+        "./packages/frontend",
+        "./packages/e2e",
+        "./packages/sdk-next-test-app",
+        "./packages/sdk-test-app"
     ]
-  }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
### Description:
Added ESLint working directories configuration to VS Code settings to improve linting support across the monorepo structure. The configuration now explicitly defines the working directories for ESLint as:
- ./packages/common
- ./packages/warehouses
- ./packages/cli
- ./packages/backend
- ./packages/frontend

Docs: https://github.com/microsoft/vscode-eslint?tab=readme-ov-file#mono-repository-setup

**Before**

Server kept crashing and no eslint errors were shown

![image.png](https://app.graphite.dev/user-attachments/assets/661d0e69-5afb-4cde-9493-36fa54bc173e.png)

**After**

![image.png](https://app.graphite.dev/user-attachments/assets/eb5cecd5-138f-432e-920e-ad7d2027c32f.png)

