### PR TITLE
feat: add dashboard save functionality to AI Agents

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -561,6 +561,35 @@ export class AiAgentController extends BaseController {
         };
     }
 
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Patch(
+        '/{agentUuid}/artifacts/{artifactUuid}/versions/{versionUuid}/savedDashboard',
+    )
+    @OperationId('updateArtifactVersionSavedDashboard')
+    async updateArtifactVersionSavedDashboard(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() artifactUuid: string,
+        @Path() versionUuid: string,
+        @Body() body: { savedDashboardUuid: string | null },
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+
+        await this.getAiAgentService().updateArtifactVersion(req.user!, {
+            agentUuid,
+            artifactUuid,
+            versionUuid,
+            savedDashboardUuid: body.savedDashboardUuid,
+        });
+
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
     protected getAiAgentService() {
         return this.services.getAiAgentService<AiAgentService>();
     }

--- a/packages/backend/src/ee/database/entities/CLAUDE.md
+++ b/packages/backend/src/ee/database/entities/CLAUDE.md
@@ -1,0 +1,1 @@
+Refer to @/packages/backend/src/database/entities/CLAUDE.md

--- a/packages/backend/src/ee/database/entities/aiArtifacts.ts
+++ b/packages/backend/src/ee/database/entities/aiArtifacts.ts
@@ -25,6 +25,7 @@ export type DbAiArtifactVersion = {
     title: string | null;
     description: string | null;
     saved_query_uuid: string | null;
+    saved_dashboard_uuid: string | null;
     chart_config: Record<string, unknown> | null;
     dashboard_config: Record<string, unknown> | null;
 };
@@ -39,6 +40,7 @@ export type AiArtifactVersionsTable = Knex.CompositeTableType<
         | 'title'
         | 'description'
         | 'saved_query_uuid'
+        | 'saved_dashboard_uuid'
         | 'chart_config'
         | 'dashboard_config'
     >

--- a/packages/backend/src/ee/database/migrations/20250911124334_ai_artifacts_dashboard_uuid.ts
+++ b/packages/backend/src/ee/database/migrations/20250911124334_ai_artifacts_dashboard_uuid.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+import { DashboardsTableName } from '../../../database/entities/dashboards';
+
+const AiArtifactVersionsTableName = 'ai_artifact_versions';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiArtifactVersionsTableName, (table) => {
+        table
+            .uuid('saved_dashboard_uuid')
+            .nullable()
+            .references('dashboard_uuid')
+            .inTable(DashboardsTableName)
+            .onDelete('SET NULL');
+        table.index('saved_dashboard_uuid');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiArtifactVersionsTableName, (table) => {
+        table.dropColumn('saved_dashboard_uuid');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -71,6 +71,7 @@ import {
     AiArtifactsTableName,
     AiArtifactVersionsTable,
     AiArtifactVersionsTableName,
+    DbAiArtifactVersion,
 } from '../database/entities/aiArtifacts';
 
 type Dependencies = {
@@ -1737,6 +1738,19 @@ export class AiAgentModel {
             });
     }
 
+    async updateArtifactVersion(
+        artifactVersionUuid: string,
+        update: Pick<AiArtifact, 'savedDashboardUuid'>,
+    ): Promise<void> {
+        await this.database(AiArtifactVersionsTableName)
+            .update({
+                saved_dashboard_uuid: update.savedDashboardUuid,
+            } satisfies Partial<DbAiArtifactVersion>)
+            .where({
+                ai_artifact_version_uuid: artifactVersionUuid,
+            });
+    }
+
     async updateSlackResponseTs(data: UpdateSlackResponseTs) {
         await this.database(AiSlackPromptTableName)
             .update({
@@ -2078,6 +2092,7 @@ export class AiAgentModel {
                             ? data.vizConfig
                             : null,
                     saved_query_uuid: null,
+                    saved_dashboard_uuid: null,
                 })
                 .returning('*');
 
@@ -2155,6 +2170,7 @@ export class AiAgentModel {
                             ? data.vizConfig
                             : null,
                     saved_query_uuid: null,
+                    saved_dashboard_uuid: null,
                 })
                 .returning('*');
 
@@ -2220,6 +2236,7 @@ export class AiAgentModel {
                 threadUuid: `${AiArtifactsTableName}.ai_thread_uuid`,
                 artifactType: `${AiArtifactsTableName}.artifact_type`,
                 savedQueryUuid: `${AiArtifactVersionsTableName}.saved_query_uuid`,
+                savedDashboardUuid: `${AiArtifactVersionsTableName}.saved_dashboard_uuid`,
                 createdAt: `${AiArtifactsTableName}.created_at`,
                 versionNumber: `${AiArtifactVersionsTableName}.version_number`,
                 versionUuid: `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
@@ -2283,6 +2300,7 @@ export class AiAgentModel {
                 threadUuid: `${AiArtifactsTableName}.ai_thread_uuid`,
                 artifactType: `${AiArtifactsTableName}.artifact_type`,
                 savedQueryUuid: `${AiArtifactVersionsTableName}.saved_query_uuid`,
+                savedDashboardUuid: `${AiArtifactVersionsTableName}.saved_dashboard_uuid`,
                 createdAt: `${AiArtifactsTableName}.created_at`,
                 versionNumber: `${AiArtifactVersionsTableName}.version_number`,
                 versionUuid: `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5467,6 +5467,14 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    savedDashboardUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                     versionNumber: { dataType: 'double', required: true },
                     versionUuid: { dataType: 'string', required: true },
                     title: {
@@ -21993,6 +22001,100 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getDashboardArtifactChartVizQuery',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_updateArtifactVersionSavedDashboard: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        artifactUuid: {
+            in: 'path',
+            name: 'artifactUuid',
+            required: true,
+            dataType: 'string',
+        },
+        versionUuid: {
+            in: 'path',
+            name: 'versionUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                savedDashboardUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/artifacts/:artifactUuid/versions/:versionUuid/savedDashboard',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.updateArtifactVersionSavedDashboard,
+        ),
+
+        async function AiAgentController_updateArtifactVersionSavedDashboard(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_updateArtifactVersionSavedDashboard,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateArtifactVersionSavedDashboard',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6045,6 +6045,10 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "savedDashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "versionNumber": {
                         "type": "number",
                         "format": "double"
@@ -6069,6 +6073,7 @@
                     "promptUuid",
                     "artifactType",
                     "savedQueryUuid",
+                    "savedDashboardUuid",
                     "versionNumber",
                     "versionUuid",
                     "title",
@@ -18940,7 +18945,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1994.0",
+        "version": "0.1995.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -317,6 +317,7 @@ export type AiArtifact = {
     promptUuid: string | null;
     artifactType: 'chart' | 'dashboard';
     savedQueryUuid: string | null;
+    savedDashboardUuid: string | null;
     createdAt: Date;
     versionNumber: number;
     versionUuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardQuickOptions.tsx
@@ -1,0 +1,90 @@
+import {
+    type AiArtifact,
+    type Dashboard,
+    type ToolDashboardArgs,
+} from '@lightdash/common';
+import { ActionIcon, Menu } from '@mantine-8/core';
+import {
+    IconDeviceFloppy,
+    IconDots,
+    IconTableShortcut,
+} from '@tabler/icons-react';
+import { Fragment, useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { AiDashboardSaveModal } from './AiDashboardSaveModal';
+
+type Props = {
+    artifactData: AiArtifact;
+    projectUuid: string;
+    agentUuid: string;
+    dashboardConfig: ToolDashboardArgs;
+};
+
+export const AiDashboardQuickOptions: FC<Props> = ({
+    artifactData,
+    projectUuid,
+    agentUuid,
+    dashboardConfig,
+}) => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const handleSaveDashboard = () => {
+        setIsModalOpen(true);
+    };
+
+    const handleCloseModal = () => {
+        setIsModalOpen(false);
+    };
+
+    const handleSaveSuccess = (_dashboard: Dashboard) => {
+        // TODO persist on artifact
+        setIsModalOpen(false);
+    };
+
+    return (
+        <Fragment>
+            <Menu withArrow>
+                <Menu.Target>
+                    <ActionIcon size="sm" variant="subtle" color="gray">
+                        <MantineIcon icon={IconDots} size="lg" color="gray" />
+                    </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    <Menu.Label>Quick actions</Menu.Label>
+                    {artifactData.savedDashboardUuid ? (
+                        <Menu.Item
+                            component={Link}
+                            to={`/projects/${projectUuid}/dashboards/${artifactData.savedDashboardUuid}`}
+                            target="_blank"
+                            leftSection={
+                                <MantineIcon icon={IconTableShortcut} />
+                            }
+                        >
+                            View saved dashboard
+                        </Menu.Item>
+                    ) : (
+                        <Menu.Item
+                            onClick={handleSaveDashboard}
+                            leftSection={
+                                <MantineIcon icon={IconDeviceFloppy} />
+                            }
+                        >
+                            Save dashboard
+                        </Menu.Item>
+                    )}
+                </Menu.Dropdown>
+            </Menu>
+
+            <AiDashboardSaveModal
+                opened={isModalOpen}
+                onClose={handleCloseModal}
+                artifactData={artifactData}
+                projectUuid={projectUuid}
+                agentUuid={agentUuid}
+                dashboardConfig={dashboardConfig}
+                onSuccess={handleSaveSuccess}
+            />
+        </Fragment>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardSaveModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardSaveModal.tsx
@@ -1,0 +1,452 @@
+import { subject } from '@casl/ability';
+import {
+    type AiArtifact,
+    type CreateDashboard,
+    type Dashboard,
+    type DashboardVersionedFields,
+    type SavedChart,
+    type ToolDashboardArgs,
+} from '@lightdash/common';
+import {
+    Button,
+    Group,
+    LoadingOverlay,
+    Stack,
+    TextInput,
+    Textarea,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconPlus } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../../../../components/common/MantineModal';
+import SaveToSpaceForm from '../../../../../components/common/modal/ChartCreateModal/SaveToSpaceForm';
+import {
+    useCreateMutation,
+    useUpdateMutation,
+} from '../../../../../hooks/dashboard/useDashboard';
+import useToaster from '../../../../../hooks/toaster/useToaster';
+import { useCreateMutation as useCreateChartMutation } from '../../../../../hooks/useSavedQuery';
+import { useSpaceManagement } from '../../../../../hooks/useSpaceManagement';
+import { useSpaceSummaries } from '../../../../../hooks/useSpaces';
+import useApp from '../../../../../providers/App/useApp';
+import {
+    getAiAgentDashboardChartVizQueryKey,
+    useUpdateArtifactVersion,
+} from '../../hooks/useProjectAiAgents';
+import { convertDashboardVisualizationsToChartData } from '../../utils/dashboardChartConverter';
+import { createTwoColumnTiles } from '../../utils/dashboardTileLayout';
+
+enum ModalStep {
+    InitialInfo = 'initialInfo',
+    SelectDestination = 'selectDestination',
+    Saving = 'saving',
+}
+
+interface FormValues {
+    dashboardName: string;
+    dashboardDescription: string;
+    spaceUuid: string | null;
+    newSpaceName: string | null;
+}
+
+interface Props extends Omit<MantineModalProps, 'children' | 'title'> {
+    artifactData: AiArtifact;
+    projectUuid: string;
+    agentUuid: string;
+    dashboardConfig: ToolDashboardArgs;
+    onSuccess?: (dashboard: Dashboard) => void;
+}
+
+export const AiDashboardSaveModal: FC<Props> = ({
+    artifactData,
+    projectUuid,
+    agentUuid,
+    dashboardConfig,
+    onSuccess,
+    onClose,
+    ...modalProps
+}) => {
+    const { user } = useApp();
+    const navigate = useNavigate();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+
+    const [currentStep, setCurrentStep] = useState<ModalStep>(
+        ModalStep.InitialInfo,
+    );
+    const { mutateAsync: patchDashboard } = useUpdateMutation();
+
+    const { mutateAsync: createDashboard } = useCreateMutation(
+        projectUuid,
+        false,
+        {
+            showToastOnSuccess: false,
+        },
+    );
+    const { mutateAsync: createChart } = useCreateChartMutation({
+        redirectOnSuccess: false,
+        showToastOnSuccess: false,
+    });
+
+    const { mutateAsync: updateArtifactVersion } = useUpdateArtifactVersion(
+        projectUuid,
+        agentUuid,
+        artifactData.artifactUuid,
+        artifactData.versionUuid,
+    );
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            dashboardName: dashboardConfig.title,
+            dashboardDescription: dashboardConfig.description,
+            spaceUuid: null,
+            newSpaceName: null,
+        },
+        validate: {
+            dashboardName: (value: string) =>
+                value.length === 0 ? 'Dashboard name is required' : null,
+        },
+    });
+
+    const spaceManagement = useSpaceManagement({
+        projectUuid,
+    });
+
+    const { isCreatingNewSpace, openCreateSpaceForm, setSelectedSpaceUuid } =
+        spaceManagement;
+
+    const {
+        data: spaces,
+        isInitialLoading: isLoadingSpaces,
+        isSuccess: isSpacesSuccess,
+    } = useSpaceSummaries(projectUuid, true, {
+        staleTime: 0,
+        select: (data) =>
+            data.filter((space) =>
+                user.data?.ability.can(
+                    'create',
+                    subject('Dashboard', {
+                        ...space,
+                        access: space.userAccess ? [space.userAccess] : [],
+                    }),
+                ),
+            ),
+    });
+
+    // Read cached viz-query results from react-query client using exported key
+    const getCachedVizQueries = useCallback(() => {
+        const results: any[] = [];
+        for (let i = 0; i < dashboardConfig.visualizations.length; i++) {
+            const key = getAiAgentDashboardChartVizQueryKey({
+                projectUuid,
+                agentUuid,
+                artifactUuid: artifactData.artifactUuid,
+                versionUuid: artifactData.versionUuid,
+                chartIndex: i,
+            });
+            const data = queryClient.getQueryData(key);
+            results.push(data);
+        }
+        return results;
+    }, [
+        dashboardConfig.visualizations.length,
+        projectUuid,
+        agentUuid,
+        artifactData.artifactUuid,
+        artifactData.versionUuid,
+        queryClient,
+    ]);
+
+    const { setFieldValue } = form;
+
+    useEffect(() => {
+        if (!isSpacesSuccess || !modalProps.opened) {
+            return;
+        }
+
+        // Set default space
+        const defaultSpace = spaces?.find((space) => !space.parentSpaceUuid);
+        if (defaultSpace) {
+            setFieldValue('spaceUuid', defaultSpace.uuid);
+            setSelectedSpaceUuid(defaultSpace.uuid);
+        }
+    }, [
+        isSpacesSuccess,
+        modalProps.opened,
+        setFieldValue,
+        spaces,
+        setSelectedSpaceUuid,
+    ]);
+
+    const handleClose = useCallback(() => {
+        form.reset();
+        setCurrentStep(ModalStep.InitialInfo);
+        onClose?.();
+    }, [form, onClose]);
+
+    const handleNextStep = () => {
+        if (form.validate().hasErrors) return;
+        setCurrentStep(ModalStep.SelectDestination);
+    };
+
+    const handleBack = () => {
+        setCurrentStep(ModalStep.InitialInfo);
+    };
+
+    const handleSaveDashboard = useCallback(
+        async (values: FormValues) => {
+            try {
+                setCurrentStep(ModalStep.Saving);
+
+                // Handle new space creation
+                let targetSpaceUuid = values.spaceUuid;
+                if (values.newSpaceName) {
+                    const newSpace = await spaceManagement.handleCreateNewSpace(
+                        {
+                            isPrivate: false,
+                        },
+                    );
+                    targetSpaceUuid = newSpace?.uuid || values.spaceUuid;
+                }
+
+                // 1. Create empty dashboard
+                const dashboardData: CreateDashboard = {
+                    name: values.dashboardName,
+                    description: values.dashboardDescription,
+                    spaceUuid: targetSpaceUuid!,
+                    tiles: [],
+                    tabs: [],
+                };
+
+                const dashboard = await createDashboard(dashboardData);
+                await updateArtifactVersion({
+                    savedDashboardUuid: dashboard.uuid,
+                });
+
+                // 2. Get all visualization query results from cache
+                const cached = getCachedVizQueries();
+                if (cached.some((q) => !q)) {
+                    showToastApiError({
+                        title: 'Dashboard save failed',
+                        apiError: {
+                            name: 'ValidationError',
+                            message:
+                                'Visualization results not found in cache. Please preview the charts and try again.',
+                            statusCode: 400,
+                            data: {},
+                        } as any,
+                    });
+                    setCurrentStep(ModalStep.SelectDestination);
+                    return;
+                }
+                const vizQueryResults = cached as any[];
+
+                const chartDataArray =
+                    convertDashboardVisualizationsToChartData(
+                        dashboardConfig,
+                        vizQueryResults,
+                        {
+                            dashboardUuid: dashboard.uuid,
+                            dashboardName: dashboard.name,
+                            userId: user.data?.userUuid,
+                        },
+                    );
+
+                // Create all charts sequentially
+                const savedCharts: SavedChart[] = [];
+                for (let i = 0; i < chartDataArray.length; i++) {
+                    const chartData = chartDataArray[i];
+                    const savedChart = await createChart({
+                        ...chartData,
+                        name: dashboardConfig.visualizations[i].title,
+                    });
+                    savedCharts.push(savedChart);
+                }
+
+                const tilesAccumulator = createTwoColumnTiles(
+                    savedCharts,
+                    dashboard.tabs?.[0]?.uuid,
+                );
+
+                const updateFields: DashboardVersionedFields = {
+                    filters: {
+                        dimensions: [],
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                    tiles: tilesAccumulator,
+                    tabs: [],
+                };
+
+                await patchDashboard({
+                    id: dashboard.uuid,
+                    data: updateFields,
+                });
+
+                showToastSuccess({
+                    title: 'Dashboard created successfully!',
+                    action: {
+                        children: 'Open dashboard',
+                        onClick: () =>
+                            navigate(
+                                `/projects/${projectUuid}/dashboards/${dashboard.uuid}`,
+                            ),
+                    },
+                });
+
+                onSuccess?.(dashboard);
+                handleClose();
+            } catch (error) {
+                console.error(error);
+                showToastApiError({
+                    title: 'Failed to create dashboard',
+                    apiError: error as any,
+                });
+                setCurrentStep(ModalStep.SelectDestination);
+            }
+        },
+        [
+            createDashboard,
+            createChart,
+            dashboardConfig,
+            user.data?.userUuid,
+            spaceManagement,
+            navigate,
+            projectUuid,
+            onSuccess,
+            showToastSuccess,
+            showToastApiError,
+            handleClose,
+            getCachedVizQueries,
+            patchDashboard,
+            updateArtifactVersion,
+        ],
+    );
+
+    const shouldShowNewSpaceButton = useMemo(
+        () =>
+            currentStep === ModalStep.SelectDestination && !isCreatingNewSpace,
+        [currentStep, isCreatingNewSpace],
+    );
+
+    const isFormReadyToSave = useMemo(
+        () =>
+            currentStep === ModalStep.SelectDestination &&
+            form.values.dashboardName &&
+            (form.values.newSpaceName || form.values.spaceUuid),
+        [
+            currentStep,
+            form.values.dashboardName,
+            form.values.newSpaceName,
+            form.values.spaceUuid,
+        ],
+    );
+
+    const isLoading =
+        isLoadingSpaces || spaceManagement.createSpaceMutation.isLoading;
+
+    if (isLoadingSpaces || !spaces) return null;
+
+    const modalActions = (
+        <>
+            <div>
+                {shouldShowNewSpaceButton && (
+                    <Button
+                        variant="subtle"
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        onClick={openCreateSpaceForm}
+                    >
+                        New Space
+                    </Button>
+                )}
+            </div>
+
+            <Group>
+                {currentStep === ModalStep.SelectDestination && (
+                    <Button onClick={handleBack} variant="outline">
+                        Back
+                    </Button>
+                )}
+                <Button onClick={handleClose} variant="outline">
+                    Cancel
+                </Button>
+                <Button
+                    type="submit"
+                    disabled={
+                        currentStep === ModalStep.SelectDestination
+                            ? !isFormReadyToSave
+                            : !form.values.dashboardName
+                    }
+                    form="dashboard-save-form"
+                >
+                    {currentStep === ModalStep.InitialInfo ? 'Next' : 'Save'}
+                </Button>
+            </Group>
+        </>
+    );
+
+    return (
+        <MantineModal
+            {...modalProps}
+            title="Save Dashboard"
+            onClose={handleClose}
+            size="lg"
+            actions={modalActions}
+            modalActionsProps={{ justify: 'space-between' }}
+        >
+            <LoadingOverlay
+                visible={isLoading || currentStep === ModalStep.Saving}
+            />
+
+            <form
+                id="dashboard-save-form"
+                onSubmit={form.onSubmit((values: FormValues) => {
+                    if (currentStep === ModalStep.InitialInfo) {
+                        handleNextStep();
+                    } else if (currentStep === ModalStep.SelectDestination) {
+                        void handleSaveDashboard(values);
+                    }
+                })}
+            >
+                {currentStep === ModalStep.InitialInfo && (
+                    <Stack gap="md">
+                        <TextInput
+                            label="Dashboard name"
+                            placeholder="eg. Sales KPI Dashboard"
+                            required
+                            {...form.getInputProps('dashboardName')}
+                        />
+                        <Textarea
+                            label="Dashboard description"
+                            placeholder="A few words to give your team some context"
+                            autosize
+                            maxRows={3}
+                            {...form.getInputProps('dashboardDescription')}
+                        />
+                    </Stack>
+                )}
+
+                {currentStep === ModalStep.SelectDestination && (
+                    <SaveToSpaceForm
+                        form={form}
+                        spaces={spaces}
+                        projectUuid={projectUuid}
+                        isLoading={isLoading}
+                        spaceManagement={spaceManagement}
+                        selectedSpaceName={
+                            spaces.find(
+                                (space) => space.uuid === form.values.spaceUuid,
+                            )?.name
+                        }
+                    />
+                )}
+            </form>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
@@ -15,6 +15,7 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { clearArtifact } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
+import { AiDashboardQuickOptions } from './AiDashboardQuickOptions';
 import { AiDashboardVisualizationItem } from './AiDashboardVisualizationItem';
 
 type Props = {
@@ -51,7 +52,12 @@ export const AiDashboardVisualization: FC<Props> = memo(
                             )}
                         </Stack>
                         <Group gap="sm" display={isMobile ? 'none' : 'flex'}>
-                            {/* TODO: Add more quick actions here (Save Dashboard, Export, etc.) */}
+                            <AiDashboardQuickOptions
+                                artifactData={artifactData}
+                                projectUuid={projectUuid}
+                                agentUuid={agentUuid}
+                                dashboardConfig={dashboardConfig}
+                            />
                             <ActionIcon
                                 size="sm"
                                 variant="subtle"

--- a/packages/frontend/src/ee/features/aiCopilot/utils/dashboardChartConverter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/dashboardChartConverter.ts
@@ -1,0 +1,86 @@
+import {
+    type ApiAiAgentThreadMessageVizQuery,
+    type CreateSavedChartVersion,
+    type DashboardVisualization,
+} from '@lightdash/common';
+import { getChartConfigFromAiAgentVizConfig } from './echarts';
+
+function convertAiVisualizationToCreateSavedChartVersion(
+    aiVizData: ApiAiAgentThreadMessageVizQuery,
+    dashboardVisualization: DashboardVisualization,
+    options: {
+        name: string;
+        description?: string;
+        dashboardUuid?: string;
+        dashboardName?: string;
+        userId?: string;
+    },
+): CreateSavedChartVersion {
+    const { query, metadata } = aiVizData;
+    const { metricQuery } = query;
+
+    const chartConfig = getChartConfigFromAiAgentVizConfig({
+        vizConfig: dashboardVisualization,
+        metricQuery,
+        rows: [], // Empty rows array - charts will load data dynamically
+        maxQueryLimit: 500, // TODO :: useHealth health.query.maxLimit
+        fieldsMap: aiVizData.query.fields,
+    });
+
+    // Create table config with proper column order
+    const tableConfig = {
+        columnOrder: [
+            ...metricQuery.dimensions,
+            ...metricQuery.metrics,
+            ...metricQuery.tableCalculations.map((tc) => tc.name),
+        ],
+    };
+
+    const result: CreateSavedChartVersion = {
+        description: options.description || metadata.description || undefined,
+        tableName: metricQuery.exploreName,
+        metricQuery,
+        chartConfig: chartConfig.echartsConfig,
+        tableConfig,
+        dashboardUuid: options.dashboardUuid,
+        dashboardName: options.dashboardName,
+    };
+
+    return result;
+}
+
+export function convertDashboardVisualizationsToChartData(
+    dashboardConfig: {
+        title: string;
+        description: string;
+        visualizations: DashboardVisualization[];
+    },
+    vizQueryResults: ApiAiAgentThreadMessageVizQuery[],
+    options: {
+        dashboardUuid?: string;
+        dashboardName?: string;
+        userId?: string;
+    },
+): CreateSavedChartVersion[] {
+    if (dashboardConfig.visualizations.length !== vizQueryResults.length) {
+        throw new Error(
+            `Mismatch between visualization count (${dashboardConfig.visualizations.length}) and query results count (${vizQueryResults.length})`,
+        );
+    }
+
+    return dashboardConfig.visualizations.map((visualization, index) => {
+        const vizQueryResult = vizQueryResults[index];
+
+        return convertAiVisualizationToCreateSavedChartVersion(
+            vizQueryResult,
+            visualization,
+            {
+                name: visualization.title,
+                description: visualization.description,
+                dashboardUuid: options.dashboardUuid,
+                dashboardName: options.dashboardName,
+                userId: options.userId,
+            },
+        );
+    });
+}

--- a/packages/frontend/src/ee/features/aiCopilot/utils/dashboardTileLayout.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/dashboardTileLayout.ts
@@ -1,0 +1,40 @@
+import {
+    DashboardTileTypes,
+    getChartKind,
+    getDefaultChartTileSize,
+    type DashboardChartTile,
+    type SavedChart,
+} from '@lightdash/common';
+import { v4 as uuid4 } from 'uuid';
+
+export function createTwoColumnTiles(
+    savedCharts: SavedChart[],
+    firstTabUuid?: string,
+): DashboardChartTile[] {
+    return savedCharts.map((chart, index) => {
+        const defaultSize = getDefaultChartTileSize(chart.chartConfig?.type);
+
+        return {
+            uuid: uuid4(),
+            type: DashboardTileTypes.SAVED_CHART,
+            tabUuid: firstTabUuid,
+            properties: {
+                belongsToDashboard: true,
+                savedChartUuid: chart.uuid,
+                chartName: chart.name,
+                chartSlug: chart.slug,
+                lastVersionChartKind:
+                    getChartKind(
+                        chart.chartConfig?.type,
+                        chart.chartConfig?.config,
+                    ) || null,
+            },
+            // Alternate between left (x:0) and right (x:18) columns
+            x: (index % 2) * 18,
+            w: 18,
+            // Stack rows, each row is the height of the default tile
+            y: Math.floor(index / 2) * defaultSize.h,
+            h: defaultSize.h,
+        };
+    });
+}

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -385,9 +385,21 @@ export const useUpdateDashboard = (
     );
 };
 
+// Minimal patch hook to update a dashboard by id (no toasts/redirects)
+export const useUpdateMutation = () => {
+    return useMutation<
+        Dashboard,
+        ApiError,
+        { id: string; data: UpdateDashboard }
+    >(({ id, data }) => updateDashboard(id, data), {
+        mutationKey: ['dashboard_update_once'],
+    });
+};
+
 export const useCreateMutation = (
     projectUuid: string | undefined,
     showRedirectButton: boolean = false,
+    { showToastOnSuccess = true }: { showToastOnSuccess?: boolean } = {},
 ) => {
     const navigate = useNavigate();
     const { showToastSuccess, showToastApiError } = useToaster();
@@ -406,19 +418,22 @@ export const useCreateMutation = (
                     'most-popular-and-recently-updated',
                 ]);
                 await queryClient.invalidateQueries(['content']);
-                showToastSuccess({
-                    title: `Success! Dashboard was created.`,
-                    action: showRedirectButton
-                        ? {
-                              children: 'Open dashboard',
-                              icon: IconArrowRight,
-                              onClick: () =>
-                                  navigate(
-                                      `/projects/${projectUuid}/dashboards/${result.uuid}`,
-                                  ),
-                          }
-                        : undefined,
-                });
+
+                if (showToastOnSuccess) {
+                    showToastSuccess({
+                        title: `Success! Dashboard was created.`,
+                        action: showRedirectButton
+                            ? {
+                                  children: 'Open dashboard',
+                                  icon: IconArrowRight,
+                                  onClick: () =>
+                                      navigate(
+                                          `/projects/${projectUuid}/dashboards/${result.uuid}`,
+                                      ),
+                              }
+                            : undefined,
+                    });
+                }
             },
             onError: ({ error }) => {
                 showToastApiError({

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -345,7 +345,8 @@ export const useUpdateMutation = (
 
 export const useCreateMutation = ({
     redirectOnSuccess = true,
-}: { redirectOnSuccess?: boolean } = {}) => {
+    showToastOnSuccess = true,
+}: { redirectOnSuccess?: boolean; showToastOnSuccess?: boolean } = {}) => {
     const navigate = useNavigate();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
@@ -360,16 +361,18 @@ export const useCreateMutation = ({
             onSuccess: (data) => {
                 const navigateUrl = `/projects/${projectUuid}/saved/${data.uuid}/view`;
                 queryClient.setQueryData(['saved_query', data.uuid], data);
-                showToastSuccess({
-                    title: `Success! Chart was saved.`,
-                    action: redirectOnSuccess
-                        ? undefined
-                        : {
-                              children: 'View chart',
-                              icon: IconArrowRight,
-                              onClick: () => navigate(navigateUrl),
-                          },
-                });
+                if (showToastOnSuccess) {
+                    showToastSuccess({
+                        title: `Success! Chart was saved.`,
+                        action: redirectOnSuccess
+                            ? undefined
+                            : {
+                                  children: 'View chart',
+                                  icon: IconArrowRight,
+                                  onClick: () => navigate(navigateUrl),
+                              },
+                    });
+                }
                 if (redirectOnSuccess) {
                     void navigate(navigateUrl, {
                         replace: true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added the ability to save AI-generated dashboards to spaces. This PR introduces two new components:

1. `AiDashboardQuickOptions` - A menu component that provides quick actions for AI dashboards, including the option to save the dashboard.

2. `AiDashboardSaveModal` - A multi-step modal that guides users through naming the dashboard, adding a description, and selecting a destination space.

The implementation includes utility functions to convert AI visualization data to chart formats and build dashboard tiles from saved charts. The save process creates individual charts and then assembles them into a dashboard with a stacked layout.
