### PR TITLE
feat: generate title for ai agent threads

### DIFF
--- a/packages/backend/src/database/migrations/20250821071500_add_title_to_ai_thread.ts
+++ b/packages/backend/src/database/migrations/20250821071500_add_title_to_ai_thread.ts
@@ -10,7 +10,7 @@ export async function up(knex: Knex): Promise<void> {
     }
 
     await knex.schema.alterTable(AiThreadTableName, (table) => {
-        table.string('title', 255).nullable();
+        table.string('title').nullable();
         table.timestamp('title_generated_at', { useTz: false }).nullable();
     });
 

--- a/packages/backend/src/database/migrations/20250821071500_add_title_to_ai_thread.ts
+++ b/packages/backend/src/database/migrations/20250821071500_add_title_to_ai_thread.ts
@@ -1,0 +1,30 @@
+import { Knex } from 'knex';
+
+const AiThreadTableName = 'ai_thread';
+
+export async function up(knex: Knex): Promise<void> {
+    const hasTitle = await knex.schema.hasColumn(AiThreadTableName, 'title');
+
+    if (hasTitle) {
+        return;
+    }
+
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.string('title', 255).nullable();
+        table.timestamp('title_generated_at', { useTz: false }).nullable();
+    });
+
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.index(['title'], 'ai_thread_title_idx');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(AiThreadTableName, 'title')) {
+        await knex.schema.alterTable(AiThreadTableName, (table) => {
+            table.dropIndex(['title'], 'ai_thread_title_idx');
+            table.dropColumn('title_generated_at');
+            table.dropColumn('title');
+        });
+    }
+}

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -6,6 +6,7 @@ import {
     ApiAiAgentThreadCreateRequest,
     ApiAiAgentThreadCreateResponse,
     ApiAiAgentThreadGenerateResponse,
+    ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
@@ -346,6 +347,34 @@ export class AiAgentController extends BaseController {
             status: 'ok',
             results: {
                 response,
+            },
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/generate-title')
+    @OperationId('generateAgentThreadTitle')
+    async generateAgentThreadTitle(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+    ): Promise<ApiAiAgentThreadGenerateTitleResponse> {
+        this.setStatus(200);
+
+        const title = await this.getAiAgentService().generateThreadTitle(
+            req.user!,
+            {
+                agentUuid,
+                threadUuid,
+            },
+        );
+
+        return {
+            status: 'ok',
+            results: {
+                title,
             },
         };
     }

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -9,6 +9,8 @@ export type DbAiThread = {
     organization_uuid: string;
     project_uuid: string;
     created_from: string; // slack, web, etc
+    title: string | null;
+    title_generated_at: Date | null;
 };
 
 export type AiThreadTable = Knex.CompositeTableType<
@@ -16,6 +18,12 @@ export type AiThreadTable = Knex.CompositeTableType<
     Pick<
         DbAiThread,
         'organization_uuid' | 'project_uuid' | 'created_from' | 'agent_uuid'
+    >,
+    Partial<
+        Pick<
+            DbAiThread,
+            'agent_uuid' | 'title' | 'title_generated_at' | 'project_uuid'
+        >
     >
 >;
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -701,6 +701,8 @@ export class AiAgentModel {
                     | 'agent_uuid'
                     | 'created_at'
                     | 'created_from'
+                    | 'title'
+                    | 'title_generated_at'
                 > &
                     Pick<DbAiPrompt, 'prompt' | 'ai_prompt_uuid'> &
                     Pick<DbUser, 'user_uuid'> &
@@ -712,6 +714,8 @@ export class AiAgentModel {
                 `${AiThreadTableName}.agent_uuid`,
                 `${AiThreadTableName}.created_at`,
                 `${AiThreadTableName}.created_from`,
+                `${AiThreadTableName}.title`,
+                `${AiThreadTableName}.title_generated_at`,
                 `${AiPromptTableName}.prompt`,
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${UserTableName}.user_uuid`,
@@ -741,6 +745,10 @@ export class AiAgentModel {
             agentUuid: row.agent_uuid!,
             createdAt: row.created_at as unknown as string,
             createdFrom: row.created_from,
+            title: row.title,
+            titleGeneratedAt: row.title_generated_at as unknown as
+                | string
+                | null,
             firstMessage: {
                 uuid: row.ai_prompt_uuid,
                 message: row.prompt,
@@ -1994,5 +2002,20 @@ export class AiAgentModel {
             .orderBy(`${AiArtifactsTableName}.created_at`, 'desc');
 
         return results;
+    }
+
+    async updateThreadTitle({
+        threadUuid,
+        title,
+    }: {
+        threadUuid: string;
+        title: string;
+    }): Promise<void> {
+        await this.database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .update({
+                title,
+                title_generated_at: new Date(),
+            });
     }
 }

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -746,9 +746,7 @@ export class AiAgentModel {
             createdAt: row.created_at as unknown as string,
             createdFrom: row.created_from,
             title: row.title,
-            titleGeneratedAt: row.title_generated_at as unknown as
-                | string
-                | null,
+            titleGeneratedAt: row.title_generated_at?.toString() ?? null,
             firstMessage: {
                 uuid: row.ai_prompt_uuid,
                 message: row.prompt,

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -1,11 +1,15 @@
 import { CoreMessage, generateObject, LanguageModelV1 } from 'ai';
 import { z } from 'zod';
 
+const TITLE_MAX_LENGTH_CHARS = 60;
 const TitleSchema = z.object({
     title: z
         .string()
         .min(1, 'Title must not be empty')
-        .max(60, 'Title must be 60 characters or less')
+        .max(
+            TITLE_MAX_LENGTH_CHARS,
+            `Title must be ${TITLE_MAX_LENGTH_CHARS} characters or less`,
+        )
         .describe('A concise, descriptive title for the conversation thread'),
 });
 
@@ -23,15 +27,13 @@ export async function generateThreadTitle(
                 role: 'system',
                 content: `You are a helpful assistant that creates short, descriptive titles for conversations.
 
-Generate a concise title (maximum 60 characters) that summarizes the main topic or question being discussed.
+Generate a concise title (maximum ${TITLE_MAX_LENGTH_CHARS} characters) that summarizes the main topic or question being discussed.
 
 Good examples:
-- "Order data analysis"
-- "Sales performance review" 
-- "Customer insights report"
-- "Revenue trends by region"
-- "Dashboard creation help"
-- "Chart formatting issues"
+- "Order data analysis for last 30 days"
+- "Revenue over last 12 months" 
+- "Avg shipping cost by center for promo express orders"
+- "Top 5 shipping methods by order percentage"
 
 The title should be clear, specific, and helpful for someone browsing a list of conversations.`,
             },
@@ -42,7 +44,6 @@ The title should be clear, specific, and helpful for someone browsing a list of 
             },
             ...messages,
         ],
-        maxTokens: 30,
         temperature: 0.3,
     });
 

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -1,0 +1,50 @@
+import { CoreMessage, generateObject, LanguageModelV1 } from 'ai';
+import { z } from 'zod';
+
+const TitleSchema = z.object({
+    title: z
+        .string()
+        .min(1, 'Title must not be empty')
+        .max(60, 'Title must be 60 characters or less')
+        .describe('A concise, descriptive title for the conversation thread'),
+});
+
+export type GeneratedTitle = z.infer<typeof TitleSchema>;
+
+export async function generateThreadTitle(
+    model: LanguageModelV1,
+    messages: CoreMessage[],
+): Promise<string> {
+    const result = await generateObject({
+        model,
+        schema: TitleSchema,
+        messages: [
+            {
+                role: 'system',
+                content: `You are a helpful assistant that creates short, descriptive titles for conversations.
+
+Generate a concise title (maximum 60 characters) that summarizes the main topic or question being discussed.
+
+Good examples:
+- "Order data analysis"
+- "Sales performance review" 
+- "Customer insights report"
+- "Revenue trends by region"
+- "Dashboard creation help"
+- "Chart formatting issues"
+
+The title should be clear, specific, and helpful for someone browsing a list of conversations.`,
+            },
+            {
+                role: 'user',
+                content:
+                    'Please create a title for this conversation based on the messages.',
+            },
+            ...messages,
+        ],
+        maxTokens: 30,
+        temperature: 0.3,
+    });
+
+    return result.object.title;
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5017,6 +5017,22 @@ const models: TsoaRoute.Models = {
                     },
                     required: true,
                 },
+                titleGeneratedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 createdFrom: { dataType: 'string', required: true },
                 createdAt: { dataType: 'string', required: true },
                 agentUuid: { dataType: 'string', required: true },
@@ -5057,6 +5073,22 @@ const models: TsoaRoute.Models = {
                         message: { dataType: 'string', required: true },
                         uuid: { dataType: 'string', required: true },
                     },
+                    required: true,
+                },
+                titleGeneratedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
                     required: true,
                 },
                 createdFrom: { dataType: 'string', required: true },
@@ -5325,6 +5357,24 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         response: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadGenerateTitleResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        title: { dataType: 'string', required: true },
                     },
                     required: true,
                 },
@@ -21044,6 +21094,78 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'generateAgentThreadResponse',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_generateAgentThreadTitle: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/generate-title',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.generateAgentThreadTitle,
+        ),
+
+        async function AiAgentController_generateAgentThreadTitle(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_generateAgentThreadTitle,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'generateAgentThreadTitle',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5580,6 +5580,14 @@
                         "required": ["message", "uuid"],
                         "type": "object"
                     },
+                    "titleGeneratedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "createdFrom": {
                         "type": "string"
                     },
@@ -5596,6 +5604,8 @@
                 "required": [
                     "user",
                     "firstMessage",
+                    "titleGeneratedAt",
+                    "title",
                     "createdFrom",
                     "createdAt",
                     "agentUuid",
@@ -5637,6 +5647,14 @@
                         "required": ["message", "uuid"],
                         "type": "object"
                     },
+                    "titleGeneratedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "createdFrom": {
                         "type": "string"
                     },
@@ -5653,6 +5671,8 @@
                 "required": [
                     "user",
                     "firstMessage",
+                    "titleGeneratedAt",
+                    "title",
                     "createdFrom",
                     "createdAt",
                     "agentUuid",
@@ -5927,6 +5947,26 @@
                             }
                         },
                         "required": ["response"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadGenerateTitleResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["title"],
                         "type": "object"
                     },
                     "status": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -140,6 +140,8 @@ export type AiAgentThreadSummary<TUser extends AiAgentUser = AiAgentUser> = {
     agentUuid: string;
     createdAt: string;
     createdFrom: string;
+    title: string | null;
+    titleGeneratedAt: string | null;
     firstMessage: {
         uuid: string;
         message: string;
@@ -231,6 +233,13 @@ export type ApiAiAgentThreadGenerateResponse = {
     status: 'ok';
     results: {
         response: string;
+    };
+};
+
+export type ApiAiAgentThreadGenerateTitleResponse = {
+    status: 'ok';
+    results: {
+        title: string;
     };
 };
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -123,10 +123,12 @@ import { type ValidationResponse } from './types/validation';
 import type {
     ApiAiAgentArtifactResponse,
     ApiAiAgentThreadCreateResponse,
+    ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadMessageVizResponse,
     ApiAiAgentThreadResponse,
+    ApiAiAgentThreadSummaryListResponse,
     ApiGetUserAgentPreferencesResponse,
     ApiUpdateUserAgentPreferencesResponse,
     DecodedEmbed,
@@ -940,8 +942,10 @@ type ApiResults =
     | ApiGetProjectParametersListResults
     | ApiAiAgentThreadCreateResponse['results']
     | ApiAiAgentThreadMessageCreateResponse['results']
-    | Account
-    | ApiAiAgentArtifactResponse['results'];
+    | ApiAiAgentArtifactResponse['results']
+    | ApiAiAgentThreadGenerateTitleResponse['results']
+    | ApiAiAgentThreadSummaryListResponse['results']
+    | Account;
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ConversationsList.tsx
@@ -71,7 +71,8 @@ export const ConversationsList: FC<ConversationsListProps> = ({
                                 }}
                             >
                                 <Table.Td>
-                                    {thread.firstMessage.message}
+                                    {thread.title ??
+                                        thread.firstMessage.message}
                                 </Table.Td>
                                 <Table.Td>{thread.user.name}</Table.Td>
                                 <Table.Td>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
@@ -3,6 +3,7 @@ import type {
     ApiAiAgentResponse,
     ApiAiAgentThreadCreateRequest,
     ApiAiAgentThreadCreateResponse,
+    ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQuery,
@@ -264,6 +265,53 @@ const createOptimisticMessages = (
     ];
 };
 
+const generateAgentThreadTitle = async (
+    projectUuid: string,
+    agentUuid: string,
+    threadUuid: string,
+) =>
+    lightdashApi<ApiAiAgentThreadGenerateTitleResponse['results']>({
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/generate-title`,
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+
+export const useGenerateAgentThreadTitleMutation = (
+    projectUuid: string,
+    agentUuid: string,
+) => {
+    const queryClient = useQueryClient();
+    return useMutation<
+        ApiAiAgentThreadGenerateTitleResponse['results'],
+        ApiError,
+        { threadUuid: string }
+    >({
+        mutationFn: ({ threadUuid }) =>
+            generateAgentThreadTitle(projectUuid, agentUuid, threadUuid),
+        onSuccess: (data, { threadUuid }) => {
+            queryClient.setQueryData(
+                [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', 'user'],
+                (
+                    currentData:
+                        | ApiAiAgentThreadSummaryListResponse['results']
+                        | undefined,
+                ) => {
+                    if (!currentData) return currentData;
+                    return currentData.map((thread) =>
+                        thread.uuid === threadUuid
+                            ? { ...thread, title: data.title }
+                            : thread,
+                    );
+                },
+            );
+        },
+        onError: ({ error }) => {
+            // Silently fail - don't show error toast or navigate for background title generation
+            console.warn('Failed to generate thread title:', error);
+        },
+    });
+};
+
 const createAgentThread = async (
     projectUuid: string,
     agentUuid: string | undefined,
@@ -285,6 +333,8 @@ export const useCreateAgentThreadMutation = (
     const { user } = useApp();
     const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
     const { streamMessage } = useAiAgentThreadStreamMutation();
+    const { mutateAsync: generateThreadTitle } =
+        useGenerateAgentThreadTitleMutation(projectUuid!, agentUuid!);
 
     return useMutation<
         ApiAiAgentThreadCreateResponse['results'],
@@ -301,6 +351,8 @@ export const useCreateAgentThreadMutation = (
                 queryKey: [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads'],
             });
 
+            void generateThreadTitle({ threadUuid: thread.uuid });
+
             queryClient.setQueryData(
                 [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', thread.uuid],
                 () => {
@@ -313,6 +365,8 @@ export const useCreateAgentThreadMutation = (
                         firstMessage: thread.firstMessage,
                         agentUuid: agentUuid,
                         uuid: thread.uuid,
+                        title: null,
+                        titleGeneratedAt: null,
                         messages: createOptimisticMessages(
                             thread.uuid,
                             thread.firstMessage.uuid,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useOrganizationAiAgents.ts
@@ -276,7 +276,7 @@ const generateAgentThreadTitle = async (
         body: JSON.stringify({}),
     });
 
-export const useGenerateAgentThreadTitleMutation = (
+const useGenerateAgentThreadTitleMutation = (
     projectUuid: string,
     agentUuid: string,
 ) => {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -64,7 +64,7 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
         })}
         label={
             <Text truncate="end" size="sm" c="gray.7">
-                {thread.firstMessage.message}
+                {thread.title || thread.firstMessage.message}
             </Text>
         }
         active={isActive}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -8,7 +8,6 @@ import {
     useAiAgent,
     useAiAgentThread,
     useCreateAgentThreadMessageMutation,
-    useGenerateAgentThreadTitleMutation,
 } from '../../features/aiCopilot/hooks/useOrganizationAiAgents';
 import { useAiAgentPageLayout } from '../../features/aiCopilot/providers/AiLayoutProvider';
 import { useAiAgentThreadStreaming } from '../../features/aiCopilot/streaming/useAiAgentThreadStreamQuery';
@@ -63,15 +62,10 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         agentUuid,
         threadUuid,
     );
-    const { mutateAsync: generateThreadTitle } =
-        useGenerateAgentThreadTitleMutation(projectUuid!, agentUuid!);
     const isStreaming = useAiAgentThreadStreaming(threadUuid!);
 
     const handleSubmit = (prompt: string) => {
-        void Promise.all([
-            createAgentThreadMessage({ prompt }),
-            generateThreadTitle({ threadUuid: threadUuid! }),
-        ]);
+        void createAgentThreadMessage({ prompt });
     };
 
     if (isLoadingThread || !thread || agentQuery.isLoading) {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -8,6 +8,7 @@ import {
     useAiAgent,
     useAiAgentThread,
     useCreateAgentThreadMessageMutation,
+    useGenerateAgentThreadTitleMutation,
 } from '../../features/aiCopilot/hooks/useOrganizationAiAgents';
 import { useAiAgentPageLayout } from '../../features/aiCopilot/providers/AiLayoutProvider';
 import { useAiAgentThreadStreaming } from '../../features/aiCopilot/streaming/useAiAgentThreadStreamQuery';
@@ -62,10 +63,15 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         agentUuid,
         threadUuid,
     );
+    const { mutateAsync: generateThreadTitle } =
+        useGenerateAgentThreadTitleMutation(projectUuid!, agentUuid!);
     const isStreaming = useAiAgentThreadStreaming(threadUuid!);
 
     const handleSubmit = (prompt: string) => {
-        void createAgentThreadMessage({ prompt });
+        void Promise.all([
+            createAgentThreadMessage({ prompt }),
+            generateThreadTitle({ threadUuid: threadUuid! }),
+        ]);
     };
 
     if (isLoadingThread || !thread || agentQuery.isLoading) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15317
### Description:
Add thread title generation for AI conversations

This PR adds the ability to automatically generate titles for AI agent conversation threads. It includes:

1. A database migration to add `title` and `title_generated_at` columns to the `ai_thread` table
2. A new title generator service that creates concise, descriptive titles (max 60 chars) based on conversation content
3. A new API endpoint to generate titles for existing threads
4. Automatic title generation when creating new threads or adding messages
5. Updated UI to display titles in the conversation list and thread navigation

The titles make it easier for users to identify and navigate between their AI conversations.

![AI Thread Titles](https://placeholder-for-screenshot.com)