### PR TITLE
fix: scheduled deliveries send now URL too long error

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -226,8 +226,6 @@ export default class SchedulerTask {
         chartUuid: string | null,
         dashboardUuid: string | null,
         schedulerUuid: string | undefined,
-        sendNowSchedulerFilters: DashboardFilterRule[] | undefined,
-        sendNowSchedulerParameters: ParametersValuesMap | undefined,
         context: DownloadCsv['properties']['context'],
         selectedTabs: string[] | null,
     ) {
@@ -257,16 +255,6 @@ export default class SchedulerTask {
 
             const queryParams = new URLSearchParams();
             if (schedulerUuid) queryParams.set('schedulerUuid', schedulerUuid);
-            if (sendNowSchedulerFilters)
-                queryParams.set(
-                    'sendNowSchedulerFilters',
-                    JSON.stringify(sendNowSchedulerFilters),
-                );
-            if (sendNowSchedulerParameters)
-                queryParams.set(
-                    'sendNowSchedulerParameters',
-                    JSON.stringify(sendNowSchedulerParameters),
-                );
             if (selectedTabs)
                 queryParams.set('selectedTabs', JSON.stringify(selectedTabs));
             if (context) queryParams.set('context', context);
@@ -347,8 +335,6 @@ export default class SchedulerTask {
             savedChartUuid,
             dashboardUuid,
             schedulerUuid,
-            sendNowSchedulerFilters,
-            sendNowSchedulerParameters,
             context,
             selectedTabs,
         );
@@ -383,6 +369,8 @@ export default class SchedulerTask {
                         context: ScreenshotContext.SCHEDULED_DELIVERY,
                         contextId: jobId,
                         selectedTabs,
+                        sendNowSchedulerFilters,
+                        sendNowSchedulerParameters,
                     });
                     if (unfurlImage.imageUrl === undefined) {
                         throw new Error('Unable to unfurl image');

--- a/packages/common/src/constants/sessionStorageKeys.ts
+++ b/packages/common/src/constants/sessionStorageKeys.ts
@@ -1,0 +1,4 @@
+export enum SessionStorageKeys {
+    SEND_NOW_SCHEDULER_FILTERS = 'sendNowSchedulerFilters',
+    SEND_NOW_SCHEDULER_PARAMETERS = 'sendNowSchedulerParameters',
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -201,6 +201,7 @@ export * from './compiler/filtersCompiler';
 export * from './compiler/parameters';
 export * from './compiler/translator';
 export * from './constants/pivot';
+export * from './constants/sessionStorageKeys';
 export * from './constants/sqlRunner';
 export { default as DbtSchemaEditor } from './dbt/DbtSchemaEditor/DbtSchemaEditor';
 export * from './dbt/validation';

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -1,9 +1,15 @@
-import type { DashboardTab } from '@lightdash/common';
+import type {
+    DashboardFilterRule,
+    DashboardTab,
+    ParametersValuesMap,
+} from '@lightdash/common';
 import {
     assertUnreachable,
     DashboardTileTypes,
     isDashboardScheduler,
+    SessionStorageKeys,
 } from '@lightdash/common';
+import { useSessionStorage } from '@mantine/hooks';
 import { IconLayoutDashboard } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
@@ -35,10 +41,19 @@ const MinimalDashboard: FC = () => {
     }>();
 
     const schedulerUuid = useSearchParams('schedulerUuid');
-    const sendNowSchedulerFilters = useSearchParams('sendNowSchedulerFilters');
-    const sendNowSchedulerParameters = useSearchParams(
-        'sendNowSchedulerParameters',
-    );
+
+    const [sendNowSchedulerFilters] = useSessionStorage<
+        DashboardFilterRule[] | undefined
+    >({
+        key: SessionStorageKeys.SEND_NOW_SCHEDULER_FILTERS,
+    });
+
+    const [sendNowSchedulerParameters] = useSessionStorage<
+        ParametersValuesMap | undefined
+    >({
+        key: SessionStorageKeys.SEND_NOW_SCHEDULER_PARAMETERS,
+    });
+
     const schedulerTabs = useSearchParams('selectedTabs');
     const dateZoom = useDateZoomGranularitySearch();
 
@@ -69,20 +84,16 @@ const MinimalDashboard: FC = () => {
         if (schedulerUuid && scheduler && isDashboardScheduler(scheduler)) {
             return scheduler.filters;
         }
-        if (sendNowSchedulerFilters) {
-            return JSON.parse(sendNowSchedulerFilters);
-        }
-        return undefined;
+
+        return sendNowSchedulerFilters;
     }, [scheduler, schedulerUuid, sendNowSchedulerFilters]);
 
     const schedulerParameters = useMemo(() => {
         if (schedulerUuid && scheduler && isDashboardScheduler(scheduler)) {
             return scheduler.parameters;
         }
-        if (sendNowSchedulerParameters) {
-            return JSON.parse(sendNowSchedulerParameters);
-        }
-        return undefined;
+
+        return sendNowSchedulerParameters;
     }, [scheduler, schedulerUuid, sendNowSchedulerParameters]);
 
     const schedulerTabsSelected = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16859

### Description:
Refactored scheduler filters and parameters to use session storage instead of URL parameters. This change:

1. Removes `sendNowSchedulerFilters` and `sendNowSchedulerParameters` from URL query parameters in the scheduler task
2. Adds these parameters to the UnfurlService methods to pass them through the screenshot process
3. Creates a new `SessionStorageKeys` enum in common package to standardize storage keys
4. Updates the MinimalDashboard component to read filters and parameters from session storage instead of URL

This approach improves security and avoids potential URL length limitations when dealing with complex filters or parameters.