### PR TITLE
refactor: import lodash functions individually instead of entire package

### DIFF
--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -1,5 +1,5 @@
 import { type AbilityBuilder } from '@casl/ability';
-import { flow } from 'lodash';
+import flow from 'lodash/flow';
 import { type CreateEmbedJwt } from '../ee';
 import type { OssEmbed } from '../types/auth';
 import type { MemberAbility } from './types';

--- a/packages/common/src/authorization/parseScopes.ts
+++ b/packages/common/src/authorization/parseScopes.ts
@@ -1,4 +1,5 @@
-import { camelCase, upperFirst } from 'lodash';
+import camelCase from 'lodash/camelCase';
+import upperFirst from 'lodash/upperFirst';
 import { type ScopeModifer, type ScopeName } from '../types/scopes';
 import { getAllScopeMap } from './scopes';
 import { type AbilityAction, type CaslSubjectNames } from './types';

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { Ability, AbilityBuilder } from '@casl/ability';
-import { groupBy, isEqual } from 'lodash';
+import groupBy from 'lodash/groupBy';
+import isEqual from 'lodash/isEqual';
 import { ProjectMemberRole } from '../types/projectMemberRole';
 import { projectMemberAbilities } from './projectMemberAbility';
 import {

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1,4 +1,4 @@
-import { flow } from 'lodash';
+import flow from 'lodash/flow';
 import { ProjectType } from '../types/projects';
 import {
     type Scope,

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 import {
     SupportedDbtAdapter,
     buildModelGraph,

--- a/packages/common/src/ee/AiAgent/filterExploreByTags.ts
+++ b/packages/common/src/ee/AiAgent/filterExploreByTags.ts
@@ -1,4 +1,8 @@
-import { concat, flatMap, intersection, mapValues, pickBy } from 'lodash';
+import concat from 'lodash/concat';
+import flatMap from 'lodash/flatMap';
+import intersection from 'lodash/intersection';
+import mapValues from 'lodash/mapValues';
+import pickBy from 'lodash/pickBy';
 
 type FilterableTable = {
     dimensions: Record<string, { tags?: string[] }>;

--- a/packages/common/src/types/applyDimensionOverrides.test.ts
+++ b/packages/common/src/types/applyDimensionOverrides.test.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { DimensionType } from './field';
 import {
     applyDimensionOverrides,

--- a/packages/common/src/types/filter.test.ts
+++ b/packages/common/src/types/filter.test.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import {
     type AndFilterGroup,
     compressDashboardFiltersToParam,

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -1,4 +1,4 @@
-import { includes } from 'lodash';
+import includes from 'lodash/includes';
 import { type SlackPromptJobPayload } from '../ee';
 import { type SchedulerIndexCatalogJobPayload } from './catalog';
 import { type UploadMetricGsheetPayload } from './gdrive';

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -1,4 +1,4 @@
-import { findLast } from 'lodash';
+import findLast from 'lodash/findLast';
 import { v4 as uuidv4 } from 'uuid';
 import type {
     ConditionalFormattingRowFields,

--- a/packages/common/src/utils/i18n/merge.ts
+++ b/packages/common/src/utils/i18n/merge.ts
@@ -3,7 +3,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { isObject, transform } from 'lodash';
+import isObject from 'lodash/isObject';
+import transform from 'lodash/transform';
 
 export const mergeExisting = (left: any, right: any) =>
     transform(

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -1,7 +1,9 @@
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
-import { groupBy, mapKeys, type Dictionary } from 'lodash';
+import { type Dictionary } from 'lodash';
+import groupBy from 'lodash/groupBy';
+import mapKeys from 'lodash/mapKeys';
 import { v4 as uuidv4 } from 'uuid';
 import { type AnyType } from '../types/any';
 import type { MetricWithAssociatedTimeDimension } from '../types/catalog';

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -1,4 +1,4 @@
-import { intersectionBy } from 'lodash';
+import intersectionBy from 'lodash/intersectionBy';
 import { getFirstIndexColumns } from '../pivot/utils';
 import { type AnyType } from '../types/any';
 import {

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -25,7 +25,7 @@ import {
 import { useForm } from '@mantine/form';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconChartAreaLine } from '@tabler/icons-react';
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import React, {
     forwardRef,
     useEffect,

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -24,7 +24,7 @@ import {
 import { useForm } from '@mantine/form';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import React, { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import { useChartSummariesV2 } from '../../../hooks/useChartSummariesV2';

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFormatConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFormatConfig.tsx
@@ -1,7 +1,7 @@
 import { Format } from '@lightdash/common';
 import { Box, Group, Select, Text } from '@mantine/core';
 import { IconClearAll, IconPercentage } from '@tabler/icons-react';
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 

--- a/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
@@ -9,7 +9,7 @@ import {
     IconEyeOff,
     IconLayoutAlignCenter,
 } from '@tabler/icons-react';
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -20,7 +20,7 @@ import {
     IconSum,
     IconTrendingUp,
 } from '@tabler/icons-react';
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { usePillSelectStyles } from '../hooks/usePillSelectStyles';

--- a/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
@@ -7,7 +7,7 @@ import {
 } from '@lightdash/common';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import {
     resetChartState,
     setChartConfig,

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
@@ -24,7 +24,7 @@ import {
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconX } from '@tabler/icons-react';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { useEffect, useMemo, type FC } from 'react';
 import { z } from 'zod';
 import useToaster from '../../../hooks/toaster/useToaster';

--- a/packages/frontend/src/components/Explorer/FormatModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatModal/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@lightdash/common';
 import { Button, Group, Modal, Stack, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useCallback, useEffect } from 'react';
 import { type ValueOf } from 'type-fest';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceModal.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/AddResourceToSpaceModal.tsx
@@ -20,7 +20,7 @@ import {
 import { useForm } from '@mantine/form';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconFolder } from '@tabler/icons-react';
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import React, {
     forwardRef,
     useCallback,

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -29,7 +29,7 @@ import {
     IconRefresh,
     IconTrash,
 } from '@tabler/icons-react';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import { z } from 'zod';

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberComparison.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberComparison.tsx
@@ -8,7 +8,7 @@ import {
     Switch,
     TextInput,
 } from '@mantine/core';
-import { startCase } from 'lodash';
+import startCase from 'lodash/startCase';
 import { isBigNumberVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItemColorRange.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItemColorRange.tsx
@@ -7,7 +7,7 @@ import {
 } from '@lightdash/common';
 import { Group, Select, Stack } from '@mantine/core';
 import { IconPercentage } from '@tabler/icons-react';
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 import { type FC } from 'react';
 import FilterNumberInput from '../../common/Filters/FilterInputs/FilterNumberInput';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -24,7 +24,7 @@ import {
 } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
-import { differenceBy } from 'lodash';
+import differenceBy from 'lodash/differenceBy';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import FieldSelect from '../../common/FieldSelect';

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberRangeInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberRangeInput.tsx
@@ -1,5 +1,5 @@
 import { Group, Stack, Text, type TextInputProps } from '@mantine/core';
-import { isNil } from 'lodash';
+import isNil from 'lodash/isNil';
 import { type FC } from 'react';
 import z from 'zod';
 import FilterNumberInput from './FilterNumberInput';

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -20,7 +20,8 @@ import {
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconUsers } from '@tabler/icons-react';
-import { uniq, uniqBy } from 'lodash';
+import uniq from 'lodash/uniq';
+import uniqBy from 'lodash/uniqBy';
 import {
     forwardRef,
     useEffect,

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
@@ -29,7 +29,7 @@ import {
     IconUsers,
     type Icon as TablerIconType,
 } from '@tabler/icons-react';
-import { chunk } from 'lodash';
+import chunk from 'lodash/chunk';
 import { forwardRef, useCallback, useMemo, useState, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {

--- a/packages/frontend/src/ee/features/aiDashboardSummary/PresetsForm/index.tsx
+++ b/packages/frontend/src/ee/features/aiDashboardSummary/PresetsForm/index.tsx
@@ -1,7 +1,7 @@
 import { DashboardSummaryTone, type DashboardSummary } from '@lightdash/common';
 import { Button, Flex, Select, Stack, Textarea } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 import { type FC } from 'react';
 import { z } from 'zod';
 import { getToneEmoji } from '../utils';

--- a/packages/frontend/src/ee/features/customRoles/DuplicateRoleModal.tsx
+++ b/packages/frontend/src/ee/features/customRoles/DuplicateRoleModal.tsx
@@ -11,7 +11,7 @@ import { useForm } from '@mantine/form';
 import { type FC, useMemo } from 'react';
 
 import { type Role, type RoleWithScopes } from '@lightdash/common';
-import { startCase } from 'lodash';
+import startCase from 'lodash/startCase';
 import { validateRoleName } from './utils/roleValidation';
 
 type Props = {

--- a/packages/frontend/src/ee/features/customRoles/utils/scopeUtils.ts
+++ b/packages/frontend/src/ee/features/customRoles/utils/scopeUtils.ts
@@ -1,5 +1,5 @@
 import { getScopes, ScopeGroup, type Scope } from '@lightdash/common';
-import { startCase } from 'lodash';
+import startCase from 'lodash/startCase';
 
 const GROUP_DISPLAY_NAMES: Record<ScopeGroup, string> = {
     [ScopeGroup.CONTENT]: 'Content Management',

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
@@ -6,7 +6,7 @@ import {
     type DashboardFilters,
 } from '@lightdash/common';
 import { Flex } from '@mantine/core';
-import { mapValues } from 'lodash';
+import mapValues from 'lodash/mapValues';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import ActiveFilters from '../../../../../components/DashboardFilter/ActiveFilters';
 import FiltersProvider from '../../../../../components/common/Filters/FiltersProvider';

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -1,5 +1,5 @@
 import { type LanguageMap, type SavedChart } from '@lightdash/common';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useAccount } from '../../../hooks/user/useAccount';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -9,7 +9,9 @@ import {
     UnstyledButton,
     useMantineTheme,
 } from '@mantine/core';
-import { differenceBy, filter, includes } from 'lodash';
+import differenceBy from 'lodash/differenceBy';
+import filter from 'lodash/filter';
+import includes from 'lodash/includes';
 import {
     memo,
     useCallback,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -44,7 +44,7 @@ import {
     IconSitemap,
     IconX,
 } from '@tabler/icons-react';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { type MRT_TableInstance } from 'mantine-react-table';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -17,7 +17,7 @@ import {
     type DefaultMantineColor,
 } from '@mantine/core';
 import dayjs from 'dayjs';
-import { uniqBy } from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import { memo, useMemo, type FC } from 'react';
 import { type TooltipProps } from 'recharts';
 import {

--- a/packages/frontend/src/features/omnibar/api/search.ts
+++ b/packages/frontend/src/features/omnibar/api/search.ts
@@ -1,5 +1,6 @@
 import { type SearchFilters, type SearchResults } from '@lightdash/common';
-import { isNil, omitBy } from 'lodash';
+import isNil from 'lodash/isNil';
+import omitBy from 'lodash/omitBy';
 import { lightdashApi } from '../../../api';
 
 export const getSearchResults = async ({

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -57,7 +57,9 @@ import {
     IconSettings,
 } from '@tabler/icons-react';
 import MDEditor, { commands } from '@uiw/react-md-editor';
-import { debounce, intersection, isEqual } from 'lodash';
+import debounce from 'lodash/debounce';
+import intersection from 'lodash/intersection';
+import isEqual from 'lodash/isEqual';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { CronInternalInputs } from '../../../components/ReactHookForm/CronInput';
 import FieldSelect from '../../../components/common/FieldSelect';

--- a/packages/frontend/src/features/scheduler/components/SchedulerParameters.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerParameters.tsx
@@ -14,7 +14,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconPencil, IconRotate2 } from '@tabler/icons-react';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { ParameterInput } from '../../parameters/components/ParameterInput';

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -17,7 +17,7 @@ import {
     IconTrash,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import {

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -6,7 +6,8 @@ import Editor, {
     type OnMount,
 } from '@monaco-editor/react';
 import { IconAlertCircle } from '@tabler/icons-react';
-import { debounce, isEmpty } from 'lodash';
+import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
 import { type editor } from 'monaco-editor';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -25,7 +25,7 @@ import {
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import Fuse from 'fuse.js';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { memo, useEffect, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';

--- a/packages/frontend/src/features/sqlRunner/hooks/useMultipleTableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useMultipleTableFields.tsx
@@ -1,6 +1,6 @@
 import { type ApiError } from '@lightdash/common';
 import { useQueries } from '@tanstack/react-query';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useMemo } from 'react';
 import {
     fetchTableFields,

--- a/packages/frontend/src/features/sqlRunner/hooks/useTableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useTableFields.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import Fuse from 'fuse.js';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { lightdashApi } from '../../../api';
 
 export type GetTableFieldsParams = {

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
@@ -1,6 +1,6 @@
 import { ChartKind } from '@lightdash/common';
 import { isAnyOf } from '@reduxjs/toolkit';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { setChartOptionsAndConfig } from '../../../components/DataViz/store/actions/commonChartActions';
 import {
     selectChartFieldConfigByKind,

--- a/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
@@ -33,7 +33,7 @@ import {
     IconTableAlias,
     IconTrash,
 } from '@tabler/icons-react';
-import { groupBy } from 'lodash';
+import groupBy from 'lodash/groupBy';
 import { memo, useEffect, useMemo, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -9,7 +9,7 @@ import {
 } from '@lightdash/common';
 import { useMantineTheme } from '@mantine/core';
 import { type EChartsOption, type FunnelSeriesOption } from 'echarts';
-import { round } from 'lodash';
+import round from 'lodash/round';
 import { useMemo } from 'react';
 import { isFunnelVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -21,7 +21,7 @@ import {
     type TableChart,
 } from '@lightdash/common';
 import { createWorkerFactory, useWorker } from '@shopify/react-web-worker';
-import { uniq } from 'lodash';
+import uniq from 'lodash/uniq';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import { useCalculateSubtotals } from '../useCalculateSubtotals';

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -18,7 +18,7 @@ import {
     type SavedChartsInfoForDashboardAvailableFilters,
     type SortField,
 } from '@lightdash/common';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import min from 'lodash/min';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #13587


### Description:
Refactors lodash imports to use individual function imports instead of importing the entire library. This change improves bundle size by only including the specific lodash functions that are actually used.

For example, instead of:
```javascript
import { flow } from 'lodash';
```

Now using:
```javascript
import flow from 'lodash/flow';
```

This pattern is applied consistently across all files that use lodash functions, reducing the amount of unused code that gets bundled into the application.


Effect on `@lightdash/sdk`

Before:

![image.png](https://app.graphite.dev/user-attachments/assets/426fe68d-f312-45f8-add5-d75f96866458.png)

After:

![image.png](https://app.graphite.dev/user-attachments/assets/56eb881d-7a29-407f-a4bf-13fa258d1bc0.png)

