### PR TITLE
fix: check if ai copilot enable for ff-required orgs

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -114,7 +114,12 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             throw new Error('User is required to check if AI agent is enabled');
         }
 
-        if (!this.lightdashConfig.ai.copilot.enabled) {
+        const { enabled: isAiCopilotEnabled } = await this.getAiCopilotFlag({
+            featureFlagId,
+            user,
+        });
+
+        if (!isAiCopilotEnabled) {
             return {
                 id: featureFlagId,
                 enabled: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactors the AI agent enablement check in `CommercialFeatureFlagModel` to use the `getAiCopilotFlag` method instead of directly accessing the config. This ensures consistent flag checking behavior throughout the application.

The PR replaces the direct config check with a proper feature flag lookup that considers user-specific settings when determining if the AI copilot feature is enabled.