### PR TITLE
feat: add metadata field to AI agent tool results

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -165,7 +165,9 @@ export type DbAiAgentToolResult = {
     tool_call_id: string;
     tool_name: string;
     result: string;
+    metadata: object | null;
     created_at: Date;
+    // TODO add updated_at
 };
 
 export type AiAgentToolResultTable = Knex.CompositeTableType<
@@ -173,6 +175,7 @@ export type AiAgentToolResultTable = Knex.CompositeTableType<
     Pick<
         DbAiAgentToolResult,
         'ai_prompt_uuid' | 'tool_call_id' | 'tool_name' | 'result'
-    >,
+    > &
+        Partial<Pick<DbAiAgentToolResult, 'metadata'>>,
     never
 >;

--- a/packages/backend/src/ee/database/migrations/20251002084611_add_tool_result_metadata_column.ts
+++ b/packages/backend/src/ee/database/migrations/20251002084611_add_tool_result_metadata_column.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const AiAgentToolResultTableName = 'ai_agent_tool_result';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiAgentToolResultTableName))) return;
+
+    await knex.schema.alterTable(AiAgentToolResultTableName, (table) => {
+        table.jsonb('metadata').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiAgentToolResultTableName))) return;
+
+    await knex.schema.alterTable(AiAgentToolResultTableName, (table) => {
+        table.dropColumn('metadata');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1,4 +1,5 @@
 import {
+    AgentToolOutput,
     AiAgentAdminConversationsSummary,
     AiAgentAdminFilters,
     AiAgentAdminSort,
@@ -15,6 +16,7 @@ import {
     AiAgentNotFoundError,
     AiAgentSummary,
     AiAgentThreadSummary,
+    AiAgentToolResult,
     AiAgentUser,
     AiAgentUserPreferences,
     AiArtifact,
@@ -1255,6 +1257,10 @@ export class AiAgentModel {
                 row.ai_prompt_uuid,
             );
 
+            const toolResults = await this.getToolResultsForPrompt(
+                row.ai_prompt_uuid,
+            );
+
             if (row.responded_at != null) {
                 const artifacts = artifactsMap.get(row.ai_prompt_uuid) || [];
 
@@ -1282,6 +1288,7 @@ export class AiAgentModel {
                             toolName: tc.tool_name,
                             toolArgs: tc.tool_args,
                         })),
+                    toolResults,
                     savedQueryUuid: row.saved_query_uuid,
                 });
             }
@@ -1505,6 +1512,9 @@ export class AiAgentModel {
                 const toolCalls = await this.getToolCallsForPrompt(
                     row.ai_prompt_uuid,
                 );
+                const toolResults = await this.getToolResultsForPrompt(
+                    row.ai_prompt_uuid,
+                );
                 return {
                     role: 'assistant',
                     uuid: row.ai_prompt_uuid,
@@ -1532,6 +1542,7 @@ export class AiAgentModel {
                             toolName: tc.tool_name,
                             toolArgs: tc.tool_args,
                         })),
+                    toolResults,
                     savedQueryUuid: row.saved_query_uuid,
                 } satisfies AiAgentMessageAssistant;
             default:
@@ -2071,12 +2082,51 @@ export class AiAgentModel {
             .orderBy('created_at', 'asc');
     }
 
+    async getToolResultsForPrompt(
+        promptUuid: string,
+    ): Promise<AiAgentToolResult[]> {
+        const rows = await this.database(AiAgentToolResultTableName)
+            .select<
+                Pick<
+                    DbAiAgentToolResult,
+                    | 'ai_agent_tool_result_uuid'
+                    | 'ai_prompt_uuid'
+                    | 'tool_call_id'
+                    | 'tool_name'
+                    | 'result'
+                    | 'metadata'
+                    | 'created_at'
+                >[]
+            >(
+                'ai_agent_tool_result_uuid',
+                'ai_prompt_uuid',
+                'tool_call_id',
+                'tool_name',
+                'result',
+                'metadata',
+                'created_at',
+            )
+            .where('ai_prompt_uuid', promptUuid)
+            .orderBy('created_at', 'asc');
+
+        return rows.map((row) => ({
+            uuid: row.ai_agent_tool_result_uuid,
+            promptUuid: row.ai_prompt_uuid,
+            toolCallId: row.tool_call_id,
+            toolName: row.tool_name,
+            result: row.result,
+            metadata: row.metadata as AgentToolOutput['metadata'] | null,
+            createdAt: row.created_at,
+        }));
+    }
+
     async createToolResults(
         data: Array<{
             promptUuid: string;
             toolCallId: string;
             toolName: string;
             result: string;
+            metadata?: AgentToolOutput['metadata'];
         }>,
     ): Promise<string[]> {
         if (data.length === 0) return [];
@@ -2089,20 +2139,13 @@ export class AiAgentModel {
                         tool_call_id: item.toolCallId,
                         tool_name: item.toolName,
                         result: item.result,
+                        ...(item.metadata && { metadata: item.metadata }),
                     })),
                 )
                 .returning('ai_agent_tool_result_uuid');
 
             return toolResults.map((tr) => tr.ai_agent_tool_result_uuid);
         });
