### PR TITLE
fix: find tile targets first by tileSlug

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -30,6 +30,7 @@ import {
     SpaceMemberRole,
     SpaceSummary,
     UpdatedByUser,
+    type DashboardTileWithSlug,
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
@@ -209,7 +210,7 @@ export class CoderService extends BaseService {
      */
     static getFiltersWithTileUuids(
         dashboardAsCode: DashboardAsCode,
-        tilesWithUuids: DashboardTile[],
+        tilesWithUuids: DashboardTileWithSlug[],
     ): DashboardDAO['filters'] {
         const dimensionFiltersWithUuids: DashboardDAO['filters']['dimensions'] =
             dashboardAsCode.filters.dimensions.map((filter) => {
@@ -220,7 +221,9 @@ export class CoderService extends BaseService {
                         const tileUuid = tilesWithUuids.find(
                             (t) =>
                                 isAnyChartTile(t) &&
-                                t.properties.chartSlug === tileSlug,
+                                // Match first by tileSlug, then by chartSlug (for the case of tile not having a slug)
+                                (t.tileSlug === tileSlug ||
+                                    t.properties.chartSlug === tileSlug),
                         )?.uuid;
                         if (!tileUuid) {
                             console.error(
@@ -310,7 +313,7 @@ export class CoderService extends BaseService {
     async convertTileWithSlugsToUuids(
         projectUuid: string,
         tiles: DashboardTileAsCode[],
-    ): Promise<DashboardTile[]> {
+    ): Promise<DashboardTileWithSlug[]> {
         const chartSlugs: string[] = tiles.reduce<string[]>(
             (acc, tile) =>
                 isAnyChartTile(tile)
@@ -344,9 +347,10 @@ export class CoderService extends BaseService {
                         ...tile.properties,
                         savedChartUuid: savedChart.uuid,
                     },
-                } as DashboardTile;
+                } as DashboardTileWithSlug;
             }
-            return tile as DashboardTile;
+
+            return tile as DashboardTileWithSlug;
         });
     }
 

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -71,6 +71,10 @@ export type DashboardTileAsCode = Omit<DashboardTile, 'properties' | 'uuid'> & {
         | DashboardLoomTileProperties['properties'];
 };
 
+export type DashboardTileWithSlug = DashboardTile & {
+    tileSlug: string | undefined;
+};
+
 export type DashboardAsCode = Pick<
     Dashboard,
     'name' | 'description' | 'updatedAt' | 'tabs' | 'slug'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17160

### Description:
Added support for matching dashboard tiles by `tileSlug` in addition to `chartSlug` when converting dashboard filters from code to database format. This fixes an issue where filters weren't properly associated with tiles that changed slug.

This would effectively remove the tile target from the filter.

The changes include:
- Created a new type `DashboardTileWithSlug` that extends `DashboardTile` with a `tileSlug` property
- Updated the filter matching logic to check both `tileSlug` and `chartSlug` when finding the corresponding tile
- Updated return types in relevant functions to use the new type

**Steps to reproduce**

1. Download a dashboard with filters
2. Update tile target `tileSlug` and tile `tileSlug` but keep `chartSlug` the same.
3. Run `lightdash upload --force`

**Test yaml**
Notice `tileSlug` being `saved-in-dashboard-how-much-revenue-do-we-have-per-payment-method-1` while `chartSlug` is different

```yaml
name: Dashboard with dashboard charts
description: null
updatedAt: "2025-10-01T12:23:21.376Z"
tiles:
  - x: 0
    "y": 0
    h: 9
    w: 24
    tabUuid: null
    type: saved_chart
    properties:
      title: ""
      hideTitle: false
      chartSlug: saved-in-dashboard-how-much-revenue-do-we-have-per-payment-method
      chartName: "[Saved in dashboard] How much revenue do we have per payment method?"
    tileSlug: saved-in-dashboard-how-much-revenue-do-we-have-per-payment-method-1
filters:
  metrics: []
  dimensions:
    - target:
        fieldId: payments_payment_method
        fieldName: payment_method
        tableName: payments
      values:
        - bank_transfer
      disabled: false
      operator: equals
      tileTargets:
        saved-in-dashboard-how-much-revenue-do-we-have-per-payment-method-1:
          fieldId: payments_payment_method
          tableName: payments
  tableCalculations: []
tabs: []
slug: dashboard-with-dashboard-charts
spaceSlug: jaffle-shop
version: 1
downloadedAt: "2025-10-01T12:23:32.454Z"
```

**Before**
<img width="1089" height="25" alt="image" src="https://github.com/user-attachments/assets/834f2a6c-1433-4d64-9592-de232c038096" />
