### PR TITLE
fix: dont auto-run query on new chart

### DIFF
--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -48,6 +48,10 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             enabled: !!unsavedChartVersionTableName,
         });
 
+        const isSavedChart = useExplorerContext(
+            (context) => !!context.state.savedChart,
+        );
+
         const fromDashboard = useExplorerContext(
             (context) => context.state.fromDashboard,
         );
@@ -61,10 +65,10 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         );
 
         useEffect(() => {
-            if (!previouslyFetchedState && (fromDashboard || isEditMode)) {
+            if (!previouslyFetchedState && (fromDashboard || isSavedChart)) {
                 fetchResults();
             }
-        }, [previouslyFetchedState, fetchResults, fromDashboard, isEditMode]);
+        }, [previouslyFetchedState, fetchResults, fromDashboard, isSavedChart]);
 
         useEffect(() => {
             if (isError) {


### PR DESCRIPTION
### Description:

The issue: we were always auto-running queries on the first change in edit mode

The fix: now we only auto-run the query if the chart has a saved version OR its from a dashboard (explore from here)

I tested:
- Saved charts load on first view
- New Explores do not load until Run query is clicked
- Dashboard -> explore from here -> chart loads
- Dashboard -> edit chart -> chart loads
