### PR TITLE
fix: handle null values in AI thread feedback counts and improve feedback display

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -784,10 +784,10 @@ export class AiAgentModel {
             .select([
                 'ai_thread_uuid',
                 this.database.raw(`
-                     COUNT(CASE WHEN human_score = 1 THEN 1 END) as upvotes,
-                     COUNT(CASE WHEN human_score = -1 THEN 1 END) as downvotes,
-                     COUNT(CASE WHEN human_score = 0 THEN 1 END) as neutral,
-                     COUNT(*) as total_feedback
+                     COUNT(CASE WHEN human_score = 1 THEN 1 END)::integer as upvotes,
+                     COUNT(CASE WHEN human_score = -1 THEN 1 END)::integer as downvotes,
+                     COUNT(CASE WHEN human_score = 0 THEN 1 END)::integer as neutral,
+                     COUNT(*)::integer as total_feedback
                  `),
             ])
             .from(AiPromptTableName)
@@ -823,13 +823,13 @@ export class AiAgentModel {
                     project_uuid: DbAiThread['project_uuid'];
 
                     // Feedback aggregation from CTE
-                    upvotes: number;
-                    downvotes: number;
-                    neutral: number;
-                    total_feedback: number;
+                    upvotes: number | null;
+                    downvotes: number | null;
+                    neutral: number | null;
+                    total_feedback: number | null;
 
                     // Prompt count from CTE
-                    prompt_count: number;
+                    prompt_count: number | null;
                 }[]
             >([
                 // Original thread fields
@@ -1034,10 +1034,10 @@ export class AiAgentModel {
                     name: row.project_name,
                 },
                 feedbackSummary: {
-                    upvotes: row.upvotes,
-                    downvotes: row.downvotes,
-                    neutral: row.neutral,
-                    total: row.total_feedback,
+                    upvotes: row.upvotes || 0,
+                    downvotes: row.downvotes || 0,
+                    neutral: row.neutral || 0,
+                    total: row.total_feedback || 0,
                 },
                 promptCount: row.prompt_count || 0,
             }),

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -16,6 +16,7 @@ import {
     IconArrowsSort,
     IconArrowUp,
     IconBox,
+    IconCircleDotted,
     IconClick,
     IconClock,
     IconMessageCircleStar,
@@ -23,6 +24,9 @@ import {
     IconRadar,
     IconRobotFace,
     IconTextCaption,
+    IconThumbDown,
+    IconThumbUp,
+    IconTilde,
     IconUser,
 } from '@tabler/icons-react';
 import {
@@ -371,20 +375,49 @@ const AiAgentAdminThreadsTable = ({
                 const { feedbackSummary } = row.original;
                 return (
                     <Group gap="xs">
-                        {feedbackSummary.neutral > 0 && (
-                            <Text fz="xs" c="gray.6">
-                                ~{feedbackSummary.neutral}
-                            </Text>
-                        )}
-                        {feedbackSummary.upvotes > 0 && (
-                            <Text fz="xs" c="green.6">
-                                ↑{feedbackSummary.upvotes}
-                            </Text>
-                        )}
-                        {feedbackSummary.downvotes > 0 && (
-                            <Text fz="xs" c="red.6">
-                                ↓{feedbackSummary.downvotes}
-                            </Text>
+                        {feedbackSummary.neutral === 0 &&
+                        feedbackSummary.upvotes === 0 &&
+                        feedbackSummary.downvotes === 0 ? (
+                            <MantineIcon
+                                icon={IconCircleDotted}
+                                color="gray.6"
+                            />
+                        ) : (
+                            <Group gap="sm">
+                                {feedbackSummary.neutral > 0 && (
+                                    <Group gap="two">
+                                        <MantineIcon
+                                            icon={IconTilde}
+                                            color="yellow.8"
+                                        />
+                                        <Text fz="xs" c="yellow.8" fw={500}>
+                                            {String(feedbackSummary.neutral)}
+                                        </Text>
+                                    </Group>
+                                )}
+                                {feedbackSummary.upvotes > 0 && (
+                                    <Group gap="two">
+                                        <MantineIcon
+                                            icon={IconThumbUp}
+                                            color="green.9"
+                                        />
+                                        <Text fz="xs" c="green.9" fw={500}>
+                                            {String(feedbackSummary.upvotes)}
+                                        </Text>
+                                    </Group>
+                                )}
+                                {feedbackSummary.downvotes > 0 && (
+                                    <Group gap="two">
+                                        <MantineIcon
+                                            icon={IconThumbDown}
+                                            color="red.9"
+                                        />
+                                        <Text fz="xs" c="red.9" fw={500}>
+                                            {String(feedbackSummary.downvotes)}
+                                        </Text>
+                                    </Group>
+                                )}
+                            </Group>
                         )}
                     </Group>
                 );


### PR DESCRIPTION
### Description:
Improves the AI Agent feedback display in the admin threads table by:

1. Fixing type issues in the backend by:
   - Casting SQL count results to integers
   - Making feedback aggregation fields nullable
   - Adding null handling with default values of 0

2. Enhancing the feedback UI in the admin threads table:
   - Adding proper icons for thumbs up, thumbs down, and neutral feedback
   - Improving the visual presentation with better colors and spacing
   - Adding a placeholder icon when no feedback is available

This change ensures consistent data types between the backend and frontend while providing a more intuitive visual representation of user feedback.