### PR TITLE
fix: check for enabled property in useSqlPivotResults

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -56,7 +56,7 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
             resultsData?.pivotDetails?.groupByColumns || []
         ).map((c: { reference: string }) => c.reference);
         // Only show when using SQL pivot results
-        if (!useSqlPivotResults) return false;
+        if (!useSqlPivotResults?.enabled) return false;
         // If both sides empty/undefined, no warning
         if (
             resultsPivotDimensions.length === 0 &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Fix SQL pivot results check in VisualizationWarning component by updating the condition to check for `useSqlPivotResults.enabled` instead of just `useSqlPivotResults`. This ensures the warning is only shown when SQL pivot results are actually enabled, preventing false warnings when the feature flag object exists but is not enabled.