### PR TITLE
fix: feedback, follow up tools, explore in lightdash and links not being sent to slack after agent response

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2377,7 +2377,7 @@ export class AiAgentModel {
         threadUuid: string,
         artifactType?: AiArtifact['artifactType'],
     ): Promise<AiArtifact[]> {
-        const results = await this.database
+        const query = this.database
             .select({
                 artifactUuid: `${AiArtifactsTableName}.ai_artifact_uuid`,
                 threadUuid: `${AiArtifactsTableName}.ai_thread_uuid`,
@@ -2402,10 +2402,6 @@ export class AiAgentModel {
             )
             .where(`${AiArtifactsTableName}.ai_thread_uuid`, threadUuid)
             .andWhere(
-                `${AiArtifactsTableName}.artifact_type`,
-                artifactType ?? `${AiArtifactsTableName}.artifact_type`,
-            )
-            .andWhere(
                 `${AiArtifactVersionsTableName}.version_number`,
                 this.database
                     .select(this.database.raw('MAX(version_number)'))
@@ -2419,6 +2415,14 @@ export class AiAgentModel {
             )
             .orderBy(`${AiArtifactsTableName}.created_at`, 'desc');
 
+        if (artifactType) {
+            void query.andWhere(
+                `${AiArtifactsTableName}.artifact_type`,
+                artifactType,
+            );
+        }
+
+        const results = await query;
         return results;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixed a bug in the `getArtifactsByThreadUuid` method where the artifact type filter was always applied, even when not provided. Now the filter is only applied conditionally when an artifact type is specified.



Before: 

![CleanShot 2025-09-24 at 11.08.34@2x.png](https://app.graphite.dev/user-attachments/assets/02fa01a2-8dc2-4561-a1d5-379c4d481f8a.png)

After: 



![CleanShot 2025-09-24 at 11.08.49@2x.png](https://app.graphite.dev/user-attachments/assets/4af0936b-66e9-4e9d-95a1-13e1100711c9.png)

