### PR TITLE
fix(cli): temporarily disable permissions warning for project creation

### DIFF
--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -13,6 +13,7 @@ import { getConfig, setAnswer } from '../config';
 import { getDbtContext } from '../dbt/context';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { checkProjectCreationPermission, lightdashApi } from './dbt/apiClient';
 import getDbtProfileTargetName from './dbt/getDbtProfileTargetName';
 import { getDbtVersion } from './dbt/getDbtVersion';
@@ -81,11 +82,11 @@ type CreateProjectOptions = {
 export const createProject = async (
     options: CreateProjectOptions,
 ): Promise<ApiCreateProjectResults | undefined> => {
-    // Check permissions before proceeding
-    await checkProjectCreationPermission(
-        options.upstreamProjectUuid,
-        options.type,
-    );
+    // TODO enable this when the problem with the permission check is fixed, back-end permission check works as expected
+    // await checkProjectCreationPermission(
+    //     options.upstreamProjectUuid,
+    //     options.type,
+    // );
 
     const dbtVersion = await getDbtVersion();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Temporarily disables the project creation permission check in the CLI to work around an issue with the permission check. The back-end permission check is still working as expected. Added a TODO comment to re-enable this check once the issue is fixed.
