### PR TITLE
fix: allow viewing pending eval and improve polling

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRuns.tsx
@@ -70,16 +70,13 @@ const EvalRunItem: FC<RunItemProps> = ({
             p="sm"
             withBorder
             style={{
-                cursor: run.status === 'pending' ? 'not-allowed' : 'pointer',
-                opacity: run.status === 'pending' ? 0.6 : 1,
+                cursor: 'pointer',
                 borderColor: isSelected
                     ? 'var(--mantine-color-blue-5)'
                     : undefined,
             }}
             onClick={() => {
-                if (run.status !== 'pending') {
-                    onSelectRun(run);
-                }
+                onSelectRun(run);
             }}
         >
             <Group justify="space-between" align="center">
@@ -97,38 +94,32 @@ const EvalRunItem: FC<RunItemProps> = ({
                             {run.status}
                         </Badge>
                     </Group>
-                    <Tooltip
-                        label={
-                            <Text size="xs" c="dimmed">
-                                Started{' '}
-                                {new Date(run.createdAt).toLocaleString()}
-                                {run.completedAt && (
-                                    <>
-                                        {' '}
-                                        • Completed{' '}
-                                        {new Date(
-                                            run.completedAt,
-                                        ).toLocaleString()}
-                                    </>
-                                )}
-                            </Text>
-                        }
-                    >
-                        <Text
-                            size="xs"
-                            c="dimmed"
-                            display={
-                                run.status === 'pending' ? 'none' : 'block'
+                    {run.completedAt && (
+                        <Tooltip
+                            label={
+                                <Text size="xs" c="dimmed">
+                                    Started{' '}
+                                    {new Date(run.createdAt).toLocaleString()}
+                                    {run.completedAt && (
+                                        <>
+                                            {' '}
+                                            • Completed{' '}
+                                            {new Date(
+                                                run.completedAt,
+                                            ).toLocaleString()}
+                                        </>
+                                    )}
+                                </Text>
                             }
                         >
-                            Duration: {runDuration}
-                        </Text>
-                    </Tooltip>
+                            <Text size="xs" c="dimmed">
+                                Duration: {runDuration}
+                            </Text>
+                        </Tooltip>
+                    )}
                 </Stack>
                 <Group gap="sm">
-                    {run.status !== 'pending' && (
-                        <MantineIcon icon={IconChevronRight} />
-                    )}
+                    <MantineIcon icon={IconChevronRight} />
                 </Group>
             </Group>
         </Card>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Enables viewing pending evaluation threads by making pending evaluation runs clickable in the UI. Previously, only completed runs could be viewed. The PR also adds polling for evaluation run details to automatically update the UI when a run's status changes, and increases the polling interval from 2 to 4 seconds to reduce server load.

[CleanShot 2025-09-24 at 10.01.41.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/1ab06c4c-05bc-40c8-af1a-7854859e547f.mp4" />](https://app.graphite.dev/user-attachments/video/1ab06c4c-05bc-40c8-af1a-7854859e547f.mp4)