### PR TITLE
feat: include original entity in propose change tool response

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/tools/toolProposeChange.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolProposeChange.ts
@@ -196,6 +196,12 @@ export const toolProposeChangeOutputSchema = z.object({
                 .enum(['accepted', 'rejected'])
                 .default('accepted')
                 .optional(),
+            originalEntity: z
+                .object({
+                    label: z.string().optional(),
+                    description: z.string().optional(),
+                })
+                .optional(),
         }),
         z.object({
             status: z.literal('error'),

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
@@ -1,4 +1,7 @@
-import { assertUnreachable } from '@lightdash/common';
+import {
+    assertUnreachable,
+    type ToolProposeChangeOutput,
+} from '@lightdash/common';
 import { Stack } from '@mantine-8/core';
 import { toPairs } from 'lodash';
 import { OperationRenderer } from './OperationRenderer';
@@ -20,20 +23,22 @@ import type {
 
 type UpdateChangeProps = {
     patch: UpdateTablePatch | UpdateDimensionPatch | UpdateMetricPatch;
+    metadata: ToolProposeChangeOutput['metadata'] | null;
 };
 
-const UpdateChange = ({ patch }: UpdateChangeProps) => {
+const UpdateChange: React.FC<UpdateChangeProps> = ({ patch, metadata }) => {
     const operations = toPairs(patch)
         .filter(([, op]) => op !== null)
         .map(([property, op]) => ({ property, op: op! }));
 
     return (
-        <Stack gap="xs" px="xs">
+        <Stack gap="xs">
             {operations.map(({ property, op }) => (
                 <OperationRenderer
                     key={property}
                     operation={op}
                     property={property}
+                    metadata={metadata}
                 />
             ))}
         </Stack>
@@ -47,15 +52,23 @@ const UpdateChange = ({ patch }: UpdateChangeProps) => {
 type TableChangeProps = {
     change: TableChange;
     entityTableName: string;
+    metadata: ToolProposeChangeOutput['metadata'] | null;
 };
 
-const TableChangeRender = ({ change, entityTableName }: TableChangeProps) => {
+const TableChangeRender = ({
+    change,
+    entityTableName,
+    metadata,
+}: TableChangeProps) => {
     switch (change.value.type) {
         case 'update':
             return (
                 <Stack gap="xs">
                     <TableBreadcrumb entityTableName={entityTableName} />
-                    <UpdateChange patch={change.value.patch} />
+                    <UpdateChange
+                        patch={change.value.patch}
+                        metadata={metadata}
+                    />
                 </Stack>
             );
         default:
@@ -73,11 +86,13 @@ const TableChangeRender = ({ change, entityTableName }: TableChangeProps) => {
 type DimensionChangeProps = {
     change: DimensionChange;
     entityTableName: string;
+    metadata: ToolProposeChangeOutput['metadata'] | null;
 };
 
 const DimensionChangeRender = ({
     change,
     entityTableName,
+    metadata,
 }: DimensionChangeProps) => {
     switch (change.value.type) {
         case 'update':
@@ -88,7 +103,10 @@ const DimensionChangeRender = ({
                         fieldType="dimension"
                         fieldId={change.fieldId}
                     />
-                    <UpdateChange patch={change.value.patch} />
+                    <UpdateChange
+                        patch={change.value.patch}
+                        metadata={metadata}
+                    />
                 </Stack>
             );
         default:
@@ -106,9 +124,14 @@ const DimensionChangeRender = ({
 type MetricChangeProps = {
     change: MetricChange;
     entityTableName: string;
+    metadata: ToolProposeChangeOutput['metadata'] | null;
 };
 
-const MetricChangeRender = ({ change, entityTableName }: MetricChangeProps) => {
+const MetricChangeRender = ({
+    change,
+    entityTableName,
+    metadata,
+}: MetricChangeProps) => {
     switch (change.value.type) {
         case 'update':
             return (
@@ -118,7 +141,10 @@ const MetricChangeRender = ({ change, entityTableName }: MetricChangeProps) => {
                         fieldType="metric"
                         fieldId={change.fieldId}
                     />
-                    <UpdateChange patch={change.value.patch} />
+                    <UpdateChange
+                        patch={change.value.patch}
+                        metadata={metadata}
+                    />
                 </Stack>
             );
         case 'create':
@@ -146,18 +172,21 @@ const MetricChangeRender = ({ change, entityTableName }: MetricChangeProps) => {
 type ChangeRendererProps = {
     change: EntityChange;
     entityTableName: string;
+    metadata: ToolProposeChangeOutput['metadata'] | null;
 };
 
-export const ChangeRenderer = ({
+export const ChangeRenderer: React.FC<ChangeRendererProps> = ({
     change,
     entityTableName,
-}: ChangeRendererProps) => {
+    metadata,
+}) => {
     switch (change.entityType) {
         case 'table':
             return (
                 <TableChangeRender
                     change={change}
                     entityTableName={entityTableName}
+                    metadata={metadata}
                 />
             );
         case 'dimension':
@@ -165,6 +194,7 @@ export const ChangeRenderer = ({
                 <DimensionChangeRender
                     change={change}
                     entityTableName={entityTableName}
+                    metadata={metadata}
                 />
             );
         case 'metric':
@@ -172,6 +202,7 @@ export const ChangeRenderer = ({
                 <MetricChangeRender
                     change={change}
                     entityTableName={entityTableName}
+                    metadata={metadata}
                 />
             );
         default:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/OperationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/OperationRenderer.tsx
@@ -1,30 +1,59 @@
-import { assertUnreachable, capitalize } from '@lightdash/common';
-import { Paper, Stack, Text } from '@mantine-8/core';
+import {
+    assertUnreachable,
+    capitalize,
+    type ToolProposeChangeOutput,
+} from '@lightdash/common';
+import { Box, Divider, Paper, Stack, Text } from '@mantine-8/core';
 import MDEditor from '@uiw/react-md-editor';
 import rehypeExternalLinks from 'rehype-external-links';
 import {
     mdEditorComponents,
     rehypeRemoveHeaderLinks,
-    useMdEditorStyle,
 } from '../../../../../../../utils/markdownUtils';
 import type { Operation } from './types';
 
 type ReplaceOperationProps = {
     value: string;
     name: string;
+    metadata: ToolProposeChangeOutput['metadata'] | null;
 };
 
-const ReplaceOrAddOperation = ({ value, name }: ReplaceOperationProps) => {
-    const mdStyle = useMdEditorStyle();
+const ReplaceOrAddOperation: React.FC<ReplaceOperationProps> = ({
+    value,
+    name,
+    metadata,
+}) => {
+    console.log(metadata && 'originalEntity' in metadata);
 
     return (
         <Paper bg="gray.0" p="xs" component={Stack} gap="xxs">
             <Text component="code" size="xs" fw={600} c="gray.7">
                 {capitalize(name)}
             </Text>
-            <MDEditor.Markdown
+
+            {metadata && 'originalEntity' in metadata ? (
+                <Box
+                    component={MDEditor.Markdown}
+                    source={metadata.originalEntity?.description ?? 'testing'}
+                    fs="md"
+                    bg="red.1"
+                    p="0"
+                    rehypeRewrite={rehypeRemoveHeaderLinks}
+                    rehypePlugins={[
+                        [rehypeExternalLinks, { target: '_blank' }],
+                    ]}
+                    components={mdEditorComponents}
+                />
+            ) : null}
+
+            <Divider />
+
+            <Box
+                component={MDEditor.Markdown}
                 source={value}
-                style={mdStyle}
+                fs="md"
+                bg="green.1"
+                p="0"
                 rehypeRewrite={rehypeRemoveHeaderLinks}
                 rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
                 components={mdEditorComponents}
@@ -36,11 +65,13 @@ const ReplaceOrAddOperation = ({ value, name }: ReplaceOperationProps) => {
 type OperationRendererProps = {
     operation: Operation;
     property: string;
+    metadata: ToolProposeChangeOutput['metadata'] | null;
 };
 
 export const OperationRenderer = ({
     operation,
     property,
+    metadata,
 }: OperationRendererProps) => {
     switch (operation.op) {
         case 'replace':
@@ -49,6 +80,7 @@ export const OperationRenderer = ({
                 <ReplaceOrAddOperation
                     value={operation.value}
                     name={property}
+                    metadata={metadata}
                 />
             );
         default:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
@@ -30,7 +30,7 @@ const CHANGE_COLORS = {
     create: 'green',
 } as const satisfies Record<'update' | 'create', DefaultMantineColor>;
 
-export const AiProposeChangeToolCall = ({
+export const AiProposeChangeToolCall: React.FC<Props> = ({
     change,
     entityTableName,
     defaultOpened = true,
@@ -39,7 +39,7 @@ export const AiProposeChangeToolCall = ({
     threadUuid,
     promptUuid,
     toolResult,
-}: Props) => {
+}) => {
     const changeType = change.value.type;
     const changeColor: DefaultMantineColor =
         CHANGE_COLORS[changeType] ?? 'gray';
@@ -106,6 +106,7 @@ export const AiProposeChangeToolCall = ({
                 <ChangeRenderer
                     change={change}
                     entityTableName={entityTableName}
+                    metadata={metadata}
                 />
 
                 <Group w="100%" justify="flex-end" pr="xs">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1234

### Description:
Added support for displaying original entity values in AI-proposed changes. When the AI suggests updates to tables, dimensions, or metrics, the UI now shows both the original and proposed values side by side, making it easier for users to compare changes before accepting them.

The backend now captures and returns the original entity data (label and description) when proposing changes, and the frontend renders this information alongside the proposed updates in the AI copilot interface.