### PR TITLE
feat: add OpenAI responses API support option

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -17,6 +17,7 @@ export const aiCopilotConfigSchema = z
                     modelName: z.string().default(DEFAULT_OPENAI_MODEL_NAME),
                     baseUrl: z.string().optional(),
                     temperature: z.number().min(0).max(2).default(0.2),
+                    responsesApi: z.boolean().default(false),
                 })
                 .optional(),
             azure: z

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -205,6 +205,7 @@ export const lightdashConfigMock: LightdashConfig = {
                     apiKey: 'mock_api_key',
                     modelName: 'mock_model_name',
                     temperature: 0.2,
+                    responsesApi: false,
                 },
             },
         },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1089,6 +1089,7 @@ export const parseConfig = (): LightdashConfig => {
                       baseUrl: process.env.OPENAI_BASE_URL,
                       temperature:
                           getFloatFromEnvironmentVariable('OPENAI_TEMPERATURE'),
+                      responsesApi: process.env.OPENAI_RESPONSES_API === 'true',
                   }
                 : undefined,
             anthropic: process.env.ANTHROPIC_API_KEY

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -34,6 +34,7 @@ describeOrSkip.concurrent('agent integration tests', () => {
         temperature: process.env.OPENAI_TEMPERATURE
             ? parseFloat(process.env.OPENAI_TEMPERATURE)
             : 0.2,
+        responsesApi: false,
     });
 
     beforeAll(async () => {

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -14,7 +14,9 @@ export const getOpenaiGptmodel = (
         ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
     });
 
-    const model = openai(config.modelName);
+    const model = config.responsesApi
+        ? openai.responses(config.modelName)
+        : openai(config.modelName);
 
     return {
         model,


### PR DESCRIPTION
### Description:
Added support for OpenAI Responses API by introducing a new configuration option `responsesApi` in the AI copilot schema. This boolean flag defaults to false and can be enabled via the `OPENAI_RESPONSES_API` environment variable. When enabled, the system will use OpenAI's responses API instead of the standard API for model interactions.