### PR TITLE
feat: add reject functionality for AI proposed changes frontend

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -99,6 +99,10 @@ const AssistantBubbleContent: FC<{
         : (message.toolCalls.find((t) => t.toolName === 'proposeChange')
               ?.toolArgs as ToolProposeChangeArgs); // TODO: fix message type, it's `object` now
 
+    const proposeChangeToolResult = message.toolResults.find(
+        (result) => result.toolName === 'proposeChange',
+    );
+
     return (
         <>
             {hasStreamingError && (
@@ -288,6 +292,11 @@ const AssistantBubbleContent: FC<{
                 <AiProposeChangeToolCall
                     change={proposeChangeToolCall.change}
                     entityTableName={proposeChangeToolCall.entityTableName}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    threadUuid={message.threadUuid}
+                    promptUuid={message.uuid}
+                    toolResult={proposeChangeToolResult}
                 />
             )}
         </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
@@ -1,12 +1,28 @@
-import { type ToolProposeChangeArgs } from '@lightdash/common';
-import { Badge, type DefaultMantineColor, Group, Stack } from '@mantine-8/core';
-import { IconGitBranch } from '@tabler/icons-react';
+import {
+    type AiAgentToolResult,
+    type ToolProposeChangeArgs,
+} from '@lightdash/common';
+import {
+    Badge,
+    Button,
+    type DefaultMantineColor,
+    Group,
+    Stack,
+} from '@mantine-8/core';
+import { IconGitBranch, IconX } from '@tabler/icons-react';
+import MantineIcon from '../../../../../../../components/common/MantineIcon';
+import { useRevertChangeMutation } from '../../../../hooks/useProjectAiAgents';
 import { ToolCallPaper } from '../ToolCallPaper';
 import { ChangeRenderer } from './ChangeRenderer';
 
 interface Props
     extends Pick<ToolProposeChangeArgs, 'change' | 'entityTableName'> {
     defaultOpened?: boolean;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+    toolResult: AiAgentToolResult | undefined;
 }
 
 const CHANGE_COLORS = {
@@ -18,10 +34,37 @@ export const AiProposeChangeToolCall = ({
     change,
     entityTableName,
     defaultOpened = true,
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    promptUuid,
+    toolResult,
 }: Props) => {
     const changeType = change.value.type;
     const changeColor: DefaultMantineColor =
         CHANGE_COLORS[changeType] ?? 'gray';
+
+    const { mutate: revertChange, isLoading } = useRevertChangeMutation(
+        projectUuid,
+        agentUuid,
+        threadUuid,
+    );
+
+    const metadata =
+        toolResult?.toolName === 'proposeChange' &&
+        toolResult.metadata?.status === 'success'
+            ? toolResult.metadata
+            : null;
+
+    const changeUuid = metadata?.changeUuid;
+
+    const isRejected = metadata?.userFeedback === 'rejected';
+
+    const handleReject = () => {
+        if (changeUuid) {
+            revertChange({ promptUuid, changeUuid });
+        }
+    };
 
     return (
         <ToolCallPaper
@@ -47,17 +90,18 @@ export const AiProposeChangeToolCall = ({
                     entityTableName={entityTableName}
                 />
 
-                {/*TODO
-                <Group w="100%" justify="flex-end">
+                <Group w="100%" justify="flex-end" pr="xs">
                     <Button
-                        variant="outline"
-                        size="xs"
-                        color="dark"
-                        leftSection={<MantineIcon icon={IconX} size={14} />}
+                        variant="default"
+                        size="compact-xs"
+                        leftSection={<MantineIcon icon={IconX} size={12} />}
+                        onClick={handleReject}
+                        disabled={!changeUuid || isRejected || isLoading}
+                        loading={isLoading}
                     >
-                        Reject
+                        {isRejected ? 'Rejected' : 'Reject'}
                     </Button>
-                </Group>*/}
+                </Group>
             </Stack>
         </ToolCallPaper>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
Added the ability to reject AI-proposed changes in the chat interface. This feature allows users to revert changes made by the AI assistant directly from the chat bubble. The implementation includes:

- Added a "Reject" button to the AI propose change tool call component
- Connected the button to a new revert change mutation
- Added necessary props to pass project, agent, thread, and prompt UUIDs to the component
- Implemented state handling to show when a change has been rejected
- Added visual feedback during the rejection process

