### PR TITLE
feat(backend): introduce changes and changesets tables

### DIFF
--- a/packages/backend/src/database/migrations/20250929132418_add_changesets_and_changes.ts
+++ b/packages/backend/src/database/migrations/20250929132418_add_changesets_and_changes.ts
@@ -1,0 +1,118 @@
+import { Knex } from 'knex';
+
+const ChangesetsTableName = 'changesets';
+const ChangesTableName = 'changes';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(ChangesetsTableName))) {
+        await knex.schema.createTable(ChangesetsTableName, (table) => {
+            table.comment(
+                'Represents a collection of related changes made to a project',
+            );
+            table
+                .uuid('changeset_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+
+            table
+                .uuid('created_by_user_uuid')
+                .notNullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('CASCADE');
+
+            table
+                .uuid('updated_by_user_uuid')
+                .notNullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('CASCADE');
+
+            table
+                .uuid('project_uuid')
+                .notNullable()
+                .references('project_uuid')
+                .inTable('projects')
+                .onDelete('CASCADE');
+
+            table.string('status').notNullable();
+
+            table.string('name').notNullable();
+
+            table.index('project_uuid');
+            table.index('status');
+            table.index(['project_uuid', 'status']);
+        });
+    }
+
+    if (!(await knex.schema.hasTable(ChangesTableName))) {
+        await knex.schema.createTable(ChangesTableName, (table) => {
+            table.comment(
+                'Individual changes within a changeset, representing specific modifications to entities (table, metrics, dimensions)',
+            );
+            table
+                .uuid('change_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+
+            table
+                .uuid('changeset_uuid')
+                .notNullable()
+                .references('changeset_uuid')
+                .inTable('changesets')
+                .onDelete('CASCADE');
+
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+
+            table
+                .uuid('created_by_user_uuid')
+                .notNullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('CASCADE');
+
+            table
+                .uuid('source_prompt_uuid')
+                .nullable()
+                .references('ai_prompt_uuid')
+                .inTable('ai_prompt')
+                .onDelete('SET NULL');
+
+            table.string('type').notNullable();
+
+            table.string('entity_type').notNullable();
+
+            table
+                .uuid('entity_explore_uuid')
+                .nullable()
+                .references('cached_explore_uuid')
+                .inTable('cached_explore')
+                .onDelete('SET NULL');
+
+            table.string('entity_name').notNullable();
+
+            table.jsonb('payload').notNullable();
+
+            table.index('changeset_uuid');
+            table.index('entity_explore_uuid');
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(ChangesTableName);
+    await knex.schema.dropTableIfExists(ChangesetsTableName);
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a migration creating `changesets` and `changes` tables with FKs to `users`, `projects`, `ai_prompt`, `cached_explore`, plus indexes; includes rollback.
> 
> - **Database migration** (`packages/backend/src/database/migrations/20250929132418_add_changesets_and_changes.ts`):
>   - **Create `changesets`**:
>     - Columns: `changeset_uuid` (PK, UUID v4), timestamps (`created_at`, `updated_at`), `created_by_user_uuid`, `updated_by_user_uuid` → `users`, `project_uuid` → `projects`, `status`, `name`.
>     - Indexes: `project_uuid`, `status`, `project_uuid + status`.
>   - **Create `changes`**:
>     - Columns: `change_uuid` (PK, UUID v4), `changeset_uuid` → `changesets`, `created_at`, `created_by_user_uuid` → `users`, `source_prompt_uuid` → `ai_prompt` (SET NULL), `type`, `entity_type`, `entity_explore_uuid` → `cached_explore` (SET NULL), `entity_name`, `payload` (JSONB).
>     - Indexes: `changeset_uuid`, `entity_explore_uuid`.
>   - **Rollback**: drops `changes` then `changesets`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fb31a63783ccb7e4dc88a4f458e69736c57cf2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->