### PR TITLE
fix: remove unique project uuid name constraint from tags

### DIFF
--- a/packages/backend/src/database/migrations/20250912162343_remove_tags_unique_constraint_name_project_uuid.ts
+++ b/packages/backend/src/database/migrations/20250912162343_remove_tags_unique_constraint_name_project_uuid.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const TAGS_TABLE = 'tags';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TAGS_TABLE, (table) => {
+        table.dropUnique(['project_uuid', 'name']);
+        table.index('name');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // This migration fixes a bug in a projectuuid + name unique constraint that was created in 20241104105903_add-project-tags-table.ts.
+    // It was too restrictive and prevented tags from being created with the same name in the same project.
+    await knex.schema.alterTable(TAGS_TABLE, (table) => {
+        table.dropIndex('name');
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16878

Fixes: LIGHTDASH-BACKEND-490

### Description:
This PR removes the unique constraint on `project_uuid` and `name` columns in the `tags` table and adds an index on the `name` column instead. The previous constraint was too restrictive as it prevented tags with the same name from being created within the same project.

The migration includes both up and down functions to properly handle the schema changes, fixing a bug that was introduced in a previous migration (`20241104105903_add-project-tags-table.ts`).