### PR TITLE
fix: add file extension to file name

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -65,8 +65,17 @@ export default class EmailClient {
                 ? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
                 : 'text/csv';
 
+        const fileExtension =
+            format === SchedulerFormat.XLSX
+                ? SchedulerFormat.XLSX
+                : SchedulerFormat.CSV;
+
+        const fileName = attachment.filename.endsWith(fileExtension)
+            ? attachment.filename
+            : `${attachment.filename}.${fileExtension}`;
+
         return {
-            filename: attachment.filename,
+            filename: fileName,
             path: attachment.localPath || attachment.path,
             contentType,
         };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixed email attachment file extension handling in the EmailClient. Now the code properly appends the correct file extension (.xlsx or .csv) to attachment filenames when they don't already have the appropriate extension, ensuring that recipients can open the files with the correct applications.