### PR TITLE
feat: add analytics dashboard embed to AI agent admin page

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -740,6 +740,8 @@ export type LightdashConfig = {
     logging: LoggingConfig;
     ai: {
         copilot: AiCopilotConfigSchemaType;
+        analyticsProjectUuid?: string;
+        analyticsDashboardUuid?: string;
     };
     embedding: {
         enabled: boolean;
@@ -833,6 +835,7 @@ export type LightdashConfig = {
     customRoles: {
         enabled: boolean;
     };
+    analyticsEmbedSecret?: string;
 };
 
 export type SlackConfig = {
@@ -1538,6 +1541,8 @@ export const parseConfig = (): LightdashConfig => {
         },
         ai: {
             copilot: copilotConfig,
+            analyticsProjectUuid: process.env.AI_ANALYTICS_PROJECT_UUID,
+            analyticsDashboardUuid: process.env.AI_ANALYTICS_DASHBOARD_UUID,
         },
         embedding: {
             enabled: process.env.EMBEDDING_ENABLED === 'true',
@@ -1604,5 +1609,6 @@ export const parseConfig = (): LightdashConfig => {
         customRoles: {
             enabled: process.env.CUSTOM_ROLES_ENABLED === 'true',
         },
+        analyticsEmbedSecret: process.env.ANALYTICS_EMBED_SECRET,
     };
 };

--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -109,6 +109,24 @@ export class AiAgentAdminController extends BaseController {
         };
     }
 
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/embed-token')
+    @OperationId('getEmbedToken')
+    async getEmbedToken(
+        @Request() req: express.Request,
+    ): Promise<{ status: string; results: { token: string; url: string } }> {
+        const results = await this.getAiAgentAdminService().generateEmbedToken(
+            req.user!,
+        );
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
     protected getAiAgentAdminService() {
         return this.services.getAiAgentAdminService<AiAgentAdminService>();
     }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -108,9 +108,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     openIdIdentityModel: models.getOpenIdIdentityModel(),
                     spaceService: repository.getSpaceService(),
                 }),
-            aiAgentAdminService: ({ models }) =>
+            aiAgentAdminService: ({ models, context }) =>
                 new AiAgentAdminService({
                     aiAgentModel: models.getAiAgentModel(),
+                    lightdashConfig: context.lightdashConfig,
                 }),
             scimService: ({ models, context }) =>
                 new ScimService({

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -9,17 +9,23 @@ import {
     KnexPaginatedData,
     type SessionUser,
 } from '@lightdash/common';
+import jwt from 'jsonwebtoken';
+import { type LightdashConfig } from '../../config/parseConfig';
 import { AiAgentModel } from '../models/AiAgentModel';
 
 type AiAgentAdminServiceDependencies = {
     aiAgentModel: AiAgentModel;
+    lightdashConfig: LightdashConfig;
 };
 
 export class AiAgentAdminService {
     private readonly aiAgentModel: AiAgentModel;
 
+    private readonly lightdashConfig: LightdashConfig;
+
     constructor(dependencies: AiAgentAdminServiceDependencies) {
         this.aiAgentModel = dependencies.aiAgentModel;
+        this.lightdashConfig = dependencies.lightdashConfig;
     }
 
     private static checkOrganizationAdminAccess(user: SessionUser): void {
@@ -75,5 +81,83 @@ export class AiAgentAdminService {
         return this.aiAgentModel.findAllAgents({
             organizationUuid,
         });
+    }
+
+    /**
+     * Generate an embed token for the analytics dashboard
+     * Only accessible by organization admins
+     *
+     * Security considerations:
+     * - Only uses authenticated user's organization UUID (no client-controlled filtering)
+     * - Token includes user email and a unique external ID for audit trails
+     * - Token expires after 1 hour to limit exposure
+     * - TODO: Add rate limiting to prevent token generation abuse
+     * - TODO: Consider caching tokens to reduce generation overhead
+     *
+     * @param user - The authenticated session user (must be org admin)
+     * @returns JWT token and embed URL for the analytics dashboard
+     */
+    async generateEmbedToken(
+        user: SessionUser,
+    ): Promise<{ token: string; url: string }> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        AiAgentAdminService.checkOrganizationAdminAccess(user);
+
+        const { analyticsEmbedSecret } = this.lightdashConfig;
+
+        if (!analyticsEmbedSecret) {
+            throw new Error('ANALYTICS_EMBED_SECRET is not configured');
+        }
+
+        const projectUuid = this.lightdashConfig.ai?.analyticsProjectUuid;
+        const dashboardUuid = this.lightdashConfig.ai?.analyticsDashboardUuid;
+
+        if (!projectUuid || !dashboardUuid) {
+            throw new Error(
+                'AI agent analytics dashboard configuration is missing. Please configure AI_ANALYTICS_PROJECT_UUID and AI_ANALYTICS_DASHBOARD_UUID',
+            );
+        }
+
+        const userAttributes: Record<string, string> = {
+            lightdash_embed_ai_agents_organization_uuid: organizationUuid,
+        };
+
+        const data = {
+            content: {
+                type: 'dashboard',
+                projectUuid,
+                dashboardUuid,
+                dashboardFiltersInteractivity: {
+                    enabled: 'none',
+                    allowedFilters: undefined,
+                },
+                canExportCsv: false,
+                canExportImages: false,
+                canExportPagePdf: false,
+                canDateZoom: false,
+                canExplore: false,
+                canViewUnderlyingData: false,
+            },
+            user: {
+                externalId: `org_${organizationUuid}_user_${user.userUuid}`,
+                email: user.email,
+            },
+            userAttributes,
+        };
+
+        const token = jwt.sign(data, analyticsEmbedSecret, {
+            expiresIn: '1 hour',
+        });
+
+        const baseUrl = `https://analytics.lightdash.cloud/embed/${projectUuid}`;
+        const url = new URL(`${baseUrl}#${token}`);
+
+        return {
+            token,
+            url: url.href,
+        };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -23213,6 +23213,61 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getEmbedToken: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/embed-token',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getEmbedToken,
+        ),
+
+        async function AiAgentAdminController_getEmbedToken(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getEmbedToken,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getEmbedToken',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsValidationController_post: Record<
         string,
         TsoaRoute.ParameterSchema

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
@@ -1,12 +1,15 @@
 import { type AiAgentAdminThreadSummary } from '@lightdash/common';
 import {
     Box,
+    Button,
     Group,
+    Modal,
     Stack,
     Text,
     Title,
     useMantineTheme,
 } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconGripVertical, IconLock, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
@@ -17,6 +20,7 @@ import SuboptimalState from '../../../../../components/common/SuboptimalState/Su
 import useApp from '../../../../../providers/App/useApp';
 import AiAgentAdminThreadsTable from './AiAgentAdminThreadsTable';
 import styles from './AiAgentsAdminLayout.module.css';
+import { AnalyticsEmbedDashboard } from './AnalyticsEmbedDashboard';
 import { ThreadPreviewSidebar } from './ThreadPreviewSidebar';
 
 export const AiAgentsAdminLayout = () => {
@@ -25,6 +29,8 @@ export const AiAgentsAdminLayout = () => {
     const [selectedThread, setSelectedThread] =
         useState<AiAgentAdminThreadSummary | null>(null);
     const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+    const [isAnalyticsEmbedOpen, { toggle: toggleAnalyticsEmbed }] =
+        useDisclosure(false);
 
     const canManageOrganization = user.data?.ability.can(
         'manage',
@@ -34,6 +40,9 @@ export const AiAgentsAdminLayout = () => {
     const handleThreadSelect = (thread: AiAgentAdminThreadSummary): void => {
         setSelectedThread(thread);
         setIsSidebarOpen(true);
+        if (isAnalyticsEmbedOpen) {
+            toggleAnalyticsEmbed();
+        }
     };
 
     const handleCloseSidebar = () => {
@@ -69,7 +78,19 @@ export const AiAgentsAdminLayout = () => {
                 >
                     <Group justify="space-between" my="lg">
                         <Box>
-                            <Title order={2}>AI Agents Admin Panel</Title>
+                            <Group>
+                                <Title order={2}>AI Agents Admin Panel</Title>
+                                <Group justify="space-between" my="lg">
+                                    <Button
+                                        onClick={toggleAnalyticsEmbed}
+                                        variant="filled"
+                                        size="compact-sm"
+                                        color="indigo"
+                                    >
+                                        View Insights
+                                    </Button>
+                                </Group>
+                            </Group>
                             <Text c="gray.6" size="sm" fw={400}>
                                 View and manage AI Agents threads
                             </Text>
@@ -126,6 +147,22 @@ export const AiAgentsAdminLayout = () => {
                     </>
                 )}
             </PanelGroup>
+            <Modal
+                opened={isAnalyticsEmbedOpen}
+                size="xl"
+                onClose={toggleAnalyticsEmbed}
+                title={<Text fw={700}>AI Agents Insights</Text>}
+                padding="0"
+                centered
+                styles={{
+                    header: {
+                        borderBottom: `1px solid ${theme.colors.gray[2]}`,
+                        padding: theme.spacing.md,
+                    },
+                }}
+            >
+                <AnalyticsEmbedDashboard />
+            </Modal>
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AnalyticsEmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AnalyticsEmbedDashboard.tsx
@@ -1,0 +1,35 @@
+import { Box, Paper, Skeleton, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+import { useAiAgentAdminEmbedToken } from '../../hooks/useAiAgentAdmin';
+
+export const AnalyticsEmbedDashboard: FC = () => {
+    const { data: embedData, isLoading: isEmbedLoading } =
+        useAiAgentAdminEmbedToken();
+
+    if (!embedData) {
+        return (
+            <Paper h={450}>
+                <Text c="gray.6">Unable to load analytics dashboard</Text>
+            </Paper>
+        );
+    }
+
+    return (
+        <Box h={500}>
+            {isEmbedLoading ? (
+                <Skeleton h={450} />
+            ) : (
+                <iframe
+                    src={embedData.url}
+                    width="100%"
+                    height="100%"
+                    frameBorder="0"
+                    style={{
+                        border: 'none',
+                    }}
+                    title="Analytics Dashboard"
+                />
+            )}
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -103,3 +103,22 @@ export const useAiAgentAdminAgents = () => {
         keepPreviousData: true,
     });
 };
+
+const getAiAgentAdminEmbedToken = async () => {
+    return lightdashApi<{ token: string; url: string }>({
+        version: 'v1',
+        url: `/aiAgents/admin/embed-token`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useAiAgentAdminEmbedToken = () => {
+    return useQuery<{ token: string; url: string }, ApiError>({
+        queryKey: ['ai-agent-admin-embed-token'],
+        queryFn: getAiAgentAdminEmbedToken,
+        keepPreviousData: true,
+        refetchOnWindowFocus: false,
+        staleTime: 30 * 60 * 1000, // 30 minutes (token expires in 1 hour)
+    });
+};


### PR DESCRIPTION
Closes: #16678

### Description:
Add analytics dashboard embed functionality to AI Agent admin page

This PR adds the ability to embed an analytics dashboard in the AI Agent admin interface. It includes:

1. A new configuration option `analyticsEmbedSecret` for JWT token generation
2. A new API endpoint `/aiAgents/admin/embed-token` to generate embed tokens
3. A React component `AnalyticsEmbedDashboard` that displays the embedded dashboard
4. Integration with the AI Agents admin layout

The embedded dashboard provides analytics about AI agent usage directly within the admin interface, making it easier for admins to monitor and analyze usage patterns.


<img width="1710" height="856" alt="Screenshot 2025-09-16 at 11 21 47" src="https://github.com/user-attachments/assets/1a106b3b-9ff9-418e-94e0-21219dac942a" />
