### PR TITLE
feat: add metadata field to AI agent tool results

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -165,7 +165,9 @@ export type DbAiAgentToolResult = {
     tool_call_id: string;
     tool_name: string;
     result: string;
+    metadata: object | null;
     created_at: Date;
+    // TODO add updated_at
 };
 
 export type AiAgentToolResultTable = Knex.CompositeTableType<
@@ -173,6 +175,7 @@ export type AiAgentToolResultTable = Knex.CompositeTableType<
     Pick<
         DbAiAgentToolResult,
         'ai_prompt_uuid' | 'tool_call_id' | 'tool_name' | 'result'
-    >,
+    > &
+        Partial<Pick<DbAiAgentToolResult, 'metadata'>>,
     never
 >;

--- a/packages/backend/src/ee/database/migrations/20251002084611_add_tool_result_metadata_column.ts
+++ b/packages/backend/src/ee/database/migrations/20251002084611_add_tool_result_metadata_column.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const AiAgentToolResultTableName = 'ai_agent_tool_result';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiAgentToolResultTableName))) return;
+
+    await knex.schema.alterTable(AiAgentToolResultTableName, (table) => {
+        table.jsonb('metadata').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiAgentToolResultTableName))) return;
+
+    await knex.schema.alterTable(AiAgentToolResultTableName, (table) => {
+        table.dropColumn('metadata');
+    });
+}

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1588,6 +1588,7 @@ export class AiAgentService {
                                     toolName: toolCallAndResult.tool_name,
                                     output: {
                                         type: 'json',
+                                        // TODO :: based on tool, if there's a need for it we can use the metadata here
                                         value: toolCallAndResult.result,
                                     },
                                 } satisfies ToolResultPart),

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -417,13 +417,14 @@ export const generateAgentResponse = async ({
                                         toolResult.output,
                                     )})`,
                                 );
+                                const output =
+                                    toolResult.output as AgentToolOutput;
                                 return {
                                     promptUuid: args.promptUuid,
                                     toolCallId: toolResult.toolCallId,
                                     toolName: toolResult.toolName,
-                                    result: (
-                                        toolResult.output as AgentToolOutput
-                                    ).result,
+                                    result: output.result,
+                                    metadata: output.metadata,
                                 };
                             }),
                     );
@@ -556,6 +557,9 @@ export const streamAgentResponse = async ({
                                     result: (
                                         event.chunk.output as AgentToolOutput
                                     ).result,
+                                    metadata: (
+                                        event.chunk.output as AgentToolOutput
+                                    ).metadata,
                                 },
                             ])
                             .catch((error) => {

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -1,5 +1,6 @@
 import {
     AdditionalMetric,
+    AgentToolOutput,
     AiArtifact,
     AiMetricQueryWithFilters,
     AiWebAppPrompt,
@@ -114,6 +115,7 @@ export type StoreToolResultsFn = (
         toolCallId: string;
         toolName: string;
         result: string;
+        metadata?: AgentToolOutput['metadata'];
     }>,
 ) => Promise<void>;
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5501,6 +5501,242 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentToolResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                createdAt: { dataType: 'datetime', required: true },
+                metadata: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        status: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['error'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                result: { dataType: 'string', required: true },
+                toolName: { dataType: 'string', required: true },
+                promptUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_':
         {
             dataType: 'refAlias',
@@ -5572,6 +5808,11 @@ const models: TsoaRoute.Models = {
                         { dataType: 'string' },
                         { dataType: 'enum', enums: [null] },
                     ],
+                    required: true,
+                },
+                toolResults: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiAgentToolResult' },
                     required: true,
                 },
                 toolCalls: {
@@ -7060,8 +7301,8 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 projectUuid: { dataType: 'string', required: true },
                 createdAt: { dataType: 'datetime', required: true },
-                validationId: { dataType: 'double', required: true },
                 error: { dataType: 'string', required: true },
+                validationId: { dataType: 'double', required: true },
                 errorType: { ref: 'ValidationErrorType', required: true },
                 spaceUuid: {
                     dataType: 'union',
@@ -9675,8 +9916,8 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 createdAt: { dataType: 'datetime', required: true },
-                validationId: { dataType: 'double', required: true },
                 error: { dataType: 'string', required: true },
+                validationId: { dataType: 'double', required: true },
             },
             validators: {},
         },
@@ -13871,7 +14112,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -13881,7 +14122,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -13891,7 +14132,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -13904,7 +14145,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6190,6 +6190,46 @@
                 ],
                 "type": "object"
             },
+            "AiAgentToolResult": {
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "metadata": {
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "enum": ["success", "error"]
+                            }
+                        },
+                        "required": ["status"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "result": {
+                        "type": "string"
+                    },
+                    "toolName": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "createdAt",
+                    "metadata",
+                    "result",
+                    "toolName",
+                    "promptUuid",
+                    "uuid"
+                ],
+                "type": "object"
+            },
             "Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_": {
                 "properties": {
                     "description": {
@@ -6242,6 +6282,12 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "toolResults": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentToolResult"
+                        },
+                        "type": "array"
+                    },
                     "toolCalls": {
                         "items": {
                             "$ref": "#/components/schemas/AiAgentToolCall"
@@ -6275,6 +6321,7 @@
                 "required": [
                     "artifacts",
                     "savedQueryUuid",
+                    "toolResults",
                     "toolCalls",
                     "humanScore",
                     "createdAt",
@@ -7668,12 +7715,12 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "error": {
+                        "type": "string"
+                    },
                     "validationId": {
                         "type": "number",
                         "format": "double"
-                    },
-                    "error": {
-                        "type": "string"
                     },
                     "errorType": {
                         "$ref": "#/components/schemas/ValidationErrorType"
@@ -7688,8 +7735,8 @@
                 "required": [
                     "projectUuid",
                     "createdAt",
-                    "validationId",
                     "error",
+                    "validationId",
                     "errorType"
                 ],
                 "type": "object",
@@ -10331,15 +10378,15 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "error": {
+                        "type": "string"
+                    },
                     "validationId": {
                         "type": "number",
                         "format": "double"
-                    },
-                    "error": {
-                        "type": "string"
                     }
                 },
-                "required": ["createdAt", "validationId", "error"],
+                "required": ["createdAt", "error", "validationId"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -14641,22 +14688,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -20136,7 +20183,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2034.0",
+        "version": "0.2036.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -12,6 +12,7 @@ import type {
     ToolTimeSeriesArgs,
     ToolVerticalBarArgs,
 } from '../..';
+import { type AgentToolOutput } from './schemas';
 import { type AiMetricQuery, type AiResultType } from './types';
 
 export * from './adminTypes';
@@ -139,6 +140,7 @@ export type AiAgentMessageAssistant = {
     humanScore: number | null;
 
     toolCalls: AiAgentToolCall[];
+    toolResults: AiAgentToolResult[];
     savedQueryUuid: string | null;
 
     artifacts: AiAgentMessageAssistantArtifact[] | null;
@@ -312,6 +314,15 @@ export type AiAgentToolCall = {
     // TODO: tsoa does not support zod infer schemas - https://github.com/lukeautry/tsoa/issues/1256
     toolName: string; // ToolName zod enum
     toolArgs: object;
+};
+
+export type AiAgentToolResult = {
+    uuid: string;
+    promptUuid: string;
+    toolName: string;
+    result: string;
+    metadata: AgentToolOutput['metadata'] | null;
+    createdAt: Date;
 };
 
 export type AiAgentExploreAccessSummary = {

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -26,6 +26,7 @@ import {
 
 export * from './customMetrics';
 export * from './filters';
+export * from './outputMetadata';
 export * from './sortField';
 export * from './tools';
 export * from './visualizations';

--- a/packages/common/src/ee/AiAgent/schemas/outputMetadata.ts
+++ b/packages/common/src/ee/AiAgent/schemas/outputMetadata.ts
@@ -3,3 +3,5 @@ import { z } from 'zod';
 export const baseOutputMetadataSchema = z.object({
     status: z.enum(['success', 'error']),
 });
+
+export type BaseOutputMetadata = z.infer<typeof baseOutputMetadataSchema>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
This PR adds a metadata column to the AI agent tool results table to store additional information about tool execution. The changes include:

1. Adding a `metadata` field to the `DbAiAgentToolResult` type
2. Creating a migration to add the `metadata` column to the database table
3. Updating the `AiAgentModel` to handle the new metadata field when creating and retrieving tool results
4. Modifying the agent service to pass metadata from tool outputs to the database
5. Adding a new `AiAgentToolResult` type to the common package for use in the frontend

