### PR TITLE
fix: skip user setup when analytics tracking is disabled

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -227,13 +227,14 @@ export class UserModel {
             isVerified?: boolean;
         },
     ) {
+        const canSkipSetupForAnalytics = !this.lightdashConfig.rudder.writeKey;
         const userIn: DbUserIn = isOpenIdUser(createUser)
             ? {
                   first_name: createUser.openId.firstName || '',
                   last_name: createUser.openId.lastName || '',
                   is_marketing_opted_in: false,
                   is_tracking_anonymized: this.canTrackingBeAnonymized(),
-                  is_setup_complete: false,
+                  is_setup_complete: canSkipSetupForAnalytics,
                   is_active: createUser.isActive,
               }
             : {
@@ -241,7 +242,7 @@ export class UserModel {
                   last_name: createUser.lastName.trim(),
                   is_marketing_opted_in: false,
                   is_tracking_anonymized: this.canTrackingBeAnonymized(),
-                  is_setup_complete: false,
+                  is_setup_complete: canSkipSetupForAnalytics,
                   is_active: createUser.isActive,
               };
         const [newUser] = await trx<DbUser>('users')

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -99,23 +99,6 @@ const UserCompletionModal: FC = () => {
         setFieldValue('enableEmailDomainAccess', true);
     }, [canEnableEmailDomainAccess, setFieldValue]);
 
-    useEffect(() => {
-        // Tracking is disabled, we complete the user tracking with default values
-        if (
-            health.data?.rudder.writeKey === undefined &&
-            !isLoading &&
-            user.data &&
-            !user.data.isSetupComplete
-        ) {
-            mutate({
-                jobTitle: 'Other',
-                enableEmailDomainAccess: false,
-                isMarketingOptedIn: false,
-                isTrackingAnonymized: true,
-            });
-        }
-    }, [health.data?.rudder.writeKey, isLoading, mutate, user.data]);
-
     if (
         !user.data ||
         user.data.isSetupComplete ||


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16747

### Description:

Skip user setup completion modal when analytics tracking is disabled. This change automatically marks users as having completed setup when Rudder analytics is not configured, eliminating the need for users to go through the setup completion process in environments where tracking is disabled.

The PR:

1. Automatically sets `is_setup_complete` to true during user creation when Rudder write key is not present
2. Removes the effect hook that was previously handling this scenario in the frontend
