### PR TITLE
feat: add thread cloning functionality to AI agents

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -237,6 +237,7 @@ import {
     WarehouseAvailableTablesTableName,
 } from '../database/entities/warehouseAvailableTables';
 import {
+    AiAgentToolCallTable,
     AiAgentToolCallTableName,
     AiAgentToolResultTable,
     AiAgentToolResultTableName,

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -19,6 +19,7 @@ import {
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadSummaryListResponse,
+    ApiCloneWebAppThreadResponse,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
     ApiCreateEvaluationRequest,
@@ -386,6 +387,34 @@ export class AiAgentController extends BaseController {
             results: {
                 title,
             },
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/clone/{promptUuid}')
+    @OperationId('cloneAgentThread')
+    async cloneAgentThread(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Path() promptUuid: string,
+        @Query() createdFrom?: 'web_app' | 'evals',
+    ): Promise<ApiCloneWebAppThreadResponse> {
+        this.setStatus(200);
+
+        const clonedThread = await this.getAiAgentService().cloneWebAppThread(
+            req.user!,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            { createdFrom },
+        );
+
+        return {
+            status: 'ok',
+            results: clonedThread,
         };
     }
 

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -8,7 +8,7 @@ export type DbAiThread = {
     created_at: Date;
     organization_uuid: string;
     project_uuid: string;
-    created_from: string; // slack, web, etc
+    created_from: 'slack' | 'web_app' | 'evals'; // slack, web_app, evals etc
     title: string | null;
     title_generated_at: Date | null;
 };

--- a/packages/backend/src/ee/database/entities/aiArtifacts.ts
+++ b/packages/backend/src/ee/database/entities/aiArtifacts.ts
@@ -32,16 +32,18 @@ export type DbAiArtifactVersion = {
 
 export type AiArtifactVersionsTable = Knex.CompositeTableType<
     DbAiArtifactVersion,
-    Pick<
-        DbAiArtifactVersion,
-        | 'ai_artifact_uuid'
-        | 'ai_prompt_uuid'
-        | 'version_number'
-        | 'title'
-        | 'description'
-        | 'saved_query_uuid'
-        | 'saved_dashboard_uuid'
-        | 'chart_config'
-        | 'dashboard_config'
+    Partial<
+        Pick<
+            DbAiArtifactVersion,
+            | 'ai_artifact_uuid'
+            | 'ai_prompt_uuid'
+            | 'version_number'
+            | 'title'
+            | 'description'
+            | 'saved_query_uuid'
+            | 'saved_dashboard_uuid'
+            | 'chart_config'
+            | 'dashboard_config'
+        >
     >
 >;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5716,6 +5716,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCloneWebAppThreadResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiAgentThreadSummary_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentExploreAccessSummary: {
         dataType: 'refAlias',
         type: {
@@ -6183,35 +6188,50 @@ const models: TsoaRoute.Models = {
     AiAgentEvaluationPrompt: {
         dataType: 'refAlias',
         type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                createdAt: { dataType: 'datetime', required: true },
-                aiThreadUuid: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        createdAt: { dataType: 'datetime', required: true },
+                        evalPromptUuid: { dataType: 'string', required: true },
+                    },
+                },
+                {
                     dataType: 'union',
                     subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                prompt: { dataType: 'string', required: true },
+                                type: {
+                                    dataType: 'enum',
+                                    enums: ['string'],
+                                    required: true,
+                                },
+                            },
+                        },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                threadUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                promptUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                type: {
+                                    dataType: 'enum',
+                                    enums: ['thread'],
+                                    required: true,
+                                },
+                            },
+                        },
                     ],
-                    required: true,
                 },
-                aiPromptUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                prompt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                promptUuid: { dataType: 'string', required: true },
-            },
+            ],
             validators: {},
         },
     },
@@ -22626,6 +22646,93 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'generateAgentThreadTitle',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_cloneAgentThread: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        promptUuid: {
+            in: 'path',
+            name: 'promptUuid',
+            required: true,
+            dataType: 'string',
+        },
+        createdFrom: {
+            in: 'query',
+            name: 'createdFrom',
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['web_app'] },
+                { dataType: 'enum', enums: ['evals'] },
+            ],
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/clone/:promptUuid',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.cloneAgentThread,
+        ),
+
+        async function AiAgentController_cloneAgentThread(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_cloneAgentThread,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'cloneAgentThread',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6397,6 +6397,9 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ApiCloneWebAppThreadResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentThreadSummary_"
+            },
             "AiAgentExploreAccessSummary": {
                 "properties": {
                     "metrics": {
@@ -6835,35 +6838,60 @@
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentEvaluationSummary-Array_"
             },
             "AiAgentEvaluationPrompt": {
-                "properties": {
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
+                "allOf": [
+                    {
+                        "properties": {
+                            "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "evalPromptUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["createdAt", "evalPromptUuid"],
+                        "type": "object"
                     },
-                    "aiThreadUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "aiPromptUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "prompt": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "promptUuid": {
-                        "type": "string"
+                    {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "prompt": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": ["string"],
+                                        "nullable": false
+                                    }
+                                },
+                                "required": ["prompt", "type"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "threadUuid": {
+                                        "type": "string"
+                                    },
+                                    "promptUuid": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": ["thread"],
+                                        "nullable": false
+                                    }
+                                },
+                                "required": [
+                                    "threadUuid",
+                                    "promptUuid",
+                                    "type"
+                                ],
+                                "type": "object"
+                            }
+                        ]
                     }
-                },
-                "required": [
-                    "createdAt",
-                    "aiThreadUuid",
-                    "aiPromptUuid",
-                    "prompt",
-                    "promptUuid"
-                ],
-                "type": "object"
+                ]
             },
             "AiAgentEvaluation": {
                 "properties": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -355,12 +355,19 @@ export type ApiAiAgentArtifactResponseTSOACompat =
     ApiSuccess<AiArtifactTSOACompat>;
 
 export type AiAgentEvaluationPrompt = {
-    promptUuid: string;
-    prompt: string | null;
-    aiPromptUuid: string | null;
-    aiThreadUuid: string | null;
+    evalPromptUuid: string;
     createdAt: Date;
-};
+} & (
+    | {
+          type: 'string';
+          prompt: string;
+      }
+    | {
+          type: 'thread';
+          promptUuid: string;
+          threadUuid: string;
+      }
+);
 
 export type AiAgentEvaluation = {
     evalUuid: string;
@@ -447,3 +454,5 @@ export type ApiCreateEvaluationResponse = ApiSuccess<
     Pick<AiAgentEvaluation, 'evalUuid'>
 >;
 export type ApiUpdateEvaluationResponse = ApiSuccess<AiAgentEvaluation>;
+
+export type ApiCloneWebAppThreadResponse = ApiSuccess<AiAgentThreadSummary>;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -97,3 +97,10 @@ export type AiAgentEvalRunJobPayload = TraceTaskBase & {
     agentUuid: string;
     threadUuid: string;
 };
+
+export type CloneWebAppThread = {
+    sourceThreadUuid: string;
+    sourcePromptUuid: string;
+    targetUserUuid: string;
+    createdFrom?: 'web_app' | 'evals';
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR adds the ability to clone AI agent threads.

The implementation includes:

- New model methods to handle thread cloning, including:
  - `cloneWebAppThread` - Clones a thread and its prompts
  - `cloneThreadArtifacts` - Clones artifacts associated with a thread
  - `cloneWebAppPrompt` - Clones individual prompts with their responses
- A transaction helper method `getTrx` to ensure database operations are atomic
