### PR TITLE
fix: add dbt version support for metadata structure

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -5,6 +5,7 @@ import {
     DimensionType,
     ParseError,
     patchPathParts,
+    SupportedDbtVersions,
 } from '@lightdash/common';
 import { WarehouseClient, WarehouseTableSchema } from '@lightdash/warehouses';
 import execa from 'execa';
@@ -68,24 +69,41 @@ type GenerateModelYamlArgs = {
     model: CompiledModel;
     table: WarehouseTableSchema;
     includeMeta: boolean;
+    dbtVersion?: SupportedDbtVersions;
 };
+
+// Check if we should use dbt 1.10+ metadata structure
+const wrapInConfig = (
+    dbtVersion: SupportedDbtVersions | undefined,
+    meta: Record<string, unknown>,
+) => {
+    const useDbt110Metadata =
+        dbtVersion &&
+        Object.values(SupportedDbtVersions).indexOf(dbtVersion) >=
+            Object.values(SupportedDbtVersions).indexOf(
+                SupportedDbtVersions.V1_10,
+            );
+    return useDbt110Metadata ? { config: { meta } } : { meta };
+};
+
 const generateModelYml = ({
     model,
     table,
     includeMeta,
+    dbtVersion,
 }: GenerateModelYamlArgs) => ({
     name: model.name,
     columns: Object.entries(table).map(([columnName, dimensionType]) => ({
         name: columnName,
         description: '',
         ...(includeMeta
-            ? {
+            ? wrapInConfig(dbtVersion, {
                   meta: {
                       dimension: {
                           type: dimensionType,
                       },
                   },
-              }
+              })
             : {}),
     })),
 });
@@ -143,6 +161,7 @@ type FindAndUpdateModelYamlArgs = {
     projectDir: string;
     projectName: string;
     assumeYes: boolean;
+    dbtVersion?: SupportedDbtVersions;
 };
 export const findAndUpdateModelYaml = async ({
     model,
@@ -152,6 +171,7 @@ export const findAndUpdateModelYaml = async ({
     projectDir,
     projectName,
     assumeYes,
+    dbtVersion,
 }: FindAndUpdateModelYamlArgs): Promise<{
     updatedYml: DbtSchemaEditor;
     outputFilePath: string;
@@ -160,6 +180,7 @@ export const findAndUpdateModelYaml = async ({
         model,
         table,
         includeMeta,
+        dbtVersion,
     });
     const filenames = [];
     const { patchPath, packageName } = model;
@@ -196,7 +217,9 @@ export const findAndUpdateModelYaml = async ({
     const match = await searchForModel({
         modelName: model.name,
         filenames,
+        dbtVersion,
     });
+
     if (match) {
         const { schemaEditor } = match;
         const docsNames = Object.values(docs).map((doc) => doc.name);
@@ -238,7 +261,7 @@ export const findAndUpdateModelYaml = async ({
                 columnName: column.name,
                 properties: {
                     description,
-                    meta,
+                    ...(meta ? wrapInConfig(dbtVersion, meta) : {}),
                 },
             });
         }
@@ -292,7 +315,9 @@ export const findAndUpdateModelYaml = async ({
     }
 
     return {
-        updatedYml: new DbtSchemaEditor().addModel(generatedModel),
+        updatedYml: new DbtSchemaEditor('', '', dbtVersion).addModel(
+            generatedModel,
+        ),
         outputFilePath,
     };
 };

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -1,5 +1,7 @@
 import {
+    DbtVersionOptionLatest,
     getErrorMessage,
+    getLatestSupportDbtVersion,
     getModelsFromManifest,
     ParseError,
 } from '@lightdash/common';
@@ -105,6 +107,15 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                 warehouseClient,
                 preserveColumnCase: options.preserveColumnCase,
             });
+            // Resolve dbt version for metadata structure
+            const resolvedDbtVersion =
+                dbtVersion.versionOption === DbtVersionOptionLatest.LATEST
+                    ? getLatestSupportDbtVersion()
+                    : dbtVersion.versionOption;
+            GlobalState.debug(
+                `Using detected dbt version ${resolvedDbtVersion} for metadata structure`,
+            );
+
             const { updatedYml, outputFilePath } = await findAndUpdateModelYaml(
                 {
                     model: compiledModel,
@@ -114,6 +125,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
                     projectDir: absoluteProjectPath,
                     projectName: context.projectName,
                     assumeYes: options.assumeYes,
+                    dbtVersion: resolvedDbtVersion,
                 },
             );
             try {

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -11,7 +11,6 @@ import {
 } from 'yaml';
 import { parseAllReferences } from '../../compiler/exploreCompiler';
 import lightdashDbtYamlSchema from '../../schemas/json/lightdash-dbt-2.0.json';
-import { type DeepPartialNullable } from '../../types/deepPartial';
 import { ParseError } from '../../types/errors';
 import {
     defaultSql,
@@ -402,7 +401,7 @@ export default class DbtSchemaEditor {
     }: {
         modelName: string;
         columnName: string;
-        properties?: DeepPartialNullable<YamlColumn>;
+        properties?: Record<string, unknown>;
     }) {
         const column = this.getColumnByName(modelName, columnName);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/15195

> lightdash generate --project-dir ./examples/full-jaffle-shop-demo/dbt/ --profiles-dir ./examples/full-jaffle-shop-demo/profiles/ --profile jaffle_shop -s users

Before

<img width="916" height="418" alt="Screenshot from 2025-09-22 15-54-29" src="https://github.com/user-attachments/assets/d94ce22c-e11b-47bf-9949-f6bc521c4337" />

After


<img width="916" height="418" alt="image" src="https://github.com/user-attachments/assets/00541bc8-884c-4311-9bd6-fee8db0bae61" />

### Description:
This PR adds support for different dbt metadata structures based on version compatibility. It introduces two new CLI options for the `generate` command:

- `--use-dbt-1-10-metadata`: Forces the use of dbt 1.10+ metadata structure (config.meta)
- `--use-legacy-metadata`: Forces the use of legacy metadata structure (meta)

The PR modifies the `DbtSchemaEditor` initialization to accept a dbt version parameter, which determines the metadata structure format. It also updates the schema handling logic to detect and use the appropriate metadata format based on the dbt version, with options to override the detected version.

Additionally, the PR cleans up the orders.yml example file by removing redundant fields and fixing spacing in array brackets.