### PR TITLE
fix: reduce email socket timeout to prevent scheduler conflicts

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -18,11 +18,11 @@ import path from 'path';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 
-// Timeout configurations aligned with Nodemailer defaults and RFC 5321
+// Timeout configurations based on Nodemailer defaults, adjusted for scheduler compatibility
 export const SMTP_CONNECTION_CONFIG = {
     connectionTimeout: 120000, // 2 minutes - max time to establish connection (default)
     greetingTimeout: 30000, // 30 seconds - max time to wait for greeting (default)
-    socketTimeout: 600000, // 10 minutes - max time for idle socket (default)
+    socketTimeout: 180000, // 3 minutes - reduced from default to allow retry logic within default scheduler timeout (10min)
 } as const;
 
 export type AttachmentUrl = {


### PR DESCRIPTION

### Description:
Reduce SMTP `socketTimeout` from 10 min to 3 min to allow email retry logic to work properly within the default scheduler job timeout.

#### Problem
- Email `socketTimeout` matches scheduler `jobTimeout` (both 10min)
- When SMTP connections hung, the scheduler timeout would kill jobs before email retries could complete (1 retry takes 10min)
- This resulted in "Failed to send email after 1 attempts" instead of the expected 3 retry attempts

Reducing the email `socketTimeout` to 3 minutes allows the completion of the 3 retry attempts (9 min total). I think 3 min is realistically enough to detect a timeout and we will be able to quickly retry instead of having a long hang