### PR TITLE
feat: add dbt version detection for schema editor

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/lightdash_exposures.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/lightdash_exposures.yml
@@ -12,75 +12,12 @@ exposures:
       - lightdash
       - project
     depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
       - ref('plan')
-      - ref('customers')
       - ref('membership')
-      - ref('orders')
-      - ref('payments')
-  - name: ld_chart_01962af0_d72a_4428_913b_2673298d752d
-    type: analysis
-    owner:
-      name: David Attenborough
-      email: ""
-    label: How many users were created each month ?
-    description: A pivot table sample
-    url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/01962af0-d72a-4428-913b-2673298d752d/view
-    tags:
-      - lightdash
-      - chart
-    depends_on:
-      - ref('plan')
-      - ref('customers')
-      - ref('membership')
-  - name: ld_chart_c53c4c5b_10d3_4b79_a616_0f7797c8fc21
-    type: analysis
-    owner:
-      name: David Attenborough
-      email: ""
-    label: What's our total revenue to date?
-    description: A single number showing the sum of all historical revenue
-    url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/c53c4c5b-10d3-4b79-a616-0f7797c8fc21/view
-    tags:
-      - lightdash
-      - chart
-    depends_on:
-      - ref('orders')
-      - ref('payments')
-      - ref('customers')
-  - name: ld_chart_be15e7e2_2ad4_49c7_b1fe_40d334e17373
-    type: analysis
-    owner:
-      name: David Attenborough
-      email: ""
-    label: How many orders did we get in June?
-    description: A single value of the total number of orders received in June
-    url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/be15e7e2-2ad4-49c7-b1fe-40d334e17373/view
-    tags:
-      - lightdash
-      - chart
-    depends_on:
-      - ref('orders')
-      - ref('customers')
-  - name: ld_chart_d801d67d_2852_4a94_a6cc_ac32e5a089bf
-    type: analysis
-    owner:
-      name: David Attenborough
-      email: ""
-    label: How much revenue do we have per payment method each month?
-    description: A pivot table sample
-    url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/d801d67d-2852-4a94-a6cc-ac32e5a089bf/view
-    tags:
-      - lightdash
-      - chart
-    depends_on:
-      - ref('orders')
-      - ref('payments')
-      - ref('customers')
-  - name: ld_chart_3dc53928_60a1_450f_a351_9f443b87d988
+  - name: ld_chart_2d9ae94c_faf6_49c0_9048_3f1f3ed18434
     type: analysis
     owner:
       name: David Attenborough
@@ -90,7 +27,7 @@ exposures:
       Total revenue received via coupons, gift cards, bank transfers, and credit
       cards
     url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/3dc53928-60a1-450f-a351-9f443b87d988/view
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/2d9ae94c-faf6-49c0-9048-3f1f3ed18434/view
     tags:
       - lightdash
       - chart
@@ -98,7 +35,23 @@ exposures:
       - ref('orders')
       - ref('payments')
       - ref('customers')
-  - name: ld_chart_66d48c9a_4b09_45b2_a38b_09750abc569b
+  - name: ld_chart_fdde7313_3e84_4ad8_a598_71f9b483454b
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: What's our total revenue to date?
+    description: A single number showing the sum of all historical revenue
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/fdde7313-3e84-4ad8-a598-71f9b483454b/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_chart_2a6dc141_176c_483f_a9d9_2f1df53ed8a6
     type: analysis
     owner:
       name: David Attenborough
@@ -106,14 +59,14 @@ exposures:
     label: How many orders we have over time ?
     description: Time series of orders received per day and total orders over time
     url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/66d48c9a-4b09-45b2-a38b-09750abc569b/view
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/2a6dc141-176c-483f-a9d9-2f1df53ed8a6/view
     tags:
       - lightdash
       - chart
     depends_on:
       - ref('orders')
       - ref('customers')
