### PR TITLE
feat: ask user to create metric from custom metric after ai artifact

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -180,6 +180,7 @@ const getAgentTools = (
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
         enableDataAccess: args.enableDataAccess,
+        enableSelfImprovement: args.enableSelfImprovement,
     });
 
     const generateTimeSeriesVizConfig = getGenerateTimeSeriesVizConfig({
@@ -191,6 +192,7 @@ const getAgentTools = (
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
         enableDataAccess: args.enableDataAccess,
+        enableSelfImprovement: args.enableSelfImprovement,
     });
 
     const generateTableVizConfig = getGenerateTableVizConfig({
@@ -202,6 +204,7 @@ const getAgentTools = (
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
         enableDataAccess: args.enableDataAccess,
+        enableSelfImprovement: args.enableSelfImprovement,
     });
 
     const generateDashboard = getGenerateDashboard({

--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -32,6 +32,7 @@ type Dependencies = {
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
     enableDataAccess: boolean;
+    enableSelfImprovement: boolean;
 };
 
 export const getGenerateBarVizConfig = ({
@@ -43,6 +44,7 @@ export const getGenerateBarVizConfig = ({
     createOrUpdateArtifact,
     maxLimit,
     enableDataAccess,
+    enableSelfImprovement,
 }: Dependencies) =>
     tool({
         description: toolVerticalBarArgsSchema.description,
@@ -71,6 +73,12 @@ export const getGenerateBarVizConfig = ({
                     description: toolArgs.description,
                     vizConfig: toolArgs,
                 });
+                const selfImprovementResultFollowUp =
+                    enableSelfImprovement &&
+                    vizTool.customMetrics &&
+                    vizTool.customMetrics.length > 0
+                        ? `\nCan you propose the creation of this metric as a metric to the semantic layer to the user?`
+                        : '';
 
                 if (!enableDataAccess && !isSlackPrompt(prompt)) {
                     return {
@@ -117,7 +125,7 @@ export const getGenerateBarVizConfig = ({
 
                 if (!enableDataAccess) {
                     return {
-                        result: `Success`,
+                        result: `Success. ${selfImprovementResultFollowUp}`,
                         metadata: {
                             status: 'success',
                         },
@@ -127,7 +135,10 @@ export const getGenerateBarVizConfig = ({
                 const csv = convertQueryResultsToCsv(queryResults);
 
                 return {
-                    result: serializeData(csv, 'csv'),
+                    result: `${serializeData(
+                        csv,
+                        'csv',
+                    )} ${selfImprovementResultFollowUp}`,
                     metadata: {
                         status: 'success',
                     },

--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -30,6 +30,7 @@ type Dependencies = {
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
     enableDataAccess: boolean;
+    enableSelfImprovement: boolean;
 };
 
 export const getGenerateTableVizConfig = ({
@@ -41,6 +42,7 @@ export const getGenerateTableVizConfig = ({
     createOrUpdateArtifact,
     maxLimit,
     enableDataAccess,
+    enableSelfImprovement,
 }: Dependencies) =>
     tool({
         description: toolTableVizArgsSchema.description,
@@ -72,6 +74,13 @@ export const getGenerateTableVizConfig = ({
                     description: toolArgs.description,
                     vizConfig: toolArgs,
                 });
+
+                const selfImprovementResultFollowUp =
+                    enableSelfImprovement &&
+                    vizTool.customMetrics &&
+                    vizTool.customMetrics.length > 0
+                        ? `\nCan you propose the creation of this metric as a metric to the semantic layer to the user?`
+                        : '';
 
                 const metricQuery = metricQueryTableViz({
                     vizConfig: vizTool.vizConfig,
@@ -117,7 +126,7 @@ export const getGenerateTableVizConfig = ({
                             result: `Here's the result:\n${serializeData(
                                 csv,
                                 'csv',
-                            )}`,
+                            )} ${selfImprovementResultFollowUp}`,
                             metadata: {
                                 status: 'success',
                             },
@@ -133,7 +142,10 @@ export const getGenerateTableVizConfig = ({
                 }
 
                 return {
-                    result: serializeData(csv, 'csv'),
+                    result: `Here's the result:\n${serializeData(
+                        csv,
+                        'csv',
+                    )} ${selfImprovementResultFollowUp}`,
                     metadata: {
                         status: 'success',
                     },

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -32,6 +32,7 @@ type Dependencies = {
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
     enableDataAccess: boolean;
+    enableSelfImprovement: boolean;
 };
 
 export const getGenerateTimeSeriesVizConfig = ({
@@ -43,6 +44,7 @@ export const getGenerateTimeSeriesVizConfig = ({
     createOrUpdateArtifact,
     maxLimit,
     enableDataAccess,
+    enableSelfImprovement,
 }: Dependencies) =>
     tool({
         description: toolTimeSeriesArgsSchema.description,
@@ -72,6 +74,13 @@ export const getGenerateTimeSeriesVizConfig = ({
                     description: toolArgs.description,
                     vizConfig: toolArgs,
                 });
+
+                const selfImprovementResultFollowUp =
+                    enableSelfImprovement &&
+                    toolArgs.customMetrics &&
+                    toolArgs.customMetrics.length > 0
+                        ? `\nCan you propose the creation of this metric as a metric to the semantic layer to the user?`
+                        : '';
 
                 if (!enableDataAccess && !isSlackPrompt(prompt)) {
                     return {
@@ -118,7 +127,7 @@ export const getGenerateTimeSeriesVizConfig = ({
 
                 if (!enableDataAccess) {
                     return {
-                        result: `Success`,
+                        result: `Success. ${selfImprovementResultFollowUp}`,
                         metadata: {
                             status: 'success',
                         },
@@ -128,7 +137,10 @@ export const getGenerateTimeSeriesVizConfig = ({
                 const csv = convertQueryResultsToCsv(queryResults);
 
                 return {
-                    result: serializeData(csv, 'csv'),
+                    result: `${serializeData(
+                        csv,
+                        'csv',
+                    )} ${selfImprovementResultFollowUp}`,
                     metadata: {
                         status: 'success',
                     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Added self-improvement capability to visualization tools. When custom metrics are created during visualization generation, the AI agent can now suggest creating these metrics in the semantic layer if `enableSelfImprovement` is enabled.

This enhancement was implemented across bar, table, and time series visualization tools, allowing the agent to provide follow-up suggestions when it identifies opportunities to improve the semantic layer with newly created metrics.

![image.png](https://app.graphite.dev/user-attachments/assets/74510058-21bf-49a2-b939-4211528b28d9.png)

