### PR TITLE
chore: update Hono dependency to v4.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "overrides": {
         "@mantine/core@8.0.0>@mantine/hooks": "$@mantine-8/hooks"
     },
+    "pnpm": {
+        "overrides": {
+            "hono": "^4.9.6"
+        }
+    },
     "dependencies": {
         "tslib": "^2.8.1"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@types/react': 19.0.2
   '@types/react-dom': 19.0.2
   typescript: 5.5.4
+  hono: ^4.9.6
 
 pnpmfileChecksum: p23nxduvlqdbqsdejaxzk56may
 
@@ -8283,7 +8284,6 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
-    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -11312,7 +11312,7 @@ packages:
       '@valibot/to-json-schema': ^1.0.0-beta.3
       arktype: ^2.0.0
       effect: ^3.11.3
-      hono: ^4.6.13
+      hono: ^4.9.6
       openapi-types: ^12.1.3
       valibot: ^1.0.0-beta.9
       zod: ^3.23.8
@@ -11345,12 +11345,8 @@ packages:
       zod-openapi:
         optional: true
 
-  hono@4.8.7:
-    resolution: {integrity: sha512-gS/IyUw6MzcdnOyVRcRshn9hc/EygYc75glsnI3iESod3kGg9Mz194Y9NWJN8O/4qybIoonyIq6E4agc/t0i/g==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.9.6:
-    resolution: {integrity: sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA==}
+  hono@4.9.7:
+    resolution: {integrity: sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -20707,8 +20703,8 @@ snapshots:
       ai-v5: ai@5.0.28(zod@3.25.55)
       date-fns: 3.6.0
       dotenv: 16.6.1
-      hono: 4.9.6
-      hono-openapi: 0.4.8(hono@4.9.6)(openapi-types@12.1.3)(zod@3.25.55)
+      hono: 4.9.7
+      hono-openapi: 0.4.8(hono@4.9.7)(openapi-types@12.1.3)(zod@3.25.55)
       js-tiktoken: 1.0.21
       json-schema: 0.4.0
       json-schema-to-zod: 2.6.1
@@ -20757,7 +20753,7 @@ snapshots:
       find-workspaces: 0.3.1
       fs-extra: 11.3.0
       globby: 14.1.0
-      hono: 4.8.7
+      hono: 4.9.7
       resolve-from: 5.0.0
       rollup: 4.44.2
       rollup-plugin-esbuild: 6.2.1(esbuild@0.25.8)(rollup@4.44.2)
@@ -30711,17 +30707,15 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono-openapi@0.4.8(hono@4.9.6)(openapi-types@12.1.3)(zod@3.25.55):
+  hono-openapi@0.4.8(hono@4.9.7)(openapi-types@12.1.3)(zod@3.25.55):
     dependencies:
       json-schema-walker: 2.0.0
       openapi-types: 12.1.3
     optionalDependencies:
-      hono: 4.9.6
+      hono: 4.9.7
       zod: 3.25.55
 
-  hono@4.8.7: {}
-
-  hono@4.9.6: {}
+  hono@4.9.7: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Add a PNPM override for Hono to ensure version ^4.9.6 is used consistently across the project. This fixes the issue where multiple versions of Hono (4.8.7 and 4.9.6) were being used simultaneously, which could lead to compatibility issues. The PR updates the package.json with the override configuration and updates the lock file to use Hono 4.9.7 throughout the project.