### PR TITLE
feat: replace entity explore uuid for table name

### DIFF
--- a/packages/backend/src/database/migrations/20250930132139_replace_entity_explore_uuid_for_name.ts
+++ b/packages/backend/src/database/migrations/20250930132139_replace_entity_explore_uuid_for_name.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('changes', (table) => {
+        table.dropColumn('entity_explore_uuid');
+        table.string('entity_table_name').notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('changes', (table) => {
+        table.dropColumn('entity_table_name');
+        table.uuid('entity_explore_uuid').nullable();
+        /**
+         * We are not doing a data migration here because:
+         * - no code is actually using the explore uuid column
+         * - it's not trivial to get explore uuid from a name.
+         */
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Database migration updates the `changes` table, replacing `entity_explore_uuid` with non-nullable `entity_table_name` and providing a reversible down migration.
> 
> - **Database Migration**:
>   - **Schema change** in `packages/backend/src/database/migrations/20250930132139_replace_entity_explore_uuid_for_name.ts`:
>     - Drop `changes.entity_explore_uuid`.
>     - Add `changes.entity_table_name` (string, not nullable).
>   - **Down migration**: remove `entity_table_name` and re-add nullable `entity_explore_uuid` (no data backfill).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73c845ab27a20f09f0115451efe7e78ffebaaf75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->