### PR TITLE
fix: lightdash validate command shows success despite compilation errors

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -14,7 +14,11 @@ import {
     type DbtModelNode,
     type LineageGraph,
 } from '../types/dbt';
-import { MissingCatalogEntryError, ParseError } from '../types/errors';
+import {
+    CompileError,
+    MissingCatalogEntryError,
+    ParseError,
+} from '../types/errors';
 import {
     InlineErrorType,
     type Explore,
@@ -821,7 +825,8 @@ export const convertExplores = async (
                         {
                             // TODO improve parsing of error type
                             type:
-                                e instanceof ParseError
+                                e instanceof ParseError ||
+                                e instanceof CompileError
                                     ? InlineErrorType.METADATA_PARSE_ERROR
                                     : InlineErrorType.NO_DIMENSIONS_FOUND,
                             message:


### PR DESCRIPTION
Closes: #16405

### Description:

Adds support for handling `CompileError` in the explore conversion process. Now, both `ParseError` and `CompileError` will be properly categorized as `METADATA_PARSE_ERROR` type when encountered during explore conversion.

before:
![CleanShot 2025-08-22 at 13.16.30@2x.png](https://app.graphite.dev/user-attachments/assets/e3fe8a96-ac74-43a2-9d0f-7a86873219b7.png)

after:
![CleanShot 2025-08-22 at 13.18.37@2x.png](https://app.graphite.dev/user-attachments/assets/b12e94d7-f743-4d4e-91d6-b3eb08fe2647.png)