### PR TITLE
fix: support multiple artifacts per AI agent message

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5,6 +5,7 @@ import {
     AiAgentAdminThreadSummary,
     AiAgentMessage,
     AiAgentMessageAssistant,
+    AiAgentMessageAssistantArtifact,
     AiAgentMessageUser,
     AiAgentNotFoundError,
     AiAgentSummary,
@@ -1097,7 +1098,7 @@ export class AiAgentModel {
             slackUserId: string | null;
         }>[]
     > {
-        const rows = await this.database(AiPromptTableName)
+        const promptRows = await this.database(AiPromptTableName)
             .join(
                 UserTableName,
                 `${AiPromptTableName}.created_by_user_uuid`,
@@ -1127,12 +1128,6 @@ export class AiAgentModel {
                     Pick<DbAiSlackPrompt, 'slack_user_id'> &
                     Pick<DbAiWebAppPrompt, 'user_uuid'> & {
                         user_name: string;
-                        ai_artifact_uuid: string | null;
-                        version_number: number | null;
-                        ai_artifact_version_uuid: string | null;
-                        title: string | null;
-                        description: string | null;
-                        artifact_type: string | null;
                     })[]
             >(
                 `${AiPromptTableName}.ai_prompt_uuid`,
@@ -1149,12 +1144,6 @@ export class AiAgentModel {
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackPromptTableName}.slack_user_id`,
                 `${AiWebAppPromptTableName}.user_uuid`,
-                `${AiArtifactsTableName}.ai_artifact_uuid`,
-                `${AiArtifactVersionsTableName}.version_number`,
-                `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
-                `${AiArtifactVersionsTableName}.title`,
-                `${AiArtifactVersionsTableName}.description`,
-                `${AiArtifactsTableName}.artifact_type`,
                 this.database.raw(
                     `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
                 ),
@@ -1169,16 +1158,6 @@ export class AiAgentModel {
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${AiWebAppPromptTableName}.ai_prompt_uuid`,
             )
-            .leftJoin(
-                AiArtifactVersionsTableName,
-                `${AiPromptTableName}.ai_prompt_uuid`,
-                `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
-            )
-            .leftJoin(
-                AiArtifactsTableName,
-                `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
-                `${AiArtifactsTableName}.ai_artifact_uuid`,
-            )
             .where(`${AiPromptTableName}.ai_thread_uuid`, threadUuid)
             .andWhere(
                 `${AiThreadTableName}.organization_uuid`,
@@ -1186,7 +1165,11 @@ export class AiAgentModel {
             )
             .orderBy(`${AiPromptTableName}.created_at`, 'asc');
 
-        const messagesPromises = rows.map(async (row) => {
+        const promptUuids = promptRows.map((row) => row.ai_prompt_uuid);
+
+        const artifactsMap = await this.findThreadArtifacts({ promptUuids });
+
+        const messagesPromises = promptRows.map(async (row) => {
             const messages: AiAgentMessage<{
                 uuid: string;
                 name: string;
@@ -1211,6 +1194,8 @@ export class AiAgentModel {
             );
 
             if (row.responded_at != null) {
+                const artifacts = artifactsMap.get(row.ai_prompt_uuid) || [];
+
                 messages.push({
                     role: 'assistant',
                     uuid: row.ai_prompt_uuid,
@@ -1218,18 +1203,7 @@ export class AiAgentModel {
                     message: row.response,
                     createdAt: row.responded_at.toISOString(),
                     humanScore: row.human_score,
-                    artifact: row.ai_artifact_uuid
-                        ? {
-                              uuid: row.ai_artifact_uuid,
-                              versionNumber: row.version_number ?? 1,
-                              versionUuid: row.ai_artifact_version_uuid!,
-                              title: row.title,
-                              description: row.description,
-                              artifactType: row.artifact_type as
-                                  | 'chart'
-                                  | 'dashboard',
-                          }
-                        : null,
+                    artifacts: artifacts.length > 0 ? artifacts : null,
                     toolCalls: toolCalls
                         .filter(
                             (
@@ -1254,6 +1228,61 @@ export class AiAgentModel {
         });
 
         return (await Promise.all(messagesPromises)).flat();
+    }
+
+    async findThreadArtifacts({
+        promptUuids,
+    }: {
+        promptUuids: string[];
+    }): Promise<Map<string, AiAgentMessageAssistantArtifact[]>> {
+        const artifactsMap = new Map<
+            string,
+            AiAgentMessageAssistantArtifact[]
+        >();
+
+        if (promptUuids.length > 0) {
+            const artifactRows = await this.database(
+                AiArtifactVersionsTableName,
+            )
+                .join(
+                    AiArtifactsTableName,
+                    `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    `${AiArtifactsTableName}.ai_artifact_uuid`,
+                )
+                .select(
+                    `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+                    `${AiArtifactsTableName}.ai_artifact_uuid`,
+                    `${AiArtifactVersionsTableName}.version_number`,
+                    `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                    `${AiArtifactVersionsTableName}.title`,
+                    `${AiArtifactVersionsTableName}.description`,
+                    `${AiArtifactsTableName}.artifact_type`,
+                )
+                .whereIn(
+                    `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+                    promptUuids,
+                )
+                .orderBy(`${AiArtifactVersionsTableName}.created_at`, 'asc');
+
+            for (const artifactRow of artifactRows) {
+                const promptUuid = artifactRow.ai_prompt_uuid;
+                if (!artifactsMap.has(promptUuid)) {
+                    artifactsMap.set(promptUuid, []);
+                }
+                artifactsMap.get(promptUuid)!.push({
+                    artifactUuid: artifactRow.ai_artifact_uuid,
+                    versionNumber: artifactRow.version_number ?? 1,
+                    versionUuid: artifactRow.ai_artifact_version_uuid,
+                    title: artifactRow.title,
+                    description: artifactRow.description,
+                    artifactType: artifactRow.artifact_type as
+                        | 'chart'
+                        | 'dashboard',
+                });
+            }
+        }
+
+        return artifactsMap;
     }
 
     async findThreadMessage(
@@ -1292,6 +1321,7 @@ export class AiAgentModel {
             messageUuid: string;
         },
     ): Promise<AiAgentMessage> {
+        // First query: Get the prompt without artifacts to avoid duplicates
         const row = await this.database(AiPromptTableName)
             .select<
                 (Pick<
@@ -1312,12 +1342,6 @@ export class AiAgentModel {
                     Pick<DbAiSlackPrompt, 'slack_user_id'> &
                     Pick<DbAiWebAppPrompt, 'user_uuid'> & {
                         user_name: string;
-                        ai_artifact_uuid: string | null;
-                        version_number: number | null;
-                        ai_artifact_version_uuid: string | null;
-                        title: string | null;
-                        description: string | null;
-                        artifact_type: string | null;
                     })[]
             >(
                 `${AiPromptTableName}.ai_prompt_uuid`,
@@ -1334,12 +1358,6 @@ export class AiAgentModel {
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiSlackPromptTableName}.slack_user_id`,
                 `${AiWebAppPromptTableName}.user_uuid`,
-                `${AiArtifactsTableName}.ai_artifact_uuid`,
-                `${AiArtifactVersionsTableName}.version_number`,
-                `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
-                `${AiArtifactVersionsTableName}.title`,
-                `${AiArtifactVersionsTableName}.description`,
-                `${AiArtifactsTableName}.artifact_type`,
                 this.database.raw(
                     `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
                 ),
@@ -1364,16 +1382,6 @@ export class AiAgentModel {
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${AiWebAppPromptTableName}.ai_prompt_uuid`,
             )
-            .leftJoin(
-                AiArtifactVersionsTableName,
-                `${AiPromptTableName}.ai_prompt_uuid`,
-                `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
-            )
-            .leftJoin(
-                AiArtifactsTableName,
-                `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
-                `${AiArtifactsTableName}.ai_artifact_uuid`,
-            )
             .where(`${AiPromptTableName}.ai_thread_uuid`, threadUuid)
             .andWhere(
                 `${AiThreadTableName}.organization_uuid`,
@@ -1388,6 +1396,36 @@ export class AiAgentModel {
                 `AI agent message not found for uuid: ${messageUuid}`,
             );
         }
+
+        const artifactRows = await this.database(AiArtifactVersionsTableName)
+            .select<
+                (DbAiArtifactVersion & {
+                    artifact_type: 'chart' | 'dashboard';
+                })[]
+            >(
+                `${AiArtifactsTableName}.ai_artifact_uuid`,
+                `${AiArtifactVersionsTableName}.version_number`,
+                `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                `${AiArtifactVersionsTableName}.title`,
+                `${AiArtifactVersionsTableName}.description`,
+                `${AiArtifactsTableName}.artifact_type`,
+            )
+            .join(
+                AiArtifactsTableName,
+                `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                `${AiArtifactsTableName}.ai_artifact_uuid`,
+            )
+            .where(`${AiArtifactVersionsTableName}.ai_prompt_uuid`, messageUuid)
+            .orderBy(`${AiArtifactVersionsTableName}.created_at`, 'asc');
+
+        const artifacts = artifactRows.map((artifactRow) => ({
+            artifactUuid: artifactRow.ai_artifact_uuid,
+            versionNumber: artifactRow.version_number,
+            versionUuid: artifactRow.ai_artifact_version_uuid,
+            title: artifactRow.title,
+            description: artifactRow.description,
+            artifactType: artifactRow.artifact_type as 'chart' | 'dashboard',
+        }));
 
         switch (role) {
             case 'user':
@@ -1416,18 +1454,7 @@ export class AiAgentModel {
                     createdAt: row.responded_at?.toString() ?? '',
 
                     humanScore: row.human_score,
-                    artifact: row.ai_artifact_uuid
-                        ? {
-                              uuid: row.ai_artifact_uuid,
-                              versionNumber: row.version_number ?? 1,
-                              versionUuid: row.ai_artifact_version_uuid!,
-                              title: row.title,
-                              description: row.description,
-                              artifactType: row.artifact_type as
-                                  | 'chart'
-                                  | 'dashboard',
-                          }
-                        : null,
+                    artifacts: artifacts.length > 0 ? artifacts : null,
                     toolCalls: toolCalls
                         .filter(
                             (

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1321,7 +1321,6 @@ export class AiAgentModel {
             messageUuid: string;
         },
     ): Promise<AiAgentMessage> {
-        // First query: Get the prompt without artifacts to avoid duplicates
         const row = await this.database(AiPromptTableName)
             .select<
                 (Pick<

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5359,53 +5359,65 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    description: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    artifactUuid: { dataType: 'string', required: true },
+                    versionNumber: { dataType: 'double', required: true },
+                    versionUuid: { dataType: 'string', required: true },
+                    title: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    artifactType: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'enum', enums: ['chart'] },
+                            { dataType: 'enum', enums: ['dashboard'] },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentMessageAssistantArtifact: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentMessageAssistant: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                artifact: {
+                artifacts: {
                     dataType: 'union',
                     subSchemas: [
                         {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                artifactType: {
-                                    dataType: 'union',
-                                    subSchemas: [
-                                        { dataType: 'enum', enums: ['chart'] },
-                                        {
-                                            dataType: 'enum',
-                                            enums: ['dashboard'],
-                                        },
-                                    ],
-                                    required: true,
-                                },
-                                description: {
-                                    dataType: 'union',
-                                    subSchemas: [
-                                        { dataType: 'string' },
-                                        { dataType: 'enum', enums: [null] },
-                                    ],
-                                    required: true,
-                                },
-                                title: {
-                                    dataType: 'union',
-                                    subSchemas: [
-                                        { dataType: 'string' },
-                                        { dataType: 'enum', enums: [null] },
-                                    ],
-                                    required: true,
-                                },
-                                versionUuid: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                versionNumber: {
-                                    dataType: 'double',
-                                    required: true,
-                                },
-                                uuid: { dataType: 'string', required: true },
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'AiAgentMessageAssistantArtifact',
                             },
                         },
                         { dataType: 'enum', enums: [null] },
@@ -5667,8 +5679,9 @@ const models: TsoaRoute.Models = {
                     },
                     createdAt: { dataType: 'datetime', required: true },
                     artifactUuid: { dataType: 'string', required: true },
-                    threadUuid: { dataType: 'string', required: true },
-                    promptUuid: {
+                    versionNumber: { dataType: 'double', required: true },
+                    versionUuid: { dataType: 'string', required: true },
+                    title: {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'string' },
@@ -5684,6 +5697,15 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    threadUuid: { dataType: 'string', required: true },
+                    promptUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                     savedQueryUuid: {
                         dataType: 'union',
                         subSchemas: [
@@ -5693,16 +5715,6 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     savedDashboardUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'enum', enums: [null] },
-                        ],
-                        required: true,
-                    },
-                    versionNumber: { dataType: 'double', required: true },
-                    versionUuid: { dataType: 'string', required: true },
-                    title: {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'string' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6065,42 +6065,52 @@
                 ],
                 "type": "object"
             },
+            "Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_": {
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "artifactUuid": {
+                        "type": "string"
+                    },
+                    "versionNumber": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "versionUuid": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "artifactType": {
+                        "type": "string",
+                        "enum": ["chart", "dashboard"]
+                    }
+                },
+                "required": [
+                    "description",
+                    "artifactUuid",
+                    "versionNumber",
+                    "versionUuid",
+                    "title",
+                    "artifactType"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "AiAgentMessageAssistantArtifact": {
+                "$ref": "#/components/schemas/Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_"
+            },
             "AiAgentMessageAssistant": {
                 "properties": {
-                    "artifact": {
-                        "properties": {
-                            "artifactType": {
-                                "type": "string",
-                                "enum": ["chart", "dashboard"]
-                            },
-                            "description": {
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "title": {
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "versionUuid": {
-                                "type": "string"
-                            },
-                            "versionNumber": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            }
+                    "artifacts": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentMessageAssistantArtifact"
                         },
-                        "required": [
-                            "artifactType",
-                            "description",
-                            "title",
-                            "versionUuid",
-                            "versionNumber",
-                            "uuid"
-                        ],
-                        "type": "object",
+                        "type": "array",
                         "nullable": true
                     },
                     "savedQueryUuid": {
@@ -6138,7 +6148,7 @@
                     }
                 },
                 "required": [
-                    "artifact",
+                    "artifacts",
                     "savedQueryUuid",
                     "toolCalls",
                     "humanScore",
@@ -6349,25 +6359,6 @@
                     "artifactUuid": {
                         "type": "string"
                     },
-                    "threadUuid": {
-                        "type": "string"
-                    },
-                    "promptUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "artifactType": {
-                        "type": "string",
-                        "enum": ["chart", "dashboard"]
-                    },
-                    "savedQueryUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "savedDashboardUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "versionNumber": {
                         "type": "number",
                         "format": "double"
@@ -6376,6 +6367,25 @@
                         "type": "string"
                     },
                     "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "artifactType": {
+                        "type": "string",
+                        "enum": ["chart", "dashboard"]
+                    },
+                    "threadUuid": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "savedQueryUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "savedDashboardUuid": {
                         "type": "string",
                         "nullable": true
                     },
@@ -6388,14 +6398,14 @@
                     "description",
                     "createdAt",
                     "artifactUuid",
-                    "threadUuid",
-                    "promptUuid",
-                    "artifactType",
-                    "savedQueryUuid",
-                    "savedDashboardUuid",
                     "versionNumber",
                     "versionUuid",
                     "title",
+                    "artifactType",
+                    "threadUuid",
+                    "promptUuid",
+                    "savedQueryUuid",
+                    "savedDashboardUuid",
                     "versionCreatedAt"
                 ],
                 "type": "object",
@@ -19283,7 +19293,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2005.0",
+        "version": "0.2006.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -108,6 +108,16 @@ export type AiAgentMessageUser<TUser extends AiAgentUser = AiAgentUser> = {
     user: TUser;
 };
 
+export type AiAgentMessageAssistantArtifact = Pick<
+    AiArtifact,
+    | 'artifactUuid'
+    | 'versionNumber'
+    | 'versionUuid'
+    | 'title'
+    | 'description'
+    | 'artifactType'
+>;
+
 export type AiAgentMessageAssistant = {
     role: 'assistant';
     uuid: string;
@@ -124,14 +134,7 @@ export type AiAgentMessageAssistant = {
     toolCalls: AiAgentToolCall[];
     savedQueryUuid: string | null;
 
-    artifact: {
-        uuid: string;
-        versionNumber: number;
-        versionUuid: string;
-        title: string | null;
-        description: string | null;
-        artifactType: 'chart' | 'dashboard';
-    } | null;
+    artifacts: AiAgentMessageAssistantArtifact[] | null;
 };
 
 export type AiAgentMessage<TUser extends AiAgentUser = AiAgentUser> =

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -278,7 +278,9 @@ export const AssistantBubble: FC<Props> = memo(
         if (!projectUuid) throw new Error(`Project Uuid not found`);
         if (!agentUuid) throw new Error(`Agent Uuid not found`);
 
-        const isArtifactAvailable = !!message.artifact;
+        const isArtifactAvailable = !!(
+            message.artifacts && message.artifacts.length > 0
+        );
 
         const [isDrawerOpen, { open: openDrawer, close: closeDrawer }] =
             useDisclosure(debug);
@@ -332,33 +334,41 @@ export const AssistantBubble: FC<Props> = memo(
                 />
 
                 {isArtifactAvailable && projectUuid && agentUuid && (
-                    <AiArtifactButton
-                        onClick={() => {
-                            if (
-                                artifact?.artifactUuid ===
-                                    message.artifact?.uuid &&
-                                artifact?.versionUuid ===
-                                    message.artifact?.versionUuid
-                            ) {
-                                return;
-                            }
-                            dispatch(
-                                setArtifact({
-                                    artifactUuid: message.artifact!.uuid,
-                                    versionUuid: message.artifact!.versionUuid,
-                                    message: message,
-                                    projectUuid: projectUuid,
-                                    agentUuid: agentUuid,
-                                }),
-                            );
-                        }}
-                        isArtifactOpen={
-                            artifact?.artifactUuid === message.artifact?.uuid &&
-                            artifact?.versionUuid ===
-                                message.artifact?.versionUuid
-                        }
-                        artifact={message.artifact}
-                    />
+                    <Stack gap="xs">
+                        {message.artifacts!.map((messageArtifact) => (
+                            <AiArtifactButton
+                                key={`${messageArtifact.artifactUuid}-${messageArtifact.versionUuid}`}
+                                onClick={() => {
+                                    if (
+                                        artifact?.artifactUuid ===
+                                            messageArtifact.artifactUuid &&
+                                        artifact?.versionUuid ===
+                                            messageArtifact.versionUuid
+                                    ) {
+                                        return;
+                                    }
+                                    dispatch(
+                                        setArtifact({
+                                            artifactUuid:
+                                                messageArtifact.artifactUuid,
+                                            versionUuid:
+                                                messageArtifact.versionUuid,
+                                            message: message,
+                                            projectUuid: projectUuid,
+                                            agentUuid: agentUuid,
+                                        }),
+                                    );
+                                }}
+                                isArtifactOpen={
+                                    artifact?.artifactUuid ===
+                                        messageArtifact.artifactUuid &&
+                                    artifact?.versionUuid ===
+                                        messageArtifact.versionUuid
+                                }
+                                artifact={messageArtifact}
+                            />
+                        ))}
+                    </Stack>
                 )}
                 <Group gap={0}>
                     <CopyButton value={message.message ?? ''}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ArtifactButton/AiArtifactButton.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ArtifactButton/AiArtifactButton.tsx
@@ -15,7 +15,7 @@ import styles from './AiArtifactButton.module.css';
 interface AiArtifactButtonProps {
     onClick: () => void;
     isArtifactOpen: boolean;
-    artifact: AiAgentMessageAssistant['artifact'];
+    artifact: NonNullable<AiAgentMessageAssistant['artifacts']>[0] | null;
     isLoading?: boolean;
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ScrollToBottom.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ScrollToBottom.tsx
@@ -83,7 +83,9 @@ const ThreadScrollToBottom = ({
     // Scroll to bottom when the last message gets a chart visualization
     const lastMessage = thread.data?.messages?.at(-1);
     const lastMessageViz =
-        lastMessage?.role === 'assistant' && lastMessage?.artifact;
+        lastMessage?.role === 'assistant' &&
+        lastMessage?.artifacts &&
+        lastMessage.artifacts.length > 0;
 
     useLayoutEffect(() => {
         if (!lastMessageViz) return;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
@@ -37,7 +37,13 @@ export const useAiAgentThreadArtifact = ({
 
     const latestAssistantMessage = useMemo(() => {
         const msg = thread?.messages?.at(-1);
-        if (!msg || msg.role !== 'assistant' || !msg.artifact) return null;
+        if (
+            !msg ||
+            msg.role !== 'assistant' ||
+            !msg.artifacts ||
+            msg.artifacts.length === 0
+        )
+            return null;
         return msg;
     }, [thread]);
 
@@ -61,10 +67,12 @@ export const useAiAgentThreadArtifact = ({
             return;
         if (artifact?.message.uuid === latestAssistantMessage.uuid) return;
 
+        const latestArtifact = latestAssistantMessage.artifacts?.at(-1);
+        if (!latestArtifact) return;
         dispatch(
             setArtifact({
-                artifactUuid: latestAssistantMessage.artifact!.uuid,
-                versionUuid: latestAssistantMessage.artifact!.versionUuid,
+                artifactUuid: latestArtifact.artifactUuid,
+                versionUuid: latestArtifact.versionUuid,
                 message: latestAssistantMessage,
                 projectUuid,
                 agentUuid,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -391,7 +391,7 @@ const createOptimisticMessages = (
             humanScore: null,
             toolCalls: [],
             savedQueryUuid: null,
-            artifact: null,
+            artifacts: null,
         },
     ];
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The reason for this change is that when the user would ask for multiple charts, there was a bug that couldn't properly handle it.

### Description:

This PR refactors the AI agent artifact handling to support multiple artifacts per message. Instead of a single `artifact` property, messages now have an `artifacts` array that can contain multiple chart or dashboard artifacts.

Key changes:

- Changed the data model from a single `artifact` property to an `artifacts` array
- Optimized database queries by separating artifact fetching from prompt fetching
- Updated the UI to display multiple artifacts when available
- Fixed potential duplicate artifacts issue by using separate queries

This change improves the AI agent's ability to generate and display multiple visualizations in a single response, enhancing the overall user experience.
