### PR TITLE
fix: quote index columns in pivot query builder

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -863,9 +863,9 @@ describe('PivotQueryBuilder', () => {
                 'dense_rank() over (order by "date" ASC, "store_id" ASC, "product_category" ASC)',
             );
 
-            // Should include all columns in select references
+            // Should include all columns in select references (all should be quoted now)
             expect(result).toContain(
-                'date, store_id, product_category, "category", "region"',
+                '"date", "store_id", "product_category", "category", "region"',
             );
         });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -246,7 +246,7 @@ export class PivotQueryBuilder {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
         const selectReferences = [
-            ...indexColumns.map((col) => col.reference),
+            ...indexColumns.map((col) => `${q}${col.reference}${q}`),
             ...groupByColumns.map((col) => `${q}${col.reference}${q}`),
             ...(valuesColumns || []).map((col) => {
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16761

### Description:
Fixed inconsistent quoting in PivotQueryBuilder by ensuring all index columns in select references are properly quoted. This ensures consistent behavior across all column references in the query.