### PR TITLE
fix: update linkifyjs to version 4.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,8 @@
         "typescript": "5.5.4"
     },
     "overrides": {
-        "@mantine/core@8.0.0>@mantine/hooks": "$@mantine-8/hooks"
-    },
-    "pnpm": {
-        "overrides": {
-            "linkifyjs": "^4.3.2"
-        }
+        "@mantine/core@8.0.0>@mantine/hooks": "$@mantine-8/hooks",
+        "linkifyjs": "^4.3.2"
     },
     "dependencies": {
         "tslib": "^2.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   '@types/react': 19.0.2
   '@types/react-dom': 19.0.2
   typescript: 5.5.4
-  linkifyjs: ^4.3.2
 
 pnpmfileChecksum: p23nxduvlqdbqsdejaxzk56may
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

● Since we're on tiptap v2 and latest is v3 (major version change), let's add an override for
  linkifyjs instead to avoid potential breaking changes:

### Description:
Upgrades linkifyjs from 4.1.3 to 4.3.2 by adding a pnpm override. This ensures all instances of linkifyjs are using the newer version, including those used by @tiptap/extension-link. 

test-frontend test-backend test-cli