### PR TITLE
fix: validate pivot configuration and prevent invalid pivot dimensions

### DIFF
--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -128,9 +128,11 @@ function getTablePivotConfiguration(
     }));
 
     // Group by columns are the pivot dimensions
-    const groupByColumns = pivotColumns.map((col: string) => ({
-        reference: col,
-    }));
+    const groupByColumns = pivotColumns
+        .map((col: string) => ({
+            reference: col,
+        }))
+        .filter((col) => metricQuery.dimensions.includes(col.reference));
 
     const partialPivotConfiguration: Omit<PivotConfiguration, 'sortBy'> = {
         indexColumn,
@@ -169,10 +171,12 @@ function getCartesianPivotConfiguration(
     } = chartConfig.config;
 
     if (pivotConfig?.columns && xField && yField) {
-        // Extract pivot columns
-        const groupByColumns = pivotConfig.columns.map((pv) => ({
-            reference: pv,
-        }));
+        // Extract and validate pivot columns
+        const groupByColumns = pivotConfig.columns
+            .map((pv) => ({
+                reference: pv,
+            }))
+            .filter((col) => metricQuery.dimensions.includes(col.reference));
 
         // Extract value columns
         const valuesColumns = yField.map((yf) => ({
@@ -218,6 +222,30 @@ function getCartesianPivotConfiguration(
     return undefined;
 }
 
+function isValid(pivotConfiguration: PivotConfiguration): boolean {
+    const { groupByColumns, indexColumn } = pivotConfiguration;
+
+    const indexColumns = normalizeIndexColumns(indexColumn);
+    if (indexColumns.length === 0) {
+        return false;
+    }
+
+    if (!groupByColumns || groupByColumns.length === 0) {
+        return false;
+    }
+
+    // Validate that no groupBy column is also part of the index columns
+    const indexRefs = new Set(indexColumns.map((c) => c.reference));
+    const overlapping = groupByColumns
+        .map((c) => c.reference)
+        .filter((ref) => indexRefs.has(ref));
+    if (overlapping.length > 0) {
+        return false;
+    }
+
+    return true;
+}
+
 export function derivePivotConfigurationFromChart(
     savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>,
     metricQuery: MetricQuery,
@@ -226,22 +254,37 @@ export function derivePivotConfigurationFromChart(
     const { chartConfig } = savedChart;
     const { type } = chartConfig;
 
+    let newConfig: PivotConfiguration | undefined;
     switch (type) {
         case ChartType.TABLE:
-            return getTablePivotConfiguration(savedChart, metricQuery, fields);
-        case ChartType.CARTESIAN:
-            return getCartesianPivotConfiguration(
+            newConfig = getTablePivotConfiguration(
                 savedChart,
                 metricQuery,
                 fields,
             );
+            break;
+        case ChartType.CARTESIAN:
+            newConfig = getCartesianPivotConfiguration(
+                savedChart,
+                metricQuery,
+                fields,
+            );
+            break;
         case ChartType.PIE:
         case ChartType.FUNNEL:
         case ChartType.TREEMAP:
         case ChartType.CUSTOM:
         case ChartType.BIG_NUMBER:
-            return undefined;
+            newConfig = undefined;
+            break;
         default:
             return assertUnreachable(type, `Unknown chart type ${type}`);
     }
+
+    // Validate pivot configuration
+    if (newConfig && isValid(newConfig)) {
+        return newConfig;
+    }
+
+    return undefined;
 }

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -225,6 +225,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                 initialPivotDimensions={
                     unsavedChartVersion.pivotConfig?.columns
                 }
+                unsavedMetricQuery={unsavedChartVersion.metricQuery}
                 resultsData={resultsData}
                 apiErrorDetail={apiErrorDetail}
                 isLoading={isLoadingQueryResults}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -32,7 +32,10 @@ import {
     calculateSeriesLikeIdentifier,
     isGroupedSeries,
 } from '../../hooks/useChartColorConfig/utils';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
+import {
+    useFeatureFlag,
+    useFeatureFlagEnabled,
+} from '../../hooks/useFeatureFlagEnabled';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
 import { type InfiniteQueryResults } from '../../hooks/useQueryResults';
 import { type EchartSeriesClickEvent } from '../SimpleChart';
@@ -50,6 +53,7 @@ export type VisualizationProviderProps = {
     minimal?: boolean;
     chartConfig: ChartConfig;
     initialPivotDimensions: string[] | undefined;
+    unsavedMetricQuery?: MetricQuery;
     resultsData: InfiniteQueryResults & {
         metricQuery?: MetricQuery;
         fields?: ItemsMap;
@@ -99,6 +103,7 @@ const VisualizationProvider: FC<
     computedSeries,
     apiErrorDetail,
     parameters,
+    unsavedMetricQuery,
 }) => {
     const itemsMap = useMemo(() => {
         return resultsData?.fields;
@@ -113,9 +118,15 @@ const VisualizationProvider: FC<
         InfiniteQueryResults & { metricQuery?: MetricQuery; fields?: ItemsMap }
     >();
 
+    const { data: useSqlPivotResults } = useFeatureFlag(
+        FeatureFlags.UseSqlPivotResults,
+    );
+
     const { validPivotDimensions, setPivotDimensions } = usePivotDimensions(
         initialPivotDimensions,
-        lastValidResultsData?.metricQuery,
+        useSqlPivotResults?.enabled
+            ? unsavedMetricQuery ?? lastValidResultsData?.metricQuery
+            : lastValidResultsData?.metricQuery,
     );
 
     const setChartType = useCallback(

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -15,6 +15,7 @@ import {
     Group,
     SegmentedControl,
     Stack,
+    TextInput,
     Tooltip,
 } from '@mantine/core';
 import { IconRotate360 } from '@tabler/icons-react';
@@ -309,6 +310,30 @@ export const Layout: FC<Props> = ({ items }) => {
                                 const inactiveItemIds = dirtyLayout?.xField
                                     ? [dirtyLayout.xField, ...pivotDimensions]
                                     : pivotDimensions;
+                                // check if is invalid reference
+                                if (!groupSelectedField) {
+                                    return (
+                                        <TextInput
+                                            key={pivotKey}
+                                            readOnly
+                                            value={pivotKey}
+                                            rightSection={
+                                                <CloseButton
+                                                    onClick={() => {
+                                                        setPivotDimensions(
+                                                            pivotDimensions.filter(
+                                                                (key) =>
+                                                                    key !==
+                                                                    pivotKey,
+                                                            ),
+                                                        );
+                                                    }}
+                                                />
+                                            }
+                                            error={'Invalid reference'}
+                                        />
+                                    );
+                                }
                                 return (
                                     <Group spacing="xs" key={pivotKey}>
                                         <FieldSelect

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -1,6 +1,12 @@
 import { CartesianSeriesType, getItemMap } from '@lightdash/common';
 import { renderHook } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('../useFeatureFlagEnabled', () => ({
+    useFeatureFlag: async () => ({ data: { enabled: false } }),
+    useFeatureFlagEnabled: async () => false,
+}));
+
 import useCartesianChartConfig from './useCartesianChartConfig';
 import {
     existingMixedSeries,

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     CartesianSeriesType,
+    FeatureFlags,
     getSeriesId,
     isCompleteEchartsConfig,
     isCompleteLayout,
@@ -25,6 +26,7 @@ import {
     getMarkLineAxis,
     type ReferenceLineField,
 } from '../../components/common/ReferenceLine';
+import { useFeatureFlag } from '../useFeatureFlagEnabled';
 import type { InfiniteQueryResults } from '../useQueryResults';
 import {
     getExpectedSeriesMap,
@@ -659,6 +661,10 @@ const useCartesianChartConfig = ({
         [getOldTableCalculationMetadataIndex, tableCalculationsMetadata],
     );
 
+    const { data: useSqlPivotResults } = useFeatureFlag(
+        FeatureFlags.UseSqlPivotResults,
+    );
+
     // Set fallout layout values
     // https://www.notion.so/lightdash/Default-chart-configurations-5d3001af990d4b6fa990dba4564540f6
     useEffect(() => {
@@ -800,7 +806,9 @@ const useCartesianChartConfig = ({
                     newYFields = [availableDimensions[1]];
                 }
 
-                if (itemsMap !== undefined) setPivotDimensions(newPivotFields);
+                // don't fallback pivot dimensions if we are using sql pivot results
+                if (itemsMap !== undefined && !useSqlPivotResults?.enabled)
+                    setPivotDimensions(newPivotFields);
                 return {
                     ...prev,
                     xField: newXField,
@@ -817,6 +825,7 @@ const useCartesianChartConfig = ({
         isFieldValidTableCalculation,
         itemsMap,
         setPivotDimensions,
+        useSqlPivotResults,
     ]);
 
     const selectedReferenceLines: ReferenceLineField[] = useMemo(() => {

--- a/packages/frontend/src/hooks/plottedData/getPlottedData.ts
+++ b/packages/frontend/src/hooks/plottedData/getPlottedData.ts
@@ -37,7 +37,7 @@ export const getPivotedData = (
                     field: key,
                     pivotValues: pivotKeys.map((pivotKey) => ({
                         field: pivotKey,
-                        value: row[pivotKey].value.raw,
+                        value: row[pivotKey]?.value.raw,
                     })),
                 };
                 const pivotedKeyHash: string =
@@ -47,8 +47,8 @@ export const getPivotedData = (
                         pivotValuesMap[pivotKey] = {};
                     }
 
-                    pivotValuesMap[pivotKey][`${row[pivotKey].value.raw}`] =
-                        row[pivotKey].value;
+                    pivotValuesMap[pivotKey][`${row[pivotKey]?.value.raw}`] =
+                        row[pivotKey]?.value;
                 });
                 pivotedRow[pivotedKeyHash] = value;
                 rowKeyMap[pivotedKeyHash] = pivotReference;
@@ -104,13 +104,21 @@ export const getPlottedData = (
 };
 
 export const getPivotedDataFromPivotDetails = (
-    resultsData: InfiniteQueryResults,
+    resultsData: InfiniteQueryResults | undefined,
     itemsMap: ItemsMap | undefined,
 ): {
     pivotValuesMap: PivotValueMap;
     rowKeyMap: RowKeyMap;
     rows: ApiQueryResults['rows'];
 } => {
+    if (!resultsData) {
+        return {
+            pivotValuesMap: {},
+            rowKeyMap: {},
+            rows: [],
+        };
+    }
+
     const { pivotDetails, rows } = resultsData;
 
     if (!pivotDetails) {

--- a/packages/frontend/src/hooks/usePivotDimensions.ts
+++ b/packages/frontend/src/hooks/usePivotDimensions.ts
@@ -1,6 +1,5 @@
-import { FeatureFlags, type MetricQuery } from '@lightdash/common';
+import { type MetricQuery } from '@lightdash/common';
 import { useMemo, useState } from 'react';
-import { useFeatureFlag } from './useFeatureFlagEnabled';
 
 const usePivotDimensions = (
     initialPivotDimensions: string[] | undefined,
@@ -10,15 +9,7 @@ const usePivotDimensions = (
         initialPivotDimensions,
     );
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
-        FeatureFlags.UseSqlPivotResults,
-    );
-
     const validPivotDimensions = useMemo(() => {
-        if (useSqlPivotResults?.enabled) {
-            // If SQL pivot is enabled, we should always use the pivot value and let the backend handle the validation
-            return dirtyPivotDimensions;
-        }
         if (metricQuery) {
             const availableDimensions = metricQuery.dimensions;
 
@@ -34,7 +25,7 @@ const usePivotDimensions = (
             }
             return undefined;
         }
-    }, [metricQuery, dirtyPivotDimensions, useSqlPivotResults]);
+    }, [metricQuery, dirtyPivotDimensions]);
 
     return {
         validPivotDimensions,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5432

### Description:
Improves pivot configuration validation to prevent invalid pivot configurations. This PR:

1. Filters out pivot columns that are not in the metric query dimensions
2. Adds a validation function to check if a pivot configuration is valid
3. Ensures pivot columns don't overlap with index columns
4. Shows an error message for invalid pivot references in the UI
5. Prevents automatic fallback to pivot dimensions when using SQL pivot results

These changes make the pivot functionality more robust by ensuring only valid configurations are used, preventing potential errors when dimensions are removed from a query but still referenced in pivot settings.

**TLDR** This PR is a mix of fixes so the FE doesn't generate invalid pivot configuration and has better fallbacks. 

Before, we would throw errors when removing/re-adding fields used in the x-axis and group by:

<img width="1440" height="884" alt="Screenshot 2025-09-05 at 10 52 48" src="https://github.com/user-attachments/assets/0bf1590a-5042-4161-8524-bead273332bb" />
<img width="1718" height="818" alt="Screenshot 2025-09-05 at 17 27 00" src="https://github.com/user-attachments/assets/d8eb13f6-7813-48be-a45e-9050a6a186d8" />


Now, we should not get those errors and we allow user to remove an invalid group by value:

<img width="1831" height="822" alt="Screenshot 2025-09-05 at 17 10 12" src="https://github.com/user-attachments/assets/35c7159e-2449-4bd3-8d00-e63ae861436a" />