### PR TITLE
feat: display ai agent admin panel for all threads

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -45,9 +45,9 @@ export class AiAgentAdminController extends BaseController {
         @Query() humanScore?: AiAgentAdminFilters['humanScore'],
         @Query() dateFrom?: AiAgentAdminFilters['dateFrom'],
         @Query() dateTo?: AiAgentAdminFilters['dateTo'],
+        @Query() search?: AiAgentAdminFilters['search'],
         // Sorting
-        @Query()
-        sortField?: AiAgentAdminSort['field'],
+        @Query() sortField?: AiAgentAdminSort['field'],
         @Query() sortDirection?: AiAgentAdminSort['direction'],
     ): Promise<ApiAiAgentAdminConversationsResponse> {
         const paginateArgs: KnexPaginateArgs | undefined =
@@ -69,6 +69,7 @@ export class AiAgentAdminController extends BaseController {
             ...(humanScore !== undefined && { humanScore }),
             ...(dateFrom && { dateFrom }),
             ...(dateTo && { dateTo }),
+            ...(search && { search }),
         };
 
         const sort: AiAgentAdminSort | undefined = sortField

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -954,6 +954,13 @@ export class AiAgentModel {
                         );
                 });
             }
+            if (filters.search) {
+                void finalQuery.where(
+                    `${AiThreadTableName}.title`,
+                    'ILIKE',
+                    `%${filters.search}%`,
+                );
+            }
         }
 
         if (sort) {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10484,6 +10484,7 @@ const models: TsoaRoute.Models = {
             'bitbucket',
             'azure_devops',
             'none',
+            'manifest',
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -10665,6 +10666,21 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'DbtProjectType.MANIFEST': {
+        dataType: 'refEnum',
+        enums: ['manifest'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DbtManifestProjectConfig: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'DbtProjectType.MANIFEST', required: true },
+            manifest: { dataType: 'string', required: true },
+            hideRefreshButton: { dataType: 'boolean', required: true },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DbtProjectConfig: {
         dataType: 'refAlias',
         type: {
@@ -10677,6 +10693,7 @@ const models: TsoaRoute.Models = {
                 { ref: 'DbtGitlabProjectConfig' },
                 { ref: 'DbtAzureDevOpsProjectConfig' },
                 { ref: 'DbtNoneProjectConfig' },
+                { ref: 'DbtManifestProjectConfig' },
             ],
             validators: {},
         },
@@ -12186,7 +12203,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12196,7 +12213,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12206,7 +12223,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -12219,7 +12236,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -22257,6 +22274,7 @@ export function RegisterRoutes(app: Router) {
         humanScore: { in: 'query', name: 'humanScore', dataType: 'double' },
         dateFrom: { in: 'query', name: 'dateFrom', dataType: 'string' },
         dateTo: { in: 'query', name: 'dateTo', dataType: 'string' },
+        search: { in: 'query', name: 'search', dataType: 'string' },
         sortField: {
             in: 'query',
             name: 'sortField',
@@ -29300,6 +29318,7 @@ export function RegisterRoutes(app: Router) {
                 dbtConnectionOverrides: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        manifest: { dataType: 'string' },
                         environment: {
                             dataType: 'array',
                             array: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11320,7 +11320,8 @@
                     "gitlab",
                     "bitbucket",
                     "azure_devops",
-                    "none"
+                    "none",
+                    "manifest"
                 ],
                 "type": "string"
             },
@@ -11614,6 +11615,26 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "DbtProjectType.MANIFEST": {
+                "enum": ["manifest"],
+                "type": "string"
+            },
+            "DbtManifestProjectConfig": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/DbtProjectType.MANIFEST"
+                    },
+                    "manifest": {
+                        "type": "string"
+                    },
+                    "hideRefreshButton": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["type", "manifest", "hideRefreshButton"],
+                "type": "object",
+                "additionalProperties": true
+            },
             "DbtProjectConfig": {
                 "anyOf": [
                     {
@@ -11636,6 +11657,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/DbtNoneProjectConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DbtManifestProjectConfig"
                     }
                 ]
             },
@@ -13020,22 +13044,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiChartAsCodeListResponse": {
@@ -18815,7 +18839,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1972.0",
+        "version": "0.1978.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -24559,6 +24583,9 @@
                                     },
                                     "dbtConnectionOverrides": {
                                         "properties": {
+                                            "manifest": {
+                                                "type": "string"
+                                            },
                                             "environment": {
                                                 "items": {
                                                     "$ref": "#/components/schemas/DbtProjectEnvironmentVariable"

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -13,6 +13,7 @@ export type AiAgentAdminFilters = {
     humanScore?: number; // (-1, 0, 1)
     dateFrom?: string; // ISO date string
     dateTo?: string; // ISO date string
+    search?: string; // Search by thread title
 };
 
 export type AiAgentAdminSortField = 'createdAt' | 'title';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -121,6 +121,7 @@ import { type UserWarehouseCredentials } from './types/userWarehouseCredentials'
 import { type ValidationResponse } from './types/validation';
 
 import type {
+    ApiAiAgentAdminConversationsResponse,
     ApiAiAgentArtifactResponse,
     ApiAiAgentThreadCreateResponse,
     ApiAiAgentThreadGenerateTitleResponse,
@@ -945,7 +946,8 @@ type ApiResults =
     | ApiAiAgentArtifactResponse['results']
     | ApiAiAgentThreadGenerateTitleResponse['results']
     | ApiAiAgentThreadSummaryListResponse['results']
-    | Account;
+    | Account
+    | ApiAiAgentAdminConversationsResponse['results'];
 
 export type ApiResponse<T extends ApiResults = ApiResults> = {
     status: 'ok';

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -1,8 +1,10 @@
 import { Navigate, type RouteObject } from 'react-router';
+import NavBar from '../components/NavBar';
 import PrivateRoute from '../components/PrivateRoute';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
 import EmbeddedApp from './features/embed/EmbeddedApp';
+import { AiAgentsAdminPage } from './pages/AiAgents/Admin/AiAgentsAdminPage';
 import AgentPage from './pages/AiAgents/AgentPage';
 import AgentsRedirect from './pages/AiAgents/AgentsRedirect';
 import AgentsWelcome from './pages/AiAgents/AgentsWelcome';
@@ -41,6 +43,15 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
 ];
 
 const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
+    {
+        path: '/ai-agents/admin',
+        element: (
+            <PrivateRoute>
+                <NavBar />
+                <AiAgentsAdminPage />
+            </PrivateRoute>
+        ),
+    },
     {
         path: '/ai-agents/',
         element: (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -1,0 +1,637 @@
+import {
+    type AiAgentAdminSortField,
+    type AiAgentAdminThreadSummary,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Divider,
+    Group,
+    Paper,
+    Text,
+    TextInput,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
+import {
+    IconArrowDown,
+    IconArrowsSort,
+    IconArrowUp,
+    IconBox,
+    IconClick,
+    IconClock,
+    IconMessageCircleStar,
+    IconRadar,
+    IconRobotFace,
+    IconSearch,
+    IconTextCaption,
+    IconUser,
+    IconX,
+} from '@tabler/icons-react';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_SortingState,
+    type MRT_Virtualizer,
+} from 'mantine-react-table';
+import {
+    useCallback,
+    useDeferredValue,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type UIEvent,
+} from 'react';
+import { LightdashUserAvatar } from '../../../../../components/Avatar';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useIsTruncated } from '../../../../../hooks/useIsTruncated';
+import SlackSvg from '../../../../../svgs/slack.svg?react';
+import { useInfiniteAiAgentAdminThreads } from '../../hooks/useAiAgentAdmin';
+
+const AiAgentAdminThreadsTable = () => {
+    const theme = useMantineTheme();
+    const [sorting, setSorting] = useState<MRT_SortingState>([
+        { id: 'createdAt', desc: true },
+    ]);
+    const [search, setSearch] = useState<string | undefined>(undefined);
+    const clearSearch = useCallback(() => setSearch(''), [setSearch]);
+    const deferredSearch = useDeferredValue(search);
+
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const rowVirtualizerInstanceRef =
+        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+
+    const sortBy:
+        | {
+              sortField: AiAgentAdminSortField;
+              sortDirection: 'asc' | 'desc';
+          }
+        | undefined = useMemo(() => {
+        if (sorting.length === 0) return undefined;
+
+        const firstSorting = sorting[0];
+        let sortField: AiAgentAdminSortField = 'createdAt';
+
+        if (firstSorting.id === 'title') {
+            sortField = 'title';
+        } else if (firstSorting.id === 'createdAt') {
+            sortField = 'createdAt';
+        }
+
+        return {
+            sortField,
+            sortDirection: firstSorting.desc ? 'desc' : 'asc',
+        };
+    }, [sorting]);
+
+    const { data, isInitialLoading, isFetching, hasNextPage, fetchNextPage } =
+        useInfiniteAiAgentAdminThreads(
+            {
+                pagination: {},
+                filters: {
+                    ...(deferredSearch && { search: deferredSearch }),
+                },
+                sort: {
+                    field: sortBy?.sortField ?? 'createdAt',
+                    direction: sortBy?.sortDirection ?? 'desc',
+                },
+            },
+            { keepPreviousData: true },
+        );
+
+    const flatData = useMemo(() => {
+        if (!data) return [];
+        return data.pages.flatMap((page) => page.data.threads);
+    }, [data]);
+
+    // Temporary workaround to resolve a memoization issue with react-mantine-table
+    const [tableData, setTableData] = useState<AiAgentAdminThreadSummary[]>([]);
+    useEffect(() => {
+        setTableData(flatData);
+    }, [flatData]);
+
+    const totalResults = useMemo(() => {
+        if (!data) return 0;
+        const lastPage = data.pages[data.pages.length - 1];
+        return lastPage.pagination?.totalResults ?? 0;
+    }, [data]);
+
+    // Called on scroll to fetch more data as the user scrolls and reaches bottom of table
+    const fetchMoreOnBottomReached = useCallback(
+        (containerRefElement?: HTMLDivElement | null) => {
+            if (containerRefElement) {
+                const { scrollHeight, scrollTop, clientHeight } =
+                    containerRefElement;
+                // Once the user has scrolled within 200px of the bottom, fetch more data if available
+                if (
+                    scrollHeight - scrollTop - clientHeight < 200 &&
+                    !isFetching &&
+                    hasNextPage
+                ) {
+                    void fetchNextPage();
+                }
+            }
+        },
+        [fetchNextPage, isFetching, hasNextPage],
+    );
+
+    // Check if we need to fetch more data on mount
+    useEffect(() => {
+        fetchMoreOnBottomReached(tableContainerRef.current);
+    }, [fetchMoreOnBottomReached]);
+
+    const columns: MRT_ColumnDef<AiAgentAdminThreadSummary>[] = [
+        {
+            accessorKey: 'title',
+            header: 'Thread',
+            enableSorting: false,
+            enableEditing: false,
+            size: 300,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconTextCaption} color="gray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const isTruncated = useIsTruncated<HTMLDivElement>();
+                const thread = row.original;
+                return (
+                    <Tooltip
+                        withinPortal
+                        variant="xs"
+                        label={thread.title || 'Untitled Thread'}
+                        disabled={!isTruncated.isTruncated}
+                        multiline
+                        maw={300}
+                    >
+                        <Text fw={500} fz="sm" truncate ref={isTruncated.ref}>
+                            {thread.title || 'Untitled Thread'}
+                        </Text>
+                    </Tooltip>
+                );
+            },
+        },
+        {
+            accessorKey: 'agent.name',
+            header: 'Agent',
+            enableSorting: false,
+            enableEditing: false,
+            size: 220,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconRobotFace} color="gray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const thread = row.original;
+                return (
+                    <Paper px="xs">
+                        <Group gap="two" wrap="nowrap">
+                            <LightdashUserAvatar
+                                size={12}
+                                variant="filled"
+                                name={thread.agent.name}
+                                src={thread.agent.imageUrl}
+                            />
+                            <Text fz="sm" fw={500} c="gray.7">
+                                {thread.agent.name}
+                            </Text>
+                        </Group>
+                    </Paper>
+                );
+            },
+        },
+        {
+            accessorKey: 'project.name',
+            header: 'Project',
+            enableSorting: false,
+            enableEditing: false,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconBox} color="gray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const thread = row.original;
+                return (
+                    <Text c="gray.9" fz="sm" fw={400}>
+                        {thread.project.name}
+                    </Text>
+                );
+            },
+        },
+        {
+            accessorKey: 'user.name',
+            header: 'User',
+            enableSorting: false,
+            enableEditing: false,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconUser} color="gray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const thread = row.original;
+                return (
+                    <Tooltip
+                        withinPortal
+                        variant="xs"
+                        label={thread.user.email}
+                    >
+                        <Text c="gray.9" fz="sm" fw={400}>
+                            {thread.user.name}
+                        </Text>
+                    </Tooltip>
+                );
+            },
+        },
+        {
+            accessorKey: 'createdFrom',
+            header: 'Source',
+            enableSorting: false,
+            enableEditing: false,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconRadar} color="gray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const thread = row.original;
+                let label = thread.createdFrom;
+                if (label === 'slack') {
+                    label = 'Slack';
+                } else if (label === 'web_app') {
+                    label = 'App';
+                }
+
+                return (
+                    <Paper px="xs">
+                        <Group gap="two">
+                            {label === 'Slack' ? (
+                                <SlackSvg
+                                    style={{
+                                        width: '12px',
+                                        height: '12px',
+                                    }}
+                                />
+                            ) : (
+                                <MantineIcon
+                                    icon={IconMessageCircleStar}
+                                    size="md"
+                                    color={'blue.6'}
+                                    stroke={1.6}
+                                />
+                            )}
+                            <Text fz="xs" c="gray.7" fw={500}>
+                                {label}
+                            </Text>
+                        </Group>
+                    </Paper>
+                );
+            },
+        },
+        {
+            accessorKey: 'feedbackSummary',
+            header: 'Feedback',
+            enableSorting: false,
+            enableEditing: false,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconClick} color="gray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const { feedbackSummary } = row.original;
+                return (
+                    <Group gap="xs">
+                        {feedbackSummary.neutral > 0 && (
+                            <Text fz="xs" c="gray.6">
+                                ~{feedbackSummary.neutral}
+                            </Text>
+                        )}
+                        {feedbackSummary.upvotes > 0 && (
+                            <Text fz="xs" c="green.6">
+                                ↑{feedbackSummary.upvotes}
+                            </Text>
+                        )}
+                        {feedbackSummary.downvotes > 0 && (
+                            <Text fz="xs" c="red.6">
+                                ↓{feedbackSummary.downvotes}
+                            </Text>
+                        )}
+                    </Group>
+                );
+            },
+        },
+        {
+            accessorKey: 'createdAt',
+            header: 'Created',
+            enableSorting: true,
+            enableEditing: false,
+            Header: ({ column }) => (
+                <Group gap="two">
+                    <MantineIcon icon={IconClock} color="gray.6" />
+                    {column.columnDef.header}
+                </Group>
+            ),
+            Cell: ({ row }) => {
+                const thread = row.original;
+                return (
+                    <Text fz="sm" c="gray.7">
+                        {new Date(thread.createdAt).toLocaleDateString()}
+                    </Text>
+                );
+            },
+        },
+    ];
+
+    const table = useMantineReactTable({
+        columns,
+        data: tableData,
+        enableColumnResizing: true,
+        enableRowNumbers: false,
+        enableRowVirtualization: true,
+        enablePagination: false,
+        enableFilters: true,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        onGlobalFilterChange: (s: string) => {
+            setSearch(s);
+        },
+        enableSorting: true,
+        manualSorting: true,
+        onSortingChange: setSorting,
+        enableTopToolbar: true,
+        positionGlobalFilter: 'left',
+        mantinePaperProps: {
+            shadow: undefined,
+            sx: {
+                border: `1px solid ${theme.colors.gray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableContainerProps: {
+            ref: tableContainerRef,
+            sx: {
+                maxHeight: 'calc(100dvh - 350px)',
+                minHeight: '600px',
+                display: 'flex',
+                flexDirection: 'column',
+            },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.target as HTMLDivElement),
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: Boolean(flatData.length),
+            sx: {
+                flexGrow: 1,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableHeadRowProps: {
+            sx: {
+                boxShadow: 'none',
+                'th > div > div:last-child': {
+                    top: -10,
+                    right: -5,
+                },
+                'th > div > div:last-child > .mantine-Divider-root': {
+                    border: 'none',
+                },
+            },
+        },
+        mantineTableHeadCellProps: (props) => {
+            const isAnyColumnResizing = props.table
+                .getAllColumns()
+                .some((c) => c.getIsResizing());
+
+            const isLastColumn =
+                props.table.getAllColumns().indexOf(props.column) ===
+                props.table.getAllColumns().length - 1;
+
+            const canResize = props.column.getCanResize();
+
+            return {
+                bg: 'gray.0',
+                h: '3xl',
+                pos: 'relative',
+                style: {
+                    padding: `${theme.spacing.xs} ${theme.spacing.xl}`,
+                    borderBottom: `1px solid ${theme.colors.gray[2]}`,
+                    borderRight: props.column.getIsResizing()
+                        ? `2px solid ${theme.colors.blue[3]}`
+                        : `1px solid ${
+                              isLastColumn
+                                  ? 'transparent'
+                                  : theme.colors.gray[2]
+                          }`,
+                    borderTop: 'none',
+                    borderLeft: 'none',
+                },
+                sx: {
+                    justifyContent: 'center',
+                    '&:hover': canResize
+                        ? {
+                              borderRight: !isAnyColumnResizing
+                                  ? `2px solid ${theme.colors.blue[3]} !important`
+                                  : undefined,
+                              transition: `border-right ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                          }
+                        : {},
+                },
+            };
+        },
+        mantineTableBodyProps: {
+            sx: {
+                flexGrow: 1,
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                'tr:last-of-type > td': {
+                    borderBottom: 'none',
+                    borderLeft: 'none !important',
+                },
+            },
+        },
+        mantineTableBodyRowProps: () => {
+            return {
+                sx: {
+                    cursor: 'pointer',
+                    '&:hover': {
+                        td: {
+                            backgroundColor: theme.colors.gray[0],
+                            transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                        },
+                    },
+                },
+                onClick: () => {
+                    // TODO: Navigate to thread detail view with row
+                },
+            };
+        },
+        mantineTableBodyCellProps: () => {
+            return {
+                h: 72,
+                style: {
+                    padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                    borderRight: 'none',
+                    borderLeft: 'none',
+                    borderBottom: `1px solid ${theme.colors.gray[2]}`,
+                    borderTop: 'none',
+                },
+                sx: {
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    flexShrink: 0,
+                },
+            };
+        },
+        renderTopToolbar: () => {
+            return (
+                <Box>
+                    <Group
+                        p={`${theme.spacing.lg} ${theme.spacing.xl}`}
+                        justify="space-between"
+                    >
+                        <Tooltip
+                            withinPortal
+                            variant="xs"
+                            label="Search by title"
+                        >
+                            <TextInput
+                                size="xs"
+                                radius="md"
+                                styles={(inputTheme) => ({
+                                    input: {
+                                        height: 32,
+                                        width: 309,
+                                        textOverflow: 'ellipsis',
+                                        fontSize: inputTheme.fontSizes.sm,
+                                        fontWeight: 400,
+                                        color: search
+                                            ? inputTheme.colors.gray[8]
+                                            : inputTheme.colors.gray[5],
+                                        boxShadow: inputTheme.shadows.subtle,
+                                        border: `1px solid ${inputTheme.colors.gray[3]}`,
+                                        '&:hover': {
+                                            border: `1px solid ${inputTheme.colors.gray[4]}`,
+                                        },
+                                        '&:focus': {
+                                            border: `1px solid ${inputTheme.colors.blue[5]}`,
+                                        },
+                                    },
+                                })}
+                                type="search"
+                                variant="default"
+                                placeholder="Search threads by title"
+                                value={search ?? ''}
+                                leftSection={
+                                    <MantineIcon
+                                        size="md"
+                                        color="gray.6"
+                                        icon={IconSearch}
+                                    />
+                                }
+                                onChange={(e) => setSearch(e.target.value)}
+                                rightSection={
+                                    search && (
+                                        <ActionIcon
+                                            onClick={clearSearch}
+                                            variant="transparent"
+                                            size="xs"
+                                            color="gray.5"
+                                        >
+                                            <MantineIcon icon={IconX} />
+                                        </ActionIcon>
+                                    )
+                                }
+                            />
+                        </Tooltip>
+                    </Group>
+                    <Divider color="gray.2" />
+                </Box>
+            );
+        },
+        renderBottomToolbar: () => (
+            <Box
+                p={`${theme.spacing.sm} ${theme.spacing.xl} ${theme.spacing.md} ${theme.spacing.xl}`}
+                fz="xs"
+                fw={500}
+                color="gray.8"
+                style={{
+                    borderTop: `1px solid ${theme.colors.gray[3]}`,
+                }}
+            >
+                {isFetching ? (
+                    <Text c="gray.8" fz="xs">
+                        Loading more...
+                    </Text>
+                ) : (
+                    <Group gap="two">
+                        <Text fz="xs" c="gray.8">
+                            {hasNextPage
+                                ? 'Scroll for more results'
+                                : 'All results loaded'}
+                        </Text>
+                        <Text fz="xs" fw={400} c="gray.6">
+                            {hasNextPage
+                                ? `(${flatData.length} of ${totalResults} loaded)`
+                                : `(${flatData.length})`}
+                        </Text>
+                    </Group>
+                )}
+            </Box>
+        ),
+        icons: {
+            IconArrowsSort: () => (
+                <MantineIcon icon={IconArrowsSort} size="md" color="gray.5" />
+            ),
+            IconSortAscending: () => (
+                <MantineIcon icon={IconArrowUp} size="md" color="blue.6" />
+            ),
+            IconSortDescending: () => (
+                <MantineIcon icon={IconArrowDown} size="md" color="blue.6" />
+            ),
+        },
+        state: {
+            sorting,
+            showProgressBars: false,
+            showSkeletons: isInitialLoading,
+            density: 'md',
+            globalFilter: search ?? '',
+        },
+        mantineLoadingOverlayProps: {
+            loaderProps: {
+                color: 'violet',
+            },
+        },
+        initialState: {
+            showGlobalFilter: true,
+        },
+        rowVirtualizerInstanceRef,
+        rowVirtualizerProps: { overscan: 40 },
+        enableFilterMatchHighlighting: true,
+        enableRowActions: false,
+    });
+
+    return <MantineReactTable table={table} />;
+};
+
+export default AiAgentAdminThreadsTable;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
@@ -1,0 +1,41 @@
+import { Box, Stack, Text, Title } from '@mantine-8/core';
+import { IconLock } from '@tabler/icons-react';
+import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
+import useApp from '../../../../../providers/App/useApp';
+import AiAgentAdminThreadsTable from './AiAgentAdminThreadsTable';
+
+export const AiAgentsAdminLayout = () => {
+    const { user } = useApp();
+    const canManageOrganization = user.data?.ability.can(
+        'manage',
+        'Organization',
+    );
+    if (!canManageOrganization) {
+        return (
+            <Box mt="30vh">
+                <SuboptimalState
+                    title={`You don't have access to this page`}
+                    description={
+                        <>
+                            You must be an organization admin to access this
+                            page.
+                        </>
+                    }
+                    icon={IconLock}
+                />
+            </Box>
+        );
+    }
+    return (
+        <Stack>
+            <Box>
+                <Title order={2}>AI Agents Admin Panel</Title>
+                <Text c="gray.6" size="sm" fw={400}>
+                    View and manage AI Agents threads
+                </Text>
+            </Box>
+
+            <AiAgentAdminThreadsTable />
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -1,0 +1,86 @@
+import {
+    type AiAgentAdminFilters,
+    type AiAgentAdminSort,
+    type ApiAiAgentAdminConversationsResponse,
+    type ApiError,
+} from '@lightdash/common';
+import {
+    useInfiniteQuery,
+    type UseInfiniteQueryOptions,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+export type AiAgentAdminThreadsArgs = {
+    filters: AiAgentAdminFilters;
+    sort: AiAgentAdminSort;
+    pagination: {
+        pageSize?: number;
+        page?: number;
+    };
+};
+
+function createQueryString(params: Record<string, any>): string {
+    const query = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(params)) {
+        if (Array.isArray(value)) {
+            value.forEach((v) => query.append(key, v));
+        } else if (value !== undefined) {
+            query.append(key, value.toString());
+        }
+    }
+    return query.toString();
+}
+
+const getAiAgentAdminThreads = async (
+    args: AiAgentAdminFilters & {
+        sortField: AiAgentAdminSort['field'];
+        sortDirection: AiAgentAdminSort['direction'];
+    } & {
+        pageSize?: number;
+        page?: number;
+    },
+) => {
+    const params = createQueryString(args);
+    return lightdashApi<ApiAiAgentAdminConversationsResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/threads?${params}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useInfiniteAiAgentAdminThreads = (
+    args: AiAgentAdminThreadsArgs,
+    infinityQueryOpts: UseInfiniteQueryOptions<
+        ApiAiAgentAdminConversationsResponse['results'],
+        ApiError
+    > = {},
+) => {
+    return useInfiniteQuery<
+        ApiAiAgentAdminConversationsResponse['results'],
+        ApiError
+    >({
+        queryKey: ['ai-agent-admin-threads', args],
+        queryFn: async ({ pageParam }) => {
+            return getAiAgentAdminThreads({
+                ...args.filters,
+                ...(args.sort && {
+                    sortField: args.sort.field,
+                    sortDirection: args.sort.direction,
+                }),
+                ...args.pagination,
+                page: (pageParam as number) ?? 1,
+            });
+        },
+        getNextPageParam: (lastPage) => {
+            if (lastPage.pagination) {
+                return lastPage.pagination.page <
+                    lastPage.pagination.totalPageCount
+                    ? lastPage.pagination.page + 1
+                    : undefined;
+            }
+        },
+        ...infinityQueryOpts,
+    });
+};

--- a/packages/frontend/src/ee/pages/AiAgents/Admin/AiAgentsAdminPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/Admin/AiAgentsAdminPage.tsx
@@ -1,0 +1,16 @@
+import Page from '../../../../components/common/Page/Page';
+import { AiAgentsAdminLayout } from '../../../features/aiCopilot/components/Admin/AiAgentsAdminLayout';
+
+export const AiAgentsAdminPage = () => {
+    return (
+        <Page
+            withCenteredRoot
+            withCenteredContent
+            withXLargePaddedContent
+            withLargeContent
+            backgroundColor="#FAFAFA"
+        >
+            <AiAgentsAdminLayout />
+        </Page>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #16675

### Description:
Adds an AI Agents Admin Panel that allows organization admins to view and manage AI Agent threads. The panel includes a table with thread details such as title, agent, project, user, source, feedback, and creation date. The table supports sorting, searching by title, and infinite scrolling.

The implementation includes:
- New admin route at `/ai-agents/admin`
- Admin threads table with "created at" sorting. More filters and sorts soon!
- Permission checks to ensure only organization admins can access the panel
- Backend API integration for fetching thread data

![Screenshot 2025-09-03 at 11.47.30.png](https://app.graphite.dev/user-attachments/assets/1fa653df-43c7-4631-bca7-bdf777065cfb.png)

![Screenshot 2025-09-03 at 11.47.14.png](https://app.graphite.dev/user-attachments/assets/58670a16-0d9e-4b2d-a1b0-9030ce24a196.png)

