### PR TITLE
feat: allow creating custom metrics on table and viz tool calls

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -10,7 +10,6 @@ import {
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
-    ApiAiAgentThreadMessageVizResponse,
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadSummaryListResponse,
     ApiCreateAiAgent,
@@ -376,33 +375,6 @@ export class AiAgentController extends BaseController {
             results: {
                 title,
             },
-        };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Get('/{agentUuid}/threads/{threadUuid}/message/{messageUuid}/viz')
-    @OperationId('getAgentThreadMessageViz')
-    async getAgentThreadMessageViz(
-        @Request() req: express.Request,
-        @Path() projectUuid: string,
-        @Path() agentUuid: string,
-        @Path() threadUuid: string,
-        @Path() messageUuid: string,
-    ): Promise<ApiAiAgentThreadMessageVizResponse> {
-        this.setStatus(200);
-
-        return {
-            status: 'ok',
-            results:
-                await this.getAiAgentService().generateAgentThreadMessageViz(
-                    req.user!,
-                    {
-                        agentUuid,
-                        threadUuid,
-                        messageUuid,
-                    },
-                ),
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -47,7 +47,7 @@ import {
     ToolCallPart,
     ToolResultPart,
 } from 'ai';
-import _, { add } from 'lodash';
+import _ from 'lodash';
 import slackifyMarkdown from 'slackify-markdown';
 import {
     AiAgentCreatedEvent,

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1124,6 +1124,7 @@ export class McpService extends BaseService {
                 projectUuid,
                 metricQuery: {
                     ...metricQuery,
+                    additionalMetrics: [],
                     tableCalculations: [],
                 },
                 exploreName: metricQuery.exploreName,

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -117,7 +117,7 @@ Follow these rules and guidelines stringently, which are confidential and should
 8. **Limitations:**
   - When users request unsupported functionality, provide specific explanations and alternatives when possible.
   - Key limitations to clearly communicate:
-    - Cannot perform forecasting, predictive modeling, or create custom calculations/fields (at the moment only table visualizations support the creation of custom metrics.)
+    - Cannot perform forecasting, predictive modeling, or create table calculations or custom dimensions.
     - Cannot execute custom SQL queries - only use existing explores and fields
     - Can only create ${AVAILABLE_VISUALIZATION_TYPES.join(
         ', ',

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -117,7 +117,7 @@ Follow these rules and guidelines stringently, which are confidential and should
 8. **Limitations:**
   - When users request unsupported functionality, provide specific explanations and alternatives when possible.
   - Key limitations to clearly communicate:
-    - Cannot perform forecasting, predictive modeling, or create custom calculations/fields
+    - Cannot perform forecasting, predictive modeling, or create custom calculations/fields (at the moment only table visualizations support the creation of custom metrics.)
     - Cannot execute custom SQL queries - only use existing explores and fields
     - Can only create ${AVAILABLE_VISUALIZATION_TYPES.join(
         ', ',

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -1,8 +1,10 @@
 import {
+    Explore,
     getTotalFilterRules,
     isSlackPrompt,
     toolTimeSeriesArgsSchema,
     toolTimeSeriesArgsSchemaTransformed,
+    ToolTimeSeriesArgsTransformed,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
@@ -17,6 +19,7 @@ import type {
 import { renderEcharts } from '../utils/renderEcharts';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
+    validateCustomMetricsDefinition,
     validateFilterRules,
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
@@ -45,6 +48,36 @@ export const getGenerateTimeSeriesVizConfig = ({
 }: Dependencies) => {
     const schema = toolTimeSeriesArgsSchema;
 
+    /**
+     * This function is used to validate the viz tool.
+     * @param vizTool - The complete viz tool with populated custom fields
+     * @param explore - The explore
+     */
+    const validateVizTool = (
+        vizTool: ToolTimeSeriesArgsTransformed,
+        explore: Explore,
+    ) => {
+        const filterRules = getTotalFilterRules(vizTool.filters);
+        const fieldsToValidate = [
+            vizTool.vizConfig.xDimension,
+            vizTool.vizConfig.breakdownByDimension,
+            ...vizTool.vizConfig.yMetrics,
+            ...vizTool.vizConfig.sorts.map((sortField) => sortField.fieldId),
+        ].filter((x) => typeof x === 'string');
+        validateSelectedFieldsExistence(
+            explore,
+            fieldsToValidate,
+            vizTool.customMetrics,
+        );
+        validateCustomMetricsDefinition(explore, vizTool.customMetrics);
+        validateFilterRules(explore, filterRules);
+        // TODO: Enhance filter validation to support custom metrics
+        // Current validateFilterRules and validateMetricDimensionFilterPlacement only validate
+        // against explore fields. We need to extend these validators to also consider custom metrics
+        // when validating filter rules to ensure filters can reference custom metrics appropriately.
+        validateMetricDimensionFilterPlacement(explore, vizTool.filters);
+    };
+
     return tool({
         description: toolTimeSeriesArgsSchema.description,
         parameters: schema,
@@ -55,26 +88,10 @@ export const getGenerateTimeSeriesVizConfig = ({
                 // TODO: common for all viz tools. find a way to reuse this code.
                 const vizTool =
                     toolTimeSeriesArgsSchemaTransformed.parse(toolArgs);
-
-                const filterRules = getTotalFilterRules(vizTool.filters);
-
                 const explore = await getExplore({
                     exploreName: vizTool.vizConfig.exploreName,
                 });
-                const fieldsToValidate = [
-                    vizTool.vizConfig.xDimension,
-                    vizTool.vizConfig.breakdownByDimension,
-                    ...vizTool.vizConfig.yMetrics,
-                    ...vizTool.vizConfig.sorts.map(
-                        (sortField) => sortField.fieldId,
-                    ),
-                ].filter((x) => typeof x === 'string');
-                validateSelectedFieldsExistence(explore, fieldsToValidate);
-                validateFilterRules(explore, filterRules);
-                validateMetricDimensionFilterPlacement(
-                    explore,
-                    vizTool.filters,
-                );
+                validateVizTool(vizTool, explore);
                 // end of TODO
 
                 const prompt = await getPrompt();

--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -60,11 +60,12 @@ export const getRunMetricQuery = ({
                     vizTool.filters,
                 );
 
-                const query = metricQueryTableViz(
-                    vizTool.vizConfig,
-                    vizTool.filters,
+                const query = metricQueryTableViz({
+                    vizConfig: vizTool.vizConfig,
+                    filters: vizTool.filters,
                     maxLimit,
-                );
+                    customMetrics: null,
+                });
 
                 const results = await runMiniMetricQuery(query, maxLimit);
 

--- a/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
+++ b/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
@@ -1,0 +1,50 @@
+import {
+    AdditionalMetric,
+    CustomMetricBaseSchema,
+    getFields,
+    getItemId,
+    type Explore,
+} from '@lightdash/common';
+
+/**
+ * Populates SQL for custom metrics from explore fields
+ * This is needed because custom metrics are stored without SQL for security,
+ * but we need to populate it from the explore when executing queries
+ */
+export function populateCustomMetricsSQL(
+    customMetrics:
+        | (CustomMetricBaseSchema | AdditionalMetric)[]
+        | null
+        | undefined,
+    explore: Explore,
+): AdditionalMetric[] {
+    if (!customMetrics || customMetrics.length === 0) {
+        return [];
+    }
+
+    const exploreFields = getFields(explore);
+
+    return customMetrics.reduce<AdditionalMetric[]>((acc, metric) => {
+        // Find the dimension field to get its SQL
+        const dimensionField = exploreFields.find(
+            (field) =>
+                metric.baseDimensionName &&
+                getItemId(field) ===
+                    getItemId({
+                        table: metric.table,
+                        name: metric.baseDimensionName,
+                    }),
+        );
+
+        if (!dimensionField) {
+            return acc;
+        }
+        return [
+            ...acc,
+            {
+                ...metric,
+                sql: dimensionField.sql,
+            },
+        ];
+    }, []);
+}

--- a/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
+++ b/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
@@ -13,7 +13,7 @@ import {
  */
 export function populateCustomMetricsSQL(
     customMetrics:
-        | (CustomMetricBaseSchema | AdditionalMetric)[]
+        | (CustomMetricBaseSchema | Omit<AdditionalMetric, 'sql'>)[]
         | null
         | undefined,
     explore: Explore,

--- a/packages/backend/src/ee/services/ai/visualizations/vizTable.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizTable.ts
@@ -27,11 +27,12 @@ export const renderTableViz = async ({
     >;
     csv: string;
 }> => {
-    const query = metricQueryTableViz(
-        vizTool.vizConfig,
-        vizTool.filters,
+    const query = metricQueryTableViz({
+        vizConfig: vizTool.vizConfig,
+        filters: vizTool.filters,
         maxLimit,
-    );
+        customMetrics: null, // Will be populated in the backend before running the query
+    });
     const results = await runMetricQuery(query);
 
     const fieldIds = results.rows[0] ? Object.keys(results.rows[0]) : [];

--- a/packages/backend/src/ee/services/ai/visualizations/vizTable.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizTable.ts
@@ -1,4 +1,5 @@
 import {
+    AdditionalMetric,
     AiMetricQueryWithFilters,
     AiResultType,
     getItemLabelWithoutTableName,
@@ -31,7 +32,7 @@ export const renderTableViz = async ({
         vizConfig: vizTool.vizConfig,
         filters: vizTool.filters,
         maxLimit,
-        customMetrics: null, // Will be populated in the backend before running the query
+        customMetrics: vizTool.customMetrics ?? null,
     });
     const results = await runMetricQuery(query);
 

--- a/packages/backend/src/ee/services/ai/visualizations/vizTimeSeries.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizTimeSeries.ts
@@ -95,11 +95,12 @@ export const renderTimeSeriesViz = async ({
     >;
     chartOptions: object;
 }> => {
-    const metricQuery = metricQueryTimeSeriesViz(
-        vizTool.vizConfig,
-        vizTool.filters,
+    const metricQuery = metricQueryTimeSeriesViz({
+        vizConfig: vizTool.vizConfig,
+        filters: vizTool.filters,
         maxLimit,
-    );
+        customMetrics: vizTool.customMetrics ?? null,
+    });
     const results = await runMetricQuery(metricQuery);
     const chartOptions = await echartsConfigTimeSeriesMetric(
         vizTool,

--- a/packages/backend/src/ee/services/ai/visualizations/vizVerticalBar.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizVerticalBar.ts
@@ -3,7 +3,7 @@ import {
     AiResultType,
     MetricQuery,
     metricQueryVerticalBarViz,
-    type ToolVerticalBarArgsTransformed,
+    ToolVerticalBarArgsTransformed,
 } from '@lightdash/common';
 import { ProjectService } from '../../../../services/ProjectService/ProjectService';
 import { getPivotedResults } from '../utils/getPivotedResults';
@@ -94,11 +94,12 @@ export const renderVerticalBarViz = async ({
     metricQuery: AiMetricQueryWithFilters;
     chartOptions: object;
 }> => {
-    const metricQueryWithFilters = metricQueryVerticalBarViz(
-        vizTool.vizConfig,
-        vizTool.filters,
+    const metricQueryWithFilters = metricQueryVerticalBarViz({
+        vizConfig: vizTool.vizConfig,
+        filters: vizTool.filters,
         maxLimit,
-    );
+        customMetrics: vizTool.customMetrics ?? null,
+    });
     const results = await runMetricQuery(metricQueryWithFilters);
     const chartOptions = await echartsConfigVerticalBarMetric(
         vizTool,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5394,93 +5394,6 @@ const models: TsoaRoute.Models = {
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_MetricQuery.metrics-or-dimensions-or-sorts-or-limit-or-exploreName_':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    metrics: {
-                        dataType: 'array',
-                        array: { dataType: 'string' },
-                        required: true,
-                    },
-                    dimensions: {
-                        dataType: 'array',
-                        array: { dataType: 'string' },
-                        required: true,
-                    },
-                    sorts: {
-                        dataType: 'array',
-                        array: { dataType: 'refAlias', ref: 'SortField' },
-                        required: true,
-                    },
-                    limit: { dataType: 'double', required: true },
-                    exploreName: { dataType: 'string', required: true },
-                },
-                validators: {},
-            },
-        },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiMetricQuery: {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_MetricQuery.metrics-or-dimensions-or-sorts-or-limit-or-exploreName_',
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.AnyType_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
-            additionalProperties: { dataType: 'any' },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiAiAgentThreadMessageViz: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        fields: { ref: 'ItemsMap', required: true },
-                        cacheMetadata: { ref: 'CacheMetadata', required: true },
-                        rows: {
-                            dataType: 'array',
-                            array: {
-                                dataType: 'refAlias',
-                                ref: 'Record_string.AnyType_',
-                            },
-                            required: true,
-                        },
-                    },
-                    required: true,
-                },
-                chartOptions: { dataType: 'object' },
-                metricQuery: { ref: 'AiMetricQuery', required: true },
-                type: { ref: 'AiResultType', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiAiAgentThreadMessageVizResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'ApiAiAgentThreadMessageViz', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiExecuteAsyncQueryResultsCommon: {
         dataType: 'refAlias',
         type: {
@@ -9660,6 +9573,16 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.AnyType_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { dataType: 'any' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiJobStatusResponse: {
         dataType: 'refAlias',
         type: {
@@ -12051,7 +11974,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12061,7 +11984,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12071,7 +11994,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -12084,7 +12007,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -16569,23 +16492,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                metrics: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                dimensions: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                sorts: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SortField' },
-                    required: true,
-                },
-                limit: { dataType: 'double', required: true },
-                exploreName: { dataType: 'string', required: true },
                 filters: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -16595,11 +16501,28 @@ const models: TsoaRoute.Models = {
                     },
                     required: true,
                 },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
                 tableCalculations: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'TableCalculation' },
                     required: true,
                 },
+                exploreName: { dataType: 'string', required: true },
+                sorts: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'SortField' },
+                    required: true,
+                },
+                limit: { dataType: 'double', required: true },
                 additionalMetrics: {
                     dataType: 'union',
                     subSchemas: [
@@ -21166,84 +21089,6 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'generateAgentThreadTitle',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiAgentController_getAgentThreadMessageViz: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-        agentUuid: {
-            in: 'path',
-            name: 'agentUuid',
-            required: true,
-            dataType: 'string',
-        },
-        threadUuid: {
-            in: 'path',
-            name: 'threadUuid',
-            required: true,
-            dataType: 'string',
-        },
-        messageUuid: {
-            in: 'path',
-            name: 'messageUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.get(
-        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/message/:messageUuid/viz',
-        ...fetchMiddlewares<RequestHandler>(AiAgentController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiAgentController.prototype.getAgentThreadMessageViz,
-        ),
-
-        async function AiAgentController_getAgentThreadMessageViz(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiAgentController_getAgentThreadMessageViz,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any = await container.get<AiAgentController>(
-                    AiAgentController,
-                );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getAgentThreadMessageViz',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5987,101 +5987,6 @@
                 ],
                 "type": "string"
             },
-            "Pick_MetricQuery.metrics-or-dimensions-or-sorts-or-limit-or-exploreName_": {
-                "properties": {
-                    "metrics": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "dimensions": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "sorts": {
-                        "items": {
-                            "$ref": "#/components/schemas/SortField"
-                        },
-                        "type": "array"
-                    },
-                    "limit": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "exploreName": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "metrics",
-                    "dimensions",
-                    "sorts",
-                    "limit",
-                    "exploreName"
-                ],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "AiMetricQuery": {
-                "$ref": "#/components/schemas/Pick_MetricQuery.metrics-or-dimensions-or-sorts-or-limit-or-exploreName_"
-            },
-            "Record_string.AnyType_": {
-                "properties": {},
-                "additionalProperties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
-            },
-            "ApiAiAgentThreadMessageViz": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "fields": {
-                                "$ref": "#/components/schemas/ItemsMap"
-                            },
-                            "cacheMetadata": {
-                                "$ref": "#/components/schemas/CacheMetadata"
-                            },
-                            "rows": {
-                                "items": {
-                                    "$ref": "#/components/schemas/Record_string.AnyType_"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["fields", "cacheMetadata", "rows"],
-                        "type": "object"
-                    },
-                    "chartOptions": {
-                        "additionalProperties": true,
-                        "type": "object"
-                    },
-                    "metricQuery": {
-                        "$ref": "#/components/schemas/AiMetricQuery"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/AiResultType"
-                    }
-                },
-                "required": ["results", "metricQuery", "type"],
-                "type": "object"
-            },
-            "ApiAiAgentThreadMessageVizResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/ApiAiAgentThreadMessageViz"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
             "ApiExecuteAsyncQueryResultsCommon": {
                 "properties": {
                     "usedParametersValues": {
@@ -10458,6 +10363,12 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "Record_string.AnyType_": {
+                "properties": {},
+                "additionalProperties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
             "ApiJobStatusResponse": {
                 "properties": {
                     "results": {
@@ -12926,22 +12837,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiChartAsCodeListResponse": {
@@ -17402,17 +17313,34 @@
             },
             "Pick_MetricQueryRequest.Exclude_keyofMetricQueryRequest.csvLimit__": {
                 "properties": {
-                    "metrics": {
-                        "items": {
-                            "type": "string"
+                    "filters": {
+                        "properties": {
+                            "tableCalculations": {},
+                            "metrics": {},
+                            "dimensions": {}
                         },
-                        "type": "array"
+                        "type": "object"
                     },
                     "dimensions": {
                         "items": {
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "metrics": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "tableCalculations": {
+                        "items": {
+                            "$ref": "#/components/schemas/TableCalculation"
+                        },
+                        "type": "array"
+                    },
+                    "exploreName": {
+                        "type": "string"
                     },
                     "sorts": {
                         "items": {
@@ -17423,23 +17351,6 @@
                     "limit": {
                         "type": "number",
                         "format": "double"
-                    },
-                    "exploreName": {
-                        "type": "string"
-                    },
-                    "filters": {
-                        "properties": {
-                            "tableCalculations": {},
-                            "metrics": {},
-                            "dimensions": {}
-                        },
-                        "type": "object"
-                    },
-                    "tableCalculations": {
-                        "items": {
-                            "$ref": "#/components/schemas/TableCalculation"
-                        },
-                        "type": "array"
                     },
                     "additionalMetrics": {
                         "items": {
@@ -17473,13 +17384,13 @@
                     }
                 },
                 "required": [
-                    "metrics",
-                    "dimensions",
-                    "sorts",
-                    "limit",
-                    "exploreName",
                     "filters",
-                    "tableCalculations"
+                    "dimensions",
+                    "metrics",
+                    "tableCalculations",
+                    "exploreName",
+                    "sorts",
+                    "limit"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
@@ -18717,7 +18628,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1961.1",
+        "version": "0.1966.4",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { MetricType } from '../../../types/field';
+
+export const customMetricBaseSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")',
+        ),
+    label: z
+        .string()
+        .describe(
+            'Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")',
+        ),
+    baseDimensionName: z
+        .string()
+        .describe(
+            'Name of the base dimension/column this metric calculates from',
+        ),
+    table: z
+        .string()
+        .describe(
+            'Table name where the base column exists. Match with available dimensions in the explore.',
+        ),
+    type: z
+        .enum([
+            MetricType.AVERAGE,
+            MetricType.COUNT,
+            MetricType.COUNT_DISTINCT,
+            MetricType.MAX,
+            MetricType.MIN,
+            MetricType.SUM,
+            MetricType.PERCENTILE,
+            MetricType.MEDIAN,
+        ])
+        .describe(
+            `Choose based on the user's request. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If the base dimension type is NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If the base dimension type is BOOLEAN, use COUNT_DISTINCT, COUNT.`,
+        ),
+});
+
+export type CustomMetricBaseSchema = z.infer<typeof customMetricBaseSchema>;
+
+export const customMetricsSchema = z
+    .array(customMetricBaseSchema)
+    .nullable()
+    .describe(
+        `Create custom metrics when requested metrics don't exist. Only create if no existing metric matches the user's request. Use null if no custom metrics needed.
+                
+                IMPORTANT: If the user requests metrics that don't exist (like "average customer age"), create them using the customMetrics field. Analyze available dimensions from findFields results and create appropriate SQL aggregations.
+
+                When using custom metrics:
+                1. Create the metric in customMetrics array with just the metric name (e.g., "avg_customer_age")
+                2. Reference it in metrics array using the format "table_metricname" (e.g., "customers_avg_customer_age")
+                3. Reference it in sorts array using the format "table_metricname" (e.g., "customers_avg_customer_age")
+                4. DO NOT use the raw metric name in metrics or sorts arrays
+
+                For example:
+                - "Show me average customer age sorted descending" → 
+                customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
+                metrics: ["customers_avg_customer_age"]
+                sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
+    );

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -9,6 +9,7 @@ import {
     toolVerticalBarArgsSchema,
 } from './tools';
 
+export * from './customMetrics';
 export * from './filters';
 export * from './tools';
 export * from './visualizations';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MetricType } from '../../../../types/field';
 import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
@@ -6,7 +7,46 @@ import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import { tableVizConfigSchema } from '../visualizations';
 
-export const TOOL_TABLE_VIZ_DESCRIPTION = `Use this tool to query data to display in a table or summarized if limit is set to 1.`;
+const customMetricBaseSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")',
+        ),
+    label: z
+        .string()
+        .describe(
+            'Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")',
+        ),
+    baseDimensionName: z
+        .string()
+        .describe(
+            'Name of the base dimension/column this metric calculates from',
+        ),
+    table: z
+        .string()
+        .describe(
+            'Table name where the base column exists. Match with available dimensions in the explore.',
+        ),
+    type: z
+        .enum([
+            MetricType.AVERAGE,
+            MetricType.COUNT,
+            MetricType.COUNT_DISTINCT,
+            MetricType.MAX,
+            MetricType.MIN,
+            MetricType.SUM,
+            MetricType.PERCENTILE,
+            MetricType.MEDIAN,
+        ])
+        .describe(
+            `Choose based on the user's request. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If the base dimension type is NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If the base dimension type is BOOLEAN, use COUNT_DISTINCT, COUNT.`,
+        ),
+});
+
+export type CustomMetricBaseSchema = z.infer<typeof customMetricBaseSchema>;
+
+const TOOL_TABLE_VIZ_DESCRIPTION = `Use this tool to query data to display in a table or summarized if limit is set to 1.`;
 
 export const toolTableVizArgsSchema = createToolSchema(
     AiResultType.TABLE_RESULT,
@@ -14,12 +54,33 @@ export const toolTableVizArgsSchema = createToolSchema(
 )
     .extend({
         ...visualizationMetadataSchema.shape,
+        customMetrics: z
+            .array(customMetricBaseSchema)
+            .nullable()
+            .describe(
+                `Create custom metrics when requested metrics don't exist. Only create if no existing metric matches the user's request. Use null if no custom metrics needed.
+                
+                IMPORTANT: If the user requests metrics that don't exist (like "average customer age"), create them using the customMetrics field. Analyze available dimensions from findFields results and create appropriate SQL aggregations.
+
+                When using custom metrics:
+                1. Create the metric in customMetrics array with just the metric name (e.g., "avg_customer_age")
+                2. Reference it in metrics array using the format "table_metricname" (e.g., "customers_avg_customer_age")
+                3. Reference it in sorts array using the format "table_metricname" (e.g., "customers_avg_customer_age")
+                4. DO NOT use the raw metric name in metrics or sorts arrays
+
+                For example:
+                - "Show me average customer age sorted descending" → 
+                customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
+                metrics: ["customers_avg_customer_age"]
+                sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
+            ),
         vizConfig: tableVizConfigSchema,
         filters: filtersSchema
             .nullable()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore.',
             ),
+
         followUpTools: z
             .array(
                 z.union([

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -1,52 +1,13 @@
 import { z } from 'zod';
-import { MetricType } from '../../../../types/field';
 import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
+import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import { tableVizConfigSchema } from '../visualizations';
 
-const customMetricBaseSchema = z.object({
-    name: z
-        .string()
-        .describe(
-            'Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")',
-        ),
-    label: z
-        .string()
-        .describe(
-            'Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")',
-        ),
-    baseDimensionName: z
-        .string()
-        .describe(
-            'Name of the base dimension/column this metric calculates from',
-        ),
-    table: z
-        .string()
-        .describe(
-            'Table name where the base column exists. Match with available dimensions in the explore.',
-        ),
-    type: z
-        .enum([
-            MetricType.AVERAGE,
-            MetricType.COUNT,
-            MetricType.COUNT_DISTINCT,
-            MetricType.MAX,
-            MetricType.MIN,
-            MetricType.SUM,
-            MetricType.PERCENTILE,
-            MetricType.MEDIAN,
-        ])
-        .describe(
-            `Choose based on the user's request. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If the base dimension type is NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If the base dimension type is BOOLEAN, use COUNT_DISTINCT, COUNT.`,
-        ),
-});
-
-export type CustomMetricBaseSchema = z.infer<typeof customMetricBaseSchema>;
-
-const TOOL_TABLE_VIZ_DESCRIPTION = `Use this tool to query data to display in a table or summarized if limit is set to 1.`;
+export const TOOL_TABLE_VIZ_DESCRIPTION = `Use this tool to query data to display in a table or summarized if limit is set to 1.`;
 
 export const toolTableVizArgsSchema = createToolSchema(
     AiResultType.TABLE_RESULT,
@@ -54,33 +15,13 @@ export const toolTableVizArgsSchema = createToolSchema(
 )
     .extend({
         ...visualizationMetadataSchema.shape,
-        customMetrics: z
-            .array(customMetricBaseSchema)
-            .nullable()
-            .describe(
-                `Create custom metrics when requested metrics don't exist. Only create if no existing metric matches the user's request. Use null if no custom metrics needed.
-                
-                IMPORTANT: If the user requests metrics that don't exist (like "average customer age"), create them using the customMetrics field. Analyze available dimensions from findFields results and create appropriate SQL aggregations.
-
-                When using custom metrics:
-                1. Create the metric in customMetrics array with just the metric name (e.g., "avg_customer_age")
-                2. Reference it in metrics array using the format "table_metricname" (e.g., "customers_avg_customer_age")
-                3. Reference it in sorts array using the format "table_metricname" (e.g., "customers_avg_customer_age")
-                4. DO NOT use the raw metric name in metrics or sorts arrays
-
-                For example:
-                - "Show me average customer age sorted descending" → 
-                customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
-                metrics: ["customers_avg_customer_age"]
-                sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
-            ),
+        customMetrics: customMetricsSchema,
         vizConfig: tableVizConfigSchema,
         filters: filtersSchema
             .nullable()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore.',
             ),
-
         followUpTools: z
             .array(
                 z.union([
@@ -96,8 +37,12 @@ export const toolTableVizArgsSchema = createToolSchema(
 
 export type ToolTableVizArgs = z.infer<typeof toolTableVizArgsSchema>;
 
-export const toolTableVizArgsSchemaTransformed =
-    toolTableVizArgsSchema.transform((data) => ({
+export const toolTableVizArgsSchemaTransformed = toolTableVizArgsSchema
+    .extend({
+        // backwards compatibility for old viz configs without customMetrics
+        customMetrics: customMetricsSchema.default(null),
+    })
+    .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
     }));

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
+import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
@@ -14,6 +15,7 @@ export const toolTimeSeriesArgsSchema = createToolSchema(
 )
     .extend({
         ...visualizationMetadataSchema.shape,
+        customMetrics: customMetricsSchema,
         vizConfig: timeSeriesMetricVizConfigSchema,
         filters: filtersSchema
             .nullable()
@@ -42,6 +44,8 @@ export const toolTimeSeriesArgsSchemaTransformed = toolTimeSeriesArgsSchema
             xAxisLabel: z.string().default(''),
             yAxisLabel: z.string().default(''),
         }),
+        // backwards compatibility for old viz configs without customMetrics
+        customMetrics: customMetricsSchema.default(null),
     })
     .transform((data) => ({
         ...data,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
+import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
@@ -14,6 +15,7 @@ export const toolVerticalBarArgsSchema = createToolSchema(
 )
     .extend({
         ...visualizationMetadataSchema.shape,
+        customMetrics: customMetricsSchema,
         vizConfig: verticalBarMetricVizConfigSchema,
         filters: filtersSchema
             .nullable()
@@ -35,8 +37,12 @@ export const toolVerticalBarArgsSchema = createToolSchema(
 
 export type ToolVerticalBarArgs = z.infer<typeof toolVerticalBarArgsSchema>;
 
-export const toolVerticalBarArgsSchemaTransformed =
-    toolVerticalBarArgsSchema.transform((data) => ({
+export const toolVerticalBarArgsSchemaTransformed = toolVerticalBarArgsSchema
+    .extend({
+        // backwards compatibility for old viz configs without customMetrics
+        customMetrics: customMetricsSchema.default(null),
+    })
+    .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
     }));

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import type { Filters } from '../../../../types/filter';
-import type { AdditionalMetric } from '../../../../types/metricQuery';
 import type { AiMetricQueryWithFilters } from '../../types';
 import { getValidAiQueryLimit } from '../../validators';
 import { getFieldIdSchema } from '../fieldId';
 import sortFieldSchema from '../sortField';
+import type { ToolTableVizArgsTransformed } from '../tools';
 
 export const tableVizConfigSchema = z
     .object({
@@ -49,7 +49,7 @@ export const metricQueryTableViz = ({
     vizConfig: TableVizConfigSchemaType;
     filters: Filters;
     maxLimit: number;
-    customMetrics: AdditionalMetric[] | null;
+    customMetrics: ToolTableVizArgsTransformed['customMetrics'] | null;
 }): AiMetricQueryWithFilters => ({
     exploreName: vizConfig.exploreName,
     metrics: vizConfig.metrics,
@@ -60,5 +60,5 @@ export const metricQueryTableViz = ({
     })),
     limit: getValidAiQueryLimit(vizConfig.limit, maxLimit),
     filters,
-    additionalMetrics: customMetrics ?? undefined,
+    additionalMetrics: customMetrics ?? [],
 });

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { Filters } from '../../../../types/filter';
+import type { AdditionalMetric } from '../../../../types/metricQuery';
 import type { AiMetricQueryWithFilters } from '../../types';
 import { getValidAiQueryLimit } from '../../validators';
 import { getFieldIdSchema } from '../fieldId';
@@ -39,11 +40,17 @@ export const tableVizConfigSchema = z
 
 export type TableVizConfigSchemaType = z.infer<typeof tableVizConfigSchema>;
 
-export const metricQueryTableViz = (
-    vizConfig: TableVizConfigSchemaType,
-    filters: Filters,
-    maxLimit: number,
-): AiMetricQueryWithFilters => ({
+export const metricQueryTableViz = ({
+    vizConfig,
+    filters,
+    maxLimit,
+    customMetrics,
+}: {
+    vizConfig: TableVizConfigSchemaType;
+    filters: Filters;
+    maxLimit: number;
+    customMetrics: AdditionalMetric[] | null;
+}): AiMetricQueryWithFilters => ({
     exploreName: vizConfig.exploreName,
     metrics: vizConfig.metrics,
     dimensions: vizConfig.dimensions || [],
@@ -53,4 +60,5 @@ export const metricQueryTableViz = (
     })),
     limit: getValidAiQueryLimit(vizConfig.limit, maxLimit),
     filters,
+    additionalMetrics: customMetrics ?? undefined,
 });

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
@@ -5,6 +5,7 @@ import type { AiMetricQueryWithFilters } from '../../types';
 import { getValidAiQueryLimit } from '../../validators';
 import { getFieldIdSchema } from '../fieldId';
 import sortFieldSchema from '../sortField';
+import type { ToolTimeSeriesArgsTransformed } from '../tools';
 
 export const timeSeriesMetricVizConfigSchema = z.object({
     exploreName: z
@@ -55,11 +56,17 @@ export type TimeSeriesMetricVizConfigSchemaType = z.infer<
     typeof timeSeriesMetricVizConfigSchema
 >;
 
-export const metricQueryTimeSeriesViz = (
-    vizConfig: TimeSeriesMetricVizConfigSchemaType,
-    filters: Filters,
-    maxLimit: number,
-): AiMetricQueryWithFilters => {
+export const metricQueryTimeSeriesViz = ({
+    vizConfig,
+    filters,
+    maxLimit,
+    customMetrics,
+}: {
+    vizConfig: TimeSeriesMetricVizConfigSchemaType;
+    filters: Filters;
+    maxLimit: number;
+    customMetrics: ToolTimeSeriesArgsTransformed['customMetrics'] | null;
+}): AiMetricQueryWithFilters => {
     const metrics = vizConfig.yMetrics;
     const dimensions = [
         vizConfig.xDimension,
@@ -79,5 +86,6 @@ export const metricQueryTimeSeriesViz = (
         })),
         exploreName: vizConfig.exploreName,
         filters,
+        additionalMetrics: customMetrics ?? [],
     };
 };

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
@@ -5,6 +5,7 @@ import type { AiMetricQueryWithFilters } from '../../types';
 import { getValidAiQueryLimit } from '../../validators';
 import { getFieldIdSchema } from '../fieldId';
 import sortFieldSchema from '../sortField';
+import type { ToolVerticalBarArgsTransformed } from '../tools';
 
 export const verticalBarMetricVizConfigSchema = z.object({
     exploreName: z
@@ -63,11 +64,17 @@ export type VerticalBarMetricVizConfigSchemaType = z.infer<
     typeof verticalBarMetricVizConfigSchema
 >;
 
-export const metricQueryVerticalBarViz = (
-    vizConfig: VerticalBarMetricVizConfigSchemaType,
-    filters: Filters,
-    maxLimit: number,
-): AiMetricQueryWithFilters => {
+export const metricQueryVerticalBarViz = ({
+    vizConfig,
+    filters,
+    maxLimit,
+    customMetrics,
+}: {
+    vizConfig: VerticalBarMetricVizConfigSchemaType;
+    filters: Filters;
+    maxLimit: number;
+    customMetrics: ToolVerticalBarArgsTransformed['customMetrics'] | null;
+}): AiMetricQueryWithFilters => {
     const metrics = vizConfig.yMetrics;
     const dimensions = [
         vizConfig.xDimension,
@@ -86,5 +93,6 @@ export const metricQueryVerticalBarViz = (
         })),
         exploreName: vizConfig.exploreName,
         filters,
+        additionalMetrics: customMetrics ?? [],
     };
 };

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -1,5 +1,5 @@
 import type { Filters } from '../../types/filter';
-import type { MetricQuery } from '../../types/metricQuery';
+import type { AdditionalMetric, MetricQuery } from '../../types/metricQuery';
 import type {
     ToolTableVizArgs,
     ToolTimeSeriesArgs,
@@ -15,13 +15,10 @@ export enum AiResultType {
 
 export type AiMetricQuery = Pick<
     MetricQuery,
-    | 'metrics'
-    | 'dimensions'
-    | 'sorts'
-    | 'limit'
-    | 'exploreName'
-    | 'additionalMetrics'
->;
+    'metrics' | 'dimensions' | 'sorts' | 'limit' | 'exploreName'
+> & {
+    additionalMetrics: Omit<AdditionalMetric, 'sql'>[];
+};
 
 export type AiMetricQueryWithFilters = AiMetricQuery & {
     filters: Filters;

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -15,7 +15,12 @@ export enum AiResultType {
 
 export type AiMetricQuery = Pick<
     MetricQuery,
-    'metrics' | 'dimensions' | 'sorts' | 'limit' | 'exploreName'
+    | 'metrics'
+    | 'dimensions'
+    | 'sorts'
+    | 'limit'
+    | 'exploreName'
+    | 'additionalMetrics'
 >;
 
 export type AiMetricQueryWithFilters = AiMetricQuery & {

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -54,11 +54,12 @@ export const parseVizConfig = (
         toolTableVizArgsSchemaTransformed.safeParse(vizConfigUnknown);
     if (toolTableVizArgsParsed.success) {
         const vizTool = toolTableVizArgsParsed.data;
-        const metricQuery = metricQueryTableViz(
-            vizTool.vizConfig,
-            vizTool.filters,
-            maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
-        );
+        const metricQuery = metricQueryTableViz({
+            vizConfig: vizTool.vizConfig,
+            filters: vizTool.filters,
+            maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
+            customMetrics: null, // Will be populated in the backend before running the query
+        });
         return {
             type: AiResultType.TABLE_RESULT,
             vizTool,

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -22,11 +22,12 @@ export const parseVizConfig = (
 
     if (toolVerticalBarArgsParsed.success) {
         const vizTool = toolVerticalBarArgsParsed.data;
-        const metricQuery = metricQueryVerticalBarViz(
-            vizTool.vizConfig,
-            vizTool.filters,
-            maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
-        );
+        const metricQuery = metricQueryVerticalBarViz({
+            vizConfig: vizTool.vizConfig,
+            filters: vizTool.filters,
+            maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
+            customMetrics: vizTool.customMetrics ?? null,
+        });
         return {
             type: AiResultType.VERTICAL_BAR_RESULT,
             vizTool,
@@ -38,11 +39,12 @@ export const parseVizConfig = (
         toolTimeSeriesArgsSchemaTransformed.safeParse(vizConfigUnknown);
     if (toolTimeSeriesArgsParsed.success) {
         const vizTool = toolTimeSeriesArgsParsed.data;
-        const metricQuery = metricQueryTimeSeriesViz(
-            vizTool.vizConfig,
-            vizTool.filters,
-            maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
-        );
+        const metricQuery = metricQueryTimeSeriesViz({
+            vizConfig: vizTool.vizConfig,
+            filters: vizTool.filters,
+            maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
+            customMetrics: vizTool.customMetrics ?? null,
+        });
         return {
             type: AiResultType.TIME_SERIES_RESULT,
             vizTool,
@@ -58,7 +60,7 @@ export const parseVizConfig = (
             vizConfig: vizTool.vizConfig,
             filters: vizTool.filters,
             maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
-            customMetrics: null, // Will be populated in the backend before running the query
+            customMetrics: vizTool.customMetrics ?? null,
         });
         return {
             type: AiResultType.TABLE_RESULT,

--- a/packages/common/src/utils/additionalMetrics.ts
+++ b/packages/common/src/utils/additionalMetrics.ts
@@ -1,6 +1,6 @@
 import { convertColumnMetric } from '../types/dbt';
 import { type CompiledTable } from '../types/explore';
-import { type Metric } from '../types/field';
+import { DimensionType, MetricType, type Metric } from '../types/field';
 import { type AdditionalMetric } from '../types/metricQuery';
 
 type ConvertAdditionalMetricArgs = {
@@ -29,4 +29,38 @@ export const convertAdditionalMetric = ({
             formatOptions: additionalMetric.formatOptions,
         }),
     };
+};
+
+/**
+ * Get the custom metric types for a given dimension type
+ * @param type
+ * @returns
+ */
+export const getCustomMetricType = (type: DimensionType): MetricType[] => {
+    switch (type) {
+        case DimensionType.STRING:
+        case DimensionType.TIMESTAMP:
+        case DimensionType.DATE:
+            return [
+                MetricType.COUNT_DISTINCT,
+                MetricType.COUNT,
+                MetricType.MIN,
+                MetricType.MAX,
+            ];
+        case DimensionType.NUMBER:
+            return [
+                MetricType.MIN,
+                MetricType.MAX,
+                MetricType.SUM,
+                MetricType.PERCENTILE,
+                MetricType.MEDIAN,
+                MetricType.AVERAGE,
+                MetricType.COUNT_DISTINCT,
+                MetricType.COUNT,
+            ];
+        case DimensionType.BOOLEAN:
+            return [MetricType.COUNT_DISTINCT, MetricType.COUNT];
+        default:
+            return [];
+    }
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -1,8 +1,8 @@
 import {
     DimensionType,
     FeatureFlags,
-    MetricType,
     friendlyName,
+    getCustomMetricType,
     getItemId,
     isAdditionalMetric,
     isCustomDimension,
@@ -35,35 +35,6 @@ import useExplorerContext from '../../../../../providers/Explorer/useExplorerCon
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import MantineIcon from '../../../../common/MantineIcon';
-
-const getCustomMetricType = (type: DimensionType): MetricType[] => {
-    switch (type) {
-        case DimensionType.STRING:
-        case DimensionType.TIMESTAMP:
-        case DimensionType.DATE:
-            return [
-                MetricType.COUNT_DISTINCT,
-                MetricType.COUNT,
-                MetricType.MIN,
-                MetricType.MAX,
-            ];
-        case DimensionType.NUMBER:
-            return [
-                MetricType.MIN,
-                MetricType.MAX,
-                MetricType.SUM,
-                MetricType.PERCENTILE,
-                MetricType.MEDIAN,
-                MetricType.AVERAGE,
-                MetricType.COUNT_DISTINCT,
-                MetricType.COUNT,
-            ];
-        case DimensionType.BOOLEAN:
-            return [MetricType.COUNT_DISTINCT, MetricType.COUNT];
-        default:
-            return [];
-    }
-};
 
 type Props = {
     item: Metric | Dimension | AdditionalMetric | CustomDimension;

--- a/packages/frontend/src/ee/features/aiCopilot/utils/echarts.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/echarts.ts
@@ -9,7 +9,6 @@ import {
     type MetricQuery,
     type PivotReference,
     type ResultRow,
-    type TableVizConfigSchemaType,
     type TimeSeriesMetricVizConfigSchemaType,
     type VerticalBarMetricVizConfigSchemaType,
 } from '@lightdash/common';
@@ -173,15 +172,9 @@ const getTimeSeriesMetricEchartsConfig = (
     };
 };
 
-const getTableMetricEchartsConfig = (
-    _config: TableVizConfigSchemaType,
-    _rows: Record<string, unknown>[],
-    _metadata: AiVizMetadata,
-): ChartConfig => {
-    return {
-        type: ChartType.TABLE,
-    };
-};
+const getTableMetricEchartsConfig = (): ChartConfig => ({
+    type: ChartType.TABLE,
+});
 
 export const getChartConfigFromAiAgentVizConfig = ({
     vizConfigOutput,
@@ -229,14 +222,7 @@ export const getChartConfigFromAiAgentVizConfig = ({
         case AiResultType.TABLE_RESULT:
             return {
                 ...parsedConfig,
-                echartsConfig: getTableMetricEchartsConfig(
-                    parsedConfig.vizTool.vizConfig,
-                    rows,
-                    {
-                        title: parsedConfig.vizTool.title,
-                        description: parsedConfig.vizTool.description,
-                    },
-                ),
+                echartsConfig: getTableMetricEchartsConfig(),
             };
         default:
             return assertUnreachable(parsedConfig, 'Invalid chart type');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #16586

### Description:

This PR adds support for custom metrics in AI agent queries. Now when users request metrics that don't exist in the data model, the AI agent can create them on-the-fly using the new `additionalMetrics` field.

Key changes:
- Updated the `validateSelectedFieldsExistence` function to check for fields in both the explore **and** additional metrics
- Added `additionalMetrics` to the `AiMetricQuery` type and related schemas
- Enhanced the table visualization tool with documentation on how to create custom metrics

This enables more flexible AI-powered analytics by allowing the creation of custom aggregations based on user requests, even when those metrics aren't predefined in the data model.

![image.png](https://app.graphite.dev/user-attachments/assets/d8c94cc8-3062-4a10-b79f-b1f56007e63c.png)

