### PR TITLE
feat: add table calculation templates

### DIFF
--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -11,6 +11,7 @@ import {
     MetricFilterRule,
     MetricOverrides,
     MetricType,
+    TableCalculationTemplate,
     TableCalculationType,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -171,6 +172,7 @@ export type DbSavedChartTableCalculation = {
     saved_queries_version_id: number;
     format?: CustomFormat;
     type?: TableCalculationType;
+    template?: TableCalculationTemplate;
 };
 
 export type DbSavedChartTableCalculationInsert = Omit<

--- a/packages/backend/src/database/migrations/20250925130222_saved_chart_table_calculation_templates.ts
+++ b/packages/backend/src/database/migrations/20250925130222_saved_chart_table_calculation_templates.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(
+        'saved_queries_version_table_calculations',
+        (tableBuilder) => {
+            tableBuilder.jsonb('template').nullable();
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(
+        'saved_queries_version_table_calculations',
+        (tableBuilder) => {
+            tableBuilder.dropColumn('template');
+        },
+    );
+}

--- a/packages/backend/src/ee/services/AiService/utils/prepareData.ts
+++ b/packages/backend/src/ee/services/AiService/utils/prepareData.ts
@@ -7,6 +7,7 @@ import {
     isCustomSqlDimension,
     isField,
     isMetric,
+    isSqlTableCalculation,
     isTableCalculation,
     Item,
     ResultRow,
@@ -72,7 +73,10 @@ export function fieldDesc(fieldName: string, item: Item) {
     }
 
     if (isTableCalculation(item)) {
-        return ` - ${fieldName}: this column is a table calculation which will be the result of the following SQL \`${item.sql}\``;
+        if (isSqlTableCalculation(item)) {
+            return ` - ${fieldName}: this column is a table calculation which will be the result of the following SQL \`${item.sql}\``;
+        }
+        return ` - ${fieldName}: this column is a table calculation`;
     }
 
     if (isAdditionalMetric(item)) {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2375,18 +2375,183 @@ const models: TsoaRoute.Models = {
         enums: ['number', 'string', 'date', 'timestamp', 'boolean'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS': {
+        dataType: 'refEnum',
+        enums: ['percent_change_from_previous'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE': {
+        dataType: 'refEnum',
+        enums: ['percent_of_previous_value'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL': {
+        dataType: 'refEnum',
+        enums: ['percent_of_column_total'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'TableCalculationTemplateType.RANK_IN_COLUMN': {
+        dataType: 'refEnum',
+        enums: ['rank_in_column'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'TableCalculationTemplateType.RUNNING_TOTAL': {
+        dataType: 'refEnum',
+        enums: ['running_total'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TableCalculationTemplate: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        orderBy: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    order: {
+                                        dataType: 'union',
+                                        subSchemas: [
+                                            {
+                                                dataType: 'enum',
+                                                enums: ['asc'],
+                                            },
+                                            {
+                                                dataType: 'enum',
+                                                enums: ['desc'],
+                                            },
+                                            { dataType: 'enum', enums: [null] },
+                                        ],
+                                        required: true,
+                                    },
+                                    fieldId: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                },
+                            },
+                            required: true,
+                        },
+                        fieldId: { dataType: 'string', required: true },
+                        type: {
+                            ref: 'TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        orderBy: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    order: {
+                                        dataType: 'union',
+                                        subSchemas: [
+                                            {
+                                                dataType: 'enum',
+                                                enums: ['asc'],
+                                            },
+                                            {
+                                                dataType: 'enum',
+                                                enums: ['desc'],
+                                            },
+                                            { dataType: 'enum', enums: [null] },
+                                        ],
+                                        required: true,
+                                    },
+                                    fieldId: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                },
+                            },
+                            required: true,
+                        },
+                        fieldId: { dataType: 'string', required: true },
+                        type: {
+                            ref: 'TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        fieldId: { dataType: 'string', required: true },
+                        type: {
+                            ref: 'TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        fieldId: { dataType: 'string', required: true },
+                        type: {
+                            ref: 'TableCalculationTemplateType.RANK_IN_COLUMN',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        fieldId: { dataType: 'string', required: true },
+                        type: {
+                            ref: 'TableCalculationTemplateType.RUNNING_TOTAL',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     TableCalculation: {
         dataType: 'refAlias',
         type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                type: { ref: 'TableCalculationType' },
-                format: { ref: 'CustomFormat' },
-                sql: { dataType: 'string', required: true },
-                displayName: { dataType: 'string', required: true },
-                name: { dataType: 'string', required: true },
-                index: { dataType: 'double' },
-            },
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: { ref: 'TableCalculationType' },
+                        format: { ref: 'CustomFormat' },
+                        displayName: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        index: { dataType: 'double' },
+                    },
+                },
+                {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                sql: { dataType: 'string', required: true },
+                            },
+                        },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                template: {
+                                    ref: 'TableCalculationTemplate',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
             validators: {},
         },
     },

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -449,7 +449,7 @@ export const metricQueryMock: MetricQuery = {
         {
             name: 'tc',
             displayName: '',
-            sql: '',
+            sql: '1',
         },
     ],
 };

--- a/packages/backend/src/services/RenameService/rename.ts
+++ b/packages/backend/src/services/RenameService/rename.ts
@@ -18,6 +18,8 @@ import {
     isDashboardScheduler,
     isFilterRule,
     isOrFilterGroup,
+    isSqlTableCalculation,
+    isTemplateTableCalculation,
     MetricFilterRule,
     MetricQuery,
     NameChanges,
@@ -547,7 +549,21 @@ export const renameMetricQuery = (
         filters: renameFilters(metricQuery.filters, replaceId),
         tableCalculations: metricQuery.tableCalculations?.map((tc) => ({
             ...tc,
-            sql: replaceReference(tc.sql),
+            ...(isSqlTableCalculation(tc) && {
+                sql: replaceReference(tc.sql),
+            }),
+            ...(isTemplateTableCalculation(tc) && {
+                template: {
+                    ...tc.template,
+                    fieldId: replaceId(tc.template.fieldId),
+                    ...('orderBy' in tc.template && {
+                        orderBy: tc.template.orderBy.map((o) => ({
+                            ...o,
+                            fieldId: replaceId(o.fieldId),
+                        })),
+                    }),
+                },
+            }),
         })),
         additionalMetrics: metricQuery.additionalMetrics?.map((am) => ({
             ...am,

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -17,6 +17,8 @@ import {
     InlineErrorType,
     isDashboardFieldTarget,
     isExploreError,
+    isSqlTableCalculation,
+    isTemplateTableCalculation,
     isValidationTargetValid,
     OrganizationMemberRole,
     RequestMethod,
@@ -100,10 +102,23 @@ export class ValidationService extends BaseService {
         >((acc, tc) => {
             const regex = /\$\{([^}]+)\}/g;
 
-            const fieldsInSql = tc.sql.match(regex);
-            if (fieldsInSql != null) {
-                return [...acc, ...fieldsInSql.map(parseTableField)];
+            if (isSqlTableCalculation(tc)) {
+                const fieldsInSql = tc.sql.match(regex);
+                if (fieldsInSql != null) {
+                    return [...acc, ...fieldsInSql.map(parseTableField)];
+                }
             }
+
+            if (isTemplateTableCalculation(tc)) {
+                const fieldsInTemplate = [
+                    tc.template.fieldId,
+                    ...('orderBy' in tc.template
+                        ? tc.template.orderBy.map((o) => o.fieldId)
+                        : []),
+                ];
+                return [...acc, ...fieldsInTemplate];
+            }
+
             return acc;
         }, []);
         return tableCalculationFieldsInSql;

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -86,6 +86,7 @@ export const warehouseClientMock: WarehouseClient = {
         }
     },
     getFieldQuoteChar: () => '"',
+    getFloatingType: () => 'FLOAT',
     getAdapterType: () => SupportedDbtAdapter.POSTGRES,
     concatString: (...args) => `(${args.join(' || ')})`,
     getAllTables(
@@ -129,6 +130,7 @@ export const bigqueryClientMock: WarehouseClient = {
         type: WarehouseTypes.BIGQUERY,
     } as CreateWarehouseCredentials,
     getFieldQuoteChar: () => '`',
+    getFloatingType: () => 'FLOAT64',
     getCatalog: async () => ({
         default: {
             public: {

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -63,6 +63,7 @@ export const warehouseClientMock: WarehouseClient = {
     getFieldQuoteChar: () => '"',
     getStringQuoteChar: () => "'",
     getEscapeStringQuoteChar: () => "'",
+    getFloatingType: () => 'FLOAT',
     getAdapterType: () => SupportedDbtAdapter.POSTGRES,
     getMetricSql: (sql, metric) => {
         switch (metric.type) {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -313,14 +313,58 @@ export enum TableCalculationType {
     BOOLEAN = 'boolean',
 }
 
+export enum TableCalculationTemplateType {
+    PERCENT_CHANGE_FROM_PREVIOUS = 'percent_change_from_previous',
+    PERCENT_OF_PREVIOUS_VALUE = 'percent_of_previous_value',
+    PERCENT_OF_COLUMN_TOTAL = 'percent_of_column_total',
+    RANK_IN_COLUMN = 'rank_in_column',
+    RUNNING_TOTAL = 'running_total',
+}
+
+export type TableCalculationTemplate =
+    | {
+          type: TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS;
+          fieldId: string;
+          orderBy: {
+              fieldId: string;
+              order: 'asc' | 'desc' | null;
+          }[];
+      }
+    | {
+          type: TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE;
+          fieldId: string;
+          orderBy: {
+              fieldId: string;
+              order: 'asc' | 'desc' | null;
+          }[];
+      }
+    | {
+          type: TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL;
+          fieldId: string;
+      }
+    | {
+          type: TableCalculationTemplateType.RANK_IN_COLUMN;
+          fieldId: string;
+      }
+    | {
+          type: TableCalculationTemplateType.RUNNING_TOTAL;
+          fieldId: string;
+      };
+
 export type TableCalculation = {
     index?: number;
     name: string;
     displayName: string; // This is a unique property of the table calculation
-    sql: string;
     format?: CustomFormat;
     type?: TableCalculationType;
-};
+} & (
+    | {
+          sql: string;
+      }
+    | {
+          template: TableCalculationTemplate;
+      }
+);
 
 export type TableCalculationMetadata = {
     oldName: string;
@@ -339,11 +383,22 @@ export const isTableCalculation = (
 ): item is TableCalculation =>
     item
         ? !isCustomDimension(item) &&
-          !!('sql' in item && item.sql) &&
+          (!!('sql' in item && item.sql) ||
+              !!('template' in item && item.template)) &&
           !('description' in item) &&
           !('tableName' in item) &&
           'displayName' in item
         : false;
+
+export const isSqlTableCalculation = (
+    calc: TableCalculation,
+): calc is TableCalculation & { sql: string } =>
+    !!calc && 'sql' in calc && !!calc.sql && calc.sql.length > 0;
+
+export const isTemplateTableCalculation = (
+    calc: TableCalculation,
+): calc is TableCalculation & { template: TableCalculationTemplate } =>
+    !!calc && 'template' in calc && !!calc.template;
 
 export type CompiledTableCalculation = TableCalculation & {
     compiledSql: string;

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -90,6 +90,7 @@ export interface WarehouseSqlBuilder {
     getStringQuoteChar: () => string;
     getEscapeStringQuoteChar: () => string;
     getFieldQuoteChar: () => string;
+    getFloatingType: () => string;
     getMetricSql: (sql: string, metric: Metric) => string;
     concatString: (...args: string[]) => string;
     escapeString: (value: string) => string;

--- a/packages/common/src/utils/convertCustomDimensionsToYaml.ts
+++ b/packages/common/src/utils/convertCustomDimensionsToYaml.ts
@@ -121,6 +121,9 @@ const warehouseClientMock: WarehouseClient = {
     getFieldQuoteChar() {
         return '"';
     },
+    getFloatingType() {
+        return 'FLOAT';
+    },
     escapeString(value) {
         return value;
     },

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -112,6 +112,7 @@ export const createTemporaryVirtualView = (
         getStringQuoteChar: () => "'",
         getEscapeStringQuoteChar: () => "''",
         getFieldQuoteChar: () => '"',
+        getFloatingType: () => 'FLOAT',
         getMetricSql: () => '',
         concatString: (...args) => args.join(''),
         getAllTables: async () => [],

--- a/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
@@ -1,64 +1,56 @@
 import {
     CustomFormatType,
     MetricType,
-    WarehouseTypes,
+    TableCalculationTemplateType,
     assertUnreachable,
-    getFieldQuoteChar,
     type CustomFormat,
     type Metric,
-    type SortField,
     type TableCalculation,
 } from '@lightdash/common';
 import { Menu } from '@mantine/core';
 import { type FC } from 'react';
-import { useParams } from 'react-router';
 import { getUniqueTableCalculationName } from '../../../features/tableCalculation/utils';
-import { useProject } from '../../../hooks/useProject';
+import { TemplateTypeLabels } from '../../../features/tableCalculation/utils/templateFormatting';
 import useExplorerContext from '../../../providers/Explorer/useExplorerContext';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import { generateTableCalculationTemplate } from './tableCalculationTemplateGenerator';
 
 type Props = {
     item: Metric;
 };
 
-enum QuickCalculation {
-    PERCENT_CHANGE_FROM_PREVIOUS = `Percent change from previous`,
-    PERCENT_OF_PREVIOUS_VALUE = `Percent of previous value`,
-    PERCENT_OF_COLUMN_TOTAL = `Percent of column total`,
-    RANK_IN_COLUMN = `Rank in column`,
-    RUNNING_TOTAL = `Running total`,
-}
+// Use shared template labels from utilities
 
 const getFormatForQuickCalculation = (
-    quickCalculation: QuickCalculation,
+    templateType: TableCalculationTemplateType,
 ): CustomFormat | undefined => {
-    switch (quickCalculation) {
-        case QuickCalculation.PERCENT_CHANGE_FROM_PREVIOUS:
-        case QuickCalculation.PERCENT_OF_PREVIOUS_VALUE:
-        case QuickCalculation.PERCENT_OF_COLUMN_TOTAL:
+    switch (templateType) {
+        case TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS:
+        case TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE:
+        case TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL:
             return {
                 type: CustomFormatType.PERCENT,
                 round: 2,
             };
-        case QuickCalculation.RANK_IN_COLUMN:
+        case TableCalculationTemplateType.RANK_IN_COLUMN:
             return undefined;
-        case QuickCalculation.RUNNING_TOTAL:
+        case TableCalculationTemplateType.RUNNING_TOTAL:
             return {
                 type: CustomFormatType.NUMBER,
                 round: 2,
             };
         default:
             assertUnreachable(
-                quickCalculation,
-                `Unknown quick calculation ${quickCalculation}`,
+                templateType,
+                `Unknown template type ${templateType}`,
             );
     }
     return undefined;
 };
 
 const isCalculationAvailable = (
-    quickCalculation: QuickCalculation,
+    templateType: TableCalculationTemplateType,
     item: Metric,
 ) => {
     const numericTypes: string[] = [
@@ -71,96 +63,27 @@ const isCalculationAvailable = (
         MetricType.SUM,
         // MIN and MAX can be of non-numeric types, like dates
     ];
-    switch (quickCalculation) {
-        case QuickCalculation.PERCENT_CHANGE_FROM_PREVIOUS:
-        case QuickCalculation.PERCENT_OF_PREVIOUS_VALUE:
-        case QuickCalculation.PERCENT_OF_COLUMN_TOTAL:
-        case QuickCalculation.RUNNING_TOTAL:
+    switch (templateType) {
+        case TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS:
+        case TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE:
+        case TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL:
+        case TableCalculationTemplateType.RUNNING_TOTAL:
             return numericTypes.includes(item.type);
-        case QuickCalculation.RANK_IN_COLUMN:
+        case TableCalculationTemplateType.RANK_IN_COLUMN:
             return true; // any type
 
         default:
-            assertUnreachable(
-                quickCalculation,
-                `Unknown quick calculation ${quickCalculation}`,
+            return assertUnreachable(
+                templateType,
+                `Unknown template type ${templateType}`,
             );
     }
-    return '';
-};
-
-const getFloatingType = (warehouseType: WarehouseTypes | undefined) => {
-    switch (warehouseType) {
-        case WarehouseTypes.BIGQUERY:
-            return 'FLOAT64';
-        case WarehouseTypes.TRINO:
-            return 'DOUBLE';
-        default:
-            return 'FLOAT';
-    }
-};
-
-const getSqlForQuickCalculation = (
-    quickCalculation: QuickCalculation,
-    fieldReference: string,
-    sorts: SortField[],
-    warehouseType: WarehouseTypes | undefined,
-) => {
-    const fieldQuoteChar = getFieldQuoteChar(warehouseType);
-    const floatType = getFloatingType(warehouseType);
-    const orderSql = (reverseSorting: boolean = false) =>
-        sorts.length > 0
-            ? `ORDER BY ${sorts
-                  .map((sort) => {
-                      const fieldSort = sort.descending ? 'DESC' : 'ASC';
-                      const reverseSort = sort.descending ? 'ASC' : 'DESC';
-                      const sortOrder = reverseSorting
-                          ? reverseSort
-                          : fieldSort;
-                      return `${fieldQuoteChar}${sort.fieldId}${fieldQuoteChar} ${sortOrder}`;
-                  })
-                  .join(', ')} `
-            : '';
-
-    switch (quickCalculation) {
-        case QuickCalculation.PERCENT_CHANGE_FROM_PREVIOUS:
-            return `(
-               CAST( \${${fieldReference}} AS ${floatType}) /
-               CAST(NULLIF(LAG(\${${fieldReference}}) OVER(${orderSql(
-                true,
-            )}) ,0)  AS ${floatType})
-            ) - 1`;
-        case QuickCalculation.PERCENT_OF_PREVIOUS_VALUE:
-            return `(
-              CAST(\${${fieldReference}} AS ${floatType}) /
-              CAST(NULLIF(LAG(\${${fieldReference}}) OVER(${orderSql(
-                true,
-            )}),0) AS ${floatType})
-            )`;
-        case QuickCalculation.PERCENT_OF_COLUMN_TOTAL:
-            return `(
-              CAST(\${${fieldReference}} AS ${floatType}) /
-              CAST(NULLIF(SUM(\${${fieldReference}}) OVER(),0) AS ${floatType})
-            )`;
-        case QuickCalculation.RANK_IN_COLUMN:
-            return `RANK() OVER(ORDER BY \${${fieldReference}} ASC)`;
-        case QuickCalculation.RUNNING_TOTAL:
-            return `SUM(\${${fieldReference}}) OVER(ORDER BY \${${fieldReference}} DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`;
-        default:
-            assertUnreachable(
-                quickCalculation,
-                `Unknown quick calculation ${quickCalculation}`,
-            );
-    }
-    return '';
 };
 
 const QuickCalculationMenuOptions: FC<Props> = ({ item }) => {
     const addTableCalculation = useExplorerContext(
         (context) => context.actions.addTableCalculation,
     );
-    const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { data: project } = useProject(projectUuid);
     const { track } = useTracking();
     const onCreate = (value: TableCalculation) => {
         addTableCalculation(value);
@@ -179,38 +102,48 @@ const QuickCalculationMenuOptions: FC<Props> = ({ item }) => {
         (sort) => !tableCalculations.some((tc) => tc.name === sort.fieldId),
     );
 
+    const handleQuickCalculation = (
+        templateType: TableCalculationTemplateType,
+    ) => {
+        const displayName = TemplateTypeLabels[templateType];
+        const name = `${displayName} of ${item.label}`;
+        const uniqueName = getUniqueTableCalculationName(
+            name,
+            tableCalculations,
+        );
+
+        const template = generateTableCalculationTemplate(
+            {
+                type: templateType,
+                field: item,
+                name: uniqueName,
+                displayName: name,
+            },
+            orderWithoutTableCalculations,
+        );
+
+        onCreate({
+            name: uniqueName,
+            displayName: name,
+            template,
+            format: getFormatForQuickCalculation(templateType),
+        });
+    };
+
     return (
         <>
             <Menu.Label>Add quick calculation</Menu.Label>
 
-            {Object.values(QuickCalculation).map((quickCalculation) => {
-                const fieldReference = `${item.table}.${item.name}`;
-                if (!isCalculationAvailable(quickCalculation, item))
-                    return null;
+            {Object.values(TableCalculationTemplateType).map((templateType) => {
+                if (!isCalculationAvailable(templateType, item)) return null;
+
+                const displayName = TemplateTypeLabels[templateType];
                 return (
                     <Menu.Item
-                        key={quickCalculation}
-                        onClick={() => {
-                            const name = `${quickCalculation} of ${item.label}`;
-                            onCreate({
-                                name: getUniqueTableCalculationName(
-                                    name,
-                                    tableCalculations,
-                                ),
-                                displayName: name,
-                                sql: getSqlForQuickCalculation(
-                                    quickCalculation as QuickCalculation,
-                                    fieldReference,
-                                    orderWithoutTableCalculations,
-                                    project?.warehouseConnection?.type,
-                                ),
-                                format: getFormatForQuickCalculation(
-                                    quickCalculation as QuickCalculation,
-                                ),
-                            });
-                        }}
+                        key={templateType}
+                        onClick={() => handleQuickCalculation(templateType)}
                     >
-                        {quickCalculation}
+                        {displayName}
                     </Menu.Item>
                 );
             })}

--- a/packages/frontend/src/components/Explorer/ResultsCard/tableCalculationTemplateGenerator.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/tableCalculationTemplateGenerator.ts
@@ -1,0 +1,72 @@
+import {
+    TableCalculationTemplateType,
+    assertUnreachable,
+    getItemId,
+    type Field,
+    type SortField,
+    type TableCalculationTemplate,
+} from '@lightdash/common';
+
+interface QuickCalculationConfig {
+    type: TableCalculationTemplateType;
+    field: Field;
+    name: string;
+    displayName: string;
+}
+
+function mapSortsToOrderBy(sorts: SortField[]): {
+    fieldId: string;
+    order: 'asc' | 'desc' | null;
+}[] {
+    if (!sorts || sorts.length === 0) return [];
+
+    return sorts.map((sort) => ({
+        fieldId: sort.fieldId,
+        order: (sort.descending ? 'asc' : 'desc') as 'asc' | 'desc',
+    }));
+}
+
+export function generateTableCalculationTemplate(
+    config: QuickCalculationConfig,
+    currentSorts: SortField[],
+): TableCalculationTemplate {
+    const { type, field } = config;
+    const fieldId = getItemId(field);
+
+    switch (type) {
+        case TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS:
+            return {
+                type: TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS,
+                fieldId,
+                orderBy: mapSortsToOrderBy(currentSorts),
+            };
+
+        case TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE:
+            return {
+                type: TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE,
+                fieldId,
+                orderBy: mapSortsToOrderBy(currentSorts),
+            };
+
+        case TableCalculationTemplateType.RUNNING_TOTAL:
+            return {
+                type: TableCalculationTemplateType.RUNNING_TOTAL,
+                fieldId,
+            };
+
+        case TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL:
+            return {
+                type: TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL,
+                fieldId,
+            };
+
+        case TableCalculationTemplateType.RANK_IN_COLUMN:
+            return {
+                type: TableCalculationTemplateType.RANK_IN_COLUMN,
+                fieldId,
+            };
+
+        default:
+            return assertUnreachable(type, `Unknown template type`);
+    }
+}

--- a/packages/frontend/src/features/tableCalculation/components/TemplateViewer/TemplateViewer.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TemplateViewer/TemplateViewer.tsx
@@ -1,0 +1,85 @@
+import {
+    friendlyName,
+    getFieldLabel,
+    type TableCalculationTemplate,
+} from '@lightdash/common';
+import { Badge, Group, Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
+import { useColumns } from '../../../../hooks/useColumns';
+import {
+    formatTemplateType,
+    getTemplateDescription,
+} from '../../utils/templateFormatting';
+
+interface TemplateViewerProps {
+    template?: TableCalculationTemplate;
+    readOnly: true;
+}
+
+export const TemplateViewer: FC<TemplateViewerProps> = ({ template }) => {
+    const columns = useColumns();
+
+    if (!template) {
+        return (
+            <Text c="dimmed" size="sm">
+                No template available
+            </Text>
+        );
+    }
+
+    const getLabel = (fieldId: string) => {
+        const field = columns.find((c) => c.id === fieldId)?.meta?.item;
+
+        return field && 'label' in field
+            ? getFieldLabel(field)
+            : friendlyName(template.fieldId);
+    };
+
+    const fieldLabel = getLabel(template.fieldId);
+
+    return (
+        <Stack spacing="md">
+            <Stack spacing="xs">
+                <Group>
+                    <Text fw={600} size="sm">
+                        Type:
+                    </Text>
+                    <Badge color="blue" variant="light">
+                        {formatTemplateType(template.type)}
+                    </Badge>
+                </Group>
+
+                <Text size="sm" c="dimmed">
+                    {getTemplateDescription(template.type)}
+                </Text>
+            </Stack>
+
+            <Group>
+                <Text fw={600} size="sm">
+                    Field:
+                </Text>
+                {fieldLabel}
+            </Group>
+
+            {'orderBy' in template &&
+                template.orderBy &&
+                template.orderBy.length > 0 && (
+                    <Group>
+                        <Text fw={600} size="sm">
+                            Order By:
+                        </Text>
+                        <Text size="sm">
+                            {template.orderBy
+                                .map(
+                                    ({ fieldId, order }) =>
+                                        `${getLabel(fieldId)} ${
+                                            order?.toUpperCase() || 'ASC'
+                                        }`,
+                                )
+                                .join(', ')}
+                        </Text>
+                    </Group>
+                )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/tableCalculation/utils/templateFormatting.ts
+++ b/packages/frontend/src/features/tableCalculation/utils/templateFormatting.ts
@@ -1,0 +1,41 @@
+import {
+    assertUnreachable,
+    TableCalculationTemplateType,
+} from '@lightdash/common';
+
+export const TemplateTypeLabels: Record<TableCalculationTemplateType, string> =
+    {
+        [TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS]:
+            'Percent change from previous',
+        [TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE]:
+            'Percent of previous value',
+        [TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL]:
+            'Percent of column total',
+        [TableCalculationTemplateType.RANK_IN_COLUMN]: 'Rank in column',
+        [TableCalculationTemplateType.RUNNING_TOTAL]: 'Running total',
+    };
+
+export const formatTemplateType = (
+    type: TableCalculationTemplateType,
+): string => {
+    return TemplateTypeLabels[type] || type;
+};
+
+export const getTemplateDescription = (
+    type: TableCalculationTemplateType,
+): string => {
+    switch (type) {
+        case TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS:
+            return 'Calculates the percentage change from the previous row value.';
+        case TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE:
+            return 'Shows the current value as a percentage of the previous row value.';
+        case TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL:
+            return 'Shows each value as a percentage of the column total.';
+        case TableCalculationTemplateType.RANK_IN_COLUMN:
+            return 'Ranks values within the column from highest to lowest.';
+        case TableCalculationTemplateType.RUNNING_TOTAL:
+            return 'Calculates a cumulative sum across rows.';
+        default:
+            return assertUnreachable(type, `Unknown template type`);
+    }
+};

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.test.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.test.tsx
@@ -4,6 +4,7 @@ import {
     CustomFormatType,
     FilterOperator,
     getItemId,
+    isSqlTableCalculation,
     type ChartConfig,
     type Filters,
     type SortField,
@@ -1464,9 +1465,10 @@ describe('ExplorerProvider reducer', () => {
             //     newState.unsavedChartVersion.metricQuery.filters.metrics
             //         ?.and?.[0]?.target?.fieldId,
             // ).toBe('orders_revenue_new');
+            const tableCalc =
+                newState.unsavedChartVersion.metricQuery.tableCalculations[0];
             expect(
-                newState.unsavedChartVersion.metricQuery.tableCalculations[0]
-                    .sql,
+                isSqlTableCalculation(tableCalc) ? tableCalc.sql : '',
             ).toContain('${orders.revenue_new}');
             expect(
                 newState.unsavedChartVersion.tableConfig.columnOrder,

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -6,6 +6,7 @@ import {
     getAvailableParametersFromTables,
     getFieldRef,
     getItemId,
+    isSqlTableCalculation,
     isTimeZone,
     lightdashVariablePattern,
     maybeReplaceFieldsInChartVersion,
@@ -570,6 +571,10 @@ export function reducer(
                 draft.unsavedChartVersion.metricQuery.tableCalculations =
                     draft.unsavedChartVersion.metricQuery.tableCalculations.map(
                         (tableCalculation) => {
+                            if (!isSqlTableCalculation(tableCalculation)) {
+                                return tableCalculation;
+                            }
+
                             const newSql = tableCalculation.sql.replace(
                                 lightdashVariablePattern,
                                 (_, fieldRef) => {

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -156,6 +156,10 @@ export class BigquerySqlBuilder extends WarehouseBaseSqlBuilder {
         return '`';
     }
 
+    getFloatingType(): string {
+        return 'FLOAT64';
+    }
+
     escapeString(value: string): string {
         if (typeof value !== 'string') {
             return value;

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -190,6 +190,10 @@ export class TrinoSqlBuilder extends WarehouseBaseSqlBuilder {
         }
     }
 
+    getFloatingType(): string {
+        return 'DOUBLE';
+    }
+
     escapeString(value: string): string {
         if (typeof value !== 'string') {
             return value;

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -46,6 +46,10 @@ export default abstract class WarehouseBaseClient<
         return this.sqlBuilder.getFieldQuoteChar();
     }
 
+    getFloatingType(): string {
+        return this.sqlBuilder.getFloatingType();
+    }
+
     abstract getCatalog(
         config: { database: string; schema: string; table: string }[],
     ): Promise<WarehouseCatalog>;

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseSqlBuilder.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseSqlBuilder.ts
@@ -34,6 +34,10 @@ export default abstract class WarehouseBaseSqlBuilder
         return '\\';
     }
 
+    getFloatingType(): string {
+        return 'FLOAT';
+    }
+
     getMetricSql(sql: string, metric: Metric): string {
         return getDefaultMetricSql(sql, metric.type);
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR adds support for table calculation templates, allowing users to create calculations using predefined formulas instead of writing raw SQL. The implementation includes:

- Added a new `template` field to the `saved_queries_version_table_calculations` table
- Created a `TableCalculationTemplate` type with support for 5 template types:
  - Percent change from previous
  - Percent of previous value
  - Percent of column total
  - Rank in column
  - Running total
- Updated the Quick Calculations menu to use templates instead of generating SQL
- Added a template viewer in the table calculation modal
- Implemented SQL generation from templates at query compilation time
- Updated validation and rename services to handle template-based calculations

This makes it easier for users to create common calculations without needing to write SQL, while maintaining backward compatibility with existing SQL-based calculations.
