### PR TITLE
refactor: move search function inside test to avoid shared state

### DIFF
--- a/packages/e2e/cypress/e2e/app/globalSearch.cy.ts
+++ b/packages/e2e/cypress/e2e/app/globalSearch.cy.ts
@@ -1,32 +1,30 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
-// Search requests are debounced, so take that into account when waiting for the search request to complete
-const SEARCHED_QUERIES = new Set<string>();
-
-function search(query: string) {
-    const hasPerformedSearch = SEARCHED_QUERIES.has(query);
-    cy.findByRole('search').click();
-
-    if (!hasPerformedSearch) {
-        SEARCHED_QUERIES.add(query);
-        cy.intercept('**/search/**').as('search');
-    }
-
-    cy.findByPlaceholderText(/Search Jaffle shop/gi)
-        .clear()
-        .type(query);
-
-    if (!hasPerformedSearch) {
-        cy.wait('@search');
-    }
-}
-
 describe('Global search', () => {
     beforeEach(() => {
         cy.login();
     });
 
     it('Should search all result types', () => {
+        // Search requests are debounced, so take that into account when waiting for the search request to complete
+        const SEARCHED_QUERIES = new Set<string>();
+
+        function search(query: string) {
+            const hasPerformedSearch = SEARCHED_QUERIES.has(query);
+            cy.findByRole('search').click();
+
+            if (!hasPerformedSearch) {
+                SEARCHED_QUERIES.add(query);
+                cy.intercept('**/search/**').as('search');
+            }
+
+            cy.findByPlaceholderText(/Search Jaffle shop/gi).clear();
+            cy.findByPlaceholderText(/Search Jaffle shop/gi).type(query);
+
+            if (!hasPerformedSearch) {
+                cy.wait('@search');
+            }
+        }
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
 
         cy.contains('Search Jaffle shop').should('be.visible');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactored the global search test by moving the `search` function and `SEARCHED_QUERIES` set inside the test scope instead of keeping them at the module level. This improves test isolation by ensuring these variables are scoped to the specific test that uses them.

Also split the type operation into separate clear and type commands for better test stability.