### PR TITLE
fix: mobile layout calculating incorrectly

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/gridUtils.ts
+++ b/packages/frontend/src/components/DashboardTabs/gridUtils.ts
@@ -10,20 +10,22 @@ export type ResponsiveGridLayoutProps = {
     rowHeight: number;
 };
 
+const DEFAULT_COLS = 36;
+
 export const getReactGridLayoutConfig = (
     tile: DashboardTile,
     isEditMode = false,
     cols = 36,
 ): Layout => {
     // Scale factor based on the number of columns (36 is the default for lg)
-    const scaleFactor = cols / 36;
+    const scaleFactor = cols / DEFAULT_COLS;
 
     return {
         minH: 1,
-        minW: Math.max(1, Math.round(6 * scaleFactor)),
-        x: Math.round(tile.x * scaleFactor),
+        minW: 6,
+        x: tile.x * scaleFactor,
         y: tile.y,
-        w: Math.round(tile.w * scaleFactor),
+        w: tile.w * scaleFactor,
         h: tile.h,
         i: tile.uuid,
         isDraggable: isEditMode,
@@ -48,6 +50,10 @@ export const getResponsiveGridLayoutProps = ({
     useCSSTransforms: enableAnimation,
     measureBeforeMount: !enableAnimation,
     breakpoints: { lg: 1200, md: 996, sm: 768 },
-    cols: { lg: 36, md: 30, sm: stackVerticallyOnSmallestBreakpoint ? 1 : 18 },
+    cols: {
+        lg: DEFAULT_COLS,
+        md: 30,
+        sm: stackVerticallyOnSmallestBreakpoint ? 1 : 18,
+    },
     rowHeight: 50,
 });

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -138,9 +138,6 @@ const MinimalDashboard: FC = () => {
             md: tiles.map<Layout>((tile) =>
                 getReactGridLayoutConfig(tile, false, gridProps.cols.md),
             ),
-            sm: tiles.map<Layout>((tile) =>
-                getReactGridLayoutConfig(tile, false, gridProps.cols.sm),
-            ),
         };
     }, [dashboard?.tiles, schedulerTabsSelected, activeTab, gridProps.cols]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16665

### Description:
Improved dashboard grid layout calculations by:
- Added a `DEFAULT_COLS` constant to standardize column references
- Removed unnecessary `Math.round()` calls for x and w coordinates to prevent rounding errors in tile positioning
- Fixed minW to be a constant value of 6 instead of scaling it
- Removed the small breakpoint layout generation which would cause issues with scheduled deliveries.

**Steps to test**
1. Create dashboard with 2 rows, top one with 3 tiles and the one below with 1 tile covering the row
2. Go to minimal view and resize window as you go, it should be responsive and stack vertically on the smallest size
3. Try to export dashboard as png

**Before**

![image.png](https://app.graphite.dev/user-attachments/assets/98ecada5-3a80-44be-ba66-280645dffa3a.png)

**After**

![image.png](https://app.graphite.dev/user-attachments/assets/049936bc-c298-4a0f-b3f8-e70cc8a2bc06.png)

@magnew had fixed this same issue in https://github.com/lightdash/lightdash/pull/16666 but it ended up causing issues with scheduled deliveries.

The reason for this was that in https://github.com/lightdash/lightdash/pull/16616 we added a layout for `sm` in `minimalDasboard`. But since we stack vertically this was breaking. Fix was to remove that layout and leave only `md` and `lg`, the smallest breakpoint will stack.

**Scheduled deliveries before previous attempt**

![Screenshot 2025-09-11 at 11.59.00.png](https://app.graphite.dev/user-attachments/assets/37a228b3-a7f7-44ad-927d-2d122abe2897.png)

**Scheduled deliveries with this fix**

![Screenshot 2025-09-11 at 12.06.51.png](https://app.graphite.dev/user-attachments/assets/8de0a6eb-8c28-4c46-8571-b01c97365e3a.png)

