### PR TITLE
fix: lazy load CommentWithMentions component to reduce bundle size

### DIFF
--- a/packages/frontend/src/features/comments/components/CommentForm.tsx
+++ b/packages/frontend/src/features/comments/components/CommentForm.tsx
@@ -8,7 +8,7 @@ import { useSpace } from '../../../hooks/useSpaces';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import { type SuggestionsItem } from '../types';
 import { getNameInitials } from '../utils';
-import { CommentWithMentions } from './CommentWithMentions';
+import { LazyCommentWithMentions } from './CommentWithMentions/LazyCommentWithMentions';
 
 type Props = {
     userName: string;
@@ -95,7 +95,7 @@ export const CommentForm: FC<Props> = ({
                     </Grid.Col>
                     <Grid.Col span={18} w={mode === 'reply' ? 300 : 350}>
                         {userNames ? (
-                            <CommentWithMentions
+                            <LazyCommentWithMentions
                                 suggestions={userNames}
                                 shouldClearEditor={shouldClearEditor}
                                 setShouldClearEditor={setShouldClearEditor}

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/LazyCommentWithMentions.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/LazyCommentWithMentions.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from '@mantine/core';
+import { lazy, Suspense, type FC } from 'react';
+import { type SuggestionsItem } from '../../types';
+
+// Lazy import the Editor type to avoid importing tiptap at the top level
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type LazyEditor = import('@tiptap/react').Editor;
+
+// Lazy load the CommentWithMentions component to reduce initial bundle size
+// This component includes heavy prosemirror dependencies via @tiptap and @mantine/tiptap
+const CommentWithMentionsComponent = lazy(() =>
+    import('./index').then((module) => ({
+        default: module.CommentWithMentions,
+    })),
+);
+
+type Props = {
+    suggestions?: SuggestionsItem[];
+    content?: string;
+    onUpdate?: (editor: LazyEditor | null) => void;
+    shouldClearEditor?: boolean;
+    setShouldClearEditor?: (shouldClearEditor: boolean) => void;
+};
+
+export const LazyCommentWithMentions: FC<Props> = (props) => (
+    <Suspense fallback={<Skeleton height={60} radius="sm" />}>
+        <CommentWithMentionsComponent {...props} />
+    </Suspense>
+);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #13587

### Description:

Lazy load the CommentWithMentions component to reduce initial bundle size. This implementation:

- Creates a new LazyCommentWithMentions component that uses React.lazy to defer loading
- Adds a loading skeleton while the component is being loaded
- Avoids importing heavy prosemirror dependencies via @tiptap and @mantine/tiptap at the top level
- Updates the CommentForm to use the lazy-loaded version

This change should improve initial load performance by deferring the loading of these heavy dependencies until they're actually needed.