-  - name: ld_chart_28287c81_c608_42c3_9fa5_af4dec1e574b
+  - name: ld_chart_48700ffb_2c5f_4168_8e9a_f77d6e0a3ce6
     type: analysis
     owner:
       name: David Attenborough
@@ -121,30 +74,14 @@ exposures:
     label: What's the average spend per customer?
     description: Average order size for each customer id
     url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/28287c81-c608-42c3-9fa5-af4dec1e574b/view
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/48700ffb-2c5f-4168-8e9a-f77d6e0a3ce6/view
     tags:
       - lightdash
       - chart
     depends_on:
       - ref('orders')
       - ref('customers')
-  - name: ld_chart_2eac20e1_e391_46a9_901e_73ee5e453e78
-    type: analysis
-    owner:
-      name: David Attenborough
-      email: ""
-    label: How do payment methods vary across different amount ranges?"
-    description: Payment range by amount
-    url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/2eac20e1-e391-46a9-901e-73ee5e453e78/view
-    tags:
-      - lightdash
-      - chart
-    depends_on:
-      - ref('orders')
-      - ref('payments')
-      - ref('customers')
-  - name: ld_chart_3cc86d58_4031_4587_bfdd_bc59a11c24b5
+  - name: ld_chart_146af96e_88aa_4835_b2a5_b6b188d5d884
     type: analysis
     owner:
       name: David Attenborough
@@ -152,7 +89,7 @@ exposures:
     label: Which customers have not recently ordered an item?
     description: A table of the 20 customers that least recently placed an order with us
     url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/3cc86d58-4031-4587-bfdd-bc59a11c24b5/view
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/146af96e-88aa-4835-b2a5-b6b188d5d884/view
     tags:
       - lightdash
       - chart
@@ -160,15 +97,144 @@ exposures:
       - ref('orders')
       - ref('payments')
       - ref('customers')
-  - name: ld_dashboard_a2a53dfe_2743_4bb6_b636_2b94a470a3da
+  - name: ld_chart_de005e1f_f86f_4038_adcb_370861b1103e
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How many orders did we get on February?
+    description: A single value of the total number of orders received in February
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/de005e1f-f86f-4038-adcb-370861b1103e/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('customers')
+  - name: ld_chart_c368ce81_9b7d_42f9_80f4_1465157d0f4a
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How much revenue do we have per payment method each month?
+    description: A pivot table sample
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/c368ce81-9b7d-42f9-80f4-1465157d0f4a/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_chart_352fa422_24e6_4553_9f0b_21dfacb8c3c3
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How many users were created each month ?
+    description: A pivot table sample
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/352fa422-24e6-4553-9f0b-21dfacb8c3c3/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('plan')
+      - ref('customers')
+      - ref('membership')
+  - name: ld_chart_a0821f6b_8ccb_482b_92b3_100c2d0814c4
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: How do payment methods vary across different amount ranges?
+    description: Payment range by amount
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/a0821f6b-8ccb-482b-92b3-100c2d0814c4/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_chart_71efd168_9d7a_4e4b_a8c2_8c64f92d3778
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: "[Saved in dashboard] How much revenue do we have per payment method?"
+    description: >-
+      Total revenue received via coupons, gift cards, bank transfers, and credit
+      cards
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/71efd168-9d7a-4e4b-a8c2-8c64f92d3778/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_chart_3ee3d90b_015f_4a5a_98c9_afbd05320525
+    type: analysis
+    owner:
+      name: David Attenborough
+      email: ""
+    label: To delete
+    description: ""
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/3ee3d90b-015f-4a5a-98c9-afbd05320525/view
+    tags:
+      - lightdash
+      - chart
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_dashboard_fedbe8b3_0cdc_4945_9325_d176a7e024a5
     type: dashboard
     owner:
       name: David Attenborough
       email: ""
     label: Jaffle dashboard
-    description: n/a
+    description: ""
     url: >-
