### PR TITLE
chore: add AI Agents link to settings page

### DIFF
--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { Box, ScrollArea, Stack, Text, Title } from '@mantine/core';
 import {
+    IconBrain,
     IconBrowser,
     IconBuildingSkyscraper,
     IconCalendarStats,
@@ -586,6 +587,20 @@ const Settings: FC = () => {
                                             }
                                         />
                                     )}
+                                {user.ability.can(
+                                    'manage',
+                                    subject('AiAgent', {
+                                        organizationUuid:
+                                            organization.organizationUuid,
+                                    }),
+                                ) && (
+                                    <RouterNavLink
+                                        label="AI Agents"
+                                        exact
+                                        to="/ai-agents/admin"
+                                        icon={<MantineIcon icon={IconBrain} />}
+                                    />
+                                )}
                             </Box>
 
                             {organization &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16754

### Description:

Added a new "AI Agents" navigation link in the Settings page for users with the appropriate permissions. The link directs to "/ai-agents/admin" and uses the IconBrain icon.
