### PR TITLE
fix: pass groupedSubtotals parameter to pivot data conversion

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -935,6 +935,7 @@ describe('convertSqlPivotedRowsToPivotData', () => {
             },
             getField: getFieldMock,
             getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
         });
         // Verify legacy way to pivot in FE
         expect(resultLegacy).toStrictEqual(EXPECTED_PIVOT_DATA);
@@ -990,6 +991,7 @@ describe('convertSqlPivotedRowsToPivotData', () => {
             },
             getField: getFieldMock,
             getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
         });
         // Verify legacy way to pivot in FE
         expect(resultLegacy).toStrictEqual(EXPECTED_PIVOT_DATA_WITH_TOTALS);
@@ -1056,6 +1058,7 @@ describe('convertSqlPivotedRowsToPivotData', () => {
                 }
                 return fieldId;
             },
+            groupedSubtotals: undefined,
         });
 
         // Verify legacy way to pivot in FE matches expected structure
@@ -1153,40 +1156,14 @@ describe('convertSqlPivotedRowsToPivotData', () => {
                 }
                 return fieldId;
             },
+            groupedSubtotals: undefined,
         });
 
         // Verify legacy way to pivot in FE matches expected structure
         expect(resultLegacy).toStrictEqual(EXPECTED_COMPLEX_PIVOT_DATA);
 
         // Verify the new conversion matches legacy method
-        expect(result.titleFields).toStrictEqual(resultLegacy.titleFields);
-        expect(result.headerValueTypes).toStrictEqual(
-            resultLegacy.headerValueTypes,
-        );
-        expect(result.headerValues).toStrictEqual(resultLegacy.headerValues);
-        expect(result.indexValueTypes).toStrictEqual(
-            resultLegacy.indexValueTypes,
-        );
-        expect(result.indexValues).toStrictEqual(resultLegacy.indexValues);
-        expect(result.dataColumnCount).toStrictEqual(
-            resultLegacy.dataColumnCount,
-        );
-        expect(result.dataValues).toStrictEqual(resultLegacy.dataValues);
-        expect(result.rowTotalFields).toStrictEqual(
-            resultLegacy.rowTotalFields,
-        );
-        expect(result.columnTotalFields).toStrictEqual(
-            resultLegacy.columnTotalFields,
-        );
-        expect(result.rowTotals).toStrictEqual(resultLegacy.rowTotals);
-        expect(result.columnTotals).toStrictEqual(resultLegacy.columnTotals);
-        expect(result.cellsCount).toStrictEqual(resultLegacy.cellsCount);
-        expect(result.rowsCount).toStrictEqual(resultLegacy.rowsCount);
-        expect(result.pivotConfig).toStrictEqual(resultLegacy.pivotConfig);
-        expect(result.retrofitData).toStrictEqual(resultLegacy.retrofitData);
-        expect(result.groupedSubtotals).toStrictEqual(
-            resultLegacy.groupedSubtotals,
-        );
+        expect(result).toStrictEqual(resultLegacy);
     });
 
     it('should convert complex SQL-pivoted rows with metric as rows to PivotData format', () => {
@@ -1277,6 +1254,7 @@ describe('convertSqlPivotedRowsToPivotData', () => {
                 }
                 return fieldId;
             },
+            groupedSubtotals: undefined,
         });
 
         // Verify legacy way to pivot in FE matches expected structure
@@ -1286,33 +1264,5 @@ describe('convertSqlPivotedRowsToPivotData', () => {
 
         // Verify the new conversion matches legacy method
         expect(result).toStrictEqual(resultLegacy);
-        expect(result.titleFields).toStrictEqual(resultLegacy.titleFields);
-        expect(result.headerValueTypes).toStrictEqual(
-            resultLegacy.headerValueTypes,
-        );
-        expect(result.headerValues).toStrictEqual(resultLegacy.headerValues);
-        expect(result.indexValueTypes).toStrictEqual(
-            resultLegacy.indexValueTypes,
-        );
-        expect(result.indexValues).toStrictEqual(resultLegacy.indexValues);
-        expect(result.dataColumnCount).toStrictEqual(
-            resultLegacy.dataColumnCount,
-        );
-        expect(result.dataValues).toStrictEqual(resultLegacy.dataValues);
-        expect(result.rowTotalFields).toStrictEqual(
-            resultLegacy.rowTotalFields,
-        );
-        expect(result.columnTotalFields).toStrictEqual(
-            resultLegacy.columnTotalFields,
-        );
-        expect(result.rowTotals).toStrictEqual(resultLegacy.rowTotals);
-        expect(result.columnTotals).toStrictEqual(resultLegacy.columnTotals);
-        expect(result.cellsCount).toStrictEqual(resultLegacy.cellsCount);
-        expect(result.rowsCount).toStrictEqual(resultLegacy.rowsCount);
-        expect(result.pivotConfig).toStrictEqual(resultLegacy.pivotConfig);
-        expect(result.retrofitData).toStrictEqual(resultLegacy.retrofitData);
-        expect(result.groupedSubtotals).toStrictEqual(
-            resultLegacy.groupedSubtotals,
-        );
     });
 });

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -961,6 +961,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     pivotConfig,
     getField,
     getFieldLabel,
+    groupedSubtotals,
 }: {
     rows: ResultRow[];
     pivotDetails: NonNullable<ReadyQueryResultsPage['pivotDetails']>;
@@ -974,6 +975,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     >; // only use properties that are not part of pivot details metadata
     getField: FieldFunction;
     getFieldLabel: FieldLabelFunction;
+    groupedSubtotals: PivotQueryResultsArgs['groupedSubtotals'];
 }): PivotData => {
     if (rows.length === 0) {
         throw new Error('Cannot convert SQL pivoted results with no rows');
@@ -1507,7 +1509,7 @@ export const convertSqlPivotedRowsToPivotData = ({
             allCombinedData,
             pivotColumnInfo,
         },
-        groupedSubtotals: undefined,
+        groupedSubtotals,
     };
 
     return combinedRetrofit(pivotData, getField, getFieldLabel);

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -355,6 +355,7 @@ const useTableConfig = (
                     pivotConfig,
                     getField,
                     getFieldLabel,
+                    groupedSubtotals,
                 })
                 .then((data) => {
                     setPivotTableData({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Added `groupedSubtotals` parameter to the `convertSqlPivotedRowsToPivotData` function to properly pass through subtotal configuration. This ensures that the pivot data structure correctly includes subtotal information when converting SQL pivoted rows.

Also simplified test assertions by using `toStrictEqual` to compare entire objects rather than comparing individual properties.