### PR TITLE
fix: increase AI agent step count limit from 10 to 20

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -31,7 +31,7 @@ import type {
 
 export const defaultAgentOptions = {
     toolChoice: 'auto' as const,
-    stopWhen: stepCountIs(10),
+    stopWhen: stepCountIs(20),
     maxRetries: 3,
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Increases the maximum step count for agents from 10 to 20, allowing agents to perform more actions before automatically stopping. This change gives agents more flexibility to complete complex tasks that require additional steps.

We've added a few tools lately and agent requires more steps