### PR TITLE
chore: add Prometheus metrics for AI agent response times

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -210,24 +210,26 @@ export default class App {
             database: this.database,
             utils: this.utils,
         });
+        this.prometheusMetrics = new PrometheusMetrics(
+            this.lightdashConfig.prometheus,
+        );
         this.clients = new ClientRepository({
             clientProviders: args.clientProviders,
             context: new OperationContext({
                 operationId: 'App#ctor',
                 lightdashAnalytics: this.analytics,
                 lightdashConfig: this.lightdashConfig,
+                prometheusMetrics: this.prometheusMetrics,
             }),
             models: this.models,
         });
-        this.prometheusMetrics = new PrometheusMetrics(
-            this.lightdashConfig.prometheus,
-        );
         this.serviceRepository = new ServiceRepository({
             serviceProviders: args.serviceProviders,
             context: new OperationContext({
                 operationId: 'App#ctor',
                 lightdashAnalytics: this.analytics,
                 lightdashConfig: this.lightdashConfig,
+                prometheusMetrics: this.prometheusMetrics,
             }),
             clients: this.clients,
             models: this.models,

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -128,24 +128,26 @@ export default class SchedulerApp {
             utils,
         });
 
+        this.prometheusMetrics = new PrometheusMetrics(
+            this.lightdashConfig.prometheus,
+        );
         this.clients = new ClientRepository({
             clientProviders: args.clientProviders,
             context: new OperationContext({
                 operationId: 'SchedulerApp#ctor',
                 lightdashAnalytics: this.analytics,
                 lightdashConfig: this.lightdashConfig,
+                prometheusMetrics: this.prometheusMetrics,
             }),
             models: this.models,
         });
-        this.prometheusMetrics = new PrometheusMetrics(
-            this.lightdashConfig.prometheus,
-        );
         this.serviceRepository = new ServiceRepository({
             serviceProviders: args.serviceProviders,
             context: new OperationContext({
                 lightdashAnalytics: this.analytics,
                 lightdashConfig: this.lightdashConfig,
                 operationId: 'SchedulerApp#ctor',
+                prometheusMetrics: this.prometheusMetrics,
             }),
             clients: this.clients,
             models: this.models,

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -108,6 +108,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     openIdIdentityModel: models.getOpenIdIdentityModel(),
                     spaceService: repository.getSpaceService(),
+                    prometheusMetrics: context.prometheusMetrics,
                 }),
             aiAgentAdminService: ({ models, context }) =>
                 new AiAgentAdminService({

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -81,6 +81,7 @@ import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { UserAttributesModel } from '../../models/UserAttributesModel';
 import { UserModel } from '../../models/UserModel';
+import PrometheusMetrics from '../../prometheus';
 import { AsyncQueryService } from '../../services/AsyncQueryService/AsyncQueryService';
 import { CatalogService } from '../../services/CatalogService/CatalogService';
 import { FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
@@ -139,6 +140,7 @@ type AiAgentServiceDependencies = {
     userAttributesModel: UserAttributesModel;
     userModel: UserModel;
     spaceService: SpaceService;
+    prometheusMetrics: PrometheusMetrics;
 };
 
 export class AiAgentService {
@@ -174,6 +176,8 @@ export class AiAgentService {
 
     private readonly spaceService: SpaceService;
 
+    private readonly prometheusMetrics: PrometheusMetrics;
+
     constructor(dependencies: AiAgentServiceDependencies) {
         this.aiAgentModel = dependencies.aiAgentModel;
         this.analytics = dependencies.analytics;
@@ -191,6 +195,7 @@ export class AiAgentService {
         this.userAttributesModel = dependencies.userAttributesModel;
         this.userModel = dependencies.userModel;
         this.spaceService = dependencies.spaceService;
+        this.prometheusMetrics = dependencies.prometheusMetrics;
     }
 
     private async getIsCopilotEnabled(
@@ -2083,6 +2088,8 @@ export class AiAgentService {
                     agentUuid: data.agentUuid,
                     instruction: data.instruction,
                 }),
+
+            prometheusMetrics: this.prometheusMetrics,
         };
 
         return stream

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -318,12 +318,13 @@ export const generateAgentResponse = async ({
     const messages = await getAgentMessages(args, dependencies);
     const tools = getAgentTools(args, dependencies);
 
+    const startTime = Date.now();
+    const modelName = args.model.modelId;
+
     try {
         logger(
             'Generate Agent Response',
-            `Calling generateText with model: ${
-                typeof args.model === 'string' ? args.model : args.model.modelId
-            }`,
+            `Calling generateText with model: ${modelName}`,
         );
         const result = await generateText({
             ...defaultAgentOptions,
@@ -424,8 +425,35 @@ export const generateAgentResponse = async ({
             'Generate Agent Response',
             `Generation complete. Result text length: ${result.text.length}`,
         );
+
+        // Record metrics
+        const duration = Date.now() - startTime;
+        if (dependencies.prometheusMetrics.aiAgentResponseDurationHistogram) {
+            dependencies.prometheusMetrics.aiAgentResponseDurationHistogram.observe(
+                {
+                    agent_name: args.agentSettings.name,
+                    model: modelName,
+                    response_type: 'generate',
+                },
+                duration,
+            );
+        }
+
         return result.text;
     } catch (error) {
+        // Record metrics even on error
+        const duration = Date.now() - startTime;
+        if (dependencies.prometheusMetrics.aiAgentResponseDurationHistogram) {
+            dependencies.prometheusMetrics.aiAgentResponseDurationHistogram.observe(
+                {
+                    agent_name: args.agentSettings.name,
+                    model: modelName,
+                    response_type: 'generate',
+                },
+                duration,
+            );
+        }
+
         Logger.error(
             `[AiAgent][Generate Agent Response] Error during agent response generation: ${
                 error instanceof Error ? error.message : 'Unknown error'
@@ -455,12 +483,14 @@ export const streamAgentResponse = async ({
     const messages = await getAgentMessages(args, dependencies);
     const tools = getAgentTools(args, dependencies);
 
+    const startTime = Date.now();
+    const modelName =
+        typeof args.model === 'string' ? args.model : args.model.modelId;
+
     try {
         logger(
             'Stream Agent Response',
-            `Calling streamText with model: ${
-                typeof args.model === 'string' ? args.model : args.model.modelId
-            }`,
+            `Calling streamText with model: ${modelName}`,
         );
         const result = streamText({
             ...defaultAgentOptions,
@@ -582,6 +612,22 @@ export const streamAgentResponse = async ({
                     'On Finish',
                     `Total tokens used: ${usage.totalTokens}, steps: ${steps.length}`,
                 );
+
+                // Record metrics
+                const duration = Date.now() - startTime;
+                if (
+                    dependencies.prometheusMetrics
+                        .aiAgentResponseDurationHistogram
+                ) {
+                    dependencies.prometheusMetrics.aiAgentResponseDurationHistogram.observe(
+                        {
+                            agent_name: args.agentSettings.name,
+                            model: modelName,
+                            response_type: 'stream',
+                        },
+                        duration,
+                    );
+                }
             },
             experimental_transform: smoothStream({
                 delayInMs: 20,
@@ -594,6 +640,22 @@ export const streamAgentResponse = async ({
                     }`,
                 );
                 Sentry.captureException(error);
+
+                // Record metrics even on error
+                const duration = Date.now() - startTime;
+                if (
+                    dependencies.prometheusMetrics
+                        .aiAgentResponseDurationHistogram
+                ) {
+                    dependencies.prometheusMetrics.aiAgentResponseDurationHistogram.observe(
+                        {
+                            agent_name: args.agentSettings.name,
+                            model: modelName,
+                            response_type: 'stream',
+                        },
+                        duration,
+                    );
+                }
             },
             experimental_telemetry: getAgentTelemetryConfig(
                 'streamAgentResponse',

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -1,5 +1,6 @@
 import { AiAgent } from '@lightdash/common';
 import { ModelMessage } from 'ai';
+import PrometheusMetrics from '../../../../prometheus';
 import { AiModel } from '../models/types';
 import {
     AppendInstructionFn,
@@ -61,6 +62,7 @@ export type AiAgentDependencies = {
     trackEvent: TrackEventFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     appendInstruction: AppendInstructionFn;
+    prometheusMetrics: PrometheusMetrics;
 };
 
 export type AiGenerateAgentResponseArgs = AiAgentArgs;

--- a/packages/backend/src/prometheus.ts
+++ b/packages/backend/src/prometheus.ts
@@ -16,6 +16,10 @@ export default class PrometheusMetrics {
     // Add query status metrics
     public queryStatusCounter: prometheus.Counter<string> | null = null;
 
+    // AI Agent response time metrics
+    public aiAgentResponseDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
     constructor(config: LightdashConfig['prometheus']) {
         this.config = config;
     }
@@ -46,6 +50,31 @@ export default class PrometheusMetrics {
                     labelNames: ['status', 'warehouse_type', 'context'],
                     ...rest,
                 });
+
+                // Initialize AI Agent response time histogram
+                this.aiAgentResponseDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'ai_agent_response_duration_ms',
+                        help: 'Histogram of AI Agent response time in milliseconds',
+                        labelNames: ['agent_name', 'model', 'response_type'],
+                        buckets: [
+                            100, // 100ms
+                            250, // 250ms
+                            500, // 500ms
+                            1000, // 1 second
+                            2500, // 2.5 seconds
+                            5000, // 5 seconds
+                            10000, // 10 seconds
+                            25000, // 25 seconds
+                            50000, // 50 seconds
+                            60000, // 1 minute
+                            120000, // 2 minutes
+                            180000, // 3 minutes
+                            240000, // 4 minutes
+                            300000, // 5 minutes
+                        ],
+                        ...rest,
+                    });
 
                 const app = express();
                 this.server = http.createServer(app);

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -157,19 +157,24 @@ export class OperationContext extends BaseService {
 
     public readonly lightdashConfig: LightdashConfig;
 
+    public readonly prometheusMetrics: PrometheusMetrics;
+
     constructor({
         operationId,
         lightdashAnalytics,
         lightdashConfig,
+        prometheusMetrics,
     }: {
         operationId: string;
         lightdashAnalytics: LightdashAnalytics;
         lightdashConfig: LightdashConfig;
+        prometheusMetrics: PrometheusMetrics;
     }) {
         super();
         this.operationId = operationId;
         this.lightdashAnalytics = lightdashAnalytics;
         this.lightdashConfig = lightdashConfig;
+        this.prometheusMetrics = prometheusMetrics;
     }
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Add Prometheus metrics for AI Agent response times to track performance. The implementation includes:

- Created a new histogram metric `ai_agent_response_duration_ms` to measure AI agent response times
- Added metrics collection for both streaming and non-streaming agent responses
- Tracked important labels including agent name, model, and response type
- Ensured metrics are recorded even when errors occur
- Fixed initialization order to make PrometheusMetrics available to all services that need it
