### PR TITLE
fix: change validation columns from string to text

### DIFF
--- a/packages/backend/src/database/migrations/20250916155604_change_validation_columns_to_text.ts
+++ b/packages/backend/src/database/migrations/20250916155604_change_validation_columns_to_text.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('validations', (table) => {
+        table.text('chart_name').nullable().alter();
+        table.text('field_name').nullable().alter();
+        table.text('model_name').nullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('validations', (table) => {
+        table.string('chart_name').nullable().alter();
+        table.string('field_name').nullable().alter();
+        table.string('model_name').nullable().alter();
+    });
+}


### PR DESCRIPTION
### Description:
Changes the data type of `chart_name`, `field_name`, and `model_name` columns in the `validations` table from `string` to `text`. This allows these columns to store longer values without truncation.