### PR TITLE
fix: mobile dashbaord layout

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/gridUtils.ts
+++ b/packages/frontend/src/components/DashboardTabs/gridUtils.ts
@@ -10,13 +10,15 @@ export type ResponsiveGridLayoutProps = {
     rowHeight: number;
 };
 
+const DEFAULT_COLS = 36;
+
 export const getReactGridLayoutConfig = (
     tile: DashboardTile,
     isEditMode = false,
-    cols = 36,
+    cols = DEFAULT_COLS,
 ): Layout => {
     // Scale factor based on the number of columns (36 is the default for lg)
-    const scaleFactor = cols / 36;
+    const scaleFactor = cols / DEFAULT_COLS;
 
     return {
         minH: 1,

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -138,8 +138,10 @@ const MinimalDashboard: FC = () => {
             md: tiles.map<Layout>((tile) =>
                 getReactGridLayoutConfig(tile, false, gridProps.cols.md),
             ),
+            // On the smallest breakpoint, we don't need to pass the cols parameter,
+            // we are stacking vertically, so we don't want to add a scale factor
             sm: tiles.map<Layout>((tile) =>
-                getReactGridLayoutConfig(tile, false, gridProps.cols.sm),
+                getReactGridLayoutConfig(tile, false),
             ),
         };
     }, [dashboard?.tiles, schedulerTabsSelected, activeTab, gridProps.cols]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16665

### Description:

We recently updated dashboards to scale tiles based on the grid columns, but it's not working right in mobile dashboards. In mobile dashboards, we override the number of grid columns with `stackVerticallyOnSmallestBreakpoint`. 

This removes the column scaling for the smallest size (mobile) minimal dashboards. 

1. Make a dashboard with a row of 3 - 4 tiles
2. Size it very narrow
3. Reload so you get the mobile version
4. All tiles should be there, stacked. 
