### PR TITLE
fix: improve token hash

### DIFF
--- a/packages/backend/src/utils/hash.ts
+++ b/packages/backend/src/utils/hash.ts
@@ -1,0 +1,23 @@
+import bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
+
+export async function hash(s: string): Promise<string> {
+    // Use LIGHTDASH_SECRET as key material to generate a consistent salt
+    const secretHash = crypto
+        .createHash('sha256')
+        .update(process.env.LIGHTDASH_SECRET!)
+        .digest('hex');
+    // Create a valid bcrypt salt format: $2b$10$ + 22 chars from the hash
+    const salt = `$2b$10$${secretHash.substring(0, 22)}`;
+    return bcrypt.hash(s, salt);
+}
+
+/* 
+@deprecated use hash instead to hash new tokens
+This is the old hash function that was used to hash the personal access tokens.
+It was replaced with bcrypt to improve security
+This is still used when filtering PAT from DB for backwards compatibility
+*/
+export function deprecatedHash(s: string): string {
+    return crypto.createHash('sha256').update(s).digest('hex');
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash-internal-work/issues/3698

Improve service account and PAT token hash, while keeping the old tokens compatible. 

Generation of new tokens and rotations: new hash
When filtering from db, we use both the new hash and the old compatible hash. 

<img width="768" height="340" alt="Screenshot from 2025-09-16 11-51-37" src="https://github.com/user-attachments/assets/66b77725-b066-4abe-abab-4b739e0ddf22" />

<img width="940" height="232" alt="Screenshot from 2025-09-16 11-51-19" src="https://github.com/user-attachments/assets/11b20c2b-19c9-4684-9cd4-01d73ee30ed9" />

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
