### PR TITLE
feat: add error logging for explore errors

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3943,6 +3943,11 @@ export class ProjectService extends BaseService {
                     );
                 }
                 if (isExploreError(explore)) {
+                    this.logger.error(
+                        `Explore "${exploreName}" has an error. ${JSON.stringify(
+                            explore.errors,
+                        )}`,
+                    );
                     throw new NotExistsError(
                         `Explore "${exploreName}" has an error.`,
                     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added error logging for explore errors in ProjectService. When an explore has an error, the service now logs the error details including the error object before throwing a NotExistsError. This will help with debugging explore-related issues by providing more context in the logs.
