### PR TITLE
feat: disable parallel tool calls for OpenAI GPT model

### DIFF
--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -25,6 +25,7 @@ export const getOpenaiGptmodel = (
         providerOptions: {
             [PROVIDER]: {
                 strictJsonSchema: true,
+                parallelToolCalls: false,
             },
         },
     };


### PR DESCRIPTION
### Description:
Disabled parallel tool calls for OpenAI GPT models by setting `parallelToolCalls: false` in the provider options. This ensures that tool calls are processed sequentially rather than in parallel, which can help with certain execution patterns or prevent race conditions.