### PR TITLE
feat: enhance AgentChatDebugDrawer with artifact visualization support

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -475,12 +475,13 @@ export const AssistantBubble: FC<Props> = memo(
                 </Group>
 
                 <AgentChatDebugDrawer
+                    agentUuid={agentUuid}
+                    projectUuid={projectUuid}
+                    artifacts={message.artifacts}
+                    toolCalls={message.toolCalls}
                     isVisualizationAvailable={isArtifactAvailable}
                     isDrawerOpen={isDrawerOpen}
-                    closeDrawer={closeDrawer}
-                    toolCalls={message.toolCalls}
-                    vizConfig={null}
-                    metricQuery={null}
+                    onClose={closeDrawer}
                 />
             </Stack>
         );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDebugDrawer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDebugDrawer.tsx
@@ -1,57 +1,65 @@
+import {
+    type AiAgentMessageAssistantArtifact,
+    type AiAgentToolCall,
+} from '@lightdash/common';
 import { Accordion, Drawer, Text } from '@mantine-8/core';
 import { Prism } from '@mantine/prism';
-import { IconChartBar, IconMathFunction, IconTools } from '@tabler/icons-react';
+import { IconChartBar, IconTools } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiAgentArtifact } from '../../hooks/useAiAgentArtifacts';
 
 type Props = {
     isVisualizationAvailable: boolean;
     isDrawerOpen: boolean;
-    closeDrawer: () => void;
-    vizConfig: object | null;
-    metricQuery: object | null;
-    toolCalls: object | null;
+    onClose: () => void;
+    artifacts: AiAgentMessageAssistantArtifact[] | null;
+    toolCalls: AiAgentToolCall[] | null;
+    agentUuid: string;
+    projectUuid: string;
 };
 
-const AgentChatDebugDrawer = ({
+const AgentChatDebugDrawer: React.FC<Props> = ({
     isVisualizationAvailable,
     isDrawerOpen,
-    closeDrawer,
-    metricQuery,
-    vizConfig,
+    onClose,
+    artifacts,
     toolCalls,
-}: Props) => {
+    agentUuid,
+    projectUuid,
+}) => {
+    const artifact = artifacts?.[artifacts.length - 1];
+
+    const { data: artifactData } = useAiAgentArtifact({
+        projectUuid: projectUuid,
+        agentUuid: agentUuid,
+        artifactUuid: artifact?.artifactUuid,
+        versionUuid: artifact?.versionUuid,
+    });
+
     return (
         <Drawer
             title="Debug information"
             opened={isVisualizationAvailable && isDrawerOpen}
-            onClose={closeDrawer}
+            onClose={onClose}
             size="xl"
         >
             <Accordion variant="contained" chevronPosition="right">
-                <Accordion.Item value="metric-query">
-                    <Accordion.Control
-                        icon={
-                            <MantineIcon icon={IconMathFunction} color="gray" />
-                        }
-                    >
-                        <Text fw={500}>Metric Query</Text>
-                    </Accordion.Control>
-                    <Accordion.Panel>
-                        <Prism language="json" withLineNumbers>
-                            {JSON.stringify(metricQuery, null, 2)}
-                        </Prism>
-                    </Accordion.Panel>
-                </Accordion.Item>
-
                 <Accordion.Item value="visualization">
                     <Accordion.Control
                         icon={<MantineIcon icon={IconChartBar} color="gray" />}
                     >
-                        <Text fw={500}>Visualization configuration</Text>
+                        <Text fw={500}>
+                            Configuration for {artifactData?.artifactType}
+                        </Text>
                     </Accordion.Control>
                     <Accordion.Panel>
                         <Prism language="json" withLineNumbers>
-                            {JSON.stringify(vizConfig, null, 2)}
+                            {JSON.stringify(
+                                artifactData?.chartConfig ??
+                                    artifactData?.dashboardConfig,
+                                null,
+                                2,
+                            )}
                         </Prism>
                     </Accordion.Panel>
                 </Accordion.Item>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentArtifacts.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentArtifacts.ts
@@ -36,7 +36,7 @@ const getAiAgentArtifactVersion = async (
 type UseAiAgentArtifactProps = {
     projectUuid: string;
     agentUuid: string;
-    artifactUuid: string;
+    artifactUuid?: string;
     versionUuid?: string;
     options?: UseQueryOptions<AiArtifact, ApiError>;
 };
@@ -67,10 +67,10 @@ export const useAiAgentArtifact = ({
               getAiAgentArtifactVersion(
                   projectUuid,
                   agentUuid,
-                  artifactUuid,
+                  artifactUuid!,
                   versionUuid,
               )
-        : () => getAiAgentArtifact(projectUuid, agentUuid, artifactUuid);
+        : () => getAiAgentArtifact(projectUuid, agentUuid, artifactUuid!);
 
     return useQuery<AiArtifact, ApiError>({
         queryKey,
@@ -91,6 +91,7 @@ export const useAiAgentArtifact = ({
             }
             options?.onError?.(error);
         },
+        enabled: !!artifactUuid && !!versionUuid && options?.enabled,
         ...options,
     });
 };


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/16863

### Description:
Enhances the Agent Chat Debug Drawer to display artifact configurations. The drawer now fetches and displays chart or dashboard configurations from artifacts instead of showing static vizConfig and metricQuery data. Added proper props to pass agent and project UUIDs, along with artifact data to enable this functionality.

The implementation also improves the conditional rendering logic to only fetch artifact data when necessary, preventing unnecessary API calls when no artifact is available.