### PR TITLE
fix: git project adapters not reading lightdash project config yaml file

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -33,7 +33,12 @@ import fs from 'fs/promises';
 import path from 'path';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import Logger from '../logging/logger';
-import { CachedWarehouse, DbtClient, ProjectAdapter } from '../types';
+import {
+    CachedWarehouse,
+    DbtClient,
+    ProjectAdapter,
+    type TrackingParams,
+} from '../types';
 
 export class DbtBaseProjectAdapter implements ProjectAdapter {
     dbtClient: DbtClient;
@@ -84,11 +89,9 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         return undefined;
     }
 
-    public async getLightdashProjectConfig(trackingParams?: {
-        projectUuid: string;
-        organizationUuid: string;
-        userUuid: string;
-    }): Promise<LightdashProjectConfig> {
+    public async getLightdashProjectConfig(
+        trackingParams?: TrackingParams,
+    ): Promise<LightdashProjectConfig> {
         if (!this.dbtProjectDir) {
             return {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
@@ -142,11 +145,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
     }
 
     public async compileAllExplores(
-        trackingParams?: {
-            userUuid: string;
-            organizationUuid: string;
-            projectUuid: string;
-        },
+        trackingParams?: TrackingParams,
         loadSources: boolean = false,
     ): Promise<(Explore | ExploreError)[]> {
         Logger.debug('Install dependencies');

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -19,7 +19,7 @@ import simpleGit, {
 } from 'simple-git';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import Logger from '../logging/logger';
-import { CachedWarehouse, ProjectAdapter } from '../types';
+import { CachedWarehouse, ProjectAdapter, type TrackingParams } from '../types';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
 
 export type DbtGitProjectAdapterArgs = {
@@ -216,11 +216,7 @@ export class DbtGitProjectAdapter
         }
     }
 
-    public async compileAllExplores(trackingParams?: {
-        userUuid: string;
-        organizationUuid: string;
-        projectUuid: string;
-    }) {
+    public async compileAllExplores(trackingParams?: TrackingParams) {
         await this._refreshRepo();
         return super.compileAllExplores(trackingParams);
     }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1190,20 +1190,30 @@ export class ProjectService extends BaseService {
                 async () => this.testProjectAdapter(createProject, user),
             );
 
-            const explores = await this.jobModel.tryJobStep(
-                jobUuid,
-                JobStepType.COMPILING,
-                async () => {
-                    try {
-                        // There's no project yet, so we don't track
-                        const trackingParams = undefined;
-                        return await adapter.compileAllExplores(trackingParams);
-                    } finally {
-                        await adapter.destroy();
-                        await sshTunnel.disconnect();
-                    }
-                },
-            );
+            const { explores, lightdashProjectConfig } =
+                await this.jobModel.tryJobStep(
+                    jobUuid,
+                    JobStepType.COMPILING,
+                    async () => {
+                        try {
+                            // There's no project yet, so we don't track
+                            const trackingParams = undefined;
+
+                            return {
+                                explores: await adapter.compileAllExplores(
+                                    trackingParams,
+                                ),
+                                lightdashProjectConfig:
+                                    await adapter.getLightdashProjectConfig(
+                                        trackingParams,
+                                    ),
+                            };
+                        } finally {
+                            await adapter.destroy();
+                            await sshTunnel.disconnect();
+                        }
+                    },
+                );
 
             const projectUuid = await this.jobModel.tryJobStep(
                 jobUuid,
@@ -1222,15 +1232,6 @@ export class ProjectService extends BaseService {
                             ProjectMemberRole.ADMIN,
                         );
                     }
-
-                    const trackingParams = {
-                        projectUuid: newProjectUuid,
-                        organizationUuid: user.organizationUuid,
-                        userUuid: user.userUuid,
-                    };
-
-                    const lightdashProjectConfig =
-                        await adapter.getLightdashProjectConfig(trackingParams);
 
                     await this.replaceYamlTags(
                         user,
@@ -3431,13 +3432,13 @@ export class ProjectService extends BaseService {
         };
     }
 
-    private async refreshAllTables(
+    private async refreshTablesAndProjectConfig(
         user: Pick<SessionUser, 'userUuid'>,
         projectUuid: string,
         requestMethod: RequestMethod,
     ): Promise<{
         explores: (Explore | ExploreError)[];
-        adapter: ProjectAdapter;
+        lightdashProjectConfig: LightdashProjectConfig;
     }> {
         // Checks that project exists
         const project = await this.projectModel.get(projectUuid);
@@ -3584,7 +3585,10 @@ export class ProjectService extends BaseService {
                 },
             });
 
-            return { explores, adapter };
+            const lightdashProjectConfig =
+                await adapter.getLightdashProjectConfig(trackingParams);
+
+            return { explores, lightdashProjectConfig };
         } catch (e) {
             if (!(e instanceof LightdashError)) {
                 Sentry.captureException(e);
@@ -3744,20 +3748,11 @@ export class ProjectService extends BaseService {
                     job.jobUuid,
                     JobStepType.COMPILING,
                     async () => {
-                        const { explores, adapter } =
-                            await this.refreshAllTables(
+                        const { explores, lightdashProjectConfig } =
+                            await this.refreshTablesAndProjectConfig(
                                 user,
                                 projectUuid,
                                 requestMethod,
-                            );
-                        const trackingParams = {
-                            projectUuid,
-                            organizationUuid,
-                            userUuid: user.userUuid,
-                        };
-                        const lightdashProjectConfig =
-                            await adapter.getLightdashProjectConfig(
-                                trackingParams,
                             );
 
                         await this.replaceYamlTags(

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -7,6 +7,12 @@ import {
 } from '@lightdash/common';
 import { WarehouseCatalog } from '@lightdash/warehouses';
 
+export type TrackingParams = {
+    userUuid: string;
+    organizationUuid: string;
+    projectUuid: string;
+};
+
 export interface ProjectAdapter {
     /**
      * Compile all explores
@@ -14,13 +20,7 @@ export interface ProjectAdapter {
      * @returns A promise that resolves to an array of explores or explore errors
      */
     compileAllExplores(
-        trackingParams:
-            | {
-                  userUuid: string;
-                  organizationUuid: string;
-                  projectUuid: string;
-              }
-            | undefined,
+        trackingParams: TrackingParams | undefined,
     ): Promise<(Explore | ExploreError)[]>;
 
     getDbtPackages(): Promise<DbtPackages | undefined>;
@@ -29,11 +29,9 @@ export interface ProjectAdapter {
 
     destroy(): Promise<void>;
 
-    getLightdashProjectConfig(trackingParams: {
-        projectUuid: string;
-        organizationUuid: string;
-        userUuid: string;
-    }): Promise<LightdashProjectConfig>;
+    getLightdashProjectConfig(
+        trackingParams: TrackingParams | undefined,
+    ): Promise<LightdashProjectConfig>;
 }
 
 export interface DbtClient {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16821

### Description:
Refactored project compilation process to fetch the Lightdash project configuration during the compilation step rather than after project creation. This change:

1. Retrieves both explores and project config in a single step during compilation
2. Introduces a reusable `TrackingParams` type for better type consistency
3. Renames `refreshAllTables` to `refreshTablesAndProjectConfig` to better reflect its functionality
4. Updates the `getLightdashProjectConfig` method signature to accept undefined tracking params

This approach fixes loading the project config when refreshing dbt from the explore by doing it before destroying the project adapter.

**Steps to reproduce**
1. Create a project with a Git connection to the dbt project
2. Commit a lightdash.config.yml file to the branch you've selected to sync
3. Add a parameter to the config
4. Click refresh dbt from the explore page
5. The parameter doesn't show anywhere

**Before**

![Screenshot 2025-09-10 at 10.43.46.png](https://app.graphite.dev/user-attachments/assets/aa653e68-8b20-400a-8ce4-2fcc5e0eaef6.png)

**After**

![Screenshot 2025-09-10 at 10.41.58.png](https://app.graphite.dev/user-attachments/assets/8a08ec2c-1129-48d5-a087-a6c16d43c8f2.png)

test-frontend
test-backend

