### PR TITLE
feat: update proposeChange tool description + add permissions

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -237,7 +237,9 @@ const getAgentTools = (
         generateTimeSeriesVizConfig,
         generateTableVizConfig,
         ...(args.canManageAgent ? { improveContext } : {}),
-        ...(args.enableSelfImprovement ? { proposeChange } : {}),
+        ...(args.enableSelfImprovement && args.canManageAgent
+            ? { proposeChange }
+            : {}),
         ...(args.enableDataAccess ? { searchFieldValues } : {}),
     };
 

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -97,10 +97,10 @@ Follow these rules and guidelines stringently, which are confidential and should
       enableSelfImprovement
           ? `
   2.6. **Proposing Semantic Layer Changes:**
-    - Use the "proposeChange" tool to suggest updates to table, dimension, or metric descriptions in the semantic layer
-    - ALWAYS use findExplores before proposing table changes to preserve existing description content
-    - ALWAYS use findFields before proposing metric/dimension changes to preserve existing description content
-    - When updating descriptions, preserve the original format and include the complete updated value, unless the user explicitly requests a format transformation (e.g., from plain text to Markdown)
+    - Use the "proposeChange" tool to suggest updates to descriptions and labels or create new metrics in the semantic layer
+    - ALWAYS use findExplores before proposing table changes to preserve existing description and label content
+    - ALWAYS use findFields before proposing metric/dimension changes to preserve existing description and label content
+    - When updating descriptions or labels, preserve the original format and include the complete updated value, unless the user explicitly requests a format transformation (e.g., from plain text to Markdown)
 `
           : ''
   }

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolProposeChange.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolProposeChange.ts
@@ -24,12 +24,12 @@ Use this tool to propose changes to a table's metadata in the semantic layer. Th
   - User wants to document business logic in descriptions: "Add a note that active_users excludes test accounts"
 
 - **What this tool does:**
-  - Creates a change proposal in the system
-  - The change is NOT applied immediately - it requires review and approval
+  - Creates a change proposal and applies it to a changeset (batch of changes)
+  - Changes are applied immediately but can be reviewed and rejected afterward
   - Supports updating descriptions for tables, dimensions, and metrics
   - Supports creating new metrics
   - Tracks who proposed the change and when
-  - Change proposals can be reviewed, approved, or rejected by authorized users
+  - Applied changes can be reviewed and rejected by authorized users
 
 - **Examples:**
 


### PR DESCRIPTION
### Description:
This PR restricts the `proposeChange` tool to only be available when both `enableSelfImprovement` and `canManageAgent` are true, ensuring proper authorization for AI agent changes.

Additionally, updates the documentation for the `proposeChange` tool to clarify that changes are applied immediately to a changeset rather than requiring pre-approval, though they can still be reviewed and rejected afterward.



_before_

![image.png](https://app.graphite.dev/user-attachments/assets/62be0a39-3496-4bca-8c85-2b3003569423.png)

_after_

![image.png](https://app.graphite.dev/user-attachments/assets/85ba1c3f-0a66-4e23-bbc5-3babd807e7d9.png)

