### PR TITLE
chore: drop 1.5 and 1.6 dbt versions from build-docker

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,19 +1,11 @@
 FROM gitpod/workspace-full
 
-# Installing multiple versions of dbt
-# dbt 1.4 is the default
+# Installing dbt 1.4 (default version)
 RUN python3 -m venv /home/gitpod/dbt1.4
 RUN /home/gitpod/dbt1.4/bin/pip install \
-    "dbt-postgres~=1.4.0" 
+    "dbt-postgres~=1.4.0"
 
-
-RUN python3 -m venv /home/gitpod/dbt1.5
-RUN /home/gitpod/dbt1.5/bin/pip install \
-    "dbt-postgres~=1.5.0"
-
-RUN ln -s /home/gitpod/dbt1.5/bin/dbt /home/gitpod/dbt1.5/bin/dbt1.5
-
-ENV PATH="${PATH}:/home/gitpod/dbt1.4/bin:/home/gitpod/dbt1.5/bin"
+ENV PATH="${PATH}:/home/gitpod/dbt1.4/bin"
 
 
 # Install postgres

--- a/dockerfile
+++ b/dockerfile
@@ -48,26 +48,6 @@ RUN python3 -m venv /usr/local/dbt1.4 \
     "psycopg2-binary==2.9.6"
 
 RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt\
-    && python3 -m venv /usr/local/dbt1.5 \
-    && /usr/local/dbt1.5/bin/pip install \
-    "dbt-postgres~=1.5.0" \
-    "dbt-redshift~=1.5.0" \
-    "dbt-snowflake~=1.5.0" \
-    "dbt-bigquery~=1.5.0" \
-    "dbt-databricks~=1.5.0" \
-    "dbt-trino==1.5.0" \
-    "psycopg2-binary==2.9.6" \
-    && ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5\
-    && python3 -m venv /usr/local/dbt1.6 \
-    && /usr/local/dbt1.6/bin/pip install \
-    "dbt-postgres~=1.6.0" \
-    "dbt-redshift~=1.6.0" \
-    "dbt-snowflake~=1.6.0" \
-    "dbt-bigquery~=1.6.0" \
-    "dbt-databricks~=1.6.0" \
-    "dbt-trino==1.6.0" \
-    "psycopg2-binary==2.9.6"\
-    && ln -s /usr/local/dbt1.6/bin/dbt /usr/local/bin/dbt1.6 \
     && python3 -m venv /usr/local/dbt1.7 \
     && /usr/local/dbt1.7/bin/pip install \
     "dbt-postgres~=1.7.0" \
@@ -260,8 +240,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=prod-builder  /usr/local/dbt1.4 /usr/local/dbt1.4
-COPY --from=prod-builder  /usr/local/dbt1.5 /usr/local/dbt1.5
-COPY --from=prod-builder  /usr/local/dbt1.6 /usr/local/dbt1.6
 COPY --from=prod-builder  /usr/local/dbt1.7 /usr/local/dbt1.7
 COPY --from=prod-builder  /usr/local/dbt1.8 /usr/local/dbt1.8
 COPY --from=prod-builder  /usr/local/dbt1.9 /usr/local/dbt1.9
@@ -269,8 +247,6 @@ COPY --from=prod-builder  /usr/local/dbt1.10 /usr/local/dbt1.10
 COPY --from=prod-builder /usr/app /usr/app
 
 RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
-    && ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5 \
-    && ln -s /usr/local/dbt1.6/bin/dbt /usr/local/bin/dbt1.6 \
     && ln -s /usr/local/dbt1.7/bin/dbt /usr/local/bin/dbt1.7 \
     && ln -s /usr/local/dbt1.8/bin/dbt /usr/local/bin/dbt1.8 \
     && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -48,26 +48,6 @@ RUN python3 -m venv /usr/local/dbt1.4 \
     "psycopg2-binary==2.9.6"
 
 RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt\
-    && python3 -m venv /usr/local/dbt1.5 \
-    && /usr/local/dbt1.5/bin/pip install \
-    "dbt-postgres~=1.5.0" \
-    "dbt-redshift~=1.5.0" \
-    "dbt-snowflake~=1.5.0" \
-    "dbt-bigquery~=1.5.0" \
-    "dbt-databricks~=1.5.0" \
-    "dbt-trino==1.5.0" \
-    "psycopg2-binary==2.9.6" \
-    && ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5\
-    && python3 -m venv /usr/local/dbt1.6 \
-    && /usr/local/dbt1.6/bin/pip install \
-    "dbt-postgres~=1.6.0" \
-    "dbt-redshift~=1.6.0" \
-    "dbt-snowflake~=1.6.0" \
-    "dbt-bigquery~=1.6.0" \
-    "dbt-databricks~=1.6.0" \
-    "dbt-trino==1.6.0" \
-    "psycopg2-binary==2.9.6"\
-    && ln -s /usr/local/dbt1.6/bin/dbt /usr/local/bin/dbt1.6 \
     && python3 -m venv /usr/local/dbt1.7 \
     && /usr/local/dbt1.7/bin/pip install \
     "dbt-postgres~=1.7.0" \
