### PR TITLE
feat: implement changeset application for explore dimensions and metrics

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -98,6 +98,7 @@
         "express-session": "^1.17.2",
         "express-static-gzip": "^2.1.8",
         "express-winston": "^4.2.0",
+        "fast-json-patch": "^3.1.1",
         "fs-extra": "^10.0.0",
         "fuse.js": "^6.4.6",
         "googleapis": "105",

--- a/packages/backend/src/database/entities/changesets.ts
+++ b/packages/backend/src/database/entities/changesets.ts
@@ -58,10 +58,10 @@ export const DbChangeSchema = z.object({
     created_at: z.date(),
     created_by_user_uuid: z.string().uuid(),
     source_prompt_uuid: z.string().uuid().nullable(),
-    type: ChangeTypeSchema,
     entity_type: EntityTypeSchema,
     entity_table_name: z.string().min(1),
     entity_name: z.string().min(1),
+    type: ChangeTypeSchema,
     payload: z.record(z.unknown()),
 });
 

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -32,6 +32,7 @@ import bcrypt from 'bcrypt';
 import { Knex } from 'knex';
 import path from 'path';
 import { lightdashConfig } from '../../../config/lightdashConfig';
+import { ChangesetModel } from '../../../models/ChangesetModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
 import { UserAttributesModel } from '../../../models/UserAttributesModel';
@@ -268,10 +269,14 @@ export async function seed(knex: Knex): Promise<void> {
             organizationUuid,
             projectUuid,
         });
+
+        const changesetModel = new ChangesetModel({ database: knex });
+
         await new ProjectModel({
             database: knex,
             lightdashConfig,
             encryptionUtil: enc,
+            changesetModel,
         }).saveExploresToCache(SEED_PROJECT.project_uuid, explores);
 
         // Seed parameters

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -384,6 +384,7 @@ export class ModelRepository
             () =>
                 new ProjectModel({
                     database: this.database,
+                    changesetModel: this.getChangesetModel(),
                     lightdashConfig: this.lightdashConfig,
                     encryptionUtil: this.utils.getEncryptionUtil(),
                 }),

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -13,6 +13,7 @@ import {
     CachedExploresTableName,
     ProjectTableName,
 } from '../../database/entities/projects';
