### PR TITLE
feat: add PAT support for instance update setup

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -457,6 +457,9 @@ export const getUpdateSetupConfig = (): LightdashConfig['updateSetup'] => {
                 process.env.LD_SETUP_DBT_VERSION,
                 SupportedDbtVersions,
             ),
+            personalAccessToken: isApiValidToken(
+                TokenEnvironmentVariable.PERSONAL_ACCESS_TOKEN,
+            )?.value,
         },
         serviceAccount: isApiValidToken(
             TokenEnvironmentVariable.SERVICE_ACCOUNT,
@@ -800,6 +803,7 @@ export type LightdashConfig = {
         project: {
             httpPath?: CreateDatabricksCredentials['httpPath'];
             dbtVersion?: DbtVersionOption;
+            personalAccessToken?: CreateDatabricksCredentials['personalAccessToken'];
         };
         serviceAccount?: {
             token: string;

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -364,7 +364,8 @@ export class InstanceConfigurationService extends BaseService {
         if (
             config.dbt?.personal_access_token ||
             config.project?.httpPath ||
-            config.project?.dbtVersion
+            config.project?.dbtVersion ||
+            config.project?.personalAccessToken
         ) {
             // This will throw an error if there is not exactly 1 project
             const projectUuid = await this.getSingleProject();
@@ -401,7 +402,10 @@ export class InstanceConfigurationService extends BaseService {
             let updatedWarehouseConnection:
                 | CreateWarehouseCredentials
                 | undefined;
-            if (config.project?.httpPath) {
+            if (
+                config.project?.httpPath ||
+                config.project?.personalAccessToken
+            ) {
                 if (warehouseConnection.type !== WarehouseTypes.DATABRICKS) {
                     throw new ParameterError(
                         `Project ${projectUuid} is not a Databricks project. Only Databricks projects are supported at the moment.`,
@@ -409,7 +413,12 @@ export class InstanceConfigurationService extends BaseService {
                 }
                 updatedWarehouseConnection = {
                     ...warehouseConnection,
-                    httpPath: config.project.httpPath,
+                    ...(config.project.httpPath && {
+                        httpPath: config.project.httpPath,
+                    }),
+                    ...(config.project.personalAccessToken && {
+                        personalAccessToken: config.project.personalAccessToken,
+                    }),
                 };
             }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/16700

### Description:

Added support for configuring Databricks personal access token through environment variables. This allows users to set up Databricks authentication using the `PERSONAL_ACCESS_TOKEN` environment variable alongside the existing HTTP path configuration option.