-      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/dashboards/a2a53dfe-2743-4bb6-b636-2b94a470a3da/view
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/dashboards/fedbe8b3-0cdc-4945-9325-d176a7e024a5/view
+    tags:
+      - lightdash
+      - dashboard
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_dashboard_129c8a1e_753e_4b69_b315_fda6126288c9
+    type: dashboard
+    owner:
+      name: David Attenborough
+      email: ""
+    label: Dashboard with dashboard charts
+    description: ""
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/dashboards/129c8a1e-753e-4b69-b315-fda6126288c9/view
+    tags:
+      - lightdash
+      - dashboard
+    depends_on:
+      - ref('orders')
+      - ref('payments')
+      - ref('customers')
+  - name: ld_dashboard_7edc1961_8dbf_46fd_9797_c30bf0fe45c5
+    type: dashboard
+    owner:
+      name: David Attenborough
+      email: ""
+    label: Jaffle with tabs
+    description: ""
+    url: >-
+      http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/dashboards/7edc1961-8dbf-46fd-9797-c30bf0fe45c5/view
     tags:
       - lightdash
       - dashboard

--- a/packages/cli/src/dbt/models.test.ts
+++ b/packages/cli/src/dbt/models.test.ts
@@ -1,3 +1,4 @@
+import { SupportedDbtVersions, DimensionType, DbtSchemaEditor } from '@lightdash/common';
 import { isDocBlock } from './models';
 
 describe('Models', () => {
@@ -13,6 +14,26 @@ describe('Models', () => {
             expect(isDocBlock('{{ref("user_id")}}')).toBe(false);
             expect(isDocBlock("doc('user_id')")).toBe(false);
             expect(isDocBlock('my description')).toBe(false);
+        });
+    });
+
+    describe('DbtSchemaEditor dbt version handling', () => {
+        test('should detect dbt v1.10+ correctly', () => {
+            const editorV110 = new DbtSchemaEditor('version: 2', '', SupportedDbtVersions.V1_10);
+            expect(editorV110.isDbtVersion110OrHigher()).toBe(true);
+        });
+
+        test('should detect dbt v1.9 and below correctly', () => {
+            const editorV19 = new DbtSchemaEditor('version: 2', '', SupportedDbtVersions.V1_9);
+            expect(editorV19.isDbtVersion110OrHigher()).toBe(false);
+
+            const editorV18 = new DbtSchemaEditor('version: 2', '', SupportedDbtVersions.V1_8);
+            expect(editorV18.isDbtVersion110OrHigher()).toBe(false);
+        });
+
+        test('should handle undefined version (defaults to false)', () => {
+            const editorNoVersion = new DbtSchemaEditor('version: 2', '');
+            expect(editorNoVersion.isDbtVersion110OrHigher()).toBe(false);
         });
     });
 });

--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -3,6 +3,7 @@ import {
     DbtModelNode,
     DbtSchemaEditor,
     DimensionType,
+    SupportedDbtVersions,
     ParseError,
     patchPathParts,
 } from '@lightdash/common';
