### PR TITLE
feat: add new cartesian chart util to handle backend pivoted data

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -171,6 +171,7 @@ const computeDashboardChartSeries = (
     chart: ApiChartAndResults['chart'],
     validPivotDimensions: string[] | undefined,
     resultData: InfiniteQueryResults | undefined,
+    itemsMap: ItemsMap,
 ) => {
     if (!chart.chartConfig || !resultData || resultData.rows.length === 0) {
         return [];
@@ -194,6 +195,7 @@ const computeDashboardChartSeries = (
             xField: chart.chartConfig.config.layout.xField,
             yFields: chart.chartConfig.config.layout.yField,
             defaultLabel: firstSerie?.label,
+            itemsMap,
         });
         const newSeries = mergeExistingAndExpectedSeries({
             expectedSeriesMap,
@@ -233,7 +235,7 @@ const ValidDashboardChartTile: FC<{
     const { health } = useApp();
 
     const {
-        executeQueryResponse: { cacheMetadata, metricQuery },
+        executeQueryResponse: { cacheMetadata, metricQuery, fields },
         chart,
     } = dashboardChartReadyQuery;
 
@@ -251,8 +253,9 @@ const ValidDashboardChartTile: FC<{
             chart,
             validPivotDimensions,
             resultsData,
+            fields,
         );
-    }, [resultsData, chart, validPivotDimensions]);
+    }, [resultsData, chart, validPivotDimensions, fields]);
 
     const resultsDataWithQueryData = useMemo(
         () => ({
@@ -331,8 +334,14 @@ const ValidDashboardChartTileMinimal: FC<{
             chart,
             validPivotDimensions,
             resultsData,
+            dashboardChartReadyQuery.executeQueryResponse?.fields,
         );
-    }, [resultsData, chart, validPivotDimensions]);
+    }, [
+        resultsData,
+        chart,
+        validPivotDimensions,
+        dashboardChartReadyQuery.executeQueryResponse?.fields,
+    ]);
 
     const resultsDataWithQueryData = useMemo(
         () => ({

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -190,7 +190,7 @@ const computeDashboardChartSeries = (
             availableDimensions: chart.metricQuery.dimensions,
             isStacked: false,
             pivotKeys: validPivotDimensions,
-            rows: resultData.rows,
+            resultsData: resultData,
             xField: chart.chartConfig.config.layout.xField,
             yFields: chart.chartConfig.config.layout.yField,
             defaultLabel: firstSerie?.label,

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.mock.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.mock.ts
@@ -82,6 +82,7 @@ export const simpleSeriesMapArgs: GetExpectedSeriesMapArgs = {
     yFields: ['my_metric', 'my_second_metric'],
     xField: 'my_dimension',
     availableDimensions: ['my_dimension', 'dimension_x'],
+    itemsMap: undefined,
 };
 
 export const expectedSimpleSeriesMap: Record<string, Series> = {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.mock.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.mock.ts
@@ -62,20 +62,22 @@ export const simpleSeriesMapArgs: GetExpectedSeriesMapArgs = {
     defaultCartesianType: CartesianSeriesType.BAR,
     defaultAreaStyle: undefined,
     isStacked: false,
-    rows: [
-        {
-            dimension_x: { value: { raw: 'a', formatted: 'a' } },
-            my_dimension: { value: { raw: 'a', formatted: 'a' } },
-            my_metric: { value: { raw: 'a', formatted: 'a' } },
-            my_second_metric: { value: { raw: 'a', formatted: 'a' } },
-        },
-        {
-            dimension_x: { value: { raw: 'b', formatted: 'b' } },
-            my_dimension: { value: { raw: 'a', formatted: 'a' } },
-            my_metric: { value: { raw: 'a', formatted: 'a' } },
-            my_second_metric: { value: { raw: 'a', formatted: 'a' } },
-        },
-    ],
+    resultsData: {
+        rows: [
+            {
+                dimension_x: { value: { raw: 'a', formatted: 'a' } },
+                my_dimension: { value: { raw: 'a', formatted: 'a' } },
+                my_metric: { value: { raw: 'a', formatted: 'a' } },
+                my_second_metric: { value: { raw: 'a', formatted: 'a' } },
+            },
+            {
+                dimension_x: { value: { raw: 'b', formatted: 'b' } },
+                my_dimension: { value: { raw: 'a', formatted: 'a' } },
+                my_metric: { value: { raw: 'a', formatted: 'a' } },
+                my_second_metric: { value: { raw: 'a', formatted: 'a' } },
+            },
+        ],
+    } as any,
     pivotKeys: undefined,
     yFields: ['my_metric', 'my_second_metric'],
     xField: 'my_dimension',
@@ -203,32 +205,34 @@ export const multiPivotSeriesMapArgs: GetExpectedSeriesMapArgs = {
     ...simpleSeriesMapArgs,
     pivotKeys: ['dimension_x', 'dimension_y'],
     yFields: ['my_metric'],
-    rows: [
-        {
-            dimension_x: { value: { raw: 'a', formatted: 'a' } },
-            dimension_y: { value: { raw: 'a', formatted: 'a' } },
-            my_dimension: { value: { raw: 'a', formatted: 'a' } },
-            my_metric: { value: { raw: 'a', formatted: 'a' } },
-        },
-        {
-            dimension_x: { value: { raw: 'b', formatted: 'b' } },
-            dimension_y: { value: { raw: 'b', formatted: 'b' } },
-            my_dimension: { value: { raw: 'a', formatted: 'a' } },
-            my_metric: { value: { raw: 'a', formatted: 'a' } },
-        },
-        {
-            dimension_x: { value: { raw: 'a', formatted: 'a' } },
-            dimension_y: { value: { raw: 'b', formatted: 'b' } },
-            my_dimension: { value: { raw: 'a', formatted: 'a' } },
-            my_metric: { value: { raw: 'a', formatted: 'a' } },
-        },
-        {
-            dimension_x: { value: { raw: 'b', formatted: 'b' } },
-            dimension_y: { value: { raw: 'a', formatted: 'a' } },
-            my_dimension: { value: { raw: 'a', formatted: 'a' } },
-            my_metric: { value: { raw: 'a', formatted: 'a' } },
-        },
-    ],
+    resultsData: {
+        rows: [
+            {
+                dimension_x: { value: { raw: 'a', formatted: 'a' } },
+                dimension_y: { value: { raw: 'a', formatted: 'a' } },
+                my_dimension: { value: { raw: 'a', formatted: 'a' } },
+                my_metric: { value: { raw: 'a', formatted: 'a' } },
+            },
+            {
+                dimension_x: { value: { raw: 'b', formatted: 'b' } },
+                dimension_y: { value: { raw: 'b', formatted: 'b' } },
+                my_dimension: { value: { raw: 'a', formatted: 'a' } },
+                my_metric: { value: { raw: 'a', formatted: 'a' } },
+            },
+            {
+                dimension_x: { value: { raw: 'a', formatted: 'a' } },
+                dimension_y: { value: { raw: 'b', formatted: 'b' } },
+                my_dimension: { value: { raw: 'a', formatted: 'a' } },
+                my_metric: { value: { raw: 'a', formatted: 'a' } },
+            },
+            {
+                dimension_x: { value: { raw: 'b', formatted: 'b' } },
+                dimension_y: { value: { raw: 'a', formatted: 'a' } },
+                my_dimension: { value: { raw: 'a', formatted: 'a' } },
+                my_metric: { value: { raw: 'a', formatted: 'a' } },
+            },
+        ],
+    } as any,
 };
 
 export const expectedMultiPivotedSeriesMap: Record<string, Series> = {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -885,6 +885,7 @@ const useCartesianChartConfig = ({
                     xField: dirtyLayout.xField,
                     yFields: dirtyLayout.yField,
                     defaultLabel,
+                    itemsMap,
                 });
                 const newSeries = mergeExistingAndExpectedSeries({
                     expectedSeriesMap,
@@ -916,6 +917,7 @@ const useCartesianChartConfig = ({
         availableDimensions,
         isStacked,
         referenceLines,
+        itemsMap,
     ]);
 
     const validConfig: CartesianChart = useMemo(() => {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -881,7 +881,7 @@ const useCartesianChartConfig = ({
                     availableDimensions,
                     isStacked,
                     pivotKeys,
-                    rows: resultsData.rows,
+                    resultsData,
                     xField: dirtyLayout.xField,
                     yFields: dirtyLayout.yField,
                     defaultLabel,

--- a/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
@@ -6,10 +6,13 @@ import {
     isDimension,
     type CartesianSeriesType,
     type ItemsMap,
-    type ResultRow,
     type Series,
 } from '@lightdash/common';
-import { getPivotedData } from '../plottedData/getPlottedData';
+import {
+    getPivotedData,
+    getPivotedDataFromPivotDetails,
+} from '../plottedData/getPlottedData';
+import type { InfiniteQueryResults } from '../useQueryResults';
 
 export type GetExpectedSeriesMapArgs = {
     defaultSmooth?: boolean;
@@ -17,7 +20,7 @@ export type GetExpectedSeriesMapArgs = {
     defaultCartesianType: CartesianSeriesType;
     defaultAreaStyle: Series['areaStyle'];
     isStacked: boolean;
-    rows: ResultRow[];
+    resultsData: InfiniteQueryResults;
     pivotKeys: string[] | undefined;
     yFields: string[];
     xField: string;
@@ -31,7 +34,7 @@ export const getExpectedSeriesMap = ({
     defaultCartesianType,
     defaultAreaStyle,
     isStacked,
-    rows,
+    resultsData,
     pivotKeys,
     yFields,
     xField,
@@ -49,12 +52,19 @@ export const getExpectedSeriesMap = ({
         label: defaultLabel,
     };
     if (pivotKeys && pivotKeys.length > 0) {
-        const { rowKeyMap } = getPivotedData(
-            rows,
-            pivotKeys,
-            yFields.filter((yField) => !availableDimensions.includes(yField)),
-            yFields.filter((yField) => availableDimensions.includes(yField)),
-        );
+        // Use new pivoted data format if available
+        const { rowKeyMap } = resultsData.pivotDetails
+            ? getPivotedDataFromPivotDetails(resultsData)
+            : getPivotedData(
+                  resultsData.rows,
+                  pivotKeys,
+                  yFields.filter(
+                      (yField) => !availableDimensions.includes(yField),
+                  ),
+                  yFields.filter((yField) =>
+                      availableDimensions.includes(yField),
+                  ),
+              );
 
         expectedSeriesMap = Object.values(rowKeyMap).reduce<
             Record<string, Series>

--- a/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
@@ -26,6 +26,7 @@ export type GetExpectedSeriesMapArgs = {
     xField: string;
     availableDimensions: string[];
     defaultLabel?: Series['label'];
+    itemsMap: ItemsMap | undefined;
 };
 
 export const getExpectedSeriesMap = ({
@@ -40,6 +41,7 @@ export const getExpectedSeriesMap = ({
     xField,
     availableDimensions,
     defaultLabel,
+    itemsMap,
 }: GetExpectedSeriesMapArgs) => {
     let expectedSeriesMap: Record<string, Series>;
 
@@ -54,7 +56,7 @@ export const getExpectedSeriesMap = ({
     if (pivotKeys && pivotKeys.length > 0) {
         // Use new pivoted data format if available
         const { rowKeyMap } = resultsData.pivotDetails
-            ? getPivotedDataFromPivotDetails(resultsData)
+            ? getPivotedDataFromPivotDetails(resultsData, itemsMap)
             : getPivotedData(
                   resultsData.rows,
                   pivotKeys,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1754,8 +1754,6 @@ const useEchartsCartesianConfig = (
     }, [resultsData?.pivotDetails]);
 
     const { rows, rowKeyMap } = useMemo(() => {
-        // TODO: Use environment variable to switch between legacy and new implementation
-        // For now, use the new implementation if pivotDetails are available
         if (resultsData?.pivotDetails) {
             return getPlottedDataFromPivotDetails(resultsData);
         }

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -61,8 +61,8 @@ import {
 } from '../../components/VisualizationConfigs/ChartConfigPanel/Grid/constants';
 import { EMPTY_X_AXIS } from '../cartesianChartConfig/useCartesianChartConfig';
 import {
+    getPivotedDataFromPivotDetails,
     getPlottedData,
-    getPlottedDataFromPivotDetails,
     type RowKeyMap,
 } from '../plottedData/getPlottedData';
 import { type InfiniteQueryResults } from '../useQueryResults';
@@ -1755,7 +1755,7 @@ const useEchartsCartesianConfig = (
 
     const { rows, rowKeyMap } = useMemo(() => {
         if (resultsData?.pivotDetails) {
-            return getPlottedDataFromPivotDetails(resultsData, undefined);
+            return getPivotedDataFromPivotDetails(resultsData, undefined);
         }
 
         // Legacy implementation - comment out when fully migrated

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1755,7 +1755,7 @@ const useEchartsCartesianConfig = (
 
     const { rows, rowKeyMap } = useMemo(() => {
         if (resultsData?.pivotDetails) {
-            return getPlottedDataFromPivotDetails(resultsData);
+            return getPlottedDataFromPivotDetails(resultsData, undefined);
         }
 
         // Legacy implementation - comment out when fully migrated

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -36,6 +36,7 @@ import {
     type Item,
     type ItemsMap,
     type PivotReference,
+    type PivotValuesColumn,
     type ResultRow,
     type Series,
     type TableCalculation,
@@ -59,7 +60,11 @@ import {
     defaultGrid,
 } from '../../components/VisualizationConfigs/ChartConfigPanel/Grid/constants';
 import { EMPTY_X_AXIS } from '../cartesianChartConfig/useCartesianChartConfig';
-import getPlottedData from '../plottedData/getPlottedData';
+import {
+    getPlottedData,
+    getPlottedDataFromPivotDetails,
+    type RowKeyMap,
+} from '../plottedData/getPlottedData';
 import { type InfiniteQueryResults } from '../useQueryResults';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
@@ -310,18 +315,41 @@ export type EChartSeries = {
     symbolSize?: number;
 };
 
+const convertPivotValuesColumnsIntoMap = (
+    valuesColumns?: PivotValuesColumn[],
+) => {
+    if (!valuesColumns) return;
+    return Object.fromEntries(
+        valuesColumns.map((column) => [column.pivotColumnName, column]),
+    );
+};
+
 export const getFormattedValue = (
     value: any,
     key: string,
     itemsMap: ItemsMap,
     convertToUTC: boolean = true,
+    pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
 ): string => {
-    return formatItemValue(itemsMap[key], value, convertToUTC);
+    const pivotValuesColumn = pivotValuesColumnsMap?.[key];
+    const item = itemsMap[pivotValuesColumn?.referenceField ?? key];
+    return formatItemValue(item, value, convertToUTC);
 };
 
 const valueFormatter =
-    (yFieldId: string, itemsMap: ItemsMap) => (rawValue: any) => {
-        return getFormattedValue(rawValue, yFieldId, itemsMap);
+    (
+        yFieldId: string,
+        itemsMap: ItemsMap,
+        pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
+    ) =>
+    (rawValue: any) => {
+        return getFormattedValue(
+            rawValue,
+            yFieldId,
+            itemsMap,
+            undefined,
+            pivotValuesColumnsMap,
+        );
     };
 
 const removeEmptyProperties = <T = Record<any, any>>(obj: T | undefined) => {
@@ -589,6 +617,7 @@ type GetPivotSeriesArg = {
     yFieldHash: string;
     xFieldHash: string;
     pivotReference: Required<PivotReference>;
+    pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null;
 };
 
 const seriesValueFormatter = (item: Item, value: unknown) => {
@@ -620,10 +649,17 @@ const getPivotSeries = ({
     yFieldHash,
     flipAxes,
     cartesianChart,
+    pivotValuesColumnsMap,
 }: GetPivotSeriesArg): EChartSeries => {
     const pivotLabel = pivotReference.pivotValues.reduce(
         (acc, { field, value }) => {
-            const formattedValue = getFormattedValue(value, field, itemsMap);
+            const formattedValue = getFormattedValue(
+                value,
+                field,
+                itemsMap,
+                undefined,
+                pivotValuesColumnsMap,
+            );
             return acc ? `${acc} - ${formattedValue}` : formattedValue;
         },
         '',
@@ -662,7 +698,11 @@ const getPivotSeries = ({
             },
         ],
         tooltip: {
-            valueFormatter: valueFormatter(series.encode.yRef.field, itemsMap),
+            valueFormatter: valueFormatter(
+                series.encode.yRef.field,
+                itemsMap,
+                pivotValuesColumnsMap,
+            ),
         },
         showSymbol: series.showSymbol ?? true,
         ...(series.label?.show && {
@@ -715,6 +755,7 @@ type GetSimpleSeriesArg = {
     flipAxes: boolean | undefined;
     yFieldHash: string;
     xFieldHash: string;
+    pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null;
 };
 
 const getSimpleSeries = ({
@@ -723,6 +764,7 @@ const getSimpleSeries = ({
     yFieldHash,
     xFieldHash,
     itemsMap,
+    pivotValuesColumnsMap,
 }: GetSimpleSeriesArg) => ({
     ...series,
     xAxisIndex: flipAxes ? series.yAxisIndex : undefined,
@@ -749,7 +791,11 @@ const getSimpleSeries = ({
         },
     ],
     tooltip: {
-        valueFormatter: valueFormatter(yFieldHash, itemsMap),
+        valueFormatter: valueFormatter(
+            yFieldHash,
+            itemsMap,
+            pivotValuesColumnsMap,
+        ),
     },
     ...getSimpleSeriesSymbolConfig(series),
     ...(series.label?.show && {
@@ -769,6 +815,87 @@ const getSimpleSeries = ({
         },
     }),
 });
+
+// New series generation for pre-pivoted data from backend
+const getEchartsSeriesFromPivotedData = (
+    itemsMap: ItemsMap,
+    cartesianChart: CartesianChart,
+    rowKeyMap: RowKeyMap,
+    pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
+): EChartSeries[] => {
+    // Use pivotDetails to find the correct column name for each series
+    const findMatchingColumnName = (series: Series): string | undefined => {
+        if (isPivotReferenceWithValues(series.encode.yRef)) {
+            const yRef = series.encode.yRef;
+            const valuesColumn = Object.values(
+                pivotValuesColumnsMap || {},
+            ).find((col) => {
+                return (
+                    col.referenceField === yRef.field &&
+                    col.pivotValues.length === yRef.pivotValues.length &&
+                    col.pivotValues.every(
+                        (pv, idx) => pv.value === yRef.pivotValues[idx].value,
+                    )
+                );
+            });
+
+            if (valuesColumn) {
+                return valuesColumn.pivotColumnName;
+            }
+        }
+
+        // For non-pivoted fields (like the index column), use the field name directly
+        return series.encode.yRef.field;
+    };
+
+    const allSeries = cartesianChart.eChartsConfig.series || [];
+
+    const resultSeries = allSeries
+        .filter((s) => !s.hidden)
+        .map<EChartSeries>((series) => {
+            const { flipAxes } = cartesianChart.layout;
+            const xFieldHash = hashFieldReference(series.encode.xRef);
+
+            // Find the actual column name in the data
+            const actualYFieldName = findMatchingColumnName(series);
+            const yFieldHash =
+                actualYFieldName || hashFieldReference(series.encode.yRef);
+
+            // For pre-pivoted data, check if this is a pivoted column
+            const yFieldReference = rowKeyMap[yFieldHash];
+
+            if (
+                yFieldReference &&
+                typeof yFieldReference === 'object' &&
+                'pivotValues' in yFieldReference &&
+                yFieldReference.pivotValues
+            ) {
+                // This is a pivoted column, use the pivot reference
+                return getPivotSeries({
+                    series,
+                    itemsMap,
+                    cartesianChart,
+                    pivotReference: yFieldReference as Required<PivotReference>,
+                    flipAxes,
+                    xFieldHash,
+                    yFieldHash,
+                    pivotValuesColumnsMap,
+                });
+            }
+
+            // Simple series for non-pivoted columns
+            return getSimpleSeries({
+                series,
+                itemsMap,
+                flipAxes,
+                yFieldHash,
+                xFieldHash,
+                pivotValuesColumnsMap,
+            });
+        });
+
+    return resultSeries;
+};
 
 const getEchartsSeries = (
     itemsMap: ItemsMap,
@@ -1619,26 +1746,58 @@ const useEchartsCartesianConfig = (
         return [];
     }, [itemsMap, validCartesianConfig]);
 
-    const { rows } = useMemo(() => {
+    const pivotValuesColumnsMap = useMemo(() => {
+        if (!resultsData?.pivotDetails) return;
+        return convertPivotValuesColumnsIntoMap(
+            resultsData.pivotDetails.valuesColumns,
+        );
+    }, [resultsData?.pivotDetails]);
+
+    const { rows, rowKeyMap } = useMemo(() => {
+        // TODO: Use environment variable to switch between legacy and new implementation
+        // For now, use the new implementation if pivotDetails are available
+        if (resultsData?.pivotDetails) {
+            return getPlottedDataFromPivotDetails(resultsData);
+        }
+
+        // Legacy implementation - comment out when fully migrated
         return getPlottedData(
             resultsData?.rows,
             pivotDimensions,
             pivotedKeys,
             nonPivotedKeys,
         );
-    }, [resultsData?.rows, pivotDimensions, pivotedKeys, nonPivotedKeys]);
+    }, [resultsData, pivotDimensions, pivotedKeys, nonPivotedKeys]);
 
     const series = useMemo(() => {
         if (!itemsMap || !validCartesianConfig || !resultsData) {
             return [];
         }
 
+        // Use new series generation for pre-pivoted data
+        if (resultsData?.pivotDetails && rowKeyMap) {
+            return getEchartsSeriesFromPivotedData(
+                itemsMap,
+                validCartesianConfig,
+                rowKeyMap,
+                pivotValuesColumnsMap,
+            );
+        }
+
+        // Legacy implementation
         return getEchartsSeries(
             itemsMap,
             validCartesianConfig,
             pivotDimensions,
         );
-    }, [validCartesianConfig, resultsData, itemsMap, pivotDimensions]);
+    }, [
+        validCartesianConfig,
+        resultsData,
+        itemsMap,
+        pivotDimensions,
+        rowKeyMap,
+        pivotValuesColumnsMap,
+    ]);
 
     const resultsAndMinsAndMaxes = useMemo(
         () => getResultValueArray(rows, true, true),
@@ -1857,6 +2016,8 @@ const useEchartsCartesianConfig = (
                                     tooltipValue,
                                     dim.split('.')[0],
                                     itemsMap,
+                                    undefined,
+                                    pivotValuesColumnsMap,
                                 )}</b></td>
                             </tr>
                         `;
@@ -1890,6 +2051,8 @@ const useEchartsCartesianConfig = (
                             fieldValue,
                             fieldValueReference.split('.')[0],
                             itemsMap,
+                            undefined,
+                            pivotValuesColumnsMap,
                         );
                         tooltipHtml = tooltipHtml.replace(
                             field,
@@ -1919,6 +2082,8 @@ const useEchartsCartesianConfig = (
                             getTooltipHeader(),
                             dimensionId,
                             itemsMap,
+                            undefined,
+                            pivotValuesColumnsMap,
                         );
 
                         return `${tooltipHeader}<br/>${tooltipHtml}<table>${tooltipRows}</table>`;
@@ -1927,7 +2092,12 @@ const useEchartsCartesianConfig = (
                 return `${getTooltipHeader()}<br/>${tooltipHtml}<table>${tooltipRows}</table>`;
             },
         }),
-        [itemsMap, validCartesianConfig?.layout.flipAxes, tooltipConfig],
+        [
+            itemsMap,
+            validCartesianConfig?.layout.flipAxes,
+            tooltipConfig,
+            pivotValuesColumnsMap,
+        ],
     );
 
     const sortedResultsByTotals = useMemo(() => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -852,6 +852,24 @@ const getEchartsSeriesFromPivotedData = (
 
     const resultSeries = allSeries
         .filter((s) => !s.hidden)
+        .sort((a, b) => {
+            const aColumnName = findMatchingColumnName(a);
+            const bColumnName = findMatchingColumnName(b);
+
+            if (aColumnName && bColumnName && pivotValuesColumnsMap) {
+                const aColumn = pivotValuesColumnsMap[aColumnName];
+                const bColumn = pivotValuesColumnsMap[bColumnName];
+
+                if (
+                    aColumn?.columnIndex !== undefined &&
+                    bColumn?.columnIndex !== undefined
+                ) {
+                    return aColumn.columnIndex - bColumn.columnIndex;
+                }
+            }
+
+            return 0;
+        })
         .map<EChartSeries>((series) => {
             const { flipAxes } = cartesianChart.layout;
             const xFieldHash = hashFieldReference(series.encode.xRef);

--- a/packages/frontend/src/hooks/plottedData/getPlottedData.ts
+++ b/packages/frontend/src/hooks/plottedData/getPlottedData.ts
@@ -158,20 +158,3 @@ export const getPivotedDataFromPivotDetails = (
         rowKeyMap,
     };
 };
-
-export const getPlottedDataFromPivotDetails = (
-    resultsData: InfiniteQueryResults,
-    itemsMap: ItemsMap | undefined,
-) => {
-    const { pivotDetails, rows } = resultsData;
-
-    if (!pivotDetails) {
-        return {
-            pivotValuesMap: {},
-            rowKeyMap: {},
-            rows,
-        };
-    }
-
-    return getPivotedDataFromPivotDetails(resultsData, itemsMap);
-};

--- a/packages/frontend/src/hooks/plottedData/getPlottedData.ts
+++ b/packages/frontend/src/hooks/plottedData/getPlottedData.ts
@@ -1,7 +1,9 @@
 import {
+    formatItemValue,
     hashFieldReference,
     type ApiQueryResults,
     type FieldId,
+    type ItemsMap,
     type PivotReference,
     type ResultRow,
     type ResultValue,
@@ -103,6 +105,7 @@ export const getPlottedData = (
 
 export const getPivotedDataFromPivotDetails = (
     resultsData: InfiniteQueryResults,
+    itemsMap: ItemsMap | undefined,
 ): {
     pivotValuesMap: PivotValueMap;
     rowKeyMap: RowKeyMap;
@@ -121,11 +124,12 @@ export const getPivotedDataFromPivotDetails = (
     const pivotValuesMap: PivotValueMap = pivotDetails.valuesColumns.reduce(
         (acc, column) => {
             column.pivotValues.forEach((value) => {
+                const field = itemsMap?.[value.referenceField];
                 acc[value.referenceField] = {
                     ...acc[value.referenceField],
                     [String(value.value)]: {
                         raw: value.value,
-                        formatted: String(value.value), // TODO: format value
+                        formatted: formatItemValue(field, value.value),
                     },
                 };
             });
@@ -157,6 +161,7 @@ export const getPivotedDataFromPivotDetails = (
 
 export const getPlottedDataFromPivotDetails = (
     resultsData: InfiniteQueryResults,
+    itemsMap: ItemsMap | undefined,
 ) => {
     const { pivotDetails, rows } = resultsData;
 
@@ -168,5 +173,5 @@ export const getPlottedDataFromPivotDetails = (
         };
     }
 
-    return getPivotedDataFromPivotDetails(resultsData);
+    return getPivotedDataFromPivotDetails(resultsData, itemsMap);
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR refactors the chart data handling to support pre-pivoted data from the backend. Instead of passing just the `rows` property to chart configuration functions, we now pass the entire `resultsData` object which may contain `pivotDetails` with pre-calculated pivot information.

Key changes:
- Modified `getExpectedSeriesMap` to use `resultsData` instead of just `rows`
- Added new functions to handle pre-pivoted data: `getPivotedDataFromPivotDetails` and `getEchartsSeriesFromPivotedData`
- Added support for pivot value column mapping to properly format values
- Updated value formatters to handle pivot column references
- Implemented conditional logic to use the new implementation when `pivotDetails` are available

This change improves performance for pivoted charts by leveraging pre-calculated pivot data from the backend rather than recalculating it in the frontend.

![image.png](https://app.graphite.dev/user-attachments/assets/71ade3ec-82f1-4ad6-bef3-285cbfa2248c.png)

