### PR TITLE
feat: add AI Agent eval database schema and migrations

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -273,6 +273,16 @@ import {
     AiArtifactVersionsTableName,
 } from '../ee/database/entities/aiArtifacts';
 import {
+    AiEvalPromptTable,
+    AiEvalPromptTableName,
+    AiEvalRunResultTable,
+    AiEvalRunResultTableName,
+    AiEvalRunTable,
+    AiEvalRunTableName,
+    AiEvalTable,
+    AiEvalTableName,
+} from '../ee/database/entities/aiEvals';
+import {
     DashboardSummariesTable,
     DashboardSummariesTableName,
 } from '../ee/database/entities/dashboardSummaries';
@@ -387,5 +397,9 @@ declare module 'knex/types/tables' {
         [ProjectParametersTableName]: ProjectParametersTable;
         [RolesTableName]: RoleTable;
         [ScopedRolesTableName]: ScopedRoleTable;
+        [AiEvalTableName]: AiEvalTable;
+        [AiEvalPromptTableName]: AiEvalPromptTable;
+        [AiEvalRunTableName]: AiEvalRunTable;
+        [AiEvalRunResultTableName]: AiEvalRunResultTable;
     }
 }

--- a/packages/backend/src/ee/database/entities/aiEvals.ts
+++ b/packages/backend/src/ee/database/entities/aiEvals.ts
@@ -1,0 +1,84 @@
+import { Knex } from 'knex';
+
+export const AiEvalTableName = 'ai_eval';
+
+export type DbAiEval = {
+    ai_eval_uuid: string;
+    agent_uuid: string;
+    title: string;
+    description: string | null;
+    created_at: Date;
+    updated_at: Date;
+    created_by_user_uuid: string;
+};
+
+export type AiEvalTable = Knex.CompositeTableType<
+    DbAiEval,
+    Omit<DbAiEval, 'ai_eval_uuid' | 'created_at' | 'updated_at'>,
+    Partial<Omit<DbAiEval, 'ai_eval_uuid' | 'created_at' | 'updated_at'>> & {
+        updated_at: Knex.Raw;
+    }
+>;
+
+export const AiEvalPromptTableName = 'ai_eval_prompt';
+
+export type DbAiEvalPrompt = {
+    ai_eval_prompt_uuid: string;
+    ai_eval_uuid: string;
+    prompt: string | null;
+    ai_prompt_uuid: string | null;
+    ai_thread_uuid: string | null;
+    created_at: Date;
+};
+
+export type AiEvalPromptTable = Knex.CompositeTableType<
+    DbAiEvalPrompt,
+    Omit<DbAiEvalPrompt, 'ai_eval_prompt_uuid' | 'created_at'>,
+    never
+>;
+
+export const AiEvalRunTableName = 'ai_eval_run';
+
+export type DbAiEvalRun = {
+    ai_eval_run_uuid: string;
+    ai_eval_uuid: string;
+    status: 'pending' | 'running' | 'completed' | 'failed';
+    completed_at: Date | null;
+    created_at: Date;
+};
+
+export type AiEvalRunTable = Knex.CompositeTableType<
+    DbAiEvalRun,
+    Omit<
+        DbAiEvalRun,
+        'ai_eval_run_uuid' | 'created_at' | 'completed_at' | 'status'
+    >,
+    Partial<Pick<DbAiEvalRun, 'status' | 'completed_at'>>
+>;
+
+export const AiEvalRunResultTableName = 'ai_eval_run_result';
+
+export type DbAiEvalRunResult = {
+    ai_eval_run_result_uuid: string;
+    ai_eval_run_uuid: string;
+    ai_eval_prompt_uuid: string | null;
+    ai_thread_uuid: string | null;
+    status: 'pending' | 'running' | 'completed' | 'failed';
+    error_message: string | null;
+    completed_at: Date | null;
+    created_at: Date;
+};
+
+export type AiEvalRunResultTable = Knex.CompositeTableType<
+    DbAiEvalRunResult,
+    Pick<
+        DbAiEvalRunResult,
+        'ai_eval_run_uuid' | 'ai_eval_prompt_uuid' | 'ai_thread_uuid'
+    >,
+    Partial<
+        Pick<
+            DbAiEvalRunResult,
+            'ai_thread_uuid' | 'status' | 'error_message' | 'completed_at'
+        >
+    >
+>;

