### PR TITLE
feat: add tooltop bar ai threads filters

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -2,6 +2,8 @@ import {
     AiAgentAdminFilters,
     AiAgentAdminSort,
     ApiAiAgentAdminConversationsResponse,
+    ApiAiAgentResponse,
+    ApiAiAgentSummaryResponse,
     ApiErrorPayload,
     KnexPaginateArgs,
 } from '@lightdash/common';
@@ -90,6 +92,20 @@ export class AiAgentAdminController extends BaseController {
         return {
             status: 'ok',
             results: threads,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/agents')
+    @OperationId('getAllAgents')
+    async getAllAgents(
+        @Request() req: express.Request,
+    ): Promise<ApiAiAgentSummaryResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().listAgents(req.user!),
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -3,6 +3,7 @@ import {
     AiAgentAdminConversationsSummary,
     AiAgentAdminFilters,
     AiAgentAdminSort,
+    AiAgentSummary,
     ForbiddenError,
     KnexPaginateArgs,
     KnexPaginatedData,
@@ -62,6 +63,17 @@ export class AiAgentAdminService {
             paginateArgs,
             filters,
             sort,
+        });
+    }
+
+    async listAgents(user: SessionUser): Promise<AiAgentSummary[]> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        AiAgentAdminService.checkOrganizationAdminAccess(user);
+        return this.aiAgentModel.findAllAgents({
+            organizationUuid,
         });
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -22339,6 +22339,61 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getAllAgents: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/agents',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getAllAgents,
+        ),
+
+        async function AiAgentAdminController_getAllAgents(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getAllAgents,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAllAgents',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsValidationController_post: Record<
         string,
         TsoaRoute.ParameterSchema

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.module.css
@@ -1,0 +1,41 @@
+.filterButton {
+    border: 1px dashed var(--mantine-color-gray-3);
+    background-color: transparent;
+    text-overflow: ellipsis;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButton:hover {
+    background-color: var(--mantine-color-gray-0);
+    transition: background-color var(--mantine-other-transitionDuration)
+        var(--mantine-other-transitionTimingFunction);
+}
+
+.filterButtonSelected {
+    border: 1px solid var(--mantine-color-indigo-2);
+    background-color: var(--mantine-color-indigo-0);
+    text-overflow: ellipsis;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButtonSelected:hover {
+    background-color: var(--mantine-color-gray-0);
+    transition: background-color var(--mantine-other-transitionDuration)
+        var(--mantine-other-transitionTimingFunction);
+}
+
+.buttonLabel {
+    height: 24px;
+}
+
+.checkboxBody {
+    align-items: center;
+}
+
+.checkboxInput {
+    border-radius: var(--mantine-radius-sm);
+}
+
+.checkboxLabel {
+    padding-left: var(--mantine-spacing-xs);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
@@ -1,0 +1,165 @@
+import {
+    ActionIcon,
+    Button,
+    Checkbox,
+    Group,
+    Popover,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconRobotFace, IconX } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import { LightdashUserAvatar } from '../../../../../components/Avatar';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiAgentAdminAgents } from '../../hooks/useAiAgentAdmin';
+import classes from './AgentsFilter.module.css';
+
+type AgentsFilterProps = {
+    selectedAgentUuids: string[];
+    setSelectedAgentUuids: (agentUuids: string[]) => void;
+};
+
+const AgentsFilter: FC<AgentsFilterProps> = ({
+    selectedAgentUuids,
+    setSelectedAgentUuids,
+}) => {
+    const hasSelectedAgents = selectedAgentUuids.length > 0;
+
+    const organizationAiAgents = useAiAgentAdminAgents();
+
+    const agentNames = useMemo(() => {
+        if (!organizationAiAgents.data) return '';
+        return organizationAiAgents.data
+            ?.filter((agent) => selectedAgentUuids.includes(agent.uuid))
+            .map((agent) => agent.name)
+            .join(', ');
+    }, [organizationAiAgents?.data, selectedAgentUuids]);
+
+    const buttonLabel = hasSelectedAgents ? agentNames : 'All agents';
+
+    return (
+        <Group gap="two">
+            <Popover width={300} position="bottom-start">
+                <Popover.Target>
+                    <Tooltip
+                        withinPortal
+                        variant="xs"
+                        label="Filter threads by AI agent"
+                    >
+                        <Button
+                            h={32}
+                            c="gray.7"
+                            fw={500}
+                            fz="sm"
+                            variant="default"
+                            radius="md"
+                            py="xs"
+                            px="sm"
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconRobotFace}
+                                    size="md"
+                                    color={
+                                        hasSelectedAgents
+                                            ? 'indigo.5'
+                                            : 'gray.5'
+                                    }
+                                />
+                            }
+                            loading={organizationAiAgents.isLoading}
+                            className={
+                                hasSelectedAgents
+                                    ? classes.filterButtonSelected
+                                    : classes.filterButton
+                            }
+                            classNames={{
+                                label: classes.buttonLabel,
+                            }}
+                        >
+                            {buttonLabel}
+                        </Button>
+                    </Tooltip>
+                </Popover.Target>
+                <Popover.Dropdown p="sm">
+                    <Stack gap={4}>
+                        <Text fz="xs" c="dark.3" fw={600}>
+                            Filter by AI agents:
+                        </Text>
+
+                        {organizationAiAgents.data?.length === 0 && (
+                            <Text fz="xs" fw={500} c="gray.6">
+                                No agents available.
+                            </Text>
+                        )}
+
+                        <Stack gap="xs">
+                            {organizationAiAgents.data?.map((agent) => (
+                                <Checkbox
+                                    key={agent.uuid}
+                                    label={
+                                        <Group gap="xs" wrap="nowrap">
+                                            <LightdashUserAvatar
+                                                size={16}
+                                                variant="filled"
+                                                name={agent.name}
+                                                src={agent.imageUrl}
+                                            />
+                                            <Text fz="sm" fw={400}>
+                                                {agent.name}
+                                            </Text>
+                                        </Group>
+                                    }
+                                    checked={selectedAgentUuids.includes(
+                                        agent.uuid,
+                                    )}
+                                    size="xs"
+                                    classNames={{
+                                        body: classes.checkboxBody,
+                                        input: classes.checkboxInput,
+                                        label: classes.checkboxLabel,
+                                    }}
+                                    onChange={() => {
+                                        if (
+                                            selectedAgentUuids.includes(
+                                                agent.uuid,
+                                            )
+                                        ) {
+                                            setSelectedAgentUuids(
+                                                selectedAgentUuids.filter(
+                                                    (uuid) =>
+                                                        uuid !== agent.uuid,
+                                                ),
+                                            );
+                                        } else {
+                                            setSelectedAgentUuids([
+                                                ...selectedAgentUuids,
+                                                agent.uuid,
+                                            ]);
+                                        }
+                                    }}
+                                />
+                            ))}
+                        </Stack>
+                    </Stack>
+                </Popover.Dropdown>
+            </Popover>
+            {hasSelectedAgents && (
+                <Tooltip variant="xs" label="Clear all agent filters">
+                    <ActionIcon
+                        size="xs"
+                        color="gray.5"
+                        variant="subtle"
+                        onClick={() => {
+                            setSelectedAgentUuids([]);
+                        }}
+                    >
+                        <MantineIcon icon={IconX} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+        </Group>
+    );
+};
+
+export default AgentsFilter;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
@@ -1,0 +1,151 @@
+import {
+    Box,
+    Divider,
+    Group,
+    Text,
+    useMantineTheme,
+    type GroupProps,
+} from '@mantine-8/core';
+import { memo, useCallback, type FC } from 'react';
+import AgentsFilter from './AgentsFilter';
+import { FeedbackFilter } from './FeedbackFilter';
+import ProjectsFilter from './ProjectsFilter';
+import { SearchFilter } from './SearchFilter';
+import { SourceFilter } from './SourceFilter';
+
+type AiAgentAdminTopToolbarProps = GroupProps & {
+    search: string | undefined;
+    setSearch: (search: string) => void;
+    selectedProjectUuids: string[];
+    setSelectedProjectUuids: (projectUuids: string[]) => void;
+    selectedAgentUuids: string[];
+    setSelectedAgentUuids: (agentUuids: string[]) => void;
+    selectedSource: 'all' | 'web_app' | 'slack';
+    setSelectedSource: (source: 'all' | 'web_app' | 'slack') => void;
+    selectedFeedback: 'all' | 'thumbs_up' | 'thumbs_down';
+    setSelectedFeedback: (
+        feedback: 'all' | 'thumbs_up' | 'thumbs_down',
+    ) => void;
+    totalResults: number;
+    isFetching: boolean;
+    hasNextPage: boolean;
+    currentResultsCount: number;
+};
+
+export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
+    ({
+        search,
+        setSearch,
+        selectedProjectUuids,
+        setSelectedProjectUuids,
+        selectedAgentUuids,
+        setSelectedAgentUuids,
+        selectedSource,
+        setSelectedSource,
+        selectedFeedback,
+        setSelectedFeedback,
+        totalResults,
+        isFetching,
+        hasNextPage,
+        currentResultsCount,
+        ...props
+    }) => {
+        const theme = useMantineTheme();
+        const clearSearch = useCallback(() => setSearch(''), [setSearch]);
+
+        return (
+            <Box>
+                <Group
+                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
+                    justify="space-between"
+                    {...props}
+                >
+                    <Group gap="xs">
+                        <SearchFilter
+                            search={search}
+                            setSearch={setSearch}
+                            clearSearch={clearSearch}
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <ProjectsFilter
+                            selectedProjectUuids={selectedProjectUuids}
+                            setSelectedProjectUuids={setSelectedProjectUuids}
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <AgentsFilter
+                            selectedAgentUuids={selectedAgentUuids}
+                            setSelectedAgentUuids={setSelectedAgentUuids}
+                        />
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <FeedbackFilter
+                            selectedFeedback={selectedFeedback}
+                            setSelectedFeedback={setSelectedFeedback}
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <SourceFilter
+                            selectedSource={selectedSource}
+                            setSelectedSource={setSelectedSource}
+                        />
+                    </Group>
+
+                    {/* Results count */}
+                    <Group gap="xs">
+                        <Box
+                            bg="#F8F9FC"
+                            c="#363F72"
+                            style={{
+                                borderRadius: 6,
+                                padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
+                                height: 32,
+                                display: 'flex',
+                                alignItems: 'center',
+                            }}
+                        >
+                            <Text fz="sm" fw={500}>
+                                {isFetching
+                                    ? 'Loading...'
+                                    : hasNextPage
+                                    ? `${currentResultsCount} of ${totalResults} threads`
+                                    : `${totalResults} threads`}
+                            </Text>
+                        </Box>
+                    </Group>
+                </Group>
+                <Divider color="gray.2" />
+            </Box>
+        );
+    },
+);
+
+AiAgentAdminTopToolbar.displayName = 'AiAgentAdminTopToolbar';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.module.css
@@ -1,0 +1,21 @@
+.segmentedControl {
+    border-radius: var(--mantine-radius-md);
+    gap: var(--mantine-spacing-two);
+    padding: var(--mantine-spacing-xxs);
+}
+
+.indicator {
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid var(--mantine-color-gray-2);
+    background-color: white;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.label {
+    height: 24px;
+    padding-top: var(--mantine-spacing-xxs);
+}
+
+.label:where([data-active]) {
+    color: var(--mantine-color-indigo-6);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.tsx
@@ -1,0 +1,85 @@
+import { Box, SegmentedControl, Text, Tooltip } from '@mantine-8/core';
+import { IconThumbDown, IconThumbUp } from '@tabler/icons-react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import classes from './FeedbackFilter.module.css';
+
+type FeedbackFilterProps = {
+    selectedFeedback: 'all' | 'thumbs_up' | 'thumbs_down';
+    setSelectedFeedback: (
+        feedback: 'all' | 'thumbs_up' | 'thumbs_down',
+    ) => void;
+};
+
+export const FeedbackFilter = ({
+    selectedFeedback,
+    setSelectedFeedback,
+}: FeedbackFilterProps) => {
+    const iconProps = {
+        style: { display: 'block' },
+        size: 18,
+        stroke: 1.5,
+    };
+    const data = [
+        {
+            value: 'all',
+            label: (
+                <Tooltip label="Show all threads" withinPortal>
+                    <Box>
+                        <Text fz="xs" fw={500}>
+                            All
+                        </Text>
+                    </Box>
+                </Tooltip>
+            ),
+        },
+        {
+            value: 'thumbs_up',
+            label: (
+                <Tooltip
+                    variant="xs"
+                    label="Show only threads with positive feedback"
+                    withinPortal
+                    maw={200}
+                >
+                    <Box>
+                        <MantineIcon icon={IconThumbUp} {...iconProps} />
+                    </Box>
+                </Tooltip>
+            ),
+        },
+        {
+            value: 'thumbs_down',
+            label: (
+                <Tooltip
+                    variant="xs"
+                    label="Show only threads with negative feedback"
+                    withinPortal
+                    maw={200}
+                >
+                    <Box pt="xxs">
+                        <MantineIcon icon={IconThumbDown} {...iconProps} />
+                    </Box>
+                </Tooltip>
+            ),
+        },
+    ];
+
+    return (
+        <SegmentedControl
+            size="xs"
+            radius="md"
+            value={selectedFeedback}
+            onChange={(value) =>
+                setSelectedFeedback(
+                    value as 'all' | 'thumbs_up' | 'thumbs_down',
+                )
+            }
+            classNames={{
+                root: classes.segmentedControl,
+                indicator: classes.indicator,
+                label: classes.label,
+            }}
+            data={data}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.module.css
@@ -1,0 +1,41 @@
+.filterButton {
+    border: 1px dashed var(--mantine-color-gray-3);
+    background-color: transparent;
+    text-overflow: ellipsis;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButton:hover {
+    background-color: var(--mantine-color-gray-0);
+    transition: background-color var(--mantine-other-transitionDuration)
+        var(--mantine-other-transitionTimingFunction);
+}
+
+.filterButtonSelected {
+    border: 1px solid var(--mantine-color-indigo-2);
+    background-color: var(--mantine-color-indigo-0);
+    text-overflow: ellipsis;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButtonSelected:hover {
+    background-color: var(--mantine-color-gray-0);
+    transition: background-color var(--mantine-other-transitionDuration)
+        var(--mantine-other-transitionTimingFunction);
+}
+
+.buttonLabel {
+    height: 24px;
+}
+
+.checkboxBody {
+    align-items: center;
+}
+
+.checkboxInput {
+    border-radius: var(--mantine-radius-sm);
+}
+
+.checkboxLabel {
+    padding-left: var(--mantine-spacing-xs);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.tsx
@@ -1,0 +1,154 @@
+import {
+    ActionIcon,
+    Button,
+    Checkbox,
+    Group,
+    Popover,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconBox, IconX } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useProjects } from '../../../../../hooks/useProjects';
+import classes from './ProjectsFilter.module.css';
+
+type ProjectsFilterProps = {
+    selectedProjectUuids: string[];
+    setSelectedProjectUuids: (projectUuids: string[]) => void;
+};
+
+const ProjectsFilter: FC<ProjectsFilterProps> = ({
+    selectedProjectUuids,
+    setSelectedProjectUuids,
+}) => {
+    const { data: projects, isLoading } = useProjects();
+
+    const hasSelectedProjects = selectedProjectUuids.length > 0;
+
+    const projectNames = useMemo(() => {
+        return projects
+            ?.filter((project) =>
+                selectedProjectUuids.includes(project.projectUuid),
+            )
+            .map((project) => project.name)
+            .join(', ');
+    }, [projects, selectedProjectUuids]);
+
+    const buttonLabel = hasSelectedProjects ? projectNames : 'All projects';
+
+    return (
+        <Group gap="two">
+            <Popover width={300} position="bottom-start">
+                <Popover.Target>
+                    <Tooltip
+                        withinPortal
+                        variant="xs"
+                        label="Filter threads by project"
+                    >
+                        <Button
+                            h={32}
+                            c="gray.7"
+                            fw={500}
+                            fz="sm"
+                            variant="default"
+                            radius="md"
+                            py="xs"
+                            px="sm"
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconBox}
+                                    size="md"
+                                    color={
+                                        hasSelectedProjects
+                                            ? 'indigo.5'
+                                            : 'gray.5'
+                                    }
+                                />
+                            }
+                            loading={isLoading}
+                            className={
+                                hasSelectedProjects
+                                    ? classes.filterButtonSelected
+                                    : classes.filterButton
+                            }
+                            classNames={{
+                                label: classes.buttonLabel,
+                            }}
+                        >
+                            {buttonLabel}
+                        </Button>
+                    </Tooltip>
+                </Popover.Target>
+                <Popover.Dropdown p="sm">
+                    <Stack gap={4}>
+                        <Text fz="xs" c="dark.3" fw={600}>
+                            Filter by projects:
+                        </Text>
+
+                        {projects?.length === 0 && (
+                            <Text fz="xs" fw={500} c="gray.6">
+                                No projects available.
+                            </Text>
+                        )}
+
+                        <Stack gap="xs">
+                            {projects?.map((project) => (
+                                <Checkbox
+                                    key={project.projectUuid}
+                                    label={project.name}
+                                    checked={selectedProjectUuids.includes(
+                                        project.projectUuid,
+                                    )}
+                                    size="xs"
+                                    classNames={{
+                                        body: classes.checkboxBody,
+                                        input: classes.checkboxInput,
+                                        label: classes.checkboxLabel,
+                                    }}
+                                    onChange={() => {
+                                        if (
+                                            selectedProjectUuids.includes(
+                                                project.projectUuid,
+                                            )
+                                        ) {
+                                            setSelectedProjectUuids(
+                                                selectedProjectUuids.filter(
+                                                    (uuid) =>
+                                                        uuid !==
+                                                        project.projectUuid,
+                                                ),
+                                            );
+                                        } else {
+                                            setSelectedProjectUuids([
+                                                ...selectedProjectUuids,
+                                                project.projectUuid,
+                                            ]);
+                                        }
+                                    }}
+                                />
+                            ))}
+                        </Stack>
+                    </Stack>
+                </Popover.Dropdown>
+            </Popover>
+            {hasSelectedProjects && (
+                <Tooltip variant="xs" label="Clear all project filters">
+                    <ActionIcon
+                        size="xs"
+                        color="gray.5"
+                        variant="subtle"
+                        onClick={() => {
+                            setSelectedProjectUuids([]);
+                        }}
+                    >
+                        <MantineIcon icon={IconX} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+        </Group>
+    );
+};
+
+export default ProjectsFilter;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.module.css
@@ -1,0 +1,37 @@
+.searchInput {
+    height: 32px;
+    width: 309px;
+    text-overflow: ellipsis;
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 400;
+    color: var(--mantine-color-gray-5);
+    box-shadow: var(--mantine-shadow-subtle);
+    border: 1px solid var(--mantine-color-gray-3);
+}
+
+.searchInput:hover {
+    border: 1px solid var(--mantine-color-gray-4);
+}
+
+.searchInput:focus {
+    border: 1px solid var(--mantine-color-blue-5);
+}
+
+.searchInputWithValue {
+    height: 32px;
+    width: 309px;
+    text-overflow: ellipsis;
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 400;
+    color: var(--mantine-color-gray-8);
+    box-shadow: var(--mantine-shadow-subtle);
+    border: 1px solid var(--mantine-color-gray-3);
+}
+
+.searchInputWithValue:hover {
+    border: 1px solid var(--mantine-color-gray-4);
+}
+
+.searchInputWithValue:focus {
+    border: 1px solid var(--mantine-color-blue-5);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.tsx
@@ -1,0 +1,50 @@
+import { ActionIcon, TextInput, Tooltip } from '@mantine-8/core';
+import { IconSearch, IconX } from '@tabler/icons-react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import classes from './SearchFilter.module.css';
+
+type SearchFilterProps = {
+    search: string | undefined;
+    setSearch: (search: string) => void;
+    clearSearch: () => void;
+};
+
+export const SearchFilter = ({
+    search,
+    setSearch,
+    clearSearch,
+}: SearchFilterProps) => {
+    return (
+        <Tooltip withinPortal variant="xs" label="Search by title">
+            <TextInput
+                size="xs"
+                radius="md"
+                classNames={{
+                    input: search
+                        ? classes.searchInputWithValue
+                        : classes.searchInput,
+                }}
+                type="search"
+                variant="default"
+                placeholder="Search threads by title"
+                value={search ?? ''}
+                leftSection={
+                    <MantineIcon size="md" color="gray.6" icon={IconSearch} />
+                }
+                onChange={(e) => setSearch(e.target.value)}
+                rightSection={
+                    search && (
+                        <ActionIcon
+                            onClick={clearSearch}
+                            variant="transparent"
+                            size="xs"
+                            color="gray.5"
+                        >
+                            <MantineIcon icon={IconX} />
+                        </ActionIcon>
+                    )
+                }
+            />
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.module.css
@@ -1,0 +1,20 @@
+.segmentedControl {
+    border-radius: var(--mantine-radius-md);
+    gap: var(--mantine-spacing-two);
+    padding: var(--mantine-spacing-xxs);
+}
+
+.indicator {
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid var(--mantine-color-gray-2);
+    background-color: white;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.label {
+    height: 24px;
+}
+
+.label:where([data-active]) {
+    color: var(--mantine-color-indigo-6);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.tsx
@@ -1,0 +1,72 @@
+import { Box, SegmentedControl, Text, Tooltip } from '@mantine-8/core';
+import { IconBrandSlack, IconMessageCircleStar } from '@tabler/icons-react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import classes from './SourceFilter.module.css';
+
+type SourceFilterProps = {
+    selectedSource: 'all' | 'web_app' | 'slack';
+    setSelectedSource: (source: 'all' | 'web_app' | 'slack') => void;
+};
+
+export const SourceFilter = ({
+    selectedSource,
+    setSelectedSource,
+}: SourceFilterProps) => {
+    const iconProps = {
+        style: { display: 'block' },
+        size: 18,
+        stroke: 1.5,
+    };
+    const data = [
+        {
+            label: (
+                <Tooltip withinPortal variant="xs" label="All sources">
+                    <Box>
+                        <Text fz="xs" fw={500}>
+                            All
+                        </Text>
+                    </Box>
+                </Tooltip>
+            ),
+            value: 'all',
+        },
+        {
+            label: (
+                <Tooltip withinPortal variant="xs" label="Web app threads">
+                    <Box>
+                        <MantineIcon
+                            icon={IconMessageCircleStar}
+                            {...iconProps}
+                        />
+                    </Box>
+                </Tooltip>
+            ),
+            value: 'web_app',
+        },
+        {
+            label: (
+                <Tooltip withinPortal variant="xs" label="Slack threads">
+                    <Box>
+                        <MantineIcon icon={IconBrandSlack} {...iconProps} />
+                    </Box>
+                </Tooltip>
+            ),
+            value: 'slack',
+        },
+    ];
+    return (
+        <SegmentedControl
+            size="xs"
+            value={selectedSource}
+            onChange={(value) =>
+                setSelectedSource(value as 'all' | 'web_app' | 'slack')
+            }
+            classNames={{
+                root: classes.segmentedControl,
+                indicator: classes.indicator,
+                label: classes.label,
+            }}
+            data={data}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -2,10 +2,12 @@ import {
     type AiAgentAdminFilters,
     type AiAgentAdminSort,
     type ApiAiAgentAdminConversationsResponse,
+    type ApiAiAgentSummaryResponse,
     type ApiError,
 } from '@lightdash/common';
 import {
     useInfiniteQuery,
+    useQuery,
     type UseInfiniteQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
@@ -82,5 +84,22 @@ export const useInfiniteAiAgentAdminThreads = (
             }
         },
         ...infinityQueryOpts,
+    });
+};
+
+const getAiAgentAdminAgents = async () => {
+    return lightdashApi<ApiAiAgentSummaryResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/agents`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useAiAgentAdminAgents = () => {
+    return useQuery<ApiAiAgentSummaryResponse['results'], ApiError>({
+        queryKey: ['ai-agent-admin-list'],
+        queryFn: getAiAgentAdminAgents,
+        keepPreviousData: true,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #16675

### Description:

Added filtering capabilities to the AI Agent Admin dashboard, allowing administrators to filter conversation threads by project, agent, source, and feedback. The implementation includes:

- New API endpoint to fetch all AI agents in the organization
- Filter components for projects, agents, source (web app/Slack), and feedback (positive/negative)
- Enhanced search functionality for thread titles
- Results count display showing the number of threads matching the filters


![image.png](https://app.graphite.dev/user-attachments/assets/593586b3-1fbf-4f07-b0a1-a4c3dfff4421.png)

