### PR TITLE
chore: add callout to personal connections page

### DIFF
--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
@@ -1,5 +1,5 @@
 import { type UserWarehouseCredentials } from '@lightdash/common';
-import { Button, Group, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Button, Group, Stack, Text, Title } from '@mantine/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useUserWarehouseCredentials } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
@@ -19,6 +19,22 @@ export const MyWarehouseConnectionsPanel = () => {
         warehouseCredentialsToBeDeleted,
         setWarehouseCredentialsToBeDeleted,
     ] = useState<UserWarehouseCredentials | undefined>(undefined);
+
+    const personalConnectionsCallout = (
+        <Text c="dimmed">
+            These credentials are only used for projects that require user
+            credentials -{' '}
+            <Anchor
+                role="button"
+                href="https://docs.lightdash.com/references/personal-warehouse-connections"
+                target="_blank"
+                rel="noreferrer"
+            >
+                learn more
+            </Anchor>
+            .
+        </Text>
+    );
 
     return (
         <>
@@ -43,6 +59,7 @@ export const MyWarehouseConnectionsPanel = () => {
                                 Add new credentials
                             </Button>
                         </Group>
+                        {personalConnectionsCallout}
                         <CredentialsTable
                             credentials={credentials}
                             setWarehouseCredentialsToBeDeleted={
@@ -64,7 +81,16 @@ export const MyWarehouseConnectionsPanel = () => {
                             />
                         }
                         title="No credentials"
-                        description="You haven't created any personal warehouse connections yet!"
+                        description={
+                            <>
+                                <Text>
+                                    You haven't created any personal warehouse
+                                    connections yet!
+                                </Text>
+                                <br />
+                                {personalConnectionsCallout}
+                            </>
+                        }
                     >
                         <Button onClick={() => setIsCreatingCredentials(true)}>
                             Add new credentials


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17193

### Description:
Added an informational callout to the Personal Warehouse Connections panel explaining that these credentials are only used for projects requiring user credentials. The callout includes a "learn more" link to the documentation. The callout appears both when credentials exist and when no credentials have been added yet.

![Screenshot 2025-10-02 at 11.05.25.png](https://app.graphite.dev/user-attachments/assets/07ee5401-c398-4651-bf7f-50821c63ac2e.png)

![Screenshot 2025-10-02 at 11.05.36.png](https://app.graphite.dev/user-attachments/assets/111db123-e472-4a25-b6c3-bb05ea571cc6.png)

test-frontend