### PR TITLE
fix: enhance agent chat input focus styling

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -7,5 +7,9 @@
 
 .input {
     background-color: rgba(255, 255, 255, 0.3) !important;
-    --input-bd-focus: var(--mantine-color-gray-5);
+
+    --input-bd-focus: var(--mantine-color-gray-7);
+    &:focus {
+        outline: 4px solid var(--mantine-color-gray-2);
+    }
 }


### PR DESCRIPTION
### Description:
Enhanced the focus state of the agent chat input by styling double border

![CleanShot 2025-09-23 at 18.44.40@2x.png](https://app.graphite.dev/user-attachments/assets/47b38f48-2d46-4e6e-9901-5799b1720a33.png)

