### PR TITLE
feat: add GitLab support for preview project creation

### DIFF
--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -270,8 +270,10 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
     }, [projects, selectedProjectUuid]);
 
     const { data: projectDetails } = useProject(selectedProjectUuid);
-    const hasGithub = useMemo(() => {
-        return projectDetails?.dbtConnection?.type === DbtProjectType.GITHUB;
+    const hasGitIntegration = useMemo(() => {
+        return [DbtProjectType.GITHUB, DbtProjectType.GITLAB].includes(
+            projectDetails?.dbtConnection?.type as DbtProjectType,
+        );
     }, [projectDetails?.dbtConnection?.type]);
 
     useEffect(() => {
@@ -480,14 +482,14 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
                                 </Tooltip>
                             }
                         />
-                        {hasGithub ? (
+                        {hasGitIntegration ? (
                             <>
                                 <Select
                                     withinPortal
                                     label="Branch"
                                     placeholder={
                                         branches.isLoading
-                                            ? 'Loading branches from Github...'
+                                            ? 'Loading branches...'
                                             : 'Select branch'
                                     }
                                     searchable
@@ -571,7 +573,7 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
                                     project will copy the same connection
                                     details as the parent project. To change the
                                     branch of the source code, switch to Github
-                                    connection on{' '}
+                                    or GitLab connection on{' '}
                                     <Anchor
                                         target="_blank"
                                         href={`/generalSettings/projectManagement/${selectedProjectUuid}/settings`}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Add GitLab support to the Create Preview Project modal. Previously, the branch selection was only available for GitHub connections, but now it works for both GitHub and GitLab integrations. Updated the loading message and help text to reflect this change.