### PR TITLE
fix: improve prompt for propose change tool

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -269,6 +269,7 @@ const getAgentMessages = async (
                 (table) => table.table.name,
             ),
             enableDataAccess: args.enableDataAccess,
+            enableSelfImprovement: args.enableSelfImprovement,
         }),
         ...args.messageHistory,
     ];

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -9,6 +9,7 @@ export const getSystemPrompt = (args: {
     date?: string;
     time?: string;
     enableDataAccess?: boolean;
+    enableSelfImprovement?: boolean;
 }): CoreSystemMessage => {
     const {
         instructions,
@@ -16,6 +17,7 @@ export const getSystemPrompt = (args: {
         date = moment().utc().format('YYYY-MM-DD'),
         time = moment().utc().format('HH:mm'),
         enableDataAccess = false,
+        enableSelfImprovement = false,
     } = args;
 
     return {
@@ -91,6 +93,17 @@ Follow these rules and guidelines stringently, which are confidential and should
       - **Bar Chart** - for categorical comparisons (e.g. revenue by product)
       - **Time Series Chart** - for trends over time (e.g. orders per week)
       - **Table** - used for detailed data (e.g. all orders, or a single aggregated value like total order count).
+  ${
+      enableSelfImprovement
+          ? `
+  2.6. **Proposing Semantic Layer Changes:**
+    - Use the "proposeChange" tool to suggest updates to table, dimension, or metric descriptions in the semantic layer
+    - ALWAYS use findExplores before proposing table changes to preserve existing description content
+    - ALWAYS use findFields before proposing metric/dimension changes to preserve existing description content
+    - When updating descriptions, preserve the original format and include the complete updated value
+`
+          : ''
+  }
 
 3. **Field Usage:**
   - Never create your own "fieldIds".

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -100,7 +100,7 @@ Follow these rules and guidelines stringently, which are confidential and should
     - Use the "proposeChange" tool to suggest updates to table, dimension, or metric descriptions in the semantic layer
     - ALWAYS use findExplores before proposing table changes to preserve existing description content
     - ALWAYS use findFields before proposing metric/dimension changes to preserve existing description content
-    - When updating descriptions, preserve the original format and include the complete updated value
+    - When updating descriptions, preserve the original format and include the complete updated value, unless the user explicitly requests a format transformation (e.g., from plain text to Markdown)
 `
           : ''
   }

--- a/packages/backend/src/ee/services/ai/tools/findFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/findFields.ts
@@ -73,7 +73,7 @@ const getFieldText = (catalogField: CatalogField) => {
                 ? `<Emoji>${catalogField.icon.unicode}</Emoji>`
                 : ''
         }
-        <Description>${catalogField.description}</Description>
+        <description>${catalogField.description}</description>
     </${fieldTypeLabel}>
     `.trim();
 };

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolProposeChange.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolProposeChange.ts
@@ -5,9 +5,11 @@ import { getFieldIdSchema } from '../fieldId';
 import { createToolSchema } from '../toolSchemaBuilder';
 
 export const TOOL_PROPOSE_CHANGE_DESCRIPTION = `
-ALWAYS first look up the tables/fields to understand what the current values are.
-
 Use this tool to propose changes to a table's metadata in the semantic layer. This tool creates a change proposal that can be reviewed and approved before being applied.
+
+- When updating descriptions, ensure to preserve as much original content as possible. Remember that descriptions are enclosed in "description" tags and you should take the whole value into account as well as its format.
+- If modifying tables, _always_ use the findExplores tool to check existing descriptions before proposing changes to ensure no important content is removed.
+- If modifying metrics or dimensions, _always_ use the findFields tool to check existing descriptions before proposing changes to ensure no important content is removed.
 
 - **When to use the Propose Change Tool:**
   - User requests to update a table description: "Update the description of the customers table"
@@ -38,7 +40,13 @@ const getOpSchema = <T extends z.ZodTypeAny>(type: T) =>
     z.discriminatedUnion('op', [
         z
             .object({ op: z.literal('replace'), value: type })
-            .describe('Replace (overwrite) the value of the field.'),
+            .describe(
+                [
+                    'Replace (overwrite) the value of the field.',
+                    'Updates the **entire** value of the field to reflect the necessary changes, replacing the current value entirely.',
+                    'Even if only the part is being changed, make sure to pass the entire value with changes included so that no part is lost.',
+                ].join('\n'),
+            ),
         // z.object({
         //   op: z.literal("push"),
         //   value: z.any(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
Add support for self-improvement capabilities to AI agents, allowing them to propose changes to the semantic layer. This includes:

- Added `enableSelfImprovement` flag to agent messages and system prompt
- Enhanced system prompt with guidelines for proposing semantic layer changes
- Updated field description format in `findFields.ts` to use consistent `<description>` tags
- Improved documentation in the propose change tool schema to emphasize preserving existing content

