### PR TITLE
feat: get updated explores before indexing catalog

### DIFF
--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -285,6 +285,7 @@ export class CatalogService<
     ) {
         const cachedExplores = await this.projectModel.findExploresFromCache(
             projectUuid,
+            'name',
         );
 
         if (!cachedExplores) return [];
@@ -331,8 +332,10 @@ export class CatalogService<
     }
 
     async indexCatalog(projectUuid: string, userUuid: string | undefined) {
-        const cachedExploresMap =
-            await this.projectModel.getAllExploresFromCache(projectUuid);
+        const cachedExploresMap = await this.projectModel.findExploresFromCache(
+            projectUuid,
+            'uuid',
+        );
 
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -1007,6 +1010,7 @@ export class CatalogService<
 
         const explores = await this.projectModel.findExploresFromCache(
             projectUuid,
+            'name',
             uniqBy(metrics, 'tableName').map((m) => m.tableName),
         );
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3835,6 +3835,7 @@ export class ProjectService extends BaseService {
 
         const cachedExplores = await this.projectModel.findExploresFromCache(
             projectUuid,
+            'name',
         );
         const explores = Object.values(cachedExplores);
 
@@ -3999,6 +4000,7 @@ export class ProjectService extends BaseService {
                 }
                 const explores = await this.projectModel.findExploresFromCache(
                     projectUuid,
+                    'name',
                     exploreNames,
                 );
 
@@ -4046,6 +4048,7 @@ export class ProjectService extends BaseService {
         }
         const cachedExplores = await this.projectModel.findExploresFromCache(
             projectUuid,
+            'name',
         );
         const explores = Object.values(cachedExplores);
 
@@ -5579,6 +5582,7 @@ export class ProjectService extends BaseService {
         }
         const cachedExplores = await this.projectModel.findExploresFromCache(
             projectUuid,
+            'name',
         );
         const allExplores = Object.values(cachedExplores);
 
@@ -6154,6 +6158,7 @@ export class ProjectService extends BaseService {
         );
         const explores = await this.projectModel.findExploresFromCache(
             projectUuid,
+            'name',
             charts.map((chart) => chart.tableName),
         );
         const replaceableFields = charts.reduce<ReplaceableCustomFields>(

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -616,7 +616,10 @@ export class ValidationService extends BaseService {
             );
         } else {
             explores = Object.values(
-                await this.projectModel.findExploresFromCache(projectUuid),
+                await this.projectModel.findExploresFromCache(
+                    projectUuid,
+                    'name',
+                ),
             );
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:

Enhanced the `findExploresFromCache` method in `ProjectModel` to support retrieving explores by either name or UUID. This change adds a new parameter `key` that allows specifying whether the returned dictionary should use explore names or UUIDs as keys.

The method now returns cached explores with the appropriate key format, making it more flexible for different use cases throughout the application. All service calls to this method have been updated to specify the desired key type.

