### PR TITLE
chore: reorder table calculation input fields in e2e tests

### DIFF
--- a/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
+++ b/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
@@ -67,14 +67,14 @@ describe('Table calculations', () => {
 
         cy.findByText('Table calculation').click();
 
-        cy.findByPlaceholderText('E.g. Cumulative order count').type('Ranking');
-
         cy.get('#ace-editor').type(
             `'rank_' || RANK() OVER(ORDER BY \${orders.total_order_amount} ASC)`,
             { parseSpecialCharSequences: false },
         );
         cy.get(`.mantine-Select-input[value='number']`).click();
         cy.contains('string').click();
+
+        cy.findByPlaceholderText('E.g. Cumulative order count').type('Ranking');
         cy.get('form').contains('Create').click({ force: true });
 
         // Run query
@@ -115,12 +115,12 @@ describe('Table calculations', () => {
 
         cy.findByText('Table calculation').click();
 
-        cy.findByPlaceholderText('E.g. Cumulative order count').type('Ranking');
-
         cy.get('#ace-editor').type(
             `RANK() OVER(ORDER BY \${orders.total_order_amount} ASC) * 100`,
             { parseSpecialCharSequences: false },
         );
+
+        cy.findByPlaceholderText('E.g. Cumulative order count').type('Ranking');
         // Defaults to number
         cy.get('form').contains('Create').click({ force: true });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Reordered the table calculation test steps to match the actual UI flow. The test now first enters the calculation formula in the editor, selects the data type if needed, and then enters the calculation name before clicking create. This better reflects how users interact with the table calculation dialog.

<img width="754" height="200" alt="Screenshot 2025-09-03 at 13 36 10" src="https://github.com/user-attachments/assets/5c29af16-9c0e-460a-93d4-0daf04b3b7ba" />
