### PR TITLE
chore: lazy load  @monaco-editor/react imports in explore

### DIFF
--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -1,14 +1,13 @@
 import { subject } from '@casl/ability';
-import { ActionIcon, CopyButton, Tooltip } from '@mantine/core';
+import { ActionIcon, CopyButton, Skeleton, Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconCheck, IconClipboard } from '@tabler/icons-react';
-import { memo, type FC } from 'react';
+import { lazy, memo, Suspense, type FC } from 'react';
 import { useCompiledSql } from '../../../hooks/useCompiledSql';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
-import { RenderedSql } from '../../RenderedSql';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
 import OpenInSqlRunnerButton from './OpenInSqlRunnerButton';
@@ -16,6 +15,13 @@ import OpenInSqlRunnerButton from './OpenInSqlRunnerButton';
 interface SqlCardProps {
     projectUuid: string;
 }
+
+// Lazy load because it imports heavy module "@monaco-editor/react"
+const LazyRenderedSql = lazy(() =>
+    import('../../RenderedSql').then((module) => ({
+        default: module.RenderedSql,
+    })),
+);
 
 const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
     const { hovered, ref: headingRef } = useHover();
@@ -89,7 +95,9 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
                 )
             }
         >
-            <RenderedSql />
+            <Suspense fallback={<Skeleton height={60} radius="sm" />}>
+                <LazyRenderedSql />
+            </Suspense>
         </CollapsableCard>
     );
 });

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -3,21 +3,28 @@ import {
     ActionIcon,
     Divider,
     Group,
+    Loader,
     ScrollArea,
     Text,
     Tooltip,
 } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
