### PR TITLE
feat: display artifact in modal on click of thread preview

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -123,8 +123,8 @@ const AiAgentAdminThreadsTable = ({
                         selectedFeedback === 'thumbs_up'
                             ? 1
                             : selectedFeedback === 'thumbs_down'
-                              ? -1
-                              : undefined,
+                            ? -1
+                            : undefined,
                 },
                 sort: {
                     field: sortBy?.sortField ?? 'createdAt',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -61,7 +61,7 @@ const AssistantBubbleContent: FC<{
     const messageContent =
         isStreaming && streamingState
             ? streamingState.content
-            : (message.message ?? 'No response...');
+            : message.message ?? 'No response...';
 
     const handleRetry = useCallback(() => {
         void streamMessage({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16675

### Description:
Added artifact viewing capability to the Thread Preview Sidebar in the AI Copilot admin interface. Users can now view artifacts directly within the admin thread preview through a modal that appears when an artifact is selected. This enhances the admin experience by allowing them to see the full context of AI agent interactions without leaving the preview panel.

The implementation includes:
- Added state management for artifact context
- Implemented modal display for artifacts
- Connected artifact viewing functionality to the existing chat display
- Added cleanup logic to clear artifacts when the sidebar closes


![image.png](https://app.graphite.dev/user-attachments/assets/06436b82-c18f-40e8-a50b-754374c0f46c.png)

