### PR TITLE
feat: add dbt version compatibility for schema editor

### DIFF
--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
@@ -4,6 +4,7 @@ import {
     CustomSqlDimension,
     DimensionType,
     MetricType,
+    SupportedDbtVersions,
 } from '@lightdash/common';
 import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
 
@@ -11,6 +12,12 @@ export const PROJECT_MODEL = {
     getExploreFromCache: jest.fn(() => ({ ymlPath: 'path/to/schema.yml' })),
     getWarehouseCredentialsForProject: jest.fn(() => ({})),
     getWarehouseClientFromCredentials: jest.fn(() => warehouseClientMock),
+    get: jest.fn(() =>
+        Promise.resolve({
+            projectUuid: 'projectUuid',
+            dbtVersion: SupportedDbtVersions.V1_9,
+        }),
+    ),
 };
 export const SAVED_CHART_MODEL = {};
 export const SPACE_MODEL = {};

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -87,6 +87,13 @@ export const SCHEMA_JSON = {
     ],
 };
 
+export const SIMPLE_SCHEMA = `version: 2
+models:
+  - name: test_table
+    columns:
+      - name: test_column
+        description: A test column`;
+
 // invalid schema: models require a `name` field
 export const INVALID_SCHEMA_YML = `
 version: 2


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/16790

<img width="1138" height="618" alt="Screenshot from 2025-09-22 10-49-40" src="https://github.com/user-attachments/assets/a6f9f757-d301-454d-9499-3d3a47455646" />

<img width="1138" height="618" alt="Screenshot from 2025-09-22 11-16-35" src="https://github.com/user-attachments/assets/7d9969c3-5a4a-4480-b92d-d1ac15479b7a" />

### Description:
This PR adds support for dbt v1.10+ compatibility in the schema editor. In dbt v1.10+, custom metrics and dimensions need to be placed under `config.meta` instead of directly under `meta`. 

The changes include:
- Added a method to detect if the dbt version is 1.10 or higher
- Modified the schema editor to place custom metrics and dimensions in the correct location based on dbt version
- Added comprehensive tests to verify the correct behavior for different dbt versions
- Updated the GitIntegrationService to pass the project's dbt version to the schema editor

These changes ensure that Lightdash can properly generate YAML files that are compatible with both older dbt versions and the newer v1.10+ format.