### PR TITLE
feat: display metric creation in Propose Change tool ui

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
@@ -1,9 +1,17 @@
-import { assertUnreachable } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import {
+    assertUnreachable,
+    type Field,
+    FieldType,
+    friendlyName,
+    getItemColor,
+} from '@lightdash/common';
+import { Group, Paper, Stack, Text } from '@mantine-8/core';
 import { toPairs } from 'lodash';
+import FieldIcon from '../../../../../../../components/common/Filters/FieldIcon';
 import { OperationRenderer } from './OperationRenderer';
 import { FieldBreadcrumb, TableBreadcrumb } from './SupportElements';
 import type {
+    CreateMetric as CreateMetricPayload,
     DimensionChange,
     EntityChange,
     MetricChange,
@@ -37,6 +45,44 @@ const UpdateChange = ({ patch }: UpdateChangeProps) => {
                 />
             ))}
         </Stack>
+    );
+};
+
+// ============================================================================
+// Metric Creation Component
+// ============================================================================
+
+type CreateMetricProps = {
+    change: CreateMetricPayload;
+};
+
+const CreateMetric = ({ change }: CreateMetricProps) => {
+    const metric = {
+        ...change.value.metric,
+        fieldType: FieldType.METRIC,
+        tableLabel: '',
+        sql: '',
+        hidden: false,
+    } satisfies Field;
+    const color = getItemColor(metric);
+
+    return (
+        <Paper
+            bg="gray.0"
+            mx="xs"
+            p="xs"
+            component={Group}
+            gap={6}
+            align="center"
+        >
+            <FieldIcon item={metric} color={color} size="md" />
+            <Text size="xs" fw={600}>
+                {metric.label}
+            </Text>
+            <Text size="xs" fw={600} c="dimmed">
+                ({friendlyName(metric.type)})
+            </Text>
+        </Paper>
     );
 };
 
@@ -129,6 +175,7 @@ const MetricChangeRender = ({ change, entityTableName }: MetricChangeProps) => {
                         fieldType="metric"
                         fieldId={change.fieldId}
                     />
+                    <CreateMetric change={change.value} />
                 </Stack>
             );
         default:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/types.ts
@@ -38,3 +38,5 @@ export type UpdateMetricPatch = Extract<
     MetricChange['value'],
     { type: 'update' }
 >['patch'];
+
+export type CreateMetric = Extract<MetricChange['value'], { type: 'create' }>;

--- a/packages/frontend/src/stories/AiProposeChangeToolCall.stories.tsx
+++ b/packages/frontend/src/stories/AiProposeChangeToolCall.stories.tsx
@@ -1,11 +1,20 @@
+import { MetricType } from '@lightdash/common';
 import '@mantine-8/core/styles.css';
 import type { Meta, StoryObj } from '@storybook/react';
+import { MemoryRouter } from 'react-router';
 import { AiProposeChangeToolCall } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall';
 import Mantine8Provider from '../providers/Mantine8Provider';
+import ReactQueryProvider from '../providers/__mocks__/ReactQueryProvider';
 
 const meta: Meta<typeof AiProposeChangeToolCall> = {
     decorators: [
-        (renderStory) => <Mantine8Provider>{renderStory()}</Mantine8Provider>,
+        (renderStory) => (
+            <MemoryRouter>
+                <ReactQueryProvider>
+                    <Mantine8Provider>{renderStory()}</Mantine8Provider>
+                </ReactQueryProvider>
+            </MemoryRouter>
+        ),
     ],
     component: AiProposeChangeToolCall,
     tags: ['autodocs'],
@@ -311,6 +320,102 @@ export const UpdateMetricDescriptionWithMarkdown: Story = {
                         op: 'replace',
                         value: 'Monthly Recurring Revenue',
                     },
+                },
+            },
+        },
+    },
+};
+
+export const CreateMetricChurnRate: Story = {
+    args: {
+        entityTableName: 'customers',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
+        change: {
+            entityType: 'metric',
+            fieldId: 'customers_churn_rate',
+            value: {
+                type: 'create',
+                value: {
+                    metric: {
+                        name: 'churn_rate',
+                        type: MetricType.AVERAGE,
+                        label: 'Churn Rate (No Orders in Last 1 Month)',
+                        table: 'customers',
+                        baseDimensionName: 'customer_id',
+                    },
+                    entityType: 'metric',
+                },
+            },
+        },
+    },
+};
+
+export const CreateMetricTotalRevenue: Story = {
+    args: {
+        entityTableName: 'orders',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
+        change: {
+            entityType: 'metric',
+            fieldId: 'orders_total_revenue',
+            value: {
+                type: 'create',
+                value: {
+                    metric: {
+                        name: 'total_revenue',
+                        type: MetricType.SUM,
+                        label: 'Total Revenue',
+                        table: 'orders',
+                        baseDimensionName: 'order_total',
+                    },
+                    entityType: 'metric',
+                },
+            },
+        },
+    },
+};
+
+export const CreateMetricCustomerCount: Story = {
+    args: {
+        entityTableName: 'customers',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
+        change: {
+            entityType: 'metric',
+            fieldId: 'customers_count',
+            value: {
+                type: 'create',
+                value: {
+                    metric: {
+                        name: 'customer_count',
+                        type: MetricType.COUNT,
+                        label: 'Total Customers',
+                        table: 'customers',
+                        baseDimensionName: 'customer_id',
+                    },
+                    entityType: 'metric',
+                },
+            },
+        },
+    },
+};
+
+export const CreateMetricAverageOrderValue: Story = {
+    args: {
+        entityTableName: 'orders',
+        projectUuid: '3675b69e-8324-4110-bdca-059031aa8da3',
+        change: {
+            entityType: 'metric',
+            fieldId: 'orders_avg_value',
+            value: {
+                type: 'create',
+                value: {
+                    metric: {
+                        name: 'average_order_value',
+                        type: MetricType.AVERAGE,
+                        label: 'Average Order Value',
+                        table: 'orders',
+                        baseDimensionName: 'order_total',
+                    },
+                    entityType: 'metric',
                 },
             },
         },


### PR DESCRIPTION

### Description:
Added a new `CreateMetric` component to render metric creation in proposed changes.

_before_
![image.png](https://app.graphite.dev/user-attachments/assets/defc2daa-e6c6-4075-9e8b-0b230b0e5c4b.png)

_after_
![image.png](https://app.graphite.dev/user-attachments/assets/dcdb2d1a-734b-406f-8380-1cd6f2133a00.png)

