### PR TITLE
fix: AI Agent link shows in settings without FF

### DIFF
--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -77,6 +77,10 @@ const Settings: FC = () => {
         CommercialFeatureFlags.Scim,
     );
 
+    const { data: isAiCopilotEnabled } = useFeatureFlag(
+        CommercialFeatureFlags.AiCopilot,
+    );
+
     const isServiceAccountFeatureFlagEnabled = useFeatureFlagEnabled(
         CommercialFeatureFlags.ServiceAccounts,
     );
@@ -590,20 +594,23 @@ const Settings: FC = () => {
                                             }
                                         />
                                     )}
-                                {user.ability.can(
-                                    'manage',
-                                    subject('AiAgent', {
-                                        organizationUuid:
-                                            organization.organizationUuid,
-                                    }),
-                                ) && (
-                                    <RouterNavLink
-                                        label="AI Agents"
-                                        exact
-                                        to="/ai-agents/admin"
-                                        icon={<MantineIcon icon={IconBrain} />}
-                                    />
-                                )}
+                                {isAiCopilotEnabled?.enabled &&
+                                    user.ability.can(
+                                        'manage',
+                                        subject('AiAgent', {
+                                            organizationUuid:
+                                                organization.organizationUuid,
+                                        }),
+                                    ) && (
+                                        <RouterNavLink
+                                            label="AI Agents"
+                                            exact
+                                            to="/ai-agents/admin"
+                                            icon={
+                                                <MantineIcon icon={IconBrain} />
+                                            }
+                                        />
+                                    )}
                             </Box>
 
                             {organization &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17084

### Description:
Added a feature flag check for AI Agents in the Settings page. The AI Agents navigation link will now only be displayed when both the AiCopilot feature flag is enabled and the user has the appropriate permissions to manage AI Agents.