### PR TITLE
fix: add thread length warning with new thread link in agent chat

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -1,6 +1,7 @@
 import {
     ActionIcon,
     alpha,
+    Anchor,
     Box,
     Paper,
     rem,
@@ -9,6 +10,7 @@ import {
 } from '@mantine-8/core';
 import { IconArrowUp } from '@tabler/icons-react';
 import { useLayoutEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
 
 import styles from './AgentChatInput.module.css';
 
@@ -18,6 +20,9 @@ interface AgentChatInputProps {
     disabled?: boolean;
     disabledReason?: string;
     placeholder?: string;
+    messageCount?: number;
+    projectUuid?: string;
+    agentUuid?: string;
 }
 
 export const AgentChatInput = ({
@@ -26,6 +31,9 @@ export const AgentChatInput = ({
     disabled = false,
     disabledReason,
     placeholder = 'Ask anything about your data...',
+    messageCount = 0,
+    projectUuid,
+    agentUuid,
 }: AgentChatInputProps) => {
     // this is a workaround to prevent the enter key from being pressed when
     // the user is composing a character
@@ -33,6 +41,7 @@ export const AgentChatInput = ({
     const [isComposing, setIsComposing] = useState(false);
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const [value, setValue] = useState('');
+    const navigate = useNavigate();
 
     useLayoutEffect(() => {
         if (!inputRef.current) return;
@@ -85,6 +94,39 @@ export const AgentChatInput = ({
 
     return (
         <Box pos="relative" pb="lg" className={styles.backdropBackground}>
+            {messageCount > 15 && (
+                <Paper
+                    px="sm"
+                    py={rem(4)}
+                    bg={alpha('var(--mantine-color-gray-1)', 0.5)}
+                    mx="md"
+                    style={{
+                        borderTopLeftRadius: rem(12),
+                        borderTopRightRadius: rem(12),
+                        borderBottomLeftRadius: 0,
+                        borderBottomRightRadius: 0,
+                    }}
+                >
+                    <Text size="xs" c="dimmed" style={{ flex: 1 }} ta="center">
+                        Agent performance degrades if a thread is too long.
+                        Please start a{' '}
+                        <Anchor
+                            size="xs"
+                            href="#"
+                            onClick={(e) => {
+                                e.preventDefault();
+                                if (projectUuid && agentUuid) {
+                                    void navigate(
+                                        `/projects/${projectUuid}/ai-agents/${agentUuid}/threads`,
+                                    );
+                                }
+                            }}
+                        >
+                            new thread
+                        </Anchor>
+                    </Text>
+                </Paper>
+            )}
             <Textarea
                 autoFocus
                 classNames={{ input: styles.input }}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -14,6 +14,8 @@ import { useNavigate } from 'react-router';
 
 import styles from './AgentChatInput.module.css';
 
+const MAX_RECOMMENDED_THREAD_MESSAGE_COUNT = 15;
+
 interface AgentChatInputProps {
     onSubmit: (message: string) => void;
     loading?: boolean;
@@ -94,7 +96,7 @@ export const AgentChatInput = ({
 
     return (
         <Box pos="relative" pb="lg" className={styles.backdropBackground}>
-            {messageCount > 15 && (
+            {messageCount > MAX_RECOMMENDED_THREAD_MESSAGE_COUNT && (
                 <Paper
                     px="sm"
                     py={rem(4)}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -75,6 +75,9 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                 loading={isCreatingMessage || isStreaming}
                 onSubmit={handleSubmit}
                 placeholder={`Ask ${agent.name} anything about your data...`}
+                messageCount={thread.messages?.length || 0}
+                projectUuid={projectUuid}
+                agentUuid={agentUuid}
             />
         </AgentChatDisplay>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a warning message in the agent chat input when the thread exceeds 15 messages, informing users that agent performance degrades with long threads. The warning includes a link to start a new thread, which navigates to the threads page for that agent.


![image.png](https://app.graphite.dev/user-attachments/assets/5067cad7-55b7-420b-a3da-fd1fdee44afb.png)

