### PR TITLE
fix: add legacy follow-up tools compatibility mapping

### DIFF
--- a/packages/common/src/ee/AiAgent/followUpTools.ts
+++ b/packages/common/src/ee/AiAgent/followUpTools.ts
@@ -11,4 +11,36 @@ export const followUpToolsText: FollowUpToolsText = {
     [AiResultType.TIME_SERIES_RESULT]: 'Generate a Time Series Chart',
 };
 
+export enum LegacyFollowUpTools {
+    GENERATE_TABLE = 'generate_table',
+    GENERATE_BAR_VIZ = 'generate_bar_viz',
+    GENERATE_TIME_SERIES_VIZ = 'generate_time_series_viz',
+}
+
+export const legacyToNewMapping: Record<string, AiResultType> = {
+    [LegacyFollowUpTools.GENERATE_TABLE]: AiResultType.TABLE_RESULT,
+    [LegacyFollowUpTools.GENERATE_BAR_VIZ]: AiResultType.VERTICAL_BAR_RESULT,
+    [LegacyFollowUpTools.GENERATE_TIME_SERIES_VIZ]:
+        AiResultType.TIME_SERIES_RESULT,
+};
+
+export const legacyFollowUpToolsTransform = (
+    tools: (
+        | AiResultType.VERTICAL_BAR_RESULT
+        | AiResultType.TABLE_RESULT
+        | AiResultType.TIME_SERIES_RESULT
+        | LegacyFollowUpTools.GENERATE_TABLE
+        | LegacyFollowUpTools.GENERATE_BAR_VIZ
+        | LegacyFollowUpTools.GENERATE_TIME_SERIES_VIZ
+    )[],
+): AiResultType[] =>
+    tools.map((tool) => {
+        if (tool in legacyToNewMapping) {
+            return legacyToNewMapping[tool];
+        }
+        return tool as unknown as AiResultType;
+    });
+
+// this is used only for slack at the moment, so no backwards compatibility is needed
+// TODO :: reuse this schema across the tools
 export const followUpToolsSchema = z.nativeEnum(AiResultType).array();

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import {
+    LegacyFollowUpTools,
+    legacyFollowUpToolsTransform,
+} from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
@@ -40,10 +44,19 @@ export const toolTableVizArgsSchemaTransformed = toolTableVizArgsSchema
     .extend({
         // backwards compatibility for old viz configs without customMetrics
         customMetrics: customMetricsSchema.default(null),
+        followUpTools: z.array(
+            z.union([
+                z.literal(AiResultType.VERTICAL_BAR_RESULT),
+                z.literal(AiResultType.TIME_SERIES_RESULT),
+                z.literal(LegacyFollowUpTools.GENERATE_BAR_VIZ),
+                z.literal(LegacyFollowUpTools.GENERATE_TIME_SERIES_VIZ),
+            ]),
+        ),
     })
     .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
+        followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 
 export type ToolTableVizArgsTransformed = z.infer<

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import {
+    LegacyFollowUpTools,
+    legacyFollowUpToolsTransform,
+} from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
@@ -45,10 +49,19 @@ export const toolTimeSeriesArgsSchemaTransformed = toolTimeSeriesArgsSchema
         }),
         // backwards compatibility for old viz configs without customMetrics
         customMetrics: customMetricsSchema.default(null),
+        followUpTools: z.array(
+            z.union([
+                z.literal(AiResultType.TABLE_RESULT),
+                z.literal(AiResultType.VERTICAL_BAR_RESULT),
+                z.literal(LegacyFollowUpTools.GENERATE_TABLE),
+                z.literal(LegacyFollowUpTools.GENERATE_BAR_VIZ),
+            ]),
+        ),
     })
     .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
+        followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 
 export type ToolTimeSeriesArgsTransformed = z.infer<

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import {
+    LegacyFollowUpTools,
+    legacyFollowUpToolsTransform,
+} from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
@@ -40,10 +44,19 @@ export const toolVerticalBarArgsSchemaTransformed = toolVerticalBarArgsSchema
     .extend({
         // backwards compatibility for old viz configs without customMetrics
         customMetrics: customMetricsSchema.default(null),
+        followUpTools: z.array(
+            z.union([
+                z.literal(AiResultType.TABLE_RESULT),
+                z.literal(AiResultType.TIME_SERIES_RESULT),
+                z.literal(LegacyFollowUpTools.GENERATE_TABLE),
+                z.literal(LegacyFollowUpTools.GENERATE_TIME_SERIES_VIZ),
+            ]),
+        ),
     })
     .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
+        followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 
 export type ToolVerticalBarArgsTransformed = z.infer<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added backward compatibility for legacy follow-up tools in AI agent visualizations. Created a mapping system between legacy tool names (`generate_table`, `generate_bar_viz`, `generate_time_series_viz`) and their new enum counterparts, along with a transformation function to convert legacy tool references to the new format. Updated schema definitions for table, time series, and vertical bar visualizations to support both legacy and new tool formats.
