### PR TITLE
fix: remove backslash agent settings

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -866,7 +866,6 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                 characters
                                             </Text>
                                         </Stack>
-                                        \
                                         <Stack gap="sm">
                                             <Title
                                                 order={6}


### PR DESCRIPTION
Removed an extra backslash character from `ProjectAiAgentEditPage`