### PR TITLE
refactor: create ToolCallPaper component

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -11,17 +11,13 @@ import {
 import {
     Badge,
     Button,
-    Collapse,
     Group,
     Paper,
     rem,
     Stack,
     Text,
     Timeline,
-    Title,
-    UnstyledButton,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconChartDots3,
     IconChartHistogram,
@@ -45,6 +41,7 @@ import {
     useAiAgentStoreSelector,
 } from '../../../store/hooks';
 import { AiChartGenerationToolCallDescription } from './AiChartGenerationToolCallDescription';
+import { ToolCallPaper } from './ToolCallPaper';
 
 const getToolIcon = (toolName: ToolName) => {
     const iconMap: Record<ToolName, (props: TablerIconsProps) => JSX.Element> =
@@ -78,35 +75,15 @@ const ToolCallContainer = ({
     children: React.ReactNode;
     defaultOpened?: boolean;
 }) => {
-    const [opened, { toggle }] = useDisclosure(defaultOpened);
-
     return (
-        <Paper
-            withBorder
-            p="xs"
-            radius="md"
-            style={{ borderStyle: 'dashed' }}
-            // default shadow is subtler than the ones we can set
-            shadow={opened ? 'none' : undefined}
+        <ToolCallPaper
+            defaultOpened={defaultOpened}
+            variant="dashed"
+            icon={IconTools}
+            title="How it is calculated"
         >
-            <UnstyledButton onClick={toggle} w="100%" h="18px">
-                <Group justify="space-between" w="100%" h="100%">
-                    <Group gap="xs">
-                        <MantineIcon
-                            icon={IconTools}
-                            size="sm"
-                            strokeWidth={1.2}
-                            color="gray.6"
-                        />
-                        <Title order={6} c="gray.6" size="xs">
-                            How it is calculated
-                        </Title>
-                    </Group>
-                    <MantineIcon icon={IconSelector} size={12} color="gray.6" />
-                </Group>
-            </UnstyledButton>
-            <Collapse in={opened}>{children}</Collapse>
-        </Paper>
+            {children}
+        </ToolCallPaper>
     );
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/OperationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/OperationRenderer.tsx
@@ -1,6 +1,5 @@
 import { assertUnreachable, capitalize } from '@lightdash/common';
-import { Stack, Text } from '@mantine-8/core';
-import { Paper } from '@mantine/core';
+import { Paper, Stack, Text } from '@mantine-8/core';
 import type { Operation } from './types';
 
 type ReplaceOperationProps = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
@@ -1,18 +1,7 @@
 import { type ToolProposeChangeArgs } from '@lightdash/common';
-import {
-    Badge,
-    Collapse,
-    type DefaultMantineColor,
-    Group,
-    Paper,
-    Stack,
-    Title,
-    UnstyledButton,
-} from '@mantine-8/core';
-import { IconGitBranch, IconSelector } from '@tabler/icons-react';
-
-import { useDisclosure } from '@mantine-8/hooks';
-import MantineIcon from '../../../../../../../components/common/MantineIcon';
+import { Badge, type DefaultMantineColor, Group, Stack } from '@mantine-8/core';
+import { IconGitBranch } from '@tabler/icons-react';
+import { ToolCallPaper } from '../ToolCallPaper';
 import { ChangeRenderer } from './ChangeRenderer';
 
 interface Props
@@ -32,55 +21,43 @@ export const AiProposeChangeToolCall = ({
     const changeType = change.value.type;
     const changeColor: DefaultMantineColor =
         CHANGE_COLORS[changeType] ?? 'gray';
-    const [containerExpanded, { toggle }] = useDisclosure(defaultOpened);
 
     return (
-        <Paper withBorder p="xs" radius="md">
-            <UnstyledButton onClick={toggle} w="100%" h="18px">
-                <Group justify="space-between" w="100%" h="100%">
-                    <Group gap="xs">
-                        <MantineIcon
-                            icon={IconGitBranch}
-                            size="sm"
-                            strokeWidth={1.2}
-                            color="gray.6"
-                        />
-                        <Title order={6} c="gray.6" size="xs">
-                            Semantic Layer changes
-                        </Title>
-                        <Badge
-                            radius="sm"
-                            size="sm"
-                            variant="light"
-                            color={changeColor}
-                        >
-                            {changeType}
-                        </Badge>
-                    </Group>
-                    <MantineIcon icon={IconSelector} size={12} color="gray.6" />
+        <ToolCallPaper
+            defaultOpened={defaultOpened}
+            icon={IconGitBranch}
+            title={
+                <Group gap="xs">
+                    <span>Semantic Layer changes</span>
+                    <Badge
+                        radius="sm"
+                        size="sm"
+                        variant="light"
+                        color={changeColor}
+                    >
+                        {changeType}
+                    </Badge>
                 </Group>
-            </UnstyledButton>
+            }
+        >
+            <Stack gap="xs" mt="xs">
+                <ChangeRenderer
+                    change={change}
+                    entityTableName={entityTableName}
+                />
 
-            <Collapse in={containerExpanded}>
-                <Stack gap="xs" mt="xs">
-                    <ChangeRenderer
-                        change={change}
-                        entityTableName={entityTableName}
-                    />
-
-                    {/*TODO
-                    <Group w="100%" justify="flex-end">
-                        <Button
-                            variant="outline"
-                            size="xs"
-                            color="dark"
-                            leftSection={<MantineIcon icon={IconX} size={14} />}
-                        >
-                            Reject
-                        </Button>
-                    </Group>*/}
-                </Stack>
-            </Collapse>
-        </Paper>
+                {/*TODO
+                <Group w="100%" justify="flex-end">
+                    <Button
+                        variant="outline"
+                        size="xs"
+                        color="dark"
+                        leftSection={<MantineIcon icon={IconX} size={14} />}
+                    >
+                        Reject
+                    </Button>
+                </Group>*/}
+            </Stack>
+        </ToolCallPaper>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallPaper.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallPaper.tsx
@@ -1,0 +1,53 @@
+import { Collapse, Group, Paper, Title, UnstyledButton } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
+import { IconSelector } from '@tabler/icons-react';
+import { type ReactNode } from 'react';
+import MantineIcon, {
+    type MantineIconProps,
+} from '../../../../../../components/common/MantineIcon';
+
+type ToolCallPaperProps = {
+    children: ReactNode;
+    title: ReactNode;
+    icon: MantineIconProps['icon'];
+    defaultOpened?: boolean;
+    variant?: 'default' | 'dashed';
+};
+
+export const ToolCallPaper = ({
+    children,
+    title,
+    icon,
+    defaultOpened = true,
+    variant = 'default',
+}: ToolCallPaperProps) => {
+    const [opened, { toggle }] = useDisclosure(defaultOpened);
+
+    return (
+        <Paper
+            withBorder
+            p="xs"
+            radius="md"
+            style={variant === 'dashed' ? { borderStyle: 'dashed' } : undefined}
+            shadow={opened ? 'none' : undefined}
+        >
+            <UnstyledButton onClick={toggle} w="100%" h="18px">
+                <Group justify="space-between" w="100%" h="100%">
+                    <Group gap="xs">
+                        <MantineIcon
+                            icon={icon}
+                            size="sm"
+                            strokeWidth={1.2}
+                            color="gray.6"
+                        />
+                        <Title order={6} c="gray.6" size="xs">
+                            {title}
+                        </Title>
+                    </Group>
+                    <MantineIcon icon={IconSelector} size={12} color="gray.6" />
+                </Group>
+            </UnstyledButton>
+            <Collapse in={opened}>{children}</Collapse>
+        </Paper>
+    );
+};


### PR DESCRIPTION
### Description:
Created a reusable `ToolCallPaper` component to standardize the expandable/collapsible paper UI pattern used in AI tool calls. This refactors the existing implementations in `AiChartToolCalls` and `AiProposeChangeToolCall` to use the new shared component, reducing code duplication and ensuring consistent behavior across different tool call types.
