### PR TITLE
chore: add ai agent admin controller

### DIFF
--- a/examples/api/ai-agents.http
+++ b/examples/api/ai-agents.http
@@ -93,3 +93,77 @@ Content-Type: application/json
 GET http://localhost:8080/api/v1/projects/PROJECT_UUID/aiAgents/AI_AGENT_UUID/artifacts/ARTIFACT_UUID/versions/VERSION_UUID
 Content-Type: application/json
 
+
+### =============================================================================
+### AI AGENT ADMIN 
+### =============================================================================
+
+### Get all threads across all agents (Admin only) 
+GET http://localhost:8080/api/v1/aiAgents/admin/threads
+Content-Type: application/json
+
+### Paginated threads
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?page=1&pageSize=25
+Content-Type: application/json
+
+### =============================================================================
+### FILTERING - Find threads for training loop analysis
+### =============================================================================
+
+### Filter by project UUIDs (analyze specific projects)
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?projectUuids=PROJECT_UUID_1&projectUuids=PROJECT_UUID_2
+Content-Type: application/json
+
+### Filter by agent UUIDs (analyze specific agents)
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?agentUuids=AGENT_UUID_1&agentUuids=AGENT_UUID_2
+Content-Type: application/json
+
+### Filter by specific user UUIDs
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?userUuids=USER_UUID_1&userUuids=USER_UUID_2
+Content-Type: application/json
+
+### Filter by conversation source (Slack vs Web App)
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?createdFrom=slack
+Content-Type: application/json
+
+### Filter by conversation source (Slack vs Web App)
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?createdFrom=web_app
+Content-Type: application/json
+
+
+### =============================================================================
+### HUMAN FEEDBACK FILTERING - Training Loop Analysis
+### =============================================================================
+
+### Find all thumbs down responses (negative feedback)
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?humanScore=-1
+Content-Type: application/json
+
+### Find all thumbs up responses (positive feedback)
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?humanScore=1
+Content-Type: application/json
+
+### Find neutral responses (no voting)
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?humanScore=0
+Content-Type: application/json
+
+### =============================================================================
+### DATE FILTERING - Temporal Analysis
+### =============================================================================
+
+### Conversations from specific date range
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?dateFrom=2025-09-01&dateTo=2025-09-02
+Content-Type: application/json
+
+### =============================================================================
+### SORTING - Organize data for analysis
+### =============================================================================
+
+### Sort by creation date (newest first) - Default
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?sortField=createdAt&sortDirection=desc
+Content-Type: application/json
+
+### Sort by title (alphabetical)
+GET http://localhost:8080/api/v1/aiAgents/admin/threads?sortField=title&sortDirection=asc
+Content-Type: application/json
+

