### PR TITLE
feat: Add version history for custom chart JSON

### DIFF
--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -4,6 +4,8 @@ import {
     ApiErrorPayload,
     ApiGetChartHistoryResponse,
     ApiGetChartVersionResponse,
+    ApiGetCustomChartJsonHistoryResponse,
+    ApiGetCustomChartJsonVersionResponse,
     ApiPromoteChartResponse,
     ApiPromotionChangesResponse,
     ApiSuccessEmpty,
@@ -257,6 +259,81 @@ export class SavedChartController extends BaseController {
         await this.services
             .getSavedChartService()
             .rollback(req.user!, chartUuid, versionUuid);
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
+     * Get custom chart JSON version history
+     * @param chartUuid chartUuid for the chart
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/custom-json-history')
+    @OperationId('GetCustomChartJsonHistory')
+    async getCustomChartJsonHistory(
+        @Path() chartUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiGetCustomChartJsonHistoryResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getSavedChartService()
+                .getCustomChartJsonHistory(req.user!, chartUuid),
+        };
+    }
+
+    /**
+     * Get custom chart JSON version
+     * @param chartUuid chartUuid for the chart
+     * @param versionUuid versionUuid for the chart version
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/custom-json-version/{versionUuid}')
+    @OperationId('GetCustomChartJsonVersion')
+    async getCustomChartJsonVersion(
+        @Path() chartUuid: string,
+        @Path() versionUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiGetCustomChartJsonVersionResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getSavedChartService()
+                .getCustomChartJsonVersion(req.user!, chartUuid, versionUuid),
+        };
+    }
+
+    /**
+     * Restore custom chart JSON to a previous version
+     * @param chartUuid chartUuid for the chart
+     * @param versionUuid versionUuid for the chart version
+     * @param req express request
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/restore-custom-json/{versionUuid}')
+    @OperationId('PostCustomChartJsonRestore')
+    async postCustomChartJsonRestore(
+        @Path() chartUuid: string,
+        @Path() versionUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        await this.services
+            .getSavedChartService()
+            .restoreCustomChartJson(req.user!, chartUuid, versionUuid);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -728,6 +728,32 @@ export type ApiGetChartVersionResponse = {
     results: ChartVersion;
 };
 
+export type CustomChartJsonVersion = {
+    versionUuid: string;
+    createdAt: Date;
+    createdBy: Pick<
+        LightdashUser,
+        'userUuid' | 'firstName' | 'lastName'
+    > | null;
+    jsonSpec: string;
+    isValid: boolean;
+    validationError?: string;
+};
+
+export type CustomChartJsonHistory = {
+    history: CustomChartJsonVersion[];
+};
+
+export type ApiGetCustomChartJsonHistoryResponse = {
+    status: 'ok';
+    results: CustomChartJsonHistory;
+};
+
+export type ApiGetCustomChartJsonVersionResponse = {
+    status: 'ok';
+    results: CustomChartJsonVersion;
+};
+
 export const getHiddenTableFields = (config: ChartConfig) => {
     // get hidden fields from chart config
 

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -14,6 +14,7 @@ import Catalog from './pages/Catalog';
 import ChartHistory from './pages/ChartHistory';
 import CreateProject from './pages/CreateProject';
 import CreateProjectSettings from './pages/CreateProjectSettings';
+import CustomChartJsonHistory from './pages/CustomChartJsonHistory';
 import Dashboard from './pages/Dashboard';
 import Explorer from './pages/Explorer';
 import Home from './pages/Home';
@@ -170,6 +171,14 @@ const CHART_ROUTES: RouteObject[] = [
                 element: (
                     <TrackPage name={PageName.CHART_HISTORY}>
                         <ChartHistory />
+                    </TrackPage>
+                ),
+            },
+            {
+                path: '/projects/:projectUuid/saved/:savedQueryUuid/json-history',
+                element: (
+                    <TrackPage name={PageName.CHART_HISTORY}>
+                        <CustomChartJsonHistory />
                     </TrackPage>
                 ),
             },

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -26,6 +26,7 @@ import {
     IconBell,
     IconCirclePlus,
     IconCirclesRelation,
+    IconCode,
     IconCopy,
     IconDatabaseExport,
     IconDots,
@@ -583,6 +584,21 @@ const SavedChartsHeader: FC = () => {
                                         Version history
                                     </Menu.Item>
                                 )}
+                                {userCanManageChart &&
+                                    savedChart?.chartKind === 'custom' && (
+                                        <Menu.Item
+                                            icon={
+                                                <MantineIcon icon={IconCode} />
+                                            }
+                                            onClick={() =>
+                                                navigate({
+                                                    pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.uuid}/json-history`,
+                                                })
+                                            }
+                                        >
+                                            Custom JSON History
+                                        </Menu.Item>
+                                    )}
                                 {
                                     <Tooltip
                                         label={

--- a/packages/frontend/src/pages/CustomChartJsonHistory.tsx
+++ b/packages/frontend/src/pages/CustomChartJsonHistory.tsx
@@ -1,0 +1,369 @@
+import { subject } from '@casl/ability';
+import { formatTimestamp, TimeFrames } from '@lightdash/common';
+import {
+    ActionIcon,
+    Alert,
+    Badge,
+    Box,
+    Button,
+    Code,
+    Flex,
+    Group,
+    Menu,
+    Modal,
+    NavLink,
+    ScrollArea,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+} from '@mantine/core';
+import {
+    IconAlertTriangle,
+    IconCheck,
+    IconCode,
+    IconDots,
+    IconHistory,
+    IconInfoCircle,
+} from '@tabler/icons-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { EmptyState } from '../components/common/EmptyState';
+import ErrorState from '../components/common/ErrorState';
+import MantineIcon from '../components/common/MantineIcon';
+import Page from '../components/common/Page/Page';
+import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
+import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
+import {
+    useCustomChartJsonHistory,
+    useCustomChartJsonRestoreMutation,
+    useCustomChartJsonVersion,
+    useSavedQuery,
+} from '../hooks/useSavedQuery';
+import { Can } from '../providers/Ability';
+import NoTableIcon from '../svgs/emptystate-no-table.svg?react';
+
+const CustomChartJsonHistory = () => {
+    const navigate = useNavigate();
+    const { savedQueryUuid, projectUuid } = useParams<{
+        savedQueryUuid: string;
+        projectUuid: string;
+    }>();
+    const [selectedVersionUuid, selectVersionUuid] = useState<string>();
+    const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
+
+    const chartQuery = useSavedQuery({
+        id: savedQueryUuid,
+    });
+    const historyQuery = useCustomChartJsonHistory(savedQueryUuid);
+
+    useEffect(() => {
+        const currentVersion = historyQuery.data?.history[0];
+        if (currentVersion && !selectedVersionUuid) {
+            selectVersionUuid(currentVersion.versionUuid);
+        }
+    }, [selectedVersionUuid, historyQuery.data]);
+
+    const versionQuery = useCustomChartJsonVersion(
+        savedQueryUuid,
+        selectedVersionUuid,
+    );
+
+    const restoreMutation = useCustomChartJsonRestoreMutation(savedQueryUuid, {
+        onSuccess: () => {
+            void navigate(
+                `/projects/${projectUuid}/saved/${savedQueryUuid}/view`,
+            );
+        },
+    });
+
+    if (historyQuery.isInitialLoading || chartQuery.isInitialLoading) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <SuboptimalState title="Loading..." loading />
+            </div>
+        );
+    }
+
+    if (historyQuery.error || chartQuery.error) {
+        return (
+            <ErrorState
+                error={historyQuery.error?.error || chartQuery.error?.error}
+            />
+        );
+    }
+
+    if (!chartQuery.data || chartQuery.data.chartKind !== 'custom') {
+        return (
+            <ErrorState
+                error={{
+                    statusCode: 400,
+                    name: 'Invalid Chart Type',
+                    message:
+                        'This feature is only available for custom charts.',
+                    data: {},
+                }}
+            />
+        );
+    }
+
+    const getValidationIcon = (isValid: boolean, validationError?: string) => {
+        if (isValid) {
+            return <MantineIcon icon={IconCheck} color="green" size="sm" />;
+        }
+        return (
+            <Tooltip label={validationError || 'Invalid JSON'}>
+                <MantineIcon icon={IconAlertTriangle} color="red" size="sm" />
+            </Tooltip>
+        );
+    };
+
+    const getValidationBadge = (isValid: boolean) => {
+        return (
+            <Badge
+                size="xs"
+                variant="light"
+                color={isValid ? 'green' : 'red'}
+                leftSection={getValidationIcon(isValid)}
+            >
+                {isValid ? 'Valid' : 'Invalid'}
+            </Badge>
+        );
+    };
+
+    return (
+        <Page
+            title="Custom Chart JSON History"
+            withSidebarFooter
+            withFullHeight
+            withPaddedContent
+            sidebar={
+                <Stack
+                    spacing="xl"
+                    mah="100%"
+                    sx={{ overflowY: 'hidden', flex: 1 }}
+                >
+                    <Flex gap="xs">
+                        <PageBreadcrumbs
+                            items={[
+                                {
+                                    title: 'Chart',
+                                    to: `/projects/${projectUuid}/saved/${savedQueryUuid}/view`,
+                                },
+                                { title: 'JSON History', active: true },
+                            ]}
+                        />
+                    </Flex>
+                    <Stack spacing="xs" sx={{ flexGrow: 1, overflowY: 'auto' }}>
+                        {historyQuery.data?.history.map((version, index) => (
+                            <NavLink
+                                key={version.versionUuid}
+                                active={
+                                    version.versionUuid === selectedVersionUuid
+                                }
+                                icon={<MantineIcon icon={IconCode} />}
+                                label={
+                                    <Group position="apart" w="100%">
+                                        <Text size="sm">
+                                            {formatTimestamp(
+                                                version.createdAt,
+                                                TimeFrames.SECOND,
+                                            )}
+                                        </Text>
+                                        {getValidationBadge(version.isValid)}
+                                    </Group>
+                                }
+                                description={
+                                    <Text size="xs">
+                                        Updated by:{' '}
+                                        {version.createdBy?.firstName}{' '}
+                                        {version.createdBy?.lastName}
+                                    </Text>
+                                }
+                                rightSection={
+                                    <>
+                                        {index === 0 && (
+                                            <Tooltip label="This is the current version.">
+                                                <Badge
+                                                    size="xs"
+                                                    variant="light"
+                                                    color="green"
+                                                >
+                                                    current
+                                                </Badge>
+                                            </Tooltip>
+                                        )}
+                                        {index !== 0 &&
+                                            version.versionUuid ===
+                                                selectedVersionUuid && (
+                                                <Can
+                                                    I="manage"
+                                                    this={subject(
+                                                        'SavedChart',
+                                                        {
+                                                            ...chartQuery.data,
+                                                        },
+                                                    )}
+                                                >
+                                                    <Menu
+                                                        withinPortal
+                                                        position="bottom-start"
+                                                        withArrow
+                                                        arrowPosition="center"
+                                                        shadow="md"
+                                                        offset={-4}
+                                                        closeOnItemClick
+                                                        closeOnClickOutside
+                                                    >
+                                                        <Menu.Target>
+                                                            <ActionIcon
+                                                                sx={(
+                                                                    theme,
+                                                                ) => ({
+                                                                    ':hover': {
+                                                                        backgroundColor:
+                                                                            theme
+                                                                                .colors
+                                                                                .gray[1],
+                                                                    },
+                                                                })}
+                                                            >
+                                                                <IconDots
+                                                                    size={16}
+                                                                />
+                                                            </ActionIcon>
+                                                        </Menu.Target>
+
+                                                        <Menu.Dropdown
+                                                            maw={320}
+                                                        >
+                                                            <Menu.Item
+                                                                component="button"
+                                                                role="menuitem"
+                                                                icon={
+                                                                    <IconHistory
+                                                                        size={
+                                                                            18
+                                                                        }
+                                                                    />
+                                                                }
+                                                                onClick={() => {
+                                                                    setIsRestoreModalOpen(
+                                                                        true,
+                                                                    );
+                                                                }}
+                                                            >
+                                                                Restore this
+                                                                JSON version
+                                                            </Menu.Item>
+                                                        </Menu.Dropdown>
+                                                    </Menu>
+                                                </Can>
+                                            )}
+                                    </>
+                                }
+                                onClick={() =>
+                                    selectVersionUuid(version.versionUuid)
+                                }
+                            />
+                        ))}
+                    </Stack>
+                    <Alert
+                        icon={<MantineIcon icon={IconInfoCircle} size={'md'} />}
+                        title="JSON Version History"
+                        color="blue"
+                        variant="light"
+                    >
+                        <p>
+                            View and restore previous versions of your custom
+                            chart JSON specification. Only the JSON
+                            configuration is restored, preserving your current
+                            chart settings.
+                        </p>
+                    </Alert>
+                </Stack>
+            }
+        >
+            {!selectedVersionUuid && (
+                <EmptyState
+                    maw={500}
+                    icon={<NoTableIcon />}
+                    title="Select a JSON version"
+                />
+            )}
+            {versionQuery.data && (
+                <Stack spacing="md" h="100%">
+                    <Group position="apart">
+                        <Title order={4}>Custom Chart JSON Version</Title>
+                        <Group spacing="xs">
+                            {getValidationBadge(versionQuery.data.isValid)}
+                            {versionQuery.data.validationError && (
+                                <Text size="sm" color="red">
+                                    {versionQuery.data.validationError}
+                                </Text>
+                            )}
+                        </Group>
+                    </Group>
+
+                    <Box
+                        sx={{
+                            border: '1px solid #dee2e6',
+                            borderRadius: '4px',
+                            padding: '16px',
+                            backgroundColor: '#f8f9fa',
+                        }}
+                    >
+                        <ScrollArea h="calc(100vh - 250px)">
+                            <Code block style={{ fontSize: '12px' }}>
+                                {versionQuery.data.jsonSpec}
+                            </Code>
+                        </ScrollArea>
+                    </Box>
+                </Stack>
+            )}
+
+            <Modal
+                opened={isRestoreModalOpen}
+                onClose={() => setIsRestoreModalOpen(false)}
+                withCloseButton={false}
+                title={
+                    <Group spacing="xs">
+                        <MantineIcon icon={IconHistory} size="lg" />
+                        <Title order={4}>Restore Custom Chart JSON</Title>
+                    </Group>
+                }
+            >
+                <Stack>
+                    <Text>
+                        By restoring this JSON version, a new chart version will
+                        be created with the selected JSON specification. Your
+                        current chart settings (filters, dimensions, etc.) will
+                        be preserved, but the JSON configuration will be
+                        replaced.
+                    </Text>
+                    <Group position="right" spacing="xs">
+                        <Button
+                            variant="outline"
+                            disabled={restoreMutation.isLoading}
+                            onClick={() => setIsRestoreModalOpen(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            loading={restoreMutation.isLoading}
+                            onClick={() =>
+                                selectedVersionUuid &&
+                                restoreMutation.mutate(selectedVersionUuid)
+                            }
+                            type="submit"
+                        >
+                            Restore JSON
+                        </Button>
+                    </Group>
+                </Stack>
+            </Modal>
+        </Page>
+    );
+};
+
+export default CustomChartJsonHistory;


### PR DESCRIPTION
## **Description:**
This PR implements version history functionality specifically for custom chart JSON configurations. Users can now view historical versions of their custom chart JSON, revert to previous versions, and see validation status indicators.

### Key Features:
- **Version History**: View all historical versions of custom chart JSON with timestamps and user attribution
- **Revert Functionality**: One-click restoration to any previous JSON version
- **Validation Status**: Visual indicators showing which versions contain valid JSON
- **Access Control**: Proper permission checks for viewing and managing versions

### Implementation:
- Added new API endpoints for custom chart JSON history
- Created dedicated frontend page for JSON version management
- Added validation logic to check JSON format
- Integrated with existing chart permission system

### Usage:
1. Open any custom chart
2. Click menu (⋯) → "Custom JSON History"
3. Select any version to view its JSON content
4. Use "Restore this JSON version" to revert to a previous version

The feature maintains the existing chart structure while allowing users to safely experiment with JSON configurations and easily revert if needed.