### PR TITLE
fix: handle metric filters in totals calculation

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -36,6 +36,7 @@ import {
     isFilterInteractivityEnabled,
     MetricQuery,
     NotFoundError,
+    NotSupportedError,
     ParameterError,
     QueryExecutionContext,
     RunQueryTags,
@@ -997,42 +998,50 @@ export class EmbedService extends BaseService {
             explore,
         );
 
-        const { totalQuery: totalMetricQuery } =
-            await this.projectService._getCalculateTotalQuery(
-                userAttributes,
-                intrinsicUserAttributes,
+        try {
+            const { totalQuery: totalMetricQuery } =
+                await this.projectService._getCalculateTotalQuery(
+                    userAttributes,
+                    intrinsicUserAttributes,
+                    explore,
+                    metricQuery,
+                    warehouseClient,
+                    availableParameters,
+                    combinedParameters,
+                );
+
+            const { rows } = await this._runEmbedQuery({
+                projectUuid,
+                metricQuery: totalMetricQuery,
                 explore,
-                metricQuery,
-                warehouseClient,
-                availableParameters,
+                queryTags: {
+                    embed: 'true',
+                    external_id: account.user.id,
+                    project_uuid: projectUuid,
+                    organization_uuid: chart.organizationUuid,
+                    chart_uuid: chart.uuid,
+                    dashboard_uuid: dashboardUuid,
+                    explore_name: chart.tableName,
+                    query_context: QueryExecutionContext.CALCULATE_TOTAL,
+                },
+                account,
                 combinedParameters,
-            );
+            });
 
-        const { rows } = await this._runEmbedQuery({
-            projectUuid,
-            metricQuery: totalMetricQuery,
-            explore,
-            queryTags: {
-                embed: 'true',
-                external_id: account.user.id,
-                project_uuid: projectUuid,
-                organization_uuid: chart.organizationUuid,
-                chart_uuid: chart.uuid,
-                dashboard_uuid: dashboardUuid,
-                explore_name: chart.tableName,
-                query_context: QueryExecutionContext.CALCULATE_TOTAL,
-            },
-            account,
-            combinedParameters,
-        });
+            if (rows.length === 0) {
+                throw new NotFoundError('No results found');
+            }
 
-        if (rows.length === 0) {
-            throw new NotFoundError('No results found');
+            const row = rows[0];
+
+            return row;
+        } catch (e) {
+            if (e instanceof NotSupportedError) {
+                this.logger.warn(e.message);
+                return {}; // no totals
+            }
+            throw e;
         }
-
-        const row = rows[0];
-
-        return row;
     }
 
     async calculateSubtotalsFromSavedChart(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -62,6 +62,7 @@ import {
     FilterOperator,
     findFieldByIdInExplore,
     findReplaceableCustomMetrics,
+    flattenFilterGroup,
     ForbiddenError,
     formatRawRows,
     formatRows,
@@ -108,6 +109,7 @@ import {
     normalizeIndexColumns,
     NotExistsError,
     NotFoundError,
+    NotSupportedError,
     OpenIdIdentityIssuerType,
     ParameterError,
     type ParametersValuesMap,
@@ -5217,6 +5219,19 @@ export class ProjectService extends BaseService {
             additionalMetrics: metricQuery.additionalMetrics,
         };
 
+        const hasMetricFilters =
+            !!totalQuery.filters.metrics &&
+            flattenFilterGroup(totalQuery.filters.metrics).length > 0;
+        const hasTableCalculationFilters =
+            !!totalQuery.filters.tableCalculations &&
+            flattenFilterGroup(totalQuery.filters.tableCalculations).length > 0;
+
+        if (hasMetricFilters || hasTableCalculationFilters) {
+            throw new NotSupportedError(
+                'Totals cannot be correctly calculated with metric filters or table calculation filters',
+            );
+        }
+
         const { query } = await ProjectService._compileQuery({
             metricQuery: totalQuery,
             explore,
@@ -5260,27 +5275,34 @@ export class ProjectService extends BaseService {
             explore,
         );
 
-        const { query } = await this._getCalculateTotalQuery(
-            userAttributes,
-            intrinsicUserAttributes,
-            explore,
-            metricQuery,
-            warehouseClient,
-            availableParameters,
-            parameters,
-        );
+        try {
+            const { query } = await this._getCalculateTotalQuery(
+                userAttributes,
+                intrinsicUserAttributes,
+                explore,
+                metricQuery,
+                warehouseClient,
+                availableParameters,
+                parameters,
+            );
+            const queryTags: RunQueryTags = {
+                ...this.getUserQueryTags(account),
+                organization_uuid: account.organization.organizationUuid,
+                project_uuid: projectUuid,
+                explore_name: explore.name,
+                query_context: QueryExecutionContext.CALCULATE_TOTAL,
+            };
 
-        const queryTags: RunQueryTags = {
-            ...this.getUserQueryTags(account),
-            organization_uuid: account.organization.organizationUuid,
-            project_uuid: projectUuid,
-            explore_name: explore.name,
-            query_context: QueryExecutionContext.CALCULATE_TOTAL,
-        };
-
-        const { rows } = await warehouseClient.runQuery(query, queryTags);
-        await sshTunnel.disconnect();
-        return { row: rows[0] };
+            const { rows } = await warehouseClient.runQuery(query, queryTags);
+            await sshTunnel.disconnect();
+            return { row: rows[0] };
+        } catch (e) {
+            if (e instanceof NotSupportedError) {
+                this.logger.warn(e.message);
+                return { row: {} }; // no totals
+            }
+            throw e;
+        }
     }
 
     async _calculateTotalFromCacheOrWarehouse(
@@ -5313,36 +5335,44 @@ export class ProjectService extends BaseService {
             explore,
         );
 
-        const { query, totalQuery } = await this._getCalculateTotalQuery(
-            userAttributes,
-            intrinsicUserAttributes,
-            explore,
-            metricQuery,
-            warehouseClient,
-            availableParameters,
-            parameters,
-        );
-
-        const queryTags: RunQueryTags = {
-            ...this.getUserQueryTags(account),
-            organization_uuid: organizationUuid,
-            project_uuid: projectUuid,
-            explore_name: explore.name,
-            query_context: QueryExecutionContext.CALCULATE_TOTAL,
-        };
-
-        const { rows, cacheMetadata } =
-            await this.getResultsFromCacheOrWarehouse({
-                projectUuid,
-                context: QueryExecutionContext.CALCULATE_TOTAL,
+        try {
+            const { query, totalQuery } = await this._getCalculateTotalQuery(
+                userAttributes,
+                intrinsicUserAttributes,
+                explore,
+                metricQuery,
                 warehouseClient,
-                metricQuery: totalQuery,
-                query,
-                queryTags,
-                invalidateCache,
-            });
-        await sshTunnel.disconnect();
-        return { row: rows[0], cacheMetadata };
+                availableParameters,
+                parameters,
+            );
+
+            const queryTags: RunQueryTags = {
+                ...this.getUserQueryTags(account),
+                organization_uuid: organizationUuid,
+                project_uuid: projectUuid,
+                explore_name: explore.name,
+                query_context: QueryExecutionContext.CALCULATE_TOTAL,
+            };
+
+            const { rows, cacheMetadata } =
+                await this.getResultsFromCacheOrWarehouse({
+                    projectUuid,
+                    context: QueryExecutionContext.CALCULATE_TOTAL,
+                    warehouseClient,
+                    metricQuery: totalQuery,
+                    query,
+                    queryTags,
+                    invalidateCache,
+                });
+            await sshTunnel.disconnect();
+            return { row: rows[0], cacheMetadata };
+        } catch (e) {
+            if (e instanceof NotSupportedError) {
+                this.logger.warn(e.message);
+                return { row: {} }; // no totals
+            }
+            throw e;
+        }
     }
 
     async calculateTotalFromSavedChart(

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -263,6 +263,17 @@ export class NotFoundError extends LightdashError {
     }
 }
 
+export class NotSupportedError extends LightdashError {
+    constructor(message: string) {
+        super({
+            message,
+            name: 'NotSupportedError',
+            statusCode: 400,
+            data: {},
+        });
+    }
+}
+
 export class InvalidUser extends LightdashError {
     constructor(message: string) {
         super({

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -238,24 +238,25 @@ export const isMetricFilterTarget = (
 ): value is { fieldRef: string } =>
     !!value && typeof value === 'object' && 'fieldRef' in value;
 
+export const flattenFilterGroup = (filterGroup: FilterGroup): FilterRule[] => {
+    // Explicitly checking for undefined filter groups (and || or), saved filter group somehow was undefined when saving
+    const groupItems: FilterGroupItem[] | undefined = isAndFilterGroup(
+        filterGroup,
+    )
+        ? filterGroup.and
+        : filterGroup.or;
+
+    return (groupItems || []).flatMap((item) => {
+        if (isFilterGroup(item)) {
+            return flattenFilterGroup(item);
+        }
+
+        return [item];
+    });
+};
+
 export const getFilterRules = (filters: Filters): FilterRule[] => {
     const rules: FilterRule[] = [];
-    const flattenFilterGroup = (filterGroup: FilterGroup): FilterRule[] => {
-        // Explicitly checking for undefined filter groups (and || or), saved filter group somehow was undefined when saving
-        const groupItems: FilterGroupItem[] | undefined = isAndFilterGroup(
-            filterGroup,
-        )
-            ? filterGroup.and
-            : filterGroup.or;
-
-        return (groupItems || []).flatMap((item) => {
-            if (isFilterGroup(item)) {
-                return flattenFilterGroup(item);
-            }
-
-            return [item];
-        });
-    };
 
     if (filters.dimensions) {
         rules.push(...flattenFilterGroup(filters.dimensions));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
This PR adds error handling for totals calculation when metric filters or table calculation filters are present. Instead of failing, the code now gracefully handles these cases by returning an empty object for totals and logging a warning message.

The implementation:
1. Adds a new `NotSupportedError` class to handle unsupported operations
2. Adds validation in `_getCalculateTotalQuery` to detect metric or table calculation filters
3. Wraps total calculation logic in try/catch blocks to handle the error gracefully
4. Extracts `flattenFilterGroup` as a standalone function to be reused

This change improves the user experience by preventing errors when calculating totals with unsupported filter configurations.