### PR TITLE
fix: prevent overlapping columns between group by and index in pivot queries

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -675,7 +675,7 @@ describe('PivotQueryBuilder', () => {
             );
         });
 
-        test('Should deduplicate index and group by columns', () => {
+        test('Should throw error when index and group by columns overlap', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -694,14 +694,11 @@ describe('PivotQueryBuilder', () => {
                 mockWarehouseSqlBuilder,
             );
 
-            const result = builder.toSql();
-
-            // Should contain "date" only once in the group by
-            const groupByMatches = result.match(/group by.*?"date"/g) || [];
-            expect(groupByMatches.length).toBe(1);
-
-            // Should not duplicate date in the select
-            expect(result).not.toContain('"date", "date"');
+            // Should throw an error since no index columns are provided
+            expect(() => builder.toSql()).toThrow(ParameterError);
+            expect(() => builder.toSql()).toThrow(
+                'Group column(s) cannot also be part of the index column(s):',
+            );
         });
     });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -370,6 +370,22 @@ export class PivotQueryBuilder {
         const { valuesColumns, groupByColumns, sortBy } =
             this.pivotConfiguration;
 
+        // Validate that no groupBy column is also part of the index columns
+        if (groupByColumns && groupByColumns.length > 0) {
+            const indexRefs = new Set(indexColumns.map((c) => c.reference));
+            const overlapping = groupByColumns
+                .map((c) => c.reference)
+                .filter((ref) => indexRefs.has(ref));
+            if (overlapping.length > 0) {
+                // Throw a clear parameter error listing the offending columns
+                throw new ParameterError(
+                    `Group column(s) cannot also be part of the index column(s): ${overlapping.join(
+                        ', ',
+                    )}`,
+                );
+            }
+        }
+
         const userSql = this.sql.replace(/;\s*$/, '');
         const groupByQuery = this.getGroupByQuerySQL(
             indexColumns,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -112,9 +112,10 @@ export const Layout: FC<Props> = ({ items }) => {
             availableDimensions.filter(
                 (item) =>
                     !pivotDimensions?.includes(getItemId(item)) &&
-                    isCartesianChart &&
-                    getItemId(item) !==
-                        visualizationConfig.chartConfig.dirtyLayout?.xField,
+                    (!isCartesianChart ||
+                        getItemId(item) !==
+                            visualizationConfig.chartConfig.dirtyLayout
+                                ?.xField),
             ),
         [
             availableDimensions,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -110,9 +110,18 @@ export const Layout: FC<Props> = ({ items }) => {
     const availableGroupByDimensions = useMemo(
         () =>
             availableDimensions.filter(
-                (item) => !pivotDimensions?.includes(getItemId(item)),
+                (item) =>
+                    !pivotDimensions?.includes(getItemId(item)) &&
+                    isCartesianChart &&
+                    getItemId(item) !==
+                        visualizationConfig.chartConfig.dirtyLayout?.xField,
             ),
-        [availableDimensions, pivotDimensions],
+        [
+            availableDimensions,
+            visualizationConfig.chartConfig,
+            isCartesianChart,
+            pivotDimensions,
+        ],
     );
 
     const canAddPivot = useMemo(
@@ -293,15 +302,12 @@ export const Layout: FC<Props> = ({ items }) => {
                                     availableDimensions.find(
                                         (item) => getItemId(item) === pivotKey,
                                     );
-                                const fieldOptions = groupSelectedField
-                                    ? [
-                                          groupSelectedField,
-                                          ...availableGroupByDimensions,
-                                      ]
-                                    : availableGroupByDimensions;
                                 const activeField = chartHasMetricOrTableCalc
                                     ? groupSelectedField
                                     : undefined;
+                                const inactiveItemIds = dirtyLayout?.xField
+                                    ? [dirtyLayout.xField, ...pivotDimensions]
+                                    : pivotDimensions;
                                 return (
                                     <Group spacing="xs" key={pivotKey}>
                                         <FieldSelect
@@ -310,7 +316,10 @@ export const Layout: FC<Props> = ({ items }) => {
                                             }
                                             placeholder="Select a field to group by"
                                             item={activeField}
-                                            items={fieldOptions}
+                                            items={availableDimensions}
+                                            inactiveItemIds={inactiveItemIds.filter(
+                                                (id) => id !== pivotKey,
+                                            )} // keep current value enabled
                                             onChange={(newValue) => {
                                                 if (!newValue) return;
                                                 setPivotDimensions(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#16703](https://github.com/lightdash/lightdash/issues/16703)

### Description:
Prevents users from selecting the same field for both index and group by columns in pivot tables, which would lead to invalid queries. This PR adds validation in the backend to throw a clear error message when this happens, and updates the frontend to disable fields in the group by dropdown that are already used as index columns.

Example:

Disabled options

<img width="388" height="588" alt="Screenshot 2025-09-03 at 11 49 58" src="https://github.com/user-attachments/assets/9d7ca6f9-9f50-449d-80a2-08d88e4942af" />

<img width="391" height="614" alt="Screenshot 2025-09-03 at 12 00 15" src="https://github.com/user-attachments/assets/23e1c4f0-f05b-4102-b5ed-affc92e3a373" />


New error message (shouldn't be possible to reach this state now)

<img width="1734" height="860" alt="Screenshot 2025-09-03 at 11 54 37" src="https://github.com/user-attachments/assets/5359af43-84bb-4f8a-9d13-e26655114e50" />

