### PR TITLE
feat: enable duplicating initial custom role

### DIFF
--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -13,6 +13,11 @@ const useStyles = createStyles((theme) => ({
     scopeDescription: {
         color: theme.colors.dark[2],
     },
+    row: {
+        '& td': {
+            maxWidth: 400,
+        },
+    },
 }));
 
 const TableRow: FC<{
@@ -24,7 +29,7 @@ const TableRow: FC<{
     const { classes } = useStyles();
 
     return (
-        <tr>
+        <tr className={classes.row}>
             <td>{name}</td>
             <td className={classes.scopeDescription}>{description || ''}</td>
             <td>{createdAt ? formatDate(createdAt) : '-'}</td>

--- a/packages/frontend/src/ee/features/customRoles/components/AddRoleButton.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/AddRoleButton.tsx
@@ -1,0 +1,38 @@
+import { Button, Menu } from '@mantine/core';
+
+import { IconPlus } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+
+type Props = {
+    onClickDuplicate: () => void;
+    size?: 'md' | 'xs';
+};
+
+/**
+ * Reusable button for adding new custom roles that includes a menu to decide between creating
+ * a new role or duplicating an existing one.
+ */
+export const AddRoleButton: FC<Props> = ({ onClickDuplicate, size = 'md' }) => {
+    return (
+        <Menu position="bottom-end">
+            <Menu.Target>
+                <Button size={size} leftIcon={<MantineIcon icon={IconPlus} />}>
+                    Add role
+                </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+                <Menu.Item
+                    component={Link}
+                    to="/generalSettings/customRoles/create"
+                >
+                    Create new role
+                </Menu.Item>
+                <Menu.Item onClick={onClickDuplicate}>
+                    Duplicate existing role
+                </Menu.Item>
+            </Menu.Dropdown>
+        </Menu>
+    );
+};

--- a/packages/frontend/src/ee/features/customRoles/useCustomRoles.ts
+++ b/packages/frontend/src/ee/features/customRoles/useCustomRoles.ts
@@ -60,6 +60,9 @@ export const useCustomRoles = () => {
             await queryClient.invalidateQueries({
                 queryKey: [CACHE_KEY, organization?.organizationUuid],
             });
+            await queryClient.invalidateQueries({
+                queryKey: [ALL_ROLES_CACHE_KEY, organization?.organizationUuid],
+            });
             showToastSuccess({
                 title: `Custom role created successfully`,
             });

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
@@ -1,12 +1,13 @@
-import { Button, Group, Menu, Stack, Title } from '@mantine/core';
-import { IconIdBadge2, IconPlus } from '@tabler/icons-react';
+import { Group, Stack, Title } from '@mantine/core';
+import { IconIdBadge2 } from '@tabler/icons-react';
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 
 import { type RoleWithScopes } from '@lightdash/common';
 import { EmptyState } from '../../../components/common/EmptyState';
 import MantineIcon from '../../../components/common/MantineIcon';
 import PageSpinner from '../../../components/PageSpinner';
+import { AddRoleButton } from '../../features/customRoles/components/AddRoleButton';
 import { CustomRolesTable } from '../../features/customRoles/CustomRolesTable';
 import { DuplicateRoleModal } from '../../features/customRoles/DuplicateRoleModal';
 import { useCustomRoles } from '../../features/customRoles/useCustomRoles';
@@ -47,31 +48,12 @@ export const CustomRoles = () => {
                 <>
                     <Group position="apart">
                         <Title order={5}>Custom roles</Title>
-                        <Menu position="bottom-end">
-                            <Menu.Target>
-                                <Button
-                                    size="xs"
-                                    leftIcon={<MantineIcon icon={IconPlus} />}
-                                >
-                                    Add role
-                                </Button>
-                            </Menu.Target>
-                            <Menu.Dropdown>
-                                <Menu.Item
-                                    component={Link}
-                                    to="/generalSettings/customRoles/create"
-                                >
-                                    Create new role
-                                </Menu.Item>
-                                <Menu.Item
-                                    onClick={() =>
-                                        setIsDuplicateModalOpen(true)
-                                    }
-                                >
-                                    Duplicate existing role
-                                </Menu.Item>
-                            </Menu.Dropdown>
-                        </Menu>
+                        <AddRoleButton
+                            onClickDuplicate={() =>
+                                setIsDuplicateModalOpen(true)
+                            }
+                            size="xs"
+                        />
                     </Group>
                     <CustomRolesTable
                         roles={listRoles?.data ?? []}
@@ -93,12 +75,10 @@ export const CustomRoles = () => {
                     title="No custom roles"
                     description="You haven't created any custom roles yet. Custom roles allow you to define specific permissions for your organization."
                 >
-                    <Button
-                        component={Link}
-                        to="/generalSettings/customRoles/create"
-                    >
-                        Create custom role
-                    </Button>
+                    <AddRoleButton
+                        onClickDuplicate={() => setIsDuplicateModalOpen(true)}
+                        size="md"
+                    />
                 </EmptyState>
             )}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16767

### Description:
Enhances the Custom Roles UI with several improvements:

1. Create a reusable `AddRoleButton` component with a dropdown menu for creating new roles or duplicating existing ones. Basically extracts the table's "Add role" button. 
2. Fixed table cell width by adding a max-width of 400px to prevent content from stretching the table. Noticed that the columns collapsed with long descriptions. 
3. Ensured proper cache invalidation when creating custom roles by adding invalidation for the ALL_ROLES_CACHE_KEY. I noticed that we had to refresh the page to duplicate newly created roles. 

### Before
![Screen Cast 2025-09-09 at 3 30 51 PM](https://github.com/user-attachments/assets/1a854e21-1226-4477-95db-813579ffdf9a)

### After
![Screen Cast 2025-09-09 at 3 29 09 PM](https://github.com/user-attachments/assets/a2674b35-7781-4859-bc58-969b578b8b30)
