### PR TITLE
chore: update psycopg2-binary from 2.9.6 to 2.9.10

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,7 +162,7 @@
                   "dbt-trino~=${adapterVersions.trino}" \
                   "dbt-clickhouse~=${adapterVersions.clickhouse}" \
                   "pytz" \
-                  "psycopg2-binary==2.9.6" \
+                  "psycopg2-binary==2.9.10" \
                   --disable-pip-version-check --no-warn-script-location || { echo "Failed to install adapters"; exit 1; }
 
                 deactivate # Deactivate after installation


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Upgrade psycopg2-binary from 2.9.6 to 2.9.10 in flake.nix to address security vulnerabilities in the older version.