### PR TITLE
feat: show thread preview on click of row

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -39,6 +39,7 @@ import {
     useState,
     type UIEvent,
 } from 'react';
+import { useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useIsTruncated } from '../../../../../hooks/useIsTruncated';
@@ -46,8 +47,19 @@ import SlackSvg from '../../../../../svgs/slack.svg?react';
 import { useInfiniteAiAgentAdminThreads } from '../../hooks/useAiAgentAdmin';
 import { AiAgentAdminTopToolbar } from './AiAgentAdminTopToolbar';
 
-const AiAgentAdminThreadsTable = () => {
+type AiAgentAdminThreadsTableProps = {
+    onThreadSelect?: (thread: AiAgentAdminThreadSummary) => void;
+    selectedThread?: AiAgentAdminThreadSummary | null;
+    setSelectedThread?: (thread: AiAgentAdminThreadSummary) => void;
+};
+
+const AiAgentAdminThreadsTable = ({
+    onThreadSelect,
+    setSelectedThread,
+    selectedThread,
+}: AiAgentAdminThreadsTableProps) => {
     const theme = useMantineTheme();
+    const navigate = useNavigate();
     const [sorting, setSorting] = useState<MRT_SortingState>([
         { id: 'createdAt', desc: true },
     ]);
@@ -111,8 +123,8 @@ const AiAgentAdminThreadsTable = () => {
                         selectedFeedback === 'thumbs_up'
                             ? 1
                             : selectedFeedback === 'thumbs_down'
-                            ? -1
-                            : undefined,
+                              ? -1
+                              : undefined,
                 },
                 sort: {
                     field: sortBy?.sortField ?? 'createdAt',
@@ -492,19 +504,37 @@ const AiAgentAdminThreadsTable = () => {
                 },
             },
         },
-        mantineTableBodyRowProps: () => {
+        mantineTableBodyRowProps: ({ row }) => {
+            const thread = row.original;
+            const isSelected = selectedThread?.uuid === thread.uuid;
+
             return {
                 sx: {
                     cursor: 'pointer',
                     '&:hover': {
                         td: {
-                            backgroundColor: theme.colors.gray[0],
+                            backgroundColor: isSelected
+                                ? theme.colors.indigo[0]
+                                : theme.colors.gray[0],
+
                             transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
                         },
                     },
+                    ...(isSelected && {
+                        td: {
+                            backgroundColor: theme.colors.indigo[0],
+                        },
+                    }),
                 },
                 onClick: () => {
-                    // TODO: Navigate to thread detail view with row
+                    setSelectedThread?.(thread);
+                    if (onThreadSelect) {
+                        onThreadSelect(thread);
+                    } else {
+                        void navigate(
+                            `/projects/${thread.project.uuid}/ai-agents/${thread.agent.uuid}/threads/${thread.uuid}`,
+                        );
+                    }
                 },
             };
         },

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -123,8 +123,8 @@ const AiAgentAdminThreadsTable = ({
                         selectedFeedback === 'thumbs_up'
                             ? 1
                             : selectedFeedback === 'thumbs_down'
-                              ? -1
-                              : undefined,
+                            ? -1
+                            : undefined,
                 },
                 sort: {
                     field: sortBy?.sortField ?? 'createdAt',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.module.css
@@ -1,0 +1,15 @@
+.resizeHandle {
+    transition: background-color 0.2s ease-in-out;
+}
+
+.resizeHandle:hover {
+    background-color: var(--mantine-color-gray-2) !important;
+}
+
+.resizeHandle[data-resize-handle-state='drag'] {
+    background-color: var(--mantine-color-gray-3) !important;
+}
+
+.threadsTable {
+    margin: 0 var(--mantine-spacing-lg);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -1,0 +1,108 @@
+import { type AiAgentAdminThreadSummary } from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Button,
+    Divider,
+    Group,
+    LoadingOverlay,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconExternalLink, IconX } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiAgentThread } from '../../hooks/useOrganizationAiAgents';
+import { AiAgentPageLayoutContext } from '../../providers/AiLayoutProvider';
+import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
+
+type ThreadPreviewSidebarProps = {
+    thread: AiAgentAdminThreadSummary;
+    isOpen: boolean;
+    onClose: () => void;
+};
+
+export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
+    thread,
+    isOpen,
+    onClose,
+}) => {
+    const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
+        thread.project.uuid,
+        thread.agent.uuid,
+        thread.uuid,
+    );
+
+    if (!isOpen) {
+        return null;
+    }
+
+    return (
+        <Box h="100%" pos="relative" bg="white">
+            <LoadingOverlay
+                pos="absolute"
+                visible={isLoadingThread}
+                loaderProps={{ color: 'dark' }}
+            />
+
+            <Group justify="space-between" align="flex-start" p="sm">
+                <Group gap="xs">
+                    <Title order={5} fw={600}>
+                        Thread Preview
+                    </Title>
+                    <Tooltip label="Open Thread" variant="xs" position="right">
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            component={Link}
+                            target="_blank"
+                            to={`/projects/${thread.project.uuid}/ai-agents/${thread.agent.uuid}/threads/${thread.uuid}`}
+                        >
+                            <MantineIcon icon={IconExternalLink} />
+                        </ActionIcon>
+                    </Tooltip>
+                </Group>
+                <Button
+                    variant="subtle"
+                    size="xs"
+                    p={4}
+                    onClick={onClose}
+                    color="gray"
+                >
+                    <MantineIcon icon={IconX} size="sm" />
+                </Button>
+            </Group>
+
+            <Divider />
+
+            {threadData && (
+                <AiAgentPageLayoutContext.Provider
+                    value={{
+                        artifact: null,
+                        setArtifact: () => {},
+                        isSidebarCollapsed: false,
+                        collapseSidebar: () => {},
+                        expandSidebar: () => {},
+                        toggleSidebar: () => {},
+                        collapseArtifact: () => {},
+                        expandArtifact: () => {},
+                        clearArtifact: () => {},
+                        agentUuid: thread.agent.uuid,
+                        projectUuid: thread.project.uuid,
+                    }}
+                >
+                    <Box
+                        mah="calc(100vh - 150px)"
+                        style={{ overflowY: 'auto' }}
+                    >
+                        <AgentChatDisplay
+                            thread={threadData}
+                            agentName={thread.agent.name}
+                        />
+                    </Box>
+                </AiAgentPageLayoutContext.Provider>
+            )}
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -61,7 +61,7 @@ const AssistantBubbleContent: FC<{
     const messageContent =
         isStreaming && streamingState
             ? streamingState.content
-            : (message.message ?? 'No response...');
+            : message.message ?? 'No response...';
 
     const handleRetry = useCallback(() => {
         void streamMessage({

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -61,7 +61,7 @@ const AssistantBubbleContent: FC<{
     const messageContent =
         isStreaming && streamingState
             ? streamingState.content
-            : message.message ?? 'No response...';
+            : (message.message ?? 'No response...');
 
     const handleRetry = useCallback(() => {
         void streamMessage({
@@ -266,8 +266,16 @@ type Props = {
 
 export const AssistantBubble: FC<Props> = memo(
     ({ message, isActive = false, debug = false }) => {
-        const { agentUuid, projectUuid } = useParams();
-        const { setArtifact, artifact } = useAiAgentPageLayout();
+        const { agentUuid: agentUuidParam, projectUuid: projectUuidParam } =
+            useParams();
+        const {
+            setArtifact,
+            artifact,
+            agentUuid: contextAgentUuid,
+            projectUuid: contextProjectUuid,
+        } = useAiAgentPageLayout();
+        const projectUuid = projectUuidParam ?? contextProjectUuid;
+        const agentUuid = agentUuidParam ?? contextAgentUuid;
         if (!projectUuid) throw new Error(`Project Uuid not found`);
         if (!agentUuid) throw new Error(`Agent Uuid not found`);
 

--- a/packages/frontend/src/ee/features/aiCopilot/providers/AiLayoutProvider.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/providers/AiLayoutProvider.tsx
@@ -25,6 +25,8 @@ export interface AiAgentPageLayoutContextType {
         messageProjectUuid: string,
         messageAgentUuid: string,
     ) => void;
+    agentUuid?: string;
+    projectUuid?: string;
 }
 
 export const AiAgentPageLayoutContext =

--- a/packages/frontend/src/ee/pages/AiAgents/Admin/AiAgentsAdminPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/Admin/AiAgentsAdminPage.tsx
@@ -1,16 +1,11 @@
 import Page from '../../../../components/common/Page/Page';
 import { AiAgentsAdminLayout } from '../../../features/aiCopilot/components/Admin/AiAgentsAdminLayout';
+import { AiAgentThreadStreamStoreProvider } from '../../../features/aiCopilot/streaming/AiAgentThreadStreamStoreProvider';
 
-export const AiAgentsAdminPage = () => {
-    return (
-        <Page
-            withCenteredRoot
-            withCenteredContent
-            withXLargePaddedContent
-            withLargeContent
-            backgroundColor="#FAFAFA"
-        >
+export const AiAgentsAdminPage = () => (
+    <AiAgentThreadStreamStoreProvider>
+        <Page title="AI Agents Admin" noContentPadding>
             <AiAgentsAdminLayout />
         </Page>
-    );
-};
+    </AiAgentThreadStreamStoreProvider>
+);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16675

### Description:
Added a thread preview sidebar to the AI Agents Admin Panel that allows admins to view thread content without leaving the admin page. The sidebar implementation includes:

- A resizable panel layout with a thread list and preview panel
- Thread selection functionality that highlights the selected thread
- A preview sidebar that displays the full conversation thread
- Navigation options to open the full thread in a new tab
- Proper loading states and error handling

The admin panel now provides a more efficient workflow for reviewing AI agent conversations, allowing admins to quickly scan through threads while maintaining context.

![Screenshot 2025-09-03 at 16.29.46.png](https://app.graphite.dev/user-attachments/assets/0dd0a54a-4b94-4dd8-ade8-b244e795fd98.png)

=== FOLDED ===




### Description:
Added artifact viewing capability to the Thread Preview Sidebar in the AI Copilot admin interface. Users can now view artifacts directly within the admin thread preview through a modal that appears when an artifact is selected. This enhances the admin experience by allowing them to see the full context of AI agent interactions without leaving the preview panel.

The implementation includes:
- Added state management for artifact context
- Implemented modal display for artifacts
- Connected artifact viewing functionality to the existing chat display
- Added cleanup logic to clear artifacts when the sidebar closes


![image.png](https://app.graphite.dev/user-attachments/assets/06436b82-c18f-40e8-a50b-754374c0f46c.png)



