### PR TITLE
fix: subtotals column orders not being respected

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -982,12 +982,17 @@ export const convertSqlPivotedRowsToPivotData = ({
     }
 
     const hiddenMetricFieldIds = pivotConfig.hiddenMetricFieldIds || [];
+    const columnOrder = pivotConfig.columnOrder || [];
 
     // Extract information from pivot details metadata
     let indexColumns: string[];
     if (pivotDetails.indexColumn) {
         if (Array.isArray(pivotDetails.indexColumn)) {
-            indexColumns = pivotDetails.indexColumn.map((col) => col.reference);
+            indexColumns = pivotDetails.indexColumn
+                .map((col) => col.reference)
+                .sort(
+                    (a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b),
+                );
         } else {
             indexColumns = [pivotDetails.indexColumn.reference];
         }
@@ -1093,10 +1098,20 @@ export const convertSqlPivotedRowsToPivotData = ({
     // Add metric labels for columns if not metrics as rows
     if (!pivotConfig.metricsAsRows && baseMetricsArray.length > 0) {
         headerValues.push(
-            pivotDetails.valuesColumns.map(({ referenceField }) => ({
-                type: 'label' as const,
-                fieldId: referenceField,
-            })),
+            pivotDetails.valuesColumns
+                .sort((a, b) => {
+                    const columnIndexSort =
+                        Number(a.columnIndex) - Number(b.columnIndex);
+                    const columnOrderSort =
+                        columnOrder.indexOf(a.referenceField) -
+                        columnOrder.indexOf(b.referenceField);
+
+                    return columnIndexSort || columnOrderSort;
+                })
+                .map(({ referenceField }) => ({
+                    type: 'label' as const,
+                    fieldId: referenceField,
+                })),
         );
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16890

### Description:
This PR enhances the pivot table functionality by respecting column ordering in two key areas:

1. Sorts index columns based on the `columnOrder` configuration when multiple index columns are present
2. Improves the sorting of value columns by considering both the column index and the column order configuration

These changes ensure that pivot tables display columns in a consistent order that matches user configuration preferences.

**Before**

https://github.com/user-attachments/assets/07a0e5e9-ec8a-4ee1-b2d6-6db7cae979fc

**After**

https://github.com/user-attachments/assets/067b2c77-adfe-4923-a584-b454a4f1af55

