### PR TITLE
fix: pivot table CSV export error when fields are missing

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -595,6 +595,17 @@ export const pivotQueryResults = ({
 
     const rowIndices = {};
     const columnIndices = {};
+    const safeGetFieldValue = (
+        row: ResultRow,
+        fieldId: string,
+    ): ResultValue => {
+        const field = row[fieldId];
+        if (field && field.value) {
+            return field.value;
+        }
+        return { raw: null, formatted: '' };
+    };
+
     let rowCount = 0;
     let columnCount = 0;
     for (let nRow = 0; nRow < N_ROWS; nRow += 1) {
@@ -605,7 +616,7 @@ export const pivotQueryResults = ({
                 .map<PivotData['indexValues'][number][number]>((fieldId) => ({
                     type: 'value',
                     fieldId,
-                    value: getObjectValue(row, fieldId).value,
+                    value: safeGetFieldValue(row, fieldId),
                     colSpan: 1,
                 }))
                 .concat(
@@ -624,7 +635,7 @@ export const pivotQueryResults = ({
                 .map<PivotData['headerValues'][number][number]>((fieldId) => ({
                     type: 'value',
                     fieldId,
-                    value: getObjectValue(row, fieldId).value,
+                    value: safeGetFieldValue(row, fieldId),
                     colSpan: 1,
                 }))
                 .concat(


### PR DESCRIPTION
Closes: #16866

### Description:
Fixed a bug where CSV export for pivoted tables would fail with "Cannot get key 'X' from object" error when expected field IDs were missing from the formatted row data.

**Changes:**
- Added safe field accessor function in `pivotQueryResults()` to handle missing fields gracefully
- Returns default values (`{ raw: null, formatted: '' }`) when fields don't exist instead of throwing errors
- Maintains all existing functionality while preventing crashes during pivot CSV export

**Testing:**
Users can now successfully export CSV files from pivoted tables without encountering the accessor error.