### PR TITLE
feat: add baseTable parameter to catalog search for improved table family filtering

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1626,9 +1626,7 @@ export class AiAgentService {
                         catalogSearch: {
                             type: CatalogType.Table,
                             yamlTags: agentSettings.tags ?? undefined,
-                            tables: args.tableName
-                                ? [args.tableName]
-                                : undefined,
+                            baseTable: args.tableName ?? undefined,
                         },
                         userAttributes,
                         context: CatalogSearchContext.AI_AGENT,
@@ -1667,7 +1665,7 @@ export class AiAgentService {
                                 catalogSearch: {
                                     type: CatalogType.Field,
                                     yamlTags: agentSettings.tags ?? undefined,
-                                    tables: [table.name],
+                                    baseTable: table.name,
                                 },
                                 userAttributes,
                                 context: CatalogSearchContext.AI_AGENT,
@@ -1757,6 +1755,7 @@ export class AiAgentService {
                         type: CatalogType.Field,
                         searchQuery: args.fieldSearchQuery.label,
                         yamlTags: agentSettings.tags ?? undefined,
+                        baseTable: args.table,
                     },
                     context: CatalogSearchContext.AI_AGENT,
                     paginateArgs: {

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -40,6 +40,7 @@ export type ApiCatalogSearch = {
     catalogTags?: string[];
     yamlTags?: string[];
     tables?: string[];
+    baseTable?: string;
 };
 
 type EmojiIcon = {


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17049

### Description:
Enhances the catalog search functionality for AI agents by introducing a `baseTable` parameter that improves how fields are filtered when using YAML tags. This change allows fields from joined tables to be properly included in search results when the base table has matching tags, while maintaining the precedence rules across the entire table family.

The implementation adds a new condition to the catalog search that specifically handles fields from joined tables when a base table is tagged, ensuring more accurate and comprehensive results when AI agents search for fields across related tables.