### PR TITLE
feat: migrate ResultsCard to use Redux store

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -4,8 +4,12 @@ import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import {
     explorerActions,
+    selectColumnOrder,
     selectIsEditMode,
     selectIsResultsExpanded,
+    selectMetricQuery,
+    selectSorts,
+    selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
@@ -32,35 +36,27 @@ const ResultsCard: FC = memo(() => {
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const resultsIsOpen = useExplorerSelector(selectIsResultsExpanded);
     const dispatch = useExplorerDispatch();
-    const tableName = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.tableName,
-    );
-    const sorts = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.metricQuery.sorts,
-    );
+    const tableName = useExplorerSelector(selectTableName);
+    const sorts = useExplorerSelector(selectSorts);
+    const metricQuery = useExplorerSelector(selectMetricQuery);
+    const columnOrder = useExplorerSelector(selectColumnOrder);
 
+    // These remain in Context as they're not part of Redux state
     const totalResults = useExplorerContext(
         (context) => context.queryResults.totalResults,
     );
+    const getDownloadQueryUuid = useExplorerContext(
+        (context) => context.actions.getDownloadQueryUuid,
+    );
+    const savedChart = useExplorerContext(
+        (context) => context.state.savedChart,
+    );
+
     const toggleExpandedSection = useCallback(
         (section: ExplorerSection) => {
             dispatch(explorerActions.toggleExpandedSection(section));
         },
         [dispatch],
-    );
-    const metricQuery = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.metricQuery,
-    );
-
-    const columnOrder = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.tableConfig.columnOrder,
-    );
-    const getDownloadQueryUuid = useExplorerContext(
-        (context) => context.actions.getDownloadQueryUuid,
-    );
-
-    const savedChart = useExplorerContext(
-        (context) => context.state.savedChart,
     );
 
     const disabled = useMemo(() => (totalResults ?? 0) <= 0, [totalResults]);

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -2,6 +2,7 @@ import {
     type CustomDimension,
     type MetricQuery,
     type ParameterValue,
+    type SortField,
     type TableCalculation,
 } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
@@ -54,6 +55,11 @@ const explorerSlice = createSlice({
         // Filters
         setFilters: (state, action: PayloadAction<MetricQuery['filters']>) => {
             state.unsavedChartVersion.metricQuery.filters = action.payload;
+        },
+
+        // Sorting actions
+        setSortFields: (state, action: PayloadAction<SortField[]>) => {
+            state.unsavedChartVersion.metricQuery.sorts = action.payload;
         },
 
         // Parameters

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -89,6 +89,17 @@ export const selectTableCalculations = createSelector(
     (metricQuery) => metricQuery.tableCalculations,
 );
 
+// ResultsCard specific selectors
+export const selectSorts = createSelector(
+    [selectMetricQuery],
+    (metricQuery) => metricQuery.sorts,
+);
+
+export const selectColumnOrder = createSelector(
+    [selectUnsavedChartVersion],
+    (unsavedChartVersion) => unsavedChartVersion.tableConfig.columnOrder,
+);
+
 // const selectDimensions = createSelector(
 //     [selectMetricQuery],
 //     (metricQuery) => metricQuery.dimensions,

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -32,6 +32,14 @@ import {
     type TableColumn,
 } from '../components/common/Table/types';
 import useEmbed from '../ee/providers/Embed/useEmbed';
+import {
+    selectAdditionalMetrics,
+    selectCustomDimensions,
+    selectSorts,
+    selectTableCalculations,
+    selectTableName,
+    useExplorerSelector,
+} from '../features/explorer/store';
 import useExplorerContext from '../providers/Explorer/useExplorerContext';
 import { useCalculateTotal } from './useCalculateTotal';
 import { useExplore } from './useExplore';
@@ -62,26 +70,16 @@ export const getValueCell = (info: CellContext<RawResultRow, string>) => {
 };
 
 export const useColumns = (): TableColumn[] => {
+    // Use Redux for state that's available
+    const tableName = useExplorerSelector(selectTableName);
+    const tableCalculations = useExplorerSelector(selectTableCalculations);
+    const customDimensions = useExplorerSelector(selectCustomDimensions);
+    const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+    const sorts = useExplorerSelector(selectSorts);
+
+    // Keep Context for computed state not in Redux
     const activeFields = useExplorerContext(
         (context) => context.state.activeFields,
-    );
-    const tableName = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.tableName,
-    );
-    const tableCalculations = useExplorerContext(
-        (context) =>
-            context.state.unsavedChartVersion.metricQuery.tableCalculations,
-    );
-    const customDimensions = useExplorerContext(
-        (context) =>
-            context.state.unsavedChartVersion.metricQuery.customDimensions,
-    );
-    const additionalMetrics = useExplorerContext(
-        (context) =>
-            context.state.unsavedChartVersion.metricQuery.additionalMetrics,
-    );
-    const sorts = useExplorerContext(
-        (context) => context.state.unsavedChartVersion.metricQuery.sorts,
     );
     const resultsMetricQuery = useExplorerContext(
         (context) => context.query.data?.metricQuery,

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -922,6 +922,15 @@ const ExplorerProvider: FC<
         reduxDispatch(explorerActions.setIsEditMode(isEditMode));
     }, [isEditMode, reduxDispatch]);
 
+    // Keep Redux sorts in sync with Context sorts
+    useEffect(() => {
+        reduxDispatch(
+            explorerActions.setSortFields(
+                unsavedChartVersion.metricQuery.sorts,
+            ),
+        );
+    }, [unsavedChartVersion.metricQuery.sorts, reduxDispatch]);
+
     // Keep Redux table name in sync with Context state
     useEffect(() => {
         const contextTableName = reducerState.unsavedChartVersion.tableName;
@@ -1035,9 +1044,10 @@ const ExplorerProvider: FC<
                 descending: boolean;
             } = { descending: false },
         ) => {
+            const sortField = { fieldId, ...options };
             dispatch({
                 type: ActionType.ADD_SORT_FIELD,
-                payload: { fieldId, ...options },
+                payload: sortField,
             });
         },
         [],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17106

### Description:
Migrates explorer state from Context to Redux for the ResultsCard component. This change moves several selectors including tableName, sorts, metricQuery, and columnOrder from the Explorer Context to Redux state. 

The PR also adds a new Redux action `setSortFields` to manage sort state and implements synchronization between Context and Redux by adding an effect in ExplorerProvider that keeps Redux sorts in sync with Context sorts.

Additionally, the useColumns hook has been updated to use the Redux selectors instead of Context for state that's now available in Redux.