### PR TITLE
fix: improve typing for artifact

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1,5 +1,7 @@
 import {
+    AiArtifactTSOACompat,
     ApiAiAgentArtifactResponse,
+    ApiAiAgentArtifactResponseTSOACompat,
     ApiAiAgentExploreAccessSummaryResponse,
     ApiAiAgentResponse,
     ApiAiAgentSummaryResponse,
@@ -461,15 +463,16 @@ export class AiAgentController extends BaseController {
         @Path() projectUuid: string,
         @Path() agentUuid: string,
         @Path() artifactUuid: string,
-    ): Promise<ApiAiAgentArtifactResponse> {
+    ): Promise<ApiAiAgentArtifactResponseTSOACompat> {
         this.setStatus(200);
+
         return {
             status: 'ok',
-            results: await this.getAiAgentService().getArtifact(
+            results: (await this.getAiAgentService().getArtifact(
                 req.user!,
                 agentUuid,
                 artifactUuid,
-            ),
+            )) as unknown as AiArtifactTSOACompat,
         };
     }
 
@@ -483,16 +486,19 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() artifactUuid: string,
         @Path() versionUuid: string,
-    ): Promise<ApiAiAgentArtifactResponse> {
+    ): Promise<ApiAiAgentArtifactResponseTSOACompat> {
         this.setStatus(200);
+
         return {
             status: 'ok',
-            results: await this.getAiAgentService().getArtifact(
+            // Use simplified type for TSOA Compat
+
+            results: (await this.getAiAgentService().getArtifact(
                 req.user!,
                 agentUuid,
                 artifactUuid,
                 versionUuid,
-            ),
+            )) as unknown as AiArtifactTSOACompat,
         };
     }
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2085,11 +2085,12 @@ export class AiAgentModel {
                 versionUuid: version.ai_artifact_version_uuid,
                 title: version.title,
                 description: version.description,
-                chartConfig: version.chart_config,
-                dashboardConfig: version.dashboard_config,
+                chartConfig: version.chart_config as AiArtifact['chartConfig'],
+                dashboardConfig:
+                    version.dashboard_config as AiArtifact['dashboardConfig'],
                 promptUuid: version.ai_prompt_uuid,
                 versionCreatedAt: version.created_at,
-            };
+            } as AiArtifact;
         });
     }
 
