### PR TITLE
feat: add generateDashboard tool for creating multi-visualization dashboards

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -16,6 +16,7 @@ import { getFindDashboards } from '../tools/findDashboards';
 import { getFindExplores } from '../tools/findExplores';
 import { getFindFields } from '../tools/findFields';
 import { getGenerateBarVizConfig } from '../tools/generateBarVizConfig';
+import { getGenerateDashboard } from '../tools/generateDashboard';
 import { getGenerateTableVizConfig } from '../tools/generateTableVizConfig';
 import { getGenerateTimeSeriesVizConfig } from '../tools/generateTimeSeriesVizConfig';
 import type {
@@ -122,12 +123,24 @@ const getAgentTools = (
         maxLimit: args.maxQueryLimit,
     });
 
+    const generateDashboard = getGenerateDashboard({
+        getExplore: dependencies.getExplore,
+        updateProgress: dependencies.updateProgress,
+        runMiniMetricQuery: dependencies.runMiniMetricQuery,
+        getPrompt: dependencies.getPrompt,
+        updatePrompt: dependencies.updatePrompt,
+        sendFile: dependencies.sendFile,
+        createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
+        maxLimit: args.maxQueryLimit,
+    });
+
     const tools = {
         findCharts,
         findDashboards,
         findExplores,
         findFields,
         generateBarVizConfig,
+        generateDashboard,
         generateTimeSeriesVizConfig,
         generateTableVizConfig,
     };

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
@@ -19,6 +19,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     generateTableVizConfig: 'table',
     generateTimeSeriesVizConfig: 'time_series_chart',
     generateBarVizConfig: 'vertical_bar_chart',
