### PR TITLE
fix: improve Snowflake token refresh error handling

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -677,9 +677,18 @@ export class ProjectService extends BaseService {
                 this.logger.error(
                     `Error refreshing snowflake token: ${JSON.stringify(e)}`,
                 );
-                throw new SnowflakeTokenError(
-                    `Error refreshing snowflake token`,
-                );
+
+                let errorMessage = '';
+                try {
+                    // Try to get detailed error message from snowflake refresh token error
+                    const errorDetails = JSON.parse(
+                        (e as { data: string }).data,
+                    ).message;
+                    errorMessage = `Error refreshing snowflake token: ${errorDetails}`;
+                } catch (e2: unknown) {
+                    errorMessage = 'Error refreshing snowflake token';
+                }
+                throw new SnowflakeTokenError(errorMessage);
             }
         }
         return args;

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
@@ -228,8 +228,10 @@ export const ExploreErrorState = ({
         title="Error loading results"
         description={
             <Fragment>
-                {errorDetail?.message ||
-                    'There was an error loading the results'}
+                <Text style={{ whiteSpace: 'pre-wrap' }}>
+                    {errorDetail?.message ||
+                        'There was an error loading the results'}
+                </Text>
                 {errorDetail?.data.documentationUrl && (
                     <Fragment>
                         <br />

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -1,5 +1,5 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
-import { Anchor } from '@mantine/core';
+import { Anchor, Text } from '@mantine/core';
 import { IconChartBarOff } from '@tabler/icons-react';
 import { Fragment, memo, type FC } from 'react';
 import { EmptyState } from '../common/EmptyState';
@@ -53,7 +53,9 @@ const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
                     title="Unable to load visualization"
                     description={
                         <Fragment>
-                            {apiErrorDetail.message}
+                            <Text style={{ whiteSpace: 'pre-wrap' }}>
+                                {apiErrorDetail.message || ''}
+                            </Text>
                             {apiErrorDetail.data.documentationUrl && (
                                 <Fragment>
                                     <br />

--- a/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
+++ b/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
@@ -37,7 +37,12 @@ const SuboptimalState: FC<Props> = ({
                 <MantineIcon color="gray.5" size="xxl" icon={icon} />
             )}
             {title && (
-                <Text color="gray.7" fz={18} fw={600}>
+                <Text
+                    color="gray.7"
+                    fz={18}
+                    fw={600}
+                    style={{ whiteSpace: 'pre-wrap' }}
+                >
                     {title}
                 </Text>
             )}

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -91,3 +91,114 @@ describe('SnowflakeTypeParsing', () => {
         expect(mapFieldType('VARCHAR(12)')).toEqual(DimensionType.STRING);
     });
 });
+
+describe('SnowflakeErrorParsing', () => {
+    let warehouse: SnowflakeWarehouseClient;
+    const originalEnv = process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE;
+
+    beforeEach(() => {
+        warehouse = new SnowflakeWarehouseClient(credentials);
+    });
+
+    afterEach(() => {
+        // Restore original environment variable
+        if (originalEnv) {
+            process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE = originalEnv;
+        } else {
+            delete process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE;
+        }
+    });
+
+    it('should return custom error message when SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE is set', () => {
+        // Set environment variable
+        process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE =
+            "You don't have access to the {snowflakeTable} table. Please go to 'analytics_{snowflakeSchema}' in sailpoint and request access";
+
+        const error = {
+            message:
+                "SQL compilation error: Object 'SNOWFLAKE_DATABASE_STAGING.JAFFLE.EVENTS' does not exist or not authorized.",
+            code: 'COMPILATION',
+            data: { type: 'COMPILATION' },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = warehouse.parseError(error as any);
+
+        expect(result.message).toBe(
+            "You don't have access to the EVENTS table. Please go to 'analytics_JAFFLE' in sailpoint and request access",
+        );
+    });
+
+    it('should return original error message when SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE is not set', () => {
+        // Make sure environment variable is not set
+        delete process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE;
+
+        const error = {
+            message:
+                "SQL compilation error: Object 'SNOWFLAKE_DATABASE_STAGING.JAFFLE.EVENTS' does not exist or not authorized.",
+            code: 'COMPILATION',
+            data: { type: 'COMPILATION' },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = warehouse.parseError(error as any);
+
+        expect(result.message).toBe(
+            "SQL compilation error: Object 'SNOWFLAKE_DATABASE_STAGING.JAFFLE.EVENTS' does not exist or not authorized.",
+        );
+    });
+
+    it('should return original error message for non-unauthorized errors', () => {
+        // Set environment variable
+        process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE =
+            "You don't have access to the {snowflakeTable} table. Please go to 'analytics_{snowflakeSchema}' in sailpoint and request access";
+
+        const error = {
+            message: 'Some other SQL error',
+            code: 'COMPILATION',
+            data: { type: 'COMPILATION' },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = warehouse.parseError(error as any);
+
+        expect(result.message).toBe('Some other SQL error');
+    });
+
+    it('should handle table names with different formats', () => {
+        process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE =
+            'Access denied for {snowflakeTable} in {snowflakeSchema}';
+
+        const error = {
+            message:
+                "Object 'DB.MY_SCHEMA.MY_TABLE' does not exist or not authorized.",
+            code: 'COMPILATION',
+            data: { type: 'COMPILATION' },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = warehouse.parseError(error as any);
+
+        expect(result.message).toBe('Access denied for MY_TABLE in MY_SCHEMA');
+    });
+
+    it('should handle errors without table information gracefully', () => {
+        process.env.SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE =
+            "You don't have access to the {snowflakeTable} table. Please go to 'analytics_{snowflakeSchema}' in sailpoint and request access";
+
+        const error = {
+            message:
+                "Object 'INCOMPLETE_TABLE_NAME' does not exist or not authorized.",
+            code: 'COMPILATION',
+            data: { type: 'COMPILATION' },
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = warehouse.parseError(error as any);
+
+        // Should still use custom message but without variable replacement
+        expect(result.message).toBe(
+            "You don't have access to the {snowflakeTable} table. Please go to 'analytics_{snowflakeSchema}' in sailpoint and request access",
+        );
+    });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #16717

Related thread: https://lightdash.slack.com/archives/C08TPMFGGTX/p1757342003467799?thread_ts=1757339728.562449&cid=C08TPMFGGTX
- Expose the full snowflake error in the general case 

Already done for most cases, I only added some extra information for SSO 

Before

<img width="1667" height="844" alt="Screenshot from 2025-09-08 13-31-05" src="https://github.com/user-attachments/assets/71393c8b-124a-4338-ba75-962a0b077105" />

After

<img width="1667" height="844" alt="Screenshot from 2025-09-08 13-45-03" src="https://github.com/user-attachments/assets/76f040fb-c3e0-40c5-b670-35c10b4d7b77" />


- In the specific case of not having access to a schema, intercept the error and format it to something more useful
- Allow (through env vars) the ability to provide a link to extend the schema error with a link to external docs.

Before

<img width="1243" height="640" alt="Screenshot from 2025-09-08 15-53-16" src="https://github.com/user-attachments/assets/12374bbb-09cd-4145-ad5c-771275f1806f" />

After

<img width="1253" height="382" alt="Screenshot from 2025-09-08 16-47-04" src="https://github.com/user-attachments/assets/2f450a90-f0f7-4834-8443-74cba8905e8e" />

Adds support to multinline strings 

<img width="1254" height="366" alt="Screenshot from 2025-09-10 13-48-16" src="https://github.com/user-attachments/assets/ea90b07c-3ea3-4281-88f3-ae8d6a297755" />

<img width="1678" height="793" alt="Screenshot from 2025-09-10 13-52-16" src="https://github.com/user-attachments/assets/bc9af4fc-5b92-4998-8b47-41c7bcfa3ef0" />

<img width="451" height="221" alt="image" src="https://github.com/user-attachments/assets/3dc50536-2314-47ea-bd5c-5f496a513a0d" />

### Description:
Improves error handling when refreshing Snowflake tokens by extracting and displaying detailed error messages from the Snowflake API response. When a token refresh fails, the system now attempts to parse the error data to provide more specific information about what went wrong, rather than just showing a generic error message.