### PR TITLE
fix: explore from here consistency

### DIFF
--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -64,11 +64,27 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             (context) => context.actions.fetchResults,
         );
 
+        const pivotConfig = useExplorerContext(
+            (context) => context.state.unsavedChartVersion.pivotConfig,
+        );
+
+        const hasPivotConfig = !!pivotConfig;
+
         useEffect(() => {
-            if (!previouslyFetchedState && (fromDashboard || isSavedChart)) {
+            const shouldAutoFetch =
+                !previouslyFetchedState &&
+                (!!fromDashboard || isSavedChart || hasPivotConfig);
+
+            if (shouldAutoFetch) {
                 fetchResults();
             }
-        }, [previouslyFetchedState, fetchResults, fromDashboard, isSavedChart]);
+        }, [
+            previouslyFetchedState,
+            fetchResults,
+            fromDashboard,
+            isSavedChart,
+            hasPivotConfig,
+        ]);
 
         useEffect(() => {
             if (isError) {

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1532,7 +1532,7 @@ const ExplorerProvider: FC<
             const metricQuery = unsavedChartVersion.metricQuery;
             let pivotConfiguration: PivotConfiguration | undefined;
 
-            if (!useSqlPivotResults?.enabled || !explore) {
+            if (!explore) {
                 return;
             }
 

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1532,6 +1532,10 @@ const ExplorerProvider: FC<
             const metricQuery = unsavedChartVersion.metricQuery;
             let pivotConfiguration: PivotConfiguration | undefined;
 
+            if (!useSqlPivotResults?.enabled || !explore) {
+                return;
+            }
+
             if (useSqlPivotResults?.enabled && explore) {
                 const items = getFieldsFromMetricQuery(metricQuery, explore);
                 pivotConfiguration = derivePivotConfigurationFromChart(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16855

### Description:
Auto-fetch results for charts with pivot configurations when loaded from dashboards or as saved charts. This ensures that charts requiring backend pivot processing are properly rendered without requiring manual user interaction.

The changes include:
- Renamed `explore` to `exploreData` to avoid naming conflicts
- Added detection for charts with pivot configurations that need backend processing
- Enhanced the auto-fetch logic to consider pivot configuration requirements
- Added safeguards to wait for explore data when backend pivot processing is needed
- Improved dependency tracking in the useEffect hook for more reliable fetching

### Recording

https://github.com/user-attachments/assets/0b899958-b600-4f39-bcf8-d6fd743c0c23

### Note
This addresses only the sorting, I haven't been able to reproduce different colors.