### PR TITLE
feat: introduce propose change tool template

### DIFF
--- a/packages/frontend/.storybook/preview.tsx
+++ b/packages/frontend/.storybook/preview.tsx
@@ -1,3 +1,5 @@
+import '@mantine-8/core/styles.css';
+
 import { MantineProvider } from '@mantine/core';
 import React from 'react';
 import { getMantineThemeOverride } from '../src/mantineTheme';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -1,4 +1,8 @@
-import { ChartKind, type AiAgentMessageAssistant } from '@lightdash/common';
+import {
+    ChartKind,
+    type AiAgentMessageAssistant,
+    type ToolProposeChangeArgs,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Alert,
@@ -48,6 +52,7 @@ import AgentChatDebugDrawer from './AgentChatDebugDrawer';
 import { AiArtifactButton } from './ArtifactButton/AiArtifactButton';
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { AiChartToolCalls } from './ToolCalls/AiChartToolCalls';
+import { AiProposeChangeToolCall } from './ToolCalls/AiProposeChangeToolCall';
 
 const AssistantBubbleContent: FC<{
     message: AiAgentMessageAssistant;
@@ -82,6 +87,12 @@ const AssistantBubbleContent: FC<{
         message.uuid,
         projectUuid,
     ]);
+
+    const proposeChangeToolCall = isStreaming
+        ? (streamingState?.toolCalls.find((t) => t.toolName === 'proposeChange')
+              ?.toolArgs as ToolProposeChangeArgs)
+        : (message.toolCalls.find((t) => t.toolName === 'proposeChange')
+              ?.toolArgs as ToolProposeChangeArgs); // TODO: fix message type, it's `object` now
 
     return (
         <>
@@ -267,6 +278,12 @@ const AssistantBubbleContent: FC<{
                 />
             ) : null}
             {isStreaming ? <Loader type="dots" color="gray" /> : null}
+            {proposeChangeToolCall && (
+                <AiProposeChangeToolCall
+                    change={proposeChangeToolCall.change}
+                    entityTableName={proposeChangeToolCall.entityTableName}
+                />
+            )}
         </>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -289,28 +289,8 @@ const ToolCallDescription: FC<{
                 </Text>
             );
         case AiResultType.IMPROVE_CONTEXT:
-            return <> </>;
         case AiResultType.PROPOSE_CHANGE:
-            return (
-                <Text c="dimmed" size="xs">
-                    Proposed change to{' '}
-                    <Badge
-                        color="gray"
-                        variant="light"
-                        size="xs"
-                        mx={rem(2)}
-                        radius="sm"
-                        style={{
-                            textTransform: 'none',
-                            fontWeight: 400,
-                        }}
-                    >
-                        {toolArgs.change.entityType === 'table'
-                            ? toolArgs.entityTableName
-                            : toolArgs.change.fieldId}
-                    </Badge>
-                </Text>
-            );
+            return <> </>;
         default:
             return assertUnreachable(toolArgs, `Unknown tool name ${toolName}`);
     }
@@ -417,6 +397,7 @@ type AiChartToolCallsProps = {
     promptUuid: string;
 };
 
