### PR TITLE
fix: pass promptUuid to ImproveContextToolCall component

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -144,6 +144,7 @@ const AssistantBubbleContent: FC<{
                     projectUuid={projectUuid}
                     agentUuid={agentUuid}
                     threadUuid={message.threadUuid}
+                    promptUuid={message.uuid}
                 />
             )}
             {!isStreaming && message.toolCalls.length > 0 && (
@@ -153,6 +154,7 @@ const AssistantBubbleContent: FC<{
                     projectUuid={projectUuid}
                     agentUuid={agentUuid}
                     threadUuid={message.threadUuid}
+                    promptUuid={message.uuid}
                 />
             )}
             {messageContent.length > 0 ? (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -320,11 +320,15 @@ const ImproveContextToolCall: FC<{
     projectUuid: string;
     agentUuid: string;
     threadUuid: string;
-}> = ({ projectUuid, agentUuid, threadUuid }) => {
-    const improveContextNotification = useAiAgentStoreSelector(
-        (state) =>
-            state.aiAgentThreadStream[threadUuid]?.improveContextNotification,
-    );
+    promptUuid: string;
+}> = ({ projectUuid, agentUuid, threadUuid, promptUuid }) => {
+    const improveContextNotification = useAiAgentStoreSelector((state) => {
+        const thread = state.aiAgentThreadStream[threadUuid];
+        if (thread?.messageUuid === promptUuid) {
+            return thread.improveContextNotification;
+        }
+        return null;
+    });
     const dispatch = useAiAgentStoreDispatch();
 
     const appendInstructionMutation = useAppendInstructionMutation(
@@ -407,9 +411,10 @@ const ImproveContextToolCall: FC<{
 type AiChartToolCallsProps = {
     toolCalls: ToolCallSummary[] | undefined;
     type: ToolCallDisplayType;
-    projectUuid?: string;
-    agentUuid?: string;
-    threadUuid?: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
 };
 
 export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({
@@ -418,6 +423,7 @@ export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({
     projectUuid,
     agentUuid,
     threadUuid,
+    promptUuid,
 }) => {
     const texts =
         type === 'streaming'
@@ -437,6 +443,7 @@ export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({
                     projectUuid={projectUuid}
                     agentUuid={agentUuid}
                     threadUuid={threadUuid}
+                    promptUuid={promptUuid}
                 />
             )}
             {!!calculationToolCalls?.length && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
Added `promptUuid` parameter to the `ImproveContextToolCall` component to ensure that improve context notifications are only displayed for the specific message they belong to. This fixes an issue where notifications were being shown incorrectly across different messages in the same thread.

