### PR TITLE
chore: make React devtools configurable via environment variables

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import { ModalsProvider } from '@mantine/modals';
 import { wrapCreateBrowserRouterV7 } from '@sentry/react';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { createBrowserRouter, Outlet, RouterProvider } from 'react-router';
 import VersionAutoUpdater from './components/VersionAutoUpdater/VersionAutoUpdater';
 import {
@@ -76,7 +75,6 @@ const App = () => (
                     </ModalsProvider>
                 </Mantine8Provider>
             </MantineProvider>
-            <ReactQueryDevtools initialIsOpen={false} />
         </ReactQueryProvider>
     </>
 );

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -10,7 +10,7 @@ import App from './App';
 
 // Trigger FE tests
 scan({
-    enabled: import.meta.env.DEV,
+    enabled: import.meta.env.DEV && REACT_SCAN_ENABLED,
 });
 
 const container = document.getElementById('root');

--- a/packages/frontend/src/providers/ReactQuery/ReactQueryProvider.tsx
+++ b/packages/frontend/src/providers/ReactQuery/ReactQueryProvider.tsx
@@ -1,4 +1,5 @@
 import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { type FC, type PropsWithChildren } from 'react';
 import { createQueryClient } from './createQueryClient';
 
@@ -8,6 +9,9 @@ const ReactQueryProvider: FC<PropsWithChildren> = ({ children }) => {
     return (
         <QueryClientProvider client={queryClient}>
             {children}
+            {import.meta.env.DEV && REACT_QUERY_DEVTOOLS_ENABLED && (
+                <ReactQueryDevtools initialIsOpen={false} />
+            )}
         </QueryClientProvider>
     );
 };

--- a/packages/frontend/vite-env.d.ts
+++ b/packages/frontend/vite-env.d.ts
@@ -1,4 +1,6 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
 
-declare const __APP_VERSION__: string
+declare const __APP_VERSION__: string;
+declare const REACT_SCAN_ENABLED: boolean;
+declare const REACT_QUERY_DEVTOOLS_ENABLED: boolean;

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -21,6 +21,9 @@ export default defineConfig(async () => {
         publicDir: 'public',
         define: {
             __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+            REACT_SCAN_ENABLED: process.env.REACT_SCAN_ENABLED ?? true,
+            REACT_QUERY_DEVTOOLS_ENABLED:
+                process.env.REACT_QUERY_DEVTOOLS_ENABLED ?? true,
         },
         plugins: [
             svgrPlugin(),


### PR DESCRIPTION
### Description:
This PR makes React Query DevTools and React Scan conditionally available in development mode based on environment variables. It moves the ReactQueryDevtools from App.tsx to the ReactQueryProvider component and adds environment flags (REACT_SCAN_ENABLED and REACT_QUERY_DEVTOOLS_ENABLED) to control their activation. This allows developers to disable these tools when not needed while keeping them available by default in development mode.