### PR TITLE
style: thin hr markdown node

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -5,6 +5,7 @@ import {
     Anchor,
     Button,
     CopyButton,
+    Divider,
     Group,
     Loader,
     Paper,
@@ -154,6 +155,7 @@ const AssistantBubbleContent: FC<{
                     style={{ padding: `0.5rem 0`, fontSize: '0.875rem' }}
                     rehypePlugins={[rehypeAiAgentContentLinks]}
                     components={{
+                        hr: () => <Divider color="gray.4" my="sm" />,
                         a: ({ node, children, ...props }) => {
                             const contentType =
                                 'data-content-type' in props &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:

Added support for horizontal rule (`<hr>`) elements in AI agent chat responses by rendering them as `<Divider>` components with consistent styling. This enhances the formatting capabilities of assistant messages in the chat interface.

before

![Screenshot 2025-09-18 at 12.32.35.png](https://app.graphite.dev/user-attachments/assets/48448ab1-33b4-4f16-af21-b14458fb6fc3.png)

after 

![Screenshot 2025-09-18 at 12.32.48.png](https://app.graphite.dev/user-attachments/assets/a1d85624-3b3f-43f6-997d-b53e222bf6d9.png)

