### PR TITLE
fix: increase validations error column size from string to text

### DIFF
--- a/packages/backend/src/database/migrations/20250916120230_increase_validations_error_column_size.ts
+++ b/packages/backend/src/database/migrations/20250916120230_increase_validations_error_column_size.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex';
+
+const tableName = 'validations';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.text('error').notNullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.string('error').notNullable().alter();
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Increases the size of the `error` column in the `validations` table by changing its type from `string` to `text`. This allows for storing larger error messages that might exceed the default string length limit.