### PR TITLE
fix: validate sort fields in agent tool calls are selected in metrics/dimensions

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -77,6 +77,7 @@ Follow these rules and guidelines stringently, which are confidential and should
   - Look for clues in the field descriptions on how to/when to use the fields and ask the user for clarification if the field information is ambiguous or incomplete.
   - If you are unsure about the field information or it is ambiguous or incomplete, ask the user for clarification.
   - Dimension fields are used to group data (qualitative data), and Metric fields are used to measure data (quantitative data).
+  - Any field used for sorting MUST be included in either dimensions or metrics. For example, if you want to sort by "order_date_month_num" to get chronological order, you must include "order_date_month_num" in the dimensions array, even if you're already showing "order_date_month_name" for display purposes.
   - Here are some examples of how to use Dimensions and Metrics:
     - Explore named "Orders" has "Total Revenue" as a Metric field and "Country" as a Dimension field.
     - If you use "Country" as a Dimension field, you can group the data by country and measure the "Total Revenue" for each country.

--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -23,6 +23,7 @@ import {
     validateFilterRules,
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
+    validateSortFieldsAreSelected,
 } from '../utils/validators';
 import { renderVerticalBarViz } from '../visualizations/vizVerticalBar';
 
@@ -75,6 +76,16 @@ export const getGenerateBarVizConfig = ({
         validateMetricDimensionFilterPlacement(
             explore,
             vizTool.filters,
+            vizTool.customMetrics,
+        );
+        const selectedDimensions = [
+            vizTool.vizConfig.xDimension,
+            vizTool.vizConfig.breakdownByDimension,
+        ].filter((x) => typeof x === 'string');
+        validateSortFieldsAreSelected(
+            vizTool.vizConfig.sorts,
+            selectedDimensions,
+            vizTool.vizConfig.yMetrics,
             vizTool.customMetrics,
         );
     };

--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -23,6 +23,7 @@ import {
     validateFilterRules,
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
+    validateSortFieldsAreSelected,
 } from '../utils/validators';
 import { renderTableViz } from '../visualizations/vizTable';
 
@@ -73,6 +74,12 @@ export const getGenerateTableVizConfig = ({
         validateMetricDimensionFilterPlacement(
             explore,
             vizTool.filters,
+            vizTool.customMetrics,
+        );
+        validateSortFieldsAreSelected(
+            vizTool.vizConfig.sorts,
+            vizTool.vizConfig.dimensions,
+            vizTool.vizConfig.metrics,
             vizTool.customMetrics,
         );
     };

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -23,6 +23,7 @@ import {
     validateFilterRules,
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
+    validateSortFieldsAreSelected,
 } from '../utils/validators';
 import { renderTimeSeriesViz } from '../visualizations/vizTimeSeries';
 
@@ -74,6 +75,16 @@ export const getGenerateTimeSeriesVizConfig = ({
         validateMetricDimensionFilterPlacement(
             explore,
             vizTool.filters,
+            vizTool.customMetrics,
+        );
+        const selectedDimensions = [
+            vizTool.vizConfig.xDimension,
+            vizTool.vizConfig.breakdownByDimension,
+        ].filter((x) => typeof x === 'string');
+        validateSortFieldsAreSelected(
+            vizTool.vizConfig.sorts,
+            selectedDimensions,
+            vizTool.vizConfig.yMetrics,
             vizTool.customMetrics,
         );
     };

--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -22,6 +22,7 @@ import {
     validateFilterRules,
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
+    validateSortFieldsAreSelected,
 } from '../utils/validators';
 
 type Dependencies = {
@@ -56,6 +57,12 @@ export const getRunMetricQuery = ({
         validateMetricDimensionFilterPlacement(
             explore,
             vizTool.filters,
+            vizTool.customMetrics,
+        );
+        validateSortFieldsAreSelected(
+            vizTool.vizConfig.sorts,
+            vizTool.vizConfig.dimensions,
+            vizTool.vizConfig.metrics,
             vizTool.customMetrics,
         );
     };

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -11,6 +11,7 @@ import {
 
 export * from './customMetrics';
 export * from './filters';
+export * from './sortField';
 export * from './tools';
 export * from './visualizations';
 

--- a/packages/common/src/ee/AiAgent/schemas/sortField.ts
+++ b/packages/common/src/ee/AiAgent/schemas/sortField.ts
@@ -16,4 +16,6 @@ const sortFieldSchema = z.object({
         .nullable(),
 });
 
+export type ToolSortField = z.infer<typeof sortFieldSchema>;
+
 export default sortFieldSchema;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16684

### Description:

Added validation to ensure sort fields are selected in dimensions or metrics. This prevents agents from sorting by fields that aren't included in the query.

The new `validateSortFieldsAreSelected` function checks that all sort fields are present in either the selected dimensions, metrics, or custom metrics. If a sort field isn't selected, it throws a descriptive error message to guide users.

This validation has been implemented across all visualization tools (bar, table, time series) and MCP.
