### PR TITLE
feat: support AI Agent evals for slack based threads

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -20,7 +20,7 @@ import {
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadSummaryListResponse,
     ApiAppendEvaluationRequest,
-    ApiCloneWebAppThreadResponse,
+    ApiCloneThreadResponse,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
     ApiCreateEvaluationRequest,
@@ -402,10 +402,10 @@ export class AiAgentController extends BaseController {
         @Path() threadUuid: string,
         @Path() promptUuid: string,
         @Query() createdFrom?: 'web_app' | 'evals',
-    ): Promise<ApiCloneWebAppThreadResponse> {
+    ): Promise<ApiCloneThreadResponse> {
         this.setStatus(200);
 
-        const clonedThread = await this.getAiAgentService().cloneWebAppThread(
+        const clonedThread = await this.getAiAgentService().cloneThread(
             req.user!,
             agentUuid,
             threadUuid,

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -3093,7 +3093,7 @@ export class AiAgentModel {
         });
     }
 
-    async cloneWebAppThread({
+    async cloneThread({
         sourceThreadUuid,
         sourcePromptUuid,
         targetUserUuid,
@@ -3125,12 +3125,6 @@ export class AiAgentModel {
                 );
             }
 
-            if (sourceThread.created_from === 'slack') {
-                throw new NotImplementedError(
-                    'Slack threads are not supported for cloning',
-                );
-            }
-
             // Create new thread using existing method
             const newThreadUuid = await this.createWebAppThread(
                 {
@@ -3138,7 +3132,8 @@ export class AiAgentModel {
                     projectUuid: sourceThread.project_uuid,
                     agentUuid: sourceThread.agent_uuid,
                     userUuid: targetUserUuid,
-                    createdFrom: createdFrom ?? sourceThread.created_from,
+                    // If `createdFrom` is not passed, default all cloned threads to web_app
+                    createdFrom: createdFrom ?? 'web_app',
                 },
                 { db: trx },
             );

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -3111,7 +3111,7 @@ export class AiAgentService {
         return exploreAccessSummary;
     }
 
-    async cloneWebAppThread(
+    async cloneThread(
         user: SessionUser,
         agentUuid: string,
         threadUuid: string,
@@ -3160,7 +3160,7 @@ export class AiAgentService {
         }
 
         // Clone the thread
-        const clonedThreadUuid = await this.aiAgentModel.cloneWebAppThread({
+        const clonedThreadUuid = await this.aiAgentModel.cloneThread({
             sourceThreadUuid: threadUuid,
             sourcePromptUuid: promptUuid,
             targetUserUuid: user.userUuid,
@@ -3245,7 +3245,7 @@ export class AiAgentService {
             let thread: AiAgentThreadSummary;
 
             if (evalPrompt.type === 'thread') {
-                thread = await this.cloneWebAppThread(
+                thread = await this.cloneThread(
                     user,
                     agentUuid,
                     evalPrompt.threadUuid,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5716,7 +5716,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiCloneWebAppThreadResponse: {
+    ApiCloneThreadResponse: {
         dataType: 'refAlias',
         type: { ref: 'ApiSuccess_AiAgentThreadSummary_', validators: {} },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6397,7 +6397,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "ApiCloneWebAppThreadResponse": {
+            "ApiCloneThreadResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentThreadSummary_"
             },
             "AiAgentExploreAccessSummary": {
@@ -19930,7 +19930,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2013.3",
+        "version": "0.2016.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -459,4 +459,4 @@ export type ApiCreateEvaluationResponse = ApiSuccess<
 >;
 export type ApiUpdateEvaluationResponse = ApiSuccess<AiAgentEvaluation>;
 
-export type ApiCloneWebAppThreadResponse = ApiSuccess<AiAgentThreadSummary>;
+export type ApiCloneThreadResponse = ApiSuccess<AiAgentThreadSummary>;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -98,7 +98,7 @@ export type AiAgentEvalRunJobPayload = TraceTaskBase & {
     threadUuid: string;
 };
 
-export type CloneWebAppThread = {
+export type CloneThread = {
     sourceThreadUuid: string;
     sourcePromptUuid: string;
     targetUserUuid: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Renamed `cloneWebAppThread` to `cloneThread` to better reflect its functionality, as it now supports cloning threads from various sources, not just web apps. This includes renaming the method in the controller, service, and model, as well as updating related type definitions.
