### PR TITLE
feat: add custom roles admin page

### DIFF
--- a/packages/backend/src/controllers/OrganizationRolesController.ts
+++ b/packages/backend/src/controllers/OrganizationRolesController.ts
@@ -67,12 +67,14 @@ export class OrganizationRolesController extends BaseController {
         @Request() req: express.Request,
         @Path() orgUuid: string,
         @Query() load?: string,
-    ): Promise<ApiGetRolesResponse> {
+        @Query() roleTypeFilter?: string,
+    ): Promise<ApiGetRolesResponse | ApiRoleWithScopesResponse> {
         const loadScopes = load === 'scopes';
         const roles = await this.getRolesService().getRolesByOrganizationUuid(
             req.account!,
             orgUuid,
             loadScopes,
+            roleTypeFilter,
         );
 
         this.setStatus(200);

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -16081,6 +16081,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiRoleWithScopesResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'RoleWithScopes', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ResultsPaginationMetadata_ResultRow_: {
         dataType: 'refAlias',
         type: {
@@ -35154,6 +35166,11 @@ export function RegisterRoutes(app: Router) {
             dataType: 'string',
         },
         load: { in: 'query', name: 'load', dataType: 'string' },
+        roleTypeFilter: {
+            in: 'query',
+            name: 'roleTypeFilter',
+            dataType: 'string',
+        },
     };
     app.get(
         '/api/v2/orgs/:orgUuid/roles',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16970,6 +16970,20 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ApiRoleWithScopesResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/RoleWithScopes"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "ResultsPaginationMetadata_ResultRow_": {
                 "allOf": [
                     {
@@ -18630,7 +18644,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1957.0",
+        "version": "0.1957.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -18729,7 +18743,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ApiGetRolesResponse"
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ApiGetRolesResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ApiRoleWithScopesResponse"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -18760,6 +18781,14 @@
                     {
                         "in": "query",
                         "name": "load",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "roleTypeFilter",
                         "required": false,
                         "schema": {
                             "type": "string"

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -37,6 +37,10 @@ export class HealthService extends BaseService {
         this.migrationModel = migrationModel;
     }
 
+    private isEnterpriseEnabled(): boolean {
+        return this.lightdashConfig.license.licenseKey !== undefined;
+    }
+
     async getHealthState(user: SessionUser | undefined): Promise<HealthState> {
         const isAuthenticated: boolean = !!user?.userUuid;
 
@@ -143,7 +147,7 @@ export class HealthService extends BaseService {
                 snowflake: {
                     enabled:
                         !!this.lightdashConfig.auth.snowflake.clientId &&
-                        !!this.lightdashConfig.license.licenseKey,
+                        this.isEnterpriseEnabled(),
                 },
             },
             hasEmailClient: !!this.lightdashConfig.smtp,
@@ -164,7 +168,9 @@ export class HealthService extends BaseService {
             hasMicrosoftTeams: this.lightdashConfig.microsoftTeams.enabled,
             isServiceAccountEnabled:
                 this.lightdashConfig.serviceAccount.enabled,
-            isCustomRolesEnabled: this.lightdashConfig.customRoles.enabled,
+            isCustomRolesEnabled:
+                this.isEnterpriseEnabled() &&
+                this.lightdashConfig.customRoles.enabled,
         };
     }
 

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesCreateModal.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesCreateModal.tsx
@@ -1,0 +1,108 @@
+import {
+    Button,
+    Group,
+    Modal,
+    Stack,
+    Text,
+    TextInput,
+    Textarea,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { type FC } from 'react';
+
+type CreateModalProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    onSave: (values: { name: string; description?: string }) => void;
+    isWorking?: boolean;
+};
+
+export const CustomRolesCreateModal: FC<CreateModalProps> = ({
+    isOpen,
+    onClose,
+    onSave,
+    isWorking = false,
+}) => {
+    const form = useForm({
+        initialValues: {
+            name: '',
+            description: '',
+        },
+        validate: {
+            name: (value) => {
+                if (!value || value.trim().length === 0) {
+                    return 'Role name is required';
+                }
+                if (value.length < 3) {
+                    return 'Role name must be at least 3 characters';
+                }
+                if (value.length > 50) {
+                    return 'Role name must be less than 50 characters';
+                }
+                return null;
+            },
+            description: (value) => {
+                if (value && value.length > 200) {
+                    return 'Description must be less than 200 characters';
+                }
+                return null;
+            },
+        },
+    });
+
+    const handleSubmit = form.onSubmit((values) => {
+        onSave({
+            name: values.name,
+            description: values.description || undefined,
+        });
+    });
+
+    const handleClose = () => {
+        form.reset();
+        onClose();
+    };
+
+    return (
+        <Modal
+            opened={isOpen}
+            onClose={handleClose}
+            title="Create custom role"
+            size="md"
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack>
+                    <TextInput
+                        label="Role name"
+                        placeholder="e.g., Finance Analyst"
+                        required
+                        disabled={isWorking}
+                        {...form.getInputProps('name')}
+                    />
+                    <Textarea
+                        label="Description"
+                        placeholder="Describe the purpose of this role"
+                        rows={3}
+                        disabled={isWorking}
+                        {...form.getInputProps('description')}
+                    />
+                    <Text size="sm" color="dimmed">
+                        You can configure permissions and scopes after creating
+                        the role.
+                    </Text>
+                    <Group position="right" mt="md">
+                        <Button
+                            variant="outline"
+                            onClick={handleClose}
+                            disabled={isWorking}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" loading={isWorking}>
+                            Create role
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesDeleteModal.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesDeleteModal.tsx
@@ -1,0 +1,55 @@
+import { Button, Group, Modal, Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
+
+import { type RoleWithScopes } from '@lightdash/common';
+
+type DeleteModalProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    onDelete: () => void;
+    isDeleting?: boolean;
+    role: RoleWithScopes;
+};
+
+export const CustomRolesDeleteModal: FC<DeleteModalProps> = ({
+    isOpen,
+    onClose,
+    onDelete,
+    isDeleting = false,
+    role,
+}) => {
+    return (
+        <Modal
+            opened={isOpen}
+            onClose={onClose}
+            title="Delete custom role"
+            size="md"
+        >
+            <Stack>
+                <Text>
+                    Are you sure you want to delete the role{' '}
+                    <Text component="span" weight="bold">
+                        {role.name}
+                    </Text>
+                    ?
+                </Text>
+                <Text size="sm" color="dimmed">
+                    This action cannot be undone. Users and groups will no
+                    longer be able to use this role.
+                </Text>
+                <Group position="right" mt="md">
+                    <Button
+                        variant="outline"
+                        onClick={onClose}
+                        disabled={isDeleting}
+                    >
+                        Cancel
+                    </Button>
+                    <Button color="red" onClick={onDelete} loading={isDeleting}>
+                        Delete role
+                    </Button>
+                </Group>
+            </Stack>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesEditModal.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesEditModal.tsx
@@ -1,0 +1,118 @@
+import {
+    Button,
+    Group,
+    Modal,
+    Stack,
+    TextInput,
+    Textarea,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { type FC, useEffect } from 'react';
+
+import { type RoleWithScopes } from '@lightdash/common';
+
+type EditModalProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    onSave: (values: { name: string; description?: string }) => void;
+    isWorking?: boolean;
+    role: RoleWithScopes;
+};
+
+export const CustomRolesEditModal: FC<EditModalProps> = ({
+    isOpen,
+    onClose,
+    onSave,
+    isWorking = false,
+    role,
+}) => {
+    const form = useForm({
+        initialValues: {
+            name: role.name,
+            description: role.description || '',
+        },
+        validate: {
+            name: (value) => {
+                if (!value || value.trim().length === 0) {
+                    return 'Role name is required';
+                }
+                if (value.length < 3) {
+                    return 'Role name must be at least 3 characters';
+                }
+                if (value.length > 50) {
+                    return 'Role name must be less than 50 characters';
+                }
+                return null;
+            },
+            description: (value) => {
+                if (value && value.length > 200) {
+                    return 'Description must be less than 200 characters';
+                }
+                return null;
+            },
+        },
+    });
+
+    // Reset form when role changes or modal opens
+    useEffect(() => {
+        if (isOpen) {
+            form.setValues({
+                name: role.name,
+                description: role.description || '',
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isOpen, role]);
+
+    const handleSubmit = form.onSubmit((values) => {
+        onSave({
+            name: values.name,
+            description: values.description || undefined,
+        });
+    });
+
+    const handleClose = () => {
+        form.reset();
+        onClose();
+    };
+
+    return (
+        <Modal
+            opened={isOpen}
+            onClose={handleClose}
+            title="Edit custom role"
+            size="md"
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack>
+                    <TextInput
+                        label="Role name"
+                        placeholder="e.g., Finance Analyst"
+                        required
+                        disabled={isWorking}
+                        {...form.getInputProps('name')}
+                    />
+                    <Textarea
+                        label="Description"
+                        placeholder="Describe the purpose of this role"
+                        rows={3}
+                        disabled={isWorking}
+                        {...form.getInputProps('description')}
+                    />
+                    <Group position="right" mt="md">
+                        <Button
+                            variant="outline"
+                            onClick={handleClose}
+                            disabled={isWorking}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" loading={isWorking}>
+                            Save changes
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -1,0 +1,163 @@
+import { Button, Group, Paper, Table } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+
+import { formatDate, type RoleWithScopes } from '@lightdash/common';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useTableStyles } from '../../../hooks/styles/useTableStyles';
+import { CustomRolesDeleteModal } from './CustomRolesDeleteModal';
+import { CustomRolesEditModal } from './CustomRolesEditModal';
+
+const TableRow: FC<{
+    role: RoleWithScopes;
+    onClickEdit: (role: RoleWithScopes) => void;
+    onClickDelete: (role: RoleWithScopes) => void;
+}> = ({ role, onClickEdit, onClickDelete }) => {
+    const { name, description, createdAt } = role;
+
+    return (
+        <tr>
+            <td>{name}</td>
+            <td>{description || '-'}</td>
+            <td>{createdAt ? formatDate(createdAt) : '-'}</td>
+            <td>
+                <Group spacing="xs" position="right">
+                    <Button
+                        px="xs"
+                        variant="outline"
+                        size="xs"
+                        color="blue"
+                        onClick={() => onClickEdit(role)}
+                    >
+                        <MantineIcon icon={IconEdit} />
+                    </Button>
+                    <Button
+                        px="xs"
+                        variant="outline"
+                        size="xs"
+                        color="red"
+                        onClick={() => onClickDelete(role)}
+                    >
+                        <MantineIcon icon={IconTrash} />
+                    </Button>
+                </Group>
+            </td>
+        </tr>
+    );
+};
+
+type TableProps = {
+    roles: RoleWithScopes[];
+    onDelete: (uuid: string) => void;
+    onEdit: (
+        uuid: string,
+        values: { name: string; description?: string },
+    ) => void;
+    isDeleting: boolean;
+    isEditing: boolean;
+};
+
+export const CustomRolesTable: FC<TableProps> = ({
+    roles,
+    onDelete,
+    onEdit,
+    isDeleting,
+    isEditing,
+}) => {
+    const { classes } = useTableStyles();
+    const [deleteOpened, { open: openDelete, close: closeDelete }] =
+        useDisclosure(false);
+    const [editOpened, { open: openEdit, close: closeEdit }] =
+        useDisclosure(false);
+    const [roleToDelete, setRoleToDelete] = useState<
+        RoleWithScopes | undefined
+    >();
+    const [roleToEdit, setRoleToEdit] = useState<RoleWithScopes | undefined>();
+
+    const handleDelete = async () => {
+        if (roleToDelete) {
+            onDelete(roleToDelete.roleUuid);
+            setRoleToDelete(undefined);
+            closeDelete();
+        }
+    };
+
+    const handleEdit = async (values: {
+        name: string;
+        description?: string;
+    }) => {
+        if (roleToEdit) {
+            onEdit(roleToEdit.roleUuid, values);
+            setRoleToEdit(undefined);
+            closeEdit();
+        }
+    };
+
+    const handleOpenDeleteModal = (role: RoleWithScopes) => {
+        setRoleToDelete(role);
+        openDelete();
+    };
+
+    const handleCloseDeleteModal = () => {
+        setRoleToDelete(undefined);
+        closeDelete();
+    };
+
+    const handleOpenEditModal = (role: RoleWithScopes) => {
+        setRoleToEdit(role);
+        openEdit();
+    };
+
+    const handleCloseEditModal = () => {
+        setRoleToEdit(undefined);
+        closeEdit();
+    };
+
+    return (
+        <>
+            <Paper withBorder>
+                <Table className={classes.root}>
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Description</th>
+                            <th>Created</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {roles.map((role) => (
+                            <TableRow
+                                key={role.roleUuid}
+                                role={role}
+                                onClickEdit={handleOpenEditModal}
+                                onClickDelete={handleOpenDeleteModal}
+                            />
+                        ))}
+                    </tbody>
+                </Table>
+            </Paper>
+
+            {roleToDelete && (
+                <CustomRolesDeleteModal
+                    isOpen={deleteOpened}
+                    onClose={handleCloseDeleteModal}
+                    isDeleting={isDeleting}
+                    onDelete={handleDelete}
+                    role={roleToDelete}
+                />
+            )}
+
+            {roleToEdit && (
+                <CustomRolesEditModal
+                    isOpen={editOpened}
+                    onClose={handleCloseEditModal}
+                    isWorking={isEditing}
+                    onSave={handleEdit}
+                    role={roleToEdit}
+                />
+            )}
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/customRoles/useCustomRoles.ts
+++ b/packages/frontend/src/ee/features/customRoles/useCustomRoles.ts
@@ -1,0 +1,133 @@
+import {
+    type ApiError,
+    type CreateRole,
+    type Role,
+    type RoleWithScopes,
+    type UpdateRole,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { lightdashApi } from '../../../api';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+const CACHE_KEY = 'custom-roles';
+
+export const useCustomRoles = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    const { data: organization } = useOrganization();
+
+    const listRoles = useQuery<RoleWithScopes[], ApiError>({
+        queryKey: [CACHE_KEY, organization?.organizationUuid],
+        queryFn: async () => {
+            if (!organization?.organizationUuid) {
+                throw new Error('Organization UUID not available');
+            }
+
+            return lightdashApi<RoleWithScopes[]>({
+                method: 'GET',
+                url: `/orgs/${organization?.organizationUuid}/roles?roleTypeFilter=user`,
+                version: 'v2',
+            });
+        },
+        enabled: !!organization?.organizationUuid,
+    });
+
+    const createRole = useMutation<Role, ApiError, CreateRole>({
+        mutationKey: [CACHE_KEY],
+        mutationFn: async (newRole: CreateRole) => {
+            if (!organization?.organizationUuid) {
+                throw new Error('Organization UUID not available');
+            }
+            return lightdashApi<Role>({
+                method: 'POST',
+                url: `/orgs/${organization.organizationUuid}/roles`,
+                version: 'v2',
+                body: JSON.stringify(newRole),
+            });
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: [CACHE_KEY, organization?.organizationUuid],
+            });
+            showToastSuccess({
+                title: `Custom role created successfully`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: `Failed to create custom role`,
+                apiError: error,
+            });
+        },
+    });
+
+    const deleteRole = useMutation<undefined, ApiError, string>({
+        mutationFn: async (roleUuid: string) => {
+            if (!organization?.organizationUuid) {
+                throw new Error('Organization UUID not available');
+            }
+            await lightdashApi<undefined>({
+                method: 'DELETE',
+                url: `/orgs/${organization.organizationUuid}/roles/${roleUuid}`,
+                version: 'v2',
+            });
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: [CACHE_KEY, organization?.organizationUuid],
+            });
+            showToastSuccess({
+                title: `Custom role deleted successfully`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: `Failed to delete custom role`,
+                apiError: error,
+            });
+        },
+    });
+
+    const updateRole = useMutation<
+        Role,
+        ApiError,
+        { roleUuid: string; data: UpdateRole }
+    >({
+        mutationFn: async ({ roleUuid, data }) => {
+            if (!organization?.organizationUuid) {
+                throw new Error('Organization UUID not available');
+            }
+            return lightdashApi<Role>({
+                method: 'PATCH',
+                url: `/orgs/${organization.organizationUuid}/roles/${roleUuid}`,
+                version: 'v2',
+                body: JSON.stringify(data),
+            });
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: [CACHE_KEY, organization?.organizationUuid],
+            });
+            showToastSuccess({
+                title: `Custom role updated successfully`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: `Failed to update custom role`,
+                apiError: error,
+            });
+        },
+    });
+
+    return useMemo(() => {
+        return {
+            listRoles,
+            createRole,
+            deleteRole,
+            updateRole,
+        };
+    }, [listRoles, createRole, deleteRole, updateRole]);
+};

--- a/packages/frontend/src/ee/pages/CustomRoles.tsx
+++ b/packages/frontend/src/ee/pages/CustomRoles.tsx
@@ -1,0 +1,84 @@
+import { Button, Group, Stack, Title } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconUserShield } from '@tabler/icons-react';
+
+import { EmptyState } from '../../components/common/EmptyState';
+import MantineIcon from '../../components/common/MantineIcon';
+import PageSpinner from '../../components/PageSpinner';
+import { CustomRolesCreateModal } from '../features/customRoles/CustomRolesCreateModal';
+import { CustomRolesTable } from '../features/customRoles/CustomRolesTable';
+import { useCustomRoles } from '../features/customRoles/useCustomRoles';
+
+export const CustomRoles = () => {
+    const [opened, { open, close }] = useDisclosure(false);
+    const { listRoles, createRole, deleteRole, updateRole } = useCustomRoles();
+
+    const handleSaveRole = async (values: {
+        name: string;
+        description?: string;
+    }) => {
+        await createRole.mutateAsync(values);
+        close();
+    };
+
+    const handleDeleteRole = (uuid: string) => {
+        deleteRole.mutate(uuid);
+    };
+
+    const handleEditRole = (
+        uuid: string,
+        values: { name: string; description?: string },
+    ) => {
+        updateRole.mutate({ roleUuid: uuid, data: values });
+    };
+
+    if (listRoles.isLoading) {
+        return <PageSpinner />;
+    }
+
+    const hasRoles = (listRoles?.data?.length ?? 0) > 0;
+
+    return (
+        <Stack mb="lg">
+            {hasRoles ? (
+                <>
+                    <Group position="apart">
+                        <Title order={5}>Custom roles</Title>
+                        <Button onClick={open} size="xs">
+                            Create custom role
+                        </Button>
+                    </Group>
+                    <CustomRolesTable
+                        roles={listRoles?.data ?? []}
+                        onDelete={handleDeleteRole}
+                        onEdit={handleEditRole}
+                        isDeleting={deleteRole.isLoading}
+                        isEditing={updateRole.isLoading}
+                    />
+                </>
+            ) : (
+                <EmptyState
+                    icon={
+                        <MantineIcon
+                            icon={IconUserShield}
+                            color="gray.6"
+                            stroke={1}
+                            size="5xl"
+                        />
+                    }
+                    title="No custom roles"
+                    description="You haven't created any custom roles yet. Custom roles allow you to define specific permissions for your organization."
+                >
+                    <Button onClick={open}>Create custom role</Button>
+                </EmptyState>
+            )}
+
+            <CustomRolesCreateModal
+                isOpen={opened}
+                onClose={close}
+                onSave={handleSaveRole}
+                isWorking={createRole.isLoading}
+            />
+        </Stack>
+    );
+};

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import {
     IconDatabase,
     IconDatabaseCog,
     IconDatabaseExport,
+    IconIdBadge2,
     IconKey,
     IconLock,
     IconPalette,
@@ -48,6 +49,7 @@ import RouterNavLink from '../components/common/RouterNavLink';
 import { SettingsGridCard } from '../components/common/Settings/SettingsCard';
 import ScimAccessTokensPanel from '../ee/features/scim/components/ScimAccessTokensPanel';
 import { ServiceAccountsPage } from '../ee/features/serviceAccounts';
+import { CustomRoles } from '../ee/pages/CustomRoles';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import {
@@ -55,6 +57,7 @@ import {
     useFeatureFlagEnabled,
 } from '../hooks/useFeatureFlagEnabled';
 import { useProject } from '../hooks/useProject';
+import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import useTracking from '../providers/Tracking/useTracking';
@@ -82,6 +85,8 @@ const Settings: FC = () => {
         },
         user: { data: user, isInitialLoading: isUserLoading, error: userError },
     } = useApp();
+
+    const isCustomRolesEnabled = health?.isCustomRolesEnabled;
 
     const userGroupsFeatureFlagQuery = useFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
@@ -327,6 +332,16 @@ const Settings: FC = () => {
             });
         }
 
+        if (
+            user?.ability.can('manage', 'Organization') &&
+            isCustomRolesEnabled
+        ) {
+            allowedRoutes.push({
+                path: '/customRoles',
+                element: <CustomRoles />,
+            });
+        }
+
         return allowedRoutes;
     }, [
         isServiceAccountsEnabled,
@@ -337,6 +352,7 @@ const Settings: FC = () => {
         organization,
         project,
         health,
+        isCustomRolesEnabled,
     ]);
     const routeElements = useRoutes(routes);
 
@@ -445,6 +461,20 @@ const Settings: FC = () => {
                                             />
                                         }
                                     />
+                                )}
+                                {isCustomRolesEnabled && (
+                                    <Can I="manage" a="Organization">
+                                        <RouterNavLink
+                                            label="Custom roles"
+                                            to="/generalSettings/customRoles"
+                                            exact
+                                            icon={
+                                                <MantineIcon
+                                                    icon={IconIdBadge2}
+                                                />
+                                            }
+                                        />
+                                    </Can>
                                 )}
 
                                 {user.ability.can(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1234

### Description:

This adds just the first iteration of custom roles. We have role management without handling scopes just yet. From here, we'll can iteratively add more capabilities.

We can:

- Create new custom role (just name + description)
- Edit the role
- Delete the role
- View all roles

### CRU

![Screen Cast 2025-08-22 at 5.29.58 PM.gif](https://app.graphite.dev/user-attachments/assets/75422dd6-e95f-4667-baa2-71b7147f3eef.gif)

### Deletes use FK Constraint if Assigned

![Screen Shot 2025-08-22 at 5.32.53 PM.png](https://app.graphite.dev/user-attachments/assets/b73db120-da81-4e85-96ab-4e5e0247b325.png)