### PR TITLE
fix: limit number of ai agent slack channels on dropdown

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -1085,11 +1085,12 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                                             },
                                                         }}
                                                         label={'Channels'}
+                                                        limit={30}
                                                         placeholder={
                                                             isLoadingSlackChannels ||
                                                             isRefreshing
                                                                 ? 'Loading channels, this might take a while if you have a lot of channels in your workspace'
-                                                                : 'Pick a channel'
+                                                                : 'Search channel(s)'
                                                         }
                                                         data={
                                                             slackChannelOptions


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16729

### Description:

Improve typing of instructions (and any form changes tbf) by limiting the number of elements the Slack Multiselect renders at a time. 

To test the before and after: toggle the `limit` prop