### PR TITLE
feat: add table calculations support for AI agent visualizations

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -370,8 +370,6 @@ export class AiAgentService {
                         metricQuery.additionalMetrics,
                         explore,
                     ),
-                    // TODO: add tableCalculations
-                    tableCalculations: [],
                 },
                 context: QueryExecutionContext.AI,
             },
@@ -1950,8 +1948,6 @@ export class AiAgentService {
                         metricQuery.additionalMetrics,
                         explore,
                     ),
-                    // TODO: add tableCalculations
-                    tableCalculations: [],
                 },
                 exploreName: metricQuery.exploreName,
                 csvLimit: metricQuery.limit,

--- a/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.test.ts
@@ -427,6 +427,7 @@ describe('McpSchemaCompatLayer', () => {
                     limit: null,
                 },
                 filters: null,
+                tableCalculations: null,
             });
         });
 
@@ -467,6 +468,7 @@ describe('McpSchemaCompatLayer', () => {
                         },
                     ],
                 },
+                tableCalculations: null,
             });
 
             expect(() => schemaTransformed.parse(parsed)).not.toThrow();
@@ -503,6 +505,7 @@ describe('McpSchemaCompatLayer', () => {
                         },
                     ],
                 },
+                tableCalculations: null,
             });
             expect(
                 mapped.parse({
@@ -533,6 +536,7 @@ describe('McpSchemaCompatLayer', () => {
                         },
                     ],
                 },
+                tableCalculations: null,
             });
         });
     });

