### PR TITLE
feat: auto-run explores from dashboards

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -684,12 +684,12 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         async (chartPathname: string, chartSearch: string) => {
             const shareUrl = await createShareUrl({
                 path: chartPathname,
-                params: `?` + chartSearch,
+                params: `?` + chartSearch + `&fromDashboard=${dashboardUuid}`,
             });
 
             window.open(`/share/${shareUrl.nanoid}`, '_blank');
         },
-        [createShareUrl],
+        [createShareUrl, dashboardUuid],
     );
 
     const [dashboardTileFilterOptions, setDashboardTileFilterOptions] =

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -48,6 +48,24 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             enabled: !!unsavedChartVersionTableName,
         });
 
+        const fromDashboard = useExplorerContext(
+            (context) => context.state.fromDashboard,
+        );
+
+        const previouslyFetchedState = useExplorerContext(
+            (context) => context.state.previouslyFetchedState,
+        );
+
+        const fetchResults = useExplorerContext(
+            (context) => context.actions.fetchResults,
+        );
+
+        useEffect(() => {
+            if (!previouslyFetchedState && (fromDashboard || isEditMode)) {
+                fetchResults();
+            }
+        }, [previouslyFetchedState, fetchResults, fromDashboard, isEditMode]);
+
         useEffect(() => {
             if (isError) {
                 // If there's an error, we set the parameter references to an empty array

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -12,7 +12,12 @@ import {
     type MetricQuery,
 } from '@lightdash/common';
 import { useEffect, useMemo } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import {
+    useLocation,
+    useNavigate,
+    useParams,
+    useSearchParams,
+} from 'react-router';
 import {
     ExplorerSection,
     type ExplorerReduceState,
@@ -110,7 +115,7 @@ type BackwardsCompatibleCreateSavedChartVersionUrlParam = Omit<
     metricQuery: Omit<MetricQuery, 'exploreName'> & { exploreName?: string };
 };
 
-const parseExplorerSearchParams = (
+const parseChartFromExplorerSearchParams = (
     search: string,
 ): CreateSavedChartVersion | undefined => {
     const searchParams = new URLSearchParams(search);
@@ -198,10 +203,13 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
         tableId: string | undefined;
     }>();
 
+    const [searchParams] = useSearchParams();
+    const fromDashboard = searchParams.get('fromDashboard');
+
     return useMemo(() => {
         if (pathParams.tableId) {
             try {
-                const unsavedChartVersion = parseExplorerSearchParams(
+                const unsavedChartVersion = parseChartFromExplorerSearchParams(
                     search,
                 ) || {
                     tableName: '',
@@ -250,6 +258,7 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                         },
                     },
                     parameters: {},
+                    fromDashboard: fromDashboard ?? undefined,
                 };
             } catch (e: any) {
                 const errorMessage = e.message ? ` Error: "${e.message}"` : '';
@@ -259,7 +268,7 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                 });
             }
         }
-    }, [pathParams, search, showToastError]);
+    }, [pathParams, search, showToastError, fromDashboard]);
 };
 
 export const createMetricPreviewUnsavedChartVersion = (

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -299,6 +299,8 @@ export interface ExplorerReduceState {
             items?: CustomDimension[] | AdditionalMetric[];
         };
     };
+
+    fromDashboard?: string;
 }
 
 export interface ExplorerState extends ExplorerReduceState {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16469 

### Description:

Auto-run queries when starting from 'Explore from here' or 'Edit chart'

This adds a `fromDashboard` url param to explore links coming from a dashboard. When present, it runs the query if it hasn't been run yet. 
