### PR TITLE
feat: add Redux feature flag for Explorer migration

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -7,6 +7,7 @@ import { LightdashConfig } from './parseConfig';
 
 export const lightdashConfigMock: LightdashConfig = {
     allowMultiOrgs: false,
+    useRedux: false,
     auth: {
         pat: {
             enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -683,6 +683,7 @@ export type LightdashConfig = {
         minConnections: number | undefined;
     };
     allowMultiOrgs: boolean;
+    useRedux: boolean;
     maxPayloadSize: string;
     query: {
         maxLimit: number;
@@ -1394,6 +1395,7 @@ export const parseConfig = (): LightdashConfig => {
             ),
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',
+        useRedux: process.env.USE_REDUX === 'true',
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',
         query: {
             maxLimit:

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -36,6 +36,7 @@ export class FeatureFlagModel {
                 this.getUserGroupsEnabled.bind(this),
             [FeatureFlags.UseSqlPivotResults]:
                 this.getUseSqlPivotResults.bind(this),
+            [FeatureFlags.UseRedux]: this.getUseRedux.bind(this),
         };
     }
 
@@ -104,6 +105,28 @@ export class FeatureFlagModel {
             (user
                 ? await isFeatureFlagEnabled(
                       FeatureFlags.UseSqlPivotResults,
+                      {
+                          userUuid: user.userUuid,
+                          organizationUuid: user.organizationUuid,
+                      },
+                      {
+                          throwOnTimeout: false,
+                          timeoutMilliseconds: 500,
+                      },
+                  )
+                : false);
+        return {
+            id: featureFlagId,
+            enabled,
+        };
+    }
+
+    private async getUseRedux({ user, featureFlagId }: FeatureFlagLogicArgs) {
+        const enabled =
+            this.lightdashConfig.useRedux ||
+            (user
+                ? await isFeatureFlagEnabled(
+                      FeatureFlags.UseRedux,
                       {
                           userUuid: user.userUuid,
                           organizationUuid: user.organizationUuid,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -62,6 +62,11 @@ export enum FeatureFlags {
      * Enable the unused content dashboard showing least viewed charts and dashboards
      */
     UnusedContentDashboard = 'unused-content-dashboard',
+
+    /**
+     * Enable Redux state management for Explorer (gradual migration from Context API)
+     */
+    UseRedux = 'use-redux',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16956

### Description:
Added a new feature flag `UseRedux` to enable Redux state management for Explorer as part of a gradual migration from Context API. The flag can be enabled via the `USE_REDUX` environment variable or through the feature flag system.