--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -1,4 +1,5 @@
 import {
+    convertAiTableCalcsSchemaToTableCalcs,
     isSlackPrompt,
     metricQueryVerticalBarViz,
     toolVerticalBarArgsSchema,
@@ -86,6 +87,9 @@ export const getGenerateBarVizConfig = ({
                     filters: vizTool.filters,
                     maxLimit,
                     customMetrics: vizTool.customMetrics ?? null,
+                    tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
+                        vizTool.tableCalculations,
+                    ),
                 });
                 const queryResults = await runMiniMetricQuery(
                     metricQuery,

--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -1,4 +1,5 @@
 import {
+    convertAiTableCalcsSchemaToTableCalcs,
     isSlackPrompt,
     metricQueryTableViz,
     toolTableVizArgsSchema,
@@ -78,6 +79,9 @@ export const getGenerateTableVizConfig = ({
                     filters: vizTool.filters,
                     maxLimit,
                     customMetrics: vizTool.customMetrics ?? null,
+                    tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
+                        vizTool.tableCalculations,
+                    ),
                 });
                 const queryResults = await runMiniMetricQuery(
                     metricQuery,

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -1,4 +1,5 @@
 import {
+    convertAiTableCalcsSchemaToTableCalcs,
     isSlackPrompt,
     metricQueryTimeSeriesViz,
     toolTimeSeriesArgsSchema,
@@ -87,6 +88,9 @@ export const getGenerateTimeSeriesVizConfig = ({
                     filters: vizTool.filters,
                     maxLimit,
                     customMetrics: vizTool.customMetrics ?? null,
+                    tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
+                        vizTool.tableCalculations,
+                    ),
                 });
                 const queryResults = await runMiniMetricQuery(
                     metricQuery,

--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -1,4 +1,5 @@
 import {
+    convertAiTableCalcsSchemaToTableCalcs,
     Explore,
     getItemLabelWithoutTableName,
     getTotalFilterRules,
@@ -89,6 +90,9 @@ export const getRunMetricQuery = ({
                     filters: vizTool.filters,
                     maxLimit,
                     customMetrics: vizTool.customMetrics,
+                    tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
+                        vizTool.tableCalculations,
+                    ),
                 });
 
                 const results = await runMiniMetricQuery(

--- a/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
@@ -9,6 +9,7 @@ import {
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
     validateSortFieldsAreSelected,
+    validateTableCalculations,
 } from './validators';
 
 export const validateBarVizConfig = (
@@ -41,6 +42,12 @@ export const validateBarVizConfig = (
     validateSortFieldsAreSelected(
         vizTool.vizConfig.sorts,
         selectedDimensions,
+        vizTool.vizConfig.yMetrics,
+        vizTool.customMetrics,
+    );
+    validateTableCalculations(
+        explore,
+        vizTool.tableCalculations,
         vizTool.vizConfig.yMetrics,
         vizTool.customMetrics,
     );

--- a/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
@@ -9,6 +9,7 @@ import {
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
     validateSortFieldsAreSelected,
+    validateTableCalculations,
 } from './validators';
 
 export const validateTableVizConfig = (
@@ -36,6 +37,12 @@ export const validateTableVizConfig = (
     validateSortFieldsAreSelected(
         vizTool.vizConfig.sorts,
         vizTool.vizConfig.dimensions,
+        vizTool.vizConfig.metrics,
+        vizTool.customMetrics,
+    );
+    validateTableCalculations(
+        explore,
+        vizTool.tableCalculations,
         vizTool.vizConfig.metrics,
         vizTool.customMetrics,
     );

--- a/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
@@ -9,6 +9,7 @@ import {
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
     validateSortFieldsAreSelected,
+    validateTableCalculations,
 } from './validators';
 
 export const validateTimeSeriesVizConfig = (
@@ -41,6 +42,12 @@ export const validateTimeSeriesVizConfig = (
     validateSortFieldsAreSelected(
         vizTool.vizConfig.sorts,
         selectedDimensions,
+        vizTool.vizConfig.yMetrics,
+        vizTool.customMetrics,
+    );
+    validateTableCalculations(
+        explore,
+        vizTool.tableCalculations,
         vizTool.vizConfig.yMetrics,
         vizTool.customMetrics,
     );

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -28,6 +28,7 @@ export * from './customMetrics';
 export * from './filters';
 export * from './outputMetadata';
 export * from './sortField';
+export * from './tableCalcs/tableCalcs';
 export * from './tools';
 export * from './visualizations';
 

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcBaseSchemas.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcBaseSchemas.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { getFieldIdSchema } from '../fieldId';
+
+export const orderBySchema = z.object({
+    fieldId: getFieldIdSchema({ additionalDescription: 'Field to order by' }),
+    order: z.enum(['asc', 'desc']).nullable(),
+});
+export const orderBySchemaDescription = [].join('\n');
+
+export const partitionBySchema = getFieldIdSchema({
+    additionalDescription: null,
+});
+export const partitionBySchemaDescription = [
+    'Fields to PARTITION BY',
+    'If you want to compare across the table, no need for partition',
+    'If you want to compare values between only rows with the same value in the partitionBy fields (e.g. same `status` or `category`), you need to partition by the fields',
+].join('\n');
+
+export const baseTableCalcSchema = z.object({
+    name: z
+        .string()
+        .describe(
+            'Unique name for the table calculation, e.g. "percent_change_from_previous"',
+        ),
+    displayName: z
+        .string()
+        .describe(
+            'Display name for the table calculation, e.g. "MoM revenue change"',
+        ),
+});

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentChangeFromPrevious.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentChangeFromPrevious.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { getFieldIdSchema } from '../fieldId';
+import {
+    baseTableCalcSchema,
+    orderBySchema,
+    orderBySchemaDescription,
+} from './tableCalcBaseSchemas';
+
+export const tableCalcPercentChangeFromPreviousSchema =
+    baseTableCalcSchema.extend({
+        type: z.literal('percent_change_from_previous'),
+        fieldId: getFieldIdSchema({
+            additionalDescription: 'Field whose values you want to compare',
+        }),
+        orderBy: z
+            .array(orderBySchema)
+            .min(1)
+            .describe(orderBySchemaDescription),
+    });
+
+export type TableCalcPercentChangeFromPreviousSchema = z.infer<
+    typeof tableCalcPercentChangeFromPreviousSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentOfColumnTotal.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentOfColumnTotal.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { getFieldIdSchema } from '../fieldId';
+import { baseTableCalcSchema } from './tableCalcBaseSchemas';
+
+export const tableCalcPercentOfColumnTotalSchema = baseTableCalcSchema.extend({
+    type: z.literal('percent_of_column_total'),
+    fieldId: getFieldIdSchema({
+        additionalDescription: 'Field to calculate percentage of column total',
+    }),
+});
+
+export type TableCalcPercentOfColumnTotalSchema = z.infer<
+    typeof tableCalcPercentOfColumnTotalSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentOfPreviousValue.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentOfPreviousValue.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { getFieldIdSchema } from '../fieldId';
+import {
+    baseTableCalcSchema,
+    orderBySchema,
+    orderBySchemaDescription,
+} from './tableCalcBaseSchemas';
+
+export const tableCalcPercentOfPreviousValueSchema = baseTableCalcSchema.extend(
+    {
+        type: z.literal('percent_of_previous_value'),
+        fieldId: getFieldIdSchema({
+            additionalDescription: 'Field whose values you want to compare',
+        }),
+        orderBy: z
+            .array(orderBySchema)
+            .min(1)
+            .describe(orderBySchemaDescription),
+    },
+);
+
+export type TableCalcPercentOfPreviousValueSchema = z.infer<
+    typeof tableCalcPercentOfPreviousValueSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcRankInColumn.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcRankInColumn.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { getFieldIdSchema } from '../fieldId';
+import { baseTableCalcSchema } from './tableCalcBaseSchemas';
+
+export const tableCalcRankInColumnSchema = baseTableCalcSchema.extend({
+    type: z.literal('rank_in_column'),
+    fieldId: getFieldIdSchema({
+        additionalDescription: 'Field to rank by',
+    }),
+});
+
+export type TableCalcRankInColumnSchema = z.infer<
+    typeof tableCalcRankInColumnSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcRunningTotal.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcRunningTotal.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { getFieldIdSchema } from '../fieldId';
+import { baseTableCalcSchema } from './tableCalcBaseSchemas';
+
+export const tableCalcRunningTotalSchema = baseTableCalcSchema.extend({
+    type: z.literal('running_total'),
+    fieldId: getFieldIdSchema({
+        additionalDescription: 'Field to calculate running total of',
+    }),
+});
+
+export type TableCalcRunningTotalSchema = z.infer<
+    typeof tableCalcRunningTotalSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.test.ts
@@ -1,0 +1,68 @@
+import { TableCalculationTemplateType } from '../../../../types/field';
+import {
+    convertAiTableCalcsSchemaToTableCalcs,
+    type TableCalcsSchema,
+} from './tableCalcs';
+
+describe('convertAiTableCalcsSchemaToTableCalcs', () => {
+    it('creates template for percent_of_column_total', () => {
+        const tableCalcs: TableCalcsSchema = [
+            {
+                type: 'percent_of_column_total',
+                name: 'percent_total_sales',
+                displayName: 'Percent of total sales',
+                fieldId: 'orders_revenue',
+            },
+        ];
+
+        const [tableCalc] = convertAiTableCalcsSchemaToTableCalcs(tableCalcs);
+
+        if (!('template' in tableCalc)) {
+            throw new Error('Table calculation is not a template');
+        }
+
+        expect(tableCalc.template).toBeDefined();
+        expect(tableCalc.template?.type).toBe(
+            TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL,
+        );
+        expect(tableCalc.template?.fieldId).toBe('orders_revenue');
+    });
+
+    it('creates template with orderBy for percent_change_from_previous', () => {
+        const tableCalcs: TableCalcsSchema = [
+            {
+                type: 'percent_change_from_previous',
+                name: 'percent_change_sales',
+                displayName: 'Percent change sales',
+                fieldId: 'orders_revenue',
+                orderBy: [
+                    {
+                        fieldId: 'percent_change_sales',
+                        order: 'asc',
+                    },
+                    {
+                        fieldId: 'orders_revenue',
+                        order: 'desc',
+                    },
+                ],
+            },
+        ];
+
+        const [tableCalc] = convertAiTableCalcsSchemaToTableCalcs(tableCalcs);
+
+        if (!('template' in tableCalc)) {
+            throw new Error('Table calculation is not a template');
+        }
+
+        expect(tableCalc.template).toBeDefined();
+        expect(tableCalc.template.type).toBe(
+            TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS,
+        );
+        if ('orderBy' in tableCalc.template!) {
+            expect(tableCalc.template.orderBy).toEqual([
+                { fieldId: 'percent_change_sales', order: 'asc' },
+                { fieldId: 'orders_revenue', order: 'desc' },
+            ]);
+        }
+    });
+});

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+import {
+    CustomFormatType,
+    NumberSeparator,
+    TableCalculationTemplateType,
+    TableCalculationType,
+    type TableCalculation,
+} from '../../../../types/field';
+import assertUnreachable from '../../../../utils/assertUnreachable';
+import { tableCalcPercentChangeFromPreviousSchema } from './tableCalcPercentChangeFromPrevious';
+import { tableCalcPercentOfColumnTotalSchema } from './tableCalcPercentOfColumnTotal';
+import { tableCalcPercentOfPreviousValueSchema } from './tableCalcPercentOfPreviousValue';
+import { tableCalcRankInColumnSchema } from './tableCalcRankInColumn';
+import { tableCalcRunningTotalSchema } from './tableCalcRunningTotal';
+
+const tableCalcSchema = z.discriminatedUnion('type', [
+    tableCalcPercentChangeFromPreviousSchema,
+    tableCalcPercentOfPreviousValueSchema,
+    tableCalcPercentOfColumnTotalSchema,
+    tableCalcRankInColumnSchema,
+    tableCalcRunningTotalSchema,
+]);
+
+export type TableCalcSchema = z.infer<typeof tableCalcSchema>;
+// TODO improve description
+export const tableCalcsSchema = z.array(tableCalcSchema).nullable().describe(`
+Table calculations are a way to perform calculations across row sets without collapsing rows. You can think of them like SQL Window Functions.
+
+Create table calculations when:
+
+- User requests percentage change between columns
+  Examples: "Show revenue growth from last month", "Calculate MoY/Month-over-month, YoY/Year-over-year sales change"
+  Recommended visualization type: Table, bar chart
+
+- User requests percentage of column compared to previous row
+  Examples: "Show revenue as % of previous month", "What percent is each quarter vs the prior quarter"
+  Recommended visualization type: Table, bar chart
+
+- User requests percentage of column total
+  Examples: "Show each product as % of total sales", "What percentage does each region contribute to overall revenue"
+  Recommended visualization type: Table, Bar chart
+
+- User requests rank within a column
+  Examples: "Rank customers by revenue", "Show top performing sales reps by deal count"
+  Recommended visualization type: Table, Bar chart
+
+- User requests running total
+  Examples: "Show cumulative revenue over time", "Running sum of orders by month"
+  Recommended visualization type: Line chart for the table calculation as Y axis and time as X axis
+`);
+
+export type TableCalcsSchema = z.infer<typeof tableCalcsSchema>;
+
+function convertTableCalcSchemaToTableCalc(
+    tableCalc: TableCalcSchema,
+): TableCalculation {
+    const { type, name, displayName, fieldId } = tableCalc;
+
+    // Build the template
+    const baseCalc: Omit<TableCalculation, 'format'> = {
+        name,
+        displayName,
+        type: TableCalculationType.NUMBER,
+    };
+
+    switch (type) {
+        case 'percent_change_from_previous':
+            return {
+                ...baseCalc,
+                template: {
+                    type: TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS,
+                    fieldId,
+                    orderBy: tableCalc.orderBy,
+                },
+                format: {
+                    type: CustomFormatType.PERCENT,
+                    separator: NumberSeparator.DEFAULT,
+                },
+            };
+        case 'percent_of_previous_value':
+            return {
+                ...baseCalc,
+                template: {
+                    type: TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE,
+                    fieldId,
+                    orderBy: tableCalc.orderBy,
+                },
+                format: {
+                    type: CustomFormatType.PERCENT,
+                    separator: NumberSeparator.DEFAULT,
+                },
+            };
+        case 'percent_of_column_total':
+            return {
+                ...baseCalc,
+                template: {
+                    type: TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL,
+                    fieldId,
+                },
+                format: {
+                    type: CustomFormatType.PERCENT,
+                    separator: NumberSeparator.DEFAULT,
+                },
+            };
+        case 'rank_in_column':
+            return {
+                ...baseCalc,
+                template: {
+                    type: TableCalculationTemplateType.RANK_IN_COLUMN,
+                    fieldId,
+                },
+                format: {
+                    type: CustomFormatType.NUMBER,
+                    separator: NumberSeparator.DEFAULT,
+                },
+            };
+        case 'running_total':
+            return {
+                ...baseCalc,
+                template: {
+                    type: TableCalculationTemplateType.RUNNING_TOTAL,
+                    fieldId,
+                },
+                format: {
+                    type: CustomFormatType.NUMBER,
+                    separator: NumberSeparator.DEFAULT,
+                },
+            };
+        default:
+            return assertUnreachable(type, 'Unknown table calc type');
+    }
+}
+
+export function convertAiTableCalcsSchemaToTableCalcs(
+    tableCalcs: TableCalcsSchema,
+): TableCalculation[] {
+    return tableCalcs?.map((tc) => convertTableCalcSchemaToTableCalc(tc)) ?? [];
+}

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardArgs.ts
@@ -4,6 +4,7 @@ import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
+import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import {
@@ -44,6 +45,7 @@ Usage tips:
 const baseVisualizationSchema = z.object({
     ...visualizationMetadataSchema.shape,
     customMetrics: customMetricsSchema,
+    tableCalculations: tableCalcsSchema,
     filters: filtersSchema
         .nullable()
         .describe(

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunMetricQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunMetricQueryArgs.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
+import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
 import { tableVizConfigSchema } from '../visualizations';
 
@@ -24,6 +25,7 @@ export const toolRunMetricQueryArgsSchema = createToolSchema(
     .extend({
         vizConfig: tableVizConfigSchema,
         customMetrics: customMetricsSchema,
+        tableCalculations: tableCalcsSchema,
         filters: filtersSchema
             .nullable()
             .describe(

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -7,6 +7,7 @@ import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
+import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import { tableVizConfigSchema } from '../visualizations';
@@ -20,6 +21,7 @@ export const toolTableVizArgsSchema = createToolSchema(
     .extend({
         ...visualizationMetadataSchema.shape,
         customMetrics: customMetricsSchema,
+        tableCalculations: tableCalcsSchema,
         vizConfig: tableVizConfigSchema,
         filters: filtersSchema
             .nullable()
@@ -45,6 +47,7 @@ export const toolTableVizArgsSchemaTransformed = toolTableVizArgsSchema
     .extend({
         // backwards compatibility for old viz configs without customMetrics
         customMetrics: customMetricsSchema.default(null),
+        tableCalculations: tableCalcsSchema.default(null),
         followUpTools: z.array(
             z.union([
                 z.literal(AiResultType.VERTICAL_BAR_RESULT),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -7,6 +7,7 @@ import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
+import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import { timeSeriesMetricVizConfigSchema } from '../visualizations/timeSeriesViz';
@@ -20,6 +21,7 @@ export const toolTimeSeriesArgsSchema = createToolSchema(
     .extend({
         ...visualizationMetadataSchema.shape,
         customMetrics: customMetricsSchema,
+        tableCalculations: tableCalcsSchema,
         vizConfig: timeSeriesMetricVizConfigSchema,
         filters: filtersSchema
             .nullable()
@@ -50,6 +52,7 @@ export const toolTimeSeriesArgsSchemaTransformed = toolTimeSeriesArgsSchema
         }),
         // backwards compatibility for old viz configs without customMetrics
         customMetrics: customMetricsSchema.default(null),
+        tableCalculations: tableCalcsSchema.default(null),
         followUpTools: z.array(
             z.union([
                 z.literal(AiResultType.TABLE_RESULT),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -7,6 +7,7 @@ import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
 import { filtersSchema, filtersSchemaTransformed } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
+import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import { verticalBarMetricVizConfigSchema } from '../visualizations';
@@ -20,6 +21,7 @@ export const toolVerticalBarArgsSchema = createToolSchema(
     .extend({
         ...visualizationMetadataSchema.shape,
         customMetrics: customMetricsSchema,
+        tableCalculations: tableCalcsSchema,
         vizConfig: verticalBarMetricVizConfigSchema,
         filters: filtersSchema
             .nullable()
@@ -45,6 +47,7 @@ export const toolVerticalBarArgsSchemaTransformed = toolVerticalBarArgsSchema
     .extend({
         // backwards compatibility for old viz configs without customMetrics
         customMetrics: customMetricsSchema.default(null),
+        tableCalculations: tableCalcsSchema.default(null),
         followUpTools: z.array(
             z.union([
                 z.literal(AiResultType.TABLE_RESULT),

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { type TableCalculation } from '../../../../types/field';
 import type { Filters } from '../../../../types/filter';
 import type { AiMetricQueryWithFilters } from '../../types';
 import { getValidAiQueryLimit } from '../../validators';
@@ -45,11 +46,13 @@ export const metricQueryTableViz = ({
     filters,
     maxLimit,
     customMetrics,
+    tableCalculations,
 }: {
     vizConfig: TableVizConfigSchemaType;
     filters: Filters;
     maxLimit: number;
     customMetrics: ToolTableVizArgsTransformed['customMetrics'] | null;
+    tableCalculations: TableCalculation[];
 }): AiMetricQueryWithFilters => ({
     exploreName: vizConfig.exploreName,
     metrics: vizConfig.metrics,
@@ -61,4 +64,5 @@ export const metricQueryTableViz = ({
     limit: getValidAiQueryLimit(vizConfig.limit, maxLimit),
     filters,
     additionalMetrics: customMetrics ?? [],
+    tableCalculations,
 });

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { TableCalculation } from '../../../../types/field';
 import type { Filters } from '../../../../types/filter';
 import { AI_DEFAULT_MAX_QUERY_LIMIT } from '../../constants';
 import type { AiMetricQueryWithFilters } from '../../types';
@@ -61,11 +62,13 @@ export const metricQueryTimeSeriesViz = ({
     filters,
     maxLimit,
     customMetrics,
+    tableCalculations,
 }: {
     vizConfig: TimeSeriesMetricVizConfigSchemaType;
     filters: Filters;
     maxLimit: number;
     customMetrics: ToolTimeSeriesArgsTransformed['customMetrics'] | null;
+    tableCalculations: TableCalculation[];
 }): AiMetricQueryWithFilters => {
     const metrics = vizConfig.yMetrics;
     const dimensions = [
@@ -87,5 +90,6 @@ export const metricQueryTimeSeriesViz = ({
         exploreName: vizConfig.exploreName,
         filters,
         additionalMetrics: customMetrics ?? [],
+        tableCalculations,
     };
 };

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { type TableCalculation } from '../../../../types/field';
 import type { Filters } from '../../../../types/filter';
 import { AI_DEFAULT_MAX_QUERY_LIMIT } from '../../constants';
 import type { AiMetricQueryWithFilters } from '../../types';
@@ -69,11 +70,13 @@ export const metricQueryVerticalBarViz = ({
     filters,
     maxLimit,
     customMetrics,
+    tableCalculations,
 }: {
     vizConfig: VerticalBarMetricVizConfigSchemaType;
     filters: Filters;
     maxLimit: number;
     customMetrics: ToolVerticalBarArgsTransformed['customMetrics'] | null;
+    tableCalculations: TableCalculation[];
 }): AiMetricQueryWithFilters => {
     const metrics = vizConfig.yMetrics;
     const dimensions = [
@@ -94,5 +97,7 @@ export const metricQueryVerticalBarViz = ({
         exploreName: vizConfig.exploreName,
         filters,
         additionalMetrics: customMetrics ?? [],
+        // TODO: add tableCalculations
+        tableCalculations,
     };
 };

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -17,7 +17,12 @@ export enum AiResultType {
 
 export type AiMetricQuery = Pick<
     MetricQuery,
-    'metrics' | 'dimensions' | 'sorts' | 'limit' | 'exploreName'
+    | 'metrics'
+    | 'dimensions'
+    | 'sorts'
+    | 'limit'
+    | 'exploreName'
+    | 'tableCalculations'
 > & {
     additionalMetrics: Omit<AdditionalMetric, 'sql'>[];
 };

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -1,5 +1,6 @@
 import { AI_DEFAULT_MAX_QUERY_LIMIT } from './constants';
 import {
+    convertAiTableCalcsSchemaToTableCalcs,
     metricQueryTableViz,
     metricQueryTimeSeriesViz,
     metricQueryVerticalBarViz,
@@ -27,6 +28,9 @@ export const parseVizConfig = (
             filters: vizTool.filters,
             maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
             customMetrics: vizTool.customMetrics ?? null,
+            tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
+                vizTool.tableCalculations,
+            ),
         });
         return {
             type: AiResultType.VERTICAL_BAR_RESULT,
@@ -44,6 +48,9 @@ export const parseVizConfig = (
             filters: vizTool.filters,
             maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
             customMetrics: vizTool.customMetrics ?? null,
+            tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
+                vizTool.tableCalculations,
+            ),
         });
         return {
             type: AiResultType.TIME_SERIES_RESULT,
@@ -61,6 +68,9 @@ export const parseVizConfig = (
             filters: vizTool.filters,
             maxLimit: maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
             customMetrics: vizTool.customMetrics ?? null,
+            tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
+                vizTool.tableCalculations,
+            ),
         });
         return {
             type: AiResultType.TABLE_RESULT,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -121,6 +121,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
                 columnOrder={[
                     ...metricQuery.dimensions,
                     ...metricQuery.metrics,
+                    ...metricQuery.tableCalculations.map((tc) => tc.name),
                 ]}
                 pivotTableMaxColumnLimit={
                     health?.pivotTable.maxColumnLimit ?? 60


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Add table calculations support to AI agent visualizations

This PR adds support for table calculations in AI-generated visualizations. Table calculations allow users to perform operations like percent change, running totals, and rankings across rows without collapsing data.

Key changes:
- Created schemas for different table calculation types (percent change, running total, etc.)
- Added validation for table calculations to ensure they reference valid metrics
- Implemented conversion from AI table calculation schema to Lightdash table calculation format
- Integrated table calculations into visualization tools (bar, table, time series)
- Removed TODO comments for table calculations that are now implemented
- Updated column ordering in visualization renderer to include table calculation columns