### PR TITLE
feat: migrate ParametersCard to Redux store

### DIFF
--- a/packages/frontend/src/components/Explorer/ParametersCard/ParametersCard.tsx
+++ b/packages/frontend/src/components/Explorer/ParametersCard/ParametersCard.tsx
@@ -5,6 +5,9 @@ import {
     explorerActions,
     selectIsEditMode,
     selectIsParametersExpanded,
+    selectParameterDefinitions,
+    selectParameters,
+    selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
@@ -19,10 +22,17 @@ const ParametersCard = memo(
 
         const paramsIsOpen = useExplorerSelector(selectIsParametersExpanded);
         const isEditMode = useExplorerSelector(selectIsEditMode);
+        const tableName = useExplorerSelector(selectTableName);
+        const parameterDefinitions = useExplorerSelector(
+            selectParameterDefinitions,
+        );
+        const parameterValues = useExplorerSelector(selectParameters);
         const dispatch = useExplorerDispatch();
 
-        const tableName = useExplorerContext(
-            (context) => context.state.unsavedChartVersion.tableName,
+        // TODO: REDUX-MIGRATION - Move missingRequiredParameters computation to Redux selectors
+        // Keep missingRequiredParameters from Context for now (it's computed state)
+        const missingRequiredParameters = useExplorerContext(
+            (context) => context.state.missingRequiredParameters,
         );
 
         const toggleExpandedSection = useCallback(
@@ -30,10 +40,6 @@ const ParametersCard = memo(
                 dispatch(explorerActions.toggleExpandedSection(section));
             },
             [dispatch],
-        );
-
-        const parameterDefinitions = useExplorerContext(
-            (context) => context.state.parameterDefinitions,
         );
 
         const filteredParameterDefinitions = useMemo(() => {
@@ -44,17 +50,18 @@ const ParametersCard = memo(
             );
         }, [parameterDefinitions, parameterReferences]);
 
-        const parameterValues = useExplorerContext(
-            (context) => context.state.unsavedChartVersion.parameters || {},
-        );
-
-        const setParameter = useExplorerContext(
+        // TODO: REDUX-MIGRATION - Use Redux actions directly once Context sync is removed
+        // Currently using Context actions to ensure proper sync and trigger side effects
+        const setParameterFromContext = useExplorerContext(
             (context) => context.actions.setParameter,
         );
 
-        const clearAllParameters = useExplorerContext(
+        const clearAllParametersFromContext = useExplorerContext(
             (context) => context.actions.clearAllParameters,
         );
+
+        const setParameter = setParameterFromContext;
+        const clearAllParameters = clearAllParametersFromContext;
 
         const handleParameterChange = (
             paramKey: string,
@@ -62,10 +69,6 @@ const ParametersCard = memo(
         ) => {
             setParameter(paramKey, value);
         };
-
-        const missingRequiredParameters = useExplorerContext(
-            (context) => context.state.missingRequiredParameters,
-        );
 
         return (
             <CollapsableCard

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -81,11 +81,22 @@ const explorerSlice = createSlice({
             }
         },
 
+        clearAllParameters: (state) => {
+            state.unsavedChartVersion.parameters = {};
+        },
+
         setParameterReferences: (
             state,
             action: PayloadAction<string[] | null>,
         ) => {
             state.parameterReferences = action.payload;
+        },
+
+        setParameterDefinitions: (
+            state,
+            action: PayloadAction<ExplorerReduceState['parameterDefinitions']>,
+        ) => {
+            state.parameterDefinitions = action.payload;
         },
 
         // Visualization config

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -48,11 +48,6 @@ export const selectIsResultsExpanded = createSelector(
     (expandedSections) => expandedSections.includes(ExplorerSection.RESULTS),
 );
 
-// const selectPreviouslyFetchedState = createSelector(
-//     [selectExplorerState],
-//     (explorer) => explorer.previouslyFetchedState,
-// );
-
 export const selectIsVisualizationConfigOpen = createSelector(
     [selectExplorerState],
     (explorer) => explorer.isVisualizationConfigOpen,
@@ -89,6 +84,21 @@ export const selectTableCalculations = createSelector(
     (metricQuery) => metricQuery.tableCalculations,
 );
 
+// Parameter selectors
+export const selectParameters = createSelector(
+    [selectUnsavedChartVersion],
+    (unsavedChartVersion) => unsavedChartVersion.parameters || {},
+);
+
+export const selectParameterDefinitions = createSelector(
+    [selectExplorerState],
+    (explorer) => explorer.parameterDefinitions,
+);
+
+// TODO: REDUX-MIGRATION - Add missingRequiredParameters as a computed selector once all dependencies are in Redux
+// TODO: REDUX-MIGRATION - Add selectParameterReferences once ParametersCard uses Redux for parameterReferences
+// Currently missingRequiredParameters is computed state in Context, not stored in Redux
+
 // ResultsCard specific selectors
 export const selectSorts = createSelector(
     [selectMetricQuery],
@@ -99,18 +109,3 @@ export const selectColumnOrder = createSelector(
     [selectUnsavedChartVersion],
     (unsavedChartVersion) => unsavedChartVersion.tableConfig.columnOrder,
 );
-
-// const selectDimensions = createSelector(
-//     [selectMetricQuery],
-//     (metricQuery) => metricQuery.dimensions,
-// );
-//
-// const selectMetrics = createSelector(
-//     [selectMetricQuery],
-//     (metricQuery) => metricQuery.metrics,
-// );
-//
-// const selectTableName = createSelector(
-//     [selectUnsavedChartVersion],
-//     (unsavedChartVersion) => unsavedChartVersion.tableName,
-// );

--- a/packages/frontend/src/features/parameters/components/ParameterInput.tsx
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.tsx
@@ -161,7 +161,8 @@ export const ParameterInput: FC<ParameterInputProps> = ({
             return uniq([...parameterOptions, ...filteredCurrentValues]);
         }
 
-        return parameterOptions;
+        // Always return a copy to avoid Redux immutability issues
+        return [...parameterOptions];
     }, [
         parameter.options,
         parameter.allow_custom_values,
@@ -222,7 +223,7 @@ export const ParameterInput: FC<ParameterInputProps> = ({
               )
             : optionsData;
 
-        const regularItems = baseItems
+        const regularItems = [...baseItems] // Create a copy to avoid mutating Redux state
             .sort((a, b) => String(a).localeCompare(String(b)))
             .map((option) => ({
                 value: String(option),
@@ -234,7 +235,7 @@ export const ParameterInput: FC<ParameterInputProps> = ({
                 ? [
                       {
                           group: 'Dimension values',
-                          items: fetchedResults
+                          items: [...fetchedResults] // Create a copy to avoid mutating Redux state
                               .sort((a, b) => a.localeCompare(b))
                               .map((option) => ({
                                   value: option,

--- a/packages/frontend/src/hooks/useCompiledSql.ts
+++ b/packages/frontend/src/hooks/useCompiledSql.ts
@@ -77,7 +77,7 @@ export const useCompiledSql = (
         queryParameters,
     ];
     return useQuery<ApiCompiledQueryResults, ApiError>({
-        enabled: tableId !== undefined,
+        enabled: !!tableId,
         queryKey,
         queryFn: () =>
             getCompiledQuery(

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -917,6 +917,8 @@ const ExplorerProvider: FC<
     const reduxFilters = useExplorerSelector(selectFilters);
     const reduxDispatch = useExplorerDispatch();
 
+    // TODO: REDUX-MIGRATION - Remove these sync effects once all components use Redux directly
+    // START TRANSITIONAL SYNC CODE
     // Keep Redux isEditMode in sync with prop changes
     useEffect(() => {
         reduxDispatch(explorerActions.setIsEditMode(isEditMode));
@@ -938,6 +940,7 @@ const ExplorerProvider: FC<
             reduxDispatch(explorerActions.setTableName(contextTableName));
         }
     }, [reducerState.unsavedChartVersion.tableName, reduxDispatch]);
+    // END TRANSITIONAL SYNC CODE
 
     const computedMetricQuery = useMemo(
         () => ({
@@ -981,7 +984,7 @@ const ExplorerProvider: FC<
                 type: ActionType.SET_TABLE_NAME,
                 payload: tableName,
             });
-            // Sync to Redux for components that have been migrated
+            // TODO: REDUX-MIGRATION - Remove Context dispatch once all components use Redux
             reduxDispatch(explorerActions.setTableName(tableName));
         },
         [dispatch, reduxDispatch],
@@ -1100,13 +1103,17 @@ const ExplorerProvider: FC<
                     payload: { key, value },
                 });
             }
+            // TODO: REDUX-MIGRATION - Remove Context dispatch once all components use Redux
+            reduxDispatch(explorerActions.setParameter({ key, value }));
         },
-        [],
+        [reduxDispatch],
     );
 
     const clearAllParameters = useCallback(() => {
         dispatch({ type: ActionType.CLEAR_ALL_PARAMETERS });
-    }, []);
+        // TODO: REDUX-MIGRATION - Remove Context dispatch once all components use Redux
+        reduxDispatch(explorerActions.clearAllParameters());
+    }, [reduxDispatch]);
 
     const setPivotFields = useCallback((fields: FieldId[] = []) => {
         dispatch({
@@ -1419,6 +1426,14 @@ const ExplorerProvider: FC<
         };
     }, [projectParameters, exploreParameterDefinitions]);
 
+    // TODO: REDUX-MIGRATION - Remove once parameterDefinitions are computed in Redux
+    // Keep Redux parameter definitions in sync
+    useEffect(() => {
+        reduxDispatch(
+            explorerActions.setParameterDefinitions(parameterDefinitions),
+        );
+    }, [parameterDefinitions, reduxDispatch]);
+
     const missingRequiredParameters = useMemo(() => {
         // If no required parameters are set, return null, this will disable query execution
         if (reducerState.parameterReferences === null) return null;
@@ -1684,6 +1699,35 @@ const ExplorerProvider: FC<
         runQuery();
     }, [runQuery, autoFetchEnabled, isEditMode, query.isFetched]);
 
+    // TODO: REDUX-MIGRATION - Remove this effect once parameter changes trigger query updates properly
+    // Trigger query update when parameters change (if query has been run before)
+    useEffect(() => {
+        // Only update if we have a valid query and parameters have actually been set
+        if (
+            query.isFetched &&
+            unsavedChartVersion.parameters &&
+            Object.keys(unsavedChartVersion.parameters).length > 0
+        ) {
+            // Check if parameters have changed from what's in validQueryArgs
+            const currentParams = JSON.stringify(
+                validQueryArgs?.parameters ?? {},
+            );
+            const newParams = JSON.stringify(unsavedChartVersion.parameters);
+            if (currentParams !== newParams) {
+                // Parameters changed, need to update the query
+                if (autoFetchEnabled) {
+                    runQuery();
+                }
+            }
+        }
+    }, [
+        unsavedChartVersion.parameters,
+        query.isFetched,
+        validQueryArgs?.parameters,
+        autoFetchEnabled,
+        runQuery,
+    ]);
+
     const clearExplore = useCallback(async () => {
         resetCachedChartConfig();
         // cancel query creation
@@ -1790,8 +1834,12 @@ const ExplorerProvider: FC<
                 type: ActionType.SET_PARAMETER_REFERENCES,
                 payload: parameterReferences,
             });
+            // Sync to Redux for components that have been migrated
+            reduxDispatch(
+                explorerActions.setParameterReferences(parameterReferences),
+            );
         },
-        [],
+        [reduxDispatch],
     );
     const actions = useMemo(
         () => ({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17115

### Description:
This PR migrates the Parameters Card component to use Redux selectors and actions instead of the Explorer Context. Key changes include:

1. Added new Redux selectors for parameters:
   - `selectParameters`
   - `selectParameterDefinitions`
   - `selectTableName`

2. Added new Redux actions:
   - `clearAllParameters`
   - `setParameterDefinitions`

3. Updated ParametersCard to use Redux selectors while maintaining backward compatibility with Context for computed state (missingRequiredParameters)

4. Added synchronization between Context and Redux state for parameters to ensure proper transitions during migration

5. Fixed parameter handling in ParameterInput to avoid Redux immutability issues by creating copies of arrays

6. Added an effect to trigger query updates when parameters change

7. Fixed a condition in useCompiledSql to properly check for tableId existence