### PR TITLE
fix: empty maximum billed bytes error

### DIFF
--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -36,7 +36,8 @@ const credentialsTarget = (
                     timeout_seconds: credentials.timeoutSeconds,
                     priority: credentials.priority,
                     retries: credentials.retries,
-                    maximum_bytes_billed: credentials.maximumBytesBilled,
+                    maximum_bytes_billed:
+                        credentials.maximumBytesBilled || undefined, // form allows empty string, converting to undefined here
                     execution_project: credentials.executionProject,
                 },
                 environment: {},


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17136

### Description:
Fix handling of empty string in `maximumBytesBilled` by converting it to `undefined` when generating dbt profiles. This ensures that empty form inputs don't cause issues with the dbt configuration.

Related PR: https://github.com/lightdash/lightdash/pull/16164

**Before**

![image.png](https://app.graphite.dev/user-attachments/assets/c92ae056-f26b-480d-a8b3-c92b0eaf8d09.png)

**After**

![image.png](https://app.graphite.dev/user-attachments/assets/69089117-d247-47ae-b116-0b406e01be1a.png)

