### PR TITLE
feat: add schema compatibility layer for MCP service

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -54,6 +54,7 @@
         "@lightdash/warehouses": "workspace:*",
         "@mastra/core": "^0.11.1",
         "@mastra/evals": "^0.10.7",
+        "@mastra/schema-compat": "^0.10.7",
         "@modelcontextprotocol/sdk": "^1.17.0",
         "@node-oauth/oauth2-server": "^5.2.0",
         "@octokit/app": "^14.0.2",

--- a/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.ts
+++ b/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.ts
@@ -1,0 +1,93 @@
+/* eslint-disable class-methods-use-this */
+import { AnyType } from '@lightdash/common';
+import {
+    SchemaCompatLayer,
+    isArr,
+    isNumber,
+    isObj,
+    isOptional,
+    isString,
+    isUnion,
+} from '@mastra/schema-compat';
+import { ZodDate, ZodDefault, ZodTypeAny } from 'zod';
+
+// These are not exported by @mastra/schema-compat, so we need to define them here
+// copied from source
+const isDate = (value: ZodTypeAny): value is ZodDate =>
+    value._def.typeName === 'ZodDate';
+const isDefault = (v: ZodTypeAny): v is ZodDefault<AnyType> =>
+    v instanceof ZodDefault;
+
+export class McpSchemaCompatLayer extends SchemaCompatLayer {
+    constructor() {
+        // We don't need a real model for MCP, just pass dummy info
+        super({
+            modelId: 'mcp-lightdash',
+            provider: 'lightdash',
+            supportsStructuredOutputs: true,
+        });
+    }
+
+    getSchemaTarget() {
+        return 'jsonSchema7' as const;
+    }
+
+    shouldApply() {
+        // Always apply this compatibility layer when explicitly used
+        return true;
+    }
+
+    processZodType(value: ZodTypeAny): ZodTypeAny {
+        // Handle nullable types (e.g., z.string().nullable())
+        if (value._def.typeName === 'ZodNullable') {
+            const innerType = this.processZodType(value._def.innerType);
+            return innerType.optional();
+        }
+
+        // Identical to packages/backend/node_modules/@mastra/schema-compat/src/provider-compats/openai-reasoning.ts
+        if (isOptional(value)) {
+            const innerType = this.processZodType(value._def.innerType);
+            return innerType.optional();
+        }
+        if (isObj(value)) {
+            return this.defaultZodObjectHandler(value, { passthrough: false });
+        }
+        if (isArr(value)) {
+            return this.defaultZodArrayHandler(value);
+        }
+        if (isUnion(value)) {
+            return this.defaultZodUnionHandler(value);
+        }
+
+        if (isDefault(value)) {
+            const defaultDef = value._def;
+            const { innerType } = defaultDef;
+            const defaultValue = defaultDef.defaultValue();
+            const constraints: { defaultValue?: unknown } = {};
+            if (defaultValue !== undefined) {
+                constraints.defaultValue = defaultValue;
+            }
+
+            const description = this.mergeParameterDescription(
+                value.description,
+                constraints,
+            );
+            let result = this.processZodType(innerType);
+            if (description) {
+                result = result.describe(description);
+            }
+            return result;
+        }
+        if (isNumber(value)) {
+            // This is to make sure .coerce works
+            return value;
+        }
+        if (isString(value)) {
+            return this.defaultZodStringHandler(value);
+        }
+        if (isDate(value)) {
+            return this.defaultZodDateHandler(value);
+        }
+        return this.defaultUnsupportedZodTypeHandler(value);
+    }
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@casl/ability": "^5.4.3",
+        "@mastra/schema-compat": "^0.10.7",
         "@types/lodash": "^4.14.202",
         "ajv": "^8.3.0",
         "ajv-errors": "^3.0.0",

--- a/packages/common/src/ee/AiAgent/schemas/sortField.ts
+++ b/packages/common/src/ee/AiAgent/schemas/sortField.ts
@@ -11,7 +11,7 @@ const sortFieldSchema = z.object({
     nullsFirst: z
         .boolean()
         .describe(
-            'If true sorts nulls first, if false sorts nulls last, if null then sorts by warehouse default',
+            'If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default',
         )
         .nullable(),
 });

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
@@ -6,12 +6,12 @@ import { createToolSchema } from '../toolSchemaBuilder';
 export const TOOL_SEARCH_FIELD_VALUES_DESCRIPTION = `Tool: searchFieldValues
 
 Purpose:
-Search for unique values of a specific field in a table. This is useful for finding suggestions for field values when building filters or exploring data.
+Search for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.
 
 Usage Tips:
 - Specify the table and field you want to search values for
-- Use the query parameter to filter values by a specific string
-- Optionally add filters to narrow down the results
+- Query parameter: use it to narrow down the search to matching values
+- Optionally add filters to further restrict the results
 - Results are returned as a list of unique field values (limited to 100)
 `;
 
@@ -26,9 +26,7 @@ export const toolSearchFieldValuesArgsSchema = createToolSchema(
         }),
         query: z
             .string()
