### PR TITLE
fix: custom metrics are created with the wrong id

### DIFF
--- a/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
+++ b/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
@@ -172,7 +172,7 @@ describe('Custom dimensions', () => {
 
         const sqlLines = [
             `"payments".payment_method AS "payments_payment_method",`,
-            `MAX((("orders".amount)) / 10) AS "payments_discounted amount_max_of_discounted_amount",`,
+            `MAX((("orders".amount)) / 10) AS "payments_discounted_amount_max_of_discounted_amount",`,
             `GROUP BY 1`,
             `ORDER BY "payments_payment_method"`,
         ];

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -189,6 +189,8 @@ export const prepareCustomMetricData = ({
                 'baseDimensionName' in item &&
                 item.baseDimensionName
                 ? item.baseDimensionName
+                : isCustomDimension(item)
+                ? item.id // Custom dimensions have ids instead of names
                 : item.name,
         ),
         ...(isEditingCustomMetric &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17159 

### Description:

**The bug:**
Creating a table calculation from a custom metric based on a custom dimension was failing. The real issue here was that custom metrics based on custom dimensions were being created with the wrong (bad) id. Dimensions have a `name` and a `label`, while custom dimensions have a `name` and an `id`, but the name is really the label. 

**The fix:**
Create custom metrics based on custom dimensions using the custom dimension ID instead of the name.

**A custom dimension before (bug)**
```
{
    "uuid": "58a8e89a-7ac9-4565-bb62-ee73f93f9f90",
    "table": "orders",
    ...
    "label": "Count of A custom dimension",
    "name": "A custom dimension_count_of_a_custom_dimension" // this is wrong
}
```

**The same custom dimension now**
```
{
    "uuid": "9b754d9f-aed6-4191-b6ef-86237f310443",
    "table": "orders",
    ...
    "label": "Count of A custom dimension",
    "name": "a_custom_dimension_count_of_a_custom_dimension" // this id is right
}
```

**To test:**
- Create a custom dimension with spaces in its name
- Create a custom metric based on that custom dimension
- Create a table calculation based on the custom metric

