### PR TITLE
feat: add listExplores function for AI agent dependencies

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -253,11 +253,9 @@ const getAgentMessages = async (
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger('Agent Messages', 'Getting agent messages.');
 
-    const availableExplores = await dependencies.findExplores({
+    const availableExplores = await dependencies.listExplores({
         page: 1,
         pageSize: args.availableExploresPageSize,
-        tableName: null,
-        includeFields: false,
     });
 
     const messages = [

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -6,7 +6,7 @@ export const getSystemPrompt = (args: {
     instructions?: string;
     agentName?: string;
     enableDataAccess?: boolean;
-    availableExplores: Awaited<ReturnType<AiAgentDependencies['findExplores']>>;
+    availableExplores: Awaited<ReturnType<AiAgentDependencies['listExplores']>>;
 }): SystemModelMessage => {
     const {
         instructions,
@@ -159,13 +159,18 @@ Adhere to these guidelines to ensure your responses are clear, informative, and 
 
 Your name is "${agentName}".
 
-You have access to the following explores (listing ${
-            args.availableExplores.tablesWithFields.length
-        } out of ${
-            args.availableExplores.pagination.totalResults
-        } explores): ${args.availableExplores.tablesWithFields
-            .map((table) => table.table.name)
-            .join(', ')}.
+${
+    args.availableExplores.tables.length > 0
+        ? `You have access to the following explores (listing ${
+              args.availableExplores.tables.length
+          } out of ${
+              args.availableExplores.pagination.totalResults
+          } explores): ${args.availableExplores.tables
+              .map((table) => table.name)
+              .join(', ')}.
+`
+        : 'You have no access to any explores. Suggest the user to tag the project with the correct tags and redeploy the project.'
+}
 
 ${instructions ? `Special instructions: ${instructions}` : ''}`,
     };

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -10,6 +10,7 @@ import {
     FindFieldFn,
     GetExploreFn,
     GetPromptFn,
+    ListExploresFn,
     RunMiniMetricQueryFn,
     SearchFieldValuesFn,
     SendFileFn,
@@ -52,6 +53,7 @@ export type PerformanceMetrics = {
 };
 
 export type AiAgentDependencies = {
+    listExplores: ListExploresFn;
     findCharts: FindChartsFn;
     findDashboards: FindDashboardsFn;
     findExplores: FindExploresFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -28,6 +28,11 @@ type Pagination = KnexPaginateArgs & {
     totalResults: number;
 };
 
+export type ListExploresFn = (args: KnexPaginateArgs) => Promise<{
+    tables: CatalogTable[];
+    pagination: Pagination;
+}>;
+
 export type FindExploresFn = (
     args: {
         tableName: string | null;

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -99,6 +99,12 @@ export type CatalogTable = Pick<
 
 export type CatalogItem = CatalogField | CatalogTable;
 
+export const isCatalogField = (item: CatalogItem): item is CatalogField =>
+    item.type === CatalogType.Field;
+
+export const isCatalogTable = (item: CatalogItem): item is CatalogTable =>
+    item.type === CatalogType.Table;
+
 export type CatalogMetricsTreeNode = Pick<
     CatalogField,
     'catalogSearchUuid' | 'name' | 'tableName'


### PR DESCRIPTION

### Description:
This PR adds a new `listExplores` function to the AI agent dependencies, which is a simplified version of the existing `findExplores` function. The new function only requires pagination parameters and doesn't need table name or field inclusion parameters.

The PR also refactors the CatalogModel by extracting reusable query conditions into static methods (`whereTablesConfiguration`, `whereUserAttributes`, and `whereYamlTags`), making the code more maintainable. These extracted methods are then used in both the existing `search` method and the new `searchExplores` method.

Additionally, the system prompt has been updated to handle the case when no explores are available, providing a more helpful message to users in that scenario.