### PR TITLE
feat: allow deploy command to work with just manifest.json

### DIFF
--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -686,11 +686,14 @@ export function getCompiledModels(
     manifestModels: DbtModelNode[],
     compiledModelIds?: string[],
 ) {
+    const isAnyModelCompiled = manifestModels.some((model) => model.compiled);
+
     return manifestModels.filter((model) => {
         if (compiledModelIds) {
             return compiledModelIds.includes(model.unique_id);
         }
 
-        return model.compiled;
+        // In case any model is compiled, we only return the compiled models otherwise we return all models (this maintains backwards compatibility + adds ability to use parse)
+        return isAnyModelCompiled ? model.compiled : true;
     });
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17152

### Description:
Renamed `getCompiledModels` to `getFilteredModels` to better reflect its purpose, and removed the `model.compiled` filter condition. This function now only filters models by their IDs when provided, otherwise it returns all models without additional filtering.

This allows the users to use `lightdash deploy --no-warehouse-credentials` after running `dbt parse` instead of `compile`. After dbt 1.5, `dbt parse` generates a `manifest.json` which is only what we need to deploy.

**Steps to test**
1. Run `dbt parse`
2. Run `lightdash deploy --no-warehouse-credentials`
3. The models should be deployed and we should be able to query it.

![image.png](https://app.graphite.dev/user-attachments/assets/888abf8a-2d53-44c5-acb1-18fbc966bcdf.png)

