### PR TITLE
fix: pass hiddenMetricFieldIds from pivotConfig to pivotData

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1215,7 +1215,7 @@ export const convertSqlPivotedRowsToPivotData = ({
             pivotDetails.groupByColumns?.map((col) => col.reference) || [],
         metricsAsRows: pivotConfig.metricsAsRows || false,
         columnOrder: pivotConfig.columnOrder,
-        hiddenMetricFieldIds: [],
+        hiddenMetricFieldIds: pivotConfig.hiddenMetricFieldIds || [],
         columnTotals: pivotConfig.columnTotals,
         rowTotals: pivotConfig.rowTotals,
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#16671](https://github.com/lightdash/lightdash/issues/16671)

### Description:
Pass `hiddenMetricFieldIds` from `pivotConfig` to the pivot data configuration, ensuring that hidden metric fields are properly respected when converting SQL pivoted rows to pivot data. This fixes a bug where hidden metric fields were not being properly applied in the pivot view.

