### PR TITLE
fix: additional_dimensions in meta config

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -450,6 +450,11 @@ export const convertTable = (
                         meta: {
                             dimension: subDimension,
                         },
+                        config: {
+                            meta: {
+                                dimension: subDimension,
+                            },
+                        },
                     },
                     undefined,
                     undefined,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16783

### Description:

Added dimension metadata to the config object in the convertTable function to ensure consistent dimension information is available throughout the component hierarchy.



how to test

```
 - name: status
        description: '{{ doc("orders_status") }}'
        config:
          meta:
            dimension:
              type: string
              label: "Order Status"
              colors:
                # Hex colors are supported in both chart config and echarts
                "placed": "#e6fa0f"
                "completed": "#00FF00"
                # Rgb/rgba/name colors are not supported in chart config, but supported in echarts
                "shipped": "rgba(47, 119, 150, 0.7)"
                "return_pending": "orange"
                "returned": "rgb(247, 32, 32)"
            additional_dimensions:
              status_order:
                type: number
                label: "Status Order"
                sql: case
                  when status = 'placed' then 1
                  when status = 'shipped' then 2
                  when status = 'completed' then 3
                  when status = 'return_pending' then 4
                  when status = 'returned' then 5
                  end
```



before

![Screenshot 2025-09-12 at 08.50.54.png](https://app.graphite.dev/user-attachments/assets/14fc4778-81a8-4dcd-bbad-e3f68fb5e862.png)



after

![Screenshot 2025-09-12 at 08.56.06.png](https://app.graphite.dev/user-attachments/assets/b226a2fa-932d-4cfb-aa9c-564930463cf5.png)