@@ -143,6 +144,7 @@ type FindAndUpdateModelYamlArgs = {
     projectDir: string;
     projectName: string;
     assumeYes: boolean;
+    dbtVersion: SupportedDbtVersions;
 };
 export const findAndUpdateModelYaml = async ({
     model,
@@ -152,6 +154,7 @@ export const findAndUpdateModelYaml = async ({
     projectDir,
     projectName,
     assumeYes,
+    dbtVersion,
 }: FindAndUpdateModelYamlArgs): Promise<{
     updatedYml: DbtSchemaEditor;
     outputFilePath: string;
@@ -196,6 +199,7 @@ export const findAndUpdateModelYaml = async ({
     const match = await searchForModel({
         modelName: model.name,
         filenames,
+        dbtVersion,
     });
     if (match) {
         const { schemaEditor } = match;
@@ -292,7 +296,7 @@ export const findAndUpdateModelYaml = async ({
     }
 
     return {
-        updatedYml: new DbtSchemaEditor().addModel(generatedModel),
+        updatedYml: new DbtSchemaEditor('', '', dbtVersion).addModel(generatedModel),
         outputFilePath,
     };
 };

--- a/packages/cli/src/dbt/schema.ts
+++ b/packages/cli/src/dbt/schema.ts
@@ -1,4 +1,4 @@
-import { DbtSchemaEditor, DimensionType, ParseError } from '@lightdash/common';
+import { DbtSchemaEditor, DimensionType, SupportedDbtVersions, ParseError } from '@lightdash/common';
 import { promises as fs } from 'fs';
 
 type YamlColumnMeta = {
@@ -24,9 +24,9 @@ export type YamlSchema = {
     models?: YamlModel[];
 };
 
-const loadYamlSchema = async (path: string): Promise<DbtSchemaEditor> => {
+const loadYamlSchema = async (path: string, dbtVersion?: SupportedDbtVersions): Promise<DbtSchemaEditor> => {
     try {
-        return new DbtSchemaEditor(await fs.readFile(path, 'utf8'));
+        return new DbtSchemaEditor(await fs.readFile(path, 'utf8'), path, dbtVersion);
     } catch (e) {
         if (e instanceof ParseError) {
             // Prefix error message with file path
@@ -41,13 +41,15 @@ const loadYamlSchema = async (path: string): Promise<DbtSchemaEditor> => {
 type FindModelInYamlArgs = {
     filename: string;
     modelName: string;
+    dbtVersion?: SupportedDbtVersions;
 };
 const findModelInYaml = async ({
     filename,
     modelName,
+    dbtVersion,
 }: FindModelInYamlArgs) => {
     try {
-        const schemaEditor = await loadYamlSchema(filename);
+        const schemaEditor = await loadYamlSchema(filename, dbtVersion);
 
         if (schemaEditor.findModelByName(modelName)) {
             return schemaEditor;
@@ -64,13 +66,15 @@ const findModelInYaml = async ({
 type SearchForModelArgs = {
     modelName: string;
     filenames: string[];
+    dbtVersion?: SupportedDbtVersions;
 };
 export const searchForModel = async ({
     modelName,
     filenames,
+    dbtVersion,
 }: SearchForModelArgs) => {
     for await (const filename of filenames) {
-        const schemaEditor = await findModelInYaml({ filename, modelName });
+        const schemaEditor = await findModelInYaml({ filename, modelName, dbtVersion });
         if (schemaEditor) {
             return {
                 schemaEditor,

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -2,6 +2,8 @@ import {
     getErrorMessage,
     getModelsFromManifest,
     ParseError,
+    DbtVersionOptionLatest,
+    getLatestSupportDbtVersion,
 } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import inquirer from 'inquirer';
@@ -105,6 +107,9 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                 warehouseClient,
                 preserveColumnCase: options.preserveColumnCase,
             });
+            const resolvedDbtVersion = dbtVersion.versionOption === DbtVersionOptionLatest.LATEST
+                ? getLatestSupportDbtVersion()
+                : dbtVersion.versionOption;
             const { updatedYml, outputFilePath } = await findAndUpdateModelYaml(
                 {
                     model: compiledModel,
@@ -114,6 +119,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                     projectDir: absoluteProjectPath,
                     projectName: context.projectName,
                     assumeYes: options.assumeYes,
+                    dbtVersion: resolvedDbtVersion,
                 },
             );
             try {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1234

### Description:
This PR updates the Lightdash exposures in the jaffle-shop demo and adds dbt version handling to the CLI schema editor. 

Key changes:
- Updated chart and dashboard IDs in the demo exposures file
- Added new dashboard exposures for "Dashboard with dashboard charts" and "Jaffle with tabs"
- Added tests for dbt version detection in the schema editor
- Enhanced the `DbtSchemaEditor` to handle dbt version information (v1.10+ vs earlier versions)
- Modified the CLI generate handler to properly pass dbt version information to the schema editor