### PR TITLE
feat: add ai agents mobile view

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -16,9 +16,10 @@ import {
     IconHome,
     IconLayoutDashboard,
     IconLogout,
+    IconRobot,
 } from '@tabler/icons-react';
 import posthog from 'posthog-js';
-import React, { useCallback, useState, type FC } from 'react';
+import { useCallback, useState, type FC } from 'react';
 import {
     Link,
     Navigate,
@@ -34,6 +35,7 @@ import MobileView from './components/Mobile';
 import ProjectSwitcher from './components/NavBar/ProjectSwitcher';
 import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
+import { useAiAgentButtonVisibility } from './ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useActiveProjectUuid } from './hooks/useActiveProject';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
 import AuthPopupResult, {
@@ -74,7 +76,7 @@ const RedirectToResource: FC = () => {
     return <Navigate to="/no-mobile-page" />;
 };
 
-const MobileNavBar: FC = () => {
+export const MobileNavBar: FC = () => {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const toggleMenu = useCallback(
         () => setIsMenuOpen((prevValue) => !prevValue),
@@ -89,6 +91,8 @@ const MobileNavBar: FC = () => {
             window.location.href = '/login';
         },
     });
+
+    const isAiAgentButtonVisible = useAiAgentButtonVisibility();
 
     return (
         <MantineProvider inherit theme={{ colorScheme: 'dark' }}>
@@ -149,6 +153,15 @@ const MobileNavBar: FC = () => {
                     icon={<MantineIcon icon={IconChartAreaLine} />}
                     onClick={toggleMenu}
                 />
+                {isAiAgentButtonVisible && (
+                    <RouterNavLink
+                        exact
+                        label="Ask AI"
+                        to={`/projects/${activeProjectUuid}/ai-agents`}
+                        icon={<MantineIcon icon={IconRobot} />}
+                        onClick={toggleMenu}
+                    />
+                )}
                 <Divider my="lg" />
                 <RouterNavLink
                     exact

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -1,66 +1,18 @@
-import { CommercialFeatureFlags } from '@lightdash/common';
 import { Button } from '@mantine/core';
 import { IconMessageCircleStar } from '@tabler/icons-react';
 import { useNavigate } from 'react-router';
-import { useAiAgentPermission } from '../../ee/features/aiCopilot/hooks/useAiAgentPermission';
-import { useProjectAiAgents } from '../../ee/features/aiCopilot/hooks/useProjectAiAgents';
+import { useAiAgentButtonVisibility } from '../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useActiveProject } from '../../hooks/useActiveProject';
-import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
-import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 
 export const AiAgentsButton = () => {
     // Using `navigate` instead of the `Link` component to ensure round corners within a button group
     const navigate = useNavigate();
     const { data: projectUuid } = useActiveProject();
-    const canViewAiAgents = useAiAgentPermission({
-        action: 'view',
-        projectUuid: projectUuid ?? undefined,
-    });
-    const appQuery = useApp();
-    const canManageAiAgents = useAiAgentPermission({
-        action: 'manage',
-        projectUuid: projectUuid ?? undefined,
-    });
-    const aiCopilotFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiCopilot);
-    const aiAgentFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiAgent);
-    const agents = useProjectAiAgents({
-        projectUuid,
-        options: {
-            enabled:
-                aiAgentFlagQuery.isSuccess && aiAgentFlagQuery.data.enabled,
-        },
-        redirectOnUnauthorized: false,
-    });
-
-    const canViewButton =
-        (canViewAiAgents &&
-            agents.isSuccess &&
-            agents.data?.length &&
-            agents.data.length > 0) ||
-        canManageAiAgents;
-
-    if (
-        !appQuery.user.isSuccess ||
-        !aiCopilotFlagQuery.isSuccess ||
-        !aiAgentFlagQuery.isSuccess
-    ) {
+    const isVisible = useAiAgentButtonVisibility();
+    if (!isVisible) {
         return null;
     }
-
-    const isAiCopilotEnabled = aiCopilotFlagQuery.data.enabled;
-    const isAiAgentEnabled = aiAgentFlagQuery.data.enabled;
-
-    if (
-        !canViewButton ||
-        !canViewAiAgents ||
-        !isAiCopilotEnabled ||
-        !isAiAgentEnabled ||
-        !projectUuid
-    ) {
-        return null;
-    }
-
     return (
         <Button
             size="xs"

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -1,9 +1,7 @@
-import { Navigate, Outlet, type RouteObject } from 'react-router';
-import NavBar from '../components/NavBar';
+import { Navigate, type RouteObject } from 'react-router';
 import PrivateRoute from '../components/PrivateRoute';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
-import { AiAgentThreadStreamStoreProvider } from './features/aiCopilot/streaming/AiAgentThreadStreamStoreProvider';
 import EmbeddedApp from './features/embed/EmbeddedApp';
 import AgentPage from './pages/AiAgents/AgentPage';
 import AgentsRedirect from './pages/AiAgents/AgentsRedirect';
@@ -11,6 +9,7 @@ import AgentsWelcome from './pages/AiAgents/AgentsWelcome';
 import AiAgentThreadPage from './pages/AiAgents/AgentThreadPage';
 import AiAgentNewThreadPage from './pages/AiAgents/AiAgentNewThreadPage';
 import AiAgentsNotAuthorizedPage from './pages/AiAgents/AiAgentsNotAuthorizedPage';
+import { AiAgentsRootLayout } from './pages/AiAgents/AiAgentsRootLayout';
 import ProjectAiAgentEditPage from './pages/AiAgents/ProjectAiAgentEditPage';
 import EmbedDashboard from './pages/EmbedDashboard';
 import EmbedExplore from './pages/EmbedExplore';
@@ -54,10 +53,7 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
         path: '/projects/:projectUuid/ai-agents',
         element: (
             <PrivateRoute>
-                <NavBar />
-                <AiAgentThreadStreamStoreProvider>
-                    <Outlet />
-                </AiAgentThreadStreamStoreProvider>
+                <AiAgentsRootLayout />
             </PrivateRoute>
         ),
         children: [
@@ -125,4 +121,7 @@ export const CommercialWebAppRoutes = [
     ...COMMERCIAL_SLACK_AUTH_ROUTES,
 ];
 
-export const CommercialMobileRoutes = [...COMMERCIAL_EMBED_ROUTES];
+export const CommercialMobileRoutes = [
+    ...COMMERCIAL_EMBED_ROUTES,
+    ...COMMERCIAL_AI_AGENTS_ROUTES,
+];

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -1,5 +1,6 @@
 import { type AiAgentMessageAssistant } from '@lightdash/common';
-import { Box, Flex } from '@mantine-8/core';
+import { Box, Drawer, Flex } from '@mantine-8/core';
+import { useMediaQuery } from '@mantine-8/hooks';
 import {
     IconLayoutSidebar,
     IconLayoutSidebarLeftCollapseFilled,
@@ -48,6 +49,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
     const [contextArtifact, setContextArtifact] = useState<ArtifactData | null>(
         null,
     );
+    const isMobile = useMediaQuery('(max-width: 768px)');
 
     const updateCollapsedState = () => {
         const isCollapsed = sidebarPanelRef.current?.isCollapsed() ?? false;
@@ -210,21 +212,46 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                         <Box className={styles.chatContent}>{children}</Box>
                     </Panel>
 
-                    {contextArtifact && (
-                        <PanelResizeHandle className={styles.resizeHandle} />
-                    )}
+                    {!isMobile && (
+                        <>
+                            {contextArtifact && (
+                                <PanelResizeHandle
+                                    className={styles.resizeHandle}
+                                />
+                            )}
 
-                    <Panel
-                        id="artifact"
-                        ref={artifactPanelRef}
-                        defaultSize={0}
-                        minSize={50}
-                        collapsible
-                        collapsedSize={0}
-                        className={styles.artifact}
-                    >
-                        {contextArtifact && <AiArtifactPanel />}
-                    </Panel>
+                            <Panel
+                                id="artifact"
+                                ref={artifactPanelRef}
+                                defaultSize={0}
+                                minSize={50}
+                                collapsible
+                                collapsedSize={0}
+                                className={styles.artifact}
+                            >
+                                {contextArtifact && <AiArtifactPanel />}
+                            </Panel>
+                        </>
+                    )}
+                    {isMobile && (
+                        <Drawer
+                            opened={!!contextArtifact}
+                            onClose={clearArtifact}
+                            size="75%"
+                            position="bottom"
+                            h="75%"
+                            withCloseButton={false}
+                            styles={{
+                                body: {
+                                    padding: 0,
+                                    paddingBottom: 'var(--mantine-spacing-lg)',
+                                    height: '100%',
+                                },
+                            }}
+                        >
+                            {contextArtifact && <AiArtifactPanel />}
+                        </Drawer>
+                    )}
                 </ErrorBoundary>
             </PanelGroup>
         </AiAgentPageLayoutContext.Provider>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -7,6 +7,7 @@ import {
     type ApiError,
 } from '@lightdash/common';
 import { ActionIcon, Box, Group, Stack, Text, Title } from '@mantine-8/core';
+import { useMediaQuery } from '@mantine-8/hooks';
 import { IconX } from '@tabler/icons-react';
 import { type QueryObserverSuccessResult } from '@tanstack/react-query';
 import { useMemo, useState, type FC } from 'react';
@@ -48,6 +49,7 @@ export const AiChartVisualization: FC<Props> = ({
     projectUuid,
     message,
 }) => {
+    const isMobile = useMediaQuery('(max-width: 768px)');
     const { data: health } = useHealth();
     const { data: organization } = useOrganization();
     const { metricQuery, fields } = queryExecutionHandle.data.query;
@@ -141,7 +143,7 @@ export const AiChartVisualization: FC<Props> = ({
                                 {queryExecutionHandle.data.metadata.description}
                             </Text>
                         </Stack>
-                        <Group gap="sm">
+                        <Group gap="sm" display={isMobile ? 'none' : 'flex'}>
                             <ViewSqlButton sql={compiledSql?.query} />
                             <AiChartQuickOptions
                                 message={message}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
@@ -1,0 +1,63 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
+import { useActiveProject } from '../../../../hooks/useActiveProject';
+import { useFeatureFlag } from '../../../../hooks/useFeatureFlagEnabled';
+import useApp from '../../../../providers/App/useApp';
+import { useAiAgentPermission } from './useAiAgentPermission';
+import { useProjectAiAgents } from './useProjectAiAgents';
+
+/**
+ * This hook is used to determine if the ai agent button should be visible
+ * @returns true if the ai agent button should be visible
+ */
+export const useAiAgentButtonVisibility = () => {
+    const { data: projectUuid } = useActiveProject();
+    const canViewAiAgents = useAiAgentPermission({
+        action: 'view',
+        projectUuid: projectUuid ?? undefined,
+    });
+    const appQuery = useApp();
+    const canManageAiAgents = useAiAgentPermission({
+        action: 'manage',
+        projectUuid: projectUuid ?? undefined,
+    });
+    const aiCopilotFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiCopilot);
+    const aiAgentFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiAgent);
+    const agents = useProjectAiAgents({
+        projectUuid,
+        options: {
+            enabled:
+                aiAgentFlagQuery.isSuccess && aiAgentFlagQuery.data.enabled,
+        },
+        redirectOnUnauthorized: false,
+    });
+
+    const canViewButton =
+        (canViewAiAgents &&
+            agents.isSuccess &&
+            agents.data?.length &&
+            agents.data.length > 0) ||
+        canManageAiAgents;
+
+    if (
+        !appQuery.user.isSuccess ||
+        !aiCopilotFlagQuery.isSuccess ||
+        !aiAgentFlagQuery.isSuccess
+    ) {
+        return false;
+    }
+
+    const isAiCopilotEnabled = aiCopilotFlagQuery.data.enabled;
+    const isAiAgentEnabled = aiAgentFlagQuery.data.enabled;
+
+    if (
+        !canViewButton ||
+        !canViewAiAgents ||
+        !isAiCopilotEnabled ||
+        !isAiAgentEnabled ||
+        !projectUuid
+    ) {
+        return false;
+    }
+
+    return true;
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentsRootLayout.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentsRootLayout.tsx
@@ -1,0 +1,17 @@
+import { useMediaQuery } from '@mantine-8/hooks';
+import { Outlet } from 'react-router';
+import NavBar from '../../../components/NavBar';
+import { MobileNavBar } from '../../../MobileRoutes';
+import { AiAgentThreadStreamStoreProvider } from '../../features/aiCopilot/streaming/AiAgentThreadStreamStoreProvider';
+
+export const AiAgentsRootLayout = () => {
+    const isMobile = useMediaQuery('(max-width: 768px)');
+    return (
+        <>
+            {isMobile ? <MobileNavBar /> : <NavBar />}
+            <AiAgentThreadStreamStoreProvider>
+                <Outlet />
+            </AiAgentThreadStreamStoreProvider>
+        </>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Add AI Agents support to mobile view by:
- Adding an "Ask AI" navigation link in the mobile navigation bar
- Creating a shared hook `useAiAgentButtonVisibility` to determine when to show AI-related buttons
- Adding mobile-specific UI adaptations for AI agent components
- Creating a responsive `AiAgentsRootLayout` that uses the appropriate navigation bar based on screen size
- Adapting the AI chart visualization to hide certain controls on mobile
- Using a bottom drawer for artifact panels on mobile instead of the desktop side panel


![Screenshot 2025-09-01 at 16.35.45.png](https://app.graphite.dev/user-attachments/assets/acd32642-c360-4b24-9683-c177fdda3b82.png)

![image.png](https://app.graphite.dev/user-attachments/assets/a2b7c635-632d-403b-96f5-f1c050b2d145.png)

![image.png](https://app.graphite.dev/user-attachments/assets/0d299638-ed10-40f1-8b99-fd13c8947f8e.png)

