### PR TITLE
feat: add view changeset button in propose change tool ui

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
@@ -1,6 +1,6 @@
-import {
-    type AiAgentToolResult,
-    type ToolProposeChangeArgs,
+import type {
+    AiAgentToolResult,
+    ToolProposeChangeArgs,
 } from '@lightdash/common';
 import {
     Badge,
@@ -9,7 +9,7 @@ import {
     Group,
     Stack,
 } from '@mantine-8/core';
-import { IconGitBranch, IconX } from '@tabler/icons-react';
+import { IconExternalLink, IconGitBranch, IconX } from '@tabler/icons-react';
 import MantineIcon from '../../../../../../../components/common/MantineIcon';
 import { useRevertChangeMutation } from '../../../../hooks/useProjectAiAgents';
 import { ToolCallPaper } from '../ToolCallPaper';
@@ -82,6 +82,24 @@ export const AiProposeChangeToolCall = ({
                         {changeType}
                     </Badge>
                 </Group>
+            }
+            rightAction={
+                <Button
+                    component="a"
+                    href={`/generalSettings/projectManagement/${projectUuid}/changesets`}
+                    target="_blank"
+                    variant="subtle"
+                    size="compact-xs"
+                    rightSection={
+                        <MantineIcon icon={IconExternalLink} size={14} />
+                    }
+                    // do not bubble up event to close the collapsible
+                    onClick={(e) => {
+                        e.stopPropagation();
+                    }}
+                >
+                    View Changeset
+                </Button>
             }
         >
             <Stack gap="xs" mt="xs">

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallPaper.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallPaper.tsx
@@ -12,6 +12,7 @@ type ToolCallPaperProps = {
     icon: MantineIconProps['icon'];
     defaultOpened?: boolean;
     variant?: 'default' | 'dashed';
+    rightAction?: ReactNode;
 };
 
 export const ToolCallPaper = ({
@@ -20,6 +21,7 @@ export const ToolCallPaper = ({
     icon,
     defaultOpened = true,
     variant = 'default',
+    rightAction,
 }: ToolCallPaperProps) => {
     const [opened, { toggle }] = useDisclosure(defaultOpened);
 
@@ -44,7 +46,14 @@ export const ToolCallPaper = ({
                             {title}
                         </Title>
                     </Group>
-                    <MantineIcon icon={IconSelector} size={12} color="gray.6" />
+                    <Group gap="xs">
+                        {rightAction}
+                        <MantineIcon
+                            icon={IconSelector}
+                            size={12}
+                            color="gray.6"
+                        />
+                    </Group>
                 </Group>
             </UnstyledButton>
             <Collapse in={opened}>{children}</Collapse>

--- a/packages/frontend/src/stories/AiProposeChangeToolCall.stories.tsx
+++ b/packages/frontend/src/stories/AiProposeChangeToolCall.stories.tsx
@@ -18,6 +18,7 @@ type Story = StoryObj<typeof AiProposeChangeToolCall>;
 export const UpdateTableDescription: Story = {
     args: {
         entityTableName: 'customers',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'table',
             value: {
@@ -37,6 +38,7 @@ export const UpdateTableDescription: Story = {
 export const UpdateTableLabel: Story = {
     args: {
         entityTableName: 'orders',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'table',
             value: {
@@ -56,6 +58,7 @@ export const UpdateTableLabel: Story = {
 export const UpdateTableLabelAndDescription: Story = {
     args: {
         entityTableName: 'products',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'table',
             value: {
@@ -78,6 +81,7 @@ export const UpdateTableLabelAndDescription: Story = {
 export const UpdateDimensionDescription: Story = {
     args: {
         entityTableName: 'customers',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'dimension',
             fieldId: 'customer_name',
@@ -98,6 +102,7 @@ export const UpdateDimensionDescription: Story = {
 export const UpdateDimensionLabel: Story = {
     args: {
         entityTableName: 'customers',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'dimension',
             fieldId: 'customer_email',
@@ -118,6 +123,7 @@ export const UpdateDimensionLabel: Story = {
 export const UpdateDimensionLabelAndDescription: Story = {
     args: {
         entityTableName: 'customers',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'dimension',
             fieldId: 'signup_date',
@@ -141,6 +147,7 @@ export const UpdateDimensionLabelAndDescription: Story = {
 export const UpdateMetricDescription: Story = {
     args: {
         entityTableName: 'orders',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'metric',
             fieldId: 'total_revenue',
@@ -161,6 +168,7 @@ export const UpdateMetricDescription: Story = {
 export const UpdateMetricLabel: Story = {
     args: {
         entityTableName: 'orders',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'metric',
             fieldId: 'avg_order_value',
@@ -181,6 +189,7 @@ export const UpdateMetricLabel: Story = {
 export const UpdateMetricLabelAndDescription: Story = {
     args: {
         entityTableName: 'users',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'metric',
             fieldId: 'active_users',
@@ -204,6 +213,7 @@ export const UpdateMetricLabelAndDescription: Story = {
 export const UpdateTableDescriptionWithMarkdown: Story = {
     args: {
         entityTableName: 'customers',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'table',
             value: {
@@ -235,6 +245,7 @@ For more information, see the [customer onboarding guide](https://example.com/do
 export const UpdateDimensionDescriptionWithMarkdown: Story = {
     args: {
         entityTableName: 'orders',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'dimension',
             fieldId: 'order_status',
@@ -271,6 +282,7 @@ GROUP BY order_status
 export const UpdateMetricDescriptionWithMarkdown: Story = {
     args: {
         entityTableName: 'revenue',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
         change: {
             entityType: 'metric',
             fieldId: 'mrr',


### PR DESCRIPTION
### Description:
Added a "View Changeset" button to the AI propose change tool call component that links to the project's changeset page. 

![image.png](https://app.graphite.dev/user-attachments/assets/da3f909a-75ed-4c06-bb97-307b57286299.png)

