### PR TITLE
fix: improve performance when checking if a chart exists on a dashboard

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -595,12 +595,13 @@ export class EmbedService extends BaseService {
             );
         }
 
-        const chartInDashboards = await this.dashboardModel.getAllByProject(
-            projectUuid,
-            chartUuid,
-        );
-        const chartInDashboardUuids = chartInDashboards.map((d) => d.uuid);
-        if (!chartInDashboardUuids.includes(dashboardUuid)) {
+        const chartExists =
+            await this.dashboardModel.savedChartExistsInDashboard(
+                projectUuid,
+                dashboardUuid,
+                chartUuid,
+            );
+        if (!chartExists) {
             throw new ForbiddenError(
                 `This chart does not belong to dashboard ${dashboardUuid}`,
             );

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -216,6 +216,62 @@ describe('DashboardModel', () => {
         expect(tracker.history.select).toHaveLength(2);
     });
 
+    test('should check if saved chart exists in dashboard', async () => {
+        const testProjectUuid = 'test-project-uuid';
+        const testDashboardUuid = 'test-dashboard-uuid';
+        const testChartUuid = 'test-chart-uuid';
+
+        // Mock any select query that contains these parameters
+        tracker.on
+            .select(
+                ({ sql, bindings }: RawQuery) =>
+                    sql.includes('latest_dashboard_version_cte') &&
+                    bindings.includes(testDashboardUuid) &&
+                    bindings.includes(testProjectUuid) &&
+                    bindings.includes(testChartUuid),
+            )
+            .response([
+                {
+                    dashboard_uuid: testDashboardUuid,
+                },
+            ]);
+
+        const result = await model.savedChartExistsInDashboard(
+            testProjectUuid,
+            testDashboardUuid,
+            testChartUuid,
+        );
+
+        expect(result).toBe(true);
+        expect(tracker.history.select).toHaveLength(1);
+    });
+
+    test('should return false when saved chart does not exist in dashboard', async () => {
+        const testProjectUuid = 'test-project-uuid';
+        const testDashboardUuid = 'test-dashboard-uuid';
+        const testChartUuid = 'test-chart-uuid';
+
+        // Mock any select query that contains these parameters with empty response
+        tracker.on
+            .select(
+                ({ sql, bindings }: RawQuery) =>
+                    sql.includes('latest_dashboard_version_cte') &&
+                    bindings.includes(testDashboardUuid) &&
+                    bindings.includes(testProjectUuid) &&
+                    bindings.includes(testChartUuid),
+            )
+            .response([]);
+
+        const result = await model.savedChartExistsInDashboard(
+            testProjectUuid,
+            testDashboardUuid,
+            testChartUuid,
+        );
+
+        expect(result).toBe(false);
+        expect(tracker.history.select).toHaveLength(1);
+    });
+
     test('should create dashboard with tile ids', async () => {
         tracker.on.select(SpaceTableName).responseOnce([spaceEntry]);
         tracker.on.insert(DashboardsTableName).responseOnce([dashboardEntry]);

--- a/packages/backend/src/services/PermissionsService/PermissionsService.ts
+++ b/packages/backend/src/services/PermissionsService/PermissionsService.ts
@@ -34,13 +34,13 @@ export class PermissionsService extends BaseService {
             );
         }
 
-        const chartInDashboards = await this.dashboardModel.getAllByProject(
-            projectUuid,
-            savedChartUuid,
-        );
-
-        const chartInDashboardUuids = chartInDashboards.map((d) => d.uuid);
-        if (!chartInDashboardUuids.includes(dashboardUuid)) {
+        const chartExists =
+            await this.dashboardModel.savedChartExistsInDashboard(
+                projectUuid,
+                dashboardUuid,
+                savedChartUuid,
+            );
+        if (!chartExists) {
             throw new ForbiddenError(
                 `This chart does not belong to dashboard ${dashboardUuid}`,
             );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17073

  # Optimize embed permission checks with targeted chart existence query

  ## Problem
  The `EmbedService` and `PermissionsService` were using `getAllByProject()` for permission checks, causing severe performance bottlenecks. This method performs complex joins across 10+ database tables to fetch complete dashboard data when only a
  boolean chart existence check was needed.

  ## Solution
  - **Added `savedChartExistsInDashboard()` method** to `DashboardModel` using efficient CTE pattern
  - **Replaced expensive `getAllByProject()` calls** in embed permission flows with targeted existence checks
  - **Maintains security** through proper project UUID filtering and dashboard version handling

  ## Performance Impact
  - **100-500x faster** permission checks (3+ seconds → ~5ms)
  - **Eliminates unnecessary data processing** - no more fetching complete dashboard records for boolean checks
  - **Reduces database load** with lightweight existence queries instead of heavy joins
  - **Improves user experience** with near-instantaneous embed permission validation

## Side-by-side comparison

**Old Query**

https://github.com/user-attachments/assets/a846160e-349e-4042-840a-70a75f8be626

**New Query**

https://github.com/user-attachments/assets/d3ec96d1-7f1f-43b9-8c52-83d03b0bd3b9

## Performance Test Setup
  To test these improvements we manually seeded the database with the following:

  - **5000 test dashboards** with realistic complexity
  - **15-25 chart tiles per dashboard** initial version
  - **3-5 additional versions per dashboard** (4-6 total versions each)
  - **10-25 tiles per additional version**
  - **Strategic chart distribution**: Target chart appears in every dashboard (worst-case for old method)
  - **Total scale**: ~75,000-375,000 chart tiles across all dashboard versions

**Note:** Can provide the seed file used if needed for testing

 ### Performance Results

  #### New Optimized Query (`savedChartExistsInDashboard`)
```
permissionsGetChartAndResults took 1.7817189999987022ms for chart e7e4a5ec-60ae-41d4-98dc-4d62dd38cc38
permissionsGetChartAndResults took 1.4853000000002794ms for chart 2029940a-d0f6-4948-83d7-7508dd12b594
permissionsGetChartAndResults took 3.8617729999969015ms for chart 2a57c460-40b4-41a1-9b4a-46385196afcd
permissionsGetChartAndResults took 5.0430710000000545ms for chart 72506d99-7855-437b-91d9-6487343f0746
permissionsGetChartAndResults took 5.946993000005023ms for chart f55da24c-cfc8-4208-b9d4-4657ff81c095
permissionsGetChartAndResults took 4.155108000006294ms for chart a9e40be0-2cd0-439f-8e23-65411da57e9a
permissionsGetChartAndResults took 6.313454000002821ms for chart f23d18ea-54ae-41ff-87e3-059c38163ceb
permissionsGetChartAndResults took 0.9285470000031637ms for chart 6f500c66-7699-4061-9019-9ce49efa4d74
```

  #### Old Query (`getAllByProject`)
```
permissionsGetChartAndResults took 1259.6274190000004ms for chart 72506d99-7855-437b-91d9-6487343f0746
permissionsGetChartAndResults took 1647.6218260000005ms for chart a9e40be0-2cd0-439f-8e23-65411da57e9a
permissionsGetChartAndResults took 2006.5089339999995ms for chart f55da24c-cfc8-4208-b9d4-4657ff81c095
permissionsGetChartAndResults took 2395.0078859999994ms for chart 6f500c66-7699-4061-9019-9ce49efa4d74
permissionsGetChartAndResults took 2753.8945350000013ms for chart f23d18ea-54ae-41ff-87e3-059c38163ceb
permissionsGetChartAndResults took 3315.4993570000024ms for chart e7e4a5ec-60ae-41d4-98dc-4d62dd38cc38
permissionsGetChartAndResults took 654.9349050000019ms for chart 2a57c460-40b4-41a1-9b4a-46385196afcd
permissionsGetChartAndResults took 955.8077209999974ms for chart 2029940a-d0f6-4948-83d7-7508dd12b594
```

  #### Performance Improvement Summary

  | Metric | Old Method | New Method | Improvement |
  |--------|------------|------------|-------------|
  | **Best Case** | 655ms | 0.93ms | **704x faster** |
  | **Worst Case** | 3,316ms | 6.31ms | **525x faster** |

test-frontend
test-backend