### PR TITLE
chore: add support for SQL-pivoted results conversion to PivotData format

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.mock.ts
+++ b/packages/common/src/pivot/pivotQueryResults.mock.ts
@@ -1,5 +1,18 @@
+import { type ItemsMap, type ReadyQueryResultsPage } from '../index';
+import {
+    CustomFormatType,
+    DimensionType,
+    FieldType,
+    MetricType,
+} from '../types/field';
 import { type MetricQuery } from '../types/metricQuery';
+import { type PivotData } from '../types/pivot';
 import { type ResultRow } from '../types/results';
+import {
+    SortByDirection,
+    VizAggregationOptions,
+    VizIndexType,
+} from '../visualizations/types';
 
 export const METRIC_QUERY_2DIM_2METRIC: Pick<
     MetricQuery,
@@ -85,3 +98,2367 @@ export const RESULT_ROWS_0DIM_2METRIC: ResultRow[] = [
         devices: { value: { raw: 7, formatted: '7.0' } },
     },
 ];
+
+export const getFieldMock = (fieldId: string): ItemsMap[string] | undefined => {
+    if (fieldId === 'orders_is_completed') {
+        return {
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.BOOLEAN,
+            name: 'is_completed',
+            label: 'Is completed',
+            table: 'orders',
+            tableLabel: 'Orders',
+            sql: '${TABLE}.is_completed',
+            hidden: false,
+        };
+    }
+    if (fieldId === 'payments_payment_method') {
+        return {
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.STRING,
+            name: 'payment_method',
+            label: 'Payment Method',
+            table: 'payments',
+            tableLabel: 'Payments',
+            sql: '${TABLE}.payment_method',
+            hidden: false,
+        };
+    }
+    if (fieldId === 'orders_order_date_year') {
+        return {
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.TIMESTAMP,
+            name: 'order_date_year',
+            label: 'Order Date Year',
+            table: 'orders',
+            tableLabel: 'Orders',
+            sql: '${TABLE}.order_date_year',
+            hidden: false,
+        };
+    }
+    if (fieldId === 'payments_total_revenue') {
+        return {
+            fieldType: FieldType.METRIC,
+            type: MetricType.SUM,
+            name: 'total_revenue',
+            label: 'Total Revenue',
+            table: 'payments',
+            tableLabel: 'Payments',
+            sql: 'SUM(${TABLE}.amount)',
+            hidden: false,
+        };
+    }
+    if (fieldId === 'orders_total_order_amount') {
+        return {
+            fieldType: FieldType.METRIC,
+            type: MetricType.SUM,
+            name: 'total_order_amount',
+            label: 'Order Amount',
+            table: 'orders',
+            tableLabel: 'Orders',
+            sql: 'SUM(${TABLE}.amount)',
+            hidden: false,
+            format: CustomFormatType.CURRENCY,
+        };
+    }
+    if (fieldId === 'orders_average_order_size') {
+        return {
+            fieldType: FieldType.METRIC,
+            type: MetricType.AVERAGE,
+            name: 'average_order_size',
+            label: 'Average Order Size',
+            table: 'orders',
+            tableLabel: 'Orders',
+            sql: 'AVG(${TABLE}.amount)',
+            hidden: false,
+            format: CustomFormatType.CURRENCY,
+        };
+    }
+
+    // default
+    return undefined;
+};
+
+export const NON_PIVOTED_ROWS: ResultRow[] = [
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'bank_transfer',
+                formatted: 'bank_transfer',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2025-01-01T00:00:00Z',
+                formatted: '2025',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 493.78,
+                formatted: '493.78',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'coupon',
+                formatted: 'coupon',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2025-01-01T00:00:00Z',
+                formatted: '2025',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 125.64,
+                formatted: '125.64',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'credit_card',
+                formatted: 'credit_card',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2025-01-01T00:00:00Z',
+                formatted: '2025',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 780.06,
+                formatted: '780.06',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'gift_card',
+                formatted: 'gift_card',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2025-01-01T00:00:00Z',
+                formatted: '2025',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 347.29,
+                formatted: '347.29',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'bank_transfer',
+                formatted: 'bank_transfer',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2024-01-01T00:00:00Z',
+                formatted: '2024',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 301.9,
+                formatted: '301.9',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'coupon',
+                formatted: 'coupon',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2024-01-01T00:00:00Z',
+                formatted: '2024',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 82,
+                formatted: '82',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'credit_card',
+                formatted: 'credit_card',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2024-01-01T00:00:00Z',
+                formatted: '2024',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 630.1,
+                formatted: '630.1',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'gift_card',
+                formatted: 'gift_card',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2024-01-01T00:00:00Z',
+                formatted: '2024',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 175.6,
+                formatted: '175.6',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'bank_transfer',
+                formatted: 'bank_transfer',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2023-01-01T00:00:00Z',
+                formatted: '2023',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 10.5,
+                formatted: '10.5',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'coupon',
+                formatted: 'coupon',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2023-01-01T00:00:00Z',
+                formatted: '2023',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 51,
+                formatted: '51',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'credit_card',
+                formatted: 'credit_card',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2023-01-01T00:00:00Z',
+                formatted: '2023',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 42,
+                formatted: '42',
+            },
+        },
+    },
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'gift_card',
+                formatted: 'gift_card',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2023-01-01T00:00:00Z',
+                formatted: '2023',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 14,
+                formatted: '14',
+            },
+        },
+    },
+];
+
+export const SQL_PIVOTED_ROWS: ResultRow[] = [
+    {
+        orders_order_date_year: {
+            value: {
+                raw: '2025-01-01T00:00:00Z',
+                formatted: '2025',
+            },
+        },
+        payments_total_revenue_any_bank_transfer: {
+            value: {
+                raw: 493.78,
+                formatted: '493.78',
+            },
+        },
+        payments_total_revenue_any_coupon: {
+            value: {
+                raw: 125.64,
+                formatted: '125.64',
+            },
+        },
+        payments_total_revenue_any_credit_card: {
+            value: {
+                raw: 780.06,
+                formatted: '780.06',
+            },
+        },
+        payments_total_revenue_any_gift_card: {
+            value: {
+                raw: 347.29,
+                formatted: '347.29',
+            },
+        },
+    },
+    {
+        orders_order_date_year: {
+            value: {
+                raw: '2024-01-01T00:00:00Z',
+                formatted: '2024',
+            },
+        },
+        payments_total_revenue_any_bank_transfer: {
+            value: {
+                raw: 301.9,
+                formatted: '301.9',
+            },
+        },
+        payments_total_revenue_any_coupon: {
+            value: {
+                raw: 82,
+                formatted: '82',
+            },
+        },
+        payments_total_revenue_any_credit_card: {
+            value: {
+                raw: 630.1,
+                formatted: '630.1',
+            },
+        },
+        payments_total_revenue_any_gift_card: {
+            value: {
+                raw: 175.6,
+                formatted: '175.6',
+            },
+        },
+    },
+    {
+        orders_order_date_year: {
+            value: {
+                raw: '2023-01-01T00:00:00Z',
+                formatted: '2023',
+            },
+        },
+        payments_total_revenue_any_bank_transfer: {
+            value: {
+                raw: 10.5,
+                formatted: '10.5',
+            },
+        },
+        payments_total_revenue_any_coupon: {
+            value: {
+                raw: 51,
+                formatted: '51',
+            },
+        },
+        payments_total_revenue_any_credit_card: {
+            value: {
+                raw: 42,
+                formatted: '42',
+            },
+        },
+        payments_total_revenue_any_gift_card: {
+            value: {
+                raw: 14,
+                formatted: '14',
+            },
+        },
+    },
+];
+
+export const SQL_PIVOT_DETAILS: NonNullable<
+    ReadyQueryResultsPage['pivotDetails']
+> = {
+    totalColumnCount: 4,
+    valuesColumns: [
+        {
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    value: 'bank_transfer',
+                    referenceField: 'payments_payment_method',
+                },
+            ],
+            referenceField: 'payments_total_revenue',
+            pivotColumnName: 'payments_total_revenue_any_bank_transfer',
+        },
+        {
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    value: 'coupon',
+                    referenceField: 'payments_payment_method',
+                },
+            ],
+            referenceField: 'payments_total_revenue',
+            pivotColumnName: 'payments_total_revenue_any_coupon',
+        },
+        {
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    value: 'credit_card',
+                    referenceField: 'payments_payment_method',
+                },
+            ],
+            referenceField: 'payments_total_revenue',
+            pivotColumnName: 'payments_total_revenue_any_credit_card',
+        },
+        {
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    value: 'gift_card',
+                    referenceField: 'payments_payment_method',
+                },
+            ],
+            referenceField: 'payments_total_revenue',
+            pivotColumnName: 'payments_total_revenue_any_gift_card',
+        },
+    ],
+    indexColumn: [
+        {
+            type: VizIndexType.TIME,
+            reference: 'orders_order_date_year',
+        },
+    ],
+    groupByColumns: [
+        {
+            reference: 'payments_payment_method',
+        },
+    ],
+    sortBy: [
+        {
+            direction: SortByDirection.DESC,
+            reference: 'orders_order_date_year',
+        },
+    ],
+    originalColumns: {},
+};
+
+export const EXPECTED_PIVOT_DATA: PivotData = {
+    titleFields: [
+        [
+            {
+                fieldId: 'payments_payment_method',
+                direction: 'header',
+            },
+        ],
+        [
+            {
+                fieldId: 'orders_order_date_year',
+                direction: 'index',
+            },
+        ],
+    ],
+    headerValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'payments_payment_method',
+        },
+        {
+            type: FieldType.METRIC,
+        },
+    ],
+    headerValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'bank_transfer',
+                    formatted: 'bank_transfer',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'coupon',
+                    formatted: 'coupon',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'credit_card',
+                    formatted: 'credit_card',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'gift_card',
+                    formatted: 'gift_card',
+                },
+                colSpan: 1,
+            },
+        ],
+        [
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+    ],
+    indexValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_order_date_year',
+        },
+    ],
+    indexValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2025-01-01T00:00:00Z',
+                    formatted: '2025',
+                },
+                colSpan: 1,
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2024-01-01T00:00:00Z',
+                    formatted: '2024',
+                },
+                colSpan: 1,
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2023-01-01T00:00:00Z',
+                    formatted: '2023',
+                },
+                colSpan: 1,
+            },
+        ],
+    ],
+    dataColumnCount: 4,
+    dataValues: [
+        [
+            {
+                raw: 493.78,
+                formatted: '493.78',
+            },
+            {
+                raw: 125.64,
+                formatted: '125.64',
+            },
+            {
+                raw: 780.06,
+                formatted: '780.06',
+            },
+            {
+                raw: 347.29,
+                formatted: '347.29',
+            },
+        ],
+        [
+            {
+                raw: 301.9,
+                formatted: '301.9',
+            },
+            {
+                raw: 82,
+                formatted: '82',
+            },
+            {
+                raw: 630.1,
+                formatted: '630.1',
+            },
+            {
+                raw: 175.6,
+                formatted: '175.6',
+            },
+        ],
+        [
+            {
+                raw: 10.5,
+                formatted: '10.5',
+            },
+            {
+                raw: 51,
+                formatted: '51',
+            },
+            {
+                raw: 42,
+                formatted: '42',
+            },
+            {
+                raw: 14,
+                formatted: '14',
+            },
+        ],
+    ],
+    cellsCount: 5,
+    rowsCount: 3,
+    pivotConfig: {
+        pivotDimensions: ['payments_payment_method'],
+        metricsAsRows: false,
+        columnOrder: [
+            'payments_payment_method',
+            'orders_order_date_year',
+            'payments_total_revenue',
+        ],
+        hiddenMetricFieldIds: [],
+        columnTotals: false,
+        rowTotals: false,
+    },
+    retrofitData: {
+        allCombinedData: [
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2025-01-01T00:00:00Z',
+                        formatted: '2025',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__0: {
+                    value: {
+                        raw: 493.78,
+                        formatted: '493.78',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__1: {
+                    value: {
+                        raw: 125.64,
+                        formatted: '125.64',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__2: {
+                    value: {
+                        raw: 780.06,
+                        formatted: '780.06',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__3: {
+                    value: {
+                        raw: 347.29,
+                        formatted: '347.29',
+                    },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2024-01-01T00:00:00Z',
+                        formatted: '2024',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__0: {
+                    value: {
+                        raw: 301.9,
+                        formatted: '301.9',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__1: {
+                    value: {
+                        raw: 82,
+                        formatted: '82',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__2: {
+                    value: {
+                        raw: 630.1,
+                        formatted: '630.1',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__3: {
+                    value: {
+                        raw: 175.6,
+                        formatted: '175.6',
+                    },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2023-01-01T00:00:00Z',
+                        formatted: '2023',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__0: {
+                    value: {
+                        raw: 10.5,
+                        formatted: '10.5',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__1: {
+                    value: {
+                        raw: 51,
+                        formatted: '51',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__2: {
+                    value: {
+                        raw: 42,
+                        formatted: '42',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__3: {
+                    value: {
+                        raw: 14,
+                        formatted: '14',
+                    },
+                },
+            },
+        ],
+        pivotColumnInfo: [
+            {
+                fieldId: 'orders_order_date_year',
+                columnType: 'indexValue',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__payments_total_revenue__0',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__payments_total_revenue__1',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__payments_total_revenue__2',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__payments_total_revenue__3',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+        ],
+    },
+    rowTotalFields: undefined,
+    rowTotals: undefined,
+    columnTotalFields: undefined,
+    columnTotals: undefined,
+    groupedSubtotals: undefined,
+};
+
+export const EXPECTED_PIVOT_DATA_WITH_TOTALS: PivotData = {
+    titleFields: [
+        [
+            {
+                fieldId: 'payments_payment_method',
+                direction: 'header',
+            },
+        ],
+        [
+            {
+                fieldId: 'orders_order_date_year',
+                direction: 'index',
+            },
+        ],
+    ],
+    headerValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'payments_payment_method',
+        },
+        {
+            type: FieldType.METRIC,
+        },
+    ],
+    headerValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'bank_transfer',
+                    formatted: 'bank_transfer',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'coupon',
+                    formatted: 'coupon',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'credit_card',
+                    formatted: 'credit_card',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'gift_card',
+                    formatted: 'gift_card',
+                },
+                colSpan: 1,
+            },
+        ],
+        [
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+    ],
+    indexValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_order_date_year',
+        },
+    ],
+    indexValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2025-01-01T00:00:00Z',
+                    formatted: '2025',
+                },
+                colSpan: 1,
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2024-01-01T00:00:00Z',
+                    formatted: '2024',
+                },
+                colSpan: 1,
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2023-01-01T00:00:00Z',
+                    formatted: '2023',
+                },
+                colSpan: 1,
+            },
+        ],
+    ],
+    dataColumnCount: 4,
+    dataValues: [
+        [
+            {
+                raw: 493.78,
+                formatted: '493.78',
+            },
+            {
+                raw: 125.64,
+                formatted: '125.64',
+            },
+            {
+                raw: 780.06,
+                formatted: '780.06',
+            },
+            {
+                raw: 347.29,
+                formatted: '347.29',
+            },
+        ],
+        [
+            {
+                raw: 301.9,
+                formatted: '301.9',
+            },
+            {
+                raw: 82,
+                formatted: '82',
+            },
+            {
+                raw: 630.1,
+                formatted: '630.1',
+            },
+            {
+                raw: 175.6,
+                formatted: '175.6',
+            },
+        ],
+        [
+            {
+                raw: 10.5,
+                formatted: '10.5',
+            },
+            {
+                raw: 51,
+                formatted: '51',
+            },
+            {
+                raw: 42,
+                formatted: '42',
+            },
+            {
+                raw: 14,
+                formatted: '14',
+            },
+        ],
+    ],
+    rowTotalFields: [
+        [null],
+        [
+            {
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+    ],
+    columnTotalFields: [[{ fieldId: undefined }]],
+    rowTotals: [[1746.77], [1189.6], [117.5]],
+    columnTotals: [[806.18, 258.64, 1452.1599999999999, 536.89]],
+    cellsCount: 6,
+    rowsCount: 3,
+    pivotConfig: {
+        pivotDimensions: ['payments_payment_method'],
+        metricsAsRows: false,
+        columnOrder: [
+            'payments_payment_method',
+            'orders_order_date_year',
+            'payments_total_revenue',
+        ],
+        hiddenMetricFieldIds: [],
+        columnTotals: true,
+        rowTotals: true,
+    },
+    retrofitData: {
+        allCombinedData: [
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2025-01-01T00:00:00Z',
+                        formatted: '2025',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__0: {
+                    value: {
+                        raw: 493.78,
+                        formatted: '493.78',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__1: {
+                    value: {
+                        raw: 125.64,
+                        formatted: '125.64',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__2: {
+                    value: {
+                        raw: 780.06,
+                        formatted: '780.06',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__3: {
+                    value: {
+                        raw: 347.29,
+                        formatted: '347.29',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 1746.77,
+                        formatted: '1,746.77',
+                    },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2024-01-01T00:00:00Z',
+                        formatted: '2024',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__0: {
+                    value: {
+                        raw: 301.9,
+                        formatted: '301.9',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__1: {
+                    value: {
+                        raw: 82,
+                        formatted: '82',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__2: {
+                    value: {
+                        raw: 630.1,
+                        formatted: '630.1',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__3: {
+                    value: {
+                        raw: 175.6,
+                        formatted: '175.6',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 1189.6,
+                        formatted: '1,189.6',
+                    },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2023-01-01T00:00:00Z',
+                        formatted: '2023',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__0: {
+                    value: {
+                        raw: 10.5,
+                        formatted: '10.5',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__1: {
+                    value: {
+                        raw: 51,
+                        formatted: '51',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__2: {
+                    value: {
+                        raw: 42,
+                        formatted: '42',
+                    },
+                },
+                payments_payment_method__payments_total_revenue__3: {
+                    value: {
+                        raw: 14,
+                        formatted: '14',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 117.5,
+                        formatted: '117.5',
+                    },
+                },
+            },
+        ],
+        pivotColumnInfo: [
+            {
+                fieldId: 'orders_order_date_year',
+                columnType: 'indexValue',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__payments_total_revenue__0',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__payments_total_revenue__1',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__payments_total_revenue__2',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__payments_total_revenue__3',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'row-total-0',
+                baseId: 'row-total-0',
+                underlyingId: 'payments_total_revenue',
+                columnType: 'rowTotal',
+            },
+        ],
+    },
+    groupedSubtotals: undefined,
+};
+
+export const EXPECTED_PIVOT_DATA_METRICS_AS_ROWS: PivotData = {
+    titleFields: [
+        [
+            {
+                fieldId: 'orders_order_date_year',
+                direction: 'index',
+            },
+            {
+                fieldId: 'payments_payment_method',
+                direction: 'header',
+            },
+        ],
+    ],
+    headerValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'payments_payment_method',
+        },
+    ],
+    headerValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'bank_transfer',
+                    formatted: 'bank_transfer',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'coupon',
+                    formatted: 'coupon',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'credit_card',
+                    formatted: 'credit_card',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'gift_card',
+                    formatted: 'gift_card',
+                },
+                colSpan: 1,
+            },
+        ],
+    ],
+    indexValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_order_date_year',
+        },
+        {
+            type: FieldType.METRIC,
+        },
+    ],
+    indexValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2025-01-01T00:00:00Z',
+                    formatted: '2025',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2024-01-01T00:00:00Z',
+                    formatted: '2024',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2023-01-01T00:00:00Z',
+                    formatted: '2023',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+    ],
+    dataColumnCount: 4,
+    dataValues: [
+        [
+            {
+                raw: 493.78,
+                formatted: '493.78',
+            },
+            {
+                raw: 125.64,
+                formatted: '125.64',
+            },
+            {
+                raw: 780.06,
+                formatted: '780.06',
+            },
+            {
+                raw: 347.29,
+                formatted: '347.29',
+            },
+        ],
+        [
+            {
+                raw: 301.9,
+                formatted: '301.9',
+            },
+            {
+                raw: 82,
+                formatted: '82',
+            },
+            {
+                raw: 630.1,
+                formatted: '630.1',
+            },
+            {
+                raw: 175.6,
+                formatted: '175.6',
+            },
+        ],
+        [
+            {
+                raw: 10.5,
+                formatted: '10.5',
+            },
+            {
+                raw: 51,
+                formatted: '51',
+            },
+            {
+                raw: 42,
+                formatted: '42',
+            },
+            {
+                raw: 14,
+                formatted: '14',
+            },
+        ],
+    ],
+    rowTotalFields: [[{ fieldId: undefined }]],
+    columnTotalFields: [
+        [
+            null,
+            {
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+    ],
+    rowTotals: [[1746.77], [1189.6], [117.5]],
+    columnTotals: [[806.18, 258.64, 1452.1599999999999, 536.89]],
+    cellsCount: 7,
+    rowsCount: 3,
+    pivotConfig: {
+        pivotDimensions: ['payments_payment_method'],
+        metricsAsRows: true,
+        columnOrder: [
+            'payments_payment_method',
+            'orders_order_date_year',
+            'payments_total_revenue',
+        ],
+        hiddenMetricFieldIds: [],
+        columnTotals: true,
+        rowTotals: true,
+    },
+    retrofitData: {
+        allCombinedData: [
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2025-01-01T00:00:00Z',
+                        formatted: '2025',
+                    },
+                },
+                'label-1': {
+                    value: {
+                        raw: 'Payments Total revenue',
+                        formatted: 'Payments Total revenue',
+                    },
+                },
+                payments_payment_method__0: {
+                    value: {
+                        raw: 493.78,
+                        formatted: '493.78',
+                    },
+                },
+                payments_payment_method__1: {
+                    value: {
+                        raw: 125.64,
+                        formatted: '125.64',
+                    },
+                },
+                payments_payment_method__2: {
+                    value: {
+                        raw: 780.06,
+                        formatted: '780.06',
+                    },
+                },
+                payments_payment_method__3: {
+                    value: {
+                        raw: 347.29,
+                        formatted: '347.29',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 1746.77,
+                        formatted: '1,746.77',
+                    },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2024-01-01T00:00:00Z',
+                        formatted: '2024',
+                    },
+                },
+                'label-1': {
+                    value: {
+                        raw: 'Payments Total revenue',
+                        formatted: 'Payments Total revenue',
+                    },
+                },
+                payments_payment_method__0: {
+                    value: {
+                        raw: 301.9,
+                        formatted: '301.9',
+                    },
+                },
+                payments_payment_method__1: {
+                    value: {
+                        raw: 82,
+                        formatted: '82',
+                    },
+                },
+                payments_payment_method__2: {
+                    value: {
+                        raw: 630.1,
+                        formatted: '630.1',
+                    },
+                },
+                payments_payment_method__3: {
+                    value: {
+                        raw: 175.6,
+                        formatted: '175.6',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 1189.6,
+                        formatted: '1,189.6',
+                    },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2023-01-01T00:00:00Z',
+                        formatted: '2023',
+                    },
+                },
+                'label-1': {
+                    value: {
+                        raw: 'Payments Total revenue',
+                        formatted: 'Payments Total revenue',
+                    },
+                },
+                payments_payment_method__0: {
+                    value: {
+                        raw: 10.5,
+                        formatted: '10.5',
+                    },
+                },
+                payments_payment_method__1: {
+                    value: {
+                        raw: 51,
+                        formatted: '51',
+                    },
+                },
+                payments_payment_method__2: {
+                    value: {
+                        raw: 42,
+                        formatted: '42',
+                    },
+                },
+                payments_payment_method__3: {
+                    value: {
+                        raw: 14,
+                        formatted: '14',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 117.5,
+                        formatted: '117.5',
+                    },
+                },
+            },
+        ],
+        pivotColumnInfo: [
+            {
+                fieldId: 'orders_order_date_year',
+                columnType: 'indexValue',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId: 'label-1',
+                columnType: 'label',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__0',
+                baseId: 'payments_payment_method',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__1',
+                baseId: 'payments_payment_method',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__2',
+                baseId: 'payments_payment_method',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__3',
+                baseId: 'payments_payment_method',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'row-total-0',
+                baseId: 'row-total-0',
+                columnType: 'rowTotal',
+                underlyingId: undefined,
+            },
+        ],
+    },
+    groupedSubtotals: undefined,
+};
+
+export const COMPLEX_NON_PIVOTED_ROWS: ResultRow[] = [
+    {
+        payments_payment_method: {
+            value: {
+                raw: 'bank_transfer',
+                formatted: 'bank_transfer',
+            },
+        },
+        orders_order_date_year: {
+            value: {
+                raw: '2025-01-01T00:00:00Z',
+                formatted: '2025',
+            },
+        },
+        orders_is_completed: {
+            value: {
+                raw: false,
+                formatted: 'False',
+            },
+        },
+        orders_promo_code: {
+            value: {
+                raw: 'AFTER',
+                formatted: 'AFTER',
+            },
+        },
+        payments_total_revenue: {
+            value: {
+                raw: 52.5,
+                formatted: '52.5',
+            },
+        },
+        orders_average_order_size: {
+            value: {
+                raw: 52.5,
+                formatted: '$52.50',
+            },
+        },
+        orders_total_order_amount: {
+            value: {
+                raw: 52.5,
+                formatted: '$52.50',
+            },
+        },
+    },
+];
+
+export const COMPLEX_SQL_PIVOTED_ROWS: ResultRow[] = [
+    {
+        orders_order_date_year: {
+            value: {
+                raw: '2025-01-01T00:00:00Z',
+                formatted: '2025',
+            },
+        },
+        orders_promo_code: {
+            value: {
+                raw: 'AFTER',
+                formatted: 'AFTER',
+            },
+        },
+        payments_total_revenue_any_bank_transfer_false: {
+            value: {
+                raw: 52.5,
+                formatted: '52.5',
+            },
+        },
+        orders_average_order_size_any_bank_transfer_false: {
+            value: {
+                raw: 52.5,
+                formatted: '$52.50',
+            },
+        },
+        orders_total_order_amount_any_bank_transfer_false: {
+            value: {
+                raw: 52.5,
+                formatted: '$52.50',
+            },
+        },
+    },
+];
+
+export const COMPLEX_SQL_PIVOT_DETAILS: NonNullable<
+    ReadyQueryResultsPage['pivotDetails']
+> = {
+    totalColumnCount: 3,
+    valuesColumns: [
+        {
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    value: 'bank_transfer',
+                    referenceField: 'payments_payment_method',
+                },
+                {
+                    value: false,
+                    referenceField: 'orders_is_completed',
+                },
+            ],
+            referenceField: 'payments_total_revenue',
+            pivotColumnName: 'payments_total_revenue_any_bank_transfer_false',
+        },
+        {
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    value: 'bank_transfer',
+                    referenceField: 'payments_payment_method',
+                },
+                {
+                    value: false,
+                    referenceField: 'orders_is_completed',
+                },
+            ],
+            referenceField: 'orders_average_order_size',
+            pivotColumnName:
+                'orders_average_order_size_any_bank_transfer_false',
+        },
+        {
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    value: 'bank_transfer',
+                    referenceField: 'payments_payment_method',
+                },
+                {
+                    value: false,
+                    referenceField: 'orders_is_completed',
+                },
+            ],
+            referenceField: 'orders_total_order_amount',
+            pivotColumnName:
+                'orders_total_order_amount_any_bank_transfer_false',
+        },
+    ],
+    indexColumn: [
+        {
+            type: VizIndexType.TIME,
+            reference: 'orders_order_date_year',
+        },
+        {
+            type: VizIndexType.CATEGORY,
+            reference: 'orders_promo_code',
+        },
+    ],
+    groupByColumns: [
+        {
+            reference: 'payments_payment_method',
+        },
+        {
+            reference: 'orders_is_completed',
+        },
+    ],
+    sortBy: [
+        {
+            direction: SortByDirection.DESC,
+            reference: 'orders_order_date_year',
+        },
+    ],
+    originalColumns: {},
+};
+
+// multiple dimensions, multiple metrics, multiple pivots, totals
+// @ts-ignore
+export const EXPECTED_COMPLEX_PIVOT_DATA: PivotData = {
+    titleFields: [
+        [
+            null,
+            {
+                fieldId: 'payments_payment_method',
+                direction: 'header',
+            },
+        ],
+        [
+            null,
+            {
+                fieldId: 'orders_is_completed',
+                direction: 'header',
+            },
+        ],
+        [
+            {
+                fieldId: 'orders_order_date_year',
+                direction: 'index',
+            },
+            {
+                fieldId: 'orders_promo_code',
+                direction: 'index',
+            },
+        ],
+    ],
+    headerValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'payments_payment_method',
+        },
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_is_completed',
+        },
+        {
+            type: FieldType.METRIC,
+        },
+    ],
+    headerValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'bank_transfer',
+                    formatted: 'bank_transfer',
+                },
+                colSpan: 3,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'bank_transfer',
+                    formatted: 'bank_transfer',
+                },
+                colSpan: 0,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'bank_transfer',
+                    formatted: 'bank_transfer',
+                },
+                colSpan: 0,
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_is_completed',
+                value: {
+                    raw: false,
+                    formatted: 'False',
+                },
+                colSpan: 3,
+            },
+            {
+                type: 'value',
+                fieldId: 'orders_is_completed',
+                value: {
+                    raw: false,
+                    formatted: 'False',
+                },
+                colSpan: 0,
+            },
+            {
+                type: 'value',
+                fieldId: 'orders_is_completed',
+                value: {
+                    raw: false,
+                    formatted: 'False',
+                },
+                colSpan: 0,
+            },
+        ],
+        [
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+            {
+                type: 'label',
+                fieldId: 'orders_average_order_size',
+            },
+            {
+                type: 'label',
+                fieldId: 'orders_total_order_amount',
+            },
+        ],
+    ],
+    indexValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_order_date_year',
+        },
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_promo_code',
+        },
+    ],
+    indexValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2025-01-01T00:00:00Z',
+                    formatted: '2025',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'orders_promo_code',
+                value: {
+                    raw: 'AFTER',
+                    formatted: 'AFTER',
+                },
+                colSpan: 1,
+            },
+        ],
+    ],
+    dataColumnCount: 3,
+    dataValues: [
+        [
+            {
+                raw: 52.5,
+                formatted: '52.5',
+            },
+            {
+                raw: 52.5,
+                formatted: '$52.50',
+            },
+            {
+                raw: 52.5,
+                formatted: '$52.50',
+            },
+        ],
+    ],
+    rowTotalFields: [
+        [null, null],
+        [null, null],
+        [
+            {
+                fieldId: 'payments_total_revenue',
+            },
+            {
+                fieldId: 'orders_total_order_amount',
+            },
+        ],
+    ],
+    columnTotalFields: [[null, { fieldId: undefined }]],
+    rowTotals: [[52.5, 52.5]],
+    columnTotals: [[52.5, 52.5, 52.5]],
+    cellsCount: 7,
+    rowsCount: 1,
+    pivotConfig: {
+        pivotDimensions: ['payments_payment_method', 'orders_is_completed'],
+        metricsAsRows: false,
+        columnOrder: [
+            'payments_payment_method',
+            'orders_order_date_year',
+            'orders_is_completed',
+            'orders_promo_code',
+            'payments_total_revenue',
+            'orders_average_order_size',
+            'orders_total_order_amount',
+        ],
+        hiddenMetricFieldIds: [],
+        columnTotals: true,
+        rowTotals: true,
+    },
+    retrofitData: {
+        allCombinedData: [
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2025-01-01T00:00:00Z',
+                        formatted: '2025',
+                    },
+                },
+                orders_promo_code: {
+                    value: {
+                        raw: 'AFTER',
+                        formatted: 'AFTER',
+                    },
+                },
+                payments_payment_method__orders_is_completed__payments_total_revenue__0:
+                    {
+                        value: {
+                            raw: 52.5,
+                            formatted: '52.5',
+                        },
+                    },
+                payments_payment_method__orders_is_completed__orders_average_order_size__1:
+                    {
+                        value: {
+                            raw: 52.5,
+                            formatted: '$52.50',
+                        },
+                    },
+                payments_payment_method__orders_is_completed__orders_total_order_amount__2:
+                    {
+                        value: {
+                            raw: 52.5,
+                            formatted: '$52.50',
+                        },
+                    },
+                'row-total-0': {
+                    value: {
+                        raw: 52.5,
+                        formatted: '52.5',
+                    },
+                },
+                'row-total-1': {
+                    value: {
+                        raw: 52.5,
+                        formatted: '52.5',
+                    },
+                },
+            },
+        ],
+        pivotColumnInfo: [
+            {
+                fieldId: 'orders_order_date_year',
+                columnType: 'indexValue',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId: 'orders_promo_code',
+                columnType: 'indexValue',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId:
+                    'payments_payment_method__orders_is_completed__payments_total_revenue__0',
+                baseId: 'payments_total_revenue',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId:
+                    'payments_payment_method__orders_is_completed__orders_average_order_size__1',
+                baseId: 'orders_average_order_size',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId:
+                    'payments_payment_method__orders_is_completed__orders_total_order_amount__2',
+                baseId: 'orders_total_order_amount',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'row-total-0',
+                baseId: 'row-total-0',
+                underlyingId: 'payments_total_revenue',
+                columnType: 'rowTotal',
+            },
+            {
+                fieldId: 'row-total-1',
+                baseId: 'row-total-1',
+                underlyingId: 'orders_total_order_amount',
+                columnType: 'rowTotal',
+            },
+        ],
+    },
+    groupedSubtotals: undefined,
+};
+
+// multiple dimensions, multiple metrics, multiple pivots, totals and metric as rows
+export const EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS: PivotData = {
+    titleFields: [
+        [
+            null,
+            null,
+            {
+                fieldId: 'payments_payment_method',
+                direction: 'header',
+            },
+        ],
+        [
+            {
+                fieldId: 'orders_order_date_year',
+                direction: 'index',
+            },
+            {
+                fieldId: 'orders_promo_code',
+                direction: 'index',
+            },
+            {
+                fieldId: 'orders_is_completed',
+                direction: 'header',
+            },
+        ],
+    ],
+    headerValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'payments_payment_method',
+        },
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_is_completed',
+        },
+    ],
+    headerValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'payments_payment_method',
+                value: {
+                    raw: 'bank_transfer',
+                    formatted: 'bank_transfer',
+                },
+                colSpan: 1,
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_is_completed',
+                value: {
+                    raw: false,
+                    formatted: 'False',
+                },
+                colSpan: 1,
+            },
+        ],
+    ],
+    indexValueTypes: [
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_order_date_year',
+        },
+        {
+            type: FieldType.DIMENSION,
+            fieldId: 'orders_promo_code',
+        },
+        {
+            type: FieldType.METRIC,
+        },
+    ],
+    indexValues: [
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2025-01-01T00:00:00Z',
+                    formatted: '2025',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'orders_promo_code',
+                value: {
+                    raw: 'AFTER',
+                    formatted: 'AFTER',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2025-01-01T00:00:00Z',
+                    formatted: '2025',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'orders_promo_code',
+                value: {
+                    raw: 'AFTER',
+                    formatted: 'AFTER',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'label',
+                fieldId: 'orders_average_order_size',
+            },
+        ],
+        [
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: {
+                    raw: '2025-01-01T00:00:00Z',
+                    formatted: '2025',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'orders_promo_code',
+                value: {
+                    raw: 'AFTER',
+                    formatted: 'AFTER',
+                },
+                colSpan: 1,
+            },
+            {
+                type: 'label',
+                fieldId: 'orders_total_order_amount',
+            },
+        ],
+    ],
+    dataColumnCount: 1,
+    dataValues: [
+        [
+            {
+                raw: 52.5,
+                formatted: '52.5',
+            },
+        ],
+        [
+            {
+                raw: 52.5,
+                formatted: '$52.50',
+            },
+        ],
+        [
+            {
+                raw: 52.5,
+                formatted: '$52.50',
+            },
+        ],
+    ],
+    rowTotalFields: [[null], [{ fieldId: undefined }]],
+    columnTotalFields: [
+        [
+            null,
+            null,
+            {
+                fieldId: 'payments_total_revenue',
+            },
+        ],
+        [
+            null,
+            null,
+            {
+                fieldId: 'orders_total_order_amount',
+            },
+        ],
+    ],
+    rowTotals: [[52.5], [52.5], [52.5]],
+    columnTotals: [[52.5], [52.5]],
+    cellsCount: 5,
+    rowsCount: 3,
+    pivotConfig: {
+        pivotDimensions: ['payments_payment_method', 'orders_is_completed'],
+        metricsAsRows: true,
+        columnOrder: [
+            'payments_payment_method',
+            'orders_order_date_year',
+            'orders_is_completed',
+            'orders_promo_code',
+            'payments_total_revenue',
+            'orders_average_order_size',
+            'orders_total_order_amount',
+        ],
+        hiddenMetricFieldIds: [],
+        columnTotals: true,
+        rowTotals: true,
+    },
+    retrofitData: {
+        allCombinedData: [
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2025-01-01T00:00:00Z',
+                        formatted: '2025',
+                    },
+                },
+                orders_promo_code: {
+                    value: {
+                        raw: 'AFTER',
+                        formatted: 'AFTER',
+                    },
+                },
+                'label-2': {
+                    value: {
+                        raw: 'Payments Total revenue',
+                        formatted: 'Payments Total revenue',
+                    },
+                },
+                payments_payment_method__orders_is_completed__0: {
+                    value: {
+                        raw: 52.5,
+                        formatted: '52.5',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 52.5,
+                        formatted: '52.5',
+                    },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2025-01-01T00:00:00Z',
+                        formatted: '2025',
+                    },
+                },
+                orders_promo_code: {
+                    value: {
+                        raw: 'AFTER',
+                        formatted: 'AFTER',
+                    },
+                },
+                'label-2': {
+                    value: {
+                        raw: 'Orders Average order size',
+                        formatted: 'Orders Average order size',
+                    },
+                },
+                payments_payment_method__orders_is_completed__0: {
+                    value: {
+                        raw: 52.5,
+                        formatted: '$52.50',
+                    },
+                },
+            },
+            {
+                orders_order_date_year: {
+                    value: {
+                        raw: '2025-01-01T00:00:00Z',
+                        formatted: '2025',
+                    },
+                },
+                orders_promo_code: {
+                    value: {
+                        raw: 'AFTER',
+                        formatted: 'AFTER',
+                    },
+                },
+                'label-2': {
+                    value: {
+                        raw: 'Orders Total order amount',
+                        formatted: 'Orders Total order amount',
+                    },
+                },
+                payments_payment_method__orders_is_completed__0: {
+                    value: {
+                        raw: 52.5,
+                        formatted: '$52.50',
+                    },
+                },
+                'row-total-0': {
+                    value: {
+                        raw: 52.5,
+                        formatted: '52.5',
+                    },
+                },
+            },
+        ],
+        pivotColumnInfo: [
+            {
+                fieldId: 'orders_order_date_year',
+                columnType: 'indexValue',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId: 'orders_promo_code',
+                columnType: 'indexValue',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId: 'label-2',
+                columnType: 'label',
+                baseId: undefined,
+                underlyingId: undefined,
+            },
+            {
+                fieldId: 'payments_payment_method__orders_is_completed__0',
+                baseId: 'orders_is_completed',
+                underlyingId: undefined,
+                columnType: undefined,
+            },
+            {
+                fieldId: 'row-total-0',
+                baseId: 'row-total-0',
+                columnType: 'rowTotal',
+                underlyingId: undefined,
+            },
+        ],
+    },
+    groupedSubtotals: undefined,
+};

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1,6 +1,7 @@
 import isNumber from 'lodash/isNumber';
 import last from 'lodash/last';
 import { type Entries } from 'type-fest';
