### PR TITLE
fix: chart config tooltip cut off

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -68,7 +68,7 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
                     Configure chart
                 </Text>
 
-                <Tooltip label="Close visualization config">
+                <Tooltip label="Close visualization config" position="right">
                     <ActionIcon size="sm" onClick={onClose}>
                         <MantineIcon icon={IconX} />
                     </ActionIcon>


### PR DESCRIPTION
### Description:

The tooltip to close chart config was cut off. This was bugging me. 

**Before**
<img width="559" height="302" alt="Screenshot 2025-09-25 at 17 40 38" src="https://github.com/user-attachments/assets/68401d71-1cc1-415a-9b2a-2753d4b6f1b3" />

**After**
<img width="649" height="318" alt="Screenshot 2025-09-25 at 17 40 16" src="https://github.com/user-attachments/assets/34111fa4-f2ca-4d0a-b3e0-29e8379c2cfd" />
