### PR TITLE
fix: add upstreamProjectUuid to project creation permission check in CLI

### DIFF
--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -82,7 +82,10 @@ export const createProject = async (
     options: CreateProjectOptions,
 ): Promise<ApiCreateProjectResults | undefined> => {
     // Check permissions before proceeding
-    await checkProjectCreationPermission(options.type);
+    await checkProjectCreationPermission(
+        options.upstreamProjectUuid,
+        options.type,
+    );
 
     const dbtVersion = await getDbtVersion();
 

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -76,6 +76,7 @@ export const getUserContext =
         });
 
 export const checkProjectCreationPermission = async (
+    upstreamProjectUuid: string | undefined,
     projectType: ProjectType,
 ): Promise<void> => {
     try {
@@ -84,11 +85,18 @@ export const checkProjectCreationPermission = async (
         // Build CASL ability from user's ability rules (same as backend)
         const ability = new Ability<PossibleAbilities>(user.abilityRules);
 
+        if (!user.organizationUuid) {
+            throw new ForbiddenError(
+                `You don't have permission to create projects.`,
+            );
+        }
+
         // Check if user has permission to create project of the specified type
         const canCreate = ability.can(
             'create',
             subject('Project', {
-                organizationUuid: user.organizationUuid || '',
+                organizationUuid: user.organizationUuid,
+                upstreamProjectUuid,
                 type: projectType,
             }),
         );


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/16638

### Description:

Fixes project creation permission checks by adding `upstreamProjectUuid` parameter to the `checkProjectCreationPermission` function.