### PR TITLE
feat: add SCIM discovery endpoints for identity provider integration

### DIFF
--- a/examples/api/scim-org-tokens.http
+++ b/examples/api/scim-org-tokens.http
@@ -37,3 +37,21 @@ GET http://localhost:8080/api/v1/logout
 ### Make a request using the scim token
 GET http://localhost:8080/api/v1/scim/v2/Groups
 Authorization: Bearer scim_1b593fb911bbe92cbabd67b6f6234957
+
+### SCIM Discovery Endpoints
+
+### Get SCIM Service Provider Configuration
+GET http://localhost:8080/api/v1/scim/v2/ServiceProviderConfig
+Authorization: Bearer scim_1b593fb911bbe92cbabd67b6f6234957
+
+### Get SCIM Schemas
+GET http://localhost:8080/api/v1/scim/v2/Schemas
+Authorization: Bearer scim_1b593fb911bbe92cbabd67b6f6234957
+
+### Get SCIM Resource Types
+GET http://localhost:8080/api/v1/scim/v2/ResourceTypes
+Authorization: Bearer scim_1b593fb911bbe92cbabd67b6f6234957
+
+### Test SCIM Root Endpoint (for connectivity)
+GET http://localhost:8080/api/v1/scim/v2/
+Authorization: Bearer scim_1b593fb911bbe92cbabd67b6f6234957

--- a/packages/backend/src/ee/controllers/scimRootController.ts
+++ b/packages/backend/src/ee/controllers/scimRootController.ts
@@ -1,8 +1,15 @@
+/* eslint-disable class-methods-use-this */
+import {
+    ScimResourceType,
+    ScimSchema,
+    ScimServiceProviderConfig,
+} from '@lightdash/common';
 import {
     Get,
     Hidden,
     Middlewares,
     OperationId,
+    Path,
     Request,
     Response,
     Route,
@@ -11,6 +18,7 @@ import {
 import express from 'express';
 import { BaseController } from '../../controllers/baseController';
 import { isScimAuthenticated } from '../authentication';
+import { ScimService } from '../services/ScimService/ScimService';
 
 @Route('/api/v1/scim/v2')
 @Hidden()
@@ -27,5 +35,67 @@ export class ScimRootController extends BaseController {
     async getScimRoot(@Request() req: express.Request): Promise<void> {
         // Return empty success response as expected by identity providers
         this.setStatus(200);
+    }
+
+    /**
+     * Get SCIM service provider configuration
+     * @param req express request
+     */
+    @Get('/ServiceProviderConfig')
+    @OperationId('GetScimServiceProviderConfig')
+    @Response<ScimServiceProviderConfig>('200', 'Success')
+    async getServiceProviderConfig(
+        @Request() req: express.Request,
+    ): Promise<ScimServiceProviderConfig> {
+        return ScimService.getServiceProviderConfig();
+    }
+
+    /**
+     * Get SCIM schemas
+     * @param req express request
+     */
+    @Get('/Schemas')
+    @OperationId('GetScimSchemas')
+    @Response<ScimSchema[]>('200', 'Success')
+    async getSchemas(@Request() req: express.Request): Promise<ScimSchema[]> {
+        return ScimService.getSchemas();
+    }
+
+    /**
+     * Get SCIM resource types
+     * @param req express request
+     */
+    @Get('/ResourceTypes')
+    @OperationId('GetScimResourceTypes')
+    @Response<ScimResourceType[]>('200', 'Success')
+    async getResourceTypes(
+        @Request() req: express.Request,
+    ): Promise<ScimResourceType[]> {
+        return ScimService.getResourceTypes();
+    }
+
+    /**
+     * Get individual SCIM resource type
+     * @param req express request
+     * @param resourceTypeId resource type identifier
+     */
+    @Get('/ResourceTypes/{resourceTypeId}')
+    @OperationId('GetScimResourceType')
+    @Response<ScimResourceType>('200', 'Success')
+    async getResourceType(
+        @Request() req: express.Request,
+        @Path() resourceTypeId: string,
+    ): Promise<ScimResourceType> {
+        const resourceTypes = ScimService.getResourceTypes();
+        const resourceType = resourceTypes.find(
+            (rt) => rt.id === resourceTypeId,
+        );
+
+        if (!resourceType) {
+            this.setStatus(404);
+            throw new Error(`Resource type ${resourceTypeId} not found`);
+        }
+
+        return resourceType;
     }
 }

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -450,4 +450,177 @@ describe('ScimService', () => {
             ).toThrow();
         });
     });