-            .describe(
-                'Query string to filter field values. Optional, pass `null` to get all values',
-            )
+            .describe('Query string to filter field values')
             .nullable(),
         filters: filtersSchema
             .nullable()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@mastra/evals':
         specifier: ^0.10.7
         version: 0.10.7(@mastra/core@0.11.1(encoding@0.1.13)(openapi-types@12.1.3)(react@19.0.0)(zod@3.25.55))(ai@4.3.16(react@19.0.0)(zod@3.25.55))
+      '@mastra/schema-compat':
+        specifier: ^0.10.7
+        version: 0.10.7(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.0
         version: 1.17.0
@@ -643,6 +646,9 @@ importers:
       '@casl/ability':
         specifier: ^5.4.3
         version: 5.4.4
+      '@mastra/schema-compat':
+        specifier: ^0.10.7
+        version: 0.10.7(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202
@@ -3611,6 +3617,12 @@ packages:
 
   '@mastra/schema-compat@0.10.5':
     resolution: {integrity: sha512-Qhz8W4Hz7b9tNoVW306NMzotVy11bya1OjiTN+pthj00HZoaH7nmK8SWBiX4drS+PyhIqA16X5AenELe2QgZag==}
+    peerDependencies:
+      ai: ^4.0.0
+      zod: ^3.0.0
+
+  '@mastra/schema-compat@0.10.7':
+    resolution: {integrity: sha512-lY1V57fHfCRVafNuwmDEmQJNncVZI+wdOdvL/WbgYWLQmL3YjBl3CrM+7yTOM/gG/GPKm8BRxmqnHLhS1rD1zg==}
     peerDependencies:
       ai: ^4.0.0
       zod: ^3.0.0
@@ -8015,6 +8027,7 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
+    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -20261,6 +20274,14 @@ snapshots:
       - supports-color
 
   '@mastra/schema-compat@0.10.5(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)':
+    dependencies:
+      ai: 4.3.16(react@19.0.0)(zod@3.25.55)
+      json-schema: 0.4.0
+      zod: 3.25.55
+      zod-from-json-schema: 0.0.5
+      zod-to-json-schema: 3.24.6(zod@3.25.55)
+
+  '@mastra/schema-compat@0.10.7(ai@4.3.16(react@19.0.0)(zod@3.25.55))(zod@3.25.55)':
     dependencies:
       ai: 4.3.16(react@19.0.0)(zod@3.25.55)
       json-schema: 0.4.0


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16430

### Description:

Added schema compatibility layer for MCP (Model Context Protocol) to ensure proper handling of nullable and optional fields. This implementation:

- Adds `@mastra/schema-compat` dependency to handle schema transformations
- Creates a new `McpSchemaCompatLayer` class to process Zod schemas for MCP compatibility
- Updates tool registrations to use the compatibility layer for input schemas
- Adds proper transformation of arguments to maintain backward compatibility
- Improves handling of nullable fields, optional values, and default values
