### PR TITLE
fix: slack app in socket mode

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -69,6 +69,7 @@
         "@sentry/node": "^9.46.0",
         "@sentry/profiling-node": "^9.46.0",
         "@slack/bolt": "^3.22.0",
+        "@slack/oauth": "^3.0.4",
         "@slack/web-api": "^6.13.0",
         "@tsoa/runtime": "^6.6.0",
         "@types/async": "^3.2.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@slack/bolt':
         specifier: ^3.22.0
         version: 3.22.0
+      '@slack/oauth':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@slack/web-api':
         specifier: ^6.13.0
         version: 6.13.0
@@ -5925,6 +5928,10 @@ packages:
     resolution: {integrity: sha512-1amXs6xRkJpoH6zSgjVPgGEJXCibKNff9WNDijcejIuVy1HFAl1adh7lehaGNiHhTWfQkfKxBiF+BGn56kvoFw==}
     engines: {node: '>=12.13.0', npm: '>=6.12.0'}
 
+  '@slack/oauth@3.0.4':
+    resolution: {integrity: sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+
   '@slack/socket-mode@1.3.6':
     resolution: {integrity: sha512-G+im7OP7jVqHhiNSdHgv2VVrnN5U7KY845/5EZimZkrD4ZmtV0P3BiWkgeJhPtdLuM7C7i6+M6h6Bh+S4OOalA==}
     engines: {node: '>=12.13.0', npm: '>=6.12.0'}
@@ -5936,6 +5943,10 @@ packages:
   '@slack/web-api@6.13.0':
     resolution: {integrity: sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.10.0':
+    resolution: {integrity: sha512-kT+07JvOqpYH3b/ttVo3iqKIFiHV2NKmD6QUc/F7HrjCgSdSA10zxqi0euXEF2prB49OU7SfjadzQ0WhNc7tiw==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@smithy/abort-controller@3.1.1':
     resolution: {integrity: sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==}
@@ -23445,6 +23456,16 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@slack/oauth@3.0.4':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.10.0
+      '@types/jsonwebtoken': 9.0.5
+      '@types/node': 22.15.3
+      jsonwebtoken: 9.0.2
+    transitivePeerDependencies:
+      - debug
+
   '@slack/socket-mode@1.3.6':
     dependencies:
       '@slack/logger': 3.0.0
@@ -23474,6 +23495,23 @@ snapshots:
       is-stream: 1.1.0
       p-queue: 6.6.2
       p-retry: 4.6.2
+    transitivePeerDependencies:
+      - debug
+
+  '@slack/web-api@7.10.0':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/types': 2.13.1
+      '@types/node': 22.15.3
+      '@types/retry': 0.12.0
+      axios: 1.12.2
+      eventemitter3: 5.0.1
+      form-data: 4.0.4
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
     transitivePeerDependencies:
       - debug
 
@@ -25201,7 +25239,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 24.3.1
+      '@types/node': 22.15.3
 
   '@types/btoa-lite@1.0.2': {}
 
@@ -25327,7 +25365,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 24.3.1
+      '@types/node': 22.15.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -25605,7 +25643,7 @@ snapshots:
 
   '@types/pg@8.15.5':
     dependencies:
-      '@types/node': 24.3.1
+      '@types/node': 22.15.3
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
@@ -25676,7 +25714,7 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 24.3.1
+      '@types/node': 22.15.3
 
   '@types/serve-static@1.13.9':
     dependencies:
@@ -25686,7 +25724,7 @@ snapshots:
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.3.1
+      '@types/node': 22.15.3
       '@types/send': 0.17.5
 
   '@types/shimmer@1.2.0': {}
@@ -33913,7 +33951,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.3.1
+      '@types/node': 22.15.3
       long: 5.3.2
 
   proxy-addr@2.0.7:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Adds support for OAuth flow in Slack socket mode by integrating the `@slack/oauth` package. This implementation creates an `InstallProvider` to handle OAuth callbacks and registers a route at `/api/v1/slack/oauth_redirect` to properly manage the Slack OAuth flow. The code also improves error handling when starting the Slack app and refactors the initialization process to reduce code duplication.

So the app works in `socketMode` we need to change the manifest to include: `"socket_mode_enabled": true`

![image.png](https://app.graphite.dev/user-attachments/assets/8a96ef67-0c83-418e-b631-e8927505216e.png)