### PR TITLE
chore: track ai agent tool calling

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1408,6 +1408,20 @@ export type McpToolCallEvent = BaseTrack & {
     };
 };
 
+export type AiAgentToolCallEvent = BaseTrack & {
+    event: 'ai_agent_tool_call';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        aiAgentId: string;
+        agentName: string;
+        toolName: string;
+        threadId: string;
+        promptId: string;
+    };
+};
+
 type TypedEvent =
     | TrackSimpleEvent
     | CreateUserEvent
@@ -1505,7 +1519,8 @@ type TypedEvent =
     | AiAgentEvalCreatedEvent
     | AiAgentEvalRunEvent
     | AiAgentEvalAppendedEvent
-    | McpToolCallEvent;
+    | McpToolCallEvent
+    | AiAgentToolCallEvent;
 
 type UntypedEvent<T extends BaseTrack> = Omit<BaseTrack, 'event'> &
     T & {

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -70,6 +70,7 @@ import {
     AiAgentPromptCreatedEvent,
     AiAgentPromptFeedbackEvent,
     AiAgentResponseStreamed,
+    AiAgentToolCallEvent,
     AiAgentUpdatedEvent,
     LightdashAnalytics,
 } from '../../analytics/LightdashAnalytics';
@@ -2080,8 +2081,9 @@ export class AiAgentService {
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
             ) => this.aiAgentModel.updateModelResponse(update),
-            trackEvent: (event: AiAgentResponseStreamed) =>
-                this.analytics.track(event),
+            trackEvent: (
+                event: AiAgentResponseStreamed | AiAgentToolCallEvent,
+            ) => this.analytics.track(event),
 
             createOrUpdateArtifact: (data) =>
                 this.aiAgentModel.createOrUpdateArtifact(data),

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -356,8 +356,22 @@ export const generateAgentResponse = async ({
                                         toolCall.input,
                                     )})`,
                                 );
-                            }
-                            if (toolCall) {
+
+                                dependencies.trackEvent({
+                                    event: 'ai_agent_tool_call',
+                                    userId: args.userId,
+                                    properties: {
+                                        organizationId: args.organizationId,
+                                        projectId:
+                                            args.agentSettings.projectUuid,
+                                        aiAgentId: args.agentSettings.uuid,
+                                        agentName: args.agentSettings.name,
+                                        toolName: toolCall.toolName,
+                                        threadId: args.threadUuid,
+                                        promptId: args.promptUuid,
+                                    },
+                                });
+
                                 await dependencies.storeToolCall({
                                     promptUuid: args.promptUuid,
                                     toolCallId: toolCall.toolCallId,
@@ -481,6 +495,22 @@ export const streamAgentResponse = async ({
                                 event.chunk.toolCallId
                             }) (ARGS: ${JSON.stringify(event.chunk.input)})`,
                         );
+
+                        // Track tool call analytics
+                        dependencies.trackEvent({
+                            event: 'ai_agent_tool_call',
+                            userId: args.userId,
+                            properties: {
+                                organizationId: args.organizationId,
+                                projectId: args.agentSettings.projectUuid,
+                                aiAgentId: args.agentSettings.uuid,
+                                agentName: args.agentSettings.name,
+                                toolName: event.chunk.toolName,
+                                threadId: args.threadUuid,
+                                promptId: args.promptUuid,
+                            },
+                        });
+
                         void dependencies
                             .storeToolCall({
                                 promptUuid: args.promptUuid,

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -20,7 +20,10 @@ import {
     UpdateSlackResponse,
     UpdateWebAppResponse,
 } from '@lightdash/common';
-import { AiAgentResponseStreamed } from '../../../../analytics/LightdashAnalytics';
+import {
+    AiAgentResponseStreamed,
+    AiAgentToolCallEvent,
+} from '../../../../analytics/LightdashAnalytics';
 import { PostSlackFile } from '../../../../clients/Slack/SlackClient';
 
 type Pagination = KnexPaginateArgs & {
@@ -112,7 +115,9 @@ export type StoreToolResultsFn = (
     }>,
 ) => Promise<void>;
 
-export type TrackEventFn = (event: AiAgentResponseStreamed) => void;
+export type TrackEventFn = (
+    event: AiAgentResponseStreamed | AiAgentToolCallEvent,
+) => void;
 
 export type SearchFieldValuesFn = (args: {
     table: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Added tracking for AI agent tool calls with `AiAgentToolCallEvent` 
- tracking details such as the organization, project, agent, tool name, and thread information. 

![Screenshot 2025-09-26 at 15.01.32.png](https://app.graphite.dev/user-attachments/assets/a85339d9-4a63-4cf5-ba87-55e13db869d5.png)

![Screenshot 2025-09-26 at 15.01.28.png](https://app.graphite.dev/user-attachments/assets/cf157875-acdf-4575-95d6-4cbc23054de8.png)

