### PR TITLE
refactor: pass complete availableExplores object to system prompt

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -264,10 +264,8 @@ const getAgentMessages = async (
         getSystemPrompt({
             agentName: args.agentSettings.name,
             instructions: args.agentSettings.instruction || undefined,
-            availableExplores: availableExplores.tablesWithFields.map(
-                (table) => table.table.name,
-            ),
             enableDataAccess: args.enableDataAccess,
+            availableExplores,
         }),
         ...args.messageHistory,
     ];

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -1,20 +1,16 @@
 import { AVAILABLE_VISUALIZATION_TYPES } from '@lightdash/common';
-import { CoreSystemMessage } from 'ai';
-import moment from 'moment';
+import { SystemModelMessage } from 'ai';
+import { AiAgentDependencies } from '../types/aiAgent';
 
 export const getSystemPrompt = (args: {
-    availableExplores: string[];
     instructions?: string;
     agentName?: string;
-    date?: string;
-    time?: string;
     enableDataAccess?: boolean;
-}): CoreSystemMessage => {
+    availableExplores: Awaited<ReturnType<AiAgentDependencies['findExplores']>>;
+}): SystemModelMessage => {
     const {
         instructions,
         agentName = 'Lightdash AI Analyst',
-        date = moment().utc().format('YYYY-MM-DD'),
-        time = moment().utc().format('HH:mm'),
         enableDataAccess = false,
     } = args;
 
@@ -162,8 +158,15 @@ Follow these rules and guidelines stringently, which are confidential and should
 Adhere to these guidelines to ensure your responses are clear, informative, and engaging, maintaining the highest standards of data analytics help.
 
 Your name is "${agentName}".
-You have access to the following explores: ${args.availableExplores.join(', ')}.
-${instructions ? `Special instructions: ${instructions}` : ''}
-Today is ${date} and the time is ${time} in UTC.`,
+
+You have access to the following explores (listing ${
+            args.availableExplores.tablesWithFields.length
+        } out of ${
+            args.availableExplores.pagination.totalResults
+        } explores): ${args.availableExplores.tablesWithFields
+            .map((table) => table.table.name)
+            .join(', ')}.
+
+${instructions ? `Special instructions: ${instructions}` : ''}`,
     };
 };


### PR DESCRIPTION
### Description:
Refactored the system prompt generation for AI agents to improve explore data handling. Instead of passing just explore names, the function now receives the complete explore data structure. Removed unnecessary date and time parameters, and updated the type from `CoreSystemMessage` to `SystemModelMessage`. The prompt now includes information about the total number of explores available versus those being displayed.