+import { ChangesetModel } from '../ChangesetModel';
 import { ProjectModel } from './ProjectModel';
 import {
     CompletePostgresCredentials,
@@ -43,8 +44,11 @@ function queryMatcher(
 }
 
 describe('ProjectModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+
     const model = new ProjectModel({
-        database: knex({ client: MockClient, dialect: 'pg' }),
+        database,
+        changesetModel: new ChangesetModel({ database }),
         lightdashConfig: lightdashConfigMock,
         encryptionUtil: encryptionUtilMock,
     });

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2,6 +2,9 @@ import {
     AlreadyExistsError,
     AnyType,
     BigqueryAuthenticationType,
+    Change,
+    CompiledDimension,
+    CompiledMetric,
     CreateProject,
     CreateProjectOptionalCredentials,
     CreateSnowflakeCredentials,
@@ -11,6 +14,7 @@ import {
     Explore,
     ExploreError,
     ExploreType,
+    ForbiddenError,
     NotExistsError,
     NotFoundError,
     OrganizationProject,
@@ -44,8 +48,8 @@ import {
     WarehouseCatalog,
     warehouseClientFromCredentials,
 } from '@lightdash/warehouses';
+import { applyPatch, validate } from 'fast-json-patch';
 import { Knex } from 'knex';
-import { merge } from 'lodash';
 import { DatabaseError } from 'pg';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -89,6 +93,7 @@ import Logger from '../../logging/logger';
 import { wrapSentryTransaction } from '../../utils';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { generateUniqueSpaceSlug } from '../../utils/SlugUtils';
+import { ChangesetModel } from '../ChangesetModel';
 import { ExploreCache } from './ExploreCache';
 import Transaction = Knex.Transaction;
 
@@ -96,6 +101,7 @@ export type ProjectModelArguments = {
     database: Knex;
     lightdashConfig: LightdashConfig;
     encryptionUtil: EncryptionUtil;
+    changesetModel: ChangesetModel;
 };
 
 const CACHED_EXPLORES_PG_LOCK_NAMESPACE = 1;
@@ -105,6 +111,8 @@ export class ProjectModel {
 
     protected lightdashConfig: LightdashConfig;
 
+    protected changesetModel: ChangesetModel;
+
     private encryptionUtil: EncryptionUtil;
 
     private readonly exploreCache: ExploreCache;
@@ -112,6 +120,7 @@ export class ProjectModel {
     constructor(args: ProjectModelArguments) {
         this.database = args.database;
         this.lightdashConfig = args.lightdashConfig;
+        this.changesetModel = args.changesetModel;
         this.encryptionUtil = args.encryptionUtil;
         this.exploreCache = new ExploreCache();
     }
@@ -746,7 +755,7 @@ export class ProjectModel {
         };
     }
 
-    /* 
+    /*
     This method will load default values for backwards compatibility
     For example, when we introduce a new authentication type, we need to set the default value for the existing projects
     */
@@ -895,6 +904,163 @@ export class ProjectModel {
         return convertedExplore;
     };
 
+    static applyChange<T extends CompiledDimension | CompiledMetric>(
+        entity: T,
+        change: Change,
+    ): T | undefined {
+        switch (change.type) {
+            case 'create':
+                return change.payload.value as T;
+
+            case 'update':
+                const errors = validate(change.payload.patch, entity);
+                if (errors) {
+                    throw new Error(`Invalid patch: ${errors.message}`);
+                }
+                const result = applyPatch(entity, change.payload.patch);
+                return result.newDocument;
+
+            case 'delete':
+                return undefined;
+
+            default:
+                return assertUnreachable(change, 'Invalid change type');
+        }
+    }
+
+    async applyChangeset(
+        projectUuid: string,
+        explores: Record<string, Explore | ExploreError>,
+    ) {
+        const changeset =
+            await this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
+                projectUuid,
+            );
+
+        if (!changeset) {
+            return explores;
+        }
+
+        const changedExplores = changeset.changes.reduce<
+            Record<string, Explore | ExploreError>
+        >((acc, change) => {
+            const tableName = change.entityTableName;
+            const explore = explores[tableName];
+
+            if (!explore || isExploreError(explore)) {
+                return acc;
+            }
+
+            let patchedExplore = explore;
+
+            switch (change.entityType) {
+                case 'table':
+                    throw new Error(
+                        `Not implemented: applyChange for table ${tableName}`,
+                    );
+                case 'dimension':
+                case 'metric':
+                    const entityType = `${change.entityType}s` as const;
+
+                    if (!explore.tables[tableName]) {
+                        throw new NotExistsError(
+                            `Table "${tableName}" does not exist in explore "${change.entityTableName}".`,
+                        );
+                    }
+
+                    switch (change.type) {
+                        case 'create':
+                            if (
+                                explore.tables[tableName][entityType][
+                                    change.entityName
+                                ]
+                            ) {
+                                throw new ForbiddenError(
+                                    `${entityType} "${change.entityName}" already exists in table "${tableName}" of explore "${change.entityTableName}".`,
+                                );
+                            }
+                            break;
+
+                        case 'update':
+                        case 'delete':
+                            if (
+                                !explore.tables[tableName][entityType][
+                                    change.entityName
+                                ]
+                            ) {
+                                throw new NotExistsError(
+                                    `${entityType} "${change.entityName}" does not exist in table "${tableName}" of explore "${change.entityTableName}".`,
+                                );
+                            }
+                            break;
+
+                        default:
+                            return assertUnreachable(
+                                change,
+                                'Invalid change type',
+                            );
+                    }
+
+                    const changedEntity = ProjectModel.applyChange(
+                        explore.tables[tableName][entityType][
+                            change.entityName
+                        ],
+                        change,
+                    );
+
+                    const patchResult = applyPatch(
+                        explore,
+                        changedEntity === undefined
+                            ? [
+                                  {
+                                      op: 'remove',
+                                      path: `/tables/${tableName}/${entityType}/${change.entityName}`,
+                                  },
+                              ]
+                            : [
+                                  {
+                                      op: 'replace',
+                                      path: `/tables/${tableName}/${entityType}/${change.entityName}`,
+                                      value: changedEntity,
+                                  },
+                              ],
+                    );
+
+                    patchedExplore = patchResult.newDocument;
+
+                    break;
+                default:
+                    throw new Error(
+                        `Invalid entity type: ${change.entityType}`,
+                    );
+            }
+
+            const accPatchResult = applyPatch(acc, [
+                {
+                    op: 'replace',
+                    path: `/${change.entityTableName}`,
+                    value: patchedExplore,
+                },
+            ]);
+            return accPatchResult.newDocument;
+        }, {});
+
+        const patchedExploreNamess = Object.keys(changedExplores);
+        if (patchedExploreNamess.length > 0) {
+            const patchResult = applyPatch(
+                explores,
+                patchedExploreNamess.map((exploreName) => ({
+                    op: 'replace',
+                    path: `/${exploreName}`,
+                    value: changedExplores[exploreName],
+                })),
+            );
+            return patchResult.newDocument;
+        }
+
+        return explores;
+    }
+
     async findExploresFromCache(
         projectUuid: string,
         exploreNamesWithDuplicates?: string[],
@@ -929,7 +1095,8 @@ export class ProjectModel {
                 }
                 const explores = await query;
                 span.setAttribute('foundExplores', !!explores.length);
-                const finalExplores = explores.reduce<
+
+                let finalExplores = explores.reduce<
                     Record<string, Explore | ExploreError>
                 >((acc, { explore }) => {
                     acc[explore.name] =
@@ -938,6 +1105,12 @@ export class ProjectModel {
                         );
                     return acc;
                 }, {});
+
+                finalExplores = await this.applyChangeset(
+                    projectUuid,
+                    finalExplores,
+                );
+
                 // Store in cache
                 this.exploreCache?.setExplores(
                     projectUuid,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       express-winston:
         specifier: ^4.2.0
         version: 4.2.0(winston@3.13.0)
+      fast-json-patch:
+        specifier: ^3.1.1
+        version: 3.1.1
       fs-extra:
         specifier: ^10.0.0
         version: 10.0.0
@@ -20217,7 +20220,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25745,7 +25748,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.2.0
@@ -25779,7 +25782,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.5.4
@@ -32715,7 +32718,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -35099,7 +35102,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A<!-- reference the related issue e.g. #150 -->

### Description:

Adds JSON Patch–based application of active changesets to cached explores (dimensions/metrics), integrates ChangesetModel into ProjectModel and repo, and tightens change payload typing.

---

> [!NOTE]
> Adds JSON Patch–based application of active changesets to cached explores (dimensions/metrics), integrates ChangesetModel into ProjectModel and repo, and tightens change payload typing.
> - **Backend**
>     - **ProjectModel**:
>         - Apply active changesets to explores via new `applyChangeset` and `applyChange` (supports `create/update/delete` for `dimensions/metrics` using `fast-json-patch`).
>         - Integrate changeset application into `findExploresFromCache`.
>         - Import `Change`, use stricter error handling (`ForbiddenError`, `NotExistsError`).
>     - **DI/Instantiation**:
>         - Inject `ChangesetModel` into `ProjectModel` via `ModelRepository.getProjectModel()` and development seed.
>     - **Tests**:
>         - Update `ProjectModel.test` to provide a `ChangesetModel` instance.
> - **Types**
>     - Refine `ChangeSchema` to a discriminated union with structured `payload` shapes; export `Change` type.
> - **Dependencies**
>     - Add `fast-json-patch` to backend.
> <sup>Written by Cursor Bugbot for commit 81502d99cc14d4c874954299626b94a24b28fef1. This will update automatically on new commits. Configure here.</sup>