### PR TITLE
feat: add visualization warning for incorrect chart configurations

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -245,13 +245,16 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                     isVisualizationCard
                     onToggle={toggleSection}
                     headerElement={
-                        <VisualizationWarning
-                            pivotDimensions={
-                                unsavedChartVersion.pivotConfig?.columns
-                            }
-                            resultsData={resultsData}
-                            isLoading={isLoadingQueryResults}
-                        />
+                        isOpen && (
+                            <VisualizationWarning
+                                pivotDimensions={
+                                    unsavedChartVersion.pivotConfig?.columns
+                                }
+                                chartConfig={unsavedChartVersion.chartConfig}
+                                resultsData={resultsData}
+                                isLoading={isLoadingQueryResults}
+                            />
+                        )
                     }
                     rightHeaderElement={
                         isOpen && (

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -39,6 +39,7 @@ import { type EchartSeriesClickEvent } from '../../SimpleChart';
 import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
 import { SeriesContextMenu } from './SeriesContextMenu';
+import VisualizationWarning from './VisualizationWarning';
 
 export type EchartsClickEvent = {
     event: EchartSeriesClickEvent;
@@ -243,6 +244,15 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                     isOpen={isOpen}
                     isVisualizationCard
                     onToggle={toggleSection}
+                    headerElement={
+                        <VisualizationWarning
+                            pivotDimensions={
+                                unsavedChartVersion.pivotConfig?.columns
+                            }
+                            resultsData={resultsData}
+                            isLoading={isLoadingQueryResults}
+                        />
+                    }
                     rightHeaderElement={
                         isOpen && (
                             <>

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -1,0 +1,91 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Badge, Tooltip } from '@mantine-8/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import isEqual from 'lodash/isEqual';
+import { useMemo, type FC } from 'react';
+import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
+import { type InfiniteQueryResults } from '../../../hooks/useQueryResults';
+import MantineIcon from '../../common/MantineIcon';
+
+export type PivotMismatchWarningProps = {
+    pivotDimensions: string[] | undefined;
+    resultsData: Pick<
+        InfiniteQueryResults,
+        | 'isFetchingRows'
+        | 'isInitialLoading'
+        | 'isFetchingFirstPage'
+        | 'pivotDetails'
+    >;
+    isLoading: boolean;
+};
+
+const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
+    pivotDimensions,
+    resultsData,
+    isLoading,
+}) => {
+    const { data: useSqlPivotResults } = useFeatureFlag(
+        FeatureFlags.UseSqlPivotResults,
+    );
+
+    // Determine pivot used to compute current results
+    const resultsPivotDimensions = useMemo<string[]>(() => {
+        const groupBy = resultsData?.pivotDetails?.groupByColumns;
+        return groupBy
+            ? groupBy.map((c: { reference: string }) => c.reference)
+            : [];
+    }, [resultsData?.pivotDetails]);
+
+    const dirtyPivotDimensions = useMemo(
+        () => pivotDimensions ?? [],
+        [pivotDimensions],
+    );
+
+    const isQueryFetching = Boolean(
+        resultsData?.isInitialLoading ||
+            resultsData?.isFetchingFirstPage ||
+            resultsData?.isFetchingRows,
+    );
+
+    const shouldShow = useMemo(() => {
+        // Only show when not loading/fetching
+        if (isLoading || isQueryFetching) return false;
+        // Only show when using SQL pivot results
+        if (!useSqlPivotResults) return false;
+        // If both sides empty/undefined, no warning
+        if (
+            resultsPivotDimensions.length === 0 &&
+            dirtyPivotDimensions.length === 0
+        )
+            return false;
+        // Show when arrays differ
+        return !isEqual(dirtyPivotDimensions, resultsPivotDimensions);
+    }, [
+        useSqlPivotResults,
+        dirtyPivotDimensions,
+        isLoading,
+        isQueryFetching,
+        resultsPivotDimensions,
+    ]);
+
+    if (!shouldShow) return null;
+
+    return (
+        <Tooltip
+            label={`Please re-run the query to fetch the latest data with correct group by settings.`}
+            multiline
+            position={'bottom'}
+        >
+            <Badge
+                leftSection={<MantineIcon icon={IconAlertCircle} size={'sm'} />}
+                color="yellow"
+                variant="outline"
+                tt="none"
+            >
+                Results may be incorrect
+            </Badge>
+        </Tooltip>
+    );
+};
+
+export default VisualizationWarning;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -1,5 +1,13 @@
-import { FeatureFlags } from '@lightdash/common';
-import { Badge, Tooltip } from '@mantine-8/core';
+import {
+    ChartType,
+    FeatureFlags,
+    isCustomDimension,
+    isDimension,
+    type ChartConfig,
+    type ItemsMap,
+    type MetricQuery,
+} from '@lightdash/common';
+import { Badge, List, Tooltip } from '@mantine-8/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import isEqual from 'lodash/isEqual';
 import { useMemo, type FC } from 'react';
@@ -9,32 +17,26 @@ import MantineIcon from '../../common/MantineIcon';
 
 export type PivotMismatchWarningProps = {
     pivotDimensions: string[] | undefined;
+    chartConfig: ChartConfig;
     resultsData: Pick<
         InfiniteQueryResults,
         | 'isFetchingRows'
         | 'isInitialLoading'
         | 'isFetchingFirstPage'
         | 'pivotDetails'
-    >;
+    > & { metricQuery?: MetricQuery; fields?: ItemsMap };
     isLoading: boolean;
 };
 
 const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
     pivotDimensions,
+    chartConfig,
     resultsData,
     isLoading,
 }) => {
     const { data: useSqlPivotResults } = useFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
-
-    // Determine pivot used to compute current results
-    const resultsPivotDimensions = useMemo<string[]>(() => {
-        const groupBy = resultsData?.pivotDetails?.groupByColumns;
-        return groupBy
-            ? groupBy.map((c: { reference: string }) => c.reference)
-            : [];
-    }, [resultsData?.pivotDetails]);
 
     const dirtyPivotDimensions = useMemo(
         () => pivotDimensions ?? [],
@@ -47,9 +49,12 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
             resultsData?.isFetchingRows,
     );
 
-    const shouldShow = useMemo(() => {
-        // Only show when not loading/fetching
-        if (isLoading || isQueryFetching) return false;
+    // Determine if configured pivot dimensions are different from the ones used to compute the results
+    const shouldShowPivotMismatch = useMemo(() => {
+        // Determine pivot used to compute current results
+        const resultsPivotDimensions = (
+            resultsData?.pivotDetails?.groupByColumns || []
+        ).map((c: { reference: string }) => c.reference);
         // Only show when using SQL pivot results
         if (!useSqlPivotResults) return false;
         // If both sides empty/undefined, no warning
@@ -61,18 +66,87 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
         // Show when arrays differ
         return !isEqual(dirtyPivotDimensions, resultsPivotDimensions);
     }, [
+        resultsData?.pivotDetails?.groupByColumns,
         useSqlPivotResults,
         dirtyPivotDimensions,
-        isLoading,
-        isQueryFetching,
-        resultsPivotDimensions,
     ]);
 
-    if (!shouldShow) return null;
+    // Determine if query includes dimensions not used in the cartesian chart config
+    const shouldShowUnusedDims = useMemo(() => {
+        // Don't show when not using cartesian charts
+        if (chartConfig?.type !== ChartType.CARTESIAN) {
+            return false;
+        }
+
+        const itemsMap = resultsData?.fields;
+        const layout = chartConfig.config?.layout as
+            | { xField?: string; yField?: string[] }
+            | undefined;
+        const usedDims = new Set<string>();
+
+        const maybeAddIfDimension = (field?: string) => {
+            if (!field || !itemsMap) return;
+            const item = itemsMap[field];
+            if ((item && isDimension(item)) || isCustomDimension(item))
+                usedDims.add(field);
+        };
+
+        maybeAddIfDimension(layout?.xField);
+        (layout?.yField ?? []).forEach((f) => maybeAddIfDimension(f));
+        (dirtyPivotDimensions ?? []).forEach((f) => usedDims.add(f));
+
+        const metricQueryDims = resultsData?.metricQuery?.dimensions ?? [];
+        const unusedQueryDimensions = metricQueryDims.filter(
+            (d) => !usedDims.has(d),
+        );
+        return unusedQueryDimensions.length > 0;
+    }, [
+        resultsData?.metricQuery?.dimensions,
+        resultsData?.fields,
+        chartConfig?.type,
+        chartConfig.config,
+        dirtyPivotDimensions,
+    ]);
+
+    // Determine how many messages to show
+    const messages = useMemo(() => {
+        // Only show when not loading/fetching
+        if (isLoading || isQueryFetching) return [];
+
+        const _messages: string[] = [];
+        if (shouldShowUnusedDims) {
+            _messages.push(
+                'Your query includes dimensions that are not used in the chart configuration (x-axis, y-axis, or group by). Remove them from the query to avoid incorrect results.',
+            );
+        }
+        if (shouldShowPivotMismatch) {
+            _messages.push(
+                'Please re-run the query to fetch the latest data with correct group by settings.',
+            );
+        }
+        return _messages;
+    }, [
+        isLoading,
+        isQueryFetching,
+        shouldShowPivotMismatch,
+        shouldShowUnusedDims,
+    ]);
+
+    if (messages.length === 0) return null;
 
     return (
         <Tooltip
-            label={`Please re-run the query to fetch the latest data with correct group by settings.`}
+            label={
+                messages.length === 1 ? (
+                    messages[0]
+                ) : (
+                    <List size={'xs'} pr={'sm'}>
+                        {messages.map((m, i) => (
+                            <List.Item key={i}>{m}</List.Item>
+                        ))}
+                    </List>
+                )
+            }
             multiline
             position={'bottom'}
         >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#16686](https://github.com/lightdash/lightdash/issues/16686)

### Description:
Added a new visualization warning component that alerts users when their chart configuration might lead to incorrect results. The warning appears in two scenarios:

1. When dimensions in the query are not used in the chart configuration (x-axis, y-axis, or group by)
2. When there's a mismatch between configured pivot dimensions and the ones used to compute the results

The warning badge displays "Results may be incorrect" with a tooltip explaining the specific issues and recommended actions.

#### Overview
<img width="1662" height="836" alt="Screenshot 2025-09-04 at 15 31 16" src="https://github.com/user-attachments/assets/eeb9dc93-1953-4824-92f4-41bb7da047af" />

#### When there are unused dimensions 

<img width="347" height="140" alt="Screenshot 2025-09-04 at 15 36 45" src="https://github.com/user-attachments/assets/d6d0849b-b5f9-462e-970d-5647fac18805" />

#### When group by config changed

<img width="353" height="118" alt="Screenshot 2025-09-04 at 15 36 18" src="https://github.com/user-attachments/assets/5142def7-d9a4-41a5-9728-5d73ee15723e" />

#### With both 

<img width="352" height="208" alt="Screenshot 2025-09-04 at 15 31 32" src="https://github.com/user-attachments/assets/25a91688-8d60-4e76-b300-4726585a369e" />



