### PR TITLE
feat: add support for creating metrics via AI agent

### DIFF
--- a/packages/backend/src/database/entities/changesets.ts
+++ b/packages/backend/src/database/entities/changesets.ts
@@ -63,15 +63,24 @@ export const DbChangeSchema = z.object({
     entity_table_name: z.string().min(1),
     entity_name: z.string().min(1),
     type: ChangeTypeSchema,
-    payload: z.object({
-        patches: z.array(
+    payload: z.union([
+        z.discriminatedUnion('type', [
             z.object({
-                op: z.enum(['replace']),
-                path: z.string(),
+                type: z.literal('metric'),
+                // TODO: add metric schema
                 value: z.unknown(),
             }),
-        ),
-    }),
+        ]),
+        z.object({
+            patches: z.array(
+                z.object({
+                    op: z.enum(['replace', 'add']),
+                    path: z.string(),
+                    value: z.unknown().refine((value) => value !== undefined),
+                }),
+            ),
+        }),
+    ]),
 });
 
 export type DbChange = z.infer<typeof DbChangeSchema>;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -115,6 +115,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     openIdIdentityModel: models.getOpenIdIdentityModel(),
                     spaceService: repository.getSpaceService(),
+                    projectModel: models.getProjectModel(),
                     prometheusMetrics,
                 }),
             aiAgentAdminService: ({ models, context }) =>

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -3,9 +3,7 @@ import {
     Account,
     AiAgent,
     AiAgentEvalRunJobPayload,
-    AiAgentEvaluation,
     AiAgentEvaluationRun,
-    AiAgentEvaluationRunResult,
     AiAgentEvaluationSummary,
     AiAgentNotFoundError,
     AiAgentThread,
@@ -29,6 +27,7 @@ import {
     CatalogFilter,
     CatalogType,
     CommercialFeatureFlags,
+    ExploreCompiler,
     filterExploreByTags,
     followUpToolsText,
     ForbiddenError,
@@ -36,18 +35,17 @@ import {
     KnexPaginateArgs,
     LightdashUser,
     NotFoundError,
-    NotImplementedError,
     OpenIdIdentityIssuerType,
     ParameterError,
     parseVizConfig,
     QueryExecutionContext,
     SlackPrompt,
     toolDashboardArgsSchema,
-    toolDashboardArgsSchemaTransformed,
     UpdateSlackResponse,
     UpdateWebAppResponse,
     type SessionUser,
 } from '@lightdash/common';
+import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
 import { AllMiddlewareArgs, App, SlackEventMiddlewareArgs } from '@slack/bolt';
 import { Block, KnownBlock, WebClient } from '@slack/web-api';
 import { MessageElement } from '@slack/web-api/dist/response/ConversationsHistoryResponse';
@@ -82,6 +80,7 @@ import { CatalogSearchContext } from '../../models/CatalogModel/CatalogModel';
 import { ChangesetModel } from '../../models/ChangesetModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { OpenIdIdentityModel } from '../../models/OpenIdIdentitiesModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { UserAttributesModel } from '../../models/UserAttributesModel';
@@ -147,6 +146,7 @@ type AiAgentServiceDependencies = {
     userAttributesModel: UserAttributesModel;
     userModel: UserModel;
     spaceService: SpaceService;
+    projectModel: ProjectModel;
     prometheusMetrics?: PrometheusMetrics;
 };
 
@@ -185,6 +185,8 @@ export class AiAgentService {
 
     private readonly spaceService: SpaceService;
 
+    private readonly projectModel: ProjectModel;
+
     private readonly prometheusMetrics?: PrometheusMetrics;
 
     constructor(dependencies: AiAgentServiceDependencies) {
@@ -205,6 +207,7 @@ export class AiAgentService {
         this.userAttributesModel = dependencies.userAttributesModel;
         this.userModel = dependencies.userModel;
         this.spaceService = dependencies.spaceService;
+        this.projectModel = dependencies.projectModel;
         this.prometheusMetrics = dependencies.prometheusMetrics;
     }
 
@@ -1952,6 +1955,20 @@ export class AiAgentService {
             return results;
         };
 
+        const getExploreCompiler = async () => {
+            const warehouseCredentials =
+                await this.projectModel.getWarehouseCredentialsForProject(
+                    projectUuid,
+                );
+
+            return new ExploreCompiler(
+                warehouseSqlBuilderFromType(
+                    warehouseCredentials.type,
+                    warehouseCredentials.startOfWeek,
+                ),
+            );
+        };
+
         const createChange: CreateChangeFn = async (params) => {
             await this.changesetModel.createChange(projectUuid, {
                 createdByUserUuid: user.userUuid,
@@ -1978,6 +1995,7 @@ export class AiAgentService {
             storeToolResults,
             searchFieldValues,
             createChange,
+            getExploreCompiler,
         };
     }
 
@@ -2052,6 +2070,7 @@ export class AiAgentService {
             storeToolResults,
             searchFieldValues,
             createChange,
+            getExploreCompiler,
         } = this.getAiAgentDependencies(user, prompt);
 
         const modelProperties = getModel(this.lightdashConfig.ai.copilot);
@@ -2100,6 +2119,7 @@ export class AiAgentService {
             storeToolCall,
             storeToolResults,
             searchFieldValues,
+            getExploreCompiler,
             updateProgress: (progress: string) => updateProgress(progress),
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -220,6 +220,7 @@ const getAgentTools = (
     const proposeChange = getProposeChange({
         createChange: dependencies.createChange,
         getExplore: dependencies.getExplore,
+        getExploreCompiler: dependencies.getExploreCompiler,
     });
 
     const searchFieldValues = getSearchFieldValues({

--- a/packages/backend/src/ee/services/ai/tools/proposeChange.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.test.ts
@@ -1,27 +1,56 @@
-import { AiResultType } from '@lightdash/common';
+import {
+    AiResultType,
+    type Explore,
+    SupportedDbtAdapter,
+} from '@lightdash/common';
 import { translateToolProposeChangeArgs } from './proposeChange';
+
+const mockExplore: Explore = {
+    name: 'customers',
+    label: 'Customers',
+    tags: [],
+    baseTable: 'customers',
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    joinedTables: [],
+    tables: {
+        customers: {
+            name: 'customers',
+            label: 'Customers',
+            database: 'test',
+            schema: 'public',
+            sqlTable: 'customers',
+            lineageGraph: {},
+            dimensions: {},
+            metrics: {},
+        },
+    },
+};
 
 describe('translateToolProposeChangeArgs', () => {
     it('should translate table update changes', () => {
         expect(
-            translateToolProposeChangeArgs({
-                type: AiResultType.PROPOSE_CHANGE,
-                entityTableName: 'customers',
-                rationale: 'Update the description of the customers table',
-                change: {
-                    value: {
-                        type: 'update',
-                        patch: {
-                            label: { value: 'customers', op: 'replace' },
-                            description: {
-                                value: 'Customer records including both B2B and B2C customers',
-                                op: 'replace',
+            translateToolProposeChangeArgs(
+                {
+                    type: AiResultType.PROPOSE_CHANGE,
+                    entityTableName: 'customers',
+                    rationale: 'Update the description of the customers table',
+                    change: {
+                        value: {
+                            type: 'update',
+                            patch: {
+                                label: { value: 'customers', op: 'replace' },
+                                description: {
+                                    value: 'Customer records including both B2B and B2C customers',
+                                    op: 'replace',
+                                },
                             },
                         },
+                        entityType: 'table',
                     },
-                    entityType: 'table',
                 },
-            }),
+                mockExplore,
+                jest.fn(),
+            ),
         ).toEqual({
             type: 'update',
             entityType: 'table',
@@ -46,25 +75,29 @@ describe('translateToolProposeChangeArgs', () => {
 
     it('should translate dimension update changes', () => {
         expect(
-            translateToolProposeChangeArgs({
-                type: AiResultType.PROPOSE_CHANGE,
-                entityTableName: 'customers',
-                rationale: 'Update the description of the customers table',
-                change: {
-                    value: {
-                        type: 'update',
-                        patch: {
-                            label: null,
-                            description: {
-                                value: 'Customer records including both B2B and B2C customers',
-                                op: 'replace',
+            translateToolProposeChangeArgs(
+                {
+                    type: AiResultType.PROPOSE_CHANGE,
+                    entityTableName: 'customers',
+                    rationale: 'Update the description of the customers table',
+                    change: {
+                        value: {
+                            type: 'update',
+                            patch: {
+                                label: null,
+                                description: {
+                                    value: 'Customer records including both B2B and B2C customers',
+                                    op: 'replace',
+                                },
                             },
                         },
+                        entityType: 'dimension',
+                        fieldId: 'customer_name',
                     },
-                    entityType: 'dimension',
-                    fieldId: 'customer_name',
                 },
-            }),
+                mockExplore,
+                jest.fn(),
+            ),
         ).toEqual({
             type: 'update',
             entityType: 'dimension',
@@ -84,25 +117,29 @@ describe('translateToolProposeChangeArgs', () => {
 
     it('should translate metric update changes', () => {
         expect(
-            translateToolProposeChangeArgs({
-                type: AiResultType.PROPOSE_CHANGE,
-                entityTableName: 'customers',
-                rationale: 'Update the description of the customers table',
-                change: {
-                    value: {
-                        type: 'update',
-                        patch: {
-                            label: null,
-                            description: {
-                                value: 'Customer total revenue',
-                                op: 'replace',
+            translateToolProposeChangeArgs(
+                {
+                    type: AiResultType.PROPOSE_CHANGE,
+                    entityTableName: 'customers',
+                    rationale: 'Update the description of the customers table',
+                    change: {
+                        value: {
+                            type: 'update',
+                            patch: {
+                                label: null,
+                                description: {
+                                    value: 'Customer total revenue',
+                                    op: 'replace',
+                                },
                             },
                         },
+                        entityType: 'metric',
+                        fieldId: 'customer_total_revenue',
                     },
-                    entityType: 'metric',
-                    fieldId: 'customer_total_revenue',
                 },
-            }),
+                mockExplore,
+                jest.fn(),
+            ),
         ).toEqual({
             type: 'update',
             entityType: 'metric',

--- a/packages/backend/src/ee/services/ai/tools/proposeChange.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.ts
@@ -1,36 +1,85 @@
 import {
-    CreateChangeParams,
-    NotImplementedError,
+    assertUnreachable,
+    convertAdditionalMetric,
+    Explore,
     ToolProposeChangeArgs,
     toolProposeChangeArgsSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
-import type { GetExploreFn } from '../types/aiAgentDependencies';
+import type {
+    GetExploreCompilerFn,
+    GetExploreFn,
+} from '../types/aiAgentDependencies';
 import { CreateChangeFn } from '../types/aiAgentDependencies';
+import { populateCustomMetricSQL } from '../utils/populateCustomMetricsSQL';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
     validateFieldEntityType,
     validateTableNames,
 } from '../utils/validators';
 
-export const translateToolProposeChangeArgs = (
+export const translateToolProposeChangeArgs = async (
     toolArgs: ToolProposeChangeArgs,
+    explore: Explore,
+    getExploreCompiler: GetExploreCompilerFn,
 ) => {
     const { entityTableName, change } = toolArgs;
     const { entityType, value } = change;
-    const { type, patch } = value;
 
-    // Convert patch object to JSON patch format
-    const patches = Object.entries(patch)
-        .filter(([, patchValue]) => patchValue !== null)
-        .map(([key, patchValue]) => {
-            if (!patchValue) throw new Error('Patch value is null');
-            return {
-                op: patchValue.op,
-                path: `/${key}`,
-                value: patchValue.value,
+    let payload: object = {};
+
+    switch (value.type) {
+        case 'update':
+            // Convert patch object to JSON patch format
+            const patches = Object.entries(value.patch)
+                .filter(([, patchValue]) => patchValue !== null)
+                .map(([key, patchValue]) => {
+                    if (!patchValue) throw new Error('Patch value is null');
+                    return {
+                        op: patchValue.op,
+                        path: `/${key}`,
+                        value: patchValue.value,
+                    };
+                });
+
+            payload = {
+                patches,
             };
-        });
+            break;
+        case 'create':
+            const exploreCompiler = await getExploreCompiler();
+
+            const additionalMetric = populateCustomMetricSQL(
+                value.value.metric,
+                explore,
+            );
+
+            if (!additionalMetric) {
+                throw new Error(
+                    'Dimension field not found. Try using the right table name and dimension name',
+                );
+            }
+
+            const metric = convertAdditionalMetric({
+                additionalMetric,
+                table: explore.tables[value.value.metric.table],
+            });
+
+            const compiledMetric = exploreCompiler.compileMetric(
+                metric,
+                explore.tables,
+                [],
+            );
+
+            payload = {
+                type: value.value.entityType,
+                value: compiledMetric,
+            };
+            break;
+
+        default:
+            return assertUnreachable(value, 'Invalid change type');
+    }
 
     // Determine entityName based on entityType
     const entityName =
@@ -39,24 +88,24 @@ export const translateToolProposeChangeArgs = (
             : change.fieldId.replace(new RegExp(`^${entityTableName}_`), '');
 
     return {
-        type,
+        type: value.type,
         entityType,
         entityTableName,
         entityName,
-        payload: {
-            patches,
-        },
+        payload,
     };
 };
 
 type GetProposeChangeArgs = {
     createChange: CreateChangeFn;
     getExplore: GetExploreFn;
+    getExploreCompiler: GetExploreCompilerFn;
 };
 
 export const getProposeChange = ({
     createChange,
     getExplore,
+    getExploreCompiler,
 }: GetProposeChangeArgs) =>
     tool({
         description: toolProposeChangeArgsSchema.description,
@@ -68,16 +117,49 @@ export const getProposeChange = ({
                     exploreName: entityTableName,
                 });
 
-                validateTableNames(explore, [entityTableName]);
-                if (change.entityType !== 'table') {
-                    validateFieldEntityType(
-                        explore,
-                        [change.fieldId],
-                        change.entityType,
-                    );
+                switch (change.entityType) {
+                    case 'table':
+                        switch (change.value.type) {
+                            case 'update':
+                                validateTableNames(explore, [entityTableName]);
+                                break;
+                            default:
+                                return assertUnreachable(
+                                    change.value.type,
+                                    'Invalid change type',
+                                );
+                        }
+                        break;
+                    case 'dimension':
+                    case 'metric':
+                        switch (change.value.type) {
+                            case 'create':
+                                validateTableNames(explore, [entityTableName]);
+                                break;
+                            case 'update':
+                                validateTableNames(explore, [entityTableName]);
+                                validateFieldEntityType(
+                                    explore,
+                                    [change.fieldId],
+                                    change.entityType,
+                                );
+                                break;
+                            default:
+                                return assertUnreachable(
+                                    change.value,
+                                    'Invalid change type',
+                                );
+                        }
+                        break;
+                    default:
+                        return assertUnreachable(change, 'Invalid entity type');
                 }
 
-                const translatedArgs = translateToolProposeChangeArgs(toolArgs);
+                const translatedArgs = await translateToolProposeChangeArgs(
+                    toolArgs,
+                    explore,
+                    getExploreCompiler,
+                );
                 await createChange(translatedArgs);
                 return `Successfully proposed change to ${translatedArgs.entityType} "${translatedArgs.entityName}" in table "${translatedArgs.entityTableName}"`;
             } catch (error) {

--- a/packages/backend/src/ee/services/ai/tools/proposeChange.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.ts
@@ -56,7 +56,7 @@ export const translateToolProposeChangeArgs = async (
 
             if (!additionalMetric) {
                 throw new Error(
-                    'Dimension field not found. Try using the right table name and dimension name',
+                    'Base dimension field not found. Try using the right table name and dimension name',
                 );
             }
 

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -8,6 +8,7 @@ import {
     FindDashboardsFn,
     FindExploresFn,
     FindFieldFn,
+    GetExploreCompilerFn,
     GetExploreFn,
     GetPromptFn,
     RunMiniMetricQueryFn,
@@ -58,6 +59,7 @@ export type AiAgentDependencies = {
     findExplores: FindExploresFn;
     findFields: FindFieldFn;
     getExplore: GetExploreFn;
+    getExploreCompiler: GetExploreCompilerFn;
     runMiniMetricQuery: RunMiniMetricQueryFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -11,6 +11,7 @@ import {
     CreateChangeParams,
     DashboardSearchResult,
     Explore,
+    ExploreCompiler,
     Filters,
     ItemsMap,
     KnexPaginateArgs,
@@ -148,3 +149,5 @@ export type CreateChangeFn = (
         'type' | 'entityName' | 'entityType' | 'entityTableName' | 'payload'
     >,
 ) => Promise<void>;
+
+export type GetExploreCompilerFn = () => Promise<ExploreCompiler>;

--- a/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
+++ b/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
@@ -1,10 +1,42 @@
 import {
     AdditionalMetric,
-    CustomMetricBaseSchema,
+    CustomMetricBase,
     getFields,
     getItemId,
     type Explore,
 } from '@lightdash/common';
+
+/**
+ * Populates SQL for a single custom metric from explore fields
+ * This is needed because custom metrics are stored without SQL for security,
+ * but we need to populate it from the explore when executing queries
+ */
+export function populateCustomMetricSQL(
+    metric: CustomMetricBase | Omit<AdditionalMetric, 'sql'>,
+    explore: Explore,
+): AdditionalMetric | null {
+    const exploreFields = getFields(explore);
+
+    // Find the dimension field to get its SQL
+    const dimensionField = exploreFields.find(
+        (field) =>
+            metric.baseDimensionName &&
+            getItemId(field) ===
+                getItemId({
+                    table: metric.table,
+                    name: metric.baseDimensionName,
+                }),
+    );
+
+    if (!dimensionField) {
+        return null;
+    }
+
+    return {
+        ...metric,
+        sql: dimensionField.sql,
+    };
+}
 
 /**
  * Populates SQL for custom metrics from explore fields
@@ -13,7 +45,7 @@ import {
  */
 export function populateCustomMetricsSQL(
     customMetrics:
-        | (CustomMetricBaseSchema | Omit<AdditionalMetric, 'sql'>)[]
+        | (CustomMetricBase | Omit<AdditionalMetric, 'sql'>)[]
         | null
         | undefined,
     explore: Explore,
@@ -22,29 +54,11 @@ export function populateCustomMetricsSQL(
         return [];
     }
 
-    const exploreFields = getFields(explore);
-
     return customMetrics.reduce<AdditionalMetric[]>((acc, metric) => {
-        // Find the dimension field to get its SQL
-        const dimensionField = exploreFields.find(
-            (field) =>
-                metric.baseDimensionName &&
-                getItemId(field) ===
-                    getItemId({
-                        table: metric.table,
-                        name: metric.baseDimensionName,
-                    }),
-        );
-
-        if (!dimensionField) {
-            return acc;
+        const populatedMetric = populateCustomMetricSQL(metric, explore);
+        if (populatedMetric) {
+            acc.push(populatedMetric);
         }
-        return [
-            ...acc,
-            {
-                ...metric,
-                sql: dimensionField.sql,
-            },
-        ];
+        return acc;
     }, []);
 }

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -4,7 +4,6 @@ import {
     booleanFilterSchema,
     CompiledField,
     convertAdditionalMetric,
-    CustomMetricBaseSchema,
     dateFilterSchema,
     Explore,
     FilterRule,
@@ -19,7 +18,6 @@ import {
     isAdditionalMetric,
     isDimension,
     isMetric,
-    Metric,
     numberFilterSchema,
     renderFilterRuleSql,
     renderFilterRuleSqlFromField,
@@ -27,6 +25,7 @@ import {
     SupportedDbtAdapter,
     ToolSortField,
     WeekDay,
+    type CustomMetricBase,
 } from '@lightdash/common';
 import Logger from '../../../../logging/logger';
 import { populateCustomMetricsSQL } from './populateCustomMetricsSQL';
@@ -39,9 +38,7 @@ import { serializeData } from './serializeData';
 export function validateSelectedFieldsExistence(
     explore: Explore,
     selectedFieldIds: string[],
-    customMetrics?:
-        | (CustomMetricBaseSchema | Omit<AdditionalMetric, 'sql'>)[]
-        | null,
+    customMetrics?: (CustomMetricBase | Omit<AdditionalMetric, 'sql'>)[] | null,
 ) {
     const exploreFieldIds = getFields(explore).map(getItemId);
     const customMetricIds = customMetrics?.map(getItemId);
@@ -76,7 +73,7 @@ ${nonExploreFields.join('\n')}
  */
 export function validateCustomMetricsDefinition(
     explore: Explore,
-    customMetrics: CustomMetricBaseSchema[] | null,
+    customMetrics: CustomMetricBase[] | null,
 ) {
     if (!customMetrics || customMetrics.length === 0) {
         return;
@@ -257,7 +254,7 @@ ${serializeData(filterRule, 'json')}`;
 export function validateFilterRules(
     explore: Explore,
     filterRules: FilterRule[],
-    customMetrics?: CustomMetricBaseSchema[] | null,
+    customMetrics?: CustomMetricBase[] | null,
 ) {
     const exploreFields = getFields(explore);
     const customMetricFields = populateCustomMetricsSQL(
@@ -315,7 +312,7 @@ ${filterRuleErrorStrings}`;
 export function validateMetricDimensionFilterPlacement(
     explore: Explore,
     filters?: Filters,
-    customMetrics?: CustomMetricBaseSchema[] | null,
+    customMetrics?: CustomMetricBase[] | null,
 ) {
     if (!filters) return;
 
@@ -414,7 +411,7 @@ export function validateSortFieldsAreSelected(
     sorts: ToolSortField[],
     selectedDimensions: string[],
     selectedMetrics: string[],
-    customMetrics?: CustomMetricBaseSchema[] | null,
+    customMetrics?: CustomMetricBase[] | null,
 ) {
     if (!sorts || sorts.length === 0) {
         return;

--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -38,25 +38,25 @@ export const customMetricBaseSchema = z.object({
         ),
 });
 
-export type CustomMetricBaseSchema = z.infer<typeof customMetricBaseSchema>;
+export type CustomMetricBase = z.infer<typeof customMetricBaseSchema>;
 
 export const customMetricsSchema = z
     .array(customMetricBaseSchema)
     .nullable()
     .describe(
         `Create custom metrics when requested metrics don't exist. Only create if no existing metric matches the user's request. Use null if no custom metrics needed.
-                
-                IMPORTANT: If the user requests metrics that don't exist (like "average customer age"), create them using the customMetrics field. Analyze available dimensions from findFields results and create appropriate SQL aggregations.
 
-                When using custom metrics:
-                1. Create the metric in customMetrics array with just the metric name (e.g., "avg_customer_age")
-                2. Reference it in metrics array using the format "table_metricname" (e.g., "customers_avg_customer_age")
-                3. Reference it in sorts array using the format "table_metricname" (e.g., "customers_avg_customer_age")
-                4. DO NOT use the raw metric name in metrics or sorts arrays
+IMPORTANT: If the user requests metrics that don't exist (like "average customer age"), create them using the customMetrics field. Analyze available dimensions from findFields results and create appropriate SQL aggregations.
 
-                For example:
-                - "Show me average customer age sorted descending" → 
-                customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
-                metrics: ["customers_avg_customer_age"]
-                sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
+When using custom metrics:
+1. Create the metric in customMetrics array with just the metric name (e.g., "avg_customer_age")
+2. Reference it in metrics array using the format "table_metricname" (e.g., "customers_avg_customer_age")
+3. Reference it in sorts array using the format "table_metricname" (e.g., "customers_avg_customer_age")
+4. DO NOT use the raw metric name in metrics or sorts arrays
+
+For example:
+- "Show me average customer age sorted descending" →
+customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
+metrics: ["customers_avg_customer_age"]
+sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
     );

--- a/packages/common/src/types/changeset.ts
+++ b/packages/common/src/types/changeset.ts
@@ -28,9 +28,13 @@ export const ChangeSchema = z
         z.discriminatedUnion('type', [
             z.object({
                 type: z.literal('create'),
-                payload: z.object({
-                    value: z.unknown(),
-                }),
+                payload: z.discriminatedUnion('type', [
+                    z.object({
+                        type: z.literal('metric'),
+                        // TODO: add metric schema
+                        value: z.unknown(),
+                    }),
+                ]),
             }),
             z.object({
                 type: z.literal('update'),

--- a/packages/common/src/utils/changeset.ts
+++ b/packages/common/src/utils/changeset.ts
@@ -144,7 +144,7 @@ export class ChangesetUtils {
                                         {
                                             op: 'replace',
                                             path: `/tables/${tableName}/${entityType}/${change.entityName}`,
-                                            value: change,
+                                            value: change.payload.value,
                                         },
                                     ],
                                 );


### PR DESCRIPTION
### Description:
This PR adds support for creating metrics via the AI agent's proposeChange tool. The implementation includes:

1. Updated the DbChangeSchema to support a new payload type for metric creation
2. Enhanced the proposeChange tool to handle metric creation requests
3. Added the ExploreCompiler dependency to the AiAgentService to compile SQL for new metrics
4. Created a utility function to populate custom metric SQL from explore fields
5. Updated the changesets utility to properly handle metric creation changes

This allows users to request the AI agent to create new metrics in the semantic layer, which will be proposed as changes that can be reviewed and approved.