### PR TITLE
feat: add changesetModel to AiAgentService for proposing changes

### DIFF
--- a/packages/backend/src/database/entities/changesets.ts
+++ b/packages/backend/src/database/entities/changesets.ts
@@ -62,7 +62,15 @@ export const DbChangeSchema = z.object({
     entity_table_name: z.string().min(1),
     entity_name: z.string().min(1),
     type: ChangeTypeSchema,
-    payload: z.record(z.unknown()),
+    payload: z.object({
+        patches: z.array(
+            z.object({
+                op: z.enum(['replace']),
+                path: z.string(),
+                value: z.unknown(),
+            }),
+        ),
+    }),
 });
 
 export type DbChange = z.infer<typeof DbChangeSchema>;
@@ -78,6 +86,6 @@ export const DbChangeInsertSchema = DbChangeSchema.pick({
     payload: true,
 });
 
-type DbChangeInsert = z.infer<typeof DbChangeInsertSchema>;
+export type DbChangeInsert = z.infer<typeof DbChangeInsertSchema>;
 
 export type ChangesTable = Knex.CompositeTableType<DbChange, DbChangeInsert>;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -99,6 +99,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     userModel: models.getUserModel(),
                     aiAgentModel: models.getAiAgentModel(),
+                    changesetModel: models.getChangesetModel(),
                     groupsModel: models.getGroupsModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     slackClient: clients.getSlackClient(),

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -79,6 +79,7 @@ import { type SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { CatalogSearchContext } from '../../models/CatalogModel/CatalogModel';
+import { ChangesetModel } from '../../models/ChangesetModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { OpenIdIdentityModel } from '../../models/OpenIdIdentitiesModel';
 import { SearchModel } from '../../models/SearchModel';
@@ -100,6 +101,7 @@ import { generateThreadTitle as generateTitleFromMessages } from './ai/agents/ti
 import { getModel } from './ai/models';
 import { AiAgentArgs, AiAgentDependencies } from './ai/types/aiAgent';
 import {
+    CreateChangeFn,
     FindChartsFn,
     FindDashboardsFn,
     FindExploresFn,
@@ -131,6 +133,7 @@ type AiAgentServiceDependencies = {
     analytics: LightdashAnalytics;
     asyncQueryService: AsyncQueryService;
     catalogService: CatalogService;
+    changesetModel: ChangesetModel;
     searchModel: SearchModel;
     spaceModel: SpaceModel;
     featureFlagService: FeatureFlagService;
@@ -155,6 +158,8 @@ export class AiAgentService {
     private readonly asyncQueryService: AsyncQueryService;
 
     private readonly catalogService: CatalogService;
+
+    private readonly changesetModel: ChangesetModel;
 
     private readonly featureFlagService: FeatureFlagService;
 
@@ -187,6 +192,7 @@ export class AiAgentService {
         this.analytics = dependencies.analytics;
         this.asyncQueryService = dependencies.asyncQueryService;
         this.catalogService = dependencies.catalogService;
+        this.changesetModel = dependencies.changesetModel;
         this.searchModel = dependencies.searchModel;
         this.featureFlagService = dependencies.featureFlagService;
         this.groupsModel = dependencies.groupsModel;
@@ -1944,6 +1950,26 @@ export class AiAgentService {
             return results;
         };
 
+        const createChange: CreateChangeFn = async (params) => {
+            const webOrSlackPrompt = isSlackPrompt(prompt)
+                ? await this.aiAgentModel.findSlackPrompt(prompt.promptUuid)
+                : await this.aiAgentModel.findWebAppPrompt(prompt.promptUuid);
+
+            await this.changesetModel.createChange({
+                projectUuid: params.projectUuid,
+                createdByUserUuid: params.createdByUserUuid,
+                sourcePromptUuid:
+                    params.sourcePromptUuid ??
+                    webOrSlackPrompt?.promptUuid ??
+                    null,
+                type: params.type,
+                entityType: params.entityType,
+                entityExploreUuid: params.entityExploreUuid,
+                entityName: params.entityName,
+                payload: params.payload,
+            });
+        };
+
         return {
             findCharts,
             findDashboards,
@@ -1957,6 +1983,7 @@ export class AiAgentService {
             storeToolCall,
             storeToolResults,
             searchFieldValues,
+            createChange,
         };
     }
 
@@ -2030,6 +2057,7 @@ export class AiAgentService {
             storeToolCall,
             storeToolResults,
             searchFieldValues,
+            createChange,
         } = this.getAiAgentDependencies(user, prompt);
 
         const modelProperties = getModel(this.lightdashConfig.ai.copilot);
@@ -2087,6 +2115,8 @@ export class AiAgentService {
 
             createOrUpdateArtifact: (data) =>
                 this.aiAgentModel.createOrUpdateArtifact(data),
+
+            createChange,
 
             perf: {
                 measureGenerateResponseTime: (durationMs) => {

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1951,22 +1951,10 @@ export class AiAgentService {
         };
 
         const createChange: CreateChangeFn = async (params) => {
-            const webOrSlackPrompt = isSlackPrompt(prompt)
-                ? await this.aiAgentModel.findSlackPrompt(prompt.promptUuid)
-                : await this.aiAgentModel.findWebAppPrompt(prompt.promptUuid);
-
-            await this.changesetModel.createChange({
-                projectUuid: params.projectUuid,
-                createdByUserUuid: params.createdByUserUuid,
-                sourcePromptUuid:
-                    params.sourcePromptUuid ??
-                    webOrSlackPrompt?.promptUuid ??
-                    null,
-                type: params.type,
-                entityType: params.entityType,
-                entityExploreUuid: params.entityExploreUuid,
-                entityName: params.entityName,
-                payload: params.payload,
+            await this.changesetModel.createChange(projectUuid, {
+                createdByUserUuid: user.userUuid,
+                sourcePromptUuid: prompt.promptUuid,
+                ...params,
             });
         };
 

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -217,7 +217,9 @@ const getAgentTools = (
 
     const improveContext = getImproveContext();
 
-    const proposeChange = getProposeChange();
+    const proposeChange = getProposeChange({
+        createChange: dependencies.createChange,
+    });
 
     const searchFieldValues = getSearchFieldValues({
         searchFieldValues: dependencies.searchFieldValues,

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
@@ -22,6 +22,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     generateBarVizConfig: 'vertical_bar_chart',
     generateDashboard: 'generate_dashboard',
     improveContext: 'improve_context',
+    proposeChange: 'propose_change',
 } satisfies Record<ToolName, string>;
 
 const getToolInfo = (toolName: string) => {
@@ -299,7 +300,7 @@ Evaluate the tool usage across three dimensions:
    - adequate: Tools accomplished the expected outcome but with some issues
    - poor: Tools partially accomplished the expected outcome with significant issues
    - failed: Tools did not accomplish the expected outcome
-   
+
    Consider:
    - Did the tools accomplish the expected outcome?
    - Were the tool arguments appropriate and complete?

--- a/packages/backend/src/ee/services/ai/tools/proposeChange.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.test.ts
@@ -1,0 +1,123 @@
+import { AiResultType } from '@lightdash/common';
+import { translateToolProposeChangeArgs } from './proposeChange';
+
+describe('translateToolProposeChangeArgs', () => {
+    it('should translate table update changes', () => {
+        expect(
+            translateToolProposeChangeArgs({
+                type: AiResultType.PROPOSE_CHANGE,
+                entityTableName: 'customers',
+                fieldId: 'customer_id',
+                rationale: 'Update the description of the customers table',
+                change: {
+                    value: {
+                        type: 'update',
+                        patch: {
+                            label: { value: 'customers', op: 'replace' },
+                            description: {
+                                value: 'Customer records including both B2B and B2C customers',
+                                op: 'replace',
+                            },
+                        },
+                    },
+                    entityType: 'table',
+                },
+            }),
+        ).toEqual({
+            type: 'update',
+            entityType: 'table',
+            entityTableName: 'customers',
+            entityName: 'customers',
+            payload: {
+                patches: [
+                    {
+                        op: 'replace',
+                        path: '/label',
+                        value: 'customers',
+                    },
+                    {
+                        op: 'replace',
+                        path: '/description',
+                        value: 'Customer records including both B2B and B2C customers',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('should translate dimension update changes', () => {
+        expect(
+            translateToolProposeChangeArgs({
+                type: AiResultType.PROPOSE_CHANGE,
+                entityTableName: 'customers',
+                fieldId: 'customer_name',
+                rationale: 'Update the description of the customers table',
+                change: {
+                    value: {
+                        type: 'update',
+                        patch: {
+                            label: null,
+                            description: {
+                                value: 'Customer records including both B2B and B2C customers',
+                                op: 'replace',
+                            },
+                        },
+                    },
+                    entityType: 'dimension',
+                },
+            }),
+        ).toEqual({
+            type: 'update',
+            entityType: 'dimension',
+            entityTableName: 'customers',
+            entityName: 'customer_name',
+            payload: {
+                patches: [
+                    {
+                        op: 'replace',
+                        path: '/description',
+                        value: 'Customer records including both B2B and B2C customers',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('should translate metric update changes', () => {
+        expect(
+            translateToolProposeChangeArgs({
+                type: AiResultType.PROPOSE_CHANGE,
+                entityTableName: 'customers',
+                fieldId: 'customer_total_revenue',
+                rationale: 'Update the description of the customers table',
+                change: {
+                    value: {
+                        type: 'update',
+                        patch: {
+                            label: null,
+                            description: {
+                                value: 'Customer total revenue',
+                                op: 'replace',
+                            },
+                        },
+                    },
+                    entityType: 'metric',
+                },
+            }),
+        ).toEqual({
+            type: 'update',
+            entityType: 'metric',
+            entityTableName: 'customers',
+            entityName: 'customer_total_revenue',
+            payload: {
+                patches: [
+                    {
+                        op: 'replace',
+                        path: '/description',
+                        value: 'Customer total revenue',
+                    },
+                ],
+            },
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/proposeChange.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.test.ts
@@ -7,7 +7,6 @@ describe('translateToolProposeChangeArgs', () => {
             translateToolProposeChangeArgs({
                 type: AiResultType.PROPOSE_CHANGE,
                 entityTableName: 'customers',
-                fieldId: 'customer_id',
                 rationale: 'Update the description of the customers table',
                 change: {
                     value: {
@@ -50,7 +49,6 @@ describe('translateToolProposeChangeArgs', () => {
             translateToolProposeChangeArgs({
                 type: AiResultType.PROPOSE_CHANGE,
                 entityTableName: 'customers',
-                fieldId: 'customer_name',
                 rationale: 'Update the description of the customers table',
                 change: {
                     value: {
@@ -64,6 +62,7 @@ describe('translateToolProposeChangeArgs', () => {
                         },
                     },
                     entityType: 'dimension',
+                    fieldId: 'customer_name',
                 },
             }),
         ).toEqual({
@@ -88,7 +87,6 @@ describe('translateToolProposeChangeArgs', () => {
             translateToolProposeChangeArgs({
                 type: AiResultType.PROPOSE_CHANGE,
                 entityTableName: 'customers',
-                fieldId: 'customer_total_revenue',
                 rationale: 'Update the description of the customers table',
                 change: {
                     value: {
@@ -102,6 +100,7 @@ describe('translateToolProposeChangeArgs', () => {
                         },
                     },
                     entityType: 'metric',
+                    fieldId: 'customer_total_revenue',
                 },
             }),
         ).toEqual({

--- a/packages/backend/src/ee/services/ai/tools/proposeChange.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.ts
@@ -1,15 +1,25 @@
-import { toolProposeChangeArgsSchema } from '@lightdash/common';
+import {
+    NotImplementedError,
+    ToolProposeChangeArgs,
+    toolProposeChangeArgsSchema,
+} from '@lightdash/common';
 import { tool } from 'ai';
+import { CreateChangeFn } from '../types/aiAgentDependencies';
 
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 
-export const getProposeChange = () =>
+type GetProposeChangeArgs = {
+    createChange: CreateChangeFn;
+};
+
+export const getProposeChange = ({ createChange }: GetProposeChangeArgs) =>
     tool({
         description: toolProposeChangeArgsSchema.description,
         inputSchema: toolProposeChangeArgsSchema,
         execute: async (toolArgs) => {
             try {
                 console.dir(toolArgs, { depth: null });
+                // createChange is now available but not used yet
                 return `Success`;
             } catch (error) {
                 return toolErrorHandler(error, 'Error proposing change');

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -2,6 +2,7 @@ import { AiAgent } from '@lightdash/common';
 import { ModelMessage } from 'ai';
 import { AiModel, AiProvider } from '../models/types';
 import {
+    CreateChangeFn,
     CreateOrUpdateArtifactFn,
     FindChartsFn,
     FindDashboardsFn,
@@ -66,6 +67,7 @@ export type AiAgentDependencies = {
     searchFieldValues: SearchFieldValuesFn;
     trackEvent: TrackEventFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
+    createChange: CreateChangeFn;
     perf: PerformanceMetrics;
 };
 

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -8,6 +8,7 @@ import {
     CacheMetadata,
     CatalogField,
     CatalogTable,
+    CreateChangeParams,
     DashboardSearchResult,
     Explore,
     Filters,
@@ -140,3 +141,5 @@ export type CheckUserPermissionFn = (args: {
     organizationId: string;
     permission: string;
 }) => Promise<boolean>;
+
+export type CreateChangeFn = (params: CreateChangeParams) => Promise<void>;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -142,4 +142,9 @@ export type CheckUserPermissionFn = (args: {
     permission: string;
 }) => Promise<boolean>;
 
-export type CreateChangeFn = (params: CreateChangeParams) => Promise<void>;
+export type CreateChangeFn = (
+    params: Pick<
+        CreateChangeParams,
+        'type' | 'entityName' | 'entityType' | 'entityTableName' | 'payload'
+    >,
+) => Promise<void>;

--- a/packages/backend/src/models/ChangesetModel.ts
+++ b/packages/backend/src/models/ChangesetModel.ts
@@ -2,6 +2,7 @@ import {
     ChangeSchema,
     ChangesetWithChanges,
     ChangesetWithChangesSchema,
+    CreateChangeParams,
     NotFoundError,
     ParseError,
 } from '@lightdash/common';
@@ -9,7 +10,6 @@ import { Knex } from 'knex';
 import {
     ChangesetsTableName,
     ChangesTableName,
-    ChangeType,
     DbChange,
     DbChangeInsertSchema,
     DbChangeSchema,
@@ -18,17 +18,6 @@ import {
 
 type ChangesetModelArguments = {
     database: Knex;
-};
-
-type CreateChangeParams = {
-    projectUuid: string;
-    createdByUserUuid: string;
-    sourcePromptUuid: string | null;
-    type: ChangeType;
-    entityType: EntityType;
-    entityExploreUuid: string | null;
-    entityName: string;
-    payload: Record<string, unknown>;
 };
 
 export class ChangesetModel {

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -20,6 +20,7 @@ export const ToolNameSchema = z.enum([
     'findDashboards',
     'findCharts',
     'improveContext',
+    'proposeChange',
 ]);
 
 export type ToolName = z.infer<typeof ToolNameSchema>;

--- a/packages/common/src/types/changeset.ts
+++ b/packages/common/src/types/changeset.ts
@@ -62,10 +62,22 @@ export const ChangesetWithChangesSchema = ChangesetSchema.extend({
 
 export type Changeset = z.infer<typeof ChangesetSchema>;
 export type ChangesetWithChanges = z.infer<typeof ChangesetWithChangesSchema>;
+export type Change = z.infer<typeof ChangeSchema>;
 
 export type ApiChangesetsResponse = {
     status: 'ok';
     results: ChangesetWithChanges[];
+};
+
+export type CreateChangeParams = {
+    projectUuid: string;
+    createdByUserUuid: string;
+    sourcePromptUuid: string | null;
+    type: Change['type'];
+    entityType: Change['entityType'];
+    entityExploreUuid: string | null;
+    entityName: string;
+    payload: Record<string, unknown>;
 };
 
 // tsoa does not support z.infer schemas - https://github.com/lukeautry/tsoa/issues/1256

--- a/packages/common/src/types/changeset.ts
+++ b/packages/common/src/types/changeset.ts
@@ -13,48 +13,26 @@ export const ChangesetSchema = z.object({
     name: z.string().min(1),
 });
 
-export const ChangeSchema = z
-    .object({
-        changeUuid: z.string().uuid(),
-        changesetUuid: z.string().uuid(),
-        createdAt: z.date(),
-        createdByUserUuid: z.string().uuid(),
-        sourcePromptUuid: z.string().uuid().nullable(),
-        type: z.enum(['create', 'update', 'delete']),
-        entityType: z.enum(['table', 'dimension', 'metric']),
-        entityTableName: z.string().min(1),
-        entityName: z.string().min(1),
-        payload: z.record(z.unknown()),
-    })
-    .and(
-        z.discriminatedUnion('type', [
+export const ChangeSchema = z.object({
+    changeUuid: z.string().uuid(),
+    changesetUuid: z.string().uuid(),
+    createdAt: z.date(),
+    createdByUserUuid: z.string().uuid(),
+    sourcePromptUuid: z.string().uuid().nullable(),
+    type: z.enum(['create', 'update', 'delete']),
+    entityType: z.enum(['table', 'dimension', 'metric']),
+    entityTableName: z.string().min(1),
+    entityName: z.string().min(1),
+    payload: z.object({
+        patches: z.array(
             z.object({
-                type: z.literal('create'),
-                payload: z.object({ value: z.unknown() }),
+                op: z.enum(['replace']),
+                path: z.string(),
+                value: z.unknown(),
             }),
-            z.object({
-                type: z.literal('update'),
-                payload: z.object({
-                    patch: z.array(
-                        z.object({
-                            op: z.enum(['replace']),
-                            path: z.string(),
-                            value: z
-                                .unknown()
-                                // TODO: fix types
-                                .refine((value) => value !== undefined),
-                        }),
-                    ),
-                }),
-            }),
-            z.object({
-                type: z.literal('delete'),
-                payload: z.object({}),
-            }),
-        ]),
-    );
-
-export type Change = z.infer<typeof ChangeSchema>;
+        ),
+    }),
+});
 
 export const ChangesetWithChangesSchema = ChangesetSchema.extend({
     changes: z.array(ChangeSchema),
@@ -69,16 +47,16 @@ export type ApiChangesetsResponse = {
     results: ChangesetWithChanges[];
 };
 
-export type CreateChangeParams = {
-    projectUuid: string;
-    createdByUserUuid: string;
-    sourcePromptUuid: string | null;
-    type: Change['type'];
-    entityType: Change['entityType'];
-    entityExploreUuid: string | null;
-    entityName: string;
-    payload: Record<string, unknown>;
-};
+export type CreateChangeParams = Pick<
+    Change,
+    | 'createdByUserUuid'
+    | 'sourcePromptUuid'
+    | 'type'
+    | 'entityName'
+    | 'entityType'
+    | 'entityTableName'
+    | 'payload'
+>;
 
 // tsoa does not support z.infer schemas - https://github.com/lukeautry/tsoa/issues/1256
 type ChangesetTSOACompat = Record<string, unknown>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -28,6 +28,7 @@ import {
     IconChartLine,
     IconDashboard,
     IconDatabase,
+    IconPencil,
     IconSchool,
     IconSearch,
     IconSelector,
@@ -58,6 +59,7 @@ const getToolIcon = (toolName: ToolName) => {
             findDashboards: IconDashboard,
             findCharts: IconChartDots3,
             improveContext: IconSchool,
+            proposeChange: IconPencil,
         };
 
     return iconMap[toolName];
@@ -288,6 +290,27 @@ const ToolCallDescription: FC<{
             );
         case AiResultType.IMPROVE_CONTEXT:
             return <> </>;
+        case AiResultType.PROPOSE_CHANGE:
+            return (
+                <Text c="dimmed" size="xs">
+                    Proposed change to{' '}
+                    <Badge
+                        color="gray"
+                        variant="light"
+                        size="xs"
+                        mx={rem(2)}
+                        radius="sm"
+                        style={{
+                            textTransform: 'none',
+                            fontWeight: 400,
+                        }}
+                    >
+                        {toolArgs.change.entityType === 'table'
+                            ? toolArgs.entityTableName
+                            : toolArgs.change.fieldId}
+                    </Badge>
+                </Text>
+            );
         default:
             return assertUnreachable(toolArgs, `Unknown tool name ${toolName}`);
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:

Adds the ability to create changes from AI agent prompts. This PR:

- Adds a `createChange` function to the AI agent dependencies
- Integrates the `changesetModel` into the AI agent service
- Implements translation logic for proposed changes to tables, dimensions, and metrics
- Adds tests for the change translation functionality

The implementation allows AI agents to propose metadata changes that can be tracked and managed through the changeset system.

<!-- CURSOR_SUMMARY -->

---

> [!NOTE]
> Adds proposeChange tooling that translates and saves AI-proposed table/field updates into project changesets, with schema/type updates, service wiring, UI display, and tests.
> - **AI Agent**:
>     - Adds `createChange` dependency and wires `ChangesetModel` into `AiAgentService`; exposes to agents in both streamed and non-streamed flows.
>     - Integrates new `proposeChange` tool that translates tool args to JSON Patch and calls `createChange`.
>     - Updates tool registry/types to include `proposeChange` across backend and test utilities.
> - **Changesets/Schema**:
>     - Changes `DbChangeSchema.payload` to structured `{ patches: [{ op: 'replace', path, value }] }` and aligns `ChangeSchema` types.
>     - Refactors `ChangesetModel.createChange(projectUuid, change)`; stores `entity_table_name` and returns typed `Change`.
>     - Introduces shared `CreateChangeParams` type in `@lightdash/common`.
> - **Tooling & Tests**:
>     - Implements `translateToolProposeChangeArgs` for tables/dimensions/metrics; adds unit tests covering patch translation.
> - **Frontend**:
>     - Displays propose-change tool calls in chat timeline with pencil icon and concise summary.
> <sup>Written by Cursor Bugbot for commit 622b75a67bab3eb12b37a21ba9816f2e57332de1. This will update automatically on new commits. Configure here.</sup>

<!-- /CURSOR_SUMMARY -->