### PR TITLE
feat: add permission check for CLI project creation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,7 @@
     ],
     "dependencies": {
         "@actions/core": "^1.11.1",
+        "@casl/ability": "^5.4.3",
         "@lightdash/common": "workspace:*",
         "@lightdash/warehouses": "workspace:*",
         "@types/columnify": "^1.5.1",

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -13,7 +13,7 @@ import { getConfig, setAnswer } from '../config';
 import { getDbtContext } from '../dbt/context';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
-import { lightdashApi } from './dbt/apiClient';
+import { checkProjectCreationPermission, lightdashApi } from './dbt/apiClient';
 import getDbtProfileTargetName from './dbt/getDbtProfileTargetName';
 import { getDbtVersion } from './dbt/getDbtVersion';
 import getWarehouseClient from './dbt/getWarehouseClient';
@@ -81,6 +81,9 @@ type CreateProjectOptions = {
 export const createProject = async (
     options: CreateProjectOptions,
 ): Promise<ApiCreateProjectResults | undefined> => {
+    // Check permissions before proceeding
+    await checkProjectCreationPermission(options.type);
+
     const dbtVersion = await getDbtVersion();
 
     const absoluteProjectPath = path.resolve(options.projectDir);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {
+    ForbiddenError,
     getErrorMessage,
     LightdashError,
     RenameType,
@@ -918,8 +919,21 @@ ${styles.bold('Examples:')}
     .action(diagnosticsHandler);
 
 const errorHandler = (err: Error) => {
-    console.error(styles.error(getErrorMessage(err)));
-    if (err.name === 'AuthorizationError') {
+    // Use error message with fallback for safety
+    const errorMessage = getErrorMessage(err) || 'An unexpected error occurred';
+    console.error(styles.error(errorMessage));
+
+    if (err.name === 'ForbiddenError' || err instanceof ForbiddenError) {
+        // For permission errors, show clear message with fallback
+        const permissionMessage =
+            err.message || "You don't have permission to perform this action";
+        if (permissionMessage !== errorMessage) {
+            console.error(styles.error(permissionMessage));
+        }
+        console.error(
+            `\n💡 Contact your Lightdash administrator to request project creation access or if you believe this is incorrect.\n`,
+        );
+    } else if (err.name === 'AuthorizationError') {
         console.error(
             `Looks like you did not authenticate or the personal access token expired.\n\n👀 See https://docs.lightdash.com/guides/cli/cli-authentication for help and examples`,
         );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,6 +549,9 @@ importers:
       '@actions/core':
         specifier: ^1.11.1
         version: 1.11.1
+      '@casl/ability':
+        specifier: ^5.4.3
+        version: 5.4.4
       '@lightdash/common':
         specifier: workspace:*
         version: link:../common


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/16572

### Description:

Added permission checks to the CLI project creation flow to prevent users from creating projects when they don't have the required permissions. This implements the same CASL-based permission system used in the backend to validate if a user can create projects of a specific type before attempting the operation.

The PR adds:

- Permission validation before project creation attempts
- Improved error handling with helpful messages for permission-related errors
- User-friendly guidance when permission errors occur, directing users to contact their Lightdash administrator
- does not have access to create preview project:

![CleanShot 2025-08-26 at 12.12.27@2x.png](https://app.graphite.dev/user-attachments/assets/98bdf8ff-3fd4-40f4-b2b4-4aa3dd49b4c7.png)

- does not have access to create default project

![CleanShot 2025-08-26 at 12.11.55@2x.png](https://app.graphite.dev/user-attachments/assets/f402db84-3f7d-4eaa-9e05-c325d81ab122.png)

has access to create project

![CleanShot 2025-08-26 at 12.13.37@2x.png](https://app.graphite.dev/user-attachments/assets/1195ae57-39a6-4511-89f1-1aa8de98ee1f.png)