### PR TITLE
fix: include table calcs in pivot values columns

### DIFF
--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -17,7 +17,14 @@ import {
 
 // Jest provides describe/it/expect globals
 
-import { BinType, CustomDimensionType, type ItemsMap } from '../types/field';
+import {
+    BinType,
+    CustomDimensionType,
+    FieldType,
+    MetricType,
+    type ItemsMap,
+    type TableCalculation,
+} from '../types/field';
 import type { MetricQuery } from '../types/metricQuery';
 
 describe('derivePivotConfigurationFromChart', () => {
@@ -230,6 +237,283 @@ describe('derivePivotConfigurationFromChart', () => {
                     direction: SortByDirection.DESC,
                 },
             ],
+        });
+    });
+
+    describe('Table Calculations Support', () => {
+        const mockTableCalculation: TableCalculation = {
+            name: 'revenue_per_order',
+            displayName: 'Revenue per Order',
+            sql: '${payments_total_revenue} / ${orders_count}',
+        };
+
+        const mockTableCalculation2: TableCalculation = {
+            name: 'revenue_growth',
+            displayName: 'Revenue Growth',
+            sql: '(${payments_total_revenue} - LAG(${payments_total_revenue})) / LAG(${payments_total_revenue})',
+        };
+
+        it('includes table calculations in valuesColumns for Table charts', () => {
+            const tableChartConfig = {
+                type: ChartType.TABLE,
+                config: {},
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: tableChartConfig,
+                pivotConfig: {
+                    columns: ['payments_payment_method'],
+                },
+            };
+
+            const metricQueryWithTC: MetricQuery = {
+                ...mockMetricQuery,
+                tableCalculations: [
+                    mockTableCalculation,
+                    mockTableCalculation2,
+                ],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                metricQueryWithTC,
+                mockItems,
+            );
+
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+                {
+                    reference: 'revenue_per_order',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+                {
+                    reference: 'revenue_growth',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+        });
+
+        it('includes table calculations in valuesColumns for Cartesian charts when in yField', () => {
+            const cartesianChartWithTC: CartesianChartConfig = {
+                type: ChartType.CARTESIAN,
+                config: {
+                    layout: {
+                        xField: 'payments_payment_method',
+                        yField: ['payments_total_revenue', 'revenue_per_order'],
+                    },
+                    eChartsConfig: { series: [] },
+                },
+            };
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: cartesianChartWithTC,
+                pivotConfig: { columns: ['orders_status'] },
+            };
+
+            const metricQueryWithTC: MetricQuery = {
+                ...mockMetricQuery,
+                tableCalculations: [mockTableCalculation],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                metricQueryWithTC,
+                mockItems,
+            );
+
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+                {
+                    reference: 'revenue_per_order',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+        });
+
+        it('filters out table calculations not in yField for Cartesian charts', () => {
+            const cartesianChartWithTC: CartesianChartConfig = {
+                type: ChartType.CARTESIAN,
+                config: {
+                    layout: {
+                        xField: 'payments_payment_method',
+                        yField: ['payments_total_revenue'], // Only metric, not the table calc
+                    },
+                    eChartsConfig: { series: [] },
+                },
+            };
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: cartesianChartWithTC,
+                pivotConfig: { columns: ['orders_status'] },
+            };
+
+            const metricQueryWithTC: MetricQuery = {
+                ...mockMetricQuery,
+                tableCalculations: [mockTableCalculation], // TC exists but not in yField
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                metricQueryWithTC,
+                mockItems,
+            );
+
+            // Should only include the metric that's actually in yField
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+        });
+
+        it('handles mixed metrics and table calculations in Table charts', () => {
+            const tableChartConfig = {
+                type: ChartType.TABLE,
+                config: {},
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: tableChartConfig,
+                pivotConfig: {
+                    columns: ['orders_status'],
+                },
+            };
+
+            // Add another metric to mockItems
+            const itemsWithMoreMetrics: ItemsMap = {
+                ...mockItems,
+                orders_count: {
+                    sql: 'COUNT(${TABLE}.order_id)',
+                    name: 'count',
+                    type: MetricType.COUNT,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    label: 'Order Count',
+                    hidden: false,
+                    index: 0,
+                    filters: [],
+                    groups: [],
+                },
+            };
+
+            const metricQueryWithMixed: MetricQuery = {
+                ...mockMetricQuery,
+                metrics: ['payments_total_revenue', 'orders_count'],
+                tableCalculations: [mockTableCalculation],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                metricQueryWithMixed,
+                itemsWithMoreMetrics,
+            );
+
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+                {
+                    reference: 'orders_count',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+                {
+                    reference: 'revenue_per_order',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+        });
+
+        it('handles empty table calculations array', () => {
+            const tableChartConfig = {
+                type: ChartType.TABLE,
+                config: {},
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: tableChartConfig,
+                pivotConfig: {
+                    columns: ['payments_payment_method'],
+                },
+            };
+
+            const metricQueryWithEmptyTC: MetricQuery = {
+                ...mockMetricQuery,
+                tableCalculations: [],
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                metricQueryWithEmptyTC,
+                mockItems,
+            );
+
+            // Should only have the metric
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+        });
+
+        it('handles undefined table calculations', () => {
+            const tableChartConfig = {
+                type: ChartType.TABLE,
+                config: {},
+            } as const;
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: tableChartConfig,
+                pivotConfig: {
+                    columns: ['payments_payment_method'],
+                },
+            };
+
+            const metricQueryNoTC: MetricQuery = {
+                ...mockMetricQuery,
+                // tableCalculations field is optional, so it can be undefined
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                metricQueryNoTC,
+                mockItems,
+            );
+
+            // Should only have the metric
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
         });
     });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17077 

### Description:

Table calculations were not being included in values columns used in pivoting. In the customer issue, the only column was a table calc, so the result was an error: `cannot get header values`. But the issue shows up if you try to use a table calc at all. 

Repro in main:
- In the orders explore select two dimensions an a metric
- Make a table calc that relies on the metric
- Pivot by a dimension
- Notice you dont see a column for the TC
- If you hide the metric, you'll get the error
- Here is a [localhost repro](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/orders?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_estimated_delivery_days%22%2C%22orders_order_date_month%22%5D%2C%22metrics%22%3A%5B%22orders_fulfillment_rate%22%2C%22orders_avg_shipping_cost%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_estimated_delivery_days%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%7B%22name%22%3A%22f_r%22%2C%22displayName%22%3A%22FR%22%2C%22sql%22%3A%22%24%7Borders.fulfillment_rate%7D+%2B+10%5Cn%22%2C%22format%22%3A%7B%22type%22%3A%22default%22%2C%22separator%22%3A%22default%22%7D%2C%22type%22%3A%22number%22%7D%2C%7B%22name%22%3A%22cost%22%2C%22displayName%22%3A%22Cost%22%2C%22sql%22%3A%22%24%7Borders.avg_shipping_cost%7D+-1+%22%2C%22format%22%3A%7B%22type%22%3A%22default%22%2C%22separator%22%3A%22default%22%7D%2C%22type%22%3A%22number%22%7D%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_estimated_delivery_days%22%2C%22orders_order_date_month%22%2C%22orders_fulfillment_rate%22%2C%22f_r%22%2C%22orders_avg_shipping_cost%22%2C%22cost%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22table%22%2C%22config%22%3A%7B%22showColumnCalculation%22%3Afalse%2C%22showRowCalculation%22%3Afalse%2C%22showTableNames%22%3Atrue%2C%22showResultsTotal%22%3Afalse%2C%22showSubtotals%22%3Afalse%2C%22columns%22%3A%7B%22cost%22%3A%7B%22visible%22%3Afalse%7D%2C%22f_r%22%3A%7B%22name%22%3A%22FR+TC%22%7D%2C%22orders_avg_shipping_cost%22%3A%7B%22visible%22%3Afalse%7D%2C%22orders_fulfillment_rate%22%3A%7B%22visible%22%3Afalse%7D%7D%2C%22hideRowNumbers%22%3Afalse%2C%22conditionalFormattings%22%3A%5B%5D%2C%22metricsAsRows%22%3Afalse%7D%7D%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22orders_estimated_delivery_days%22%5D%7D%7D)
