### PR TITLE
feat: handle ai metric creation on catalog_search index

### DIFF
--- a/packages/common/src/types/changeset.ts
+++ b/packages/common/src/types/changeset.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { FieldType, MetricType } from './field';
 
 const ChangesetStatusSchema = z.enum(['draft', 'applied']);
 
@@ -31,8 +32,25 @@ export const ChangeSchema = z
                 payload: z.discriminatedUnion('type', [
                     z.object({
                         type: z.literal('metric'),
-                        // TODO: add metric schema
-                        value: z.unknown(),
+                        value: z.object({
+                            fieldType: z.literal(FieldType.METRIC),
+                            type: z.nativeEnum(MetricType),
+                            name: z.string(),
+                            label: z.string(),
+                            table: z.string(),
+                            tableLabel: z.string(), // Table friendly name
+                            sql: z.string(), // Templated sql
+                            description: z.string().optional(),
+                            hidden: z.boolean(),
+                            compiledSql: z.string(),
+                            tablesReferences: z.array(z.string()),
+                            tablesRequiredAttributes: z
+                                .record(
+                                    z.string(),
+                                    z.record(z.string(), z.string()),
+                                )
+                                .optional(),
+                        }),
                     }),
                 ]),
             }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Adds support for creating metrics through changesets. This PR:

- Implements the `create` change type for metrics in the `CatalogModel`
- Adds the metric schema definition in the `ChangeSchema` to validate metric payloads
- Passes the explore cache map to catalog search functions to ensure metrics have access to their associated explore data
- Updates the catalog service to load explore data from cache when processing metrics

This enables users to create metrics through the changeset workflow, with proper validation and integration into the catalog system.