+const EXCLUDED_TOOL_NAMES = ['improveContext', 'proposeChange'];
 export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({
     toolCalls,
     type,
@@ -431,7 +412,7 @@ export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({
             : TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL;
 
     const calculationToolCalls = toolCalls?.filter(
-        (toolCall) => toolCall.toolName !== 'improveContext',
+        (toolCall) => !EXCLUDED_TOOL_NAMES.includes(toolCall.toolName),
     );
 
     if (!toolCalls || toolCalls.length === 0) return null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
@@ -1,0 +1,170 @@
+import { assertUnreachable } from '@lightdash/common';
+import { Stack } from '@mantine-8/core';
+import { toPairs } from 'lodash';
+import { OperationRenderer } from './OperationRenderer';
+import { FieldBreadcrumb, TableBreadcrumb } from './SupportElements';
+import type {
+    DimensionChange,
+    EntityChange,
+    MetricChange,
+    TableChange,
+    UpdateDimensionPatch,
+    UpdateMetricPatch,
+    UpdateTablePatch,
+} from './types';
+
+// ============================================================================
+// Unified Update Change Component
+// [ separate into entity-specific components if needed in the future ]
+// ============================================================================
+
+type UpdateChangeProps = {
+    patch: UpdateTablePatch | UpdateDimensionPatch | UpdateMetricPatch;
+};
+
+const UpdateChange = ({ patch }: UpdateChangeProps) => {
+    const operations = toPairs(patch)
+        .filter(([, op]) => op !== null)
+        .map(([property, op]) => ({ property, op: op! }));
+
+    return (
+        <Stack gap="xs" px="xs">
+            {operations.map(({ property, op }) => (
+                <OperationRenderer
+                    key={property}
+                    operation={op}
+                    property={property}
+                />
+            ))}
+        </Stack>
+    );
+};
+
+// ============================================================================
+// Table Changes
+// ============================================================================
+
+type TableChangeProps = {
+    change: TableChange;
+    entityTableName: string;
+};
+
+const TableChangeRender = ({ change, entityTableName }: TableChangeProps) => {
+    switch (change.value.type) {
+        case 'update':
+            return (
+                <Stack gap="xs">
+                    <TableBreadcrumb entityTableName={entityTableName} />
+                    <UpdateChange patch={change.value.patch} />
+                </Stack>
+            );
+        default:
+            return assertUnreachable(
+                change.value.type,
+                'Unknown table change type',
+            );
+    }
+};
+
+// ============================================================================
+// Dimension Changes
+// ============================================================================
+
+type DimensionChangeProps = {
+    change: DimensionChange;
+    entityTableName: string;
+};
+
+const DimensionChangeRender = ({
+    change,
+    entityTableName,
+}: DimensionChangeProps) => {
+    switch (change.value.type) {
+        case 'update':
+            return (
+                <Stack gap="xs">
+                    <FieldBreadcrumb
+                        entityTableName={entityTableName}
+                        fieldType="dimension"
+                        fieldId={change.fieldId}
+                    />
+                    <UpdateChange patch={change.value.patch} />
+                </Stack>
+            );
+        default:
+            return assertUnreachable(
+                change.value.type,
+                'Unknown dimension change type',
+            );
+    }
+};
+
+// ============================================================================
+// Metric Changes
+// ============================================================================
+
+type MetricChangeProps = {
+    change: MetricChange;
+    entityTableName: string;
+};
+
+const MetricChangeRender = ({ change, entityTableName }: MetricChangeProps) => {
+    switch (change.value.type) {
+        case 'update':
+            return (
+                <Stack gap="xs">
+                    <FieldBreadcrumb
+                        entityTableName={entityTableName}
+                        fieldType="metric"
+                        fieldId={change.fieldId}
+                    />
+                    <UpdateChange patch={change.value.patch} />
+                </Stack>
+            );
+        default:
+            return assertUnreachable(
+                change.value.type,
+                'Unknown metric change type',
+            );
+    }
+};
+
+// ============================================================================
+// Main Renderer
+// ============================================================================
+
+type ChangeRendererProps = {
+    change: EntityChange;
+    entityTableName: string;
+};
+
+export const ChangeRenderer = ({
+    change,
+    entityTableName,
+}: ChangeRendererProps) => {
+    switch (change.entityType) {
+        case 'table':
+            return (
+                <TableChangeRender
+                    change={change}
+                    entityTableName={entityTableName}
+                />
+            );
+        case 'dimension':
+            return (
+                <DimensionChangeRender
+                    change={change}
+                    entityTableName={entityTableName}
+                />
+            );
+        case 'metric':
+            return (
+                <MetricChangeRender
+                    change={change}
+                    entityTableName={entityTableName}
+                />
+            );
+        default:
+            return assertUnreachable(change, 'Unknown entity type');
+    }
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/OperationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/OperationRenderer.tsx
@@ -1,0 +1,37 @@
+import { assertUnreachable, capitalize } from '@lightdash/common';
+import { Stack, Text } from '@mantine-8/core';
+import { Paper } from '@mantine/core';
+import type { Operation } from './types';
+
+type ReplaceOperationProps = {
+    value: string;
+    name: string;
+};
+
+const ReplaceOperation = ({ value, name }: ReplaceOperationProps) => {
+    return (
+        <Paper bg="gray.0" p="xs" component={Stack} gap="xxs">
+            <Text component="code" size="xs" fw={600} c="gray.7">
+                {capitalize(name)}
+            </Text>
+            <Text size="sm">"{value}"</Text>
+        </Paper>
+    );
+};
+
+type OperationRendererProps = {
+    operation: Operation;
+    property: string;
+};
+
+export const OperationRenderer = ({
+    operation,
+    property,
+}: OperationRendererProps) => {
+    switch (operation.op) {
+        case 'replace':
+            return <ReplaceOperation value={operation.value} name={property} />;
+        default:
+            return assertUnreachable(operation.op, 'Unknown operation type');
+    }
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/SupportElements.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/SupportElements.tsx
@@ -1,0 +1,42 @@
+import { capitalize } from '@lightdash/common';
+import { Group, Text } from '@mantine-8/core';
+import { IconChevronRight, IconTable } from '@tabler/icons-react';
+import MantineIcon from '../../../../../../../components/common/MantineIcon';
+
+type EntityBreadcrumbProps = {
+    entityTableName: string;
+};
+
+export const TableBreadcrumb = ({ entityTableName }: EntityBreadcrumbProps) => (
+    <Group gap="xxs" align="center" c="gray.7">
+        <MantineIcon icon={IconTable} size={12} />
+        <Text size="xs" fw={600}>
+            {capitalize(entityTableName)}
+        </Text>
+    </Group>
+);
+
+type FieldBreadcrumbProps = EntityBreadcrumbProps & {
+    fieldType: 'dimension' | 'metric';
+    fieldId: string;
+};
+
+export const FieldBreadcrumb = ({
+    entityTableName,
+    fieldType,
+    fieldId,
+}: FieldBreadcrumbProps) => (
+    <Group gap="xxs" align="center" c="gray.5">
+        <MantineIcon icon={IconTable} size={12} />
+        <Text size="xs" fw={500}>
+            {capitalize(entityTableName)}
+        </Text>
+        <MantineIcon icon={IconChevronRight} size="sm" />
+        <Text size="xs" fw={600} c="gray.7">
+            {capitalize(fieldType)}:
+        </Text>
+        <Text size="xs" c="gray.7" component="code" fw={600}>
+            {fieldId}
+        </Text>
+    </Group>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
@@ -1,0 +1,86 @@
+import { type ToolProposeChangeArgs } from '@lightdash/common';
+import {
+    Badge,
+    Collapse,
+    type DefaultMantineColor,
+    Group,
+    Paper,
+    Stack,
+    Title,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { IconGitBranch, IconSelector } from '@tabler/icons-react';
+
+import { useDisclosure } from '@mantine-8/hooks';
+import MantineIcon from '../../../../../../../components/common/MantineIcon';
+import { ChangeRenderer } from './ChangeRenderer';
+
+interface Props
+    extends Pick<ToolProposeChangeArgs, 'change' | 'entityTableName'> {
+    defaultOpened?: boolean;
+}
+
+const CHANGE_COLORS = {
+    update: 'blue',
+} as const satisfies Record<'update', DefaultMantineColor>;
+
+export const AiProposeChangeToolCall = ({
+    change,
+    entityTableName,
+    defaultOpened = true,
+}: Props) => {
+    const changeType = change.value.type;
+    const changeColor: DefaultMantineColor =
+        CHANGE_COLORS[changeType] ?? 'gray';
+    const [containerExpanded, { toggle }] = useDisclosure(defaultOpened);
+
+    return (
+        <Paper withBorder p="xs" radius="md">
+            <UnstyledButton onClick={toggle} w="100%" h="18px">
+                <Group justify="space-between" w="100%" h="100%">
+                    <Group gap="xs">
+                        <MantineIcon
+                            icon={IconGitBranch}
+                            size="sm"
+                            strokeWidth={1.2}
+                            color="gray.6"
+                        />
+                        <Title order={6} c="gray.6" size="xs">
+                            Semantic Layer changes
+                        </Title>
+                        <Badge
+                            radius="sm"
+                            size="sm"
+                            variant="light"
+                            color={changeColor}
+                        >
+                            {changeType}
+                        </Badge>
+                    </Group>
+                    <MantineIcon icon={IconSelector} size={12} color="gray.6" />
+                </Group>
+            </UnstyledButton>
+
+            <Collapse in={containerExpanded}>
+                <Stack gap="xs" mt="xs">
+                    <ChangeRenderer
+                        change={change}
+                        entityTableName={entityTableName}
+                    />
+
+                    {/*TODO
+                    <Group w="100%" justify="flex-end">
+                        <Button
+                            variant="outline"
+                            size="xs"
+                            color="dark"
+                            leftSection={<MantineIcon icon={IconX} size={14} />}
+                        >
+                            Reject
+                        </Button>
+                    </Group>*/}
+                </Stack>
+            </Collapse>
+        </Paper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/types.ts
@@ -1,0 +1,40 @@
+import type {
+    ToolProposeChangeArgs,
+    ToolProposeChangeReplaceStringOp,
+} from '@lightdash/common';
+
+export type TableChange = Extract<
+    ToolProposeChangeArgs['change'],
+    { entityType: 'table' }
+>;
+
+export type DimensionChange = Extract<
+    ToolProposeChangeArgs['change'],
+    { entityType: 'dimension' }
+>;
+
+export type MetricChange = Extract<
+    ToolProposeChangeArgs['change'],
+    { entityType: 'metric' }
+>;
+
+export type EntityChange = ToolProposeChangeArgs['change'];
+
+export type ChangeValue = ToolProposeChangeArgs['change']['value'];
+
+export type Operation = ToolProposeChangeReplaceStringOp; // extend as needed in the future;
+
+export type UpdateTablePatch = Extract<
+    TableChange['value'],
+    { type: 'update' }
+>['patch'];
+
+export type UpdateDimensionPatch = Extract<
+    DimensionChange['value'],
+    { type: 'update' }
+>['patch'];
+
+export type UpdateMetricPatch = Extract<
+    MetricChange['value'],
+    { type: 'update' }
+>['patch'];

--- a/packages/frontend/src/stories/AiProposeChangeToolCall.stories.tsx
+++ b/packages/frontend/src/stories/AiProposeChangeToolCall.stories.tsx
@@ -1,0 +1,202 @@
+import '@mantine-8/core/styles.css';
+import type { Meta, StoryObj } from '@storybook/react';
+import { AiProposeChangeToolCall } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall';
+import Mantine8Provider from '../providers/Mantine8Provider';
+
+const meta: Meta<typeof AiProposeChangeToolCall> = {
+    decorators: [
+        (renderStory) => <Mantine8Provider>{renderStory()}</Mantine8Provider>,
+    ],
+    component: AiProposeChangeToolCall,
+    tags: ['autodocs'],
+    title: 'AI Copilot/AiProposeChangeToolCall',
+};
+
+export default meta;
+type Story = StoryObj<typeof AiProposeChangeToolCall>;
+
+export const UpdateTableDescription: Story = {
+    args: {
+        entityTableName: 'customers',
+        change: {
+            entityType: 'table',
+            value: {
+                type: 'update',
+                patch: {
+                    description: {
+                        op: 'replace',
+                        value: 'Customer information including both B2B and B2C customers',
+                    },
+                    label: null,
+                },
+            },
+        },
+    },
+};
+
+export const UpdateTableLabel: Story = {
+    args: {
+        entityTableName: 'orders',
+        change: {
+            entityType: 'table',
+            value: {
+                type: 'update',
+                patch: {
+                    description: null,
+                    label: {
+                        op: 'replace',
+                        value: 'Customer Orders',
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const UpdateTableLabelAndDescription: Story = {
+    args: {
+        entityTableName: 'products',
+        change: {
+            entityType: 'table',
+            value: {
+                type: 'update',
+                patch: {
+                    description: {
+                        op: 'replace',
+                        value: 'Product catalog containing all active and archived products',
+                    },
+                    label: {
+                        op: 'replace',
+                        value: 'Product Catalog',
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const UpdateDimensionDescription: Story = {
+    args: {
+        entityTableName: 'customers',
+        change: {
+            entityType: 'dimension',
+            fieldId: 'customer_name',
+            value: {
+                type: 'update',
+                patch: {
+                    description: {
+                        op: 'replace',
+                        value: 'Full name of the customer as registered in the system',
+                    },
+                    label: null,
+                },
+            },
+        },
+    },
+};
+
+export const UpdateDimensionLabel: Story = {
+    args: {
+        entityTableName: 'customers',
+        change: {
+            entityType: 'dimension',
+            fieldId: 'customer_email',
+            value: {
+                type: 'update',
+                patch: {
+                    description: null,
+                    label: {
+                        op: 'replace',
+                        value: 'Email Address',
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const UpdateDimensionLabelAndDescription: Story = {
+    args: {
+        entityTableName: 'customers',
+        change: {
+            entityType: 'dimension',
+            fieldId: 'signup_date',
+            value: {
+                type: 'update',
+                patch: {
+                    description: {
+                        op: 'replace',
+                        value: 'Date when the customer first registered on the platform',
+                    },
+                    label: {
+                        op: 'replace',
+                        value: 'Registration Date',
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const UpdateMetricDescription: Story = {
+    args: {
+        entityTableName: 'orders',
+        change: {
+            entityType: 'metric',
+            fieldId: 'total_revenue',
+            value: {
+                type: 'update',
+                patch: {
+                    description: {
+                        op: 'replace',
+                        value: 'Net revenue after taxes and discounts, excluding refunds',
+                    },
+                    label: null,
+                },
+            },
+        },
+    },
+};
+
+export const UpdateMetricLabel: Story = {
+    args: {
+        entityTableName: 'orders',
+        change: {
+            entityType: 'metric',
+            fieldId: 'avg_order_value',
+            value: {
+                type: 'update',
+                patch: {
+                    description: null,
+                    label: {
+                        op: 'replace',
+                        value: 'Average Order Value (AOV)',
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const UpdateMetricLabelAndDescription: Story = {
+    args: {
+        entityTableName: 'users',
+        change: {
+            entityType: 'metric',
+            fieldId: 'active_users',
+            value: {
+                type: 'update',
+                patch: {
+                    description: {
+                        op: 'replace',
+                        value: 'Count of active users in the last 30 days, excluding test accounts',
+                    },
+                    label: {
+                        op: 'replace',
+                        value: 'Monthly Active Users',
+                    },
+                },
+            },
+        },
+    },
+};


### PR DESCRIPTION
### Description: 

This PR adds a UI component to display proposed changes tool calls in the UI.

- Created a new `AiProposeChangeToolCall` component to render proposed changes
- Implemented renderers for different entity types (table, dimension, metric)
- Added support for displaying field operations (currently only 'replace')
- Added storybook `stories` file to test multiple variants of the component without the need to prompt ai 