### PR TITLE
feat: extend "Write back to dbt" to support GitLab projects

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -133,12 +133,14 @@ export const getFileContent = async ({
     repo,
     branch,
     token,
+    hostDomain,
 }: {
     fileName: string;
     owner: string;
     repo: string;
     branch: string;
     token: string;
+    hostDomain?: string;
 }) => {
     const { octokit, headers } = getOctokitRestForUser(token);
     try {
@@ -177,12 +179,14 @@ export const createBranch = async ({
     sha,
     branch,
     token,
+    hostDomain,
 }: {
     owner: string;
     repo: string;
     sha: string;
     branch: string;
     token: string;
+    hostDomain?: string;
 }) => {
     const { octokit, headers } = getOctokitRestForUser(token);
 
@@ -219,7 +223,7 @@ export const updateFile = async ({
     fileName,
     content,
     fileSha,
-    branchName,
+    branch,
     message,
     token,
 }: {
@@ -228,7 +232,7 @@ export const updateFile = async ({
     fileName: string;
     content: string;
     fileSha: string;
-    branchName: string;
+    branch: string;
     message: string;
     token: string;
 }) => {
@@ -241,7 +245,7 @@ export const updateFile = async ({
             message,
             content: Buffer.from(content, 'utf-8').toString('base64'),
             sha: fileSha,
-            branch: branchName,
+            branch,
             headers,
             committer: {
                 name: 'Lightdash',

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -1,0 +1,296 @@
+import {
+    AlreadyExistsError,
+    ForbiddenError,
+    getErrorMessage,
+    NotFoundError,
+    ParameterError,
+    UnexpectedGitError,
+} from '@lightdash/common';
+
+const DEFAULT_GITLAB_HOST_DOMAIN = 'gitlab.com';
+
+type GitlabApiParams = {
+    owner: string;
+    repo: string;
+    token: string;
+    hostDomain?: string;
+};
+
+type GitlabFileParams = GitlabApiParams & {
+    fileName: string;
+    branch: string;
+};
+
+type GitlabBranchParams = GitlabApiParams & {
+    branch: string;
+    sha: string;
+};
+
+type GitlabUpdateFileParams = GitlabFileParams & {
+    content: string;
+    fileSha?: string;
+    message: string;
+};
+
+type GitlabCreateFileParams = GitlabFileParams & {
+    content: string;
+    message: string;
+};
+
+type GitlabPullRequestParams = GitlabApiParams & {
+    title: string;
+    body: string;
+    head: string;
+    base: string;
+};
+
+const getProjectId = (owner: string, repo: string) =>
+    encodeURIComponent(`${owner}/${repo}`);
+
+const getApiUrl = (hostDomain: string, endpoint: string) =>
+    `https://${hostDomain}/api/v4${endpoint}`;
+
+const makeGitlabRequest = async (
+    url: string,
+    token: string,
+    options: RequestInit = {},
+) => {
+    const response = await fetch(url, {
+        ...options,
+        headers: {
+            'PRIVATE-TOKEN': token,
+            'Content-Type': 'application/json',
+            ...options.headers,
+        },
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        if (response.status === 401) {
+            throw new ForbiddenError('Invalid GitLab access token');
+        }
+        if (response.status === 403) {
+            throw new ForbiddenError(
+                'Insufficient permissions for GitLab repository',
+            );
+        }
+        if (response.status === 404) {
+            throw new NotFoundError('GitLab resource not found');
+        }
+        throw new UnexpectedGitError(
+            `GitLab API error: ${response.status} ${errorText}`,
+        );
+    }
+
+    return response.json();
+};
+
+export const getLastCommit = async ({
+    owner,
+    repo,
+    branch,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: Omit<GitlabFileParams, 'fileName'>) => {
+    const projectId = getProjectId(owner, repo);
+    const url = getApiUrl(
+        hostDomain,
+        `/projects/${projectId}/repository/commits?ref_name=${branch}&per_page=1`,
+    );
+
+    const commits = await makeGitlabRequest(url, token);
+    if (!commits || commits.length === 0) {
+        throw new NotFoundError(`No commits found for branch ${branch}`);
+    }
+
+    return { sha: commits[0].id };
+};
+
+export const getFileContent = async ({
+    fileName,
+    owner,
+    repo,
+    branch,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabFileParams) => {
+    const projectId = getProjectId(owner, repo);
+    const encodedPath = encodeURIComponent(fileName);
+    const url = getApiUrl(
+        hostDomain,
+        `/projects/${projectId}/repository/files/${encodedPath}?ref=${branch}`,
+    );
+
+    const fileData = await makeGitlabRequest(url, token);
+
+    return {
+        content: Buffer.from(fileData.content, 'base64').toString('utf-8'),
+        sha: fileData.last_commit_id,
+    };
+};
+
+export const createBranch = async ({
+    branch,
+    owner,
+    repo,
+    sha,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabBranchParams) => {
+    const projectId = getProjectId(owner, repo);
+    const url = getApiUrl(
+        hostDomain,
+        `/projects/${projectId}/repository/branches`,
+    );
+
+    try {
+        return await makeGitlabRequest(url, token, {
+            method: 'POST',
+            body: JSON.stringify({
+                branch,
+                ref: sha,
+            }),
+        });
+    } catch (error) {
+        if (getErrorMessage(error).includes('already exists')) {
+            throw new AlreadyExistsError(`Branch ${branch} already exists`);
+        }
+        throw error;
+    }
+};
+
+export const checkFileDoesNotExist = async ({
+    owner,
+    repo,
+    path,
+    branch,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabApiParams & { path: string; branch: string }) => {
+    try {
+        await getFileContent({
+            fileName: path,
+            owner,
+            repo,
+            branch,
+            token,
+            hostDomain,
+        });
+        throw new AlreadyExistsError(`File ${path} already exists`);
+    } catch (error) {
+        if (error instanceof NotFoundError) {
+            // File doesn't exist, which is what we want
+            return;
+        }
+        throw error;
+    }
+};
+
+export const createFile = async ({
+    fileName,
+    content,
+    message,
+    owner,
+    repo,
+    branch,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabCreateFileParams) => {
+    const projectId = getProjectId(owner, repo);
+    const encodedPath = encodeURIComponent(fileName);
+    const url = getApiUrl(
+        hostDomain,
+        `/projects/${projectId}/repository/files/${encodedPath}`,
+    );
+
+    return makeGitlabRequest(url, token, {
+        method: 'POST',
+        body: JSON.stringify({
+            branch,
+            content: Buffer.from(content, 'utf-8').toString('base64'),
+            commit_message: message,
+            encoding: 'base64',
+        }),
+    });
+};
+
+export const updateFile = async ({
+    fileName,
+    content,
+    fileSha,
+    message,
+    owner,
+    repo,
+    branch,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabUpdateFileParams) => {
+    const projectId = getProjectId(owner, repo);
+    const encodedPath = encodeURIComponent(fileName);
+    const url = getApiUrl(
+        hostDomain,
+        `/projects/${projectId}/repository/files/${encodedPath}`,
+    );
+
+    const body: Record<string, string | number> = {
+        branch,
+        content: Buffer.from(content, 'utf-8').toString('base64'),
+        commit_message: message,
+        encoding: 'base64',
+    };
+
+    if (fileSha) {
+        body.last_commit_id = fileSha;
+    }
+
+    return makeGitlabRequest(url, token, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+    });
+};
+
+export const createPullRequest = async ({
+    title,
+    body,
+    head,
+    base,
+    owner,
+    repo,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabPullRequestParams) => {
+    const projectId = getProjectId(owner, repo);
+    const url = getApiUrl(hostDomain, `/projects/${projectId}/merge_requests`);
+
+    const mergeRequest = await makeGitlabRequest(url, token, {
+        method: 'POST',
+        body: JSON.stringify({
+            source_branch: head,
+            target_branch: base,
+            title,
+            description: body,
+        }),
+    });
+
+    return {
+        html_url: mergeRequest.web_url,
+        title: mergeRequest.title,
+        number: mergeRequest.iid,
+    };
+};
+
+export const getBranches = async ({
+    owner,
+    repo,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabApiParams) => {
+    const projectId = getProjectId(owner, repo);
+    const url = getApiUrl(
+        hostDomain,
+        `/projects/${projectId}/repository/branches`,
+    );
+
+    const branches = await makeGitlabRequest(url, token);
+    return branches;
+};

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -57,7 +57,7 @@ const gitErrorHandler = (e: unknown, repository: string) => {
     }
     if (e.message.includes('Repository not found')) {
         throw new NotFoundError(
-            `Could not find Git repository "${repository}". Check that your personal access token has access to the repository and that the repository name is correct.`,
+            `Could not find git repository "${repository}". Check that your personal access token has access to the repository and that the repository name is correct.`,
         );
     }
     if (e instanceof GitError) {

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -1,3 +1,4 @@
+import { DbtProjectType } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { updateFile } from '../../clients/github/Github';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
@@ -48,11 +49,13 @@ describe('GitIntegrationService', () => {
                 repo: 'repo',
                 path: 'path',
                 projectUuid: 'projectUuid',
-                type: 'customMetrics',
+                fieldType: 'customMetrics',
                 fields: [CUSTOM_METRIC],
                 branch: 'branch',
                 token: 'token',
                 quoteChar: `'`,
+                mainBranch: 'main',
+                type: DbtProjectType.GITHUB,
             });
             expect(updateFile).toHaveBeenCalledTimes(1);
             expect(updateFile).toHaveBeenCalledWith(
@@ -67,11 +70,13 @@ describe('GitIntegrationService', () => {
                 repo: 'repo',
                 path: 'path',
                 projectUuid: 'projectUuid',
-                type: 'customDimensions',
+                fieldType: 'customDimensions',
                 fields: [CUSTOM_DIMENSION],
                 branch: 'branch',
                 token: 'token',
                 quoteChar: `'`,
+                mainBranch: 'main',
+                type: DbtProjectType.GITHUB,
             });
             expect(updateFile).toHaveBeenCalledTimes(1);
             // @ts-expect-error

--- a/packages/frontend/src/components/Explorer/WriteBackModal/CreatedPullRequestModalContent.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/CreatedPullRequestModalContent.tsx
@@ -1,5 +1,5 @@
 import { Anchor, Button, Group, Modal, Stack, Text } from '@mantine/core';
-import { IconBrandGithub } from '@tabler/icons-react';
+import { IconGitBranch } from '@tabler/icons-react';
 import MantineIcon from '../../common/MantineIcon';
 
 export const CreatedPullRequestModalContent = ({
@@ -18,7 +18,7 @@ export const CreatedPullRequestModalContent = ({
             title={
                 <Group spacing="xs">
                     <MantineIcon
-                        icon={IconBrandGithub}
+                        icon={IconGitBranch}
                         size="lg"
                         color="gray.7"
                     />
@@ -36,7 +36,7 @@ export const CreatedPullRequestModalContent = ({
                     <Anchor href={data.prUrl} target="_blank" span fw={700}>
                         #{data.prUrl.split('/').pop()}
                     </Anchor>{' '}
-                    was successfully created on Github.
+                    was successfully created on git.
                     <Text pt="md">
                         Once it is merged, refresh your dbt connection to see
                         your updated metrics and dimensions.

--- a/packages/frontend/src/components/Explorer/WriteBackModal/hooks.ts
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/hooks.ts
@@ -97,7 +97,9 @@ export const useWriteBackCustomMetrics = (projectUuid: string) => {
     );
 };
 
-export const useIsGithubProject = (projectUuid: string) => {
+export const useIsGitProject = (projectUuid: string) => {
     const { data: project } = useProject(projectUuid);
-    return project?.dbtConnection.type === DbtProjectType.GITHUB;
+    return [DbtProjectType.GITHUB, DbtProjectType.GITLAB].includes(
+        project?.dbtConnection.type as DbtProjectType,
+    );
 };

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -16,7 +16,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { Prism } from '@mantine/prism';
-import { IconBrandGithub, IconInfoCircle } from '@tabler/icons-react';
+import { IconGitBranch, IconInfoCircle } from '@tabler/icons-react';
 import * as yaml from 'js-yaml';
 import { useMemo, useState } from 'react';
 import { useParams } from 'react-router';
@@ -26,14 +26,14 @@ import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
 import { CreatedPullRequestModalContent } from './CreatedPullRequestModalContent';
 import {
-    useIsGithubProject,
+    useIsGitProject,
     useWriteBackCustomDimensions,
     useWriteBackCustomMetrics,
 } from './hooks';
 import { convertToDbt, getItemId, getItemLabel, match } from './utils';
 
 const prDisabledMessage =
-    'Pull requests can only be opened for GitHub connected projects';
+    'Pull requests can only be opened for Git connected projects (GitHub/GitLab)';
 const texts = {
     customDimension: {
         name: 'custom dimension',
@@ -100,7 +100,7 @@ const SingleItemModalContent = ({
     const [showDiff, setShowDiff] = useState(true);
     const [error, setError] = useState<string | undefined>();
 
-    const isGithubProject = useIsGithubProject(projectUuid);
+    const isGitProject = useIsGitProject(projectUuid);
 
     const previewCode = useMemo(() => {
         try {
@@ -125,7 +125,7 @@ const SingleItemModalContent = ({
         );
     }
 
-    const disableErrorTooltip = isGithubProject && !error;
+    const disableErrorTooltip = isGitProject && !error;
 
     const errorTooltipLabel = error
         ? `Unsupported ${texts[type].baseName} definition`
@@ -144,7 +144,7 @@ const SingleItemModalContent = ({
             title={
                 <Group spacing="xs">
                     <MantineIcon
-                        icon={IconBrandGithub}
+                        icon={IconGitBranch}
                         size="lg"
                         color="gray.7"
                     />
@@ -171,8 +171,8 @@ const SingleItemModalContent = ({
         >
             <Stack p="md">
                 <Text>
-                    Create a pull request in your dbt project's GitHub
-                    repository for the following {texts[type].name}:
+                    Create a pull request in your dbt project's git repository
+                    for the following {texts[type].name}:
                 </Text>
                 <List spacing="xs" pl="xs">
                     <List.Item fz="xs" ff="monospace">
@@ -273,7 +273,7 @@ const MultipleItemsModalContent = ({
         () => writeBackCustomMetricsIsLoading,
     );
 
-    const isGithubProject = useIsGithubProject(projectUuid);
+    const isGitProject = useIsGitProject(projectUuid);
 
     const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
 
@@ -313,11 +313,11 @@ const MultipleItemsModalContent = ({
     }
 
     const disableErrorTooltip =
-        isGithubProject && selectedItemIds.length > 0 && !error;
+        isGitProject && selectedItemIds.length > 0 && !error;
 
     const errorTooltipLabel = error
         ? `Unsupported ${texts[type].baseName} definition`
-        : !isGithubProject
+        : !isGitProject
         ? prDisabledMessage
         : `Select ${texts[type].baseName}s to open a pull request`;
 
@@ -332,7 +332,7 @@ const MultipleItemsModalContent = ({
             title={
                 <Group spacing="xs">
                     <MantineIcon
-                        icon={IconBrandGithub}
+                        icon={IconGitBranch}
                         size="lg"
                         color="gray.7"
                     />
@@ -352,8 +352,8 @@ const MultipleItemsModalContent = ({
                     borderBottom: `1px solid ${theme.colors.gray[4]}`,
                 })}
             >
-                Create a pull request in your dbt project's GitHub repository
-                for the following {texts[type].baseName}s
+                Create a pull request in your dbt project's git repository for
+                the following {texts[type].baseName}s
             </Text>
 
             <Stack p="md">

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -58,8 +58,10 @@ export const HeaderCreate: FC = () => {
 
     const [writeBackDisabledMessage, writeBackOpenUrl] = useMemo(() => {
         const hasGithubEnabled = gitIntegration?.enabled;
-        const hasGithubProject =
-            project?.dbtConnection.type === DbtProjectType.GITHUB;
+        const hasGitProject = [
+            DbtProjectType.GITHUB,
+            DbtProjectType.GITLAB,
+        ].includes(project?.dbtConnection.type as DbtProjectType);
         const hasGithubIntegration = health?.data?.hasGithub;
 
         if (!hasGithubIntegration) {
@@ -74,15 +76,15 @@ export const HeaderCreate: FC = () => {
                 `${health?.data?.siteUrl}/generalSettings/integrations`,
             ];
         }
-        if (!hasGithubProject) {
+        if (!hasGitProject) {
             return [
                 <Text key="writeBackDisabledMessage">
                     This project{' '}
                     <Text span fw={600}>
                         {project?.name}
                     </Text>{' '}
-                    is not connected to a Github repository, click here to open
-                    project settings page
+                    is not connected to a GitHub or GitLab repository, click
+                    here to open project settings page
                 </Text>,
                 `${health?.data?.siteUrl}/generalSettings/projectManagement/${projectUuid}/settings`,
             ];

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
@@ -61,7 +61,9 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
 
     const canWriteToDbtProject = !!(
         health?.hasGithub &&
-        project?.dbtConnection.type === DbtProjectType.GITHUB
+        [DbtProjectType.GITHUB, DbtProjectType.GITLAB].includes(
+            project?.dbtConnection.type as DbtProjectType,
+        )
     );
 
     useEffect(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #16636

This works with gitlab personall acccess token, Oauth is not required for this functionallity to work.

<img width="666" height="479" alt="Screenshot from 2025-08-29 09-12-32" src="https://github.com/user-attachments/assets/9654db05-5bee-4430-b4a3-c4cfd8ef8582" />

<img width="842" height="588" alt="image" src="https://github.com/user-attachments/assets/554e8910-2be9-4500-a1a6-1e58c42ec5c1" />
<img width="1263" height="448" alt="Screenshot from 2025-08-29 09-07-31" src="https://github.com/user-attachments/assets/0f1bceb6-2b0d-4822-9b6e-606677996c82" />

### Description:
Extend "Write back to dbt" feature to support GitLab projects in addition to GitHub. This PR adds GitLab integration using personal access tokens, allowing users to create merge requests directly from Lightdash.

Key changes:
- Created a new GitLab client to interact with GitLab API
- Extended the GitIntegrationService to support both GitHub and GitLab
- Updated frontend components to recognize GitLab projects
- Updated UI messaging to reference "Git" instead of "GitHub" specifically
- Maintained backward compatibility with existing GitHub functionality

This implementation allows GitLab users to create merge requests for custom metrics, custom dimensions, and from SQL runner - providing feature parity with GitHub users.