### PR TITLE
fix: dashboard responsive layout depending on columns

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/gridUtils.ts
+++ b/packages/frontend/src/components/DashboardTabs/gridUtils.ts
@@ -1,20 +1,35 @@
 import { type DashboardTile } from '@lightdash/common';
 import { type Layout } from 'react-grid-layout';
 
+export type ResponsiveGridLayoutProps = {
+    draggableCancel: string;
+    useCSSTransforms: boolean;
+    measureBeforeMount: boolean;
+    breakpoints: { lg: number; md: number; sm: number };
+    cols: { lg: number; md: number; sm: number };
+    rowHeight: number;
+};
+
 export const getReactGridLayoutConfig = (
     tile: DashboardTile,
     isEditMode = false,
-): Layout => ({
-    minH: 1,
-    minW: 6,
-    x: tile.x,
-    y: tile.y,
-    w: tile.w,
-    h: tile.h,
-    i: tile.uuid,
-    isDraggable: isEditMode,
-    isResizable: isEditMode,
-});
+    cols = 36,
+): Layout => {
+    // Scale factor based on the number of columns (36 is the default for lg)
+    const scaleFactor = cols / 36;
+
+    return {
+        minH: 1,
+        minW: Math.max(1, Math.round(6 * scaleFactor)),
+        x: Math.round(tile.x * scaleFactor),
+        y: tile.y,
+        w: Math.round(tile.w * scaleFactor),
+        h: tile.h,
+        i: tile.uuid,
+        isDraggable: isEditMode,
+        isResizable: isEditMode,
+    };
+};
 
 export const getResponsiveGridLayoutProps = ({
     enableAnimation = false,
@@ -28,7 +43,7 @@ export const getResponsiveGridLayoutProps = ({
      * viewports.
      */
     stackVerticallyOnSmallestBreakpoint?: boolean;
-} = {}) => ({
+} = {}): ResponsiveGridLayoutProps => ({
     draggableCancel: '.non-draggable',
     useCSSTransforms: enableAnimation,
     measureBeforeMount: !enableAnimation,

--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -63,14 +63,35 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     setGridWidth,
     setAddingTab,
 }) => {
+    const gridProps = getResponsiveGridLayoutProps();
     const layouts = useMemo(
         () => ({
             lg:
                 dashboardTiles?.map<Layout>((tile) =>
-                    getReactGridLayoutConfig(tile, isEditMode),
+                    getReactGridLayoutConfig(
+                        tile,
+                        isEditMode,
+                        gridProps.cols.lg,
+                    ),
+                ) ?? [],
+            md:
+                dashboardTiles?.map<Layout>((tile) =>
+                    getReactGridLayoutConfig(
+                        tile,
+                        isEditMode,
+                        gridProps.cols.md,
+                    ),
+                ) ?? [],
+            sm:
+                dashboardTiles?.map<Layout>((tile) =>
+                    getReactGridLayoutConfig(
+                        tile,
+                        isEditMode,
+                        gridProps.cols.sm,
+                    ),
                 ) ?? [],
         }),
-        [dashboardTiles, isEditMode],
+        [dashboardTiles, isEditMode, gridProps],
     );
 
     const { search } = useLocation();
@@ -343,7 +364,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                     px="xs"
                                 >
                                     <ResponsiveGridLayout
-                                        {...getResponsiveGridLayoutProps()}
+                                        {...gridProps}
                                         className={`${
                                             hasRequiredDashboardFiltersToSet
                                                 ? 'locked'

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -130,7 +130,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 visible={isLoading ?? false}
                 zIndex={getDefaultZIndex('modal') - 10}
             />
-
             <HeaderContainer
                 $isEditMode={isEditMode}
                 $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
@@ -319,7 +318,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                     ) : null}
                 </Group>
             </HeaderContainer>
-
             <ChartContainer
                 className="non-draggable sentry-block ph-no-capture"
                 onMouseEnter={
@@ -331,7 +329,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
             >
                 {children}
             </ChartContainer>
-
             {isEditingTileContent &&
                 (tile.type === DashboardTileTypes.SAVED_CHART ||
                 tile.type === DashboardTileTypes.SQL_CHART ? (
@@ -365,7 +362,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                         }}
                     />
                 ))}
-
             <DeleteChartTileThatBelongsToDashboardModal
                 className={'non-draggable'}
                 name={chartName ?? ''}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -11,6 +11,7 @@ import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import {
     getReactGridLayoutConfig,
     getResponsiveGridLayoutProps,
+    type ResponsiveGridLayoutProps,
 } from '../../../../../components/DashboardTabs/gridUtils';
 import LoomTile from '../../../../../components/DashboardTiles/DashboardLoomTile';
 import SqlChartTile from '../../../../../components/DashboardTiles/DashboardSqlChartTile';
@@ -31,11 +32,12 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
 
 const EmbedDashboardGrid: FC<{
     filteredTiles: DashboardTile[];
-    layouts: { lg: Layout[] };
+    layouts: { lg: Layout[]; md: Layout[]; sm: Layout[] };
     dashboard: any;
     projectUuid: string;
     hasRequiredDashboardFiltersToSet: boolean;
     isTabEmpty?: boolean;
+    gridProps: ResponsiveGridLayoutProps;
 }> = ({
     filteredTiles,
     layouts,
@@ -43,6 +45,7 @@ const EmbedDashboardGrid: FC<{
     projectUuid,
     hasRequiredDashboardFiltersToSet,
     isTabEmpty,
+    gridProps,
 }) => (
     <Group grow pt="sm" px="xs">
         {isTabEmpty ? (
@@ -59,7 +62,7 @@ const EmbedDashboardGrid: FC<{
             </div>
         ) : (
             <ResponsiveGridLayout
-                {...getResponsiveGridLayoutProps({ enableAnimation: false })}
+                {...gridProps}
                 layouts={layouts}
                 className={`react-grid-layout-dashboard ${
                     hasRequiredDashboardFiltersToSet ? 'locked' : ''
@@ -263,6 +266,22 @@ const EmbedDashboard: FC<{
     const tabsEnabled = sortedTabs.length > 1;
     const MAGIC_SCROLL_AREA_HEIGHT = 40;
 
+    const gridProps = getResponsiveGridLayoutProps({ enableAnimation: false });
+    const layouts = useMemo(
+        () => ({
+            lg: filteredTiles.map<Layout>((tile) =>
+                getReactGridLayoutConfig(tile, false, gridProps.cols.lg),
+            ),
+            md: filteredTiles.map<Layout>((tile) =>
+                getReactGridLayoutConfig(tile, false, gridProps.cols.md),
+            ),
+            sm: filteredTiles.map<Layout>((tile) =>
+                getReactGridLayoutConfig(tile, false, gridProps.cols.sm),
+            ),
+        }),
+        [filteredTiles, gridProps.cols],
+    );
+
     if (!projectUuid) {
         return (
             <div style={{ marginTop: '20px' }}>
@@ -304,10 +323,6 @@ const EmbedDashboard: FC<{
             </div>
         );
     }
-
-    const layouts = {
-        lg: filteredTiles.map<Layout>((tile) => getReactGridLayoutConfig(tile)),
-    };
 
     // Check if current tab is empty
     const isTabEmpty = tabsEnabled && filteredTiles.length === 0;
@@ -375,6 +390,7 @@ const EmbedDashboard: FC<{
                             hasRequiredDashboardFiltersToSet
                         }
                         isTabEmpty={isTabEmpty}
+                        gridProps={gridProps}
                     />
                 </Tabs>
             ) : (
@@ -386,6 +402,7 @@ const EmbedDashboard: FC<{
                     hasRequiredDashboardFiltersToSet={
                         hasRequiredDashboardFiltersToSet
                     }
+                    gridProps={gridProps}
                 />
             )}
         </div>

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -117,21 +117,32 @@ const MinimalDashboard: FC = () => {
         });
     }, [sortedTabs, generateTabUrl]);
 
+    const gridProps = getResponsiveGridLayoutProps({
+        stackVerticallyOnSmallestBreakpoint: true,
+    });
+
     const layouts = useMemo(() => {
+        const tiles =
+            dashboard?.tiles.filter((tile) =>
+                // If there are selected tabs when sending now/scheduling, aggregate ALL tiles into one view.
+                schedulerTabsSelected
+                    ? schedulerTabsSelected.includes(tile.tabUuid)
+                    : // This is when viewed a dashboard with tabs in mobile mode - you can navigate between tabs.
+                      !activeTab || activeTab.uuid === tile.tabUuid,
+            ) ?? [];
+
         return {
-            lg:
-                dashboard?.tiles
-                    .filter((tile) =>
-                        // If there are selected tabs when sending now/scheduling, aggregate ALL tiles into one view.
-                        schedulerTabsSelected
-                            ? schedulerTabsSelected.includes(tile.tabUuid)
-                            : // This is when viewed a dashboard with tabs in mobile mode - you can navigate between tabs.
-                              !activeTab || activeTab.uuid === tile.tabUuid,
-                    )
-                    .map<Layout>((tile) => getReactGridLayoutConfig(tile)) ??
-                [],
+            lg: tiles.map<Layout>((tile) =>
+                getReactGridLayoutConfig(tile, false, gridProps.cols.lg),
+            ),
+            md: tiles.map<Layout>((tile) =>
+                getReactGridLayoutConfig(tile, false, gridProps.cols.md),
+            ),
+            sm: tiles.map<Layout>((tile) =>
+                getReactGridLayoutConfig(tile, false, gridProps.cols.sm),
+            ),
         };
-    }, [dashboard?.tiles, schedulerTabsSelected, activeTab]);
+    }, [dashboard?.tiles, schedulerTabsSelected, activeTab, gridProps.cols]);
 
     const filteredDashboardTiles = useMemo(() => {
         return (
@@ -191,12 +202,7 @@ const MinimalDashboard: FC = () => {
                     sx={{ marginTop: '40px' }}
                 />
             ) : (
-                <ResponsiveGridLayout
-                    {...getResponsiveGridLayoutProps({
-                        stackVerticallyOnSmallestBreakpoint: true,
-                    })}
-                    layouts={layouts}
-                >
+                <ResponsiveGridLayout {...gridProps} layouts={layouts}>
                     {filteredDashboardTiles.map((tile) => (
                         <div key={tile.uuid}>
                             {tile.type === DashboardTileTypes.SAVED_CHART ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #4161

### Description:
Implemented responsive grid layouts for dashboards to properly scale tiles across different screen sizes. The changes include:

1. Enhanced `getReactGridLayoutConfig` to scale tile dimensions based on the number of columns in the current breakpoint
2. Added support for medium and small breakpoints in dashboard layouts
3. Created a TypeScript type for `ResponsiveGridLayoutProps` to improve type safety
4. Optimized grid layout configuration by reusing the same grid props instance
5. Applied responsive layouts to all dashboard views (standard, minimal, and embedded)

This ensures dashboard tiles maintain proper proportions when viewed on different devices, providing a better user experience across various screen sizes.

**Before**

![image.png](https://app.graphite.dev/user-attachments/assets/a730d4f7-fadd-479c-8557-0941ed414771.png)

**After**

![image.png](https://app.graphite.dev/user-attachments/assets/3c0f1658-8be5-4aba-bb28-48a5a9775f0e.png)