-    }
-
-    async getToolResultsForPrompt(
-        promptUuid: string,
-    ): Promise<DbAiAgentToolResult[]> {
-        return this.database(AiAgentToolResultTableName)
-            .where('ai_prompt_uuid', promptUuid)
-            .orderBy('created_at', 'asc');
     }
 
     async getToolCallsAndResultsForPrompt(promptUuid: string) {
@@ -3076,7 +3119,13 @@ export class AiAgentModel {
 
                 // Clone tool results
                 const toolResults = await trx(AiAgentToolResultTableName)
-                    .select('tool_call_id', 'tool_name', 'result', 'created_at')
+                    .select(
+                        'tool_call_id',
+                        'tool_name',
+                        'result',
+                        'metadata',
+                        'created_at',
+                    )
                     .where('ai_prompt_uuid', sourcePromptUuid);
 
                 const toolResultUpdates = toolResults.map((toolResult) => ({
@@ -3084,6 +3133,7 @@ export class AiAgentModel {
                     tool_call_id: toolResult.tool_call_id,
                     tool_name: toolResult.tool_name,
                     result: toolResult.result,
+                    metadata: toolResult.metadata,
                 }));
 
                 await Promise.all([

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -416,13 +416,14 @@ export const generateAgentResponse = async ({
                                         toolResult.output,
                                     )})`,
                                 );
+                                const output =
+                                    toolResult.output as AgentToolOutput;
                                 return {
                                     promptUuid: args.promptUuid,
                                     toolCallId: toolResult.toolCallId,
                                     toolName: toolResult.toolName,
-                                    result: (
-                                        toolResult.output as AgentToolOutput
-                                    ).result,
+                                    result: output.result,
+                                    metadata: output.metadata,
                                 };
                             }),
                     );
@@ -555,6 +556,9 @@ export const streamAgentResponse = async ({
                                     result: (
                                         event.chunk.output as AgentToolOutput
                                     ).result,
+                                    metadata: (
+                                        event.chunk.output as AgentToolOutput
+                                    ).metadata,
                                 },
                             ])
                             .catch((error) => {

--- a/packages/backend/src/ee/services/ai/tools/findFields.ts
+++ b/packages/backend/src/ee/services/ai/tools/findFields.ts
@@ -6,8 +6,8 @@ import {
     getFilterTypeFromItemType,
     getItemId,
     isEmojiIcon,
-    toolFindFieldsArgsOutputSchema,
     toolFindFieldsArgsSchema,
+    toolFindFieldsOutputSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import { z } from 'zod';
@@ -98,7 +98,7 @@ export const getFindFields = ({ findFields, pageSize }: Dependencies) =>
     tool({
         description: toolFindFieldsArgsSchema.description,
         inputSchema: toolFindFieldsArgsSchema,
-        outputSchema: toolFindFieldsArgsOutputSchema,
+        outputSchema: toolFindFieldsOutputSchema,
         execute: async (args) => {
             try {
                 const fieldSearchQueryResults = await Promise.all(

--- a/packages/backend/src/ee/services/ai/tools/improveContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/improveContext.ts
@@ -26,16 +26,15 @@ export const getImproveContext = () =>
                         '[AI Agent] Confidence too low to improve context',
                     );
                     return {
-                        result: `
-                        <InstructionLearned>
-                            <Status>rejected</Status>
-                            <Reason>confidence_too_low</Reason>
-                            <Message>
-                                Context improved but confidence too low to
-                                create permanent instruction
-                            </Message>
-                        </InstructionLearned>
-                    )`.trim(),
+                        result: `\
+<InstructionLearned>
+    <Status>rejected</Status>
+    <Reason>confidence_too_low</Reason>
+    <Message>
+        Context improved but confidence too low to
+        create permanent instruction
+    </Message>
+</InstructionLearned>`.trim(),
                         metadata: {
                             status: 'success',
                         },
@@ -47,15 +46,15 @@ export const getImproveContext = () =>
                 );
 
                 return {
-                    result: `
-                    <InstructionLearned>
-                        <Status>learned</Status>
-                        <Instruction>
-                            ${toolArgs.suggestedInstruction}
-                        </Instruction>
-                        <Category>${toolArgs.category}</Category>
-                        <Confidence>${toolArgs.confidence}</Confidence>
-                    </InstructionLearned>`.trim(),
+                    result: `\
+<InstructionLearned>
+    <Status>learned</Status>
+    <Instruction>
+        ${toolArgs.suggestedInstruction}
+    </Instruction>
+    <Category>${toolArgs.category}</Category>
+    <Confidence>${toolArgs.confidence}</Confidence>
+</InstructionLearned>`.trim(),
                     metadata: {
                         status: 'success',
                     },

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -1,5 +1,6 @@
 import {
     AdditionalMetric,
+    AgentToolOutput,
     AiArtifact,
     AiMetricQueryWithFilters,
     AiWebAppPrompt,
@@ -113,6 +114,7 @@ export type StoreToolResultsFn = (
         toolCallId: string;
         toolName: string;
         result: string;
+        metadata?: AgentToolOutput['metadata'];
     }>,
 ) => Promise<void>;
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5501,6 +5501,242 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentToolResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                createdAt: { dataType: 'datetime', required: true },
+                metadata: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                result: { dataType: 'string', required: true },
+                toolName: { dataType: 'string', required: true },
+                promptUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_':
         {
             dataType: 'refAlias',
@@ -5572,6 +5808,11 @@ const models: TsoaRoute.Models = {
                         { dataType: 'string' },
                         { dataType: 'enum', enums: [null] },
                     ],
+                    required: true,
+                },
+                toolResults: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiAgentToolResult' },
                     required: true,
                 },
                 toolCalls: {
@@ -7060,8 +7301,8 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 projectUuid: { dataType: 'string', required: true },
                 createdAt: { dataType: 'datetime', required: true },
-                validationId: { dataType: 'double', required: true },
                 error: { dataType: 'string', required: true },
+                validationId: { dataType: 'double', required: true },
                 errorType: { ref: 'ValidationErrorType', required: true },
                 spaceUuid: {
                     dataType: 'union',
@@ -9675,8 +9916,8 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 createdAt: { dataType: 'datetime', required: true },
-                validationId: { dataType: 'double', required: true },
                 error: { dataType: 'string', required: true },
+                validationId: { dataType: 'double', required: true },
             },
             validators: {},
         },
@@ -13871,7 +14112,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -13881,7 +14122,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -13891,7 +14132,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -13904,7 +14145,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6190,6 +6190,46 @@
                 ],
                 "type": "object"
             },
+            "AiAgentToolResult": {
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "metadata": {
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "enum": ["success", "error"]
+                            }
+                        },
+                        "required": ["status"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "result": {
+                        "type": "string"
+                    },
+                    "toolName": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "createdAt",
+                    "metadata",
+                    "result",
+                    "toolName",
+                    "promptUuid",
+                    "uuid"
+                ],
+                "type": "object"
+            },
             "Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_": {
                 "properties": {
                     "description": {
@@ -6242,6 +6282,12 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "toolResults": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentToolResult"
+                        },
+                        "type": "array"
+                    },
                     "toolCalls": {
                         "items": {
                             "$ref": "#/components/schemas/AiAgentToolCall"
@@ -6275,6 +6321,7 @@
                 "required": [
                     "artifacts",
                     "savedQueryUuid",
+                    "toolResults",
                     "toolCalls",
                     "humanScore",
                     "createdAt",
@@ -7668,12 +7715,12 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "error": {
+                        "type": "string"
+                    },
                     "validationId": {
                         "type": "number",
                         "format": "double"
-                    },
-                    "error": {
-                        "type": "string"
                     },
                     "errorType": {
                         "$ref": "#/components/schemas/ValidationErrorType"
@@ -7688,8 +7735,8 @@
                 "required": [
                     "projectUuid",
                     "createdAt",
-                    "validationId",
                     "error",
+                    "validationId",
                     "errorType"
                 ],
                 "type": "object",
@@ -10331,15 +10378,15 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "error": {
+                        "type": "string"
+                    },
                     "validationId": {
                         "type": "number",
                         "format": "double"
-                    },
-                    "error": {
-                        "type": "string"
                     }
                 },
-                "required": ["createdAt", "validationId", "error"],
+                "required": ["createdAt", "error", "validationId"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -14641,22 +14688,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -20136,7 +20183,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2034.0",
+        "version": "0.2036.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -12,6 +12,7 @@ import type {
     ToolTimeSeriesArgs,
     ToolVerticalBarArgs,
 } from '../..';
+import { type AgentToolOutput } from './schemas';
 import { type AiMetricQuery, type AiResultType } from './types';
 
 export * from './adminTypes';
@@ -139,6 +140,7 @@ export type AiAgentMessageAssistant = {
     humanScore: number | null;
 
     toolCalls: AiAgentToolCall[];
+    toolResults: AiAgentToolResult[];
     savedQueryUuid: string | null;
 
     artifacts: AiAgentMessageAssistantArtifact[] | null;
@@ -312,6 +314,15 @@ export type AiAgentToolCall = {
     // TODO: tsoa does not support zod infer schemas - https://github.com/lukeautry/tsoa/issues/1256
     toolName: string; // ToolName zod enum
     toolArgs: object;
+};
+
+export type AiAgentToolResult = {
+    uuid: string;
+    promptUuid: string;
+    toolName: string;
+    result: string;
+    metadata: AgentToolOutput['metadata'] | null;
+    createdAt: Date;
 };
 
 export type AiAgentExploreAccessSummary = {

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -8,8 +8,8 @@ import {
     type ToolFindDashboardsOutput,
     toolFindExploresArgsSchema,
     type ToolFindExploresOutput,
-    type ToolFindFieldsArgsOutput,
     toolFindFieldsArgsSchema,
+    type ToolFindFieldsOutput,
     toolImproveContextArgsSchema,
     type ToolImproveContextOutput,
     toolProposeChangeArgsSchema,
@@ -26,6 +26,7 @@ import {
 
 export * from './customMetrics';
 export * from './filters';
+export * from './outputMetadata';
 export * from './sortField';
 export * from './tools';
 export * from './visualizations';
@@ -51,7 +52,7 @@ export type AgentToolOutput =
     | ToolFindChartsOutput
     | ToolFindDashboardsOutput
     | ToolFindExploresOutput
-    | ToolFindFieldsArgsOutput
+    | ToolFindFieldsOutput
     | ToolImproveContextOutput
     | ToolProposeChangeOutput
     | ToolSearchFieldValuesOutput

--- a/packages/common/src/ee/AiAgent/schemas/outputMetadata.ts
+++ b/packages/common/src/ee/AiAgent/schemas/outputMetadata.ts
@@ -3,3 +3,5 @@ import { z } from 'zod';
 export const baseOutputMetadataSchema = z.object({
     status: z.enum(['success', 'error']),
 });
+
+export type BaseOutputMetadata = z.infer<typeof baseOutputMetadataSchema>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
@@ -37,11 +37,9 @@ export const toolFindFieldsArgsSchemaTransformed = toolFindFieldsArgsSchema;
 
 export type ToolFindFieldsArgsTransformed = ToolFindFieldsArgs;
 
-export const toolFindFieldsArgsOutputSchema = z.object({
+export const toolFindFieldsOutputSchema = z.object({
     result: z.string(),
     metadata: baseOutputMetadataSchema,
 });
 
-export type ToolFindFieldsArgsOutput = z.infer<
-    typeof toolFindFieldsArgsOutputSchema
->;
+export type ToolFindFieldsOutput = z.infer<typeof toolFindFieldsOutputSchema>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
This PR adds a metadata column to the AI agent tool results table to store additional information about tool execution. The metadata field can include status information (success/error) and other tool-specific data.

Key changes:
- Added a new migration to add the `metadata` column to the `ai_agent_tool_result` table
- Updated the database entity type to include the new metadata field
- Modified the AI agent model to handle the metadata in tool results
- Updated the agent service to pass metadata from tool outputs to the database
- Added TypeScript types for the tool result metadata

