### PR TITLE
fix: process env_var in project yml

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/dbt_project.yml
+++ b/examples/full-jaffle-shop-demo/dbt/dbt_project.yml
@@ -12,7 +12,7 @@ seed-paths:
   - data
 macro-paths:
   - macros
-target-path: target
+target-path: "{{ env_var('DBT_ENV__TARGET_FOLDER', 'target') }}"
 clean-targets:
   - target
   - dbt_modules

--- a/packages/cli/src/dbt/context.test.ts
+++ b/packages/cli/src/dbt/context.test.ts
@@ -1,0 +1,99 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getDbtContext } from './context';
+
+describe('getDbtContext', () => {
+    const { env } = process;
+    let tempDir: string;
+
+    beforeEach(async () => {
+        jest.resetModules();
+        process.env = { ...env };
+        // Create a temporary directory for test files
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dbt-context-test-'));
+    });
+
+    afterEach(async () => {
+        process.env = env;
+        // Clean up temporary directory
+        await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    describe('target-path with env_var templating', () => {
+        test('should resolve env_var in target-path', async () => {
+            process.env.DBT_ENV__TARGET_FOLDER = 'custom-target';
+
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+target-path: "{{ env_var('DBT_ENV__TARGET_FOLDER', 'target') }}"
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({ projectDir: tempDir });
+
+            expect(context.targetDir).toBe(path.join(tempDir, 'custom-target'));
+            expect(context.projectName).toBe('test_project');
+            expect(context.profileName).toBe('test_profile');
+        });
+
+        test('should use default value when env_var is not set', async () => {
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+target-path: "{{ env_var('DBT_ENV__TARGET_FOLDER', 'target') }}"
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({ projectDir: tempDir });
+
+            expect(context.targetDir).toBe(path.join(tempDir, 'target'));
+        });
+
+        test('should work with models-path env_var', async () => {
+            process.env.DBT_MODELS_PATH = 'custom-models';
+
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+target-path: "target"
+models-path: "{{ env_var('DBT_MODELS_PATH', 'models') }}"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({ projectDir: tempDir });
+
+            expect(context.modelsDir).toBe(path.join(tempDir, 'custom-models'));
+        });
+
+        test('should work without any templating', async () => {
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+target-path: "target"
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({ projectDir: tempDir });
+
+            expect(context.targetDir).toBe(path.join(tempDir, 'target'));
+            expect(context.modelsDir).toBe(path.join(tempDir, 'models'));
+        });
+    });
+});

--- a/packages/cli/src/dbt/context.ts
+++ b/packages/cli/src/dbt/context.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
 import GlobalState from '../globalState';
+import { renderProfilesYml } from './templating';
 
 type GetDbtContextArgs = {
     projectDir: string;
@@ -40,7 +41,9 @@ export const getDbtContext = async ({
             `Is ${initialProjectDir} a valid dbt project directory? Couldn't find a valid dbt_project.yml on ${initialProjectDir} or any of its parents:\n  ${msg}`,
         );
     }
-    const config = yaml.load(file) as Record<string, string>;
+    // Render Jinja templating (e.g., env_var) before parsing YAML
+    const renderedFile = renderProfilesYml(file);
+    const config = yaml.load(renderedFile) as Record<string, string>;
 
     const targetSubDir = config['target-path'] || './target';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/17165


> target-path: "{{ env_var('DBT_ENV__TARGET_FOLDER', 'target') }}"

> export DBT_ENV__TARGET_FOLDER='new_target'

<img width="1002" height="226" alt="image" src="https://github.com/user-attachments/assets/c29e8e85-782d-4a5e-bea1-887c4b65dadf" />

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
