### PR TITLE
fix: address scroll & filter out non-agent projects

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
@@ -91,6 +91,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                         <AgentsFilter
                             selectedAgentUuids={selectedAgentUuids}
                             setSelectedAgentUuids={setSelectedAgentUuids}
+                            selectedProjectUuids={selectedProjectUuids}
                         />
                         <Divider
                             orientation="vertical"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Enhanced the AI Agent Admin filters to improve usability and add project-agent relationship filtering:

1. Improved the Projects filter to:
   - Only show projects that have agents
   - Add a scrollable area for better navigation
   - Include a help tooltip explaining the filter behavior

2. Enhanced the Agents filter to:
   - Group agents by project
   - Filter agents based on selected projects
   - Disable agents from unselected projects
   - Add visual indicators for filtered agents
   - Add scrollable area for better navigation with many agents

3. Connected the two filters so that selecting projects automatically filters the available agents, making it easier to find relevant AI agents in multi-project environments.

![Screenshot 2025-09-05 at 10.46.31.png](https://app.graphite.dev/user-attachments/assets/039acb64-e746-4201-8ea6-814d5c209dbb.png)

![Screenshot 2025-09-05 at 10.46.26.png](https://app.graphite.dev/user-attachments/assets/d1fa80ae-8537-4484-abb1-4ed4c23c12ae.png)

[demo-scroll.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/3a641ceb-7e8b-461b-9fbd-9518bd809276.mov" />](https://app.graphite.dev/user-attachments/video/3a641ceb-7e8b-461b-9fbd-9518bd809276.mov)

