### PR TITLE
feat(cli): improved project permission errors

### DIFF
--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -82,11 +82,10 @@ type CreateProjectOptions = {
 export const createProject = async (
     options: CreateProjectOptions,
 ): Promise<ApiCreateProjectResults | undefined> => {
-    // TODO enable this when the problem with the permission check is fixed, back-end permission check works as expected
-    // await checkProjectCreationPermission(
-    //     options.upstreamProjectUuid,
-    //     options.type,
-    // );
+    await checkProjectCreationPermission(
+        options.upstreamProjectUuid,
+        options.type,
+    );
 
     const dbtVersion = await getDbtVersion();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Enables the previously commented-out project creation permission check and updates the permission validation logic to match the backend implementation. The new logic handles different project types (DEFAULT and PREVIEW) with specific permission checks for each scenario, including organization-level and project-level permissions.

![image.png](https://app.graphite.dev/user-attachments/assets/3b9e755e-7f44-4776-80e7-d983962afd52.png)


Related: https://github.com/lightdash/lightdash/pull/16639
