### PR TITLE
feat: dashboard parameters loading time by showing parameters immediately

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -91,6 +91,7 @@ const Dashboard: FC = () => {
     );
     const isDateZoomDisabled = useDashboardContext((c) => c.isDateZoomDisabled);
     const areAllChartsLoaded = useDashboardContext((c) => c.areAllChartsLoaded);
+    const parametersReady = useDashboardContext((c) => c.parametersReady);
     const missingRequiredParameters = useDashboardContext(
         (c) => c.missingRequiredParameters,
     );
@@ -733,7 +734,7 @@ const Dashboard: FC = () => {
                             onParameterChange={handleParameterChange}
                             onClearAll={clearAllParameters}
                             parameters={referencedParameters}
-                            isLoading={!areAllChartsLoaded}
+                            isLoading={!parametersReady}
                             missingRequiredParameters={
                                 missingRequiredParameters
                             }

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -298,6 +298,9 @@ const DashboardProvider: React.FC<
     // Track which tiles have loaded (to know when all are complete)
     const [loadedTiles, setLoadedTiles] = useState<Set<string>>(new Set());
 
+    // Track when parameters are ready to display
+    const [parametersReady, setParametersReady] = useState<boolean>(false);
+
     const addParameterReferences = useCallback(
         (tileUuid: string, references: string[]) => {
             setTileParameterReferences((prev) => ({
@@ -326,6 +329,7 @@ const DashboardProvider: React.FC<
     useEffect(() => {
         if (projectParameters) {
             addParameterDefinitions(projectParameters);
+            setParametersReady(true);
         }
     }, [projectParameters, addParameterDefinitions]);
 
@@ -923,6 +927,7 @@ const DashboardProvider: React.FC<
         addParameterReferences,
         tileParameterReferences,
         areAllChartsLoaded,
+        parametersReady,
         missingRequiredParameters,
         pinnedParameters,
         setPinnedParameters,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -107,6 +107,7 @@ export type DashboardContextType = {
     addParameterReferences: (tileUuid: string, references: string[]) => void;
     tileParameterReferences: Record<string, string[]>;
     areAllChartsLoaded: boolean;
+    parametersReady: boolean;
     parameterDefinitions: ParameterDefinitions;
     addParameterDefinitions: (parameters: ParameterDefinitions) => void;
     missingRequiredParameters: string[];


### PR DESCRIPTION
Closes: #16637

### Description:
Fixes dashboard parameters loading time by showing parameters immediately when available instead of waiting for all charts to load.

**Before:** Parameters were only displayed after ALL chart tiles finished loading, causing excessive wait times for dashboards with many charts.

**After:** Parameters are displayed as soon as they're fetched from the API, allowing users to interact with them immediately while charts continue loading in the background.

**Changes:**
- Added `parametersReady` state to track when parameters are available
- Modified Parameters component to use `parametersReady` instead of `areAllChartsLoaded`
- Parameters now display immediately, improving UX for heavy dashboards