### PR TITLE
fix: sorting by any field when pivoting

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -95,7 +95,7 @@ models:
           meta:
             dimension:
               type: date
-              time_intervals: ["DAY", "WEEK", "MONTH", "YEAR"]
+              time_intervals: ["DAY", "WEEK", "MONTH", "YEAR", "MONTH_NUM", "MONTH_NAME"]
             metrics:
               date_of_first_order:
                 type: min


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17018 

### Description:

Makes sorting more stable when pivoting, making it possible to sort by a field not use in the chart. The issue is explained in detail in this ticket: https://github.com/lightdash/lightdash/issues/17018

But the summary is that original sorting gets lost when you don't include the sorted field in the final query. 

This is still a bit of a WIP, but I wanted to post it and get feedback on the approach. I didn't find a way to solve this without changing the generated SQL substantially. With this change we would be producing SQL that looks like the following (explanatory comments inline). It seems to work well, but it is pretty different from what we had. 

```
WITH
-- Build base rows at (month, month_name, year) grain and capture the intended
-- sort as data using ROW_NUMBER(). We don’t rely on subquery ORDER BY to persist;
-- "original_pos" encodes (month ASC, year DESC) for stable ordering downstream.
original_query AS (
    SELECT
        *,
        ROW_NUMBER() OVER (
            ORDER BY "orders_order_date_month" ASC,
                     "orders_order_date_year"  DESC
        ) AS "original_pos"
    FROM (
        SELECT
            DATE_TRUNC('MONTH', "orders".order_date) AS "orders_order_date_month",
            TO_CHAR("orders".order_date, 'FMMonth')  AS "orders_order_date_month_name",
            DATE_TRUNC('YEAR',  "orders".order_date) AS "orders_order_date_year",
            SUM("orders".amount)                     AS "orders_total_order_amount"
        FROM "postgres"."jaffle"."orders" AS "orders"
        GROUP BY 1, 2, 3
        ORDER BY "orders_order_date_month", "orders_order_date_year" DESC
    ) base_query
),

-- Aggregate to the row×column grain we’ll pivot on later: (month_name, year).
-- We also carry the numeric month for joining to row indices. The ARRAY_AGG
-- first-element pattern avoids accidental reordering affecting the metric value.
group_by_query AS (
    SELECT
        "orders_order_date_year",
        "orders_order_date_month_name",
        "orders_order_date_month",
        (ARRAY_AGG("orders_total_order_amount"))[1] AS "orders_total_order_amount_any"
    FROM original_query
    GROUP BY
        "orders_order_date_year",
        "orders_order_date_month_name",
        "orders_order_date_month"
),

-- Reduce to one record per X-axis row (month) and anchor its position using the
-- earliest "original_pos" seen for that month. This decouples row order from labels.
row_groups AS (
    SELECT
        "orders_order_date_month",
        MIN("original_pos") AS "min_pos"
    FROM original_query
    GROUP BY "orders_order_date_month"
),

-- Turn anchored positions into consecutive row indices (1..N) for the chart rows.
-- DENSE_RANK() is robust to ties and future changes to the sort key.
row_indices AS (
    SELECT
        "orders_order_date_month",
        DENSE_RANK() OVER (ORDER BY "min_pos") AS "row_index"
    FROM row_groups
),

-- Compute pivot (column) indices. Each (year, month_name) pair gets a column_index,
-- ordered by year DESC so the newest year renders first. DISTINCT shrinks the set
-- before ranking for clarity and performance.
column_indices AS (
    SELECT
        "orders_order_date_year",
        "orders_order_date_month_name",
        DENSE_RANK() OVER (ORDER BY "orders_order_date_year" DESC) AS "column_index"
    FROM (
        SELECT DISTINCT
            "orders_order_date_year",
            "orders_order_date_month_name"
        FROM group_by_query
    ) AS distinct_groups
),

-- Apply row/column limits early to avoid building unused cells. This mirrors the
-- semantics of “filtered_rows” and makes downstream counts reflect the visible slice.
row_limited AS (
    SELECT *
    FROM row_indices
    WHERE "row_index" <= 500
),
col_limited AS (
    SELECT *
    FROM column_indices
    WHERE "column_index" <= 99
),

-- Build the pivot cells by joining the metric grain to the limited row/column indices.
-- Each output record corresponds to one chart cell with stable row/column positions.
cells AS (
    SELECT
        rl."row_index",
        cl."column_index",
        g."orders_order_date_month",
        g."orders_order_date_year",
        g."orders_order_date_month_name",
        g."orders_total_order_amount_any"
    FROM group_by_query g
    JOIN row_limited rl
      ON g."orders_order_date_month" = rl."orders_order_date_month"
    JOIN col_limited cl
      ON g."orders_order_date_year" = cl."orders_order_date_year"
     AND g."orders_order_date_month_name" = cl."orders_order_date_month_name"
),

-- Count distinct visible pivot columns (after limits) for chart layout purposes.
-- Using cells ensures the count matches what the user actually sees.
total_columns AS (
    SELECT COUNT(*) * 1 AS total_columns
    FROM (
        SELECT DISTINCT
            "orders_order_date_year",
            "orders_order_date_month_name"
        FROM cells
    ) AS distinct_groups
)

-- Final result: pivoted cells with stable row/column indices and total column count.
SELECT
    c.*,
    t.total_columns
FROM cells c
CROSS JOIN total_columns t
ORDER BY c."row_index", c."column_index";
```