+import type { ReadyQueryResultsPage } from '../index';
 import { UnexpectedIndexError, UnexpectedServerError } from '../types/errors';
 import {
     FieldType,
@@ -375,6 +376,145 @@ const combinedRetrofit = (
     return data;
 };
 
+const getHeaderValueTypes = ({
+    metricsAsRows,
+    pivotDimensionNames,
+}: {
+    metricsAsRows: boolean;
+    pivotDimensionNames: string[];
+}): PivotData['headerValueTypes'] => {
+    const headerDimensionValueTypes = pivotDimensionNames.map<{
+        type: FieldType.DIMENSION;
+        fieldId: string;
+    }>((fieldId) => ({
+        type: FieldType.DIMENSION,
+        fieldId,
+    }));
+    const headerMetricValueTypes: { type: FieldType.METRIC }[] = metricsAsRows
+        ? []
+        : [{ type: FieldType.METRIC }];
+    return [...headerDimensionValueTypes, ...headerMetricValueTypes];
+};
+
+const getColumnTotals = ({
+    summableMetricFieldIds,
+    rowIndices,
+    totalColumns,
+    dataColumns,
+    dataValues,
+    hasIndex,
+    pivotConfig,
+    indexValues,
+}: {
+    summableMetricFieldIds: string[];
+    rowIndices: RecursiveRecord<number>;
+    totalColumns: number;
+    dataColumns: number;
+    dataValues: (ResultValue | null)[][];
+    hasIndex: boolean;
+    indexValues: PivotData['indexValues'];
+    pivotConfig: Pick<PivotConfig, 'metricsAsRows' | 'columnTotals'>;
+}) => {
+    let columnTotalFields: PivotData['columnTotalFields'];
+    let columnTotals: PivotData['columnTotals'];
+    const N_DATA_COLUMNS = dataColumns;
+    if (pivotConfig.columnTotals && hasIndex) {
+        if (pivotConfig.metricsAsRows) {
+            const N_TOTAL_ROWS = summableMetricFieldIds.length;
+            const N_TOTAL_COLS = totalColumns;
+            columnTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
+            columnTotals = create2DArray(N_TOTAL_ROWS, N_DATA_COLUMNS);
+
+            summableMetricFieldIds.forEach((fieldId, metricIndex) => {
+                columnTotalFields![metricIndex][N_TOTAL_COLS - 1] = {
+                    fieldId,
+                };
+            });
+
+            columnTotals = columnTotals.map((row, rowIndex) =>
+                row.map((_, totalColIndex) => {
+                    const totalColFieldId =
+                        columnTotalFields![rowIndex][N_TOTAL_COLS - 1]?.fieldId;
+
+                    const valueColIndices = totalColFieldId
+                        ? getAllIndicesForFieldId(rowIndices, totalColFieldId)
+                        : [];
+                    return dataValues
+                        .filter((__, dataValueColIndex) =>
+                            valueColIndices.includes(dataValueColIndex),
+                        )
+                        .reduce(
+                            (acc, value) =>
+                                acc + parseNumericValue(value[totalColIndex]),
+                            0,
+                        );
+                }),
+            );
+        } else {
+            const N_TOTAL_COLS = indexValues[0].length;
+            const N_TOTAL_ROWS = 1;
+
+            columnTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
+            columnTotals = create2DArray(N_TOTAL_ROWS, N_DATA_COLUMNS);
+
+            // set the last index cell as the "Total"
+            columnTotalFields[N_TOTAL_ROWS - 1][N_TOTAL_COLS - 1] = {
+                fieldId: undefined,
+            };
+
+            columnTotals = columnTotals.map((row, _totalRowIndex) =>
+                row.map((_col, colIndex) =>
+                    dataValues
+                        .map((dataRow) => dataRow[colIndex])
+                        .reduce(
+                            (acc, value) => acc + parseNumericValue(value),
+                            0,
+                        ),
+                ),
+            );
+        }
+    }
+    return { columnTotalFields, columnTotals };
+};
+
+const getTitleFields = ({
+    hasHeader,
+    hasIndex,
+    headerValueTypes,
+    indexValueTypes,
+}: {
+    hasHeader: boolean;
+    hasIndex: boolean;
+    headerValueTypes: PivotData['headerValueTypes'];
+    indexValueTypes: PivotData['indexValueTypes'];
+}): PivotData['titleFields'] => {
+    const titleFields: PivotData['titleFields'] = create2DArray(
+        hasHeader ? headerValueTypes.length : 1,
+        hasIndex ? indexValueTypes.length : 1,
+    );
+    headerValueTypes.forEach((headerValueType, headerIndex) => {
+        if (headerValueType.type === FieldType.DIMENSION) {
+            titleFields[headerIndex][
+                hasIndex ? indexValueTypes.length - 1 : 0
+            ] = {
+                fieldId: headerValueType.fieldId,
+                direction: 'header',
+            };
+        }
+    });
+    indexValueTypes.forEach((indexValueType, indexIndex) => {
+        if (indexValueType.type === FieldType.DIMENSION) {
+            titleFields[hasHeader ? headerValueTypes.length - 1 : 0][
+                indexIndex
+            ] = {
+                fieldId: indexValueType.fieldId,
+                direction: 'index',
+            };
+        }
+    });
+    return titleFields;
+};
+
 export const pivotQueryResults = ({
     pivotConfig,
     metricQuery,
@@ -410,19 +550,10 @@ export const pivotQueryResults = ({
     const headerDimensions = pivotConfig.pivotDimensions.filter(
         (pivotDimension) => dimensions.includes(pivotDimension),
     );
-    const headerDimensionValueTypes = headerDimensions.map<{
-        type: FieldType.DIMENSION;
-        fieldId: string;
-    }>((d) => ({
-        type: FieldType.DIMENSION,
-        fieldId: d,
-    }));
-    const headerMetricValueTypes: { type: FieldType.METRIC }[] =
-        pivotConfig.metricsAsRows ? [] : [{ type: FieldType.METRIC }];
-    const headerValueTypes: PivotData['headerValueTypes'] = [
-        ...headerDimensionValueTypes,
-        ...headerMetricValueTypes,
-    ];
+    const headerValueTypes = getHeaderValueTypes({
+        metricsAsRows: pivotConfig.metricsAsRows,
+        pivotDimensionNames: headerDimensions,
+    });
 
     // Indices (row index)
     const indexDimensions = dimensions
@@ -683,89 +814,22 @@ export const pivotQueryResults = ({
         }
     }
 
-    let columnTotalFields: PivotData['columnTotalFields'];
-    let columnTotals: PivotData['columnTotals'];
-    if (pivotConfig.columnTotals && hasIndex) {
-        if (pivotConfig.metricsAsRows) {
-            const N_TOTAL_ROWS = summableMetricFieldIds.length;
-            const N_TOTAL_COLS = indexValueTypes.length;
-
-            columnTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
-            columnTotals = create2DArray(N_TOTAL_ROWS, N_DATA_COLUMNS);
-
-            summableMetricFieldIds.forEach((fieldId, metricIndex) => {
-                columnTotalFields![metricIndex][N_TOTAL_COLS - 1] = {
-                    fieldId,
-                };
-            });
-
-            columnTotals = columnTotals.map((row, rowIndex) =>
-                row.map((_, totalColIndex) => {
-                    const totalColFieldId =
-                        columnTotalFields![rowIndex][N_TOTAL_COLS - 1]?.fieldId;
-
-                    const valueColIndices = totalColFieldId
-                        ? getAllIndicesForFieldId(rowIndices, totalColFieldId)
-                        : [];
-                    return dataValues
-                        .filter((__, dataValueColIndex) =>
-                            valueColIndices.includes(dataValueColIndex),
-                        )
-                        .reduce(
-                            (acc, value) =>
-                                acc + parseNumericValue(value[totalColIndex]),
-                            0,
-                        );
-                }),
-            );
-        } else {
-            const N_TOTAL_COLS = indexValues[0].length;
-            const N_TOTAL_ROWS = 1;
-
-            columnTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
-            columnTotals = create2DArray(N_TOTAL_ROWS, N_DATA_COLUMNS);
-
-            // set the last index cell as the "Total"
-            columnTotalFields[N_TOTAL_ROWS - 1][N_TOTAL_COLS - 1] = {
-                fieldId: undefined,
-            };
-
-            columnTotals = columnTotals.map((row, _totalRowIndex) =>
-                row.map((_col, colIndex) =>
-                    dataValues
-                        .map((dataRow) => dataRow[colIndex])
-                        .reduce(
-                            (acc, value) => acc + parseNumericValue(value),
-                            0,
-                        ),
-                ),
-            );
-        }
-    }
-
-    const titleFields: PivotData['titleFields'] = create2DArray(
-        hasHeader ? headerValueTypes.length : 1,
-        hasIndex ? indexValueTypes.length : 1,
-    );
-    headerValueTypes.forEach((headerValueType, headerIndex) => {
-        if (headerValueType.type === FieldType.DIMENSION) {
-            titleFields[headerIndex][
-                hasIndex ? indexValueTypes.length - 1 : 0
-            ] = {
-                fieldId: headerValueType.fieldId,
-                direction: 'header',
-            };
-        }
+    const { columnTotalFields, columnTotals } = getColumnTotals({
+        summableMetricFieldIds,
+        totalColumns: indexValueTypes.length,
+        dataColumns: N_DATA_COLUMNS,
+        dataValues,
+        rowIndices,
+        pivotConfig,
+        indexValues,
+        hasIndex,
     });
-    indexValueTypes.forEach((indexValueType, indexIndex) => {
-        if (indexValueType.type === FieldType.DIMENSION) {
-            titleFields[hasHeader ? headerValueTypes.length - 1 : 0][
-                indexIndex
-            ] = {
-                fieldId: indexValueType.fieldId,
-                direction: 'index',
-            };
-        }
+
+    const titleFields = getTitleFields({
+        hasIndex,
+        hasHeader,
+        headerValueTypes,
+        indexValueTypes,
     });
 
     const cellsCount =
@@ -884,4 +948,583 @@ export const pivotResultsAsCsv = ({
         });
 
     return [...headers, ...pivotedRows];
+};
+
+/**
+ * Converts SQL-pivoted results to PivotData format
+ * This handles results that are already pivoted at the SQL level (e.g., payments_total_revenue_any_bank_transfer)
+ * and transforms them into the same PivotData structure as pivotQueryResults
+ */
+export const convertSqlPivotedRowsToPivotData = ({
+    rows,
+    pivotDetails,
+    pivotConfig,
+    getField,
+    getFieldLabel,
+}: {
+    rows: ResultRow[];
+    pivotDetails: NonNullable<ReadyQueryResultsPage['pivotDetails']>;
+    pivotConfig: Pick<
+        PivotConfig,
+        | 'rowTotals'
+        | 'columnTotals'
+        | 'metricsAsRows'
+        | 'hiddenMetricFieldIds'
+        | 'columnOrder'
+    >; // only use properties that are not part of pivot details metadata
+    getField: FieldFunction;
+    getFieldLabel: FieldLabelFunction;
+}): PivotData => {
+    if (rows.length === 0) {
+        throw new Error('Cannot convert SQL pivoted results with no rows');
+    }
+
+    const hiddenMetricFieldIds = pivotConfig.hiddenMetricFieldIds || [];
+
+    // Extract information from pivot details metadata
+    let indexColumns: string[];
+    if (pivotDetails.indexColumn) {
+        if (Array.isArray(pivotDetails.indexColumn)) {
+            indexColumns = pivotDetails.indexColumn.map((col) => col.reference);
+        } else {
+            indexColumns = [pivotDetails.indexColumn.reference];
+        }
+    } else {
+        indexColumns = [];
+    }
+
+    // todo: eventually this will be done in the backend with SQL
+    const sortedValuesColumns = pivotDetails.valuesColumns.sort((a, b) => {
+        if (!pivotDetails.groupByColumns) {
+            return 0;
+        }
+        // sort in order of groupByColumn
+        return pivotDetails.groupByColumns?.reduce<number>(
+            (compare, groupByColumn) => {
+                if (compare !== 0) {
+                    // already knows sort
+                    return compare;
+                }
+                // compare next pivot value
+                const aPivotValue = a.pivotValues.find(
+                    ({ referenceField }) =>
+                        referenceField === groupByColumn.reference,
+                )?.value;
+                const bPivotValue = b.pivotValues.find(
+                    ({ referenceField }) =>
+                        referenceField === groupByColumn.reference,
+                )?.value;
+
+                if (aPivotValue && bPivotValue) {
+                    return String(aPivotValue).localeCompare(
+                        String(bPivotValue),
+                    );
+                }
+                return 0;
+            },
+            0,
+        );
+    });
+
+    // Get unique base metrics from valuesColumns
+    const baseMetricsArray = Array.from(
+        new Set(sortedValuesColumns.map((col) => col.referenceField)),
+    );
+
+    const headerValueTypes = getHeaderValueTypes({
+        metricsAsRows: pivotConfig.metricsAsRows,
+        pivotDimensionNames: (pivotDetails.groupByColumns ?? []).map(
+            ({ reference }) => reference,
+        ),
+    });
+
+    const indexValueTypes: PivotData['indexValueTypes'] =
+        pivotConfig.metricsAsRows
+            ? [
+                  ...indexColumns.map((col) => ({
+                      type: FieldType.DIMENSION as const,
+                      fieldId: col,
+                  })),
+                  { type: FieldType.METRIC as const },
+              ]
+            : indexColumns.map((col) => ({
+                  type: FieldType.DIMENSION as const,
+                  fieldId: col,
+              }));
+
+    // Build header values (pivot dimension values)
+    const headerValues: PivotData['headerValues'] = [];
+    pivotDetails.groupByColumns?.forEach(({ reference }, index) => {
+        headerValues.push([]);
+        let columns = sortedValuesColumns;
+        if (pivotConfig.metricsAsRows) {
+            // For metrics as rows, we only need unique combinations of pivot values, excluding per metric duplicates
+            columns = Array.from(
+                new Map(
+                    columns.map((col) => [
+                        col.pivotValues
+                            .map(
+                                ({ referenceField, value }) =>
+                                    `${referenceField}:${value}`,
+                            )
+                            .join('|'),
+                        col,
+                    ]),
+                ).values(),
+            );
+        }
+        columns.forEach(({ pivotValues, pivotColumnName }) => {
+            const pivotValue = pivotValues.find(
+                ({ referenceField }) => referenceField === reference,
+            );
+            if (pivotValue) {
+                const field = getField(pivotValue.referenceField);
+                const formattedValue = field
+                    ? formatItemValue(field, pivotValue.value)
+                    : String(pivotValue.value);
+                const allColumnsWithSamePivotValues = columns.filter(
+                    (matchingColumn) => {
+                        const referencesToMatch = (
+                            pivotDetails.groupByColumns || []
+                        )
+                            .map((groupByColumn) => groupByColumn.reference)
+                            .slice(0, index + 1);
+                        // Match all pivot values
+                        return referencesToMatch.every((referenceToMatch) => {
+                            const pivotValueA = pivotValues.find(
+                                ({ referenceField: referenceField3 }) =>
+                                    referenceField3 === referenceToMatch,
+                            );
+                            const pivotValueB = matchingColumn.pivotValues.find(
+                                ({ referenceField: referenceField3 }) =>
+                                    referenceField3 === referenceToMatch,
+                            );
+                            return pivotValueA?.value === pivotValueB?.value;
+                        });
+                    },
+                );
+                const isFirstInGroup =
+                    allColumnsWithSamePivotValues[0].pivotColumnName ===
+                    pivotColumnName;
+                headerValues[index].push({
+                    type: 'value' as const,
+                    fieldId: reference,
+                    value: {
+                        raw: pivotValue.value,
+                        formatted: formattedValue,
+                    },
+                    colSpan: isFirstInGroup
+                        ? allColumnsWithSamePivotValues.length
+                        : 0,
+                });
+            }
+        });
+    });
+
+    // Add metric labels for columns if not metrics as rows
+    if (!pivotConfig.metricsAsRows && baseMetricsArray.length > 0) {
+        headerValues.push(
+            sortedValuesColumns.map(({ referenceField }) => ({
+                type: 'label' as const,
+                fieldId: referenceField,
+            })),
+        );
+    }
+
+    const filteredHeaderValues = headerValues.filter((row) => row.length > 0);
+
+    // Build index values (row identifiers)
+    let indexValues: PivotData['indexValues'];
+
+    if (pivotConfig.metricsAsRows) {
+        indexValues = rows.reduce<PivotData['indexValues']>((acc, row) => {
+            // multiply rows per metric
+            baseMetricsArray.forEach((metric) => {
+                acc.push([
+                    ...indexColumns.map((col) => ({
+                        type: 'value' as const,
+                        fieldId: col,
+                        value: row[col].value,
+                        colSpan: 1,
+                    })),
+                    {
+                        type: 'label' as const,
+                        fieldId: metric,
+                    },
+                ]);
+            });
+            return acc;
+        }, []);
+    } else {
+        indexValues = rows.map((row) =>
+            indexColumns.map((col) => ({
+                type: 'value' as const,
+                fieldId: col,
+                value: row[col].value,
+                colSpan: 1,
+            })),
+        );
+    }
+
+    // Build data values (the actual pivot data)
+    let dataValues: PivotData['dataValues'];
+    const rowIndices: RecursiveRecord<number> = {};
+    let rowCount = 0;
+
+    // Get unique columns
+    const uniqueColumns = pivotConfig.metricsAsRows
+        ? Array.from(
+              new Map(
+                  sortedValuesColumns.map((col) => [
+                      col.pivotValues
+                          .map(
+                              ({ referenceField, value }) =>
+                                  `${referenceField}:${value}`,
+                          )
+                          .join('|'),
+                      col,
+                  ]),
+              ).values(),
+          )
+        : sortedValuesColumns;
+
+    if (pivotConfig.metricsAsRows) {
+        // multiply rows per metric
+        dataValues = rows.reduce<PivotData['dataValues']>((acc, row) => {
+            baseMetricsArray.forEach((metric) => {
+                const indexRowValues = [
+                    ...indexColumns.map((fieldId) =>
+                        String(row[fieldId].value.raw),
+                    ),
+                    metric,
+                ];
+
+                // Build row data for this metric using unique columns
+                // For each unique column combination, find the corresponding value for this metric
+                const rowData = uniqueColumns.map((uniqueCol) => {
+                    // Find the actual column in sortedValuesColumns that matches this unique combination and metric
+                    const matchingColumn = sortedValuesColumns.find(
+                        (col) =>
+                            col.referenceField === metric &&
+                            col.pivotValues.every((pv) =>
+                                uniqueCol.pivotValues.some(
+                                    (upv) =>
+                                        upv.referenceField ===
+                                            pv.referenceField &&
+                                        upv.value === pv.value,
+                                ),
+                            ),
+                    );
+
+                    return matchingColumn && row[matchingColumn.pivotColumnName]
+                        ? row[matchingColumn.pivotColumnName].value
+                        : null;
+                });
+
+                acc.push(rowData);
+                setIndexByKey(rowIndices, indexRowValues, rowCount);
+                rowCount += 1;
+            });
+            return acc;
+        }, []);
+    } else {
+        dataValues = rows.map((row, rowIndex) => {
+            const indexRowValues = indexColumns.map((fieldId) =>
+                String(row[fieldId].value.raw),
+            );
+            setIndexByKey(rowIndices, indexRowValues, rowIndex);
+
+            return sortedValuesColumns.map((valueCol) =>
+                row[valueCol.pivotColumnName]
+                    ? row[valueCol.pivotColumnName].value
+                    : null,
+            );
+        });
+        rowCount = rows.length;
+    }
+
+    const fullPivotConfig: PivotConfig = {
+        pivotDimensions:
+            pivotDetails.groupByColumns?.map((col) => col.reference) || [],
+        metricsAsRows: pivotConfig.metricsAsRows || false,
+        columnOrder: pivotConfig.columnOrder,
+        hiddenMetricFieldIds: [],
+        columnTotals: pivotConfig.columnTotals,
+        rowTotals: pivotConfig.rowTotals,
+    };
+
+    // Compute row totals if requested
+    let rowTotalFields: PivotData['rowTotalFields'];
+    let rowTotals: PivotData['rowTotals'];
+    const hasHeader = headerValueTypes.length > 0;
+    const hasIndex = indexValueTypes.length > 0;
+    const N_DATA_ROWS = hasIndex ? dataValues.length : 1;
+    const N_DATA_COLUMNS = hasHeader ? uniqueColumns.length : 1;
+
+    // Build column indices using unique columns
+    const columnIndices = uniqueColumns.reduce<RecursiveRecord<number>>(
+        (acc, valuesColumn, index) => {
+            const pivotValues = (pivotDetails.groupByColumns || []).map(
+                (col) =>
+                    valuesColumn.pivotValues.find(
+                        ({ referenceField }) =>
+                            referenceField === col.reference,
+                    )?.value,
+            );
+
+            // Create nested structure based on pivotValues
+            let current = acc;
+            for (let i = 0; i < pivotValues.length; i += 1) {
+                const pivotValue = String(pivotValues[i]);
+                if (!current[pivotValue]) {
+                    current[pivotValue] = {};
+                }
+                current = current[pivotValue] as RecursiveRecord<number>;
+            }
+
+            // For metricsAsRows, don't include metric in column key
+            if (!pivotConfig.metricsAsRows) {
+                current[valuesColumn.referenceField] = index;
+            } else {
+                // Use a generic key since metrics are in rows, not columns
+                current.value = index;
+            }
+
+            return acc;
+        },
+        {},
+    );
+
+    const summableMetricFieldIds = baseMetricsArray.filter((metricId) => {
+        const field = getField(metricId);
+
+        // Skip if field is not found or is a dimension or is hidden
+        if (!field || isDimension(field)) return false;
+        if (hiddenMetricFieldIds.includes(metricId)) return false;
+
+        return isSummable(field);
+    });
+
+    if (fullPivotConfig.rowTotals && hasHeader) {
+        if (fullPivotConfig.metricsAsRows) {
+            const N_TOTAL_COLS = 1;
+            const N_TOTAL_ROWS = headerValues.length;
+
+            rowTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
+            rowTotals = create2DArray(N_DATA_ROWS, N_TOTAL_COLS);
+
+            // set the last header cell as the "Total"
+            rowTotalFields[N_TOTAL_ROWS - 1][N_TOTAL_COLS - 1] = {
+                fieldId: undefined,
+            };
+
+            rowTotals = rowTotals.map((row, rowIndex) =>
+                row.map(() =>
+                    dataValues[rowIndex].reduce(
+                        (acc, value) => acc + parseNumericValue(value),
+                        0,
+                    ),
+                ),
+            );
+        } else {
+            const N_TOTAL_COLS = summableMetricFieldIds.length;
+            const N_TOTAL_ROWS = headerValues.length;
+
+            rowTotalFields = create2DArray(N_TOTAL_ROWS, N_TOTAL_COLS);
+            rowTotals = create2DArray(rows.length, N_TOTAL_COLS);
+
+            // Set the last header cell as the "Total"
+            summableMetricFieldIds.forEach((fieldId, metricIndex) => {
+                rowTotalFields![N_TOTAL_ROWS - 1][metricIndex] = {
+                    fieldId,
+                };
+            });
+
+            rowTotals = rowTotals.map((row, rowIndex) =>
+                row.map((_, totalColIndex) => {
+                    const totalColFieldId =
+                        rowTotalFields![N_TOTAL_ROWS - 1][totalColIndex]
+                            ?.fieldId;
+                    const valueColIndices = totalColFieldId
+                        ? getAllIndicesForFieldId(
+                              columnIndices,
+                              totalColFieldId,
+                          )
+                        : [];
+                    return dataValues[rowIndex]
+                        .filter((__, dataValueColIndex) =>
+                            valueColIndices.includes(dataValueColIndex),
+                        )
+                        .reduce(
+                            (acc, value) => acc + parseNumericValue(value),
+                            0,
+                        );
+                }),
+            );
+        }
+    }
+
+    const { columnTotalFields, columnTotals } = getColumnTotals({
+        summableMetricFieldIds,
+        totalColumns: indexValueTypes.length,
+        dataColumns: N_DATA_COLUMNS,
+        dataValues,
+        rowIndices,
+        pivotConfig,
+        indexValues,
+        hasIndex,
+    });
+
+    // Build retrofit data for backwards compatibility
+    const allCombinedData = rows
+        .map((row) => {
+            const combinedRow: ResultRow = {};
+
+            // Add index columns
+            indexColumns.forEach((col) => {
+                combinedRow[col] = row[col];
+            });
+
+            if (pivotConfig.metricsAsRows) {
+                // Add metric label with correct index (after all index columns)
+                const labelIndex = indexColumns.length;
+                const metricLabel =
+                    getFieldLabel(baseMetricsArray[0]) || baseMetricsArray[0];
+                combinedRow[`label-${labelIndex}`] = {
+                    value: {
+                        raw: metricLabel,
+                        formatted: metricLabel,
+                    },
+                };
+            }
+
+            // Add data columns with generated field IDs using metadata
+            sortedValuesColumns.forEach((valueCol, colIndex) => {
+                const pivotDimensions = (pivotDetails.groupByColumns || []).map(
+                    (col) => col.reference,
+                );
+                const fieldId = pivotConfig.metricsAsRows
+                    ? `${pivotDimensions.join('__')}__${colIndex}`
+                    : `${pivotDimensions.join('__')}__${
+                          valueCol.referenceField
+                      }__${colIndex}`;
+
+                if (row[valueCol.pivotColumnName]) {
+                    combinedRow[fieldId] = row[valueCol.pivotColumnName];
+                }
+            });
+
+            return combinedRow;
+        })
+        .map((combinedRow, rowIndex) => {
+            // Add row totals if enabled
+            if (fullPivotConfig.rowTotals && rowTotals) {
+                const rowTotalValue = rowTotals[rowIndex]?.[0];
+                if (rowTotalValue !== undefined) {
+                    const field = getField(baseMetricsArray[0]);
+                    const formattedValue = field
+                        ? formatItemValue(field, rowTotalValue)
+                        : String(rowTotalValue);
+
+                    return {
+                        ...combinedRow,
+                        'row-total-0': {
+                            value: {
+                                raw: rowTotalValue,
+                                formatted: formattedValue,
+                            },
+                        },
+                    };
+                }
+            }
+            return combinedRow;
+        });
+
+    const pivotColumnInfo: PivotColumn[] = [
+        ...indexColumns.map((col) => ({
+            fieldId: col,
+            baseId: undefined,
+            underlyingId: undefined,
+            columnType: 'indexValue' as const,
+        })),
+        ...(pivotConfig.metricsAsRows
+            ? [
+                  {
+                      fieldId: `label-${indexColumns.length}`,
+                      baseId: undefined,
+                      underlyingId: undefined,
+                      columnType: 'label' as const,
+                  },
+              ]
+            : []),
+        ...sortedValuesColumns.map((valueCol, colIndex) => {
+            const pivotDimensions = (pivotDetails.groupByColumns || []).map(
+                (col) => col.reference,
+            );
+            const fieldId = pivotConfig.metricsAsRows
+                ? `${pivotDimensions.join('__')}__${colIndex}`
+                : `${pivotDimensions.join('__')}__${
+                      valueCol.referenceField
+                  }__${colIndex}`;
+
+            return {
+                fieldId,
+                baseId: pivotConfig.metricsAsRows
+                    ? pivotDimensions[0]
+                    : valueCol.referenceField,
+                underlyingId: undefined,
+                columnType: undefined,
+            };
+        }),
+        ...(fullPivotConfig.rowTotals
+            ? [
+                  {
+                      fieldId: 'row-total-0',
+                      baseId: 'row-total-0',
+                      underlyingId: undefined,
+                      columnType: 'rowTotal' as const,
+                  },
+              ]
+            : []),
+    ];
+
+    const titleFields = getTitleFields({
+        hasIndex,
+        hasHeader,
+        headerValueTypes,
+        indexValueTypes,
+    });
+
+    const pivotData: PivotData = {
+        titleFields,
+        headerValueTypes,
+        headerValues: filteredHeaderValues,
+        indexValueTypes,
+        indexValues,
+        dataColumnCount: N_DATA_COLUMNS,
+        dataValues,
+        rowTotalFields,
+        columnTotalFields,
+        rowTotals,
+        columnTotals,
+        cellsCount: pivotConfig.metricsAsRows
+            ? indexColumns.length +
+              1 + // label column
+              uniqueColumns.length +
+              (rowTotals ? rowTotals[0].length : 0)
+            : indexColumns.length +
+              uniqueColumns.length +
+              (rowTotals ? rowTotals[0].length : 0),
+        rowsCount: pivotConfig.metricsAsRows
+            ? rows.length * baseMetricsArray.length
+            : rows.length,
+        pivotConfig: fullPivotConfig,
+        retrofitData: {
+            allCombinedData,
+            pivotColumnInfo,
+        },
+        groupedSubtotals: undefined,
+    };
+
+    return combinedRetrofit(pivotData, getField, getFieldLabel);
 };

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1243,18 +1243,35 @@ export const convertSqlPivotedRowsToPivotData = ({
             let current = acc;
             for (let i = 0; i < pivotValues.length; i += 1) {
                 const pivotValue = String(pivotValues[i]);
-                if (!current[pivotValue]) {
-                    current[pivotValue] = {};
+                if (
+                    !Object.prototype.hasOwnProperty.call(current, pivotValue)
+                ) {
+                    Object.defineProperty(current, pivotValue, {
+                        value: {},
+                        writable: true,
+                        enumerable: true,
+                        configurable: true,
+                    });
                 }
                 current = current[pivotValue] as RecursiveRecord<number>;
             }
 
             // For metricsAsRows, don't include metric in column key
             if (!pivotConfig.metricsAsRows) {
-                current[valuesColumn.referenceField] = index;
+                Object.defineProperty(current, valuesColumn.referenceField, {
+                    value: index,
+                    writable: true,
+                    enumerable: true,
+                    configurable: true,
+                });
             } else {
                 // Use a generic key since metrics are in rows, not columns
-                current.value = index;
+                Object.defineProperty(current, 'value', {
+                    value: index,
+                    writable: true,
+                    enumerable: true,
+                    configurable: true,
+                });
             }
 
             return acc;

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -273,7 +273,10 @@ const getResultsPage = async (
 export type InfiniteQueryResults = Partial<
     Pick<
         ReadyQueryResultsPage,
-        'queryUuid' | 'totalResults' | 'initialQueryExecutionMs'
+        | 'queryUuid'
+        | 'totalResults'
+        | 'initialQueryExecutionMs'
+        | 'pivotDetails'
     >
 > & {
     projectUuid?: string;
@@ -523,6 +526,7 @@ export const useInfiniteQueryResults = (
             queryStatus: nextPageData?.status, // show latest status
             totalResults: fetchedPages[0]?.totalResults,
             initialQueryExecutionMs: fetchedPages[0]?.initialQueryExecutionMs,
+            pivotDetails: fetchedPages[0]?.pivotDetails,
             hasFetchedAllRows,
             rows: fetchedRows,
             isFetchingRows,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/16534 <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->


Util function that converts SQL pivoted results to `pivotData` which is the expected format for the table viz component. 

Needs to be tested locally with ```export USE_SQL_PIVOT_RESULTS=true```


To be fixed in separate PRs:
- Subtotals to be fixed in [#16663](https://github.com/lightdash/lightdash/issues/16663)
- Fix hidden columns for SQL pivoted results [#16671](https://github.com/lightdash/lightdash/issues/16671)