### PR TITLE
feat: set filters in url when interacting with ai admin threads

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
@@ -16,13 +16,13 @@ import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useProjects } from '../../../../../hooks/useProjects';
 import { useAiAgentAdminAgents } from '../../hooks/useAiAgentAdmin';
+import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 import classes from './AgentsFilter.module.css';
 
-type AgentsFilterProps = {
-    selectedAgentUuids: string[];
-    setSelectedAgentUuids: (agentUuids: string[]) => void;
-    selectedProjectUuids: string[];
-};
+type AgentsFilterProps = Pick<
+    ReturnType<typeof useAiAgentAdminFilters>,
+    'selectedAgentUuids' | 'setSelectedAgentUuids' | 'selectedProjectUuids'
+>;
 
 const AgentsFilter: FC<AgentsFilterProps> = ({
     selectedAgentUuids,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
@@ -1,36 +1,43 @@
 import {
     Box,
+    Button,
     Divider,
     Group,
     Text,
     useMantineTheme,
     type GroupProps,
 } from '@mantine-8/core';
-import { memo, useCallback, type FC } from 'react';
+import { IconTrash } from '@tabler/icons-react';
+import { memo, type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 import AgentsFilter from './AgentsFilter';
 import { FeedbackFilter } from './FeedbackFilter';
 import ProjectsFilter from './ProjectsFilter';
 import { SearchFilter } from './SearchFilter';
 import { SourceFilter } from './SourceFilter';
 
-type AiAgentAdminTopToolbarProps = GroupProps & {
-    search: string | undefined;
-    setSearch: (search: string) => void;
-    selectedProjectUuids: string[];
-    setSelectedProjectUuids: (projectUuids: string[]) => void;
-    selectedAgentUuids: string[];
-    setSelectedAgentUuids: (agentUuids: string[]) => void;
-    selectedSource: 'all' | 'web_app' | 'slack';
-    setSelectedSource: (source: 'all' | 'web_app' | 'slack') => void;
-    selectedFeedback: 'all' | 'thumbs_up' | 'thumbs_down';
-    setSelectedFeedback: (
-        feedback: 'all' | 'thumbs_up' | 'thumbs_down',
-    ) => void;
-    totalResults: number;
-    isFetching: boolean;
-    hasNextPage: boolean;
-    currentResultsCount: number;
-};
+type AiAgentAdminTopToolbarProps = GroupProps &
+    Pick<
+        ReturnType<typeof useAiAgentAdminFilters>,
+        | 'search'
+        | 'selectedProjectUuids'
+        | 'selectedAgentUuids'
+        | 'selectedSource'
+        | 'selectedFeedback'
+        | 'setSearch'
+        | 'setSelectedProjectUuids'
+        | 'setSelectedAgentUuids'
+        | 'setSelectedSource'
+        | 'setSelectedFeedback'
+    > & {
+        totalResults: number;
+        isFetching: boolean;
+        hasNextPage: boolean;
+        currentResultsCount: number;
+        hasActiveFilters?: boolean;
+        onClearFilters?: () => void;
+    };
 
 export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
     ({
@@ -48,10 +55,11 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
         isFetching,
         hasNextPage,
         currentResultsCount,
+        hasActiveFilters,
+        onClearFilters,
         ...props
     }) => {
         const theme = useMantineTheme();
-        const clearSearch = useCallback(() => setSearch(''), [setSearch]);
 
         return (
             <Box>
@@ -61,11 +69,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                     {...props}
                 >
                     <Group gap="xs">
-                        <SearchFilter
-                            search={search}
-                            setSearch={setSearch}
-                            clearSearch={clearSearch}
-                        />
+                        <SearchFilter search={search} setSearch={setSearch} />
 
                         <Divider
                             orientation="vertical"
@@ -118,6 +122,32 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             selectedSource={selectedSource}
                             setSelectedSource={setSelectedSource}
                         />
+
+                        {hasActiveFilters && onClearFilters && (
+                            <>
+                                <Divider
+                                    orientation="vertical"
+                                    w={1}
+                                    h={20}
+                                    style={{
+                                        alignSelf: 'center',
+                                    }}
+                                />
+                                <Button
+                                    variant="subtle"
+                                    size="xs"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconTrash}
+                                            size="sm"
+                                        />
+                                    }
+                                    onClick={onClearFilters}
+                                >
+                                    Clear all filters
+                                </Button>
+                            </>
+                        )}
                     </Group>
 
                     {/* Results count */}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.tsx
@@ -1,14 +1,13 @@
 import { Box, SegmentedControl, Text, Tooltip } from '@mantine-8/core';
 import { IconThumbDown, IconThumbUp } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 import classes from './FeedbackFilter.module.css';
 
-type FeedbackFilterProps = {
-    selectedFeedback: 'all' | 'thumbs_up' | 'thumbs_down';
-    setSelectedFeedback: (
-        feedback: 'all' | 'thumbs_up' | 'thumbs_down',
-    ) => void;
-};
+type FeedbackFilterProps = Pick<
+    ReturnType<typeof useAiAgentAdminFilters>,
+    'selectedFeedback' | 'setSelectedFeedback'
+>;
 
 export const FeedbackFilter = ({
     selectedFeedback,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.tsx
@@ -14,12 +14,13 @@ import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useProjects } from '../../../../../hooks/useProjects';
 import { useAiAgentAdminAgents } from '../../hooks/useAiAgentAdmin';
+import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 import classes from './ProjectsFilter.module.css';
 
-type ProjectsFilterProps = {
-    selectedProjectUuids: string[];
-    setSelectedProjectUuids: (projectUuids: string[]) => void;
-};
+type ProjectsFilterProps = Pick<
+    ReturnType<typeof useAiAgentAdminFilters>,
+    'selectedProjectUuids' | 'setSelectedProjectUuids'
+>;
 
 const ProjectsFilter: FC<ProjectsFilterProps> = ({
     selectedProjectUuids,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.tsx
@@ -1,19 +1,15 @@
 import { ActionIcon, TextInput, Tooltip } from '@mantine-8/core';
 import { IconSearch, IconX } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 import classes from './SearchFilter.module.css';
 
-type SearchFilterProps = {
-    search: string | undefined;
-    setSearch: (search: string) => void;
-    clearSearch: () => void;
-};
+type SearchFilterProps = Pick<
+    ReturnType<typeof useAiAgentAdminFilters>,
+    'search' | 'setSearch'
+>;
 
-export const SearchFilter = ({
-    search,
-    setSearch,
-    clearSearch,
-}: SearchFilterProps) => {
+export const SearchFilter = ({ search, setSearch }: SearchFilterProps) => {
     return (
         <Tooltip withinPortal variant="xs" label="Search by title">
             <TextInput
@@ -35,7 +31,7 @@ export const SearchFilter = ({
                 rightSection={
                     search && (
                         <ActionIcon
-                            onClick={clearSearch}
+                            onClick={() => setSearch('')}
                             variant="transparent"
                             size="xs"
                             color="gray.5"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.tsx
@@ -1,12 +1,13 @@
 import { Box, SegmentedControl, Text, Tooltip } from '@mantine-8/core';
 import { IconBrandSlack, IconMessageCircleStar } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
 import classes from './SourceFilter.module.css';
 
-type SourceFilterProps = {
-    selectedSource: 'all' | 'web_app' | 'slack';
-    setSelectedSource: (source: 'all' | 'web_app' | 'slack') => void;
-};
+type SourceFilterProps = Pick<
+    ReturnType<typeof useAiAgentAdminFilters>,
+    'selectedSource' | 'setSelectedSource'
+>;
 
 export const SourceFilter = ({
     selectedSource,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminFilters.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminFilters.ts
@@ -1,0 +1,255 @@
+import type {
+    AiAgentAdminFilters,
+    AiAgentAdminSort,
+    AiAgentAdminSortField,
+} from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import useSearchParams from '../../../../hooks/useSearchParams';
+
+export interface AiAgentAdminFiltersState {
+    search: AiAgentAdminFilters['search'];
+    selectedProjectUuids: NonNullable<AiAgentAdminFilters['projectUuids']>;
+    selectedAgentUuids: NonNullable<AiAgentAdminFilters['agentUuids']>;
+    selectedSource: 'all' | AiAgentAdminFilters['createdFrom'];
+    selectedFeedback: 'all' | 'thumbs_up' | 'thumbs_down';
+    sortField: AiAgentAdminSortField;
+    sortDirection: AiAgentAdminSort['direction'];
+}
+
+const DEFAULT_FILTERS: AiAgentAdminFiltersState = {
+    search: undefined,
+    selectedProjectUuids: [],
+    selectedAgentUuids: [],
+    selectedSource: 'all',
+    selectedFeedback: 'all',
+    sortField: 'createdAt',
+    sortDirection: 'desc',
+};
+
+/**
+ * Custom hook to manage AI Agent Admin filters with URL persistence
+ */
+export const useAiAgentAdminFilters = () => {
+    const navigate = useNavigate();
+    const { search: locationSearch, pathname } = useLocation();
+
+    const searchParam = useSearchParams<string>('search');
+    const projectsParam = useSearchParams<string>('projects');
+    const agentsParam = useSearchParams<string>('agents');
+    const sourceParam = useSearchParams<'web_app' | 'slack'>('source');
+    const feedbackParam = useSearchParams<'thumbs_up' | 'thumbs_down'>(
+        'feedback',
+    );
+    const sortByParam = useSearchParams<AiAgentAdminSortField>('sortBy');
+    const sortDirectionParam = useSearchParams<'asc' | 'desc'>('sortDirection');
+
+    const currentFilters = useMemo(
+        () => ({
+            search: searchParam || DEFAULT_FILTERS.search,
+            selectedProjectUuids:
+                projectsParam?.split(',').filter(Boolean) ||
+                DEFAULT_FILTERS.selectedProjectUuids,
+            selectedAgentUuids:
+                agentsParam?.split(',').filter(Boolean) ||
+                DEFAULT_FILTERS.selectedAgentUuids,
+            selectedSource: sourceParam || DEFAULT_FILTERS.selectedSource,
+            selectedFeedback: feedbackParam || DEFAULT_FILTERS.selectedFeedback,
+            sortField: sortByParam || DEFAULT_FILTERS.sortField,
+            sortDirection: sortDirectionParam || DEFAULT_FILTERS.sortDirection,
+        }),
+        [
+            searchParam,
+            projectsParam,
+            agentsParam,
+            sourceParam,
+            feedbackParam,
+            sortByParam,
+            sortDirectionParam,
+        ],
+    );
+
+    const updateUrl = useCallback(
+        (newFilters: AiAgentAdminFiltersState) => {
+            const searchParams = new URLSearchParams();
+
+            if (newFilters.search) {
+                searchParams.set('search', newFilters.search);
+            }
+
+            if (
+                newFilters.selectedProjectUuids &&
+                newFilters.selectedProjectUuids.length > 0
+            ) {
+                searchParams.set(
+                    'projects',
+                    newFilters.selectedProjectUuids.join(','),
+                );
+            }
+
+            if (
+                newFilters.selectedAgentUuids &&
+                newFilters.selectedAgentUuids.length > 0
+            ) {
+                searchParams.set(
+                    'agents',
+                    newFilters.selectedAgentUuids.join(','),
+                );
+            }
+
+            if (
+                newFilters.selectedSource &&
+                newFilters.selectedSource !== DEFAULT_FILTERS.selectedSource
+            ) {
+                searchParams.set('source', newFilters.selectedSource);
+            }
+
+            if (
+                newFilters.selectedFeedback !== DEFAULT_FILTERS.selectedFeedback
+            ) {
+                searchParams.set('feedback', newFilters.selectedFeedback);
+            }
+
+            if (newFilters.sortField !== DEFAULT_FILTERS.sortField) {
+                searchParams.set('sortBy', newFilters.sortField);
+            }
+
+            if (newFilters.sortDirection !== DEFAULT_FILTERS.sortDirection) {
+                searchParams.set('sortDirection', newFilters.sortDirection);
+            }
+
+            const newSearch = searchParams.toString();
+
+            // Only navigate if the search params actually changed
+            if (newSearch !== new URLSearchParams(locationSearch).toString()) {
+                void navigate(
+                    {
+                        pathname,
+                        search: newSearch,
+                    },
+                    { replace: true },
+                );
+            }
+        },
+        [navigate, pathname, locationSearch],
+    );
+
+    const setSearch = useCallback(
+        (search: AiAgentAdminFiltersState['search']) => {
+            updateUrl({ ...currentFilters, search: search || undefined });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedProjectUuids = useCallback(
+        (projectUuids: NonNullable<AiAgentAdminFilters['projectUuids']>) => {
+            updateUrl({
+                ...currentFilters,
+                selectedProjectUuids: projectUuids,
+            });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedAgentUuids = useCallback(
+        (agentUuids: NonNullable<AiAgentAdminFilters['agentUuids']>) => {
+            updateUrl({ ...currentFilters, selectedAgentUuids: agentUuids });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedSource = useCallback(
+        (source: AiAgentAdminFiltersState['selectedSource']) => {
+            updateUrl({ ...currentFilters, selectedSource: source });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedFeedback = useCallback(
+        (feedback: AiAgentAdminFiltersState['selectedFeedback']) => {
+            updateUrl({ ...currentFilters, selectedFeedback: feedback });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSorting = useCallback(
+        (
+            sortField: AiAgentAdminSortField,
+            sortDirection: AiAgentAdminSort['direction'],
+        ) => {
+            updateUrl({ ...currentFilters, sortField, sortDirection });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const resetFilters = useCallback(() => {
+        updateUrl(DEFAULT_FILTERS);
+    }, [updateUrl]);
+
+    const hasActiveFilters = useMemo(() => {
+        return (
+            currentFilters.search !== DEFAULT_FILTERS.search ||
+            (currentFilters.selectedProjectUuids &&
+                currentFilters.selectedProjectUuids.length !==
+                    DEFAULT_FILTERS.selectedProjectUuids?.length) ||
+            (currentFilters.selectedAgentUuids &&
+                currentFilters.selectedAgentUuids.length !==
+                    DEFAULT_FILTERS.selectedAgentUuids?.length) ||
+            currentFilters.selectedSource !== DEFAULT_FILTERS.selectedSource ||
+            currentFilters.selectedFeedback !==
+                DEFAULT_FILTERS.selectedFeedback ||
+            currentFilters.sortField !== DEFAULT_FILTERS.sortField ||
+            currentFilters.sortDirection !== DEFAULT_FILTERS.sortDirection
+        );
+    }, [currentFilters]);
+
+    const apiFilters = useMemo(() => {
+        const result: AiAgentAdminFilters = {};
+
+        if (currentFilters.search) {
+            result.search = currentFilters.search;
+        }
+
+        if (
+            currentFilters.selectedProjectUuids &&
+            currentFilters.selectedProjectUuids.length > 0
+        ) {
+            result.projectUuids = currentFilters.selectedProjectUuids;
+        }
+
+        if (
+            currentFilters.selectedAgentUuids &&
+            currentFilters.selectedAgentUuids.length > 0
+        ) {
+            result.agentUuids = currentFilters.selectedAgentUuids;
+        }
+
+        if (currentFilters.selectedSource !== 'all') {
+            result.createdFrom = currentFilters.selectedSource;
+        }
+
+        if (currentFilters.selectedFeedback === 'thumbs_up') {
+            result.humanScore = 1;
+        } else if (currentFilters.selectedFeedback === 'thumbs_down') {
+            result.humanScore = -1;
+        }
+
+        return result;
+    }, [currentFilters]);
+
+    return {
+        ...currentFilters,
+
+        apiFilters,
+
+        setSearch,
+        setSelectedProjectUuids,
+        setSelectedAgentUuids,
+        setSelectedSource,
+        setSelectedFeedback,
+        setSorting,
+
+        resetFilters,
+        hasActiveFilters,
+    };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Refactored AI Agent Admin filters to use URL persistence, allowing users to share and bookmark specific filter states. Created a new `useAiAgentAdminFilters` hook that centralizes filter management and synchronizes filter state with URL parameters.

Key improvements:
- Added URL persistence for all filter parameters (search, projects, agents, source, feedback, sorting)
- Implemented a "Clear all filters" button to reset filters to default state
- Refactored filter components to use the new hook through prop drilling
- Improved type safety by using TypeScript's Pick utility for component props
- Fixed sorting implementation to properly update URL parameters

This change makes the AI Agent Admin interface more user-friendly by preserving filter state across page refreshes and enabling shareable filtered views.