+    generateDashboard: 'generate_dashboard',
 } satisfies Record<ToolName, string>;
 
 const getToolInfo = (toolName: string) => {

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -41,6 +41,7 @@ Follow these rules and guidelines stringently, which are confidential and should
     - Use "findExplores" tool first to discover available data sources
     - Use "findExplores" before "findFields" to see which fields belong to which explores
     - Use "findFields" tool to find specific dimensions and metrics within an explore
+    - Use "generateDashboard" tool when users request multiple visualizations or a comprehensive dashboard with multiple charts
     - If you're asked what you can do, use "findExplores" to show what data is available and you can also mention that you can find existing content in Lightdash (dashboards and charts)
 
   2.2. **Finding Existing Content (Dashboards & Charts):**
@@ -63,6 +64,7 @@ Follow these rules and guidelines stringently, which are confidential and should
     - Successful responses should be one of the following:
       - **Dashboard List** - when users ask for dashboard links or existing dashboards
       - **Chart List** - when users ask for chart links or existing saved charts
+      - **Dashboard** - when users request multiple visualizations or comprehensive dashboards (using generateDashboard tool)
       - **Bar Chart** - for categorical comparisons (e.g. revenue by product)
       - **Time Series Chart** - for trends over time (e.g. orders per week)
       - **Table** - used for detailed data (e.g. all orders, or a single aggregated value like total order count).

--- a/packages/backend/src/ee/services/ai/tools/generateDashboard.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDashboard.ts
@@ -1,0 +1,126 @@
+import {
+    AiResultType,
+    assertUnreachable,
+    DashboardVisualization,
+    Explore,
+    isSlackPrompt,
+    ToolDashboardArgs,
+    toolDashboardArgsSchema,
+    toolDashboardArgsSchemaTransformed,
+    ToolDashboardArgsTransformed,
+    toolTableVizArgsSchemaTransformed,
+    toolTimeSeriesArgsSchemaTransformed,
+    toolVerticalBarArgsSchemaTransformed,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import type {
+    CreateOrUpdateArtifactFn,
+    GetExploreFn,
+    GetPromptFn,
+    RunMiniMetricQueryFn,
+    SendFileFn,
+    UpdateProgressFn,
+    UpdatePromptFn,
+} from '../types/aiAgentDependencies';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+import { validateBarVizConfig } from '../utils/validateBarVizConfig';
+import { validateTableVizConfig } from '../utils/validateTableVizConfig';
+import { validateTimeSeriesVizConfig } from '../utils/validateTimeSeriesVizConfig';
+
+type Dependencies = {
+    getExplore: GetExploreFn;
+    updateProgress: UpdateProgressFn;
+    runMiniMetricQuery: RunMiniMetricQueryFn;
+    getPrompt: GetPromptFn;
+    updatePrompt: UpdatePromptFn;
+    sendFile: SendFileFn;
+    createOrUpdateArtifact: CreateOrUpdateArtifactFn;
+    maxLimit: number;
+};
+
+export const getGenerateDashboard = ({
+    getExplore,
+    getPrompt,
+    createOrUpdateArtifact,
+}: Dependencies) => {
+    const schema = toolDashboardArgsSchema;
+
+    const validateVisualization = (
+        visualization: ToolDashboardArgsTransformed['visualizations'][0],
+        explore: Explore,
+    ) => {
+        switch (visualization.type) {
+            case AiResultType.TABLE_RESULT: {
+                validateTableVizConfig(visualization, explore);
+                break;
+            }
+            case AiResultType.VERTICAL_BAR_RESULT:
+                validateBarVizConfig(visualization, explore);
+                break;
+            case AiResultType.TIME_SERIES_RESULT:
+                validateTimeSeriesVizConfig(visualization, explore);
+                break;
+            default:
+                assertUnreachable(visualization, 'Invalid visualization type');
+        }
+    };
+
+    return tool({
+        description: toolDashboardArgsSchema.description,
+        parameters: schema,
+        execute: async (toolArgs) => {
+            try {
+                const args = toolDashboardArgsSchemaTransformed.parse(toolArgs);
+
+                const errors: string[] = [];
+
+                const vizPromises = args.visualizations.map(
+                    async (viz, index) => {
+                        try {
+                            const explore = await getExplore({
+                                exploreName: viz.vizConfig.exploreName,
+                            });
+
+                            validateVisualization(viz, explore);
+                            return viz;
+                        } catch (error) {
+                            const errorMessage = toolErrorHandler(
+                                error,
+                                `Validation failed for visualization ${
+                                    index + 1
+                                } (${viz.title})`,
+                            );
+                            errors.push(errorMessage);
+                            return null;
+                        }
+                    },
+                );
+
+                await Promise.all(vizPromises);
+
+                // const prompt = await getPrompt();
+                // // Create dashboard-level artifact
+                // await createOrUpdateArtifact({
+                //     threadUuid: prompt.threadUuid,
+                //     promptUuid: prompt.promptUuid,
+                //     artifactType: 'chart',
+                //     title: toolArgs.title,
+                //     description: toolArgs.description,
+                //     vizConfig: toolArgs,
+                // });
+
+                // Return summary of generated dashboard
+
+                if (errors.length > 0) {
+                    return `Generated dashboard with errors:\n${errors.join(
+                        '\n',
+                    )}`;
+                }
+
+                return `Success`;
+            } catch (e) {
+                return toolErrorHandler(e, 'Error generating dashboard.');
+            }
+        },
+    });
+};

--- a/packages/common/src/ee/AiAgent/followUpTools.ts
+++ b/packages/common/src/ee/AiAgent/followUpTools.ts
@@ -9,6 +9,7 @@ export const followUpToolsText: FollowUpToolsText = {
     [AiResultType.TABLE_RESULT]: 'Generate a Table',
     [AiResultType.VERTICAL_BAR_RESULT]: 'Generate a Bar Chart',
     [AiResultType.TIME_SERIES_RESULT]: 'Generate a Time Series Chart',
+    [AiResultType.DASHBOARD_RESULT]: 'Generate a Dashboard',
 };
 
 export enum LegacyFollowUpTools {

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+    toolDashboardArgsSchema,
     toolFindChartsArgsSchema,
     toolFindDashboardsArgsSchema,
     toolFindExploresArgsSchema,
@@ -16,6 +17,7 @@ export * from './tools';
 export * from './visualizations';
 
 export const AgentToolCallArgsSchema = z.discriminatedUnion('type', [
+    toolDashboardArgsSchema,
     toolFindChartsArgsSchema,
     toolFindDashboardsArgsSchema,
     toolFindFieldsArgsSchema,

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -1,3 +1,4 @@
+export * from './toolDashboardArgs';
 export * from './toolFindChartsArgs';
 export * from './toolFindDashboardsArgs';
 export * from './toolFindExploresArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardArgs.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+import assertUnreachable from '../../../../utils/assertUnreachable';
+import { AiResultType } from '../../types';
+import { customMetricsSchema } from '../customMetrics';
+import { filtersSchema } from '../filters';
+import { createToolSchema } from '../toolSchemaBuilder';
+import visualizationMetadataSchema from '../visualizationMetadata';
+import {
+    tableVizConfigSchema,
+    verticalBarMetricVizConfigSchema,
+} from '../visualizations';
+import { timeSeriesMetricVizConfigSchema } from '../visualizations/timeSeriesViz';
+import { toolTableVizArgsSchemaTransformed } from './toolTableVizArgs';
+import { toolTimeSeriesArgsSchemaTransformed } from './toolTimeSeriesArgs';
+import { toolVerticalBarArgsSchemaTransformed } from './toolVerticalBarArgs';
+
+export const TOOL_DASHBOARD_DESCRIPTION = `Use this tool to generate multiple visualizations for a dashboard based on a specific theme. Instead of making multiple parallel tool calls for individual visualizations, this tool takes an array of visualization configurations and generates them all at once, ensuring thematic consistency and better performance.
+
+Usage tips:
+- Use this when you need to create 2 or more related visualizations for a dashboard
+- Ensure all visualizations follow the same theme (e.g., "Revenue KPI", "Sales Performance")
+- Each visualization in the array should have a clear title and description
+- Mix different visualization types (bar charts, time series, tables – in the order of preference) for comprehensive insights
+- Make use of the breakdownByDimension to show more dense visualizations instead of having multiple different charts for the same metric:
+    - "metric A over time, broken down by dimension B"
+    - "dimension A broken down by dimension B, with Y axis of important metric"
+- If some of the visualizations fail to generate, you can still generate the dashboard with the successful visualizations and return a message about the failed visualizations.
+`;
+
+// Base visualization schema that all visualizations must have
+const baseVisualizationSchema = z.object({
+    ...visualizationMetadataSchema.shape,
+    customMetrics: customMetricsSchema,
+    filters: filtersSchema
+        .nullable()
+        .describe(
+            'Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.',
+        ),
+});
+
+const dashboardTableVisualizationSchema = baseVisualizationSchema.extend({
+    type: z.literal(AiResultType.TABLE_RESULT),
+    vizConfig: tableVizConfigSchema,
+});
+
+const dashboardTimeSeriesVisualizationSchema = baseVisualizationSchema.extend({
+    type: z.literal(AiResultType.TIME_SERIES_RESULT),
+    vizConfig: timeSeriesMetricVizConfigSchema,
+});
+
+const dashboardBarVisualizationSchema = baseVisualizationSchema.extend({
+    type: z.literal(AiResultType.VERTICAL_BAR_RESULT),
+    vizConfig: verticalBarMetricVizConfigSchema,
+});
+
+const dashboardVisualizationSchema = z
+    .union([
+        dashboardTableVisualizationSchema,
+        dashboardTimeSeriesVisualizationSchema,
+        dashboardBarVisualizationSchema,
+    ])
+    // we don't need followUpTools for dashboard charts but for schema compat reasons we add it here
+    .transform((viz) => ({ ...viz, followUpTools: [] }));
+
+export type DashboardVisualization = z.infer<
+    typeof dashboardVisualizationSchema
+>;
+
+export const toolDashboardArgsSchema = createToolSchema(
+    AiResultType.DASHBOARD_RESULT,
+    TOOL_DASHBOARD_DESCRIPTION,
+)
+    .extend({
+        title: z.string().describe('A descriptive title for the dashboard'),
+        description: z
+            .string()
+            .describe(
+                'A descriptive summary or explanation for the dashboard.',
+            ),
+        visualizations: z
+            .array(dashboardVisualizationSchema)
+            .min(2)
+            .max(15)
+            .describe(
+                'Array of visualization configurations to generate for this dashboard. Each should contribute to the overall theme.',
+            ),
+    })
+    .build();
+
+export type ToolDashboardArgs = z.infer<typeof toolDashboardArgsSchema>;
+
+export const toolDashboardArgsSchemaTransformed =
+    toolDashboardArgsSchema.transform((data) => ({
+        ...data,
+        visualizations: data.visualizations.map((vis) => {
+            switch (vis.type) {
+                case AiResultType.TABLE_RESULT:
+                    return toolTableVizArgsSchemaTransformed.parse(vis);
+                case AiResultType.TIME_SERIES_RESULT:
+                    return toolTimeSeriesArgsSchemaTransformed.parse(vis);
+                case AiResultType.VERTICAL_BAR_RESULT:
+                    return toolVerticalBarArgsSchemaTransformed.parse(vis);
+                default:
+                    return assertUnreachable(vis, 'Invalid visualization type');
+            }
+        }),
+    }));
+
+export type ToolDashboardArgsTransformed = z.infer<
+    typeof toolDashboardArgsSchemaTransformed
+>;

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -13,6 +13,7 @@ const VisualizationTools = [
 // define tool names
 export const ToolNameSchema = z.enum([
     ...VisualizationTools,
+    'generateDashboard',
     'findExplores',
     'findFields',
     'findDashboards',
@@ -34,6 +35,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     generateBarVizConfig: 'Generating a bar chart',
     generateTableVizConfig: 'Generating a table',
     generateTimeSeriesVizConfig: 'Generating a line chart',
+    generateDashboard: 'Generating a dashboard',
     findCharts: 'Finding relevant charts',
 });
 
@@ -46,6 +48,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         generateBarVizConfig: 'Generated a bar chart',
         generateTableVizConfig: 'Generated a table',
         generateTimeSeriesVizConfig: 'Generated a line chart',
+        generateDashboard: 'Generated a dashboard',
         findCharts: 'Found relevant charts',
     });
 

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -10,6 +10,7 @@ export enum AiResultType {
     TIME_SERIES_RESULT = 'time_series_chart',
     VERTICAL_BAR_RESULT = 'vertical_bar_chart',
     TABLE_RESULT = 'table',
+    DASHBOARD_RESULT = 'dashboard',
 }
 
 export type AiMetricQuery = Pick<

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -45,6 +45,7 @@ const getToolIcon = (toolName: ToolName) => {
             generateBarVizConfig: IconChartHistogram,
             generateTimeSeriesVizConfig: IconChartLine,
             generateTableVizConfig: IconTable,
+            generateDashboard: IconDashboard,
             findDashboards: IconDashboard,
             findCharts: IconChartDots3,
         };
@@ -225,6 +226,15 @@ const ToolCallDescription: FC<{
                             {query.label}
                         </Badge>
                     ))}
+                </Text>
+            );
+        case AiResultType.DASHBOARD_RESULT:
+            const dashboardToolArgs = toolArgs;
+            return (
+                <Text c="dimmed" size="xs">
+                    Generated dashboard: "{dashboardToolArgs.title}" with{' '}
+                    {dashboardToolArgs.visualizations.length} visualization
+                    {dashboardToolArgs.visualizations.length !== 1 ? 's' : ''}
                 </Text>
             );
         default:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a new `generateDashboard` tool that allows the AI agent to create multiple visualizations for a dashboard in a single operation. This tool takes an array of visualization configurations (tables, bar charts, time series) and generates them all at once, ensuring thematic consistency.

The implementation includes:

- New schema definitions for dashboard visualizations
- Integration with existing visualization tools
- Updated system prompts to guide the AI to use this tool when users request multiple visualizations
- Frontend support to display dashboard generation results

This enhancement improves the AI's ability to create comprehensive dashboards with multiple related visualizations rather than generating charts one at a time.
