### PR TITLE
feat: apply limit after pivoting/grouping

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -7,6 +7,7 @@ import {
     SortByDirection,
     WarehouseSqlBuilder,
 } from '@lightdash/common';
+import { applyLimitToSqlQuery } from './utils';
 
 const DEFAULT_PIVOT_ROW_LIMIT = 500;
 
@@ -353,6 +354,14 @@ export class PivotQueryBuilder {
         ]);
     }
 
+    private getBaseSql(): string {
+        // Remove limit and trailing semicolon from base SQL
+        return applyLimitToSqlQuery({
+            sqlQuery: this.sql,
+            limit: null,
+        }).replace(/;\s*$/, '');
+    }
+
     /**
      * Generates the final pivot SQL query.
      * @returns Complete SQL query with CTEs for pivoting the data
@@ -386,7 +395,7 @@ export class PivotQueryBuilder {
             }
         }
 
-        const userSql = this.sql.replace(/;\s*$/, '');
+        const baseSql = this.getBaseSql();
         const groupByQuery = this.getGroupByQuerySQL(
             indexColumns,
             valuesColumns,
@@ -395,7 +404,7 @@ export class PivotQueryBuilder {
 
         if (groupByColumns && groupByColumns.length > 0) {
             return this.getFullPivotSQL(
-                userSql,
+                baseSql,
                 groupByQuery,
                 indexColumns,
                 valuesColumns,
@@ -404,6 +413,6 @@ export class PivotQueryBuilder {
             );
         }
 
-        return this.getSimpleQuerySQL(userSql, groupByQuery, sortBy);
+        return this.getSimpleQuerySQL(baseSql, groupByQuery, sortBy);
     }
 }

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -479,7 +479,9 @@ export const removeCommentsAndOuterLimitOffset = (sql: string): string => {
     // remove either "LIMIT x OFFSET y" or "OFFSET y LIMIT x" at the end of the query
     const limitOffsetRegex =
         /(\b(?:(?:limit\s+\d+(?:\s+offset\s+\d+)?)|(?:offset\s+\d+\s+limit\s+\d+))\s*(?:;|\s*)?)$/i;
-    let sqlWithoutLimit = sqlWithoutStrings.replace(limitOffsetRegex, '');
+    let sqlWithoutLimit = sqlWithoutStrings
+        .trim()
+        .replace(limitOffsetRegex, '');
     // remove semicolon from the end of the query
     sqlWithoutLimit = sqlWithoutLimit.trim().replace(/;+$/g, '');
     // restore strings

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -500,7 +500,7 @@ export const applyLimitToSqlQuery = ({
     limit,
 }: {
     sqlQuery: string;
-    limit: number | undefined;
+    limit: number | null | undefined;
 }): string => {
     // do nothing if limit is undefined
     if (limit === undefined) {
@@ -508,6 +508,9 @@ export const applyLimitToSqlQuery = ({
         let sql = removeComments(sqlQuery);
         sql = sql.trim().replace(/;+$/g, '');
         return sql.trim();
+    }
+    if (limit === null) {
+        return removeCommentsAndOuterLimitOffset(sqlQuery);
     }
     // get any existing outer limit and offset from the SQL query
     const existingLimitOffset = extractOuterLimitOffsetFromSQL(sqlQuery);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#16739](https://github.com/lightdash/lightdash/issues/16739)

### Description:
Improved the PivotQueryBuilder to properly handle SQL comments and LIMIT clauses in the base query. The builder now correctly removes comments and LIMIT statements from the original SQL when constructing the pivot query, ensuring that these elements don't interfere with the pivot operation.

Added a new test case that verifies comments and LIMIT clauses are properly removed from the base SQL in the original_query CTE. This ensures that pivot visualizations work correctly regardless of comments or LIMIT statements in the underlying SQL.


<img width="1710" height="896" alt="Screenshot 2025-09-05 at 16 03 20" src="https://github.com/user-attachments/assets/8c1590d8-efcd-48c6-b602-f8f114800c76" />