@@ -260,8 +240,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=prod-builder  /usr/local/dbt1.4 /usr/local/dbt1.4
-COPY --from=prod-builder  /usr/local/dbt1.5 /usr/local/dbt1.5
-COPY --from=prod-builder  /usr/local/dbt1.6 /usr/local/dbt1.6
 COPY --from=prod-builder  /usr/local/dbt1.7 /usr/local/dbt1.7
 COPY --from=prod-builder  /usr/local/dbt1.8 /usr/local/dbt1.8
 COPY --from=prod-builder  /usr/local/dbt1.9 /usr/local/dbt1.9
@@ -269,8 +247,6 @@ COPY --from=prod-builder  /usr/local/dbt1.10 /usr/local/dbt1.10
 COPY --from=prod-builder /usr/app /usr/app
 
 RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
-    && ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5 \
-    && ln -s /usr/local/dbt1.6/bin/dbt /usr/local/bin/dbt1.6 \
     && ln -s /usr/local/dbt1.7/bin/dbt /usr/local/bin/dbt1.7 \
     && ln -s /usr/local/dbt1.8/bin/dbt /usr/local/bin/dbt1.8 \
     && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -76,8 +76,6 @@ type DbtCliArgs = {
 
 enum DbtCommands {
     DBT_1_4 = 'dbt',
-    DBT_1_5 = 'dbt1.5',
-    DBT_1_6 = 'dbt1.6',
     DBT_1_7 = 'dbt1.7',
     DBT_1_8 = 'dbt1.8',
     DBT_1_9 = 'dbt1.9',
@@ -156,10 +154,6 @@ export class DbtCliClient implements DbtClient {
         switch (this.dbtVersion) {
             case SupportedDbtVersions.V1_4:
                 return DbtCommands.DBT_1_4;
-            case SupportedDbtVersions.V1_5:
-                return DbtCommands.DBT_1_5;
-            case SupportedDbtVersions.V1_6:
-                return DbtCommands.DBT_1_6;
             case SupportedDbtVersions.V1_7:
                 return DbtCommands.DBT_1_7;
             case SupportedDbtVersions.V1_8:

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -126,7 +126,7 @@ async function dbtList(options: DbtCompileOptions): Promise<string[]> {
             'unique_id',
         ];
         const version = await getDbtVersion();
-        // only dbt 1.5 and above support --quiet flag
+        // only dbt 1.7 and above support --quiet flag
         if (version.versionOption !== SupportedDbtVersions.V1_4) {
             args.push('--quiet');
         }

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -44,8 +44,6 @@ const getSupportedDbtVersionOption = (
     if (version.match(DBT_CLOUD_CLI_REGEX))
         return DbtVersionOptionLatest.LATEST;
     if (version.startsWith('1.4.')) return SupportedDbtVersions.V1_4;
-    if (version.startsWith('1.5.')) return SupportedDbtVersions.V1_5;
-    if (version.startsWith('1.6.')) return SupportedDbtVersions.V1_6;
     if (version.startsWith('1.7.')) return SupportedDbtVersions.V1_7;
     if (version.startsWith('1.8.')) return SupportedDbtVersions.V1_8;
     if (version.startsWith('1.9.')) return SupportedDbtVersions.V1_9;
@@ -57,6 +55,7 @@ const getSupportedDbtVersionOption = (
 
 const getFallbackDbtVersionOption = (version: string): DbtVersionOption => {
     if (version.startsWith('1.3.')) return SupportedDbtVersions.V1_4; // legacy|deprecated support for dbt 1.3
+    // No fallback version for 1.5 and 1.6
     return getLatestSupportDbtVersion();
 };
 

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -160,7 +160,7 @@ describe('convert tables from dbt models', () => {
                 DEFAULT_SPOTLIGHT_CONFIG,
             ),
         ).toStrictEqual(LIGHTDASH_TABLE_WITH_DBT_METRICS);
-        // dbt 1.5 metrics
+
         expect(
             convertTable(
                 SupportedDbtAdapter.BIGQUERY,

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -241,8 +241,6 @@ export type DbtProjectEnvironmentVariable = {
 
 export enum SupportedDbtVersions {
     V1_4 = 'v1.4',
-    V1_5 = 'v1.5',
-    V1_6 = 'v1.6',
     V1_7 = 'v1.7',
     V1_8 = 'v1.8',
     V1_9 = 'v1.9',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:

Remove dbt versions 1.5 and 1.6 from the Docker image to reduce image size and simplify maintenance. This change removes the installation of these versions and their corresponding symbolic links, while maintaining support for versions 1.4, 1.7, 1.8, 1.9, and 1.10.

```
docker-build (linux/amd64)
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20250915-174315-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at GitHub.Runner.Common.HostTraceListener.TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, Int32 id, String message)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20250915-174315-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at GitHub.Runner.Common.HostTraceListener.TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, Int32 id, String message)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Common.Tracing.Error(Exception exception)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20250915-174315-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at System.Diagnostics.TraceSource.Flush()
   at GitHub.Runner.Common.Tracing.Dispose(Boolean disposing)
   at GitHub.Runner.Common.Tracing.Dispose()
   at GitHub.Runner.Common.TraceManager.Dispose(Boolean disposing)
   at GitHub.Runner.Common.TraceManager.Dispose()
   at GitHub.Runner.Common.HostContext.Dispose(Boolean disposing)
   at GitHub.Runner.Common.HostContext.Dispose()
   at GitHub.Runner.Worker.Program.Main(String[] args)
```

test-cli
test-backend
test-frontend