### PR TITLE
fix: pivot configuration derivation from chart config

### DIFF
--- a/packages/common/src/pivot/derivePivotConfigFromChart.mock.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.mock.ts
@@ -1,0 +1,88 @@
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type ItemsMap,
+} from '../types/field';
+import { type MetricQuery } from '../types/metricQuery';
+import { ChartType, type CartesianChartConfig } from '../types/savedCharts';
+
+// Items (fields) map derived from issue description
+export const mockItems: ItemsMap = {
+    payments_payment_method: {
+        sql: '${TABLE}.payment_method',
+        name: 'payment_method',
+        type: DimensionType.STRING,
+        index: 2,
+        label: 'Payment method',
+        table: 'payments',
+        groups: [],
+        hidden: false,
+        fieldType: FieldType.DIMENSION,
+        tableLabel: 'Payments',
+        description: 'Method of payment used, for example credit card',
+    },
+    orders_status: {
+        sql: '${TABLE}.status',
+        name: 'status',
+        type: DimensionType.STRING,
+        index: 4,
+        label: 'Status',
+        table: 'orders',
+        groups: [],
+        hidden: false,
+        fieldType: FieldType.DIMENSION,
+        tableLabel: 'Orders',
+        description:
+            '# Order Status\n\nOrders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n| -------------- | ---------------------------------------------------------------------------------------------------------------------- |\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |',
+    },
+    payments_total_revenue: {
+        sql: '${TABLE}.amount',
+        name: 'total_revenue',
+        type: MetricType.SUM,
+        index: 1,
+        label: 'Total revenue',
+        table: 'payments',
+        groups: [],
+        hidden: false,
+        filters: [],
+        fieldType: FieldType.METRIC,
+        spotlight: {
+            categories: [],
+            visibility: 'show',
+        },
+        tableLabel: 'Payments',
+        description: 'Sum of all payments',
+        dimensionReference: 'payments_amount',
+    },
+};
+
+export const mockMetricQuery: MetricQuery = {
+    exploreName: 'payments',
+    dimensions: ['payments_payment_method', 'orders_status'],
+    metrics: ['payments_total_revenue'],
+    filters: {},
+    sorts: [
+        {
+            fieldId: 'payments_payment_method',
+            descending: false,
+        },
+    ],
+    limit: 500,
+    tableCalculations: [],
+    additionalMetrics: [],
+    metricOverrides: {},
+};
+
+export const mockCartesianChartConfig: CartesianChartConfig = {
+    type: ChartType.CARTESIAN,
+    config: {
+        layout: {
+            xField: 'payments_payment_method',
+            yField: ['payments_total_revenue'],
+        },
+        eChartsConfig: {
+            series: [],
+        },
+    },
+};

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -1,0 +1,164 @@
+import { ChartType, type SavedChartDAO } from '../types/savedCharts';
+import {
+    SortByDirection,
+    VizAggregationOptions,
+    VizIndexType,
+} from '../visualizations/types';
+import { derivePivotConfigurationFromChart } from './derivePivotConfigFromChart';
+import {
+    mockCartesianChartConfig,
+    mockItems,
+    mockMetricQuery,
+} from './derivePivotConfigFromChart.mock';
+
+// Jest provides describe/it/expect globals
+
+describe('derivePivotConfigurationFromChart', () => {
+    it('derives pivot configuration for Cartesian charts with pivot config', () => {
+        const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
+            chartConfig: mockCartesianChartConfig,
+            pivotConfig: {
+                columns: ['orders_status'],
+            },
+        };
+
+        const result = derivePivotConfigurationFromChart(
+            savedChart,
+            mockMetricQuery,
+            mockItems,
+        );
+
+        expect(result).toEqual({
+            indexColumn: {
+                reference: 'payments_payment_method',
+                type: VizIndexType.CATEGORY,
+            },
+            valuesColumns: [
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ],
+            groupByColumns: [{ reference: 'orders_status' }],
+            sortBy: [
+                {
+                    reference: 'payments_payment_method',
+                    direction: SortByDirection.ASC,
+                },
+            ],
+        });
+    });
+
+    it('returns undefined for Cartesian charts without pivot config', () => {
+        const savedChart = {
+            chartConfig: mockCartesianChartConfig,
+            pivotConfig: undefined,
+        } as const;
+
+        const result = derivePivotConfigurationFromChart(
+            savedChart,
+            mockMetricQuery,
+            mockItems,
+        );
+
+        expect(result).toBeUndefined();
+    });
+
+    it('derives pivot configuration for Table charts with pivot config', () => {
+        const tableChartConfig = {
+            type: ChartType.TABLE,
+            config: {},
+        } as const;
+
+        // Pivot on payments_payment_method so orders_status becomes index column
+        const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
+            chartConfig: tableChartConfig,
+            pivotConfig: {
+                columns: ['payments_payment_method'],
+            },
+        };
+
+        const result = derivePivotConfigurationFromChart(
+            savedChart,
+            mockMetricQuery,
+            mockItems,
+        );
+
+        expect(result).toEqual({
+            indexColumn: [
+                {
+                    reference: 'orders_status',
+                    type: VizIndexType.CATEGORY,
+                },
+            ],
+            valuesColumns: [
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ],
+            groupByColumns: [{ reference: 'payments_payment_method' }],
+            sortBy: [
+                {
+                    reference: 'payments_payment_method',
+                    direction: SortByDirection.ASC,
+                },
+            ],
+        });
+    });
+
+    it('returns undefined for unsupported chart types (PIE)', () => {
+        const pieChartConfig = {
+            type: ChartType.PIE,
+            config: {},
+        } as const;
+
+        const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
+            chartConfig: pieChartConfig,
+            pivotConfig: { columns: ['payments_payment_method'] },
+        };
+
+        const result = derivePivotConfigurationFromChart(
+            savedChart,
+            mockMetricQuery,
+            mockItems,
+        );
+
+        expect(result).toBeUndefined();
+    });
+
+    it('filters out sorts that are not present in pivot configuration', () => {
+        const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
+            chartConfig: mockCartesianChartConfig,
+            pivotConfig: {
+                columns: ['orders_status'],
+            },
+        };
+
+        const mq = {
+            ...mockMetricQuery,
+            sorts: [
+                { fieldId: 'payments_payment_method', descending: false }, // present as index
+                { fieldId: 'payments_total_revenue', descending: true }, // present as value column
+                { fieldId: 'non_existing_field', descending: false }, // should be filtered out
+            ],
+        } as typeof mockMetricQuery;
+
+        const result = derivePivotConfigurationFromChart(
+            savedChart,
+            mq,
+            mockItems,
+        );
+
+        expect(result?.sortBy).toEqual([
+            {
+                reference: 'payments_payment_method',
+                direction: SortByDirection.ASC,
+            },
+            {
+                reference: 'payments_total_revenue',
+                direction: SortByDirection.DESC,
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#16687](https://github.com/lightdash/lightdash/issues/16687)
Closes: [#16689](https://github.com/lightdash/lightdash/issues/16689)

### Description:
Fix approach to derive pivot configuration from chart settings. This implementation now uses the saved chart's explicit `pivotConfig` property instead of trying to extract pivot information from series configuration.

The changes include:
- Created a new implementation that works with both Cartesian and Table chart types
- Added comprehensive test coverage for different chart scenarios
- Added mock data to support testing
- Simplified the logic by directly using the pivot columns defined in the chart configuration

This approach is more reliable and maintainable as it uses explicitly defined pivot settings rather than inferring them from complex chart configurations.