### PR TITLE
feat: migrate Home page and related components to Mantine v8

### DIFF
--- a/packages/frontend/src/components/ForbiddenPanel.tsx
+++ b/packages/frontend/src/components/ForbiddenPanel.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Box } from '@mantine/core';
+import { Anchor, Box } from '@mantine-8/core';
 import { IconLock } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { Group, Stack, Text, Title } from '@mantine/core';
+import { Group, Stack, Text, Title } from '@mantine-8/core';
 import { type FC } from 'react';
 
 import { Can } from '../../../providers/Ability';
@@ -15,13 +15,13 @@ interface Props {
 const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
     const { user } = useApp();
     return (
-        <Group position="apart" my="xl">
-            <Stack justify="flex-start" spacing="xs">
+        <Group justify="space-between" my="xl">
+            <Stack justify="flex-start" gap="xs">
                 <Title order={3}>
                     {`Welcome${userName ? ', ' + userName : ' to Lightdash'}!`}{' '}
                     ⚡️
                 </Title>
-                <Text color="gray.7">
+                <Text c="gray.7">
                     Run a query to ask a business question or browse your data
                     below:
                 </Text>

--- a/packages/frontend/src/components/Home/MostPopularAndRecentlyUpdatedPanel/index.tsx
+++ b/packages/frontend/src/components/Home/MostPopularAndRecentlyUpdatedPanel/index.tsx
@@ -5,7 +5,7 @@ import {
     wrapResource,
     type MostPopularAndRecentlyUpdated,
 } from '@lightdash/common';
-import { Button } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import { IconChartBar, IconPlus } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import { useNavigate } from 'react-router';
@@ -94,7 +94,7 @@ export const MostPopularAndRecentlyUpdatedPanel: FC<Props> = ({
                           action: (
                               <MantineLinkButton
                                   color="gray.6"
-                                  compact
+                                  size="compact-sm"
                                   variant="subtle"
                                   target="_blank"
                                   href="https://docs.lightdash.com/get-started/exploring-data/intro"
@@ -116,7 +116,7 @@ export const MostPopularAndRecentlyUpdatedPanel: FC<Props> = ({
                 action:
                     !isDemo && userCanCreateCharts ? (
                         <Button
-                            leftIcon={<MantineIcon icon={IconPlus} size={18} />}
+                            leftSection={<MantineIcon icon={IconPlus} size={18} />}
                             onClick={handleCreateChart}
                         >
                             Create chart

--- a/packages/frontend/src/components/Home/OnboardingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/OnboardingPanel/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Group, Paper, Stack, Text, Title } from '@mantine/core';
+import { Card, Group, Paper, Stack, Text, Title } from '@mantine-8/core';
 import React, { type FC } from 'react';
 import Step1 from '../../../svgs/onboarding1.svg';
 import Step2 from '../../../svgs/onboarding2.svg';
@@ -31,16 +31,16 @@ const onboardingSteps = [
 
 const OnboardingPanel: FC<Props> = ({ projectUuid, userName }) => {
     return (
-        <Stack justify="flex-start" spacing="xs" mt="4xl">
+        <Stack justify="flex-start" gap="xs" mt="4xl">
             <Title order={3}>
                 {`Welcome${userName ? ', ' + userName : ' to Lightdash'}! 👋`}
             </Title>
-            <Text color="gray.7">
+            <Text c="gray.7">
                 You&apos;re ready to start exploring. Here&apos;s what you can
                 do with Lightdash:
             </Text>
             <Paper withBorder p="xl" mt="lg">
-                <Group position="center">
+                <Group justify="center">
                     {onboardingSteps.map((step) => (
                         <Card key={step.title} mx="xl">
                             <Card.Section mx="lg" p="md">
@@ -49,7 +49,7 @@ const OnboardingPanel: FC<Props> = ({ projectUuid, userName }) => {
                             <Title order={5} fw={500} ta="center">
                                 {step.title}
                             </Title>
-                            <Text size="sm" color="gray.6" ta="center">
+                            <Text size="sm" c="gray.6" ta="center">
                                 {step.description}
                             </Text>
                         </Card>

--- a/packages/frontend/src/components/PageSpinner/index.tsx
+++ b/packages/frontend/src/components/PageSpinner/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Loader, Overlay, rem } from '@mantine/core';
+import { Box, Center, Loader, Overlay, rem } from '@mantine-8/core';
 import { type FC } from 'react';
 import Logo from '../../svgs/grey-icon-logo.svg?react';
 
@@ -15,7 +15,6 @@ const PageSpinner: FC = () => (
             <Loader
                 color="gray.6"
                 size={100}
-                sx={{ g: { g: { strokeWidth: rem(2) } } }}
             />
             <Overlay component={Center} bg="transparent">
                 <Logo width={rem(32)} height={rem(32)} />

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -1,5 +1,5 @@
 import { ResourceViewItemType, type PinnedItems } from '@lightdash/common';
-import { Card, Group, Text } from '@mantine/core';
+import { Card, Group, Text } from '@mantine-8/core';
 import { IconPin } from '@tabler/icons-react';
 import { type FC } from 'react';
 import usePinnedItemsContext from '../../providers/PinnedItems/usePinnedItemsContext';
@@ -42,22 +42,20 @@ const PinnedItemsPanel: FC<Props> = ({ pinnedItems, isEnabled }) => {
         // FIXME: update width with Mantine widths
         <Card
             withBorder
-            sx={(theme) => ({
-                backgroundColor: theme.colors.gray[1],
-            })}
+            bg="gray.1"
         >
-            <Group position="apart">
-                <Group position="center" spacing="xxs" my="xs" ml="xs">
+            <Group justify="space-between">
+                <Group justify="center" gap="xxs" my="xs" ml="xs">
                     <MantineIcon
                         icon={IconPin}
                         size="lg"
                         color="gray.7"
                         fill="gray.1"
                     />
-                    <Text fw={600} color="gray.7">
+                    <Text fw={600} c="gray.7">
                         No Pinned items.
                     </Text>
-                    <Text color="gray.7">
+                    <Text c="gray.7">
                         Pin items to the top of the homepage to guide users to
                         relevant content!
                     </Text>
@@ -66,7 +64,7 @@ const PinnedItemsPanel: FC<Props> = ({ pinnedItems, isEnabled }) => {
                     href="https://docs.lightdash.com/guides/pinning/"
                     target="_blank"
                     variant="subtle"
-                    compact
+                    size="compact-sm"
                     color="gray.6"
                 >
                     View docs

--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -1,5 +1,5 @@
 import { type ApiErrorDetail } from '@lightdash/common';
-import { Text } from '@mantine/core';
+import { Text } from '@mantine-8/core';
 import { Prism } from '@mantine/prism';
 import { IconAlertCircle, IconLock } from '@tabler/icons-react';
 import React, { useMemo, type ComponentProps, type FC } from 'react';
@@ -25,7 +25,7 @@ const ErrorState: FC<{
                     <Text maw={400}>{error.message}</Text>
                     {(error.sentryEventId || error.sentryTraceId) && (
                         <>
-                            <Text maw={400} weight="bold">
+                            <Text maw={400} fw="bold">
                                 Contact support with the following information:
                             </Text>
                             <Prism ta="left" language="yaml" pr="lg">
@@ -69,7 +69,7 @@ const ErrorState: FC<{
 
     return (
         <SuboptimalState
-            sx={{ marginTop: hasMarginTop ? '20px' : undefined }}
+            mt={hasMarginTop ? '20px' : undefined}
             {...props}
         />
     );

--- a/packages/frontend/src/components/common/MantineIcon/index.tsx
+++ b/packages/frontend/src/components/common/MantineIcon/index.tsx
@@ -1,8 +1,9 @@
 import {
+    parseThemeColor,
     useMantineTheme,
     type MantineColor,
-    type MantineNumberSize,
-} from '@mantine/core';
+    type MantineSize,
+} from '@mantine-8/core';
 import {
     type Icon as TablerIconType,
     type TablerIconsProps,
@@ -11,8 +12,8 @@ import { forwardRef } from 'react';
 
 export interface MantineIconProps extends Omit<TablerIconsProps, 'ref'> {
     icon: TablerIconType;
-    size?: MantineNumberSize;
-    stroke?: MantineNumberSize;
+    size?: MantineSize | number | string;
+    stroke?: number;
     color?: MantineColor;
     fill?: MantineColor;
 }
@@ -21,11 +22,24 @@ const MantineIcon = forwardRef<SVGSVGElement, MantineIconProps>(
     ({ icon: TablerIcon, size = 'md', stroke, color, fill, ...rest }, ref) => {
         const theme = useMantineTheme();
 
+        const getSize = () => {
+            if (typeof size === 'number') return size;
+            const sizeMap: Record<string, number> = {
+                xs: 12,
+                sm: 14,
+                md: 18,
+                lg: 26,
+                xl: 32,
+                xxl: 40,
+            };
+            return sizeMap[size as string] || 18;
+        };
+
         const mantineOverridedProps: TablerIconsProps = {
-            size: typeof size === 'string' ? theme.spacing[size] : size,
-            stroke: typeof stroke === 'string' ? theme.spacing[stroke] : stroke,
-            color: color ? theme.fn.themeColor(color, undefined, false) : color,
-            fill: fill ? theme.fn.themeColor(fill, undefined, false) : 'none',
+            size: getSize(),
+            stroke: stroke || undefined,
+            color: color ? parseThemeColor({ color, theme }).value : undefined,
+            fill: fill ? parseThemeColor({ color: fill, theme }).value : 'none',
             display: 'block',
         };
 

--- a/packages/frontend/src/components/common/MantineLinkButton.tsx
+++ b/packages/frontend/src/components/common/MantineLinkButton.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Button, type ButtonProps } from '@mantine/core';
+import { Anchor, Button, type ButtonProps } from '@mantine-8/core';
 import React, { type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { type EventData } from '../../providers/Tracking/types';

--- a/packages/frontend/src/components/common/Page/Page.module.css
+++ b/packages/frontend/src/components/common/Page/Page.module.css
@@ -1,0 +1,84 @@
+.root {
+    overflow-y: auto;
+}
+
+.rootFullHeight {
+    overflow-y: initial;
+}
+
+.rootWithSidebar {
+    display: flex;
+    flex-direction: row;
+}
+
+.rootResizing {
+    user-select: none;
+}
+
+.rootCentered {
+    display: flex;
+    justify-content: center;
+}
+
+.content {
+    width: 100%;
+    min-width: 992px;
+    padding-top: var(--mantine-spacing-lg);
+    padding-bottom: var(--mantine-spacing-lg);
+}
+
+.contentFlex {
+    display: flex;
+}
+
+.contentNoPadding {
+    padding: 0;
+}
+
+.contentWithSidebar {
+    min-width: 600px;
+}
+
+.contentFullHeight {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-height: 100%;
+    overflow-y: auto;
+}
+
+.contentFit {
+    width: fit-content;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.contentLarge {
+    max-width: 1400px;
+}
+
+.contentPadded {
+    padding-left: var(--mantine-spacing-lg);
+    padding-right: var(--mantine-spacing-lg);
+}
+
+.contentXLargePadded {
+    padding: var(--mantine-spacing-xxl);
+}
+
+.contentCentered {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.contentWithBorder {
+    border-left: 1px solid var(--mantine-color-gray-3);
+}
+
+.fixedContainer {
+    margin-left: auto;
+    margin-right: auto;
+    width: 992px;
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -1,6 +1,7 @@
 import { ProjectType } from '@lightdash/common';
-import { Box, createStyles } from '@mantine/core';
-import { useDisclosure, useElementSize } from '@mantine/hooks';
+import { Box } from '@mantine-8/core';
+import { useDisclosure, useElementSize } from '@mantine-8/hooks';
+import clsx from 'clsx';
 import { type FC } from 'react';
 import ErrorBoundary from '../../../features/errorBoundary/ErrorBoundary';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
@@ -19,6 +20,7 @@ import {
     PAGE_HEADER_HEIGHT,
     PAGE_MIN_CONTENT_WIDTH,
 } from './constants';
+import classes from './Page.module.css';
 import { SidebarPosition, type SidebarWidthProps } from './types';
 
 type StyleProps = {
@@ -45,147 +47,19 @@ type StyleProps = {
     backgroundColor?: string;
 };
 
-const usePageStyles = createStyles<string, StyleProps>((theme, params) => {
+const getContainerHeight = (withNavbar: boolean, withHeader: boolean, hasBanner: boolean) => {
     let containerHeight = '100vh';
-
-    if (params.withNavbar) {
+    if (withNavbar) {
         containerHeight = `calc(${containerHeight} - ${NAVBAR_HEIGHT}px)`;
     }
-    if (params.withHeader) {
+    if (withHeader) {
         containerHeight = `calc(${containerHeight} - ${PAGE_HEADER_HEIGHT}px)`;
     }
-    if (params.hasBanner) {
+    if (hasBanner) {
         containerHeight = `calc(${containerHeight} - ${BANNER_HEIGHT}px)`;
     }
-    return {
-        root: {
-            ...(params.withFullHeight
-                ? {
-                      height: containerHeight,
-                      maxHeight: containerHeight,
-                  }
-                : {
-                      height: containerHeight,
-
-                      overflowY: 'auto',
-                  }),
-
-            ...(params.withSidebar || params.withRightSidebar
-                ? {
-                      display: 'flex',
-                      flexDirection: 'row',
-                  }
-                : {}),
-
-            ...(params.isSidebarResizing
-                ? {
-                      userSelect: 'none',
-                  }
-                : {}),
-
-            ...(params.withCenteredRoot
-                ? {
-                      display: 'flex',
-                      justifyContent: 'center',
-                  }
-                : {}),
-
-            ...(params.backgroundColor
-                ? {
-                      backgroundColor: params.backgroundColor,
-                  }
-                : {}),
-        },
-
-        content: {
-            width: '100%',
-            minWidth: PAGE_CONTENT_WIDTH,
-
-            ...(params.flexContent ? { display: 'flex' } : {}),
-            ...(params.noContentPadding
-                ? {
-                      padding: 0,
-                  }
-                : {
-                      paddingTop: theme.spacing.lg,
-                      paddingBottom: theme.spacing.lg,
-                  }),
-
-            ...(params.withSidebar || params.withRightSidebar
-                ? {
-                      minWidth: PAGE_MIN_CONTENT_WIDTH,
-                  }
-                : {}),
-
-            ...(params.withFooter
-                ? {
-                      minHeight: `calc(100% - ${FOOTER_HEIGHT}px - ${theme.spacing[FOOTER_MARGIN]} - 1px)`,
-                  }
-                : {}),
-
-            ...(params.withFullHeight
-                ? {
-                      display: 'flex',
-                      flexDirection: 'column',
-
-                      height: '100%',
-                      maxHeight: '100%',
-
-                      overflowY: 'auto',
-                  }
-                : {}),
-
-            ...(params.withFitContent
-                ? {
-                      width: 'fit-content',
-                      marginLeft: 'auto',
-                      marginRight: 'auto',
-                  }
-                : {}),
-
-            ...(params.withLargeContent
-                ? {
-                      maxWidth: PAGE_CONTENT_MAX_WIDTH_LARGE,
-                  }
-                : {}),
-
-            ...(params.withPaddedContent
-                ? {
-                      paddingLeft: theme.spacing.lg,
-                      paddingRight: theme.spacing.lg,
-                  }
-                : {}),
-
-            ...(params.withXLargePaddedContent
-                ? {
-                      padding: theme.spacing.xxl,
-                  }
-                : {}),
-
-            ...(params.withCenteredContent
-                ? {
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                  }
-                : {}),
-
-            ...(params.withSidebarBorder
-                ? {
-                      borderLeft: `1px solid ${theme.colors.gray[3]}`,
-                  }
-                : {}),
-        },
-
-        fixedContainer: {
-            marginLeft: 'auto',
-            marginRight: 'auto',
-
-            width: PAGE_CONTENT_WIDTH,
-            flexShrink: 0,
-        },
-    };
-});
+    return containerHeight;
+};
 
 type Props = {
     title?: string;
@@ -239,31 +113,43 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
             project.type === ProjectType.PREVIEW,
     );
 
-    const { classes } = usePageStyles(
-        {
-            withCenteredContent,
-            withCenteredRoot,
-            withFitContent,
-            withFixedContent,
-            withLargeContent,
-            withXLargePaddedContent,
-            withFooter,
-            withFullHeight,
-            withHeader: !!header,
-            withNavbar,
-            withPaddedContent,
-            withSidebar: !!sidebar,
-            withSidebarFooter,
-            withSidebarBorder,
-            withRightSidebar: !!rightSidebar,
-            hasBanner: isCurrentProjectPreview,
-            noContentPadding,
-            flexContent,
-            isSidebarResizing,
-            backgroundColor,
-        },
-        { name: 'Page' },
+    const containerHeight = getContainerHeight(
+        withNavbar,
+        !!header,
+        isCurrentProjectPreview
     );
+
+    const rootClassName = clsx(
+        classes.root,
+        withFullHeight ? classes.rootFullHeight : null,
+        (sidebar || rightSidebar) ? classes.rootWithSidebar : null,
+        isSidebarResizing ? classes.rootResizing : null,
+        withCenteredRoot ? classes.rootCentered : null
+    );
+
+    const contentClassName = clsx(
+        classes.content,
+        flexContent ? classes.contentFlex : null,
+        noContentPadding ? classes.contentNoPadding : null,
+        (sidebar || rightSidebar) ? classes.contentWithSidebar : null,
+        withFullHeight ? classes.contentFullHeight : null,
+        withFitContent ? classes.contentFit : null,
+        withLargeContent ? classes.contentLarge : null,
+        withPaddedContent ? classes.contentPadded : null,
+        withXLargePaddedContent ? classes.contentXLargePadded : null,
+        withCenteredContent ? classes.contentCentered : null,
+        withSidebarBorder ? classes.contentWithBorder : null
+    );
+
+    const rootStyle = {
+        height: containerHeight,
+        maxHeight: withFullHeight ? containerHeight : undefined,
+        backgroundColor: backgroundColor || undefined
+    };
+
+    const contentStyle = withFooter ? {
+        minHeight: `calc(100% - ${FOOTER_HEIGHT}px - var(--mantine-spacing-${FOOTER_MARGIN}) - 1px)`
+    } : {};
 
     return (
         <>
@@ -271,7 +157,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
 
             {header}
 
-            <Box id="page-root" className={classes.root}>
+            <Box id="page-root" className={rootClassName} style={rootStyle}>
                 {sidebar ? (
                     <Sidebar
                         noSidebarPadding={noSidebarPadding}
@@ -286,7 +172,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
                     </Sidebar>
                 ) : null}
 
-                <main className={classes.content} ref={mainRef}>
+                <main className={contentClassName} style={contentStyle} ref={mainRef}>
                     <TrackSection name={SectionName.PAGE_CONTENT}>
                         <ErrorBoundary wrapper={{ mt: '4xl' }}>
                             {withFixedContent ? (

--- a/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
+++ b/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
@@ -1,4 +1,4 @@
-import { Loader, Stack, Text, type StackProps } from '@mantine/core';
+import { Loader, Stack, Text, type StackProps } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import MantineIcon, { type MantineIconProps } from '../MantineIcon';
 
@@ -20,17 +20,13 @@ const SuboptimalState: FC<Props> = ({
 }) => {
     return (
         <Stack
-            spacing="sm"
+            gap="sm"
+            h="100%"
+            w="100%"
+            align="center"
+            justify="center"
+            ta="center"
             {...rest}
-            sx={{
-                height: '100%',
-                width: '100%',
-                alignContent: 'center',
-                justifyContent: 'center',
-                textAlign: 'center',
-                alignItems: 'center',
-                ...rest?.sx,
-            }}
         >
             {loading && <Loader color="gray.6" />}
             {icon && !loading && (
@@ -38,7 +34,7 @@ const SuboptimalState: FC<Props> = ({
             )}
             {title && (
                 <Text
-                    color="gray.7"
+                    c="gray.7"
                     fz={18}
                     fw={600}
                     style={{ whiteSpace: 'pre-wrap' }}

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mantine/core';
+import { Stack } from '@mantine-8/core';
 import { type FC } from 'react';
 import { useParams } from 'react-router';
 import { useUnmount } from 'react-use';
@@ -65,7 +65,7 @@ const Home: FC = () => {
 
     return (
         <Page withFixedContent withPaddedContent withFooter>
-            <Stack spacing="xl">
+            <Stack gap="xl">
                 {!onboarding.data.ranQuery ? (
                     <OnboardingPanel
                         projectUuid={project.data.projectUuid}


### PR DESCRIPTION
## Summary
- Migrated Home.tsx and all its dependencies from Mantine v6 to v8
- Updated 12 components to use the new Mantine v8 API
- Created CSS module for Page component to replace deprecated createStyles

## Changes Made

### Component Updates
- **pages/Home.tsx** - Updated imports and changed `spacing` to `gap`
- **ForbiddenPanel** - Updated imports to use `@mantine-8/core`
- **LandingPanel** - Updated imports, changed `position` to `justify`, `spacing` to `gap`, `color` to `c`
- **MostPopularAndRecentlyUpdatedPanel** - Updated imports, changed `compact` to `size="compact-sm"`, `leftIcon` to `leftSection`
- **OnboardingPanel** - Updated imports and migrated all v6 props to v8
- **PageSpinner** - Updated imports and removed deprecated `sx` prop
- **PinnedItemsPanel** - Updated imports and migrated all Mantine v6 props to v8
- **ErrorState** - Updated imports, changed `weight` to `fw`, replaced `sx` with inline prop
- **Page** - Major refactor from `createStyles` to CSS modules approach
- **SuboptimalState** - Updated imports and replaced `sx` with inline props
- **MantineLinkButton** - Updated imports
- **MantineIcon** - Updated imports and refactored to use v8 parseThemeColor API

### Key Migration Changes
- `@mantine/core` → `@mantine-8/core`
- `@mantine/hooks` → `@mantine-8/hooks`
- `spacing` → `gap`
- `position="apart"` → `justify="space-between"`
- `position="center"` → `justify="center"`
- `color` → `c` (for text color)
- `weight` → `fw` (font weight)
- `compact` → `size="compact-sm"`
- `leftIcon` → `leftSection`
- `sx` prop removed in favor of inline props or CSS modules
- `createStyles` replaced with CSS modules for complex styling

## Test plan
- [ ] Verify Home page renders correctly
- [ ] Check all interactive elements work as expected
- [ ] Confirm styling matches previous implementation
- [ ] Test responsive behavior
- [ ] Verify no console errors

🤖 Generated with [Claude Code](https://claude.ai/code)