### PR TITLE
fix: disable send now if requried filter is missing

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -1409,9 +1409,10 @@ const SchedulerForm: FC<Props> = ({
                 }
                 onBack={onBack}
                 canSendNow={Boolean(
-                    form.values.slackTargets.length ||
+                    (form.values.slackTargets.length ||
                         form.values.emailTargets.length ||
-                        form.values.msTeamsTargets.length,
+                        form.values.msTeamsTargets.length) &&
+                        requiredFiltersWithoutValues.length === 0,
                 )}
                 onSendNow={isThresholdAlert ? undefined : handleSendNow}
                 loading={loading}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Disable send now if required filter is missing. Saving was already disabled. 

