### PR TITLE
feat: add initial project changesets table in settings

### DIFF
--- a/packages/common/src/types/changeset.ts
+++ b/packages/common/src/types/changeset.ts
@@ -63,7 +63,7 @@ export type Change = z.infer<typeof ChangeSchema>;
 
 export type ApiChangesetsResponse = {
     status: 'ok';
-    results: ChangesetWithChanges[];
+    results: ChangesetWithChanges;
 };
 
 export type CreateChangeParams = Pick<

--- a/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
+++ b/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
@@ -1,0 +1,428 @@
+import {
+    assertUnreachable,
+    type Change,
+    type ChangesetWithChanges,
+} from '@lightdash/common';
+import {
+    Alert,
+    Badge,
+    Box,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
+import { IconAlertCircle, IconClock, IconTable } from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+} from 'mantine-react-table';
+import { useMemo, type FC, type ReactNode } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useIsTruncated } from '../../../hooks/useIsTruncated';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+import { useActiveChangesets } from '../hooks';
+
+dayjs.extend(relativeTime);
+
+type Props = {
+    projectUuid: string;
+};
+
+const getChangeTypeBadgeProps = (
+    type: 'create' | 'update' | 'delete',
+): { color: string; variant: 'light' } => {
+    switch (type) {
+        case 'create':
+            return { color: 'green', variant: 'light' as const };
+        case 'update':
+            return { color: 'blue', variant: 'light' as const };
+        case 'delete':
+            return { color: 'red', variant: 'light' as const };
+        default:
+            return assertUnreachable(type, `Unknown change type: ${type}`);
+    }
+};
+
+const formatDateTime = (date: Date): string => {
+    return dayjs(date).format('MMM D, YYYY HH:mm');
+};
+
+const extractChangeValue = (change: Change): string | ReactNode => {
+    switch (change.type) {
+        case 'create':
+            return 'Create new item';
+        case 'delete':
+            return 'Delete item';
+        case 'update':
+            if (change.payload.patches.length === 0) {
+                return 'Update';
+            }
+            if (change.payload.patches.length === 1) {
+                return (
+                    <Text fz="xs">
+                        <Text fw={500} fz="xs" span>
+                            {change.payload.patches[0].path.replace('/', '')}:{' '}
+                        </Text>
+                        {String(change.payload.patches[0].value)}
+                    </Text>
+                );
+            } else {
+                return (
+                    <>
+                        {change.payload.patches.map((patch) => (
+                            <Text key={patch.path} fz="xs">
+                                <Text fw={500} fz="xs" span>
+                                    {patch.path.replace('/', '')}:{' '}
+                                </Text>
+                                {String(patch.value)}
+                            </Text>
+                        ))}
+                    </>
+                );
+            }
+
+        default:
+            return assertUnreachable(change, `Unknown change type`);
+    }
+};
+
+const getUserDisplayName = (
+    userUuid: string,
+    organizationUsers:
+        | Array<{
+              userUuid: string;
+              firstName: string;
+              lastName: string;
+              email: string;
+          }>
+        | undefined,
+): string => {
+    const user = organizationUsers?.find((u) => u.userUuid === userUuid);
+    if (!user) return userUuid.slice(0, 8);
+    return user.firstName && user.lastName
+        ? `${user.firstName} ${user.lastName}`
+        : user.email;
+};
+
+export const ProjectChangesets: FC<Props> = ({ projectUuid }) => {
+    const theme = useMantineTheme();
+
+    const {
+        data: changesets,
+        isLoading,
+        error,
+    } = useActiveChangesets(projectUuid);
+
+    const { data: organizationUsers } = useOrganizationUsers();
+
+    const allChanges = useMemo(() => {
+        if (!changesets) return [];
+
+        return changesets.changes.flatMap((change) => change);
+    }, [changesets]);
+
+    const columns: MRT_ColumnDef<ChangesetWithChanges['changes'][0]>[] =
+        useMemo(
+            () => [
+                {
+                    accessorKey: 'entityName',
+                    header: '',
+                    enableSorting: false,
+                    size: 150,
+                    Cell: ({ row }) => {
+                        const change = row.original;
+                        return (
+                            <Tooltip
+                                withinPortal
+                                label={
+                                    <Group gap="xs">
+                                        <MantineIcon
+                                            icon={IconTable}
+                                            size={16}
+                                        />
+                                        <Text size="sm">
+                                            {change.entityTableName}
+                                        </Text>
+                                    </Group>
+                                }
+                            >
+                                <Text
+                                    fw={500}
+                                    fz="sm"
+                                    truncate
+                                    style={{ cursor: 'help' }}
+                                >
+                                    {change.entityName}
+                                </Text>
+                            </Tooltip>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'change',
+                    header: 'Change',
+                    enableSorting: false,
+                    size: 200,
+
+                    Cell: ({ row }) => {
+                        const isTruncated = useIsTruncated<HTMLDivElement>();
+                        const change = row.original;
+                        const changeValue = extractChangeValue(change);
+
+                        return (
+                            <Group gap="xs" align="center">
+                                <Badge
+                                    {...getChangeTypeBadgeProps(change.type)}
+                                    radius="sm"
+                                    size="sm"
+                                    fw={400}
+                                    tt="capitalize"
+                                >
+                                    {change.type}
+                                </Badge>
+                                <Tooltip
+                                    withinPortal
+                                    label={changeValue}
+                                    disabled={!isTruncated.isTruncated}
+                                >
+                                    <Text
+                                        fz="sm"
+                                        c="gray.7"
+                                        truncate
+                                        maw={250}
+                                        ref={isTruncated.ref}
+                                        style={{ flex: 1 }}
+                                    >
+                                        {changeValue}
+                                    </Text>
+                                </Tooltip>
+                            </Group>
+                        );
+                    },
+                },
+                {
+                    accessorKey: 'createdByUserUuid',
+                    header: 'Created By',
+                    enableSorting: false,
+                    size: 200,
+                    Cell: ({ row }) => {
+                        const change = row.original;
+                        const userName = getUserDisplayName(
+                            change.createdByUserUuid,
+                            organizationUsers,
+                        );
+
+                        return (
+                            <Group gap="xs" align="center">
+                                <Tooltip
+                                    withinPortal
+                                    label={formatDateTime(change.createdAt)}
+                                >
+                                    <Box style={{ cursor: 'help' }}>
+                                        <MantineIcon
+                                            icon={IconClock}
+                                            size={16}
+                                            color="gray.6"
+                                        />
+                                    </Box>
+                                </Tooltip>
+                                <Text fz="sm" truncate>
+                                    {userName}
+                                </Text>
+                            </Group>
+                        );
+                    },
+                },
+            ],
+            [organizationUsers],
+        );
+
+    const table = useMantineReactTable({
+        columns,
+        data: allChanges,
+        enableStickyHeader: true,
+        enableColumnResizing: false,
+        enableRowNumbers: false,
+        enableRowVirtualization: false,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        enableSorting: false,
+        enableTopToolbar: false,
+        mantinePaperProps: {
+            shadow: undefined,
+            sx: {
+                border: `1px solid ${theme.colors.gray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableContainerProps: {
+            sx: {
+                maxHeight: 500,
+                minHeight: '300px',
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: Boolean(allChanges.length),
+        },
+        mantineTableHeadRowProps: {
+            sx: {
+                boxShadow: 'none',
+                'th > div > div:last-child': {
+                    top: -10,
+                    right: -5,
+                },
+                'th > div > div:last-child > .mantine-Divider-root': {
+                    border: 'none',
+                },
+            },
+        },
+        mantineTableHeadCellProps: (props) => {
+            const isAnyColumnResizing = props.table
+                .getAllColumns()
+                .some((c) => c.getIsResizing());
+
+            const isLastColumn =
+                props.table.getAllColumns().indexOf(props.column) ===
+                props.table.getAllColumns().length - 1;
+
+            const canResize = props.column.getCanResize();
+
+            return {
+                bg: 'gray.0',
+                h: '3xl',
+                pos: 'relative',
+                style: {
+                    userSelect: 'none',
+                    padding: `${theme.spacing.xs} ${theme.spacing.xl}`,
+                    borderBottom: `1px solid ${theme.colors.gray[2]}`,
+                    borderRight: props.column.getIsResizing()
+                        ? `2px solid ${theme.colors.blue[3]}`
+                        : `1px solid ${
+                              isLastColumn
+                                  ? 'transparent'
+                                  : theme.colors.gray[2]
+                          }`,
+                    borderTop: 'none',
+                    borderLeft: 'none',
+                },
+                sx: {
+                    justifyContent: 'center',
+                    '&:hover': canResize
+                        ? {
+                              borderRight: !isAnyColumnResizing
+                                  ? `2px solid ${theme.colors.blue[3]} !important`
+                                  : undefined,
+                              transition: `border-right ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                          }
+                        : {},
+                },
+            };
+        },
+        mantineTableBodyRowProps: () => {
+            return {
+                sx: {
+                    cursor: 'pointer',
+                    '&:hover': {
+                        td: {
+                            backgroundColor: theme.colors.gray[0],
+                            transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                        },
+                    },
+                },
+            };
+        },
+        renderBottomToolbar: () => (
+            <Box
+                p="sm"
+                fz="xs"
+                fw={500}
+                c="gray.8"
+                style={{
+                    borderTop: `1px solid ${theme.colors.gray[3]}`,
+                }}
+            >
+                <Text fz="xs" c="gray.8">
+                    {allChanges.length} change
+                    {allChanges.length !== 1 ? 's' : ''} found
+                </Text>
+            </Box>
+        ),
+        enableRowActions: false,
+    });
+
+    // Handle loading state
+    if (isLoading) {
+        return (
+            <Box p="xl" style={{ textAlign: 'center' }}>
+                <Loader size="lg" />
+                <Text mt="md" c="gray.6">
+                    Loading changesets...
+                </Text>
+            </Box>
+        );
+    }
+
+    // Handle error state
+    if (error) {
+        return (
+            <Alert
+                icon={<MantineIcon icon={IconAlertCircle} />}
+                title="Error loading changesets"
+                color="red"
+                variant="light"
+            >
+                {'Failed to load changesets. Please try again.'}
+            </Alert>
+        );
+    }
+
+    // Handle empty state
+    if (!changesets || changesets.changes.length === 0) {
+        return (
+            <Box p="xl" style={{ textAlign: 'center' }}>
+                <Text c="gray.6">No active changesets found.</Text>
+            </Box>
+        );
+    }
+
+    // Handle no changes in changesets
+    if (allChanges.length === 0) {
+        return (
+            <Box p="xl" style={{ textAlign: 'center' }}>
+                <Text c="gray.6">No changes found in active changesets.</Text>
+            </Box>
+        );
+    }
+
+    return (
+        <Stack gap="sm">
+            <Stack gap="xs">
+                <Title order={5}>Changesets</Title>
+                <Text c="gray.6" fz="sm">
+                    Track changes to your project over time. Changesets are
+                    updates to your Lightdash Semantic Layer.
+                </Text>
+            </Stack>
+            <MantineReactTable table={table} />
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/changesets/hooks/index.ts
+++ b/packages/frontend/src/features/changesets/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useActiveChangesets } from './useActiveChangesets';

--- a/packages/frontend/src/features/changesets/hooks/useActiveChangesets.ts
+++ b/packages/frontend/src/features/changesets/hooks/useActiveChangesets.ts
@@ -1,0 +1,18 @@
+import { type ApiChangesetsResponse, type ApiError } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const getActiveChangesets = async (projectUuid: string) =>
+    lightdashApi<ApiChangesetsResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/changesets`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useActiveChangesets = (projectUuid: string) =>
+    useQuery<ApiChangesetsResponse['results'], ApiError>({
+        queryKey: ['activeChangesets', projectUuid],
+        queryFn: () => getActiveChangesets(projectUuid),
+        enabled: !!projectUuid,
+    });

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -13,6 +13,7 @@ import ErrorState from '../components/common/ErrorState';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import SettingsEmbed from '../ee/features/embed/SettingsEmbed';
+import { ProjectChangesets } from '../features/changesets/components/ProjectChangesets';
 import { useProject } from '../hooks/useProject';
 
 const ProjectSettings: FC = () => {
@@ -36,6 +37,10 @@ const ProjectSettings: FC = () => {
                 element: (
                     <ProjectTablesConfiguration projectUuid={projectUuid} />
                 ),
+            },
+            {
+                path: `/changesets`,
+                element: <ProjectChangesets projectUuid={projectUuid} />,
             },
             {
                 path: `/projectAccess`,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import {
     IconDatabase,
     IconDatabaseCog,
     IconDatabaseExport,
+    IconHistory,
     IconIdBadge2,
     IconKey,
     IconLock,
@@ -25,7 +26,13 @@ import {
     IconVariable,
 } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
-import { Navigate, useRoutes, type RouteObject } from 'react-router';
+import {
+    Navigate,
+    matchPath,
+    useLocation,
+    useRoutes,
+    type RouteObject,
+} from 'react-router';
 import PageSpinner from '../components/PageSpinner';
 import AccessTokensPanel from '../components/UserSettings/AccessTokensPanel';
 import AllowedDomainsPanel from '../components/UserSettings/AllowedDomainsPanel';
@@ -374,6 +381,16 @@ const Settings: FC = () => {
     ]);
     const routeElements = useRoutes(routes);
 
+    const location = useLocation();
+    const isChangesetsPage = useMemo(() => {
+        return matchPath(
+            {
+                path: '/generalSettings/projectManagement/:projectUuid/changesets',
+            },
+            location.pathname,
+        );
+    }, [location.pathname]);
+
     if (
         isHealthLoading ||
         isUserLoading ||
@@ -403,7 +420,7 @@ const Settings: FC = () => {
         <Page
             withFullHeight
             withSidebarFooter
-            withFixedContent
+            withFixedContent={!isChangesetsPage}
             withPaddedContent
             title="Settings"
             sidebar={
@@ -648,6 +665,15 @@ const Settings: FC = () => {
                                             <MantineIcon
                                                 icon={IconTableOptions}
                                             />
+                                        }
+                                    />
+
+                                    <RouterNavLink
+                                        label="Changesets"
+                                        exact
+                                        to={`/generalSettings/projectManagement/${project.projectUuid}/changesets`}
+                                        icon={
+                                            <MantineIcon icon={IconHistory} />
                                         }
                                     />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Adds a new Changesets UI to the project settings page, allowing users to track changes to their project over time. The implementation includes:

- A new `ProjectChangesets` component that displays a table of changes with details like entity name, change type, and creator
- Integration with the existing changesets API
- A new "Changesets" tab in the project settings navigation
- Support for viewing different change types (create, update, delete) with appropriate styling
- Tooltips showing additional information like table names and timestamps

The UI shows changes in an organized table format with proper handling for loading, error, and empty states.

![Screenshot 2025-10-02 at 09.55.43.png](https://app.graphite.dev/user-attachments/assets/6f69e66a-dfcd-4e22-963d-d83fc6f9e05a.png)

