### PR TITLE
feat: `getJobStatus` returns more detailed information of scheduled job

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -518,7 +518,13 @@ export class SchedulerService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
-        return { status: job.status, details: job.details };
+        return {
+            status: job.status,
+            details: job.details,
+            scheduler_uuid: job.scheduler_uuid,
+            target_type: job.target_type,
+            created_at: job.created_at,
+        };
     }
 
     async setJobStatus(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: NA

### Description:

Currently, we can't get even the scheduler UUID from the response of the `Get apiv1schedulersjob status`. If we know only the scheduled delivery job ID, we need to figure out the scheduler ran the job.  So, I want to make the API respond more detailed information.

https://docs.lightdash.com/api-reference/schedulers/get-apiv1schedulersjob-status

```
{'status': 'ok', 'results': {'status': 'started', 'details': {'projectUuid': 'xxx', 'organizationUuid': 'xxx', 'createdByUserUuid': 'xxx'}}}
```
