### PR TITLE
feat: hide field labels on funnel charts when position is set to hidden

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -135,13 +135,21 @@ const useEchartsFunnelConfig = (
                         ? `${percentOfMax}%`
                         : '';
                     const valueString = labels?.showValue ? formattedValue : '';
-                    const numbersString = `${
-                        valueString || percentString ? ':' : ''
-                    } ${[percentString, valueString]
-                        .filter(Boolean)
-                        .join(' - ')}`;
+                    const fieldName =
+                        labels?.position !== FunnelChartLabelPosition.HIDDEN
+                            ? name
+                            : '';
 
-                    return `${name}${numbersString}`;
+                    const parts = [];
+                    if (fieldName) parts.push(fieldName);
+                    if (valueString || percentString) {
+                        const numbersString = [percentString, valueString]
+                            .filter(Boolean)
+                            .join(' - ');
+                        parts.push(numbersString);
+                    }
+                    
+                    return parts.join(': ');
                 },
             },
             emphasis: {

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -149,7 +149,7 @@ const useEchartsFunnelConfig = (
                         parts.push(numbersString);
                     }
                     
-                    return parts.join(': ');
+                    return fieldName ? parts.join(': ') : parts.join('');
                 },
             },
             emphasis: {


### PR DESCRIPTION
### Description

- This PR adds the ability to completely hide field labels on funnel charts while keeping values and percentages visible. 

fixes: #16291

**What it solves:**

- Users can now hide field names to reduce clutter and increase customizability
- Values and percentages remain visible when configured, even when labels are hidden
- Maintains all existing functionality for other label positions

**How it works:**

- When `Position: Hidden` is selected in the funnel chart configuration, the field names are excluded from the label display. However, if `Show value` and/or `Show percentage` are checked, those numerical values will still appear on the chart.

**Before:** Field names always showed alongside values/percentages
**After:** Field names can be hidden while preserving the numerical data display