### PR TITLE
fix: allows union types when compiling dbt yaml schema

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -48,7 +48,10 @@ export default class DbtSchemaEditor {
 
     constructor(doc: string = '', filename: string = '') {
         this.doc = parseDocument(doc);
-        const ajvCompiler = new Ajv({ coerceTypes: true });
+        const ajvCompiler = new Ajv({
+            coerceTypes: true,
+            allowUnionTypes: true,
+        });
         const validate = ajvCompiler.compile<YamlSchema>(
             lightdashDbtYamlSchema,
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16793

### Description:
Enable union types in the Ajv schema validator for the DBT Schema Editor. This change allows the schema validator to accept multiple types for a single property, providing more flexibility in schema validation.

Similar to `packages/common/src/utils/loadLightdashProjectConfig.ts`

#### Error
```
strict mode: use allowUnionTypes to allow union type keyword at "#/properties/models/items/properties/meta/properties/parameters/patternProperties/%5E%5Ba-zA-Z0-9_-%5D%2B%24/properties/default/oneOf/1…
```