### PR TITLE
fix: improve chart comparison by cleaning config and including parameters

### DIFF
--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -70,7 +70,7 @@ import {
     type ExplorerReduceState,
 } from './types';
 import { useQueryManager } from './useExplorerQueryManager';
-import { getValidChartConfig } from './utils';
+import { cleanConfig, getValidChartConfig } from './utils';
 
 const calcColumnOrder = (
     columnOrder: FieldId[],
@@ -1297,12 +1297,20 @@ const ExplorerProvider: FC<
             return !deepEqual(
                 removeEmptyProperties({
                     tableName: savedChart.tableName,
-                    chartConfig: savedChart.chartConfig,
+                    chartConfig: cleanConfig(savedChart.chartConfig),
                     metricQuery: savedChart.metricQuery,
                     tableConfig: savedChart.tableConfig,
                     pivotConfig: savedChart.pivotConfig,
+                    parameters: savedChart.parameters,
                 }),
-                removeEmptyProperties(unsavedChartVersion),
+                removeEmptyProperties({
+                    tableName: unsavedChartVersion.tableName,
+                    chartConfig: cleanConfig(unsavedChartVersion.chartConfig),
+                    metricQuery: unsavedChartVersion.metricQuery,
+                    tableConfig: unsavedChartVersion.tableConfig,
+                    pivotConfig: unsavedChartVersion.pivotConfig,
+                    parameters: unsavedChartVersion.parameters,
+                }),
             );
         }
         return isValidQuery;

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -2,6 +2,7 @@ import {
     ChartType,
     assertUnreachable,
     type ChartConfig,
+    type Series,
 } from '@lightdash/common';
 import omit from 'lodash/omit';
 import { EMPTY_CARTESIAN_CHART_CONFIG } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
@@ -112,11 +113,11 @@ export const getValidChartConfig = (
     }
 };
 
-// clean the config to remove isFilteredOut prop
-export const cleanConfig = (config: any) => {
+// Clean the config to remove runtime-only properties like isFilteredOut
+export const cleanConfig = (config: ChartConfig): ChartConfig => {
     if (
-        config?.type === ChartType.CARTESIAN &&
-        config?.config?.eChartsConfig?.series
+        config.type === ChartType.CARTESIAN &&
+        config.config?.eChartsConfig?.series
     ) {
         return {
             ...config,
@@ -124,8 +125,8 @@ export const cleanConfig = (config: any) => {
                 ...config.config,
                 eChartsConfig: {
                     ...config.config.eChartsConfig,
-                    series: config.config.eChartsConfig.series.map((s: any) =>
-                        omit(s, ['isFilteredOut']),
+                    series: config.config.eChartsConfig.series.map(
+                        (s: Series) => omit(s, ['isFilteredOut']),
                     ),
                 },
             },

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -3,6 +3,7 @@ import {
     assertUnreachable,
     type ChartConfig,
 } from '@lightdash/common';
+import omit from 'lodash/omit';
 import { EMPTY_CARTESIAN_CHART_CONFIG } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import { type ConfigCacheMap } from './types';
 
@@ -109,4 +110,26 @@ export const getValidChartConfig = (
                 `Invalid chart type ${chartType}`,
             );
     }
+};
+
+// clean the config to remove isFilteredOut prop
+export const cleanConfig = (config: any) => {
+    if (
+        config?.type === ChartType.CARTESIAN &&
+        config?.config?.eChartsConfig?.series
+    ) {
+        return {
+            ...config,
+            config: {
+                ...config.config,
+                eChartsConfig: {
+                    ...config.config.eChartsConfig,
+                    series: config.config.eChartsConfig.series.map((s: any) =>
+                        omit(s, ['isFilteredOut']),
+                    ),
+                },
+            },
+        };
+    }
+    return config;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16780

### Description:
Fixed chart comparison logic to properly detect changes between saved and unsaved chart versions. Added a `cleanConfig` utility function to remove the `isFilteredOut` property from chart series data before comparison, ensuring that UI-specific properties don't trigger false change detection. Also included parameters in the comparison to ensure all relevant chart properties are considered.

### Demo:
#### With isFilteredOut prop

https://github.com/user-attachments/assets/b6c89a98-1eb7-483b-9b6b-c34840a699cb

#### With parameters

https://github.com/user-attachments/assets/d630aaed-81ea-4c53-9f1c-cbd860ed9e36