--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -1,0 +1,98 @@
+import {
+    AiAgentAdminFilters,
+    AiAgentAdminSort,
+    ApiAiAgentAdminConversationsResponse,
+    ApiErrorPayload,
+    KnexPaginateArgs,
+} from '@lightdash/common';
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type AiAgentAdminService } from '../services/AiAgentAdminService';
+
+@Route('/api/v1/aiAgents/admin')
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class AiAgentAdminController extends BaseController {
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/threads')
+    @OperationId('getAllThreads')
+    async getAllThreads(
+        @Request() req: express.Request,
+        // Pagination
+        @Query() page?: KnexPaginateArgs['page'],
+        @Query() pageSize?: KnexPaginateArgs['pageSize'],
+        // Filtering
+        @Query() projectUuids?: AiAgentAdminFilters['projectUuids'],
+        @Query() agentUuids?: AiAgentAdminFilters['agentUuids'],
+        @Query() userUuids?: AiAgentAdminFilters['userUuids'],
+        @Query() createdFrom?: AiAgentAdminFilters['createdFrom'],
+        @Query() humanScore?: AiAgentAdminFilters['humanScore'],
+        @Query() dateFrom?: AiAgentAdminFilters['dateFrom'],
+        @Query() dateTo?: AiAgentAdminFilters['dateTo'],
+        // Sorting
+        @Query()
+        sortField?: AiAgentAdminSort['field'],
+        @Query() sortDirection?: AiAgentAdminSort['direction'],
+    ): Promise<ApiAiAgentAdminConversationsResponse> {
+        const paginateArgs: KnexPaginateArgs | undefined =
+            page !== undefined || pageSize !== undefined
+                ? {
+                      page: page ?? 1,
+                      pageSize: pageSize ?? 50,
+                  }
+                : {
+                      page: 1,
+                      pageSize: 50,
+                  };
+
+        const filters: AiAgentAdminFilters = {
+            ...(projectUuids && { projectUuids }),
+            ...(agentUuids && { agentUuids }),
+            ...(userUuids && { userUuids }),
+            ...(createdFrom && { createdFrom }),
+            ...(humanScore !== undefined && { humanScore }),
+            ...(dateFrom && { dateFrom }),
+            ...(dateTo && { dateTo }),
+        };
+
+        const sort: AiAgentAdminSort | undefined = sortField
+            ? {
+                  field: sortField,
+                  direction: sortDirection ?? 'desc',
+              }
+            : undefined;
+
+        const threads = await this.getAiAgentAdminService().getAllThreads(
+            req.user!,
+            paginateArgs,
+            filters,
+            sort,
+        );
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: threads,
+        };
+    }
+
+    protected getAiAgentAdminService() {
+        return this.services.getAiAgentAdminService<AiAgentAdminService>();
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -20,6 +20,7 @@ import { EmbedModel } from './models/EmbedModel';
 import { ServiceAccountModel } from './models/ServiceAccountModel';
 import { CommercialSchedulerClient } from './scheduler/SchedulerClient';
 import { CommercialSchedulerWorker } from './scheduler/SchedulerWorker';
+import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentService } from './services/AiAgentService';
 import { AiService } from './services/AiService/AiService';
 import { CommercialCacheService } from './services/CommercialCacheService';
@@ -106,6 +107,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     openIdIdentityModel: models.getOpenIdIdentityModel(),
                     spaceService: repository.getSpaceService(),
