### PR TITLE
feat: download async query results from scheduler

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5877,23 +5877,6 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        slackThreadTs: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        slackChannelId: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        promptCount: { dataType: 'double', required: true },
                         feedbackSummary: {
                             ref: 'AiAgentAdminFeedbackSummary',
                             required: true,
@@ -9648,6 +9631,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['exportCsvDashboard'] },
                 { dataType: 'enum', enums: ['renameResources'] },
                 { dataType: 'enum', enums: ['cleanQueryHistory'] },
+                { dataType: 'enum', enums: ['downloadAsyncQueryResults'] },
             ],
             validators: {},
         },
@@ -36751,6 +36735,78 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'downloadResults',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsQueryController_scheduleDownloadResults: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        queryUuid: {
+            in: 'path',
+            name: 'queryUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'Omit_DownloadAsyncQueryResultsRequestParams.queryUuid_',
+        },
+    };
+    app.post(
+        '/api/v2/projects/:projectUuid/query/:queryUuid/schedule-download',
+        ...fetchMiddlewares<RequestHandler>(QueryController),
+        ...fetchMiddlewares<RequestHandler>(
+            QueryController.prototype.scheduleDownloadResults,
+        ),
+
+        async function QueryController_scheduleDownloadResults(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsQueryController_scheduleDownloadResults,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<QueryController>(
+                    QueryController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'scheduleDownloadResults',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6457,18 +6457,6 @@
                     },
                     {
                         "properties": {
-                            "slackThreadTs": {
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "slackChannelId": {
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "promptCount": {
-                                "type": "number",
-                                "format": "double"
-                            },
                             "feedbackSummary": {
                                 "$ref": "#/components/schemas/AiAgentAdminFeedbackSummary"
                             },
@@ -6488,14 +6476,7 @@
                                 "$ref": "#/components/schemas/Pick_AiAgentSummary.uuid-or-name-or-imageUrl_"
                             }
                         },
-                        "required": [
-                            "slackThreadTs",
-                            "slackChannelId",
-                            "promptCount",
-                            "feedbackSummary",
-                            "project",
-                            "agent"
-                        ],
+                        "required": ["feedbackSummary", "project", "agent"],
                         "type": "object"
                     }
                 ]
@@ -10398,7 +10379,8 @@
                     "generateDailyJobs",
                     "exportCsvDashboard",
                     "renameResources",
-                    "cleanQueryHistory"
+                    "cleanQueryHistory",
+                    "downloadAsyncQueryResults"
                 ]
             },
             "SchedulerJobStatus": {
@@ -18942,7 +18924,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1992.4",
+        "version": "0.1994.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -30113,6 +30095,66 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ApiSuccess_ApiDownloadAsyncQueryResults-or-ApiDownloadAsyncQueryResultsAsCsv-or-ApiDownloadAsyncQueryResultsAsXlsx_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Downloads query results in various formats with custom formatting options",
+                "summary": "Download results",
+                "tags": ["Query"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The UUID of the completed async query to download",
+                        "in": "path",
+                        "name": "queryUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Omit_DownloadAsyncQueryResultsRequestParams.queryUuid_"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/projects/{projectUuid}/query/{queryUuid}/schedule-download": {
+            "post": {
+                "operationId": "scheduleDownloadResults",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiJobScheduledResponse"
                                 }
                             }
                         }

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -32,6 +32,7 @@ import {
     isCreateScheduler,
     isCreateSchedulerMsTeamsTarget,
     isCreateSchedulerSlackTarget,
+    type DownloadAsyncQueryResultsPayload,
     type SchedulerCreateProjectWithCompilePayload,
     type SchedulerIndexCatalogJobPayload,
 } from '@lightdash/common';
@@ -950,5 +951,32 @@ export class SchedulerClient {
             return rows;
         });
         return stats;
+    }
+
+    async downloadAsyncQueryResults(payload: DownloadAsyncQueryResultsPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const jobId = await SchedulerClient.addJob(
+            graphileClient,
+            SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS,
+            payload,
+            now,
+            JobPriority.MEDIUM,
+            1,
+        );
+
+        await this.schedulerModel.logSchedulerJob({
+            task: SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS,
+            jobId,
+            scheduledTime: now,
+            status: SchedulerJobStatus.SCHEDULED,
+            details: {
+                createdByUserUuid: payload.userUuid,
+                projectUuid: payload.projectUuid,
+                organizationUuid: payload.organizationUuid,
+            },
+        });
+
+        return jobId;
     }
 }

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -8,6 +8,7 @@ import {
     CreateSchedulerTarget,
     DashboardFilterRule,
     DashboardParameterValue,
+    type DownloadAsyncQueryResultsPayload,
     DownloadCsvPayload,
     DownloadFileType,
     EmailNotificationPayload,
@@ -3199,6 +3200,35 @@ export default class SchedulerTask {
                         payload,
                     );
                 return { results };
+            },
+        );
+    }
+
+    protected async downloadAsyncQueryResults(
+        jobId: string,
+        scheduledTime: Date,
+        payload: DownloadAsyncQueryResultsPayload,
+    ) {
+        await this.logWrapper(
+            {
+                task: SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS,
+                jobId,
+                scheduledTime,
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    projectUuid: payload.projectUuid,
+                    organizationUuid: payload.organizationUuid,
+                },
+            },
+            async () => {
+                const sessionUser = await this.userService.getSessionByUserUuid(
+                    payload.userUuid,
+                );
+                const account = Account.fromSession(sessionUser);
+                return this.asyncQueryService.download({
+                    account,
+                    ...payload,
+                });
             },
         );
     }

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -125,6 +125,11 @@ const getTagsForTask: {
     }),
 
     [SCHEDULER_TASKS.CLEAN_QUERY_HISTORY]: () => ({}),