@@ -2161,11 +2162,12 @@ export class AiAgentModel {
                 versionUuid: version.ai_artifact_version_uuid,
                 title: version.title,
                 description: version.description,
-                chartConfig: version.chart_config,
-                dashboardConfig: version.dashboard_config,
+                chartConfig: version.chart_config as AiArtifact['chartConfig'],
+                dashboardConfig:
+                    version.dashboard_config as AiArtifact['dashboardConfig'],
                 promptUuid: version.ai_prompt_uuid,
                 versionCreatedAt: version.created_at,
-            };
+            } as AiArtifact;
         });
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5415,93 +5415,118 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiArtifact: {
+    'Pick_AiArtifact.Exclude_keyofAiArtifact.chartConfig-or-dashboardConfig__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    description: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    createdAt: { dataType: 'datetime', required: true },
+                    artifactUuid: { dataType: 'string', required: true },
+                    threadUuid: { dataType: 'string', required: true },
+                    promptUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    artifactType: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'enum', enums: ['chart'] },
+                            { dataType: 'enum', enums: ['dashboard'] },
+                        ],
+                        required: true,
+                    },
+                    savedQueryUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    versionNumber: { dataType: 'double', required: true },
+                    versionUuid: { dataType: 'string', required: true },
+                    title: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    versionCreatedAt: { dataType: 'datetime', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_AiArtifact.chartConfig-or-dashboardConfig_': {
         dataType: 'refAlias',
         type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                versionCreatedAt: { dataType: 'datetime', required: true },
-                dashboardConfig: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'Record_string.unknown_' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                chartConfig: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'Record_string.unknown_' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                description: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                title: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                versionUuid: { dataType: 'string', required: true },
-                versionNumber: { dataType: 'double', required: true },
-                createdAt: { dataType: 'datetime', required: true },
-                savedQueryUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                artifactType: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'enum', enums: ['chart'] },
-                        { dataType: 'enum', enums: ['dashboard'] },
-                    ],
-                    required: true,
-                },
-                promptUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                threadUuid: { dataType: 'string', required: true },
-                artifactUuid: { dataType: 'string', required: true },
-            },
+            ref: 'Pick_AiArtifact.Exclude_keyofAiArtifact.chartConfig-or-dashboardConfig__',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiSuccess_AiArtifact_: {
+    AiArtifactTSOACompat: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Omit_AiArtifact.chartConfig-or-dashboardConfig_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardConfig: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'Record_string.unknown_' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        chartConfig: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'Record_string.unknown_' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiArtifactTSOACompat_: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                results: { ref: 'AiArtifact', required: true },
+                results: { ref: 'AiArtifactTSOACompat', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiAiAgentArtifactResponse: {
+    ApiAiAgentArtifactResponseTSOACompat: {
         dataType: 'refAlias',
-        type: { ref: 'ApiSuccess_AiArtifact_', validators: {} },
+        type: { ref: 'ApiSuccess_AiArtifactTSOACompat_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiResultType: {
@@ -5804,7 +5829,6 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     uuid: { dataType: 'string', required: true },
-                    createdFrom: { dataType: 'string', required: true },
                     title: {
                         dataType: 'union',
                         subSchemas: [
@@ -5813,6 +5837,7 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    createdFrom: { dataType: 'string', required: true },
                 },
                 validators: {},
             },
@@ -10017,8 +10042,8 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 createdAt: { dataType: 'datetime', required: true },
-                chartUuid: { dataType: 'string', required: true },
                 versionUuid: { dataType: 'string', required: true },
+                chartUuid: { dataType: 'string', required: true },
                 createdBy: {
                     dataType: 'union',
                     subSchemas: [
@@ -10122,6 +10147,7 @@ const models: TsoaRoute.Models = {
                 organizationUuid: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
                 updatedAt: { dataType: 'datetime', required: true },
+                chartConfig: { ref: 'ChartConfig', required: true },
                 spaceUuid: { dataType: 'string', required: true },
                 pinnedListUuid: {
                     dataType: 'union',
@@ -10182,7 +10208,6 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                chartConfig: { ref: 'ChartConfig', required: true },
                 tableConfig: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -12206,6 +12231,7 @@ const models: TsoaRoute.Models = {
                     },
                     name: { dataType: 'string', required: true },
                     updatedAt: { dataType: 'datetime', required: true },
+                    chartConfig: { ref: 'ChartConfig', required: true },
                     slug: { dataType: 'string', required: true },
                     tableName: { dataType: 'string', required: true },
                     metricQuery: { ref: 'MetricQuery', required: true },
@@ -12225,7 +12251,6 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
-                    chartConfig: { ref: 'ChartConfig', required: true },
                     tableConfig: {
                         dataType: 'nestedObjectLiteral',
                         nestedProperties: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6012,48 +6012,23 @@
             "ApiAiAgentExploreAccessSummaryResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentExploreAccessSummary-Array_"
             },
-            "AiArtifact": {
+            "Pick_AiArtifact.Exclude_keyofAiArtifact.chartConfig-or-dashboardConfig__": {
                 "properties": {
-                    "versionCreatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "dashboardConfig": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Record_string.unknown_"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "chartConfig": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Record_string.unknown_"
-                            }
-                        ],
-                        "nullable": true
-                    },
                     "description": {
                         "type": "string",
                         "nullable": true
-                    },
-                    "title": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "versionUuid": {
-                        "type": "string"
-                    },
-                    "versionNumber": {
-                        "type": "number",
-                        "format": "double"
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
                     },
-                    "savedQueryUuid": {
+                    "artifactUuid": {
+                        "type": "string"
+                    },
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
                         "type": "string",
                         "nullable": true
                     },
@@ -6061,38 +6036,79 @@
                         "type": "string",
                         "enum": ["chart", "dashboard"]
                     },
-                    "promptUuid": {
+                    "savedQueryUuid": {
                         "type": "string",
                         "nullable": true
                     },
-                    "threadUuid": {
+                    "versionNumber": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "versionUuid": {
                         "type": "string"
                     },
-                    "artifactUuid": {
-                        "type": "string"
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "versionCreatedAt": {
+                        "type": "string",
+                        "format": "date-time"
                     }
                 },
                 "required": [
-                    "versionCreatedAt",
-                    "dashboardConfig",
-                    "chartConfig",
                     "description",
-                    "title",
-                    "versionUuid",
-                    "versionNumber",
                     "createdAt",
-                    "savedQueryUuid",
-                    "artifactType",
-                    "promptUuid",
+                    "artifactUuid",
                     "threadUuid",
-                    "artifactUuid"
+                    "promptUuid",
+                    "artifactType",
+                    "savedQueryUuid",
+                    "versionNumber",
+                    "versionUuid",
+                    "title",
+                    "versionCreatedAt"
                 ],
-                "type": "object"
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "ApiSuccess_AiArtifact_": {
+            "Omit_AiArtifact.chartConfig-or-dashboardConfig_": {
+                "$ref": "#/components/schemas/Pick_AiArtifact.Exclude_keyofAiArtifact.chartConfig-or-dashboardConfig__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "AiArtifactTSOACompat": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Omit_AiArtifact.chartConfig-or-dashboardConfig_"
+                    },
+                    {
+                        "properties": {
+                            "dashboardConfig": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Record_string.unknown_"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "chartConfig": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Record_string.unknown_"
+                                    }
+                                ],
+                                "nullable": true
+                            }
+                        },
+                        "required": ["dashboardConfig", "chartConfig"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiSuccess_AiArtifactTSOACompat_": {
                 "properties": {
                     "results": {
-                        "$ref": "#/components/schemas/AiArtifact"
+                        "$ref": "#/components/schemas/AiArtifactTSOACompat"
                     },
                     "status": {
                         "type": "string",
@@ -6103,8 +6119,8 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "ApiAiAgentArtifactResponse": {
-                "$ref": "#/components/schemas/ApiSuccess_AiArtifact_"
+            "ApiAiAgentArtifactResponseTSOACompat": {
+                "$ref": "#/components/schemas/ApiSuccess_AiArtifactTSOACompat_"
             },
             "AiResultType": {
                 "enum": [
@@ -6385,20 +6401,20 @@
                     "uuid": {
                         "type": "string"
                     },
-                    "createdFrom": {
-                        "type": "string"
-                    },
                     "title": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "createdFrom": {
+                        "type": "string"
                     }
                 },
                 "required": [
                     "createdAt",
                     "user",
                     "uuid",
-                    "createdFrom",
-                    "title"
+                    "title",
+                    "createdFrom"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
@@ -10819,10 +10835,10 @@
                         "type": "string",
                         "format": "date-time"
                     },
-                    "chartUuid": {
+                    "versionUuid": {
                         "type": "string"
                     },
-                    "versionUuid": {
+                    "chartUuid": {
                         "type": "string"
                     },
                     "createdBy": {
@@ -10836,8 +10852,8 @@
                 },
                 "required": [
                     "createdAt",
-                    "chartUuid",
                     "versionUuid",
+                    "chartUuid",
                     "createdBy"
                 ],
                 "type": "object",
@@ -10940,6 +10956,9 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "chartConfig": {
+                        "$ref": "#/components/schemas/ChartConfig"
+                    },
                     "spaceUuid": {
                         "type": "string"
                     },
@@ -10987,9 +11006,6 @@
                         "required": ["columns"],
                         "type": "object"
                     },
-                    "chartConfig": {
-                        "$ref": "#/components/schemas/ChartConfig"
-                    },
                     "tableConfig": {
                         "properties": {
                             "columnOrder": {
@@ -11018,6 +11034,7 @@
                     "organizationUuid",
                     "uuid",
                     "updatedAt",
+                    "chartConfig",
                     "spaceUuid",
                     "pinnedListUuid",
                     "pinnedListOrder",
@@ -11027,7 +11044,6 @@
                     "dashboardName",
                     "tableName",
                     "metricQuery",
-                    "chartConfig",
                     "tableConfig",
                     "colorPalette"
                 ],
@@ -13045,6 +13061,9 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "chartConfig": {
+                        "$ref": "#/components/schemas/ChartConfig"
+                    },
                     "slug": {
                         "type": "string"
                     },
@@ -13066,9 +13085,6 @@
                         "required": ["columns"],
                         "type": "object"
                     },
-                    "chartConfig": {
-                        "$ref": "#/components/schemas/ChartConfig"
-                    },
                     "tableConfig": {
                         "properties": {
                             "columnOrder": {
@@ -13085,10 +13101,10 @@
                 "required": [
                     "name",
                     "updatedAt",
+                    "chartConfig",
                     "slug",
                     "tableName",
                     "metricQuery",
-                    "chartConfig",
                     "tableConfig"
                 ],
                 "type": "object",

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -6,6 +6,10 @@ import type {
     ApiSuccessEmpty,
     CacheMetadata,
     ItemsMap,
+    ToolDashboardArgs,
+    ToolTableVizArgs,
+    ToolTimeSeriesArgs,
+    ToolVerticalBarArgs,
 } from '../..';
 import { type AiMetricQuery, type AiResultType } from './types';
 
@@ -317,9 +321,24 @@ export type AiArtifact = {
     versionUuid: string;
     title: string | null;
     description: string | null;
-    chartConfig: Record<string, unknown> | null;
-    dashboardConfig: Record<string, unknown> | null;
+    // We store raw tool calls
+    chartConfig:
+        | ToolTableVizArgs
+        | ToolTimeSeriesArgs
+        | ToolVerticalBarArgs
+        | null;
+    dashboardConfig: ToolDashboardArgs | null;
     versionCreatedAt: Date;
 };
 
+export type AiArtifactTSOACompat = Omit<
+    AiArtifact,
+    'chartConfig' | 'dashboardConfig'
+> & {
+    chartConfig: Record<string, unknown> | null;
+    dashboardConfig: Record<string, unknown> | null;
+};
+
 export type ApiAiAgentArtifactResponse = ApiSuccess<AiArtifact>;
+export type ApiAiAgentArtifactResponseTSOACompat =
+    ApiSuccess<AiArtifactTSOACompat>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR adds proper typing for AI artifact chart and dashboard configurations. It introduces a new `AiArtifactTSOACompat` type that's compatible with TSOA, while maintaining the original `AiArtifact` type with proper tool call argument types.

The changes:

1. Create a new `AiArtifactTSOACompat` type that omits the strongly-typed chart/dashboard configs
2. Update controller return types to use the TSOA-compatible version
3. Add proper type casting in the AiAgentModel to ensure type safety
4. Update the generated routes and swagger definitions

This improves type safety when working with AI artifacts while maintaining compatibility with the API generator.