--- a/packages/backend/src/ee/database/migrations/20250917134049_ai_eval_tables.ts
+++ b/packages/backend/src/ee/database/migrations/20250917134049_ai_eval_tables.ts
@@ -1,0 +1,145 @@
+import { Knex } from 'knex';
+
+const aiEvalTable = 'ai_eval';
+const aiEvalPromptTable = 'ai_eval_prompt';
+const aiEvalRunTable = 'ai_eval_run';
+const aiEvalRunResultTable = 'ai_eval_run_result';
+const aiAgentTable = 'ai_agent';
+const aiThreadTable = 'ai_thread';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(aiEvalTable, (table) => {
+        table
+            .uuid('ai_eval_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('created_by_user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE');
+        table
+            .uuid('agent_uuid')
+            .notNullable()
+            .references('ai_agent_uuid')
+            .inTable(aiAgentTable)
+            .onDelete('CASCADE');
+        table.string('title').notNullable();
+        table.text('description');
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['created_by_user_uuid']);
+        table.index(['agent_uuid']);
+    });
+
+    await knex.schema.createTable(aiEvalPromptTable, (table) => {
+        table
+            .uuid('ai_eval_prompt_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_eval_uuid')
+            .notNullable()
+            .references('ai_eval_uuid')
+            .inTable(aiEvalTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('ai_prompt_uuid')
+            .nullable()
+            .references('ai_prompt_uuid')
+            .inTable('ai_prompt')
+            .onDelete('CASCADE');
+        table
+            .uuid('ai_thread_uuid')
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable(aiThreadTable)
+            .onDelete('CASCADE');
+        table.text('prompt').nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['ai_eval_uuid']);
+        table.index(['ai_prompt_uuid']);
+        table.index(['ai_thread_uuid']);
+    });
+
+    await knex.schema.createTable(aiEvalRunTable, (table) => {
+        table
+            .uuid('ai_eval_run_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_eval_uuid')
+            .notNullable()
+            .references('ai_eval_uuid')
+            .inTable(aiEvalTable)
+            .onDelete('CASCADE');
+        table
+            .enum('status', ['pending', 'running', 'completed', 'failed'])
+            .notNullable()
+            .defaultTo('pending');
+        table.timestamp('completed_at', { useTz: false });
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['ai_eval_uuid']);
+        table.index(['status']);
+    });
+
+    await knex.schema.createTable(aiEvalRunResultTable, (table) => {
+        table
+            .uuid('ai_eval_run_result_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_eval_run_uuid')
+            .notNullable()
+            .references('ai_eval_run_uuid')
+            .inTable(aiEvalRunTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('ai_eval_prompt_uuid')
+            .references('ai_eval_prompt_uuid')
+            .inTable(aiEvalPromptTable)
+            .onDelete('SET NULL');
+        table
+            .uuid('ai_thread_uuid')
+            .references('ai_thread_uuid')
+            .inTable(aiThreadTable)
+            .onDelete('CASCADE');
+        table
+            .enum('status', ['pending', 'running', 'completed', 'failed'])
+            .notNullable()
+            .defaultTo('pending');
+        table.text('error_message');
+        table.timestamp('completed_at', { useTz: false });
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['ai_eval_run_uuid']);
+        table.index(['ai_eval_prompt_uuid']);
+        table.index(['ai_thread_uuid']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(aiEvalRunResultTable);
+    await knex.schema.dropTableIfExists(aiEvalRunTable);
+    await knex.schema.dropTableIfExists(aiEvalPromptTable);
+    await knex.schema.dropTableIfExists(aiEvalTable);
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Adds database schema for AI evaluation functionality. This includes:

- New tables for AI evaluations, prompts, runs, and results
- Database migration script to create these tables with proper relationships
- Type definitions for database entities

The schema supports creating evaluations for agents, storing evaluation prompts, tracking evaluation runs, and recording results with status tracking.
