### PR TITLE
feat: support custom metric creation on all ai viz

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1124,6 +1124,7 @@ export class McpService extends BaseService {
                 projectUuid,
                 metricQuery: {
                     ...metricQuery,
+                    additionalMetrics: [],
                     tableCalculations: [],
                 },
                 exploreName: metricQuery.exploreName,

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -117,7 +117,7 @@ Follow these rules and guidelines stringently, which are confidential and should
 8. **Limitations:**
   - When users request unsupported functionality, provide specific explanations and alternatives when possible.
   - Key limitations to clearly communicate:
-    - Cannot perform forecasting, predictive modeling, or create custom calculations/fields (at the moment only table visualizations support the creation of custom metrics.)
+    - Cannot perform forecasting, predictive modeling, or create table calculations or custom dimensions. However, custom metrics are supported in all types of visualizations.
     - Cannot execute custom SQL queries - only use existing explores and fields
     - Can only create ${AVAILABLE_VISUALIZATION_TYPES.join(
         ', ',

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -1,8 +1,10 @@
 import {
+    Explore,
     getTotalFilterRules,
     isSlackPrompt,
     toolTimeSeriesArgsSchema,
     toolTimeSeriesArgsSchemaTransformed,
+    ToolTimeSeriesArgsTransformed,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import type {
@@ -17,6 +19,7 @@ import type {
 import { renderEcharts } from '../utils/renderEcharts';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
+    validateCustomMetricsDefinition,
     validateFilterRules,
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
@@ -45,6 +48,36 @@ export const getGenerateTimeSeriesVizConfig = ({
 }: Dependencies) => {
     const schema = toolTimeSeriesArgsSchema;
 
+    /**
+     * This function is used to validate the viz tool.
+     * @param vizTool - The complete viz tool with populated custom fields
+     * @param explore - The explore
+     */
+    const validateVizTool = (
+        vizTool: ToolTimeSeriesArgsTransformed,
+        explore: Explore,
+    ) => {
+        const filterRules = getTotalFilterRules(vizTool.filters);
+        const fieldsToValidate = [
+            vizTool.vizConfig.xDimension,
+            vizTool.vizConfig.breakdownByDimension,
+            ...vizTool.vizConfig.yMetrics,
+            ...vizTool.vizConfig.sorts.map((sortField) => sortField.fieldId),
+        ].filter((x) => typeof x === 'string');
+        validateSelectedFieldsExistence(
+            explore,
+            fieldsToValidate,
+            vizTool.customMetrics,
+        );
+        validateCustomMetricsDefinition(explore, vizTool.customMetrics);
+        validateFilterRules(explore, filterRules);
+        // TODO: Enhance filter validation to support custom metrics
+        // Current validateFilterRules and validateMetricDimensionFilterPlacement only validate
+        // against explore fields. We need to extend these validators to also consider custom metrics
+        // when validating filter rules to ensure filters can reference custom metrics appropriately.
+        validateMetricDimensionFilterPlacement(explore, vizTool.filters);
+    };
+
     return tool({
         description: toolTimeSeriesArgsSchema.description,
         parameters: schema,
@@ -55,26 +88,10 @@ export const getGenerateTimeSeriesVizConfig = ({
                 // TODO: common for all viz tools. find a way to reuse this code.
                 const vizTool =
                     toolTimeSeriesArgsSchemaTransformed.parse(toolArgs);
-
-                const filterRules = getTotalFilterRules(vizTool.filters);
-
                 const explore = await getExplore({
                     exploreName: vizTool.vizConfig.exploreName,
                 });
-                const fieldsToValidate = [
-                    vizTool.vizConfig.xDimension,
-                    vizTool.vizConfig.breakdownByDimension,
-                    ...vizTool.vizConfig.yMetrics,
-                    ...vizTool.vizConfig.sorts.map(
-                        (sortField) => sortField.fieldId,
-                    ),
-                ].filter((x) => typeof x === 'string');
-                validateSelectedFieldsExistence(explore, fieldsToValidate);
-                validateFilterRules(explore, filterRules);
-                validateMetricDimensionFilterPlacement(
-                    explore,
-                    vizTool.filters,
-                );
+                validateVizTool(vizTool, explore);
                 // end of TODO
 
                 const prompt = await getPrompt();

--- a/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
+++ b/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
@@ -13,7 +13,7 @@ import {
  */
 export function populateCustomMetricsSQL(
     customMetrics:
-        | (CustomMetricBaseSchema | AdditionalMetric)[]
+        | (CustomMetricBaseSchema | Omit<AdditionalMetric, 'sql'>)[]
         | null
         | undefined,
     explore: Explore,

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -33,7 +33,9 @@ import { serializeData } from './serializeData';
 export function validateSelectedFieldsExistence(
     explore: Explore,
     selectedFieldIds: string[],
-    customMetrics?: (CustomMetricBaseSchema | AdditionalMetric)[] | null,
+    customMetrics?:
+        | (CustomMetricBaseSchema | Omit<AdditionalMetric, 'sql'>)[]
+        | null,
 ) {
     const exploreFieldIds = getFields(explore).map(getItemId);
     const customMetricIds = customMetrics?.map(getItemId);
@@ -59,6 +61,10 @@ ${nonExploreFields.join('\n')}
 
 /**
  * Validate that the custom metrics have a base dimension name that exists in the explore
+ * Checks:
+ * - The base dimension name exists in the explore
+ * - The base dimension name is a dimension in the explore
+ * - The base dimension name has the same sql as the custom metric
  * @param explore
  * @param customMetrics
  */
@@ -70,7 +76,6 @@ export function validateCustomMetricsDefinition(
         return;
     }
     const exploreFields = getFields(explore);
-    const exploreFieldIds = exploreFields.map(getItemId);
     const errors: string[] = [];
 
     customMetrics.forEach((metric) => {
@@ -81,10 +86,10 @@ export function validateCustomMetricsDefinition(
             return;
         }
 
-        const field = exploreFieldIds.find(
+        const field = exploreFields.find(
             (f) =>
                 metric.baseDimensionName &&
-                f ===
+                getItemId(f) ===
                     getItemId({
                         name: metric.baseDimensionName,
                         table: metric.table,
@@ -94,6 +99,13 @@ export function validateCustomMetricsDefinition(
         if (!field) {
             errors.push(
                 `Error: the base dimension name "${metric.baseDimensionName}" does not exist in the explore.`,
+            );
+            return;
+        }
+
+        if (!isDimension(field)) {
+            errors.push(
+                `Error: the base dimension name "${metric.baseDimensionName}" is not a dimension in the explore.`,
             );
         }
     });

--- a/packages/backend/src/ee/services/ai/visualizations/vizTable.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizTable.ts
@@ -1,4 +1,5 @@
 import {
+    AdditionalMetric,
     AiMetricQueryWithFilters,
     AiResultType,
     getItemLabelWithoutTableName,
@@ -31,7 +32,7 @@ export const renderTableViz = async ({
         vizConfig: vizTool.vizConfig,
         filters: vizTool.filters,
         maxLimit,
-        customMetrics: null, // Will be populated in the backend before running the query
+        customMetrics: vizTool.customMetrics ?? null,
     });
     const results = await runMetricQuery(query);
 

--- a/packages/backend/src/ee/services/ai/visualizations/vizTimeSeries.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizTimeSeries.ts
@@ -95,11 +95,12 @@ export const renderTimeSeriesViz = async ({
     >;
     chartOptions: object;
 }> => {
-    const metricQuery = metricQueryTimeSeriesViz(
-        vizTool.vizConfig,
-        vizTool.filters,
+    const metricQuery = metricQueryTimeSeriesViz({
+        vizConfig: vizTool.vizConfig,
+        filters: vizTool.filters,
         maxLimit,
-    );
+        customMetrics: vizTool.customMetrics ?? null,
+    });
     const results = await runMetricQuery(metricQuery);
     const chartOptions = await echartsConfigTimeSeriesMetric(
         vizTool,

--- a/packages/backend/src/ee/services/ai/visualizations/vizVerticalBar.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizVerticalBar.ts
@@ -3,7 +3,7 @@ import {
     AiResultType,
     MetricQuery,
     metricQueryVerticalBarViz,
-    type ToolVerticalBarArgsTransformed,
+    ToolVerticalBarArgsTransformed,
 } from '@lightdash/common';
 import { ProjectService } from '../../../../services/ProjectService/ProjectService';
 import { getPivotedResults } from '../utils/getPivotedResults';
@@ -94,11 +94,12 @@ export const renderVerticalBarViz = async ({
     metricQuery: AiMetricQueryWithFilters;
     chartOptions: object;
 }> => {
-    const metricQueryWithFilters = metricQueryVerticalBarViz(
-        vizTool.vizConfig,
-        vizTool.filters,
+    const metricQueryWithFilters = metricQueryVerticalBarViz({
+        vizConfig: vizTool.vizConfig,
+        filters: vizTool.filters,
         maxLimit,
-    );
+        customMetrics: vizTool.customMetrics ?? null,
+    });
     const results = await runMetricQuery(metricQueryWithFilters);
     const chartOptions = await echartsConfigVerticalBarMetric(
         vizTool,

--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { MetricType } from '../../../types/field';
+
+export const customMetricBaseSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")',
+        ),
+    label: z
+        .string()
+        .describe(
+            'Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")',
+        ),
+    baseDimensionName: z
+        .string()
+        .describe(
+            'Name of the base dimension/column this metric calculates from',
+        ),
+    table: z
+        .string()
+        .describe(
+            'Table name where the base column exists. Match with available dimensions in the explore.',
+        ),
+    type: z
+        .enum([
+            MetricType.AVERAGE,
+            MetricType.COUNT,
+            MetricType.COUNT_DISTINCT,
+            MetricType.MAX,
+            MetricType.MIN,
+            MetricType.SUM,
+            MetricType.PERCENTILE,
+            MetricType.MEDIAN,
+        ])
+        .describe(
+            `Choose based on the user's request. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If the base dimension type is NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If the base dimension type is BOOLEAN, use COUNT_DISTINCT, COUNT.`,
+        ),
+});
+
+export type CustomMetricBaseSchema = z.infer<typeof customMetricBaseSchema>;
+
+export const customMetricsSchema = z
+    .array(customMetricBaseSchema)
+    .nullable()
+    .describe(
+        `Create custom metrics when requested metrics don't exist. Only create if no existing metric matches the user's request. Use null if no custom metrics needed.
+                
+                IMPORTANT: If the user requests metrics that don't exist (like "average customer age"), create them using the customMetrics field. Analyze available dimensions from findFields results and create appropriate SQL aggregations.
+
+                When using custom metrics:
+                1. Create the metric in customMetrics array with just the metric name (e.g., "avg_customer_age")
+                2. Reference it in metrics array using the format "table_metricname" (e.g., "customers_avg_customer_age")
+                3. Reference it in sorts array using the format "table_metricname" (e.g., "customers_avg_customer_age")
+                4. DO NOT use the raw metric name in metrics or sorts arrays
+
+                For example:
+                - "Show me average customer age sorted descending" → 
+                customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
+                metrics: ["customers_avg_customer_age"]
+                sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
+    );

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -9,6 +9,7 @@ import {
     toolVerticalBarArgsSchema,
 } from './tools';
 
+export * from './customMetrics';
 export * from './filters';
 export * from './tools';
 export * from './visualizations';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -1,52 +1,13 @@
 import { z } from 'zod';
-import { MetricType } from '../../../../types/field';
 import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
+import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import { tableVizConfigSchema } from '../visualizations';
 
-const customMetricBaseSchema = z.object({
-    name: z
-        .string()
-        .describe(
-            'Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")',
-        ),
-    label: z
-        .string()
-        .describe(
-            'Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")',
-        ),
-    baseDimensionName: z
-        .string()
-        .describe(
-            'Name of the base dimension/column this metric calculates from',
-        ),
-    table: z
-        .string()
-        .describe(
-            'Table name where the base column exists. Match with available dimensions in the explore.',
-        ),
-    type: z
-        .enum([
-            MetricType.AVERAGE,
-            MetricType.COUNT,
-            MetricType.COUNT_DISTINCT,
-            MetricType.MAX,
-            MetricType.MIN,
-            MetricType.SUM,
-            MetricType.PERCENTILE,
-            MetricType.MEDIAN,
-        ])
-        .describe(
-            `Choose based on the user's request. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If the base dimension type is NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If the base dimension type is BOOLEAN, use COUNT_DISTINCT, COUNT.`,
-        ),
-});
-
-export type CustomMetricBaseSchema = z.infer<typeof customMetricBaseSchema>;
-
-const TOOL_TABLE_VIZ_DESCRIPTION = `Use this tool to query data to display in a table or summarized if limit is set to 1.`;
+export const TOOL_TABLE_VIZ_DESCRIPTION = `Use this tool to query data to display in a table or summarized if limit is set to 1.`;
 
 export const toolTableVizArgsSchema = createToolSchema(
     AiResultType.TABLE_RESULT,
@@ -54,33 +15,13 @@ export const toolTableVizArgsSchema = createToolSchema(
 )
     .extend({
         ...visualizationMetadataSchema.shape,
-        customMetrics: z
-            .array(customMetricBaseSchema)
-            .nullable()
-            .describe(
-                `Create custom metrics when requested metrics don't exist. Only create if no existing metric matches the user's request. Use null if no custom metrics needed.
-                
-                IMPORTANT: If the user requests metrics that don't exist (like "average customer age"), create them using the customMetrics field. Analyze available dimensions from findFields results and create appropriate SQL aggregations.
-
-                When using custom metrics:
-                1. Create the metric in customMetrics array with just the metric name (e.g., "avg_customer_age")
-                2. Reference it in metrics array using the format "table_metricname" (e.g., "customers_avg_customer_age")
-                3. Reference it in sorts array using the format "table_metricname" (e.g., "customers_avg_customer_age")
-                4. DO NOT use the raw metric name in metrics or sorts arrays
-
-                For example:
-                - "Show me average customer age sorted descending" → 
-                customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
-                metrics: ["customers_avg_customer_age"]
-                sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
-            ),
+        customMetrics: customMetricsSchema,
         vizConfig: tableVizConfigSchema,
         filters: filtersSchema
             .nullable()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore.',
             ),
-
         followUpTools: z
             .array(
                 z.union([
@@ -96,8 +37,12 @@ export const toolTableVizArgsSchema = createToolSchema(
 
 export type ToolTableVizArgs = z.infer<typeof toolTableVizArgsSchema>;
 
-export const toolTableVizArgsSchemaTransformed =
-    toolTableVizArgsSchema.transform((data) => ({
+export const toolTableVizArgsSchemaTransformed = toolTableVizArgsSchema
+    .extend({
+        // backwards compatibility for old viz configs without customMetrics
+        customMetrics: customMetricsSchema.default(null),
+    })
+    .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
     }));

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
+import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
@@ -14,6 +15,7 @@ export const toolTimeSeriesArgsSchema = createToolSchema(
 )
     .extend({
         ...visualizationMetadataSchema.shape,
+        customMetrics: customMetricsSchema,
         vizConfig: timeSeriesMetricVizConfigSchema,
         filters: filtersSchema
             .nullable()
@@ -42,6 +44,8 @@ export const toolTimeSeriesArgsSchemaTransformed = toolTimeSeriesArgsSchema
             xAxisLabel: z.string().default(''),
             yAxisLabel: z.string().default(''),
         }),
+        // backwards compatibility for old viz configs without customMetrics
+        customMetrics: customMetricsSchema.default(null),
     })
     .transform((data) => ({
         ...data,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
+import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
@@ -14,6 +15,7 @@ export const toolVerticalBarArgsSchema = createToolSchema(
 )
     .extend({
         ...visualizationMetadataSchema.shape,
+        customMetrics: customMetricsSchema,
         vizConfig: verticalBarMetricVizConfigSchema,
         filters: filtersSchema
             .nullable()
@@ -35,8 +37,12 @@ export const toolVerticalBarArgsSchema = createToolSchema(
 
 export type ToolVerticalBarArgs = z.infer<typeof toolVerticalBarArgsSchema>;
 
-export const toolVerticalBarArgsSchemaTransformed =
-    toolVerticalBarArgsSchema.transform((data) => ({
+export const toolVerticalBarArgsSchemaTransformed = toolVerticalBarArgsSchema
+    .extend({
+        // backwards compatibility for old viz configs without customMetrics
+        customMetrics: customMetricsSchema.default(null),
+    })
+    .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
     }));

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import type { Filters } from '../../../../types/filter';
-import type { AdditionalMetric } from '../../../../types/metricQuery';
 import type { AiMetricQueryWithFilters } from '../../types';
 import { getValidAiQueryLimit } from '../../validators';
 import { getFieldIdSchema } from '../fieldId';
 import sortFieldSchema from '../sortField';
+import type { ToolTableVizArgsTransformed } from '../tools';
 
 export const tableVizConfigSchema = z
     .object({
@@ -49,7 +49,7 @@ export const metricQueryTableViz = ({
     vizConfig: TableVizConfigSchemaType;
     filters: Filters;
     maxLimit: number;
-    customMetrics: AdditionalMetric[] | null;
+    customMetrics: ToolTableVizArgsTransformed['customMetrics'] | null;
 }): AiMetricQueryWithFilters => ({
     exploreName: vizConfig.exploreName,
     metrics: vizConfig.metrics,
@@ -60,5 +60,5 @@ export const metricQueryTableViz = ({
     })),
     limit: getValidAiQueryLimit(vizConfig.limit, maxLimit),
     filters,
-    additionalMetrics: customMetrics ?? undefined,
+    additionalMetrics: customMetrics ?? [],
 });

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
@@ -5,6 +5,7 @@ import type { AiMetricQueryWithFilters } from '../../types';
 import { getValidAiQueryLimit } from '../../validators';
 import { getFieldIdSchema } from '../fieldId';
 import sortFieldSchema from '../sortField';
+import type { ToolTimeSeriesArgsTransformed } from '../tools';
 
 export const timeSeriesMetricVizConfigSchema = z.object({
     exploreName: z
@@ -55,11 +56,17 @@ export type TimeSeriesMetricVizConfigSchemaType = z.infer<
     typeof timeSeriesMetricVizConfigSchema
 >;
 
-export const metricQueryTimeSeriesViz = (
-    vizConfig: TimeSeriesMetricVizConfigSchemaType,
-    filters: Filters,
-    maxLimit: number,
-): AiMetricQueryWithFilters => {
+export const metricQueryTimeSeriesViz = ({
+    vizConfig,
+    filters,
+    maxLimit,
+    customMetrics,
+}: {
+    vizConfig: TimeSeriesMetricVizConfigSchemaType;
+    filters: Filters;
+    maxLimit: number;
+    customMetrics: ToolTimeSeriesArgsTransformed['customMetrics'] | null;
+}): AiMetricQueryWithFilters => {
     const metrics = vizConfig.yMetrics;
     const dimensions = [
         vizConfig.xDimension,
@@ -79,5 +86,6 @@ export const metricQueryTimeSeriesViz = (
         })),
         exploreName: vizConfig.exploreName,
         filters,
+        additionalMetrics: customMetrics ?? [],
     };
 };

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
@@ -5,6 +5,7 @@ import type { AiMetricQueryWithFilters } from '../../types';
 import { getValidAiQueryLimit } from '../../validators';
 import { getFieldIdSchema } from '../fieldId';
 import sortFieldSchema from '../sortField';
+import type { ToolVerticalBarArgsTransformed } from '../tools';
 
 export const verticalBarMetricVizConfigSchema = z.object({
     exploreName: z
@@ -63,11 +64,17 @@ export type VerticalBarMetricVizConfigSchemaType = z.infer<
     typeof verticalBarMetricVizConfigSchema
 >;
 
-export const metricQueryVerticalBarViz = (
-    vizConfig: VerticalBarMetricVizConfigSchemaType,
-    filters: Filters,
-    maxLimit: number,
-): AiMetricQueryWithFilters => {
+export const metricQueryVerticalBarViz = ({
+    vizConfig,
+    filters,
+    maxLimit,
+    customMetrics,
+}: {
+    vizConfig: VerticalBarMetricVizConfigSchemaType;
+    filters: Filters;
+    maxLimit: number;
+    customMetrics: ToolVerticalBarArgsTransformed['customMetrics'] | null;
+}): AiMetricQueryWithFilters => {
     const metrics = vizConfig.yMetrics;
     const dimensions = [
         vizConfig.xDimension,
@@ -86,5 +93,6 @@ export const metricQueryVerticalBarViz = (
         })),
         exploreName: vizConfig.exploreName,
         filters,
+        additionalMetrics: customMetrics ?? [],
     };
 };

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -1,5 +1,5 @@
 import type { Filters } from '../../types/filter';
-import type { MetricQuery } from '../../types/metricQuery';
+import type { AdditionalMetric, MetricQuery } from '../../types/metricQuery';
 import type {
     ToolTableVizArgs,
     ToolTimeSeriesArgs,
@@ -15,13 +15,10 @@ export enum AiResultType {
 
 export type AiMetricQuery = Pick<
     MetricQuery,
-    | 'metrics'
-    | 'dimensions'
-    | 'sorts'
-    | 'limit'
-    | 'exploreName'
-    | 'additionalMetrics'
->;
+    'metrics' | 'dimensions' | 'sorts' | 'limit' | 'exploreName'
+> & {
+    additionalMetrics: Omit<AdditionalMetric, 'sql'>[];
+};
 
 export type AiMetricQueryWithFilters = AiMetricQuery & {
     filters: Filters;

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -22,11 +22,12 @@ export const parseVizConfig = (
 
     if (toolVerticalBarArgsParsed.success) {
         const vizTool = toolVerticalBarArgsParsed.data;
-        const metricQuery = metricQueryVerticalBarViz(
-            vizTool.vizConfig,
-            vizTool.filters,
-            maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
-        );
+        const metricQuery = metricQueryVerticalBarViz({
+            vizConfig: vizTool.vizConfig,
+            filters: vizTool.filters,
+            maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
+            customMetrics: vizTool.customMetrics ?? null,
+        });
         return {
             type: AiResultType.VERTICAL_BAR_RESULT,
             vizTool,
@@ -38,11 +39,12 @@ export const parseVizConfig = (
         toolTimeSeriesArgsSchemaTransformed.safeParse(vizConfigUnknown);
     if (toolTimeSeriesArgsParsed.success) {
         const vizTool = toolTimeSeriesArgsParsed.data;
-        const metricQuery = metricQueryTimeSeriesViz(
-            vizTool.vizConfig,
-            vizTool.filters,
-            maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
-        );
+        const metricQuery = metricQueryTimeSeriesViz({
+            vizConfig: vizTool.vizConfig,
+            filters: vizTool.filters,
+            maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
+            customMetrics: vizTool.customMetrics ?? null,
+        });
         return {
             type: AiResultType.TIME_SERIES_RESULT,
             vizTool,
@@ -58,7 +60,7 @@ export const parseVizConfig = (
             vizConfig: vizTool.vizConfig,
             filters: vizTool.filters,
             maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
-            customMetrics: null, // Will be populated in the backend before running the query
+            customMetrics: vizTool.customMetrics ?? null,
         });
         return {
             type: AiResultType.TABLE_RESULT,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16586

### Description:
Added support for custom metrics in all visualization types, not just tables. This PR:

- Updates the system prompt to clarify that custom metrics are supported in all visualization types, **not just tables**
- Adds additionalMetrics schema to Time Series and Bar Chart visualizations
- Implements validation for custom metrics in these visualization types
- Passes additionalMetrics through the visualization rendering pipeline
- Refactors metric query generation to accept `additionalMetrics` parameter


![Screenshot 2025-08-27 at 12.20.24.png](https://app.graphite.dev/user-attachments/assets/aba1500d-0816-4f62-89f6-190806fdb375.png)

![Screenshot 2025-08-27 at 12.20.28.png](https://app.graphite.dev/user-attachments/assets/d42659ca-557a-4fa4-8b5c-53d83cba1334.png)

![Screenshot 2025-08-27 at 12.21.20.png](https://app.graphite.dev/user-attachments/assets/72583e82-5c25-42ae-bf5b-2aa0029a43e7.png)

![Screenshot 2025-08-27 at 12.21.24.png](https://app.graphite.dev/user-attachments/assets/1fbf86d3-72a8-4308-80e6-08d4dc3f92c2.png)

![Screenshot 2025-08-27 at 12.22.37.png](https://app.graphite.dev/user-attachments/assets/ce65f899-0feb-4ba8-acf8-5dfe78e0c516.png)


