### PR TITLE
feat: add duplicate role endpoint

### DIFF
--- a/examples/api/roles.http
+++ b/examples/api/roles.http
@@ -99,6 +99,25 @@ Content-Type: application/json
   ]
 }
 
+### STEP 8b: Duplicate an existing role (creates a new role with the same scopes)
+POST {{baseUrl}}/api/v2/orgs/{{orgId}}/roles/{{roleId}}/duplicate
+Content-Type: application/json
+
+{
+  "name": "Copy of: Senior Data Analyst",
+  "description": "Duplicated role with same permissions as Senior Data Analyst"
+}
+
+### STEP 8c: Duplicate a system role (creates a custom role with the same scopes as the system role)
+# Example: Duplicate the "editor" system role to create a custom variant
+POST {{baseUrl}}/api/v2/orgs/{{orgId}}/roles/editor/duplicate
+Content-Type: application/json
+
+{
+  "name": "Custom Editor",
+  "description": "Custom role based on the editor system role with same initial permissions"
+}
+
 ### STEP 9: Remove a specific scope to restrict permissions
 DELETE {{baseUrl}}/api/v2/orgs/{{orgId}}/roles/{{roleId}}/scopes/manage_space
 

--- a/packages/backend/src/controllers/OrganizationRolesController.ts
+++ b/packages/backend/src/controllers/OrganizationRolesController.ts
@@ -4,6 +4,7 @@ import {
     ApiRoleAssignmentListResponse,
     ApiRoleAssignmentResponse,
     ApiRoleWithScopesResponse,
+    CreateRole,
 } from '@lightdash/common';
 import {
     Body,
@@ -155,6 +156,37 @@ export class OrganizationRolesController extends BaseController {
         return {
             status: 'ok',
             results: assignment,
+        };
+    }
+
+    /**
+     * Duplicate a role
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Role duplicated')
+    @Post('/{roleId}/duplicate')
+    @OperationId('DuplicateRole')
+    async duplicateRole(
+        @Request() req: express.Request,
+        @Path() orgUuid: string,
+        @Path() roleId: string,
+        @Body() body: CreateRole,
+    ): Promise<ApiRoleWithScopesResponse> {
+        const duplicatedRole = await this.getRolesService().duplicateRole(
+            req.account!,
+            orgUuid,
+            roleId,
+            body,
+        );
+
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: duplicatedRole,
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -16208,6 +16208,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                columnIndex: { dataType: 'double' },
                 pivotValues: {
                     dataType: 'array',
                     array: {
@@ -35412,6 +35413,74 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationRolesController_duplicateRole: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        orgUuid: {
+            in: 'path',
+            name: 'orgUuid',
+            required: true,
+            dataType: 'string',
+        },
+        roleId: {
+            in: 'path',
+            name: 'roleId',
+            required: true,
+            dataType: 'string',
+        },
+        body: { in: 'body', name: 'body', required: true, ref: 'CreateRole' },
+    };
+    app.post(
+        '/api/v2/orgs/:orgUuid/roles/:roleId/duplicate',
+        ...fetchMiddlewares<RequestHandler>(OrganizationRolesController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationRolesController.prototype.duplicateRole,
+        ),
+
+        async function OrganizationRolesController_duplicateRole(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationRolesController_duplicateRole,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationRolesController>(
+                        OrganizationRolesController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'duplicateRole',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -17058,6 +17058,10 @@
             },
             "PivotValuesColumn": {
                 "properties": {
+                    "columnIndex": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "pivotValues": {
                         "items": {
                             "properties": {
@@ -18628,7 +18632,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1966.4",
+        "version": "0.1970.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -29204,6 +29208,64 @@
                                 },
                                 "required": ["roleId"],
                                 "type": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/orgs/{orgUuid}/roles/{roleId}/duplicate": {
+            "post": {
+                "operationId": "DuplicateRole",
+                "responses": {
+                    "201": {
+                        "description": "Role duplicated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRoleWithScopesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Duplicate a role",
+                "tags": ["v2", "Organization Roles"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orgUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "roleId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateRole"
                             }
                         }
                     }

--- a/packages/backend/src/services/RolesService/RolesService.mock.ts
+++ b/packages/backend/src/services/RolesService/RolesService.mock.ts
@@ -1,0 +1,165 @@
+import {
+    OrganizationMemberRole,
+    Role,
+    RoleWithScopes,
+    SessionAccount,
+} from '@lightdash/common';
+
+export const mockAccount = {
+    authentication: {
+        type: 'session' as const,
+        source: 'test-session-cookie',
+    },
+    user: {
+        type: 'registered' as const,
+        id: '1',
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        userUuid: 'test-user-uuid',
+        isActive: true,
+        role: OrganizationMemberRole.ADMIN,
+        ability: {
+            can: jest.fn(() => true),
+            cannot: jest.fn(() => false),
+        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        abilityRules: [] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        isSetupComplete: true,
+        userId: 1,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+    },
+    organization: {
+        organizationUuid: 'test-org-uuid',
+        name: 'Test Organization',
+        createdAt: new Date('2024-01-01'),
+    },
+    isAuthenticated: () => true,
+    isRegisteredUser: () => true,
+    isAnonymousUser: () => false,
+    isSessionUser: () => true,
+    isJwtUser: () => false,
+    isServiceAccount: () => false,
+    isPatUser: () => false,
+    isOauthUser: () => false,
+} as SessionAccount;
+
+export const mockAccountNoAccess = {
+    ...mockAccount,
+    user: {
+        ...mockAccount.user,
+        ability: {
+            can: jest.fn(() => false),
+            cannot: jest.fn(() => true),
+        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    },
+} as SessionAccount;
+
+export const mockSystemRole: RoleWithScopes = {
+    roleUuid: 'editor',
+    name: 'editor',
+    description: 'Can edit dashboards and charts',
+    organizationUuid: null,
+    ownerType: 'system',
+    createdBy: null,
+    createdAt: null,
+    updatedAt: null,
+    scopes: [
+        'view:Dashboard',
+        'view:Space',
+        'create:Space',
+        'manage:Job',
+        'manage:PinnedItems',
+    ],
+};
+
+export const mockCustomRole: Role = {
+    roleUuid: 'custom-role-uuid',
+    name: 'Custom Role',
+    description: 'A custom role for testing',
+    organizationUuid: 'test-org-uuid',
+    ownerType: 'user',
+    createdBy: 'test-user-uuid',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+};
+
+export const mockCustomRoleWithScopes: RoleWithScopes = {
+    ...mockCustomRole,
+    scopes: ['view_project', 'view_dashboard', 'manage:Space'],
+};
+
+export const mockNewRole: Role = {
+    roleUuid: 'new-role-uuid',
+    name: 'Duplicated Role',
+    description: null,
+    organizationUuid: 'test-org-uuid',
+    ownerType: 'user',
+    createdBy: 'test-user-uuid',
+    createdAt: new Date('2024-01-02'),
+    updatedAt: new Date('2024-01-02'),
+};
+
+export const mockRolesModel = {
+    getRoleByUuid: jest.fn(),
+    getRoleWithScopesByUuid: jest.fn(),
+    createRole: jest.fn(),
+    addScopesToRole: jest.fn(),
+    getRolesByOrganizationUuid: jest.fn(),
+    getRolesWithScopesByOrganizationUuid: jest.fn(),
+    updateRole: jest.fn(),
+    deleteRole: jest.fn(),
+    removeScopeFromRole: jest.fn(),
+    getOrganizationRoleAssignments: jest.fn(),
+    upsertOrganizationUserRoleAssignment: jest.fn(),
+    upsertSystemRoleProjectAccess: jest.fn(),
+    upsertCustomRoleProjectAccess: jest.fn(),
+    upsertSystemRoleGroupAccess: jest.fn(),
+    upsertCustomRoleGroupAccess: jest.fn(),
+    unassignCustomRoleFromUser: jest.fn(),
+    assignRoleToGroup: jest.fn(),
+    unassignRoleFromGroup: jest.fn(),
+    getProjectAccess: jest.fn(),
+    getGroupProjectAccess: jest.fn(),
+    removeUserProjectAccess: jest.fn(),
+    db: {
+        transaction: jest.fn().mockImplementation(async (callback) =>
+            // Mock transaction by just calling the callback with a mock transaction object
+            callback({}),
+        ),
+    },
+};
+
+export const mockAnalytics = {
+    track: jest.fn(),
+};
+
+export const mockUserModel = {
+    getUserDetailsByUuid: jest.fn().mockResolvedValue({
+        firstName: 'Test',
+        lastName: 'User',
+    }),
+};
+
+export const mockOrganizationModel = {
+    get: jest.fn().mockResolvedValue({
+        organizationUuid: 'test-org-uuid',
+        name: 'Test Organization',
+    }),
+};
+
+export const mockProjectModel = {
+    getSummary: jest.fn().mockResolvedValue({
+        projectUuid: 'test-project-uuid',
+        organizationUuid: 'test-org-uuid',
+    }),
+};
+
+export const mockGroupsModel = {
+    getGroup: jest.fn().mockResolvedValue({
+        groupUuid: 'test-group-uuid',
+        name: 'Test Group',
+    }),
+};

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -1,0 +1,322 @@
+import {
+    CreateRole,
+    ForbiddenError,
+    getSystemRoles,
+    NotFoundError,
+    ParameterError,
+} from '@lightdash/common';
+import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import { LightdashConfig } from '../../config/parseConfig';
+import { GroupsModel } from '../../models/GroupsModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { RolesModel } from '../../models/RolesModel';
+import { UserModel } from '../../models/UserModel';
+import { RolesService } from './RolesService';
+import {
+    mockAccount,
+    mockAccountNoAccess,
+    mockAnalytics,
+    mockCustomRole,
+    mockCustomRoleWithScopes,
+    mockGroupsModel,
+    mockNewRole,
+    mockOrganizationModel,
+    mockProjectModel,
+    mockRolesModel,
+    mockUserModel,
+} from './RolesService.mock';
+
+describe('RolesService', () => {
+    const service = new RolesService({
+        lightdashConfig: {} as LightdashConfig,
+        analytics: mockAnalytics as unknown as LightdashAnalytics,
+        rolesModel: mockRolesModel as unknown as RolesModel,
+        userModel: mockUserModel as unknown as UserModel,
+        organizationModel:
+            mockOrganizationModel as unknown as OrganizationModel,
+        groupsModel: mockGroupsModel as unknown as GroupsModel,
+        projectModel: mockProjectModel as unknown as ProjectModel,
+    });
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('duplicateRole', () => {
+        const organizationUuid = 'test-org-uuid';
+        const newRoleName: CreateRole = {
+            name: 'Duplicated Role',
+            description: 'Duplicated Role Description',
+        };
+
+        describe('when duplicating a system role', () => {
+            const systemRoleId = 'editor';
+
+            beforeEach(() => {
+                // Mock system role exists
+                const systemRoles = getSystemRoles();
+                const systemRole = systemRoles.find(
+                    (r) => r.roleUuid === systemRoleId,
+                );
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue(
+                    systemRole,
+                );
+                mockRolesModel.createRole.mockResolvedValue(mockNewRole);
+            });
+
+            it('should duplicate a system role with a new name', async () => {
+                const result = await service.duplicateRole(
+                    mockAccount,
+                    organizationUuid,
+                    systemRoleId,
+                    newRoleName,
+                );
+
+                // Should create role with the new name
+                expect(mockRolesModel.createRole).toHaveBeenCalledWith(
+                    organizationUuid,
+                    {
+                        name: newRoleName.name,
+                        description: newRoleName.description,
+                        created_by: mockAccount.user?.id,
+                    },
+                    {}, // transaction object
+                );
+
+                // Should add scopes from the system role
+                expect(mockRolesModel.addScopesToRole).toHaveBeenCalledWith(
+                    mockNewRole.roleUuid,
+                    expect.arrayContaining([
+                        'view:Dashboard',
+                        'view:Space',
+                        'create:Space',
+                    ]),
+                    mockAccount.user?.id,
+                    {}, // transaction object
+                );
+
+                // Should track analytics
+                expect(mockAnalytics.track).toHaveBeenNthCalledWith(2, {
+                    event: 'role.duplicated',
+                    userId: mockAccount.user?.id,
+                    properties: expect.objectContaining({
+                        sourceRoleUuid: systemRoleId,
+                        newRoleUuid: mockNewRole.roleUuid,
+                        newRoleName: newRoleName.name,
+                        isSourceSystemRole: true,
+                        organizationUuid,
+                    }),
+                });
+
+                expect(result.roleUuid).toBe(mockNewRole.roleUuid);
+                expect(result.name).toBe(newRoleName.name);
+            });
+
+            it('should handle system role not found', async () => {
+                const nonExistentRoleId = 'non-existent-system-role';
+                // This is not a system role, so it will try to get it as a custom role
+                mockRolesModel.getRoleWithScopesByUuid.mockRejectedValue(
+                    new NotFoundError('Role not found'),
+                );
+
+                await expect(
+                    service.duplicateRole(
+                        mockAccount,
+                        organizationUuid,
+                        nonExistentRoleId,
+                        newRoleName,
+                    ),
+                ).rejects.toThrow(NotFoundError);
+            });
+        });
+
+        describe('when duplicating a custom role', () => {
+            const customRoleId = 'custom-role-uuid';
+
+            beforeEach(() => {
+                mockRolesModel.getRoleByUuid.mockResolvedValue(mockCustomRole);
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue(
+                    mockCustomRoleWithScopes,
+                );
+                mockRolesModel.createRole.mockResolvedValue(mockNewRole);
+            });
+
+            it('should duplicate a custom role with a new name', async () => {
+                const result = await service.duplicateRole(
+                    mockAccount,
+                    organizationUuid,
+                    customRoleId,
+                    newRoleName,
+                );
+
+                // Should validate role ownership
+                expect(
+                    mockRolesModel.getRoleWithScopesByUuid,
+                ).toHaveBeenCalledWith(customRoleId);
+
+                // Should create role with the new name
+                expect(mockRolesModel.createRole).toHaveBeenCalledWith(
+                    organizationUuid,
+                    {
+                        name: newRoleName.name,
+                        description: newRoleName.description,
+                        created_by: mockAccount.user?.id,
+                    },
+                    {}, // transaction object
+                );
+
+                // Should add scopes from the custom role
+                expect(mockRolesModel.addScopesToRole).toHaveBeenCalledWith(
+                    mockNewRole.roleUuid,
+                    mockCustomRoleWithScopes.scopes,
+                    mockAccount.user?.id,
+                    {}, // transaction object
+                );
+
+                // Should track analytics
+                expect(mockAnalytics.track).toHaveBeenNthCalledWith(2, {
+                    event: 'role.duplicated',
+                    userId: mockAccount.user?.id,
+                    properties: expect.objectContaining({
+                        sourceRoleUuid: customRoleId,
+                        newRoleUuid: mockNewRole.roleUuid,
+                        newRoleName: newRoleName.name,
+                        isSourceSystemRole: false,
+                        organizationUuid,
+                    }),
+                });
+
+                expect(result.roleUuid).toBe(mockNewRole.roleUuid);
+                expect(result.name).toBe(newRoleName.name);
+                expect(result.scopes).toEqual(mockCustomRoleWithScopes.scopes);
+            });
+
+            it('should forbid duplicating role from different organization', async () => {
+                const roleFromDifferentOrg = {
+                    ...mockCustomRoleWithScopes,
+                    organizationUuid: 'different-org-uuid',
+                };
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue(
+                    roleFromDifferentOrg,
+                );
+
+                await expect(
+                    service.duplicateRole(
+                        mockAccount,
+                        organizationUuid,
+                        customRoleId,
+                        newRoleName,
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+            });
+        });
+
+        describe('name validation', () => {
+            const roleId = 'editor';
+
+            beforeEach(() => {
+                const systemRoles = getSystemRoles();
+                const systemRole = systemRoles.find(
+                    (r) => r.roleUuid === roleId,
+                );
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue(
+                    systemRole,
+                );
+                mockRolesModel.createRole.mockResolvedValue(mockNewRole);
+            });
+
+            it('should reject empty name', async () => {
+                await expect(
+                    service.duplicateRole(
+                        mockAccount,
+                        organizationUuid,
+                        roleId,
+                        { name: '' },
+                    ),
+                ).rejects.toThrow(ParameterError);
+            });
+
+            it('should reject name with only spaces', async () => {
+                await expect(
+                    service.duplicateRole(
+                        mockAccount,
+                        organizationUuid,
+                        roleId,
+                        { name: '   ' },
+                    ),
+                ).rejects.toThrow(ParameterError);
+                await expect(
+                    service.duplicateRole(
+                        mockAccount,
+                        organizationUuid,
+                        roleId,
+                        { name: '   ' },
+                    ),
+                ).rejects.toThrow('Role name cannot be empty');
+            });
+
+            it('should accept valid name', async () => {
+                const validName = 'Valid Role Name 123';
+                await service.duplicateRole(
+                    mockAccount,
+                    organizationUuid,
+                    roleId,
+                    { name: validName },
+                );
+
+                expect(mockRolesModel.createRole).toHaveBeenCalledWith(
+                    organizationUuid,
+                    expect.objectContaining({
+                        name: validName,
+                    }),
+                    {}, // transaction object
+                );
+            });
+        });
+
+        describe('authorization', () => {
+            const roleId = 'editor';
+
+            beforeEach(() => {
+                const systemRoles = getSystemRoles();
+                const systemRole = systemRoles.find(
+                    (r) => r.roleUuid === roleId,
+                );
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue(
+                    systemRole,
+                );
+                mockRolesModel.createRole.mockResolvedValue(mockNewRole);
+            });
+
+            it('should forbid users from different organization', async () => {
+                const accountDifferentOrg = {
+                    ...mockAccount,
+                    organization: {
+                        ...mockAccount.organization!,
+                        organizationUuid: 'different-org-uuid',
+                    },
+                };
+
+                await expect(
+                    service.duplicateRole(
+                        accountDifferentOrg,
+                        organizationUuid,
+                        roleId,
+                        newRoleName,
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+            });
+
+            it('should forbid users without manage permission', async () => {
+                await expect(
+                    service.duplicateRole(
+                        mockAccountNoAccess,
+                        organizationUuid,
+                        roleId,
+                        newRoleName,
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+            });
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/customRoles/DuplicateRoleModal.tsx
+++ b/packages/frontend/src/ee/features/customRoles/DuplicateRoleModal.tsx
@@ -1,0 +1,157 @@
+import {
+    Button,
+    Group,
+    Modal,
+    Select,
+    Stack,
+    TextInput,
+    Textarea,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { type FC, useMemo } from 'react';
+
+import { type Role, type RoleWithScopes } from '@lightdash/common';
+import { startCase } from 'lodash';
+import { validateRoleName } from './utils/roleValidation';
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    onSubmit: (data: {
+        roleId: string;
+        name: string;
+        description: string;
+    }) => Promise<void>;
+    isSubmitting?: boolean;
+    roles: Role[] | RoleWithScopes[];
+};
+
+type FormData = {
+    roleId: string;
+    name: string;
+    description: string;
+};
+
+export const DuplicateRoleModal: FC<Props> = ({
+    isOpen,
+    onClose,
+    onSubmit,
+    isSubmitting = false,
+    roles,
+}) => {
+    const form = useForm<FormData>({
+        initialValues: {
+            roleId: '',
+            name: '',
+            description: '',
+        },
+        validate: {
+            name: validateRoleName,
+            roleId: (value) => {
+                if (!value) {
+                    return 'Please select a role to duplicate';
+                }
+                return null;
+            },
+        },
+    });
+
+    const rolesSelectData = useMemo(() => {
+        const systemRoles = roles
+            .filter((role) => role.ownerType === 'system')
+            .map((role) => ({
+                value: role.roleUuid,
+                label: startCase(role.name),
+                group: 'System roles',
+            }));
+
+        const customRoles = roles
+            .filter((role) => role.ownerType === 'user')
+            .map((role) => ({
+                value: role.roleUuid,
+                label: role.name,
+                group: 'Custom roles',
+            }));
+
+        return [...systemRoles, ...customRoles];
+    }, [roles]);
+
+    const handleRoleChange = (value: string) => {
+        const selectedRole = roles.find((role) => role.roleUuid === value);
+        if (selectedRole) {
+            form.setFieldValue('name', `Copy of: ${selectedRole.name}`);
+        }
+        form.setFieldValue('roleId', value);
+    };
+
+    const handleSubmit = async (values: FormData) => {
+        await onSubmit(values);
+        form.reset();
+    };
+
+    const handleClose = () => {
+        form.reset();
+        onClose();
+    };
+
+    const getTitle = () => {
+        if (!form.values.roleId) return 'Duplicate role';
+
+        const roleName = rolesSelectData.find(
+            (role) => role.value === form.values.roleId,
+        )?.label;
+
+        return `Duplicate ${roleName} role`;
+    };
+
+    return (
+        <Modal
+            opened={isOpen}
+            onClose={handleClose}
+            title={getTitle()}
+            size="md"
+        >
+            <form onSubmit={form.onSubmit(handleSubmit)}>
+                <Stack>
+                    <Select
+                        label="Select role to duplicate"
+                        placeholder="Choose a role"
+                        searchable
+                        nothingFound="No roles found"
+                        data={rolesSelectData}
+                        required
+                        disabled={isSubmitting}
+                        value={form.values.roleId}
+                        onChange={handleRoleChange}
+                        error={form.errors.roleId}
+                    />
+                    <TextInput
+                        label="New role name"
+                        placeholder="e.g., Finance Analyst"
+                        disabled={isSubmitting}
+                        {...form.getInputProps('name')}
+                    />
+                    <Textarea
+                        label="Description"
+                        placeholder="Describe the purpose of this role"
+                        rows={3}
+                        disabled={isSubmitting}
+                        {...form.getInputProps('description')}
+                    />
+                    <Group position="right" mt="md">
+                        <Button
+                            variant="outline"
+                            onClick={handleClose}
+                            disabled={isSubmitting}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" loading={isSubmitting}>
+                            Duplicate role
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </Modal>
+    );
+};

--- a/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
@@ -2,8 +2,8 @@ import { Button, Group, Stack, TextInput, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 
-import { isSystemRole } from '@lightdash/common';
 import { Link } from 'react-router';
+import { validateRoleName, validateScopes } from '../../utils/roleValidation';
 import { ScopeSelector } from '../ScopeSelector';
 import { type RoleFormValues } from '../types';
 import styles from './RoleBuilder.module.css';
@@ -45,25 +45,8 @@ export const RoleBuilder: FC<Props> = ({
             scopes: initialScopesObject,
         },
         validate: {
-            name: (value) => {
-                if (!value || value.trim().length === 0) {
-                    return 'Role name is required';
-                }
-                if (value.length < 3) {
-                    return 'Role name must be at least 3 characters';
-                }
-                if (isSystemRole(value.toLocaleLowerCase())) {
-                    return 'Role name cannot match a system role';
-                }
-                return null;
-            },
-            scopes: (value) => {
-                const isScopesEmpty = !Object.values(value).some(Boolean);
-                if (isScopesEmpty) {
-                    return 'At least one scope is required';
-                }
-                return null;
-            },
+            name: validateRoleName,
+            scopes: validateScopes,
         },
     });
 

--- a/packages/frontend/src/ee/features/customRoles/utils/roleValidation.ts
+++ b/packages/frontend/src/ee/features/customRoles/utils/roleValidation.ts
@@ -1,0 +1,34 @@
+import { isSystemRole } from '@lightdash/common';
+
+/**
+ * Validates a role name
+ * @param value - The role name to validate
+ * @returns Error message if invalid, null if valid
+ */
+export const validateRoleName = (value: string): string | null => {
+    if (!value || value.trim().length === 0) {
+        return 'Role name is required';
+    }
+    if (value.length < 3) {
+        return 'Role name must be at least 3 characters';
+    }
+    if (isSystemRole(value.toLocaleLowerCase())) {
+        return 'Role name cannot match a system role';
+    }
+    return null;
+};
+
+/**
+ * Validates role scopes
+ * @param value - Object with scope names as keys and boolean values
+ * @returns Error message if invalid, null if valid
+ */
+export const validateScopes = (
+    value: Record<string, boolean>,
+): string | null => {
+    const isScopesEmpty = !Object.values(value).some(Boolean);
+    if (isScopesEmpty) {
+        return 'At least one scope is required';
+    }
+    return null;
+};

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
@@ -1,5 +1,6 @@
-import { Button, Group, Stack, Title } from '@mantine/core';
+import { Button, Group, Menu, Stack, Title } from '@mantine/core';
 import { IconIdBadge2, IconPlus } from '@tabler/icons-react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 
 import { type RoleWithScopes } from '@lightdash/common';
@@ -7,11 +8,14 @@ import { EmptyState } from '../../../components/common/EmptyState';
 import MantineIcon from '../../../components/common/MantineIcon';
 import PageSpinner from '../../../components/PageSpinner';
 import { CustomRolesTable } from '../../features/customRoles/CustomRolesTable';
+import { DuplicateRoleModal } from '../../features/customRoles/DuplicateRoleModal';
 import { useCustomRoles } from '../../features/customRoles/useCustomRoles';
 
 export const CustomRoles = () => {
     const navigate = useNavigate();
-    const { listRoles, deleteRole } = useCustomRoles();
+    const { listRoles, deleteRole, getAllRoles, duplicateRole } =
+        useCustomRoles();
+    const [isDuplicateModalOpen, setIsDuplicateModalOpen] = useState(false);
 
     const handleEditRole = (role: RoleWithScopes) => {
         void navigate(`/generalSettings/customRoles/${role.roleUuid}`);
@@ -19,6 +23,16 @@ export const CustomRoles = () => {
 
     const handleDeleteRole = (uuid: string) => {
         deleteRole.mutate(uuid);
+    };
+
+    const handleDuplicateRole = async (data: {
+        roleId: string;
+        name: string;
+        description: string;
+    }) => {
+        const result = await duplicateRole.mutateAsync(data);
+        setIsDuplicateModalOpen(false);
+        void navigate(`/generalSettings/customRoles/${result.roleUuid}`);
     };
 
     if (listRoles.isLoading) {
@@ -33,14 +47,31 @@ export const CustomRoles = () => {
                 <>
                     <Group position="apart">
                         <Title order={5}>Custom roles</Title>
-                        <Button
-                            component={Link}
-                            to="/generalSettings/customRoles/create"
-                            size="xs"
-                            leftIcon={<MantineIcon icon={IconPlus} />}
-                        >
-                            Create new role
-                        </Button>
+                        <Menu position="bottom-end">
+                            <Menu.Target>
+                                <Button
+                                    size="xs"
+                                    leftIcon={<MantineIcon icon={IconPlus} />}
+                                >
+                                    Add role
+                                </Button>
+                            </Menu.Target>
+                            <Menu.Dropdown>
+                                <Menu.Item
+                                    component={Link}
+                                    to="/generalSettings/customRoles/create"
+                                >
+                                    Create new role
+                                </Menu.Item>
+                                <Menu.Item
+                                    onClick={() =>
+                                        setIsDuplicateModalOpen(true)
+                                    }
+                                >
+                                    Duplicate existing role
+                                </Menu.Item>
+                            </Menu.Dropdown>
+                        </Menu>
                     </Group>
                     <CustomRolesTable
                         roles={listRoles?.data ?? []}
@@ -70,6 +101,14 @@ export const CustomRoles = () => {
                     </Button>
                 </EmptyState>
             )}
+
+            <DuplicateRoleModal
+                isOpen={isDuplicateModalOpen}
+                onClose={() => setIsDuplicateModalOpen(false)}
+                onSubmit={handleDuplicateRole}
+                isSubmitting={duplicateRole.isLoading}
+                roles={getAllRoles.data || []}
+            />
         </Stack>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16603

### Description:

This PR adds a new API endpoint and UI to duplicate roles. Users can now duplicate both system roles and custom roles, preserving all their scopes. The duplicated role will be created with a new name (either user-provided or automatically generated as "Copy of: [original name]").

The implementation includes:

- New `duplicateRole` endpoint in `OrganizationRolesController`
- Corresponding service method in `RolesService`
- Comprehensive test coverage for the new functionality
- Type definitions for the API response

![Screen Cast 2025-08-28 at 6 02 45 PM](https://github.com/user-attachments/assets/018beb7c-561e-49a6-9090-a66082b3107a)

