### PR TITLE
refactor: replace FollowUpTools enum with AiResultType

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -8,6 +8,7 @@ import {
     AiAgentUserPreferences,
     AiDuplicateSlackPromptError,
     AiMetricQueryWithFilters,
+    AiResultType,
     AiVizMetadata,
     AiWebAppPrompt,
     ApiAiAgentThreadCreateRequest,
@@ -21,7 +22,6 @@ import {
     CatalogType,
     CommercialFeatureFlags,
     filterExploreByTags,
-    FollowUpTools,
     followUpToolsText,
     ForbiddenError,
     isSlackPrompt,
@@ -2488,7 +2488,7 @@ export class AiAgentService {
 
     // eslint-disable-next-line class-methods-use-this
     public handleExecuteFollowUpTool(app: App) {
-        Object.values(FollowUpTools).forEach((tool) => {
+        Object.values(AiResultType).forEach((tool) => {
             app.action(
                 `execute_follow_up_tool.${tool}`,
                 async ({ ack, body, context, say }) => {

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -1,7 +1,6 @@
 import {
     followUpToolsSchema,
     followUpToolsText,
-    MetricQuery,
     parseVizConfig,
     SlackPrompt,
 } from '@lightdash/common';

--- a/packages/common/src/ee/AiAgent/followUpTools.ts
+++ b/packages/common/src/ee/AiAgent/followUpTools.ts
@@ -1,19 +1,14 @@
 import { z } from 'zod';
-
-export enum FollowUpTools {
-    GENERATE_TABLE = 'generate_table',
-    GENERATE_BAR_VIZ = 'generate_bar_viz',
-    GENERATE_TIME_SERIES_VIZ = 'generate_time_series_viz',
-}
+import { AiResultType } from './types';
 
 export type FollowUpToolsText = {
-    [key in FollowUpTools]: string;
+    [key in AiResultType]: string;
 };
 
 export const followUpToolsText: FollowUpToolsText = {
-    [FollowUpTools.GENERATE_TABLE]: 'Generate a Table',
-    [FollowUpTools.GENERATE_BAR_VIZ]: 'Generate a Bar Chart',
-    [FollowUpTools.GENERATE_TIME_SERIES_VIZ]: 'Generate a Time Series Chart',
+    [AiResultType.TABLE_RESULT]: 'Generate a Table',
+    [AiResultType.VERTICAL_BAR_RESULT]: 'Generate a Bar Chart',
+    [AiResultType.TIME_SERIES_RESULT]: 'Generate a Time Series Chart',
 };
 
-export const followUpToolsSchema = z.nativeEnum(FollowUpTools).array();
+export const followUpToolsSchema = z.nativeEnum(AiResultType).array();

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
@@ -25,8 +24,8 @@ export const toolTableVizArgsSchema = createToolSchema(
         followUpTools: z
             .array(
                 z.union([
-                    z.literal(FollowUpTools.GENERATE_BAR_VIZ),
-                    z.literal(FollowUpTools.GENERATE_TIME_SERIES_VIZ),
+                    z.literal(AiResultType.VERTICAL_BAR_RESULT),
+                    z.literal(AiResultType.TIME_SERIES_RESULT),
                 ]),
             )
             .describe(

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
@@ -25,12 +24,12 @@ export const toolTimeSeriesArgsSchema = createToolSchema(
         followUpTools: z
             .array(
                 z.union([
-                    z.literal(FollowUpTools.GENERATE_BAR_VIZ),
-                    z.literal(FollowUpTools.GENERATE_TIME_SERIES_VIZ),
+                    z.literal(AiResultType.TABLE_RESULT),
+                    z.literal(AiResultType.VERTICAL_BAR_RESULT),
                 ]),
             )
             .describe(
-                `The actions the User can ask for after the AI has generated the chart. NEVER include ${FollowUpTools.GENERATE_TIME_SERIES_VIZ} in this list.`,
+                `The actions the User can ask for after the AI has generated the chart.`,
             ),
     })
     .build();

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { FollowUpTools } from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
@@ -25,12 +24,12 @@ export const toolVerticalBarArgsSchema = createToolSchema(
         followUpTools: z
             .array(
                 z.union([
-                    z.literal(FollowUpTools.GENERATE_BAR_VIZ),
-                    z.literal(FollowUpTools.GENERATE_TIME_SERIES_VIZ),
+                    z.literal(AiResultType.TABLE_RESULT),
+                    z.literal(AiResultType.TIME_SERIES_RESULT),
                 ]),
             )
             .describe(
-                `The actions the User can ask for after the AI has generated the chart. NEVER include ${FollowUpTools.GENERATE_BAR_VIZ} in this list.`,
+                `The actions the User can ask for after the AI has generated the chart.`,
             ),
     })
     .build();

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -9,7 +9,6 @@ import type {
 export enum AiResultType {
     TIME_SERIES_RESULT = 'time_series_chart',
     VERTICAL_BAR_RESULT = 'vertical_bar_chart',
-    ONE_LINE_RESULT = 'one_line_result',
     TABLE_RESULT = 'table',
 }
 


### PR DESCRIPTION
### Description:
Refactored AI agent follow-up tools to use the `AiResultType` enum instead of the separate `FollowUpTools` enum. This consolidates the visualization types into a single enum, improving code consistency and maintainability.

The PR updates the follow-up tool references in multiple files, including the Slack blocks generation, tool schemas for different visualization types (table, time series, vertical bar), and the AI agent service.

Additionally, removed the unused `ONE_LINE_RESULT` type from the `AiResultType` enum and updated the follow-up tool descriptions to be more accurate.