### PR TITLE
feat: add MCP server protected resource discovery endpoint

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -587,17 +587,6 @@ export default class App {
             ),
         );
 
-        // Always allow CORS for .well-known routes (required for OAuth discovery)
-        expressApp.use(
-            '/.well-known/*',
-            cors({
-                methods: 'OPTIONS, GET, HEAD',
-                allowedHeaders: '*',
-                credentials: false,
-                origin: true, // Allow all origins for .well-known endpoints
-            }),
-        );
-
         // Root-level .well-known endpoints for OAuth discovery (required by many MCP clients)
         // Use the same handlers as the API-level endpoints to ensure consistency
         expressApp.get(
@@ -605,7 +594,16 @@ export default class App {
             oauthAuthorizationServerHandler,
         );
         expressApp.get(
+            '/.well-known/oauth-authorization-server/api/v1/mcp',
+            oauthAuthorizationServerHandler,
+        );
+
+        expressApp.get(
             '/.well-known/oauth-protected-resource',
+            oauthProtectedResourceHandler,
+        );
+        expressApp.get(
+            '/.well-known/oauth-protected-resource/api/v1/mcp',
             oauthProtectedResourceHandler,
         );
 

--- a/packages/backend/src/routers/oauthRouter.ts
+++ b/packages/backend/src/routers/oauthRouter.ts
@@ -6,7 +6,6 @@ import {
     OAuthIntrospectResponse,
 } from '@lightdash/common';
 import OAuth2Server from '@node-oauth/oauth2-server';
-import cors from 'cors';
 import express from 'express';
 import Logger from '../logging/logger';
 import { DEFAULT_OAUTH_CLIENT_ID } from '../models/OAuth2Model';
@@ -16,17 +15,6 @@ import {
 } from '../services/OAuthService/OAuthService';
 
 const oauthRouter = express.Router({ mergeParams: true });
-
-// Always allow CORS for .well-known routes (required for OAuth discovery)
-oauthRouter.use(
-    '/.well-known/*',
-    cors({
-        methods: 'OPTIONS, GET, HEAD',
-        allowedHeaders: '*',
-        credentials: false,
-        origin: true, // Allow all origins for .well-known endpoints
-    }),
-);
 
 // Get OAuth service from request
 function getOAuthService(req: express.Request): OAuthService {
@@ -430,6 +418,14 @@ export const oauthProtectedResourceHandler = (
 
 oauthRouter.get(
     '/.well-known/oauth-protected-resource',
+    oauthProtectedResourceHandler,
+);
+
+// MCP server protected resource discovery endpoint
+// This endpoint is used to discover the protected resource for MCP
+// Required by some MCP clients
+oauthRouter.get(
+    '/.well-known/oauth-protected-resource/api/v1/mcp',
     oauthProtectedResourceHandler,
 );
 


### PR DESCRIPTION
Related to: https://github.com/lightdash/lightdash/issues/16604

### Description:

Added a new OAuth endpoint `/.well-known/oauth-protected-resource/api/v1/mcp` for MCP server protected resource discovery. This endpoint is required by some MCP clients to properly discover the protected resource.

error from cursor logs:

2025-08-27 17:27:36.484 [error] Failed to complete OAuth exchange Unexpected token '<', "\<!DOCTYPE "... is not valid JSON

call to the route in logs - it is 200 because it redirects to home page:

![CleanShot 2025-08-27 at 18.02.58@2x.png](https://app.graphite.dev/user-attachments/assets/0d785fc2-4060-4398-a290-3cf427178559.png)