### PR TITLE
feat: support multiple email domains in organization setup

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -343,7 +343,9 @@ const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
                     name: process.env.LD_SETUP_ADMIN_NAME || 'Admin User',
                     email: process.env.LD_SETUP_ADMIN_EMAIL!,
                 },
-                emailDomain: process.env.LD_SETUP_ORGANIZATION_EMAIL_DOMAIN,
+                emailDomains: getArrayFromCommaSeparatedList(
+                    'LD_SETUP_ORGANIZATION_EMAIL_DOMAIN',
+                ),
                 defaultRole:
                     parseEnum<AllowedEmailDomainsRole>(
                         process.env.LD_SETUP_ORGANIZATION_DEFAULT_ROLE,
@@ -437,7 +439,9 @@ export const getUpdateSetupConfig = (): LightdashConfig['updateSetup'] => {
             admin: {
                 email: process.env.LD_SETUP_ADMIN_EMAIL,
             },
-            emailDomain: process.env.LD_SETUP_ORGANIZATION_EMAIL_DOMAIN,
+            emailDomains: getArrayFromCommaSeparatedList(
+                'LD_SETUP_ORGANIZATION_EMAIL_DOMAIN',
+            ),
             defaultRole: parseEnum<AllowedEmailDomainsRole>(
                 process.env.LD_SETUP_ORGANIZATION_DEFAULT_ROLE,
                 AllowedEmailDomainsRoles,
@@ -759,7 +763,7 @@ export type LightdashConfig = {
                 email: string;
                 name: string;
             };
-            emailDomain?: string;
+            emailDomains: string[];
             name: string;
             defaultRole: AllowedEmailDomainsRole;
         };
@@ -782,7 +786,7 @@ export type LightdashConfig = {
             admin: {
                 email?: string;
             };
-            emailDomain?: string;
+            emailDomains: string[];
             defaultRole?: AllowedEmailDomainsRole;
         };
         apiKey: {

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -186,11 +186,16 @@ export class InstanceConfigurationService extends BaseService {
             );
 
             // Optional steps are performed at the end
-            if (setup.organization.emailDomain) {
+            if (
+                setup.organization.emailDomains &&
+                setup.organization.emailDomains.length > 0
+            ) {
                 this.logger.debug(
-                    `Initial setup: Whitelisting domain "${setup.organization.emailDomain}"`,
+                    `Initial setup: Whitelisting domains "${setup.organization.emailDomains.join(
+                        ', ',
+                    )}"`,
                 );
-                const emailDomains = [setup.organization.emailDomain];
+                const { emailDomains } = setup.organization;
                 // Validates input
                 const error = validateOrganizationEmailDomains(emailDomains);
                 if (error) {
@@ -207,11 +212,13 @@ export class InstanceConfigurationService extends BaseService {
                 );
 
                 this.logger.info(
-                    `Initial setup: Whitelisted domain "${setup.organization.emailDomain}"`,
+                    `Initial setup: Whitelisted domains "${setup.organization.emailDomains.join(
+                        ', ',
+                    )}"`,
                 );
             } else {
                 this.logger.info(
-                    `Initial setup: No whitelisted domain, skipping`,
+                    `Initial setup: No whitelisted domains, skipping`,
                 );
             }
 
@@ -449,7 +456,8 @@ export class InstanceConfigurationService extends BaseService {
     ) {
         if (
             !config.organization?.defaultRole ||
-            !config.organization?.emailDomain
+            !config.organization?.emailDomains ||
+            config.organization.emailDomains.length === 0
         ) {
             this.logger.debug(
                 `Update instance: No default role config found, skipping`,
@@ -459,7 +467,7 @@ export class InstanceConfigurationService extends BaseService {
 
         const orgUuid = await this.getSingleOrg();
 
-        const emailDomains = [config.organization.emailDomain];
+        const { emailDomains } = config.organization;
         // Validates input
         const error = validateOrganizationEmailDomains(emailDomains);
         if (error) {
@@ -476,7 +484,11 @@ export class InstanceConfigurationService extends BaseService {
         );
 
         this.logger.info(
-            `Update instance: Updated default role to ${config.organization.defaultRole} for organization ${orgUuid}`,
+            `Update instance: Updated default role to ${
+                config.organization.defaultRole
+            } for domains "${emailDomains.join(
+                ', ',
+            )}" in organization ${orgUuid}`,
         );
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16642

### Description:

This PR enhances the organization email domain configuration to support multiple domains. It changes the `emailDomain` field to `emailDomains` which accepts a comma-separated list of domains through the `LD_SETUP_ORGANIZATION_EMAIL_DOMAIN` environment variable. The code now properly handles multiple whitelisted domains during both initial setup and configuration updates.