+                }),
+            aiAgentAdminService: ({ models }) =>
+                new AiAgentAdminService({
+                    aiAgentModel: models.getAiAgentModel(),
                 }),
             rolesService: ({ repository, context, models }) =>
                 new RolesService({

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1,4 +1,8 @@
 import {
+    AiAgentAdminConversationsSummary,
+    AiAgentAdminFilters,
+    AiAgentAdminSort,
+    AiAgentAdminThreadSummary,
     AiAgentMessage,
     AiAgentMessageAssistant,
     AiAgentMessageUser,
@@ -18,6 +22,8 @@ import {
     CreateWebAppPrompt,
     CreateWebAppThread,
     isToolName,
+    KnexPaginateArgs,
+    KnexPaginatedData,
     NotFoundError,
     SlackPrompt,
     ToolName,
@@ -27,7 +33,10 @@ import {
     type AiAgent,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { DbEmail, EmailTableName } from '../../database/entities/emails';
+import { DbProject, ProjectTableName } from '../../database/entities/projects';
 import { DbUser, UserTableName } from '../../database/entities/users';
+import KnexPaginate from '../../database/pagination';
 import {
     AiAgentToolCallTableName,
     AiAgentToolResultTableName,
@@ -52,6 +61,7 @@ import {
     AiAgentSlackIntegrationTableName,
     AiAgentTableName,
     AiAgentUserAccessTableName,
+    DbAiAgent,
     DbAiAgentIntegration,
     DbAiAgentSlackIntegration,
 } from '../database/entities/aiAgent';
@@ -757,6 +767,261 @@ export class AiAgentModel {
                 slackUserId: row.slack_user_id,
             },
         }));
+    }
+
+    async findAdminThreadsPaginated({
+        organizationUuid,
+        paginateArgs,
+        filters,
+        sort,
+    }: {
+        organizationUuid: string;
+        paginateArgs?: KnexPaginateArgs;
+        filters?: AiAgentAdminFilters;
+        sort?: AiAgentAdminSort;
+    }): Promise<KnexPaginatedData<AiAgentAdminConversationsSummary>> {
+        const threadFeedbackQuery = this.database(AiPromptTableName)
+            .select([
+                'ai_thread_uuid',
+                this.database.raw(`
+                     COUNT(CASE WHEN human_score = 1 THEN 1 END) as upvotes,
+                     COUNT(CASE WHEN human_score = -1 THEN 1 END) as downvotes,
+                     COUNT(CASE WHEN human_score = 0 THEN 1 END) as neutral,
+                     COUNT(*) as total_feedback
+                 `),
+            ])
+            .from(AiPromptTableName)
+            .whereNotNull('human_score')
+            .groupBy('ai_thread_uuid');
+        const threadsWithFeedbackQuery = this.database
+            .with('thread_feedback', threadFeedbackQuery)
+            .select<
+                {
+                    ai_thread_uuid: DbAiThread['ai_thread_uuid'];
+                    agent_uuid: AiAgent['uuid'];
+                    agent_image_url: AiAgent['imageUrl'];
+                    created_at: Date;
+                    created_from: DbAiThread['created_from'];
+                    title: DbAiThread['title'];
+                    title_generated_at: DbAiThread['title_generated_at'];
+                    first_prompt: DbAiPrompt['prompt'];
+                    user_uuid: DbUser['user_uuid'];
+                    user_name: string;
+                    user_email: DbEmail['email'];
+                    slack_user_id: DbAiSlackThread['slack_user_id'];
+                    agent_name: AiAgent['name'];
+                    project_name: DbProject['name'];
+                    organization_uuid: DbAiThread['organization_uuid'];
+                    project_uuid: DbAiThread['project_uuid'];
+
+                    // Feedback aggregation from CTE
+                    upvotes: number;
+                    downvotes: number;
+                    neutral: number;
+                    total_feedback: number;
+                }[]
+            >([
+                // Original thread fields
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.agent_uuid`,
+                `${AiThreadTableName}.created_at`,
+                `${AiThreadTableName}.created_from`,
+                `${AiThreadTableName}.title`,
+                `${AiThreadTableName}.title_generated_at`,
+                `${AiPromptTableName}.prompt as first_prompt`,
+                `${UserTableName}.user_uuid`,
+                this.database.raw(
+                    `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
+                ),
+                `${EmailTableName}.email as user_email`,
+                `${AiSlackThreadTableName}.slack_user_id`,
+                `${AiAgentTableName}.name as agent_name`,
+                `${AiAgentTableName}.image_url as agent_image_url`,
+                `${ProjectTableName}.name as project_name`,
+                `${ProjectTableName}.project_uuid`,
+
+                // Feedback aggregation from CTE
+                'thread_feedback.upvotes',
+                'thread_feedback.downvotes',
+                'thread_feedback.neutral',
+                'thread_feedback.total_feedback',
+            ])
+            .from(AiThreadTableName)
+            .join(
+                AiPromptTableName,
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiPromptTableName}.ai_thread_uuid`,
+            )
+            .join(
+                UserTableName,
+                `${AiPromptTableName}.created_by_user_uuid`,
+                `${UserTableName}.user_uuid`,
+            )
+            .leftJoin(
+                EmailTableName,
+                `${EmailTableName}.user_id`,
+                '=',
+                `${UserTableName}.user_id`,
+            )
+            .andWhere(`${EmailTableName}.is_primary`, true)
+            .join(
+                AiAgentTableName,
+                `${AiThreadTableName}.agent_uuid`,
+                `${AiAgentTableName}.ai_agent_uuid`,
+            )
+            .join(
+                ProjectTableName,
+                `${AiAgentTableName}.project_uuid`,
+                `${ProjectTableName}.project_uuid`,
+            )
+            .leftJoin(
+                AiSlackThreadTableName,
+                `${AiThreadTableName}.ai_thread_uuid`,
+                `${AiSlackThreadTableName}.ai_thread_uuid`,
+            )
+            .leftJoin(
+                'thread_feedback',
+                `${AiThreadTableName}.ai_thread_uuid`,
+                'thread_feedback.ai_thread_uuid',
+            )
+            .where(
+                `${AiPromptTableName}.created_at`,
+                this.database(AiPromptTableName)
+                    .select(this.database.raw('MIN(created_at)'))
+                    .whereRaw(
+                        `${AiPromptTableName}.ai_thread_uuid = ${AiThreadTableName}.ai_thread_uuid`,
+                    ),
+            )
+            .andWhere(
+                `${AiThreadTableName}.organization_uuid`,
+                organizationUuid,
+            );
+
+        const finalQuery = threadsWithFeedbackQuery;
+
+        if (filters) {
+            if (filters.projectUuids && filters.projectUuids.length > 0) {
+                void finalQuery.whereIn(
+                    `${ProjectTableName}.project_uuid`,
+                    filters.projectUuids,
+                );
+            }
+            if (filters.agentUuids && filters.agentUuids.length > 0) {
+                void finalQuery.whereIn(
+                    `${AiThreadTableName}.agent_uuid`,
+                    filters.agentUuids,
+                );
+            }
+            if (filters.userUuids && filters.userUuids.length > 0) {
+                void finalQuery.whereIn(
+                    `${UserTableName}.user_uuid`,
+                    filters.userUuids,
+                );
+            }
+            if (filters.createdFrom) {
+                void finalQuery.where(
+                    `${AiThreadTableName}.created_from`,
+                    filters.createdFrom,
+                );
+            }
+            if (filters.dateFrom) {
+                void finalQuery.where(
+                    `${AiThreadTableName}.created_at`,
+                    '>=',
+                    filters.dateFrom,
+                );
+            }
+            if (filters.dateTo) {
+                void finalQuery.where(
+                    `${AiThreadTableName}.created_at`,
+                    '<=',
+                    filters.dateTo,
+                );
+            }
+            if (filters.humanScore !== undefined) {
+                void finalQuery.whereExists((qb) => {
+                    void qb
+                        .select('*')
+                        .from(AiPromptTableName)
+                        .whereRaw(
+                            `${AiPromptTableName}.ai_thread_uuid = ${AiThreadTableName}.ai_thread_uuid`,
+                        )
+                        .where(
+                            'human_score',
+                            filters.humanScore === 0
+                                ? null
+                                : filters.humanScore,
+                        );
+                });
+            }
+        }
+
+        if (sort) {
+            const { field, direction } = sort;
+            switch (field) {
+                case 'createdAt':
+                    void finalQuery.orderBy(
+                        `${AiThreadTableName}.created_at`,
+                        direction,
+                    );
+                    break;
+                case 'title':
+                    void finalQuery.orderBy(
+                        `${AiThreadTableName}.title`,
+                        direction,
+                    );
+                    break;
+                default:
+                    void finalQuery.orderBy(
+                        `${AiThreadTableName}.created_at`,
+                        'desc',
+                    );
+            }
+        } else {
+            void finalQuery.orderBy(`${AiThreadTableName}.created_at`, 'desc');
+        }
+
+        const { pagination, data } = await KnexPaginate.paginate(
+            finalQuery,
+            paginateArgs,
+        );
+
+        const threads: AiAgentAdminThreadSummary[] = data.map(
+            (row): AiAgentAdminThreadSummary => ({
+                uuid: row.ai_thread_uuid,
+                createdAt: row.created_at.toISOString(),
+                createdFrom: row.created_from,
+                title: row.title || row.first_prompt,
+                user: {
+                    uuid: row.user_uuid,
+                    name: row.user_name,
+                    slackUserId: row.slack_user_id,
+                    email: row.user_email,
+                },
+                agent: {
+                    uuid: row.agent_uuid,
+                    name: row.agent_name,
+                    imageUrl: row.agent_image_url,
+                },
+                project: {
+                    uuid: row.project_uuid,
+                    name: row.project_name,
+                },
+                feedbackSummary: {
+                    upvotes: row.upvotes,
+                    downvotes: row.downvotes,
+                    neutral: row.neutral,
+                    total: row.total_feedback,
+                },
+            }),
+        );
+
+        return {
+            data: {
+                threads,
+            },
+            pagination,
+        };
     }
 
     async getThread({

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -1,0 +1,67 @@
+import { subject } from '@casl/ability';
+import {
+    AiAgentAdminConversationsSummary,
+    AiAgentAdminFilters,
+    AiAgentAdminSort,
+    ForbiddenError,
+    KnexPaginateArgs,
+    KnexPaginatedData,
+    type SessionUser,
+} from '@lightdash/common';
+import { AiAgentModel } from '../models/AiAgentModel';
+
+type AiAgentAdminServiceDependencies = {
+    aiAgentModel: AiAgentModel;
+};
+
+export class AiAgentAdminService {
+    private readonly aiAgentModel: AiAgentModel;
+
+    constructor(dependencies: AiAgentAdminServiceDependencies) {
+        this.aiAgentModel = dependencies.aiAgentModel;
+    }
+
+    private static checkOrganizationAdminAccess(user: SessionUser): void {
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('Organization', {
+                    organizationUuid: user.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access organization-wide AI agent data',
+            );
+        }
+    }
+
+    /**
+     * Get all threads across all agents in the organization
+     * Only accessible by organization admins
+     */
+    async getAllThreads(
+        user: SessionUser,
+        paginateArgs?: KnexPaginateArgs,
+        filters?: AiAgentAdminFilters,
+        sort?: AiAgentAdminSort,
+    ): Promise<KnexPaginatedData<AiAgentAdminConversationsSummary>> {
+        const { organizationUuid } = user;
+
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        AiAgentAdminService.checkOrganizationAdminAccess(user);
+
+        // TODO: Check if filter contains userUuid and check if they exist in the organization
+        // TODO: Check if filter contains agentUuid and check if they exist in the organization
+        // TODO: Check if filter contains projectUuid and check if they exist in the organization
+
+        return this.aiAgentModel.findAdminThreadsPaginated({
+            organizationUuid,
+            paginateArgs,
+            filters,
+            sort,
+        });
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -26,6 +26,8 @@ import { AiAgentController } from './../ee/controllers/aiAgentController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { CustomRolesController } from './../ee/controllers/CustomRolesController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AiAgentAdminController } from './../ee/controllers/AiAgentAdminController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ValidationController } from './../controllers/validationController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../controllers/userController';
@@ -5779,6 +5781,228 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccessEmpty', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiAgentThreadSummary_AiAgentUser-and-_slackUserId-string-or-null--email-string-or-null__.user-or-createdAt-or-createdFrom-or-title-or-uuid_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    createdAt: { dataType: 'string', required: true },
+                    user: {
+                        dataType: 'intersection',
+                        subSchemas: [
+                            { ref: 'AiAgentUser' },
+                            {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    email: {
+                                        dataType: 'union',
+                                        subSchemas: [
+                                            { dataType: 'string' },
+                                            { dataType: 'enum', enums: [null] },
+                                        ],
+                                        required: true,
+                                    },
+                                    slackUserId: {
+                                        dataType: 'union',
+                                        subSchemas: [
+                                            { dataType: 'string' },
+                                            { dataType: 'enum', enums: [null] },
+                                        ],
+                                        required: true,
+                                    },
+                                },
+                            },
+                        ],
+                        required: true,
+                    },
+                    uuid: { dataType: 'string', required: true },
+                    createdFrom: { dataType: 'string', required: true },
+                    title: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ThreadSummary: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AiAgentThreadSummary_AiAgentUser-and-_slackUserId-string-or-null--email-string-or-null__.user-or-createdAt-or-createdFrom-or-title-or-uuid_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiAgentSummary.uuid-or-name-or-imageUrl_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+                imageUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentAdminFeedbackSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                total: { dataType: 'double', required: true },
+                neutral: { dataType: 'double', required: true },
+                downvotes: { dataType: 'double', required: true },
+                upvotes: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentAdminThreadSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ThreadSummary' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        feedbackSummary: {
+                            ref: 'AiAgentAdminFeedbackSummary',
+                            required: true,
+                        },
+                        project: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                name: { dataType: 'string', required: true },
+                                uuid: { dataType: 'string', required: true },
+                            },
+                            required: true,
+                        },
+                        agent: {
+                            ref: 'Pick_AiAgentSummary.uuid-or-name-or-imageUrl_',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentAdminConversationsSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                threads: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentAdminThreadSummary',
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    KnexPaginateArgs: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                page: { dataType: 'double', required: true },
+                pageSize: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    KnexPaginatedData_AiAgentAdminConversationsSummary_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pagination: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'KnexPaginateArgs' },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                totalResults: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                totalPageCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+                data: {
+                    ref: 'AiAgentAdminConversationsSummary',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_KnexPaginatedData_AiAgentAdminConversationsSummary__: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'KnexPaginatedData_AiAgentAdminConversationsSummary_',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentAdminConversationsResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_KnexPaginatedData_AiAgentAdminConversationsSummary__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentAdminSortField: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['createdAt'] },
+                { dataType: 'enum', enums: ['title'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiJobScheduledResponse: {
         dataType: 'refAlias',
         type: {
@@ -9459,18 +9683,6 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 results: { ref: 'SchedulerWithLogs', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    KnexPaginateArgs: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                page: { dataType: 'double', required: true },
-                pageSize: { dataType: 'double', required: true },
             },
             validators: {},
         },
@@ -21996,6 +22208,107 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'removeScopeFromRole',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getAllThreads: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        page: { in: 'query', name: 'page', dataType: 'double' },
+        pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+        projectUuids: {
+            in: 'query',
+            name: 'projectUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        agentUuids: {
+            in: 'query',
+            name: 'agentUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        userUuids: {
+            in: 'query',
+            name: 'userUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        createdFrom: {
+            in: 'query',
+            name: 'createdFrom',
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['slack'] },
+                { dataType: 'enum', enums: ['web_app'] },
+            ],
+        },
+        humanScore: { in: 'query', name: 'humanScore', dataType: 'double' },
+        dateFrom: { in: 'query', name: 'dateFrom', dataType: 'string' },
+        dateTo: { in: 'query', name: 'dateTo', dataType: 'string' },
+        sortField: {
+            in: 'query',
+            name: 'sortField',
+            ref: 'AiAgentAdminSortField',
+        },
+        sortDirection: {
+            in: 'query',
+            name: 'sortDirection',
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['asc'] },
+                { dataType: 'enum', enums: ['desc'] },
+            ],
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/threads',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getAllThreads,
+        ),
+
+        async function AiAgentAdminController_getAllThreads(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getAllThreads,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAllThreads',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6366,6 +6366,203 @@
             "ApiRemoveScopeFromRoleResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"
             },
+            "Pick_AiAgentThreadSummary_AiAgentUser-and-_slackUserId-string-or-null--email-string-or-null__.user-or-createdAt-or-createdFrom-or-title-or-uuid_": {
+                "properties": {
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "user": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentUser"
+                            },
+                            {
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "slackUserId": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["email", "slackUserId"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "createdFrom": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "createdAt",
+                    "user",
+                    "uuid",
+                    "createdFrom",
+                    "title"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "ThreadSummary": {
+                "$ref": "#/components/schemas/Pick_AiAgentThreadSummary_AiAgentUser-and-_slackUserId-string-or-null--email-string-or-null__.user-or-createdAt-or-createdFrom-or-title-or-uuid_"
+            },
+            "Pick_AiAgentSummary.uuid-or-name-or-imageUrl_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "imageUrl": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["name", "uuid", "imageUrl"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AiAgentAdminFeedbackSummary": {
+                "properties": {
+                    "total": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "neutral": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "downvotes": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "upvotes": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["total", "neutral", "downvotes", "upvotes"],
+                "type": "object"
+            },
+            "AiAgentAdminThreadSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ThreadSummary"
+                    },
+                    {
+                        "properties": {
+                            "feedbackSummary": {
+                                "$ref": "#/components/schemas/AiAgentAdminFeedbackSummary"
+                            },
+                            "project": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "uuid": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["name", "uuid"],
+                                "type": "object"
+                            },
+                            "agent": {
+                                "$ref": "#/components/schemas/Pick_AiAgentSummary.uuid-or-name-or-imageUrl_"
+                            }
+                        },
+                        "required": ["feedbackSummary", "project", "agent"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiAgentAdminConversationsSummary": {
+                "properties": {
+                    "threads": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentAdminThreadSummary"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["threads"],
+                "type": "object"
+            },
+            "KnexPaginateArgs": {
+                "properties": {
+                    "page": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "pageSize": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["page", "pageSize"],
+                "type": "object"
+            },
+            "KnexPaginatedData_AiAgentAdminConversationsSummary_": {
+                "properties": {
+                    "pagination": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/KnexPaginateArgs"
+                            },
+                            {
+                                "properties": {
+                                    "totalResults": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "totalPageCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    }
+                                },
+                                "required": ["totalResults", "totalPageCount"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/AiAgentAdminConversationsSummary"
+                    }
+                },
+                "required": ["data"],
+                "type": "object"
+            },
+            "ApiSuccess_KnexPaginatedData_AiAgentAdminConversationsSummary__": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/KnexPaginatedData_AiAgentAdminConversationsSummary_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentAdminConversationsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_AiAgentAdminConversationsSummary__"
+            },
+            "AiAgentAdminSortField": {
+                "type": "string",
+                "enum": ["createdAt", "title"]
+            },
             "ApiJobScheduledResponse": {
                 "properties": {
                     "results": {
@@ -10253,20 +10450,6 @@
                     }
                 },
                 "required": ["results", "status"],
-                "type": "object"
-            },
-            "KnexPaginateArgs": {
-                "properties": {
-                    "page": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "pageSize": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["page", "pageSize"],
                 "type": "object"
             },
             "KnexPaginatedData_SchedulerAndTargets-Array_": {
@@ -18632,7 +18815,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1970.0",
+        "version": "0.1972.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -99,6 +99,7 @@ interface ServiceManifest {
     embedService: unknown;
     aiService: unknown;
     aiAgentService: unknown;
+    aiAgentAdminService: unknown;
     scimService: unknown;
     supportService: unknown;
     cacheService: unknown;
@@ -877,6 +878,12 @@ export class ServiceRepository
 
     public getAiAgentService<AiAgentServiceImplT>(): AiAgentServiceImplT {
         return this.getService('aiAgentService');
+    }
+
+    public getAiAgentAdminService<
+        AiAgentAdminServiceImplT,
+    >(): AiAgentAdminServiceImplT {
+        return this.getService('aiAgentAdminService');
     }
 
     public getRolesService(): RolesService {

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -1,0 +1,57 @@
+import type { ApiSuccess, KnexPaginatedData } from '../..';
+import type {
+    AiAgentSummary,
+    AiAgentThreadSummary,
+    AiAgentUser,
+} from './index';
+
+export type AiAgentAdminFilters = {
+    projectUuids?: string[];
+    agentUuids?: string[];
+    userUuids?: string[];
+    createdFrom?: 'slack' | 'web_app';
+    humanScore?: number; // (-1, 0, 1)
+    dateFrom?: string; // ISO date string
+    dateTo?: string; // ISO date string
+};
+
+export type AiAgentAdminSortField = 'createdAt' | 'title';
+
+export type AiAgentAdminSort = {
+    field: AiAgentAdminSortField;
+    direction: 'asc' | 'desc';
+};
+
+export type AiAgentAdminFeedbackSummary = {
+    upvotes: number;
+    downvotes: number;
+    neutral: number;
+    total: number;
+};
+
+type ThreadSummary = Pick<
+    AiAgentThreadSummary<
+        AiAgentUser & {
+            slackUserId: string | null;
+            email: string | null;
+        }
+    >,
+    'user' | 'createdAt' | 'createdFrom' | 'title' | 'uuid'
+>;
+
+export type AiAgentAdminThreadSummary = ThreadSummary & {
+    agent: Pick<AiAgentSummary, 'uuid' | 'name' | 'imageUrl'>;
+    project: {
+        uuid: string;
+        name: string;
+    };
+    feedbackSummary: AiAgentAdminFeedbackSummary;
+};
+
+export type AiAgentAdminConversationsSummary = {
+    threads: AiAgentAdminThreadSummary[];
+};
+
+export type ApiAiAgentAdminConversationsResponse = ApiSuccess<
+    KnexPaginatedData<AiAgentAdminConversationsSummary>
+>;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -9,6 +9,7 @@ import type {
 } from '../..';
 import { type AiMetricQuery, type AiResultType } from './types';
 
+export * from './adminTypes';
 export * from './constants';
 export * from './filterExploreByTags';
 export * from './followUpTools';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #16675

### Description:
Added an admin API endpoint for AI agent conversation analytics. This new endpoint allows organization admins to retrieve and analyze all AI agent conversations across the organization with comprehensive filtering options.

Key features:
- New `/api/v1/aiAgents/admin/threads` endpoint for organization-wide conversation analysis
- Robust filtering capabilities including:
  - Project and agent filtering
  - User-specific filtering
  - Source filtering (Slack vs Web App)
  - Human feedback filtering (thumbs up/down)
  - Date range filtering
- Pagination and sorting options
- Feedback aggregation for training loop analysis
- Comprehensive HTTP examples for API usage

This endpoint will enable admins to analyze AI agent performance, identify patterns in user feedback, and improve agent training over time.