### PR TITLE
feat: allow write back on custom metric artifact

### DIFF
--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -59,7 +59,7 @@ const parseError = (
     return `Error: ${errorTitle}\n${getErrorMessage(error)}`;
 };
 
-const SingleItemModalContent = ({
+export const SingleItemModalContent = ({
     handleClose,
     item,
     projectUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #16586

### Description:
Added the ability to write back custom metrics created by AI Copilot to dbt. Users can now click a code icon next to custom metrics in the visualization metrics panel to open the write-back modal.

Key changes:
- Exported `SingleItemModalContent` from WriteBackModal for reuse
- Enhanced `MetricDimensionItem` to display a write-back button for custom metrics
- Added tracking for when users click to write back custom metrics
- Implemented modal handling for the write-back flow
- Improved explore count detection to include tables from additional metrics

![Screenshot 2025-08-27 at 18.02.47.png](https://app.graphite.dev/user-attachments/assets/a481d726-7ae0-449e-b76a-ac636d6c3d13.png)

![Screenshot 2025-08-27 at 18.02.42.png](https://app.graphite.dev/user-attachments/assets/49b4c4a8-73cc-4d2f-a8a6-c0f3780adb4d.png)

