### PR TITLE
fix: update Slack tag regex pattern

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -2254,7 +2254,7 @@ export class AiAgentService {
             );
         }
 
-        const slackTagRegex = /^.*?(<@U\d+\w*?>)/g;
+        const slackTagRegex = /<@U\d+\w*?>/g;
 
         const uuid = await this.aiAgentModel.createSlackPrompt({
             threadUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

The problem with the original regex:

- `^.*?(<@U\d+\w*?>)` matches from the start of the string (^) up to and including the first Slack mention
- For `"Hello @bot test"`​, it would match "Hello <@U123456>" and remove that entire portion
- This left only "test"

The fixed regex:

- `<@U\d+\w*?>` matches only the Slack user mention tags (like `<@U123456>`)
- For `"Hello @bot￼ test"`​, it removes just the <@U123456> part
- This leaves "Hello test" as intended