### PR TITLE
fix: downloading pivoted tables

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1942,6 +1942,7 @@ export default class SchedulerTask {
                     onlyRaw: true,
                     maxColumnLimit:
                         this.lightdashConfig.pivotTable.maxColumnLimit,
+                    pivotDetails: null, // TODO: this is using old way of running queries + pivoting, therefore pivotDetails is not available
                 });
 
                 await this.googleDriveClient.appendCsvToSheet(
@@ -2487,6 +2488,7 @@ export default class SchedulerTask {
                         onlyRaw: true,
                         maxColumnLimit:
                             this.lightdashConfig.pivotTable.maxColumnLimit,
+                        pivotDetails: null, // TODO: this is using old way of running queries + pivoting, therefore pivotDetails is not available
                     });
                     await this.googleDriveClient.appendCsvToSheet(
                         refreshToken,
@@ -2629,6 +2631,7 @@ export default class SchedulerTask {
                                 maxColumnLimit:
                                     this.lightdashConfig.pivotTable
                                         .maxColumnLimit,
+                                pivotDetails: null, // TODO: this is using old way of running queries + pivoting, therefore pivotDetails is not available
                             });
 
                             await this.googleDriveClient.appendCsvToSheet(

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -730,7 +730,7 @@ export class CsvService extends BaseService {
                 rows,
                 itemMap,
                 metricQuery,
-
+                pivotDetails: null, // TODO: this is using old way of running queries + pivoting, therefore pivotDetails is not available
                 exploreId,
                 onlyRaw,
                 truncated,
@@ -1218,6 +1218,7 @@ export class CsvService extends BaseService {
                         onlyRaw,
                         truncated,
                         customLabels,
+                        pivotDetails: null, // TODO: this is using old way of running queries + pivoting, therefore pivotDetails is not available
                     });
 
                 this.analytics.track({

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -10,6 +10,7 @@ import {
     MetricQuery,
     PivotConfig,
     pivotResultsAsCsv,
+    type ReadyQueryResultsPage,
 } from '@lightdash/common';
 import * as Excel from 'exceljs';
 import fs from 'fs';
@@ -120,6 +121,7 @@ export class ExcelService {
         onlyRaw,
         customLabels,
         maxColumnLimit,
+        pivotDetails,
     }: {
         rows: Record<string, AnyType>[];
         itemMap: ItemsMap;
@@ -128,6 +130,7 @@ export class ExcelService {
         onlyRaw: boolean;
         customLabels: Record<string, string> | undefined;
         maxColumnLimit: number;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
     }): Promise<Excel.Buffer> {
         // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
         const formattedRows = formatRows(rows, itemMap);
@@ -140,6 +143,7 @@ export class ExcelService {
             customLabels,
             onlyRaw,
             maxColumnLimit,
+            pivotDetails,
         });
 
         // Create Excel workbook
@@ -197,12 +201,14 @@ export class ExcelService {
         storageClient,
         lightdashConfig,
         options,
+        pivotDetails,
     }: {
         resultsFileName: string;
         fields: ItemsMap;
         metricQuery: MetricQuery;
         storageClient: S3ResultsFileStorageClient; // S3ResultsFileStorageClient type
         lightdashConfig: LightdashConfig;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         options: {
             onlyRaw: boolean;
             showTableNames: boolean;
@@ -260,6 +266,7 @@ export class ExcelService {
             onlyRaw,
             customLabels,
             maxColumnLimit: lightdashConfig.pivotTable.maxColumnLimit,
+            pivotDetails,
         });
 
         // Upload the Excel buffer to storage using the storage client pattern

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -8,6 +8,7 @@ import {
     MissingConfigError,
     PivotConfig,
     pivotResultsAsCsv,
+    type ReadyQueryResultsPage,
 } from '@lightdash/common';
 import { stringify } from 'csv-stringify';
 import * as fs from 'fs';
@@ -93,12 +94,14 @@ export class PivotTableService extends BaseService {
         projectUuid,
         storageClient,
         options,
+        pivotDetails,
     }: {
         resultsFileName: string;
         fields: ItemsMap;
         metricQuery: MetricQuery;
         projectUuid: string;
         storageClient: S3ResultsFileStorageClient;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         options: {
             onlyRaw: boolean;
             showTableNames: boolean;
@@ -109,14 +112,7 @@ export class PivotTableService extends BaseService {
             attachmentDownloadName?: string;
         };
     }): Promise<{ fileUrl: string; truncated: boolean }> {
-        const {
-            onlyRaw,
-            showTableNames,
-            customLabels,
-            columnOrder,
-            hiddenFields,
-            pivotConfig,
-        } = options;
+        const { onlyRaw, customLabels, pivotConfig } = options;
 
         // Load rows from the results file using shared streaming utility
         // Use the same logic as regular CSV exports - respect csvCellsLimit with field count
@@ -165,6 +161,7 @@ export class PivotTableService extends BaseService {
             onlyRaw,
             truncated: finalTruncated,
             customLabels,
+            pivotDetails,
         });
 
         return {
@@ -188,6 +185,7 @@ export class PivotTableService extends BaseService {
         onlyRaw,
         truncated,
         customLabels,
+        pivotDetails,
     }: {
         name?: string;
         projectUuid: string;
@@ -195,6 +193,7 @@ export class PivotTableService extends BaseService {
         itemMap: ItemsMap;
         metricQuery: MetricQuery;
         pivotConfig: PivotConfig;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         exploreId: string;
         onlyRaw: boolean;
         truncated: boolean;
@@ -213,6 +212,7 @@ export class PivotTableService extends BaseService {
             customLabels,
             onlyRaw,
             maxColumnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+            pivotDetails,
         });
 
         const csvContent = await new Promise<string>((resolve, reject) => {

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -868,88 +868,6 @@ export const pivotQueryResults = ({
     return combinedRetrofit(pivotData, getField, getFieldLabel);
 };
 
-export const pivotResultsAsCsv = ({
-    pivotConfig,
-    rows,
-    itemMap,
-    metricQuery,
-    customLabels,
-    onlyRaw,
-    maxColumnLimit,
-    undefinedCharacter = '',
-}: {
-    pivotConfig: PivotConfig;
-    rows: ResultRow[];
-    itemMap: ItemsMap;
-    metricQuery: MetricQuery;
-    customLabels: Record<string, string> | undefined;
-    onlyRaw: boolean;
-    maxColumnLimit: number;
-    undefinedCharacter?: string;
-}) => {
-    const getFieldLabel = (fieldId: string) => {
-        const customLabel = customLabels?.[fieldId];
-        if (customLabel !== undefined) return customLabel;
-        const field = itemMap[fieldId];
-        return (field && isField(field) && field?.label) || fieldId;
-    };
-    const pivotedResults = pivotQueryResults({
-        pivotConfig,
-        metricQuery,
-        rows,
-        options: {
-            maxColumns: maxColumnLimit,
-        },
-        getField: (fieldId: string) => itemMap && itemMap[fieldId], // itemsMap && itemsMap[fieldId],
-        getFieldLabel,
-    });
-    const formatField = onlyRaw ? 'raw' : 'formatted';
-    const headers = pivotedResults.headerValues.reduce<string[][]>(
-        (acc, row, i) => {
-            const values = row.map((header) =>
-                'value' in header
-                    ? (header.value[formatField] as string)
-                    : getFieldLabel(header.fieldId),
-            );
-            const fields = pivotedResults.titleFields[i];
-            const fieldLabels = fields.map((field) =>
-                field ? getFieldLabel(field.fieldId) : undefinedCharacter,
-            );
-
-            // Row totals
-            const rowTotalLabels =
-                pivotedResults.rowTotalFields?.[i]?.map((totalField) =>
-                    totalField?.fieldId
-                        ? `Total ${getFieldLabel(totalField.fieldId)}`
-                        : 'Total',
-                ) || [];
-
-            acc[i] = [...fieldLabels, ...values, ...rowTotalLabels];
-            return acc;
-        },
-        [[]],
-    );
-    const fieldIds = Object.values(
-        pivotedResults.retrofitData.pivotColumnInfo,
-    ).map((field) => field.fieldId);
-
-    const hasIndex = pivotedResults.indexValues.length > 0;
-    const pivotedRows: string[][] =
-        pivotedResults.retrofitData.allCombinedData.map((row) => {
-            // Fields that return `null` don't appear in the pivot table
-            // If there are no index fields, we need to add an empty string to the beginning of the row
-            const noIndexPrefix = hasIndex ? [] : [''];
-            const formattedRows = fieldIds.map(
-                (fieldId) =>
-                    (row[fieldId]?.value?.[formatField] as string) ||
-                    undefinedCharacter,
-            );
-            return [...noIndexPrefix, ...formattedRows];
-        });
-
-    return [...headers, ...pivotedRows];
-};
-
 /**
  * Converts SQL-pivoted results to PivotData format
  * This handles results that are already pivoted at the SQL level (e.g., payments_total_revenue_any_bank_transfer)
@@ -1532,4 +1450,97 @@ export const convertSqlPivotedRowsToPivotData = ({
     };
 
     return combinedRetrofit(pivotData, getField, getFieldLabel);
+};
+
+export const pivotResultsAsCsv = ({
+    pivotConfig,
+    rows,
+    itemMap,
+    metricQuery,
+    customLabels,
+    onlyRaw,
+    maxColumnLimit,
+    undefinedCharacter = '',
+    pivotDetails,
+}: {
+    pivotConfig: PivotConfig;
+    pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+    rows: ResultRow[];
+    itemMap: ItemsMap;
+    metricQuery: MetricQuery;
+    customLabels: Record<string, string> | undefined;
+    onlyRaw: boolean;
+    maxColumnLimit: number;
+    undefinedCharacter?: string;
+}) => {
+    const getFieldLabel = (fieldId: string) => {
+        const customLabel = customLabels?.[fieldId];
+        if (customLabel !== undefined) return customLabel;
+        const field = itemMap[fieldId];
+        return (field && isField(field) && field?.label) || fieldId;
+    };
+    const pivotedResults = pivotDetails
+        ? convertSqlPivotedRowsToPivotData({
+              getField: (fieldId: string) => itemMap && itemMap[fieldId],
+              getFieldLabel,
+              rows,
+              pivotDetails,
+              pivotConfig,
+              groupedSubtotals: undefined, // TODO: is this something that we have?
+          })
+        : pivotQueryResults({
+              pivotConfig,
+              metricQuery,
+              rows,
+              options: {
+                  maxColumns: maxColumnLimit,
+              },
+              getField: (fieldId: string) => itemMap && itemMap[fieldId], // itemsMap && itemsMap[fieldId],
+              getFieldLabel,
+          });
+    const formatField = onlyRaw ? 'raw' : 'formatted';
+    const headers = pivotedResults.headerValues.reduce<string[][]>(
+        (acc, row, i) => {
+            const values = row.map((header) =>
+                'value' in header
+                    ? (header.value[formatField] as string)
+                    : getFieldLabel(header.fieldId),
+            );
+            const fields = pivotedResults.titleFields[i];
+            const fieldLabels = fields.map((field) =>
+                field ? getFieldLabel(field.fieldId) : undefinedCharacter,
+            );
+
+            // Row totals
+            const rowTotalLabels =
+                pivotedResults.rowTotalFields?.[i]?.map((totalField) =>
+                    totalField?.fieldId
+                        ? `Total ${getFieldLabel(totalField.fieldId)}`
+                        : 'Total',
+                ) || [];
+
+            acc[i] = [...fieldLabels, ...values, ...rowTotalLabels];
+            return acc;
+        },
+        [[]],
+    );
+    const fieldIds = Object.values(
+        pivotedResults.retrofitData.pivotColumnInfo,
+    ).map((field) => field.fieldId);
+
+    const hasIndex = pivotedResults.indexValues.length > 0;
+    const pivotedRows: string[][] =
+        pivotedResults.retrofitData.allCombinedData.map((row) => {
+            // Fields that return `null` don't appear in the pivot table
+            // If there are no index fields, we need to add an empty string to the beginning of the row
+            const noIndexPrefix = hasIndex ? [] : [''];
+            const formattedRows = fieldIds.map(
+                (fieldId) =>
+                    (row[fieldId]?.value?.[formatField] as string) ||
+                    undefinedCharacter,
+            );
+            return [...noIndexPrefix, ...formattedRows];
+        });
+
+    return [...headers, ...pivotedRows];
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#16866](https://github.com/lightdash/lightdash/issues/16866)

### Description:
Refactored pivot table functionality to support SQL-pivoted results in exports. Added a utility method `getPivotDetailsFromQueryHistory` to extract pivot details from query history, and updated the `pivotResultsAsCsv` function to handle both traditional and backend pivoted data. This ensures consistent pivot table behavior across all export formats (CSV, Excel) when using the new query execution path.

The changes maintain backward compatibility by adding `pivotDetails: null` comments in places where the old query execution path is still being used, marking them for future updates.

**Before**
<img width="769" height="618" alt="image" src="https://github.com/user-attachments/assets/45316e41-bbab-4079-9960-7b068dc7484b" />

**Steps to Reproduce the Bug or Issue**
1. Enable `USE_SQL_PIVOT_RESULTS` 
2. Go to explore
3. Add 2 dimensions and 1 metric
4. Set the visualization to be table
5. Move one of the dimensions to columns
6. Run query
7. Click on viz csv export

