### PR TITLE
fix: reference line label positioning inside chart area

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx
@@ -89,7 +89,12 @@ export const ReferenceLines: FC<Props> = ({ items, projectUuid }) => {
                             uuid: lineId,
                             lineStyle: { color: lineColor },
                             label: {
-                                position: labelPosition || 'end',
+                                position:
+                                    labelPosition === 'start'
+                                        ? 'insideStart'
+                                        : labelPosition === 'end'
+                                        ? 'insideEnd'
+                                        : labelPosition || 'end',
                                 formatter: label
                                     ? `${label}${useAverage ? ': {c}' : ''}`
                                     : undefined,


### PR DESCRIPTION
fixes: #16883

### Description
**Problem:** Reference line labels were appearing outside the chart area when users selected left or right alignment options.

**Solution:** Updated the label positioning logic to use ECharts' `'insideStart'` and `'insideEnd'` positions instead of `'start'` and `'end'`, ensuring labels appear inside the chart area for better user experience.

**Changes:**
- Modified `ReferenceLines.tsx` to use `'insideStart'` for left-aligned labels and `'insideEnd'` for right-aligned labels
- Middle alignment remains unchanged as it was already positioned appropriately

**Files changed:** `packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLines.tsx`

- This fix improves the visual presentation of reference lines by keeping labels within the chart boundaries, making them more readable and visually appealing.