### PR TITLE
fix: allow multiple groupByColumns in pivot configuration

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -933,7 +933,7 @@ describe('PivotQueryBuilder', () => {
                 'SELECT "category", "date" FROM original_query group by "category", "date"',
             );
             // Should calculate total_columns correctly (1 value column default)
-            expect(result).toContain('* 1) as total_columns');
+            expect(result).toContain('* 1 as total_columns');
         });
 
         test('Should handle undefined limit (defaults to 500)', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
### Description:
Refactored the pivot query total columns calculation to use a more efficient and accurate approach. Instead of counting from the filtered rows, the new implementation uses a dedicated `getTotalColumnsSQL` method that counts distinct combinations from the source data.

The new approach is more warehouse-agnostic and provides a cleaner separation of concerns by extracting the total columns logic into its own method with proper documentation.

**Note:** Multiple index columns are already supported

```
# pivot configuration
{
  indexColumn: [
    { reference: 'customers_first_name', type: 'category' },
    { reference: 'customers_last_name', type: 'category' }
  ],
  valuesColumns: [
    { reference: 'orders_completion_percentage', aggregation: 'any' },
    { reference: 'orders_unique_order_count', aggregation: 'any' }
  ],
  groupByColumns: [
    { reference: 'orders_order_date_month' },
    { reference: 'orders_currency' }
  ],
  sortBy: [ { reference: 'orders_order_date_month', direction: 'DESC' } ]
}
```

**Before**

Notice `Count(Distinct())` syntax error in `total_columns` cte

```sql
WITH original_query AS (SELECT
  "customers".first_name AS "customers_first_name",
  "customers".last_name AS "customers_last_name",
  DATE_TRUNC('MONTH', "orders".order_date) AS "orders_order_date_month",
  "orders".currency AS "orders_currency",
  (SUM(CASE WHEN (("orders".is_completed) = true) THEN ("orders".amount) ELSE NULL END))/(SUM("orders".amount)) AS "orders_completion_percentage",
  COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
FROM "postgres"."jaffle"."orders" AS "orders"
LEFT OUTER JOIN "postgres"."jaffle"."customers" AS "customers"
  ON ("customers".customer_id) = ("orders".customer_id)
GROUP BY 1,2,3,4
ORDER BY "orders_order_date_month" DESC
LIMIT 2000),
count"))[1] AS "orders_unique_order_count_any" FROM original_query group by "orders_order_date_month", "orders_currency", "customers_first_name", "customers_last_name"),
 ASC, "customers_last_name" ASC) as "row_index", dense_rank() over (order by "orders_order_date_month") as "column_index" FROM group_by_query),
filtered_rows AS (SELECT * FROM pivot_query WHERE "row_index" <= 2000),
total_columns AS (SELECT (COUNT(DISTINCT filtered_rows."orders_order_date_month", filtered_rows."orders_currency") * 2) as total_columns FROM filtered_rows)
SELECT p.*, t.total_columns FROM pivot_query p CROSS JOIN total_columns t WHERE p."row_index" <= 2000 and p."column_index" <= 49 order by p."row_index", p."column_index"
```

```json
// results

{
    "status": "ok",
    "results": {
        "status": "error",
        "queryUuid": "45d81273-adcd-4e08-a800-51340970758e",
        "error": "function count(timestamp with time zone, text) does not exist"
    }
}
```


**After**

```sql
WITH original_query AS (SELECT
  "customers".first_name AS "customers_first_name",
  "customers".last_name AS "customers_last_name",
  DATE_TRUNC('MONTH', "orders".order_date) AS "orders_order_date_month",
  "orders".currency AS "orders_currency",
  (SUM(CASE WHEN (("orders".is_completed) = true) THEN ("orders".amount) ELSE NULL END))/(SUM("orders".amount)) AS "orders_completion_percentage",
  COUNT(DISTINCT "orders".order_id) AS "orders_unique_order_count"
FROM "postgres"."jaffle"."orders" AS "orders"
LEFT OUTER JOIN "postgres"."jaffle"."customers" AS "customers"
  ON ("customers".customer_id) = ("orders".customer_id)
GROUP BY 1,2,3,4
ORDER BY "orders_order_date_month" DESC
LIMIT 2000),
count"))[1] AS "orders_unique_order_count_any" FROM original_query group by "orders_order_date_month", "orders_currency", "customers_first_name", "customers_last_name"),
 ASC, "customers_last_name" ASC) as "row_index", dense_rank() over (order by "orders_order_date_month") as "column_index" FROM group_by_query),
filtered_rows AS (SELECT * FROM pivot_query WHERE "row_index" <= 2000),
total_columns AS (SELECT COUNT(*) * 2 as total_columns FROM (SELECT DISTINCT "orders_order_date_month", "orders_currency" FROM filtered_rows) as distinct_groups)
SELECT p.*, t.total_columns FROM pivot_query p CROSS JOIN total_columns t WHERE p."row_index" <= 2000 and p."column_index" <= 49 order by p."row_index", p."column_index"
```

```json
// results

{
    "status": "ok",
    "results": {
        "rows": [
            {
                "customers_first_name": {
                    "value": {
                        "raw": "Aaron",
                        "formatted": "Aaron"
                    }
                },
                "customers_last_name": {
                    "value": {
                        "raw": "R.",
                        "formatted": "R."
                    }
                },
                "orders_completion_percentage_any_Sat Jun 01 2024 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": 1,
                        "formatted": "1"
                    }
                },
                "orders_unique_order_count_any_Sat Jun 01 2024 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": "1",
                        "formatted": "1"
                    }
                },
                "orders_completion_percentage_any_Wed Jan 01 2025 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": 1,
                        "formatted": "1"
                    }
                },
                "orders_unique_order_count_any_Wed Jan 01 2025 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": "1",
                        "formatted": "1"
                    }
                }
            },
            {
                "customers_first_name": {
                    "value": {
                        "raw": "Adam",
                        "formatted": "Adam"
                    }
                },
                "customers_last_name": {
                    "value": {
                        "raw": "A.",
                        "formatted": "A."
                    }
                },
                "orders_completion_percentage_any_Sun Jun 01 2025 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": 1,
                        "formatted": "1"
                    }
                },
                "orders_unique_order_count_any_Sun Jun 01 2025 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": "1",
                        "formatted": "1"
                    }
                }
            },
            {
                "customers_first_name": {
                    "value": {
                        "raw": "Adam",
                        "formatted": "Adam"
                    }
                },
                "customers_last_name": {
                    "value": {
                        "raw": "T.",
                        "formatted": "T."
                    }
                },
                "orders_completion_percentage_any_Mon Jul 01 2024 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": 1,
                        "formatted": "1"
                    }
                },
                "orders_unique_order_count_any_Mon Jul 01 2024 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": "1",
                        "formatted": "1"
                    }
                },
                "orders_completion_percentage_any_Wed Jan 01 2025 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": null,
                        "formatted": "∅"
                    }
                },
                "orders_unique_order_count_any_Wed Jan 01 2025 00:00:00 GMT+0000 (Coordinated Universal Time)_USD": {
                    "value": {
                        "raw": "1",
                        "formatted": "1"
                    }
                }
            },
         ]
         // rest
}
```