### PR TITLE
fix: duplicate snowflake warehouse credentials

### DIFF
--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -278,4 +278,14 @@ export class UserWarehouseCredentialsModel {
             )
             .andWhere('user_uuid', userUuid);
     }
+
+    async deleteAllByUserAndWarehouseType(
+        userUuid: string,
+        warehouseType: WarehouseTypes,
+    ): Promise<void> {
+        await this.database(UserWarehouseCredentialsTableName)
+            .delete()
+            .where('user_uuid', userUuid)
+            .andWhere('warehouse_type', warehouseType);
+    }
 }

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1715,6 +1715,12 @@ export class UserService extends BaseService {
         user: SessionUser,
         refreshToken: string,
     ) {
+        // Remove old Snowflake credentials to prevent duplicates on re-authentication
+        await this.userWarehouseCredentialsModel.deleteAllByUserAndWarehouseType(
+            user.userUuid,
+            WarehouseTypes.SNOWFLAKE,
+        );
+
         const snowflakeCredentials: UpsertUserWarehouseCredentials = {
             name: 'Default',
             credentials: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/17134


Before
<img width="897" height="410" alt="Screenshot from 2025-10-01 10-28-26" src="https://github.com/user-attachments/assets/f589434c-896d-40ef-b52e-9322b22ea108" />



After
<img width="885" height="411" alt="Screenshot from 2025-10-01 10-31-56" src="https://github.com/user-attachments/assets/0cfd9b2a-0432-4d7b-b8fc-53757001878f" />
<img width="1042" height="139" alt="Screenshot from 2025-10-01 10-27-50" src="https://github.com/user-attachments/assets/84650190-774c-4341-95d7-2e008c632930" />



### Description:
Added a method to delete all warehouse credentials for a user by warehouse type and implemented it in the Snowflake authentication flow to prevent duplicate credentials. The new `deleteAllByUserAndWarehouseType` method is called before creating new Snowflake credentials during authentication, ensuring users don't accumulate multiple sets of credentials for the same warehouse type.