### PR TITLE
fix: cascade delete on user deletion for `ai_web_app_thread` and `ai_web_app_prompt` tables

### DIFF
--- a/packages/backend/src/ee/database/migrations/20250903083645_ai_foreign_key_constraints.ts
+++ b/packages/backend/src/ee/database/migrations/20250903083645_ai_foreign_key_constraints.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+const AI_WEB_APP_THREAD_TABLE_NAME = 'ai_web_app_thread';
+const AI_WEB_APP_PROMPT_TABLE_NAME = 'ai_web_app_prompt';
+
+export async function up(knex: Knex): Promise<void> {
+    const threadTableExists = await knex.schema.hasTable(
+        AI_WEB_APP_THREAD_TABLE_NAME,
+    );
+    const promptTableExists = await knex.schema.hasTable(
+        AI_WEB_APP_PROMPT_TABLE_NAME,
+    );
+
+    if (threadTableExists) {
+        await knex.schema.alterTable(AI_WEB_APP_THREAD_TABLE_NAME, (table) => {
+            table.dropForeign(['user_uuid']);
+        });
+
+        await knex.schema.alterTable(AI_WEB_APP_THREAD_TABLE_NAME, (table) => {
+            table
+                .foreign('user_uuid')
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('CASCADE');
+        });
+    }
+
+    if (promptTableExists) {
+        await knex.schema.alterTable(AI_WEB_APP_PROMPT_TABLE_NAME, (table) => {
+            table.dropForeign(['user_uuid']);
+        });
+
+        await knex.schema.alterTable(AI_WEB_APP_PROMPT_TABLE_NAME, (table) => {
+            table
+                .foreign('user_uuid')
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('CASCADE');
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // This migration fixes a bug in foreign key constraints.
+    // Rolling back would restore the broken state that prevents user deletion.
+    // No rollback is provided for this bug fix.
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16702

### Description:

Added a migration to fix foreign key constraints for AI web app tables. The migration updates the foreign key relationships for `ai_web_app_thread` and `ai_web_app_prompt` tables to include `CASCADE` on delete, which ensures that when a user is deleted, their associated AI threads and prompts are also removed. This fixes a bug where user deletion was being prevented due to these foreign key constraints.

Users were getting this error:

```
error: delete from "users" where "user_uuid" = $1 - update or delete on table "users" violates foreign key constraint "ai_web_app_thread_user_uuid_foreign" on table "ai_web_app_thread"
```

when requesting `DELETE /api/v1/org/user/:userUuid`

To reproduce:

1. create an AI thread from web 
2. try to delete the user from step 1
