### PR TITLE
fix: add index on catalog for cached_explores

### DIFF
--- a/packages/backend/src/database/migrations/20251002111634_add_index_catalog_search_cached_explore_uuid.ts
+++ b/packages/backend/src/database/migrations/20251002111634_add_index_catalog_search_cached_explore_uuid.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('catalog_search', (table) => {
+        table.index(
+            'cached_explore_uuid',
+            'catalog_search_cached_explore_uuid_index',
+        );
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('catalog_search', (table) => {
+        table.dropIndex(
+            'cached_explore_uuid',
+            'catalog_search_cached_explore_uuid_index',
+        );
+    });
+}


### PR DESCRIPTION
Why?

- Deleting from the cached_explore table is currently extremely slow (minutes) however analytics show the delete only taking a few ms
- The reason is because `catalog_search` has an unindexed foreign key to cached_explore with cascade delete
- When we delete a bunch of entries from `cached_explore` it's actually cascading a bunch of seq scans to `catalog_search`

This should make deletes of cached_explore many times faster.

But re-indexing could be expensive.