### PR TITLE
feat: add catalog search relations table for field-explore connections

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -123,6 +123,8 @@ import {
     AnalyticsDashboardViewsTableName,
 } from '../database/entities/analytics';
 import {
+    CatalogSearchRelationsTable,
+    CatalogSearchRelationsTableName,
     CatalogTable,
     CatalogTableName,
     CatalogTagsTable,
@@ -386,6 +388,7 @@ declare module 'knex/types/tables' {
         [NotificationsTableName]: NotificationsTable;
         [DashboardSummariesTableName]: DashboardSummariesTable;
         [CatalogTableName]: CatalogTable;
+        [CatalogSearchRelationsTableName]: CatalogSearchRelationsTable;
         [SlackChannelProjectMappingsTableName]: SlackChannelProjectMappingsTable;
         [WarehouseAvailableTablesTableName]: WarehouseAvailableTablesTable;
         [TagsTableName]: TagsTable;

--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -119,6 +119,20 @@ export type DbCatalogItemsMigrateIn = Pick<
 
 export const CatalogTagsTableName = 'catalog_search_tags';
 
+export const CatalogSearchRelationsTableName = 'catalog_search_relations';
+
+export type DbCatalogSearchRelation = {
+    explore_catalog_uuid: string;
+    field_catalog_uuid: string;
+};
+
+export type DbCatalogSearchRelationIn = DbCatalogSearchRelation;
+
+export type CatalogSearchRelationsTable = Knex.CompositeTableType<
+    DbCatalogSearchRelation,
+    DbCatalogSearchRelationIn
+>;
+
 export type DbMetricsTreeEdge = {
     source_metric_catalog_search_uuid: string;
     target_metric_catalog_search_uuid: string;

--- a/packages/backend/src/database/migrations/20250924111234_add_catalog_search_relations_table.ts
+++ b/packages/backend/src/database/migrations/20250924111234_add_catalog_search_relations_table.ts
@@ -1,0 +1,38 @@
+import { Knex } from 'knex';
+
+const CATALOG_SEARCH_RELATIONS_TABLE_NAME = 'catalog_search_relations';
+const CATALOG_SEARCH_TABLE_NAME = 'catalog_search';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(
+        CATALOG_SEARCH_RELATIONS_TABLE_NAME,
+        (table) => {
+            // Reference to the explore (table item in catalog_search)
+            table
+                .uuid('explore_catalog_uuid')
+                .notNullable()
+                .references('catalog_search_uuid')
+                .inTable(CATALOG_SEARCH_TABLE_NAME)
+                .onDelete('CASCADE');
+
+            // Reference to the field (field item in catalog_search)
+            table
+                .uuid('field_catalog_uuid')
+                .notNullable()
+                .references('catalog_search_uuid')
+                .inTable(CATALOG_SEARCH_TABLE_NAME)
+                .onDelete('CASCADE');
+
+            // Primary key on the combination
+            table.primary(['explore_catalog_uuid', 'field_catalog_uuid']);
+
+            // Add indexes for efficient queries
+            table.index('explore_catalog_uuid');
+            table.index('field_catalog_uuid');
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(CATALOG_SEARCH_RELATIONS_TABLE_NAME);
+}


### PR DESCRIPTION
### Description:
Added a new `catalog_search_relations` table to track relationships between explores and fields in the catalog. This table establishes connections between explore items and their associated fields, including fields from joined tables.

The implementation includes:
- New database migration to create the table with appropriate foreign keys and indexes
- Type definitions for the new table
- Logic to populate relations during catalog updates by linking fields to their own explores and to explores that join their tables

This enhancement will enable more efficient querying of related catalog items and improve the search experience by establishing explicit relationships between explores and fields.