### PR TITLE
fix: remove relation from changes to ai-agent

### DIFF
--- a/packages/backend/src/database/migrations/20250929132418_add_changesets_and_changes.ts
+++ b/packages/backend/src/database/migrations/20250929132418_add_changesets_and_changes.ts
@@ -84,12 +84,7 @@ export async function up(knex: Knex): Promise<void> {
                 .inTable('users')
                 .onDelete('CASCADE');
 
-            table
-                .uuid('source_prompt_uuid')
-                .nullable()
-                .references('ai_prompt_uuid')
-                .inTable('ai_prompt')
-                .onDelete('SET NULL');
+            table.uuid('source_prompt_uuid').nullable();
 
             table.string('type').notNullable();
 

--- a/packages/backend/src/database/migrations/20250930083325_remove_source_prompt_reference.ts
+++ b/packages/backend/src/database/migrations/20250930083325_remove_source_prompt_reference.ts
@@ -1,0 +1,41 @@
+import { Knex } from 'knex';
+
+const ChangesTableName = 'changes';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(ChangesTableName)) {
+        if (
+            await knex.schema.hasColumn(ChangesTableName, 'source_prompt_uuid')
+        ) {
+            // Check if foreign key constraint exists
+            const constraintExists = await knex.raw(
+                `
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM information_schema.table_constraints
+                    WHERE constraint_name = ?
+                    AND table_name = ?
+                    AND constraint_type = 'FOREIGN KEY'
+                )
+            `,
+                ['changes_source_prompt_uuid_foreign', ChangesTableName],
+            );
+
+            // eslint-disable-next-line prefer-destructuring
+            const exists = constraintExists.rows[0].exists;
+
+            if (exists) {
+                await knex.schema.alterTable(ChangesTableName, (table) => {
+                    table.dropForeign(
+                        ['source_prompt_uuid'],
+                        'changes_source_prompt_uuid_foreign',
+                    );
+                });
+            }
+        }
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // do nothing
+}


### PR DESCRIPTION

### Description:
Fixing references to ee by removing foreign key constraint from the `source_prompt_uuid` column in the `changes` table. 