+
+    describe('Discovery Endpoints', () => {
+        describe('getServiceProviderConfig', () => {
+            test('should return correct service provider config', async () => {
+                const config = ScimService.getServiceProviderConfig();
+
+                expect(config).toEqual({
+                    schemas: [ScimSchemaType.SERVICE_PROVIDER_CONFIG],
+                    documentationUri: 'https://docs.lightdash.com/guides/scim',
+                    patch: { supported: true },
+                    bulk: { supported: false },
+                    filter: { supported: true, maxResults: 200 },
+                    changePassword: { supported: false },
+                    sort: { supported: false },
+                    etag: { supported: false },
+                    authenticationSchemes: [
+                        {
+                            type: 'oauthbearertoken',
+                            name: 'OAuth Bearer Token',
+                            description:
+                                'Authentication scheme using the OAuth 2.0 Bearer Token standard',
+                            primary: true,
+                        },
+                    ],
+                });
+            });
+        });
+
+        describe('getSchemas', () => {
+            test('should return correct schemas array', async () => {
+                const schemas = ScimService.getSchemas();
+
+                expect(schemas).toHaveLength(5);
+                expect(schemas.map((s) => s.id)).toEqual([
+                    ScimSchemaType.USER,
+                    ScimSchemaType.GROUP,
+                    ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+                    ScimSchemaType.SERVICE_PROVIDER_CONFIG,
+                    ScimSchemaType.RESOURCE_TYPE,
+                ]);
+
+                // Test User schema
+                const userSchema = schemas.find(
+                    (s) => s.id === ScimSchemaType.USER,
+                );
+                expect(userSchema).toBeDefined();
+                expect(userSchema!.name).toBe('User');
+                expect(userSchema!.attributes).toContainEqual(
+                    expect.objectContaining({
+                        name: 'userName',
+                        type: 'string',
+                        required: true,
+                        uniqueness: 'server',
+                    }),
+                );
+
+                // Test Group schema
+                const groupSchema = schemas.find(
+                    (s) => s.id === ScimSchemaType.GROUP,
+                );
+                expect(groupSchema).toBeDefined();
+                expect(groupSchema!.name).toBe('Group');
+                expect(groupSchema!.attributes).toContainEqual(
+                    expect.objectContaining({
+                        name: 'displayName',
+                        type: 'string',
+                        required: true,
+                    }),
+                );
+
+                // Test Lightdash extension schema
+                const extensionSchema = schemas.find(
+                    (s) => s.id === ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+                );
+                expect(extensionSchema).toBeDefined();
+                expect(extensionSchema!.name).toBe('Lightdash User Extension');
+                expect(extensionSchema!.attributes).toContainEqual(
+                    expect.objectContaining({
+                        name: 'role',
+                        type: 'string',
+                        canonicalValues: [
+                            'admin',
+                            'editor',
+                            'interactive_viewer',
+                            'viewer',
+                        ],
+                    }),
+                );
+
+                // Test ServiceProviderConfig schema
+                const serviceProviderConfigSchema = schemas.find(
+                    (s) => s.id === ScimSchemaType.SERVICE_PROVIDER_CONFIG,
+                );
+                expect(serviceProviderConfigSchema).toBeDefined();
+                expect(serviceProviderConfigSchema!.name).toBe(
+                    'Service Provider Configuration',
+                );
+                expect(serviceProviderConfigSchema!.attributes).toContainEqual(
+                    expect.objectContaining({
+                        name: 'documentationUri',
+                        type: 'reference',
+                        required: false,
+                    }),
+                );
+
+                // Test ResourceType schema
+                const resourceTypeSchema = schemas.find(
+                    (s) => s.id === ScimSchemaType.RESOURCE_TYPE,
+                );
+                expect(resourceTypeSchema).toBeDefined();
+                expect(resourceTypeSchema!.name).toBe('Resource Type');
+                expect(resourceTypeSchema!.attributes).toContainEqual(
+                    expect.objectContaining({
+                        name: 'name',
+                        type: 'string',
+                        required: true,
+                    }),
+                );
+            });
+        });
+
+        describe('getResourceTypes', () => {
+            test('should return correct resource types as array', async () => {
+                const resourceTypes = ScimService.getResourceTypes();
+
+                expect(resourceTypes).toHaveLength(2);
+
+                // Test User resource type
+                const userResourceType = resourceTypes.find(
+                    (rt) => rt.name === 'User',
+                );
+                expect(userResourceType).toEqual({
+                    schemas: [ScimSchemaType.RESOURCE_TYPE],
+                    id: 'User',
+                    name: 'User',
+                    description: 'User Account',
+                    endpoint: '/Users',
+                    schema: ScimSchemaType.USER,
+                    schemaExtensions: [
+                        {
+                            schema: ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+                            required: false,
+                        },
+                    ],
+                    meta: {
+                        resourceType: 'ResourceType',
+                        location: expect.stringContaining(
+                            '/api/v1/scim/v2/ResourceTypes/User',
+                        ),
+                    },
+                });
+
+                // Test Group resource type
+                const groupResourceType = resourceTypes.find(
+                    (rt) => rt.name === 'Group',
+                );
+                expect(groupResourceType).toEqual({
+                    schemas: [ScimSchemaType.RESOURCE_TYPE],
+                    id: 'Group',
+                    name: 'Group',
+                    description: 'Group',
+                    endpoint: '/Groups',
+                    schema: ScimSchemaType.GROUP,
+                    meta: {
+                        resourceType: 'ResourceType',
+                        location: expect.stringContaining(
+                            '/api/v1/scim/v2/ResourceTypes/Group',
+                        ),
+                    },
+                });
+            });
+        });
+    });
 });

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -15,7 +15,11 @@ import {
     ScimError,
     ScimGroup,
     ScimListResponse,
+    ScimResourceType,
+    ScimSchema,
+    ScimSchemaAttribute,
     ScimSchemaType,
+    ScimServiceProviderConfig,
     ScimUpsertGroup,
     ScimUpsertUser,
     ScimUser,
@@ -1052,5 +1056,702 @@ export class ScimService extends BaseService {
             Sentry.captureException(scimError);
             throw scimError;
         }
+    }
+
+    static getServiceProviderConfig(): ScimServiceProviderConfig {
+        return {
+            schemas: [ScimSchemaType.SERVICE_PROVIDER_CONFIG],
+            documentationUri: 'https://docs.lightdash.com/guides/scim',
+            patch: {
+                supported: true,
+            },
+            bulk: {
+                supported: false,
+            },
+            filter: {
+                supported: true,
+                maxResults: 200,
+            },
+            changePassword: {
+                supported: false,
+            },
+            sort: {
+                supported: false,
+            },
+            etag: {
+                supported: false,
+            },
+            authenticationSchemes: [
+                {
+                    type: 'oauthbearertoken',
+                    name: 'OAuth Bearer Token',
+                    description:
+                        'Authentication scheme using the OAuth 2.0 Bearer Token standard',
+                    primary: true,
+                },
+            ],
+        };
+    }
+
+    /**
+     * Type-safe mapping of ScimUser interface fields to SCIM schema attributes
+     * This ensures all fields from ScimUser are covered and only those fields
+     */
+    private static buildUserSchemaAttributes(): ScimSchemaAttribute[] {
+        // Type-safe field mapping - TypeScript will catch if ScimUser interface changes
+        type ScimUserFieldMap = {
+            [K in keyof Omit<
+                ScimUser,
+                | 'schemas'
+                | 'id'
+                | 'externalId'
+                | 'meta'
+                | ScimSchemaType.LIGHTDASH_USER_EXTENSION
+            >]: ScimSchemaAttribute;
+        };
+
+        const fieldAttributeMap: ScimUserFieldMap = {
+            userName: {
+                name: 'userName',
+                type: 'string',
+                multiValued: false,
+                description:
+                    'Unique identifier for the User, typically used for login',
+                required: true,
+                caseExact: false,
+                mutability: 'readWrite',
+                returned: 'default',
+                uniqueness: 'server',
+            },
+            name: {
+                name: 'name',
+                type: 'complex',
+                multiValued: false,
+                description: "The components of the user's real name",
+                required: false,
+                caseExact: false,
+                mutability: 'readWrite',
+                returned: 'default',
+                uniqueness: 'none',
+                subAttributes: [
+                    {
+                        name: 'givenName',
+                        type: 'string',
+                        multiValued: false,
+                        description:
+                            'The given name of the User, or first name',
+                        required: false,
+                        caseExact: false,
+                        mutability: 'readWrite',
+                        returned: 'default',
+                        uniqueness: 'none',
+                    },
+                    {
+                        name: 'familyName',
+                        type: 'string',
+                        multiValued: false,
+                        description:
+                            'The family name of the User, or last name',
+                        required: false,
+                        caseExact: false,
+                        mutability: 'readWrite',
+                        returned: 'default',
+                        uniqueness: 'none',
+                    },
+                ],
+            },
+            active: {
+                name: 'active',
+                type: 'boolean',
+                multiValued: false,
+                description:
+                    "A Boolean value indicating the User's administrative status",
+                required: false,
+                caseExact: false,
+                mutability: 'readWrite',
+                returned: 'default',
+                uniqueness: 'none',
+            },
+            emails: {
+                name: 'emails',
+                type: 'complex',
+                multiValued: true,
+                description: 'Email addresses for the user',
+                required: false,
+                caseExact: false,
+                mutability: 'readWrite',
+                returned: 'default',
+                uniqueness: 'none',
+                subAttributes: [
+                    {
+                        name: 'value',
+                        type: 'string',
+                        multiValued: false,
+                        description: 'Email address for the User',
+                        required: false,
+                        caseExact: false,
+                        mutability: 'readWrite',
+                        returned: 'default',
+                        uniqueness: 'none',
+                    },
+                    {
+                        name: 'primary',
+                        type: 'boolean',
+                        multiValued: false,
+                        description:
+                            'A Boolean value indicating the primary email address',
+                        required: false,
+                        caseExact: false,
+                        mutability: 'readWrite',
+                        returned: 'default',
+                        uniqueness: 'none',
+                    },
+                ],
+            },
+        };
+
+        // Return all attributes as array - TypeScript ensures all ScimUser fields are covered
+        return Object.values(fieldAttributeMap);
+    }
+
+    static getSchemas(): ScimSchema[] {
+        const userSchema: ScimSchema = {
+            schemas: [ScimSchemaType.SCHEMA],
+            id: ScimSchemaType.USER,
+            name: 'User',
+            description: 'User Schema - Lightdash supported attributes',
+            attributes: this.buildUserSchemaAttributes(),
+        };
+
+        const groupSchema: ScimSchema = {
+            schemas: [ScimSchemaType.SCHEMA],
+            id: ScimSchemaType.GROUP,
+            name: 'Group',
+            description: 'Group Schema',
+            attributes: [
+                {
+                    name: 'displayName',
+                    type: 'string',
+                    multiValued: false,
+                    description: 'A human-readable name for the Group',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readWrite',
+                    returned: 'default',
+                    uniqueness: 'none',
+                },
+                {
+                    name: 'members',
+                    type: 'complex',
+                    multiValued: true,
+                    description: 'A list of members of the Group',
+                    required: false,
+                    caseExact: false,
+                    mutability: 'readWrite',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'value',
+                            type: 'string',
+                            multiValued: false,
+                            description:
+                                'Identifier of the member of this Group',
+                            required: false,
+                            caseExact: false,
+                            mutability: 'readWrite',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'display',
+                            type: 'string',
+                            multiValued: false,
+                            description:
+                                'A human-readable name for the Group member',
+                            required: false,
+                            caseExact: false,
+                            mutability: 'readWrite',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const lightdashUserExtensionSchema: ScimSchema = {
+            schemas: [ScimSchemaType.SCHEMA],
+            id: ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+            name: 'Lightdash User Extension',
+            description: 'Lightdash-specific User attributes',
+            attributes: [
+                {
+                    name: 'role',
+                    type: 'string',
+                    multiValued: false,
+                    description: 'Role of the user in the organization',
+                    required: false,
+                    canonicalValues: [
+                        'admin',
+                        'editor',
+                        'interactive_viewer',
+                        'viewer',
+                    ],
+                    caseExact: false,
+                    mutability: 'readWrite',
+                    returned: 'default',
+                    uniqueness: 'none',
+                },
+            ],
+        };
+
+        const serviceProviderConfigSchema: ScimSchema = {
+            schemas: [ScimSchemaType.SCHEMA],
+            id: ScimSchemaType.SERVICE_PROVIDER_CONFIG,
+            name: 'Service Provider Configuration',
+            description:
+                "Schema for representing the service provider's configuration",
+            attributes: [
+                {
+                    name: 'documentationUri',
+                    type: 'reference',
+                    multiValued: false,
+                    description:
+                        "An HTTP-addressable URL pointing to the service provider's human-consumable help documentation",
+                    required: false,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                },
+                {
+                    name: 'patch',
+                    type: 'complex',
+                    multiValued: false,
+                    description:
+                        'A complex type that specifies PATCH configuration options',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'supported',
+                            type: 'boolean',
+                            multiValued: false,
+                            description:
+                                'A Boolean value specifying whether or not the operation is supported',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+                {
+                    name: 'bulk',
+                    type: 'complex',
+                    multiValued: false,
+                    description:
+                        'A complex type that specifies bulk configuration options',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'supported',
+                            type: 'boolean',
+                            multiValued: false,
+                            description:
+                                'A Boolean value specifying whether or not the operation is supported',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'maxOperations',
+                            type: 'integer',
+                            multiValued: false,
+                            description:
+                                'An integer value specifying the maximum number of operations',
+                            required: false,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'maxPayloadSize',
+                            type: 'integer',
+                            multiValued: false,
+                            description:
+                                'An integer value specifying the maximum payload size in bytes',
+                            required: false,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+                {
+                    name: 'filter',
+                    type: 'complex',
+                    multiValued: false,
+                    description: 'A complex type that specifies FILTER options',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'supported',
+                            type: 'boolean',
+                            multiValued: false,
+                            description:
+                                'A Boolean value specifying whether or not the operation is supported',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'maxResults',
+                            type: 'integer',
+                            multiValued: false,
+                            description:
+                                'An integer value specifying the maximum number of resources returned',
+                            required: false,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+                {
+                    name: 'changePassword',
+                    type: 'complex',
+                    multiValued: false,
+                    description:
+                        'A complex type that specifies configuration options related to changing a password',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'supported',
+                            type: 'boolean',
+                            multiValued: false,
+                            description:
+                                'A Boolean value specifying whether or not the operation is supported',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+                {
+                    name: 'sort',
+                    type: 'complex',
+                    multiValued: false,
+                    description:
+                        'A complex type that specifies sort result options',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'supported',
+                            type: 'boolean',
+                            multiValued: false,
+                            description:
+                                'A Boolean value specifying whether or not sorting is supported',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+                {
+                    name: 'etag',
+                    type: 'complex',
+                    multiValued: false,
+                    description:
+                        'A complex type that specifies ETag configuration options',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'supported',
+                            type: 'boolean',
+                            multiValued: false,
+                            description:
+                                'A Boolean value specifying whether or not the operation is supported',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+                {
+                    name: 'authenticationSchemes',
+                    type: 'complex',
+                    multiValued: true,
+                    description:
+                        'A multi-valued complex type that specifies supported authentication scheme properties',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'type',
+                            type: 'string',
+                            multiValued: false,
+                            description: 'The authentication scheme type',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'name',
+                            type: 'string',
+                            multiValued: false,
+                            description:
+                                'The common authentication scheme name',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'description',
+                            type: 'string',
+                            multiValued: false,
+                            description:
+                                'A description of the authentication scheme',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'specUri',
+                            type: 'reference',
+                            multiValued: false,
+                            description:
+                                'An HTTP-addressable URL pointing to the authentication scheme specification',
+                            required: false,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'documentationUri',
+                            type: 'reference',
+                            multiValued: false,
+                            description:
+                                'An HTTP-addressable URL pointing to the authentication scheme usage documentation',
+                            required: false,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'primary',
+                            type: 'boolean',
+                            multiValued: false,
+                            description:
+                                'A Boolean value indicating the primary authentication scheme',
+                            required: false,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const resourceTypeSchema: ScimSchema = {
+            schemas: [ScimSchemaType.SCHEMA],
+            id: ScimSchemaType.RESOURCE_TYPE,
+            name: 'Resource Type',
+            description:
+                'Specifies the schema that describes a SCIM resource type',
+            attributes: [
+                {
+                    name: 'id',
+                    type: 'string',
+                    multiValued: false,
+                    description: "The resource type's server unique id",
+                    required: false,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                },
+                {
+                    name: 'name',
+                    type: 'string',
+                    multiValued: false,
+                    description: 'The resource type name',
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                },
+                {
+                    name: 'description',
+                    type: 'string',
+                    multiValued: false,
+                    description:
+                        "The resource type's human-readable description",
+                    required: false,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                },
+                {
+                    name: 'endpoint',
+                    type: 'reference',
+                    multiValued: false,
+                    description:
+                        "The resource type's HTTP-addressable endpoint relative to the Base URL",
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                },
+                {
+                    name: 'schema',
+                    type: 'reference',
+                    multiValued: false,
+                    description: "The resource type's primary/base schema URI",
+                    required: true,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                },
+                {
+                    name: 'schemaExtensions',
+                    type: 'complex',
+                    multiValued: true,
+                    description:
+                        "A list of URIs of the resource type's schema extensions",
+                    required: false,
+                    caseExact: false,
+                    mutability: 'readOnly',
+                    returned: 'default',
+                    uniqueness: 'none',
+                    subAttributes: [
+                        {
+                            name: 'schema',
+                            type: 'reference',
+                            multiValued: false,
+                            description: 'The URI of a schema extension',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                        {
+                            name: 'required',
+                            type: 'boolean',
+                            multiValued: false,
+                            description:
+                                'A Boolean value that specifies whether or not the schema extension is required',
+                            required: true,
+                            caseExact: false,
+                            mutability: 'readOnly',
+                            returned: 'default',
+                            uniqueness: 'none',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        return [
+            userSchema,
+            groupSchema,
+            lightdashUserExtensionSchema,
+            serviceProviderConfigSchema,
+            resourceTypeSchema,
+        ];
+    }
+
+    static getResourceTypes(): ScimResourceType[] {
+        // Get base URL from environment or use default
+        const baseUrl = process.env.SITE_URL || 'http://localhost:8080';
+
+        return [
+            {
+                schemas: [ScimSchemaType.RESOURCE_TYPE],
+                id: 'User',
+                name: 'User',
+                description: 'User Account',
+                endpoint: '/Users',
+                schema: ScimSchemaType.USER,
+                schemaExtensions: [
+                    {
+                        schema: ScimSchemaType.LIGHTDASH_USER_EXTENSION,
+                        required: false,
+                    },
+                ],
+                meta: {
+                    resourceType: 'ResourceType',
+                    location: `${baseUrl}/api/v1/scim/v2/ResourceTypes/User`,
+                },
+            },
+            {
+                schemas: [ScimSchemaType.RESOURCE_TYPE],
+                id: 'Group',
+                name: 'Group',
+                description: 'Group',
+                endpoint: '/Groups',
+                schema: ScimSchemaType.GROUP,
+                meta: {
+                    resourceType: 'ResourceType',
+                    location: `${baseUrl}/api/v1/scim/v2/ResourceTypes/Group`,
+                },
+            },
+        ];
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -554,6 +554,229 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ScimSchemaType.SERVICE_PROVIDER_CONFIG': {
+        dataType: 'refEnum',
+        enums: ['urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimServiceProviderConfig: {
+        dataType: 'refObject',
+        properties: {
+            schemas: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refEnum',
+                    ref: 'ScimSchemaType.SERVICE_PROVIDER_CONFIG',
+                },
+                required: true,
+            },
+            documentationUri: { dataType: 'string' },
+            patch: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    supported: { dataType: 'boolean', required: true },
+                },
+                required: true,
+            },
+            bulk: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    maxPayloadSize: { dataType: 'double' },
+                    maxOperations: { dataType: 'double' },
+                    supported: { dataType: 'boolean', required: true },
+                },
+                required: true,
+            },
+            filter: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    maxResults: { dataType: 'double' },
+                    supported: { dataType: 'boolean', required: true },
+                },
+                required: true,
+            },
+            changePassword: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    supported: { dataType: 'boolean', required: true },
+                },
+                required: true,
+            },
+            sort: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    supported: { dataType: 'boolean', required: true },
+                },
+                required: true,
+            },
+            etag: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    supported: { dataType: 'boolean', required: true },
+                },
+                required: true,
+            },
+            authenticationSchemes: {
+                dataType: 'array',
+                array: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        primary: { dataType: 'boolean' },
+                        documentationUri: { dataType: 'string' },
+                        specUri: { dataType: 'string' },
+                        description: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        type: { dataType: 'string', required: true },
+                    },
+                },
+                required: true,
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ScimSchemaType.SCHEMA': {
+        dataType: 'refEnum',
+        enums: ['urn:ietf:params:scim:schemas:core:2.0:Schema'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimSchemaAttribute: {
+        dataType: 'refObject',
+        properties: {
+            name: { dataType: 'string', required: true },
+            type: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'enum', enums: ['string'] },
+                    { dataType: 'enum', enums: ['boolean'] },
+                    { dataType: 'enum', enums: ['decimal'] },
+                    { dataType: 'enum', enums: ['integer'] },
+                    { dataType: 'enum', enums: ['dateTime'] },
+                    { dataType: 'enum', enums: ['reference'] },
+                    { dataType: 'enum', enums: ['complex'] },
+                ],
+                required: true,
+            },
+            multiValued: { dataType: 'boolean', required: true },
+            description: { dataType: 'string' },
+            required: { dataType: 'boolean', required: true },
+            canonicalValues: {
+                dataType: 'array',
+                array: { dataType: 'string' },
+            },
+            caseExact: { dataType: 'boolean', required: true },
+            mutability: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'enum', enums: ['readOnly'] },
+                    { dataType: 'enum', enums: ['readWrite'] },
+                    { dataType: 'enum', enums: ['immutable'] },
+                    { dataType: 'enum', enums: ['writeOnly'] },
+                ],
+                required: true,
+            },
+            returned: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'enum', enums: ['always'] },
+                    { dataType: 'enum', enums: ['never'] },
+                    { dataType: 'enum', enums: ['default'] },
+                    { dataType: 'enum', enums: ['request'] },
+                ],
+                required: true,
+            },
+            uniqueness: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'enum', enums: ['none'] },
+                    { dataType: 'enum', enums: ['server'] },
+                    { dataType: 'enum', enums: ['global'] },
+                ],
+                required: true,
+            },
+            subAttributes: {
+                dataType: 'array',
+                array: { dataType: 'refObject', ref: 'ScimSchemaAttribute' },
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimSchema: {
+        dataType: 'refObject',
+        properties: {
+            schemas: {
+                dataType: 'array',
+                array: { dataType: 'refEnum', ref: 'ScimSchemaType.SCHEMA' },
+                required: true,
+            },
+            id: { dataType: 'string', required: true },
+            meta: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    version: { dataType: 'string' },
+                    location: { dataType: 'string' },
+                    lastModified: { dataType: 'datetime' },
+                    created: { dataType: 'datetime' },
+                    resourceType: { dataType: 'string' },
+                },
+            },
+            name: { dataType: 'string' },
+            description: { dataType: 'string' },
+            attributes: {
+                dataType: 'array',
+                array: { dataType: 'refObject', ref: 'ScimSchemaAttribute' },
+                required: true,
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ScimSchemaType.RESOURCE_TYPE': {
+        dataType: 'refEnum',
+        enums: ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimResourceType: {
+        dataType: 'refObject',
+        properties: {
+            schemas: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refEnum',
+                    ref: 'ScimSchemaType.RESOURCE_TYPE',
+                },
+                required: true,
+            },
+            id: { dataType: 'string', required: true },
+            meta: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    version: { dataType: 'string' },
+                    location: { dataType: 'string' },
+                    lastModified: { dataType: 'datetime' },
+                    created: { dataType: 'datetime' },
+                    resourceType: { dataType: 'string' },
+                },
+            },
+            name: { dataType: 'string', required: true },
+            description: { dataType: 'string' },
+            endpoint: { dataType: 'string', required: true },
+            schema: { dataType: 'string', required: true },
+            schemaExtensions: {
+                dataType: 'array',
+                array: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        required: { dataType: 'boolean', required: true },
+                        schema: { dataType: 'string', required: true },
+                    },
+                },
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_ServiceAccount.expiresAt-or-description_': {
         dataType: 'refAlias',
         type: {
@@ -5913,6 +6136,23 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        slackThreadTs: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        slackChannelId: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        promptCount: { dataType: 'double', required: true },
                         feedbackSummary: {
                             ref: 'AiAgentAdminFeedbackSummary',
                             required: true,
@@ -12315,7 +12555,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12325,7 +12565,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12335,7 +12575,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -12348,7 +12588,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -12756,7 +12996,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12766,7 +13006,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -12776,7 +13016,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -12789,7 +13029,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -18820,6 +19060,228 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getScimRoot',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsScimRootController_getServiceProviderConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/scim/v2/ServiceProviderConfig',
+        ...fetchMiddlewares<RequestHandler>(ScimRootController),
+        ...fetchMiddlewares<RequestHandler>(
+            ScimRootController.prototype.getServiceProviderConfig,
+        ),
+
+        async function ScimRootController_getServiceProviderConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsScimRootController_getServiceProviderConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ScimRootController>(
+                    ScimRootController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getServiceProviderConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsScimRootController_getSchemas: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/scim/v2/Schemas',
+        ...fetchMiddlewares<RequestHandler>(ScimRootController),
+        ...fetchMiddlewares<RequestHandler>(
+            ScimRootController.prototype.getSchemas,
+        ),
+
+        async function ScimRootController_getSchemas(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsScimRootController_getSchemas,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ScimRootController>(
+                    ScimRootController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getSchemas',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsScimRootController_getResourceTypes: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/scim/v2/ResourceTypes',
+        ...fetchMiddlewares<RequestHandler>(ScimRootController),
+        ...fetchMiddlewares<RequestHandler>(
+            ScimRootController.prototype.getResourceTypes,
+        ),
+
+        async function ScimRootController_getResourceTypes(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsScimRootController_getResourceTypes,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ScimRootController>(
+                    ScimRootController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getResourceTypes',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsScimRootController_getResourceType: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        resourceTypeId: {
+            in: 'path',
+            name: 'resourceTypeId',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/scim/v2/ResourceTypes/:resourceTypeId',
+        ...fetchMiddlewares<RequestHandler>(ScimRootController),
+        ...fetchMiddlewares<RequestHandler>(
+            ScimRootController.prototype.getResourceType,
+        ),
+
+        async function ScimRootController_getResourceType(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsScimRootController_getResourceType,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ScimRootController>(
+                    ScimRootController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getResourceType',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -461,6 +461,325 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "ScimSchemaType.SERVICE_PROVIDER_CONFIG": {
+                "enum": [
+                    "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
+                ],
+                "type": "string"
+            },
+            "ScimServiceProviderConfig": {
+                "properties": {
+                    "schemas": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaType.SERVICE_PROVIDER_CONFIG"
+                        },
+                        "type": "array"
+                    },
+                    "documentationUri": {
+                        "type": "string"
+                    },
+                    "patch": {
+                        "properties": {
+                            "supported": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["supported"],
+                        "type": "object"
+                    },
+                    "bulk": {
+                        "properties": {
+                            "maxPayloadSize": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "maxOperations": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "supported": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["supported"],
+                        "type": "object"
+                    },
+                    "filter": {
+                        "properties": {
+                            "maxResults": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "supported": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["supported"],
+                        "type": "object"
+                    },
+                    "changePassword": {
+                        "properties": {
+                            "supported": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["supported"],
+                        "type": "object"
+                    },
+                    "sort": {
+                        "properties": {
+                            "supported": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["supported"],
+                        "type": "object"
+                    },
+                    "etag": {
+                        "properties": {
+                            "supported": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["supported"],
+                        "type": "object"
+                    },
+                    "authenticationSchemes": {
+                        "items": {
+                            "properties": {
+                                "primary": {
+                                    "type": "boolean"
+                                },
+                                "documentationUri": {
+                                    "type": "string"
+                                },
+                                "specUri": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["description", "name", "type"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "schemas",
+                    "patch",
+                    "bulk",
+                    "filter",
+                    "changePassword",
+                    "sort",
+                    "etag",
+                    "authenticationSchemes"
+                ],
+                "type": "object",
+                "additionalProperties": true
+            },
+            "ScimSchemaType.SCHEMA": {
+                "enum": ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
+                "type": "string"
+            },
+            "ScimSchemaAttribute": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "string",
+                            "boolean",
+                            "decimal",
+                            "integer",
+                            "dateTime",
+                            "reference",
+                            "complex"
+                        ]
+                    },
+                    "multiValued": {
+                        "type": "boolean"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "required": {
+                        "type": "boolean"
+                    },
+                    "canonicalValues": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "caseExact": {
+                        "type": "boolean"
+                    },
+                    "mutability": {
+                        "type": "string",
+                        "enum": [
+                            "readOnly",
+                            "readWrite",
+                            "immutable",
+                            "writeOnly"
+                        ]
+                    },
+                    "returned": {
+                        "type": "string",
+                        "enum": ["always", "never", "default", "request"]
+                    },
+                    "uniqueness": {
+                        "type": "string",
+                        "enum": ["none", "server", "global"]
+                    },
+                    "subAttributes": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaAttribute"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "name",
+                    "type",
+                    "multiValued",
+                    "required",
+                    "caseExact",
+                    "mutability",
+                    "returned",
+                    "uniqueness"
+                ],
+                "type": "object",
+                "additionalProperties": true
+            },
+            "ScimSchema": {
+                "properties": {
+                    "schemas": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaType.SCHEMA"
+                        },
+                        "type": "array"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "meta": {
+                        "properties": {
+                            "version": {
+                                "type": "string"
+                            },
+                            "location": {
+                                "type": "string"
+                            },
+                            "lastModified": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "created": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "resourceType": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "attributes": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaAttribute"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["schemas", "id", "attributes"],
+                "type": "object",
+                "additionalProperties": true
+            },
+            "ScimSchemaType.RESOURCE_TYPE": {
+                "enum": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+                "type": "string"
+            },
+            "ScimResourceType": {
+                "properties": {
+                    "schemas": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaType.RESOURCE_TYPE"
+                        },
+                        "type": "array"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "meta": {
+                        "properties": {
+                            "version": {
+                                "type": "string"
+                            },
+                            "location": {
+                                "type": "string"
+                            },
+                            "lastModified": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "created": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "resourceType": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "endpoint": {
+                        "type": "string"
+                    },
+                    "schema": {
+                        "type": "string"
+                    },
+                    "schemaExtensions": {
+                        "items": {
+                            "properties": {
+                                "required": {
+                                    "type": "boolean"
+                                },
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["required", "schema"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["schemas", "id", "name", "endpoint", "schema"],
+                "type": "object",
+                "additionalProperties": true
+            },
             "Pick_ServiceAccount.expiresAt-or-description_": {
                 "properties": {
                     "expiresAt": {
@@ -6478,6 +6797,18 @@
                     },
                     {
                         "properties": {
+                            "slackThreadTs": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "slackChannelId": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "promptCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
                             "feedbackSummary": {
                                 "$ref": "#/components/schemas/AiAgentAdminFeedbackSummary"
                             },
@@ -6497,7 +6828,14 @@
                                 "$ref": "#/components/schemas/Pick_AiAgentSummary.uuid-or-name-or-imageUrl_"
                             }
                         },
-                        "required": ["feedbackSummary", "project", "agent"],
+                        "required": [
+                            "slackThreadTs",
+                            "slackChannelId",
+                            "promptCount",
+                            "feedbackSummary",
+                            "project",
+                            "agent"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -13147,22 +13485,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiChartAsCodeListResponse": {
@@ -13501,22 +13839,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -18945,7 +19283,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.1995.0",
+        "version": "0.2000.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -13,4 +13,6 @@ export enum ScimSchemaType {
     SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Schema',
     PATCH = 'urn:ietf:params:scim:api:messages:2.0:PatchOp',
     LIGHTDASH_USER_EXTENSION = 'urn:lightdash:params:scim:schemas:extension:2.0:User',
+    SERVICE_PROVIDER_CONFIG = 'urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig',
+    RESOURCE_TYPE = 'urn:ietf:params:scim:schemas:core:2.0:ResourceType',
 }

--- a/packages/common/src/ee/scim/types.ts
+++ b/packages/common/src/ee/scim/types.ts
@@ -131,3 +131,77 @@ export type ApiCreateScimServiceAccountRequest = Pick<
     ServiceAccount,
     'expiresAt' | 'description'
 >;
+
+export interface ScimServiceProviderConfig {
+    schemas: ScimSchemaType.SERVICE_PROVIDER_CONFIG[];
+    documentationUri?: string;
+    patch: {
+        supported: boolean;
+    };
+    bulk: {
+        supported: boolean;
+        maxOperations?: number;
+        maxPayloadSize?: number;
+    };
+    filter: {
+        supported: boolean;
+        maxResults?: number;
+    };
+    changePassword: {
+        supported: boolean;
+    };
+    sort: {
+        supported: boolean;
+    };
+    etag: {
+        supported: boolean;
+    };
+    authenticationSchemes: {
+        type: string;
+        name: string;
+        description: string;
+        specUri?: string;
+        documentationUri?: string;
+        primary?: boolean;
+    }[];
+}
+
+export interface ScimSchema extends ScimResource {
+    schemas: ScimSchemaType.SCHEMA[];
+    name?: string;
+    description?: string;
+    attributes: ScimSchemaAttribute[];
+}
+
+export interface ScimSchemaAttribute {
+    name: string;
+    type:
+        | 'string'
+        | 'boolean'
+        | 'decimal'
+        | 'integer'
+        | 'dateTime'
+        | 'reference'
+        | 'complex';
+    multiValued: boolean;
+    description?: string;
+    required: boolean;
+    canonicalValues?: string[];
+    caseExact: boolean;
+    mutability: 'readOnly' | 'readWrite' | 'immutable' | 'writeOnly';
+    returned: 'always' | 'never' | 'default' | 'request';
+    uniqueness: 'none' | 'server' | 'global';
+    subAttributes?: ScimSchemaAttribute[];
+}
+
+export interface ScimResourceType extends ScimResource {
+    schemas: ScimSchemaType.RESOURCE_TYPE[];
+    name: string;
+    description?: string;
+    endpoint: string;
+    schema: string;
+    schemaExtensions?: {
+        schema: string;
+        required: boolean;
+    }[];
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16594

### /ServiceProviderConfig

Spec 
<img width="787" height="830" alt="image" src="https://github.com/user-attachments/assets/d51d7d7f-02bf-44d1-8532-ab3e29c5767f" />

our implementation:


<img width="715" height="543" alt="image" src="https://github.com/user-attachments/assets/38927f66-65cf-41fe-9431-2d4ad2a807f9" />

### /Schemas sample 

Spec sample: 
<img width="745" height="757" alt="image" src="https://github.com/user-attachments/assets/7b1ddf37-ff2a-47b4-8f97-694c95509ddd" />

Our implementation
<img width="661" height="649" alt="image" src="https://github.com/user-attachments/assets/a6afd8e8-86bd-448c-ba5e-d573bc600448" />

### Resource types 

Spec sample

<img width="731" height="495" alt="image" src="https://github.com/user-attachments/assets/549f6d7d-6289-43f0-8cd1-2b40c1d26095" />

Our implementation

<img width="637" height="567" alt="image" src="https://github.com/user-attachments/assets/e81d88af-a378-4fbf-8b7b-63b4fb9cbf8d" />

### User resource type

<img width="621" height="342" alt="image" src="https://github.com/user-attachments/assets/2348b6d9-c7a8-4661-be14-81caed99c5f7" />

### Description:
Adds SCIM discovery endpoints to support identity provider integration. This PR implements three new endpoints:

1. `/api/v1/scim/v2/ServiceProviderConfig` - Returns configuration details about Lightdash's SCIM implementation
2. `/api/v1/scim/v2/Schemas` - Returns schema definitions for User and Group resources
3. `/api/v1/scim/v2/ResourceTypes` - Returns available resource types and their endpoints

These endpoints follow the SCIM 2.0 specification and provide identity providers with the necessary metadata to properly integrate with Lightdash's SCIM API. The implementation includes comprehensive test coverage and example HTTP requests for testing.