### PR TITLE
chore: replicate images to  container registry as well

### DIFF
--- a/.github/workflows/gcp-build-and-push.yml
+++ b/.github/workflows/gcp-build-and-push.yml
@@ -37,5 +37,5 @@ jobs:
           SENTRY_BACKEND_PROJECT: lightdash-backend
           SENTRY_ENVIRONMENT: cloud_beta
           # Configure replica regions (comma-separated)
-          GCP_REPLICA_REGIONS: "europe-west2"
+          GCP_REPLICA_REGIONS: "europe,europe-west2"
         run: bash ./scripts/gcp-build-and-push.sh


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added "europe" to the GCP replica regions in the GitHub workflow for building and pushing to GCP. The replica regions now include both "europe" and "europe-west2" instead of just "europe-west2".