### PR TITLE
chore(cli): add warning when LIGHTDASH_API_KEY environment variable is set

### DIFF
--- a/packages/cli/src/handlers/diagnostics.ts
+++ b/packages/cli/src/handlers/diagnostics.ts
@@ -115,6 +115,17 @@ export const diagnosticsHandler = async (options: DiagnosticsOptions) => {
     // Auth Status
     console.log(styles.bold('Authentication Status:'));
     const authStatus = await getAuthStatus();
+
+    // Check for LIGHTDASH_API_KEY environment variable
+    const hasEnvApiKey = !!process.env.LIGHTDASH_API_KEY;
+    if (hasEnvApiKey) {
+        console.log(
+            `  ⚠️ ${styles.warning(
+                'LIGHTDASH_API_KEY environment variable is set and will override config file credentials',
+            )}`,
+        );
+    }
+
     if (authStatus.hasAuth) {
         console.log(`  ✅ Authenticated`);
         console.log(`  Instance: ${authStatus.serverUrl}`);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a warning message in the diagnostics output when the `LIGHTDASH_API_KEY` environment variable is set, informing users that it will override credentials in the config file. This helps users troubleshoot authentication issues by making them aware of environment variables that might affect their configuration.
