### PR TITLE
fix: adding dashboard tabs can break layout

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/index.tsx
+++ b/packages/frontend/src/components/DashboardTabs/index.tsx
@@ -41,9 +41,6 @@ type DashboardTabsProps = {
     handleDeleteTile: (tile: IDashboard['tiles'][number]) => Promise<void>;
     handleBatchDeleteTiles: (tile: IDashboard['tiles'][number][]) => void;
     handleEditTile: (tiles: IDashboard['tiles'][number]) => void;
-    setActiveTab: (
-        value: React.SetStateAction<DashboardTab | undefined>,
-    ) => void;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     setGridWidth: (value: React.SetStateAction<number>) => void;
 };
@@ -54,7 +51,6 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     addingTab,
     dashboardTiles,
     activeTab,
-    setActiveTab,
     handleAddTiles,
     handleUpdateTiles,
     handleDeleteTile,
@@ -144,6 +140,21 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         isActiveTile(tile),
     );
 
+    const handleChangeTab = (tab: DashboardTab) => {
+        const newParams = new URLSearchParams(search);
+        // Change tabs by navigating to the new tab
+        // the provider sets the active tab based on the URL
+        void navigate(
+            {
+                pathname: isEditMode
+                    ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${tab?.uuid}`
+                    : `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tab?.uuid}`,
+                search: newParams.toString(),
+            },
+            { replace: true },
+        );
+    };
+
     const handleAddTab = (name: string) => {
         if (name) {
             const newTabs = dashboardTabs ? [...dashboardTabs] : [];
@@ -168,8 +179,10 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             };
             newTabs.push(newTab);
             setDashboardTabs(newTabs);
-            setActiveTab(newTab);
             setHaveTabsChanged(true);
+
+            // Navigate to the new tab
+            handleChangeTab(newTab);
         }
         setAddingTab(false);
     };
@@ -198,7 +211,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             return newTabs;
         });
         if (activeTab?.uuid === tabUuid) {
-            setActiveTab(
+            handleChangeTab(
                 dashboardTabs.filter((tab) => tab.uuid !== tabUuid)?.[0],
             );
         }
@@ -258,19 +271,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                         (t) => t.uuid === e,
                                     );
                                     if (tab) {
-                                        setActiveTab(tab);
-                                        const newParams = new URLSearchParams(
-                                            search,
-                                        );
-                                        void navigate(
-                                            {
-                                                pathname: isEditMode
-                                                    ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${tab?.uuid}`
-                                                    : `/projects/${projectUuid}/dashboards/${dashboardUuid}/view/tabs/${tab?.uuid}`,
-                                                search: newParams.toString(),
-                                            },
-                                            { replace: true },
-                                        );
+                                        handleChangeTab(tab);
                                     }
                                 }}
                                 mt={tabsEnabled ? 'sm' : 'xs'}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -79,7 +79,6 @@ const Dashboard: FC = () => {
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
     const activeTab = useDashboardContext((c) => c.activeTab);
-    const setActiveTab = useDashboardContext((c) => c.setActiveTab);
     const setDashboardFilters = useDashboardContext(
         (c) => c.setDashboardFilters,
     );
@@ -747,7 +746,6 @@ const Dashboard: FC = () => {
                         handleEditTile={handleEditTiles}
                         setGridWidth={setGridWidth}
                         activeTab={activeTab}
-                        setActiveTab={setActiveTab}
                         setAddingTab={setAddingTab}
                     />
                 </Flex>

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -226,13 +226,14 @@ const DashboardProvider: React.FC<
 
     // Set active tab when dashboard and tabs are loaded
     useEffect(() => {
-        if (dashboard?.tabs) {
+        if (dashboardTabs && dashboardTabs.length > 0) {
             const matchedTab =
-                dashboard.tabs.find((tab) => tab.uuid === tabUuid) ??
-                dashboard.tabs[0];
+                dashboardTabs.find((tab) => tab.uuid === tabUuid) ??
+                dashboardTabs[0];
+
             setActiveTab(matchedTab);
         }
-    }, [dashboard?.tabs, tabUuid]);
+    }, [dashboardTabs, tabUuid]);
 
     // Apply scheduler parameters when provided (for scheduled deliveries)
     useEffect(() => {
@@ -367,7 +368,7 @@ const DashboardProvider: React.FC<
         if (!dashboardTiles) return false;
 
         // If tabs exist, but no active tab is specified, tiles are not loaded
-        if (dashboard?.tabs && dashboard?.tabs.length > 0 && !activeTab)
+        if (dashboardTabs && dashboardTabs.length > 0 && !activeTab)
             return false;
 
         const chartTileUuids = dashboardTiles
@@ -382,7 +383,7 @@ const DashboardProvider: React.FC<
             .map((tile) => tile.uuid);
 
         return chartTileUuids.every((tileUuid) => loadedTiles.has(tileUuid));
-    }, [dashboardTiles, loadedTiles, activeTab, dashboard?.tabs]);
+    }, [dashboardTiles, loadedTiles, activeTab, dashboardTabs]);
 
     const missingRequiredParameters = useMemo(() => {
         // If no parameter references, return empty array


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17123 

### Description:

**The bug:** adding new tabs and navigating between them and existing tabs had lots of issues. One manifestation was that when tabs were first created, navigating to the first tab before saving broke the layout there since new tabs weren't set up properly. 

**Repro steps from the ticket:**
1. Create a dashboard with a few tiles, no tabs
2. Save
3. Edit the dashboard and create a second tab
4. When clicking back to the first tab while still in edit mode the charts disappear
5. If you click the first tab again, they reappear, but layout is broken

**What was wrong:** 1) We were validating tab navigation only against saved tabs (now we validate against new and saved) 2) We were setting the tab in the URL separately from in the context (now we always get the active tab from the URL)

**Before (bug)**
![before](https://github.com/user-attachments/assets/9f5d1041-b57f-48ac-8700-973bd8b8984b)

**Fixed**
![after](https://github.com/user-attachments/assets/998c178a-55a4-4eef-9a8d-8a9ae57377f7)
