### PR TITLE
feat: include changeset updatedAt in explore cache key

### DIFF
--- a/packages/backend/src/models/ProjectModel/ExploreCache.ts
+++ b/packages/backend/src/models/ProjectModel/ExploreCache.ts
@@ -19,27 +19,44 @@ export class ExploreCache {
 
     private static getCacheKey(
         projectUuid: string,
-        exploreNames?: string[] | undefined,
+        exploreNames: string[] | undefined,
+        changesetUpdatedAt: Date | undefined,
     ): string {
-        return `explores::${projectUuid}::${exploreNames?.join(',') || 'all'}`;
+        const exploreNamesString = exploreNames?.join(',') || 'all';
+
+        const cacheKey = changesetUpdatedAt
+            ? `explores::${projectUuid}::${exploreNamesString}::${changesetUpdatedAt.toISOString()}`
+            : `explores::${projectUuid}::${exploreNamesString}`;
+
+        return cacheKey;
     }
 
     public getExplores(
         projectUuid: string,
         exploreNames: string[] | undefined,
+        changesetUpdatedAt: Date | undefined,
     ): CachedExplores | undefined {
         return this.cache?.get<CachedExplores>(
-            ExploreCache.getCacheKey(projectUuid, exploreNames),
+            ExploreCache.getCacheKey(
+                projectUuid,
+                exploreNames,
+                changesetUpdatedAt,
+            ),
         );
     }
 
     public setExplores(
         projectUuid: string,
         exploreNames: string[] | undefined,
+        changesetUpdatedAt: Date | undefined,
         explore: CachedExplores,
     ): void {
         this.cache?.set(
-            ExploreCache.getCacheKey(projectUuid, exploreNames),
+            ExploreCache.getCacheKey(
+                projectUuid,
+                exploreNames,
+                changesetUpdatedAt,
+            ),
             explore,
         );
     }


### PR DESCRIPTION
### Description:
This PR improves the explore caching mechanism by incorporating the changeset's `updatedAt` timestamp into the cache key. This ensures that when a changeset is updated, the cache is properly invalidated and refreshed.

Additionally, the PR refactors the `applyChangeset` method to be static and to accept the changeset directly as a parameter rather than fetching it internally. This improves code organization and testability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Keys explore cache by changeset updatedAt and refactors applyChangeset to a static method receiving the changeset, updating cache get/set and explore retrieval flow.
> 
> - **Backend**
>   - **Caching (`ExploreCache`)**:
>     - Cache key now includes `changeset.updatedAt` to version explore entries.
>     - Update `getExplores`/`setExplores` signatures to accept `changesetUpdatedAt` and use it in cache key generation.
>   - **ProjectModel**:
>     - Fetch active changeset in `findExploresFromCache`, pass its `updatedAt` to cache get/set, and conditionally apply changes.
>     - Refactor `applyChangeset` to a static method that accepts `changeset` directly; callers provide the changeset instead of fetching internally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af71ad8fecbea3930a2e08f7371ad10ffc16b666. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->