### PR TITLE
feat: add database migration commands to documentation and change user attribute value to text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,19 @@ Generate OpenAPI specs from TSOA controllers, needs to be run when controllers c
 pnpm generate-api
 ```
 
+**Database Migrations:**
+
+```bash
+# Create new migration
+pnpm -F backend create-migration migration_name_with_underscores
+
+# Run migrations
+pnpm -F backend migrate
+
+# Rollback last migration
+pnpm -F backend rollback-last
+```
+
 ## Development Workflow
 
 1. **Package Management**: Use `pnpm` (v9.15.5+) - never use npm or yarn

--- a/packages/backend/src/database/migrations/20250917082048_change_user_attribute_value_to_text.ts
+++ b/packages/backend/src/database/migrations/20250917082048_change_user_attribute_value_to_text.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const tableName = 'organization_member_user_attributes';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.text('value').notNullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.string('value', 255).notNullable().alter();
+    });
+}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/16929

### Description:
This PR adds a database migration to change the `value` column in the `organization_member_user_attributes` table from VARCHAR(255) to TEXT type, allowing for longer attribute values to be stored.

Additionally, I've updated the CLAUDE.md documentation to include commands for database migrations, making it easier for developers to create, run, and rollback migrations.