+    [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
 } as const;
 
 // Generic accessor function

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -7,6 +7,7 @@ import {
     type CacheMetadata,
     type DashboardFilters,
     type DateZoom,
+    type DownloadAsyncQueryResultsPayload,
     type Filters,
     type ItemsMap,
     type ParametersValuesMap,
@@ -47,6 +48,12 @@ export type DownloadAsyncQueryResultsArgs = Omit<
     pivotConfig?: PivotConfig;
     attachmentDownloadName?: string;
 };
+
+export type ScheduleDownloadAsyncQueryResultsArgs = Omit<
+    CommonAsyncQueryArgs,
+    'invalidateCache' | 'context' | 'parameters'
+> &
+    Omit<DownloadAsyncQueryResultsPayload, 'userUuid' | 'organizationUuid'>;
 
 export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
     metricQuery: MetricQuery;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -1,6 +1,7 @@
 import assertUnreachable from '../utils/assertUnreachable';
 import { type AnyType } from './any';
 import { type ApiSuccess } from './api/success';
+import type { DownloadFileType } from './downloadFile';
 import { type Explore, type ExploreError } from './explore';
 import { type DashboardFilterRule, type DashboardFilters } from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
@@ -523,4 +524,16 @@ export type ExportCsvDashboardPayload = TraceTaskBase & {
     dashboardUuid: string;
     dashboardFilters: DashboardFilters;
     dateZoomGranularity?: DateGranularity;
+};
+
+export type DownloadAsyncQueryResultsPayload = TraceTaskBase & {
+    queryUuid: string;
+    type?: DownloadFileType;
+    onlyRaw?: boolean;
+    showTableNames?: boolean;
+    customLabels?: Record<string, string>;
+    columnOrder?: string[];
+    hiddenFields?: string[];
+    pivotConfig?: PivotConfig;
+    attachmentDownloadName?: string;
 };

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -5,6 +5,7 @@ import { type UploadMetricGsheetPayload } from './gdrive';
 import { type RenameResourcesPayload } from './rename';
 import {
     type CompileProjectPayload,
+    type DownloadAsyncQueryResultsPayload,
     type DownloadCsvPayload,
     type EmailNotificationPayload,
     type ExportCsvDashboardPayload,
@@ -46,6 +47,7 @@ export const SCHEDULER_TASKS = {
     EXPORT_CSV_DASHBOARD: 'exportCsvDashboard',
     RENAME_RESOURCES: 'renameResources',
     CLEAN_QUERY_HISTORY: 'cleanQueryHistory',
+    DOWNLOAD_ASYNC_QUERY_RESULTS: 'downloadAsyncQueryResults',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -74,6 +76,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
     [SCHEDULER_TASKS.RENAME_RESOURCES]: RenameResourcesPayload;
     [SCHEDULER_TASKS.CLEAN_QUERY_HISTORY]: TraceTaskBase;
+    [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: DownloadAsyncQueryResultsPayload;
 }
 
 export interface EETaskPayloadMap {

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -1,8 +1,8 @@
 import {
-    type ApiDownloadAsyncQueryResultsAsCsv,
     type ApiError,
     type ApiExecuteAsyncMetricQueryResults,
     type ApiGetAsyncQueryResults,
+    type ApiJobScheduledResponse,
     type ApiSuccessEmpty,
     assertUnreachable,
     type DateGranularity,
@@ -83,13 +83,13 @@ const executeAsyncSavedChartQuery = async (
     });
 };
 
-export const downloadQuery = async (
+export const scheduleDownloadQuery = async (
     projectUuid: string,
     queryUuid: string,
     options: DownloadOptions = {},
-) =>
-    lightdashApi<ApiDownloadAsyncQueryResultsAsCsv>({
-        url: `/projects/${projectUuid}/query/${queryUuid}/download`,
+) => {
+    return lightdashApi<ApiJobScheduledResponse['results']>({
+        url: `/projects/${projectUuid}/query/${queryUuid}/schedule-download`,
         method: 'POST',
         body: JSON.stringify({
             type: options.fileType || DownloadFileType.CSV,
@@ -103,6 +103,7 @@ export const downloadQuery = async (
         }),
         version: 'v2',
     });
+};
 
 const executeAsyncQuery = (
     data?: QueryResultsProps | null,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16743

### Description:
This PR adds a new endpoint to schedule asynchronous downloads of query results. Instead of directly downloading query results, which crash the backend server for large datasets, this implementation:

1. Adds a new `/schedule-download` endpoint in the QueryController
2. Creates a new scheduler task type `DOWNLOAD_ASYNC_QUERY_RESULTS`
3. Updates the frontend to use the new endpoint and poll for job completion

This approach improves reliability for large result sets by moving the download process to a background job, preventing timeouts and providing better user experience.