### PR TITLE
fix: invalidate dashboard chart on chart edit

### DIFF
--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -306,7 +306,19 @@ export const useUpdateMutation = (
                 await queryClient.invalidateQueries(['content']);
 
                 await queryClient.invalidateQueries(['spaces']);
+
                 queryClient.setQueryData(['saved_query', data.uuid], data);
+
+                if (dashboardUuid) {
+                    // Invalidate dashboard chart queries to refresh charts on dashboards
+                    await queryClient.resetQueries([
+                        'dashboard_chart_ready_query',
+                        data.projectUuid,
+                        data.uuid,
+                        dashboardUuid,
+                    ]);
+                }
+
                 showToastSuccess({
                     title: `Success! Chart was saved.`,
                     action: dashboardUuid
@@ -465,6 +477,16 @@ export const useAddVersionMutation = () => {
 
             queryClient.setQueryData(['saved_query', data.uuid], data);
             await queryClient.resetQueries(['savedChartResults', data.uuid]);
+
+            if (dashboardUuid) {
+                // Invalidate dashboard chart queries to refresh charts on dashboards
+                await queryClient.resetQueries([
+                    'dashboard_chart_ready_query',
+                    data.projectUuid,
+                    data.uuid,
+                    dashboardUuid,
+                ]);
+            }
 
             if (dashboardUuid)
                 showToastSuccess({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16803

### Description:

Invalidate dashboard chart queries when a saved query is updated or a new version is added. This ensures that charts on dashboards are refreshed with the latest data after changes are made to the underlying queries.

The PR adds query invalidation logic in two places:
1. In the `useUpdateMutation` hook when a chart is saved
2. In the `useAddVersionMutation` hook when a chart version is updated

This change improves the user experience by automatically refreshing dashboard charts without requiring a manual refresh.

[fix-invalidation.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/9d9f58f4-0216-4085-b2f4-767c2bbccf98.mov" />](https://app.graphite.dev/user-attachments/video/9d9f58f4-0216-4085-b2f4-767c2bbccf98.mov)

> [!TIP]
> You can test this by adding a log to the `queryFn` call in `useDashboardChartReadyQuery` **and no need to have cache disabled**