### PR TITLE
fix: parameters only wait for active tab

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,5 @@
 import {
     ContentType,
-    type DashboardTab,
     type DashboardTile,
     type Dashboard as IDashboard,
 } from '@lightdash/common';
@@ -42,11 +41,10 @@ import '../styles/react-grid.css';
 
 const Dashboard: FC = () => {
     const navigate = useNavigate();
-    const { projectUuid, dashboardUuid, mode, tabUuid } = useParams<{
+    const { projectUuid, dashboardUuid, mode } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
         mode?: string;
-        tabUuid?: string;
     }>();
     const { data: spaces } = useSpaceSummaries(projectUuid, true);
 
@@ -80,6 +78,8 @@ const Dashboard: FC = () => {
     const setHaveTabsChanged = useDashboardContext((c) => c.setHaveTabsChanged);
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
+    const activeTab = useDashboardContext((c) => c.activeTab);
+    const setActiveTab = useDashboardContext((c) => c.setActiveTab);
     const setDashboardFilters = useDashboardContext(
         (c) => c.setDashboardFilters,
     );
@@ -171,7 +171,6 @@ const Dashboard: FC = () => {
         useDisclosure();
 
     // tabs state
-    const [activeTab, setActiveTab] = useState<DashboardTab | undefined>();
     const [addingTab, setAddingTab] = useState<boolean>(false);
 
     const hasDashboardTiles = dashboardTiles && dashboardTiles.length > 0;
@@ -186,19 +185,12 @@ const Dashboard: FC = () => {
         setDashboardTiles(dashboard?.tiles ?? []);
         setDashboardTabs(dashboard?.tabs ?? []);
         setSavedParameters(dashboard?.parameters ?? {});
-        setActiveTab(
-            () =>
-                dashboard?.tabs.find((tab) => tab.uuid === tabUuid) ??
-                dashboard?.tabs[0],
-        );
     }, [
         isDashboardLoading,
         dashboard,
         dashboardTiles,
         setDashboardTiles,
         setDashboardTabs,
-        setActiveTab,
-        tabUuid,
         setSavedParameters,
     ]);
 
@@ -244,16 +236,6 @@ const Dashboard: FC = () => {
                 );
                 setDashboardTabs(unsavedDashboardTabs);
                 setHaveTabsChanged(!!unsavedDashboardTabs);
-                if (activeTab === undefined) {
-                    // set up the active tab to previously selected tab
-                    const activeTabUuid =
-                        sessionStorage.getItem('activeTabUuid');
-                    setActiveTab(
-                        unsavedDashboardTabs.find(
-                            (tab: DashboardTab) => tab.uuid === activeTabUuid,
-                        ) ?? unsavedDashboardTabs[0],
-                    );
-                }
             } catch {
                 showToastError({
                     title: 'Error parsing tabs',

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -36,6 +36,10 @@ export type DashboardContextType = {
     setHaveTabsChanged: Dispatch<SetStateAction<boolean>>;
     dashboardTabs: Dashboard['tabs'];
     setDashboardTabs: Dispatch<SetStateAction<Dashboard['tabs']>>;
+    activeTab: Dashboard['tabs'][number] | undefined;
+    setActiveTab: Dispatch<
+        SetStateAction<Dashboard['tabs'][number] | undefined>
+    >;
     dashboardFilters: DashboardFilters;
     dashboardTemporaryFilters: DashboardFilters;
     allFilters: DashboardFilters;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16734

### Description:

When there were multiple tabs on a dashboard with parameters, the parameter inputs never finished loading because we were waiting for all charts and we don't load the charts from hidden tabs. 

This moves the tab state to the provider, then only counts charts on the active tab for loading the paramters.

The parameters input will add new parameters if more are added when more tabs load. 

I'll put a demo below, but the tests steps are:
- Create two charts with two different parameters
- Put them on the same dashboard on different tabs
- Whichever tab you start on, the parameters input should populate 
- When you switch tabs, you should get those extra parameters

 
![Kapture 2025-09-09 at 15 30 10](https://github.com/user-attachments/assets/8f5b9cd3-5267-47bb-87c6-a7b836868efa)
