### PR TITLE
fix: filter invalid references in pivot configuration and validate value columns

### DIFF
--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -122,10 +122,16 @@ function getTablePivotConfiguration(
         .filter((col): col is NonNullable<typeof col> => col !== undefined);
 
     // Create value columns for each metric
-    const valuesColumns = metricQuery.metrics.map((metric) => ({
-        reference: metric,
-        aggregation: VizAggregationOptions.ANY,
-    }));
+    const valuesColumns = metricQuery.metrics
+        .map((metric) => ({
+            reference: metric,
+            aggregation: VizAggregationOptions.ANY,
+        }))
+        .filter(
+            (col) =>
+                metricQuery.dimensions.includes(col.reference) ||
+                metricQuery.metrics.includes(col.reference),
+        );
 
     // Group by columns are the pivot dimensions
     const groupByColumns = pivotColumns
@@ -179,10 +185,16 @@ function getCartesianPivotConfiguration(
             .filter((col) => metricQuery.dimensions.includes(col.reference));
 
         // Extract value columns
-        const valuesColumns = yField.map((yf) => ({
-            reference: yf,
-            aggregation: VizAggregationOptions.ANY,
-        }));
+        const valuesColumns = yField
+            .map((yf) => ({
+                reference: yf,
+                aggregation: VizAggregationOptions.ANY,
+            }))
+            .filter(
+                (col) =>
+                    metricQuery.dimensions.includes(col.reference) ||
+                    metricQuery.metrics.includes(col.reference),
+            );
 
         const xAxisDimension = fields[xField];
         let xAxisType: VizIndexType | undefined;
@@ -223,10 +235,14 @@ function getCartesianPivotConfiguration(
 }
 
 function isValid(pivotConfiguration: PivotConfiguration): boolean {
-    const { groupByColumns, indexColumn } = pivotConfiguration;
+    const { groupByColumns, valuesColumns, indexColumn } = pivotConfiguration;
 
     const indexColumns = normalizeIndexColumns(indexColumn);
     if (indexColumns.length === 0) {
+        return false;
+    }
+
+    if (valuesColumns.length === 0) {
         return false;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Fixed pivot configuration validation by adding a check for empty values columns. Also added filtering to ensure that only valid references (those included in metricQuery dimensions or metrics) are used in valuesColumns for both table and cartesian pivot configurations.


before


https://github.com/user-attachments/assets/81334933-19a5-4e38-9022-d5c3d917b3a6


after:


https://github.com/user-attachments/assets/c098c122-dccd-4b83-9ead-16a7a0dd2dec