-import { type FC, useMemo } from 'react';
+import { lazy, Suspense, useMemo, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { ConfigTabs as BigNumberConfigTabs } from '../../VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs';
 import { ConfigTabs as ChartConfigTabs } from '../../VisualizationConfigs/ChartConfigPanel/ConfigTabs';
-import { ConfigTabs as CustomVisConfigTabs } from '../../VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig';
 import { ConfigTabs as FunnelChartConfigTabs } from '../../VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs';
 import { ConfigTabs as PieChartConfigTabs } from '../../VisualizationConfigs/PieChartConfig/PieChartConfigTabs';
 import { ConfigTabs as TableConfigTabs } from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
 import { ConfigTabs as TreemapConfigTabs } from '../../VisualizationConfigs/TreemapConfig/TreemapConfigTabs';
 import VisualizationCardOptions from '../VisualizationCardOptions';
+
+// Lazy load CustomVisConfig as it includes the heavy Monaco editor
+const CustomVisConfigTabsLazy = lazy(() =>
+    import(
+        '../../VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig'
+    ).then((module) => ({ default: module.ConfigTabs })),
+);
 
 type Props = {
     chartType: ChartType;
@@ -40,7 +47,12 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
             case ChartType.TREEMAP:
                 return TreemapConfigTabs;
             case ChartType.CUSTOM:
-                return CustomVisConfigTabs;
+                // Return a wrapper component that handles lazy loading
+                return () => (
+                    <Suspense fallback={<Loader size="sm" />}>
+                        <CustomVisConfigTabsLazy />
+                    </Suspense>
+                );
             default:
                 return assertUnreachable(
                     chartType,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -12,11 +12,12 @@ import {
 import {
     Collapse,
     Group,
+    Loader,
     SegmentedControl,
     Stack,
     Switch,
 } from '@mantine/core';
-import { useMemo, type FC } from 'react';
+import { lazy, Suspense, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
@@ -24,7 +25,13 @@ import { useVisualizationContext } from '../../../LightdashVisualization/useVisu
 import { Config } from '../../common/Config';
 import { UnitInputsGrid } from '../common/UnitInputsGrid';
 import { ReferenceLines } from './ReferenceLines';
-import { TooltipConfig } from './TooltipConfig';
+
+// Lazy load because it imports heavy module "@monaco-editor/react"
+const TooltipConfig = lazy(() =>
+    import('./TooltipConfig').then((module) => ({
+        default: module.TooltipConfig,
+    })),
+);
 
 enum Positions {
     Left = 'left',
@@ -217,7 +224,9 @@ export const Legend: FC<Props> = ({ items }) => {
                 <ReferenceLines items={items} projectUuid={projectUuid} />
             )}
             {projectUuid && (
-                <TooltipConfig fields={autocompleteFieldsTooltip} />
+                <Suspense fallback={<Loader size="sm" />}>
+                    <TooltipConfig fields={autocompleteFieldsTooltip} />
+                </Suspense>
             )}
         </Stack>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #[issue number]

### Description:
Implemented lazy loading for heavy components that import the Monaco editor to improve initial load performance. This includes:

1. Lazy loaded `RenderedSql` component in `SqlCard` with a skeleton loading state
2. Lazy loaded `CustomVisConfig` in `VisualizationConfig` with a loader fallback
3. Lazy loaded `TooltipConfig` in the Legend component with a loader fallback

These changes will reduce the initial bundle size and improve page load times by only loading the Monaco editor when these specific components are actually needed.

Improvement: 20%

Before

```
sdk/dist/sdk.css 492.91 kB │ gzip: 51.69 kB
sdk/dist/sdk.cjs.js 0.31 kB │ gzip: 0.24 kB │ map: 0.09 kB
sdk/dist/IconAlignRight-BolwD1bi.js 0.50 kB │ gzip: 0.26 kB │ map: 1.74 kB
sdk/dist/setupLanguageMode-ccr_yV0z.js 4.35 kB │ gzip: 1.66 kB │ map: 16.01 kB
sdk/dist/bigquery-BGv8aVH7.js 7.16 kB │ gzip: 2.75 kB │ map: 19.01 kB
sdk/dist/snowflake-BP_IoTSN.js 13.27 kB │ gzip: 4.53 kB │ map: 29.44 kB
sdk/dist/pivotQueryResults-BRZhKzzm.js 24.28 kB │ gzip: 8.21 kB │ map: 168.43 kB
sdk/dist/SqlRunner-B9CLj9eN.js 141.99 kB │ gzip: 40.23 kB │ map: 699.21 kB
sdk/dist/index.es-BG8dAkUZ.js 159.92 kB │ gzip: 53.32 kB │ map: 649.31 kB
sdk/dist/html2canvas.esm-BvY_5rbt.js 202.42 kB │ gzip: 47.78 kB │ map: 603.32 kB
sdk/dist/index-Bw7OwIY6.js 368.53 kB │ gzip: 111.82 kB │ map: 1,656.09 kB
sdk/dist/index-D3kQ4pNj.js 857.75 kB │ gzip: 294.35 kB │ map: 3,923.31 kB
sdk/dist/vega-lite-schema-Bqfs3PfJ.js 1,440.37 kB │ gzip: 136.57 kB │ map: 0.11 kB
sdk/dist/index-CkxydP4L.js 12,496.61 kB │ gzip: 3,185.07 kB │ map: 39,674.97 kB
```

After

```
sdk/dist/stats.html                     5,841.21 kB │ gzip:   473.79 kB
sdk/dist/sdk.css                          492.91 kB │ gzip:    51.67 kB
sdk/dist/sdk.cjs.js                         0.31 kB │ gzip:     0.24 kB │ map:      0.09 kB
sdk/dist/IconAlignRight-mtYZsK1C.js         0.50 kB │ gzip:     0.26 kB │ map:      1.74 kB
sdk/dist/RenderedSql-CEKzvjIi.js            1.76 kB │ gzip:     0.90 kB │ map:      5.99 kB
sdk/dist/TooltipConfig-CxfCJ6rZ.js          3.10 kB │ gzip:     1.66 kB │ map:     12.47 kB
sdk/dist/setupLanguageMode-BuMTOppj.js      4.35 kB │ gzip:     1.66 kB │ map:     16.01 kB
sdk/dist/bigquery-BGv8aVH7.js               7.16 kB │ gzip:     2.75 kB │ map:     19.01 kB
sdk/dist/CustomVisConfig-C0_z8lnZ.js       11.06 kB │ gzip:     4.48 kB │ map:     44.70 kB
sdk/dist/snowflake-BP_IoTSN.js             13.27 kB │ gzip:     4.53 kB │ map:     29.44 kB
sdk/dist/index-BSBYjd3T.js                 14.20 kB │ gzip:     4.90 kB │ map:     47.76 kB
sdk/dist/pivotQueryResults-Dc3kX3zJ.js     24.29 kB │ gzip:     8.22 kB │ map:    168.43 kB
sdk/dist/SqlRunner-Bcz_0lcq.js            142.04 kB │ gzip:    40.27 kB │ map:    699.21 kB
sdk/dist/index.es-DsIRdBUD.js             159.92 kB │ gzip:    53.32 kB │ map:    649.31 kB
sdk/dist/html2canvas.esm-BvY_5rbt.js      202.42 kB │ gzip:    47.78 kB │ map:    603.32 kB
sdk/dist/index-Cyry0bNQ.js                368.53 kB │ gzip:   111.81 kB │ map:  1,656.09 kB
sdk/dist/index-BrCNGvfC.js                857.75 kB │ gzip:   294.35 kB │ map:  3,923.31 kB
sdk/dist/vega-lite-schema-Bqfs3PfJ.js   1,440.37 kB │ gzip:   136.57 kB │ map:      0.11 kB
sdk/dist/monaco-CeBxdM70.js             2,133.83 kB │ gzip:   553.34 kB │ map:  8,237.88 kB
sdk/dist/index-DWoHBfQ0.js              9,991.77 kB │ gzip: 2,572.18 kB │ map: 31,371.38 kB
```
