### PR TITLE
chore: dont run profiling unless enabled

### DIFF
--- a/packages/e2e/cypress/e2e/perf/explore.perf.cy.ts
+++ b/packages/e2e/cypress/e2e/perf/explore.perf.cy.ts
@@ -1,4 +1,4 @@
-import { SEED_PROJECT } from '@lightdash/common';
+import { AnyType, SEED_PROJECT } from '@lightdash/common';
 
 const RUN_ID = Cypress.env('RUN_ID') || `${Date.now()}`;
 
@@ -45,6 +45,15 @@ describe('Explore perf', () => {
         let flowId = '';
 
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
+
+        // Enable profiling capture and clear any existing data after navigation
+        cy.window().then((w) => {
+            // eslint-disable-next-line no-underscore-dangle, no-param-reassign
+            (w as AnyType).__captureProfiling = true;
+            // eslint-disable-next-line no-underscore-dangle, no-param-reassign
+            (w as AnyType).__profiling = [];
+        });
+
         cy.findByTestId('page-spinner').should('not.exist');
 
         cy.findByText('Generated a').click();

--- a/packages/frontend/src/perf/ProfilerWrapper.tsx
+++ b/packages/frontend/src/perf/ProfilerWrapper.tsx
@@ -13,6 +13,9 @@ export function ProfilerWrapper({
         startTime,
         commitTime,
     ) => {
+        // Gate capture to test window to reduce noise
+        if ((window as AnyType).__captureProfiling === false) return;
+
         (window as AnyType).__profiling = (window as AnyType).__profiling || [];
         (window as AnyType).__profiling.push({
             id: profId,


### PR DESCRIPTION
### Description:

Only collect profiling info when enabled. The overhead should be small, but we might as well not do it in prod. 

test-perf