### PR TITLE
feat: add askAiButtonEnabled configuration option

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -57,6 +57,7 @@ export const aiCopilotConfigSchema = z
         requiresFeatureFlag: z.boolean(),
         telemetryEnabled: z.boolean(),
         debugLoggingEnabled: z.boolean(),
+        askAiButtonEnabled: z.boolean(),
         maxQueryLimit: z.number().positive(),
     })
     .refine(

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -198,6 +198,7 @@ export const lightdashConfigMock: LightdashConfig = {
             maxQueryLimit: 10000,
             telemetryEnabled: false,
             requiresFeatureFlag: false,
+            askAiButtonEnabled: false,
             defaultProvider: 'openai',
             providers: {
                 openai: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1048,6 +1048,7 @@ export const parseConfig = (): LightdashConfig => {
         telemetryEnabled: process.env.AI_COPILOT_TELEMETRY_ENABLED === 'true',
         requiresFeatureFlag:
             process.env.AI_COPILOT_REQUIRES_FEATURE_FLAG === 'true',
+        askAiButtonEnabled: process.env.ASK_AI_BUTTON_ENABLED === 'true',
         defaultProvider:
             process.env.AI_DEFAULT_PROVIDER || DEFAULT_DEFAULT_AI_PROVIDER,
         providers: {

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -121,6 +121,13 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             };
         }
 
+        if (this.lightdashConfig.ai.copilot.askAiButtonEnabled) {
+            return {
+                id: featureFlagId,
+                enabled: true,
+            };
+        }
+
         return {
             id: featureFlagId,
             enabled: await isFeatureFlagEnabled(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16748

### Description:

Adds a new configuration option `askAiButtonEnabled` to control the visibility of the Ask AI button. This can be set via the `ASK_AI_BUTTON_ENABLED` environment variable. When enabled, the Ask AI button will be shown regardless of feature flag settings.

The configuration follows the same pattern as other AI Copilot settings, integrating with the existing configuration schema and commercial feature flag model.
