### PR TITLE
refactor: replace useFeatureFlagEnabled with useFeatureFlag hook

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChartDownload.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartDownload.ts
@@ -9,7 +9,7 @@ import { useCallback, useMemo } from 'react';
 import { lightdashApi } from '../../api';
 import { pollForResults } from '../../features/queryRunner/executeQuery';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
-import { useFeatureFlagEnabled } from '../useFeatureFlagEnabled';
+import { useFeatureFlag } from '../useFeatureFlagEnabled';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
 export const useDashboardChartDownload = (
@@ -30,7 +30,7 @@ export const useDashboardChartDownload = (
         (c) => c.dateZoomGranularity,
     );
 
-    const useSqlPivotResults = useFeatureFlagEnabled(
+    const { data: useSqlPivotResults } = useFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 
@@ -58,7 +58,7 @@ export const useDashboardChartDownload = (
                         limit: limit ?? MAX_SAFE_INTEGER,
                         invalidateCache: false,
                         parameters,
-                        pivotResults: useSqlPivotResults,
+                        pivotResults: useSqlPivotResults?.enabled,
                     }),
                 });
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -17,7 +17,7 @@ import { lightdashApi } from '../../api';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import { convertDateDashboardFilters } from '../../utils/dateFilter';
 import { useExplore } from '../useExplore';
-import { useFeatureFlagEnabled } from '../useFeatureFlagEnabled';
+import { useFeatureFlag } from '../useFeatureFlagEnabled';
 import { useSavedQuery } from '../useSavedQuery';
 import useSearchParams from '../useSearchParams';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
@@ -133,7 +133,7 @@ export const useDashboardChartReadyQuery = (
         return prev;
     });
 
-    const useSqlPivotResults = useFeatureFlagEnabled(
+    const { data: useSqlPivotResults } = useFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 
@@ -192,7 +192,7 @@ export const useDashboardChartReadyQuery = (
                     },
                     invalidateCache,
                     parameters: parameterValues,
-                    pivotResults: useSqlPivotResults,
+                    pivotResults: useSqlPivotResults?.enabled,
                 },
             );
 

--- a/packages/frontend/src/hooks/usePivotDimensions.ts
+++ b/packages/frontend/src/hooks/usePivotDimensions.ts
@@ -1,6 +1,6 @@
 import { FeatureFlags, type MetricQuery } from '@lightdash/common';
 import { useMemo, useState } from 'react';
-import { useFeatureFlagEnabled } from './useFeatureFlagEnabled';
+import { useFeatureFlag } from './useFeatureFlagEnabled';
 
 const usePivotDimensions = (
     initialPivotDimensions: string[] | undefined,
@@ -10,12 +10,12 @@ const usePivotDimensions = (
         initialPivotDimensions,
     );
 
-    const useSqlPivotResults = useFeatureFlagEnabled(
+    const { data: useSqlPivotResults } = useFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 
     const validPivotDimensions = useMemo(() => {
-        if (useSqlPivotResults) {
+        if (useSqlPivotResults?.enabled) {
             // If SQL pivot is enabled, we should always use the pivot value and let the backend handle the validation
             return dirtyPivotDimensions;
         }

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -28,7 +28,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { lightdashApi } from '../api';
 import { pollForResults } from '../features/queryRunner/executeQuery';
 import { convertDateFilters } from '../utils/dateFilter';
-import { useFeatureFlagEnabled } from './useFeatureFlagEnabled';
+import { useFeatureFlag } from './useFeatureFlagEnabled';
 import useQueryError from './useQueryError';
 
 export type QueryResultsProps = {
@@ -210,7 +210,7 @@ export const useGetReadyQueryResults = (
         return missingRequiredParameters.length === 0;
     }, [data, missingRequiredParameters]);
 
-    const useSqlPivotResults = useFeatureFlagEnabled(
+    const { data: useSqlPivotResults } = useFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 
@@ -225,7 +225,9 @@ export const useGetReadyQueryResults = (
         keepPreviousData: true, // needed to keep the last metric query which could break cartesian chart config
         queryFn: ({ signal }) => {
             return executeAsyncQuery(
-                data ? { ...data, pivotResults: useSqlPivotResults } : null,
+                data
+                    ? { ...data, pivotResults: useSqlPivotResults?.enabled }
+                    : null,
                 signal,
             );
         },

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -53,7 +53,7 @@ import {
 import { useParameters } from '../../hooks/parameters/useParameters';
 import useDefaultSortField from '../../hooks/useDefaultSortField';
 import { useExplore } from '../../hooks/useExplore';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
+import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
 import {
     executeQueryAndWaitForResults,
     useCancelQuery,
@@ -1405,7 +1405,7 @@ const ExplorerProvider: FC<
         // get last value from queryUuidHistory
         queryUuidHistory[queryUuidHistory.length - 1],
     );
-    const useSqlPivotResults = useFeatureFlagEnabled(
+    const { data: useSqlPivotResults } = useFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
     const getDownloadQueryUuid = useCallback(
@@ -1422,7 +1422,7 @@ const ExplorerProvider: FC<
                               ...validQueryArgs,
                               csvLimit: limit,
                               invalidateCache: minimal,
-                              pivotResults: useSqlPivotResults,
+                              pivotResults: useSqlPivotResults?.enabled,
                           }
                         : null;
                 const downloadQuery = await executeQueryAndWaitForResults(
@@ -1483,7 +1483,7 @@ const ExplorerProvider: FC<
             const metricQuery = unsavedChartVersion.metricQuery;
             let pivotConfiguration: PivotConfiguration | undefined;
 
-            if (useSqlPivotResults && explore) {
+            if (useSqlPivotResults?.enabled && explore) {
                 const items = getFieldsFromMetricQuery(metricQuery, explore);
                 pivotConfiguration = derivePivotConfigurationFromChart(
                     {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactored feature flag usage by replacing `useFeatureFlagEnabled` with `useFeatureFlag` across multiple dashboard and query-related hooks. This change improves how we access feature flag data by using the full response object and explicitly checking the `enabled` property instead of directly using the boolean return value.

The update affects chart downloads, dashboard queries, pivot dimensions, and query results, ensuring consistent feature flag handling throughout the application.


`useFeatureFlagEnabled` only checks Posthog
`useFeatureFlag` checks posthog + env var

<img width="1432" height="1285" alt="Screenshot 2025-09-01 at 14 19 02" src="https://github.com/user-attachments/assets/67e63961-e33e-44b5-af48-c5b4ed11fe46" />

