### PR TITLE
feat: upload dashboard charts when uploading dashboards

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -594,6 +594,11 @@ program
         'Skip space creation if it does not exist',
         false,
     )
+    .option(
+        '--include-charts',
+        'Include charts updates when uploading dashboards',
+        false,
+    )
     .action(uploadHandler);
 
 program


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15260

### Description:
Added a new `--include-charts` flag to the CLI upload command that automatically includes charts referenced by dashboards when uploading. This ensures that when uploading dashboards, their dependent charts are also uploaded, preventing potential issues with missing charts.

The implementation:
1. Added a new `includeCharts` boolean option to the `DownloadHandlerOptions` type
2. Created a `getDashboardChartSlugs` function to extract chart slugs from dashboard tiles
3. Modified the upload handler to include charts from dashboards when the flag is enabled
4. Added the `--include-charts` option to the CLI command with a descriptive help text

**Steps to test:**
1. Run `lightdash download -d <dashboard_slug>`
2. Change one of the downloaded charts referenced in the dashboard
3. Run `lightdash upload -d <dashboard_slug> --include-charts`

```bash
root@b9027f45005a:/usr/app/examples/full-jaffle-shop-demo/dbt# node ../../../packages/cli/dist/index.js upload -d table-dashy --include-charts
Reading dashboards from /usr/app/examples/full-jaffle-shop-demo/dbt/lightdash/dashboards
Reading charts from /usr/app/examples/full-jaffle-shop-demo/dbt/lightdash/charts
Found 3 charts files
Filtered 3 charts with slugs: test-big-table, big-table, asd
Skipping charts "asd" with no local changes
Skipping charts "test-big-table" with no local changes
Reading dashboards from /usr/app/examples/full-jaffle-shop-demo/dbt/lightdash/dashboards
Found 1 dashboards files
Filtered 1 dashboards with slugs: table-dashy
Skipping dashboards "table-dashy" with no local changes
Total charts skipped: 2 
Total spaces skipped: 1 
Total charts updated: 1  # notice here chart was updated
Total dashboards skipped: 1 
Done 🕶
```