### PR TITLE
fix: fall back when rendering templated dbt fails

### DIFF
--- a/packages/cli/src/dbt/context.ts
+++ b/packages/cli/src/dbt/context.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
 import GlobalState from '../globalState';
-import { renderProfilesYml } from './templating';
+import { renderTemplatedYml } from './templating';
 
 type GetDbtContextArgs = {
     projectDir: string;
@@ -41,8 +41,22 @@ export const getDbtContext = async ({
             `Is ${initialProjectDir} a valid dbt project directory? Couldn't find a valid dbt_project.yml on ${initialProjectDir} or any of its parents:\n  ${msg}`,
         );
     }
-    // Render Jinja templating (e.g., env_var) before parsing YAML
-    const renderedFile = renderProfilesYml(file);
+    // Try to render Jinja templating (e.g., env_var) before parsing YAML
+    // If rendering fails, fall back to parsing the raw file for back compat
+    let renderedFile: string;
+    try {
+        renderedFile = renderTemplatedYml(file);
+    } catch (e) {
+        GlobalState.debug(
+            `> Warning: Failed to render Jinja in dbt_project.yml: ${getErrorMessage(
+                e,
+            )}`,
+        );
+        GlobalState.debug(
+            '> Falling back to parsing raw YAML without Jinja rendering',
+        );
+        renderedFile = file;
+    }
     const config = yaml.load(renderedFile) as Record<string, string>;
 
     const targetSubDir = config['target-path'] || './target';

--- a/packages/cli/src/dbt/templating.ts
+++ b/packages/cli/src/dbt/templating.ts
@@ -19,15 +19,34 @@ const nunjucksContext = {
         JSON.parse(process.argv[process.argv.indexOf('--vars') + 1])[key],
 };
 
-export const renderProfilesYml = (
+/**
+ * Render a dbt YAML file with Jinja templating (env_var, var, filters)
+ * @param raw - Raw YAML content as string
+ * @param context - Additional context variables to pass to the template
+ * @returns Rendered YAML string with Jinja expressions resolved
+ */
+export const renderTemplatedYml = (
     raw: string,
     context?: Record<string, unknown>,
-) => {
+): string => {
     const template = nunjucks.compile(raw, nunjucksEnv);
-    const rendered = template.render({
+    return template.render({
         ...nunjucksContext,
         ...(context || {}),
     });
+};
+
+/**
+ * Render a profiles.yml file with Jinja templating and private key handling
+ * @param raw - Raw profiles.yml content as string
+ * @param context - Additional context variables to pass to the template
+ * @returns Rendered profiles.yml string with Jinja expressions resolved and private keys escaped
+ */
+export const renderProfilesYml = (
+    raw: string,
+    context?: Record<string, unknown>,
+): string => {
+    const rendered = renderTemplatedYml(raw, context);
     // Fix multiline privatekey strings
     // Prevents error: Error: error:1E08010C:DECODER routines::unsupported
     const privateKeyRegex =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17225, #17232

### Description:

We recently started running template replacement on `dbt_project.yml`, but some users have reported issues deploying with stack traces that look like

```
Template render error: (unknown path) [Line 1, Column 36]
  expected name as lookup value, got }}
    at Object._prettifyError (/usr/app/node_modules/.pnpm/nunjucks@3.2.3_chokidar@3.6.0/node_modules/nunjucks/src/lib.js:36:11)
    at Template.render (/usr/app/node_modules/.pnpm/nunjucks@3.2.3_chokidar@3.6.0/node_modules/nunjucks/src/environment.js:538:21)
    at renderProfilesYml (/usr/app/packages/cli/dist/dbt/templating.js:25:31)
    at getDbtContext (/usr/app/packages/cli/dist/dbt/context.js:30:61)
    at async createProject (/usr/app/packages/cli/dist/handlers/createProject.js:63:21)
    at async Command.previewHandler (/usr/app/packages/cli/dist/handlers/preview.js:105:25)
    at async Command.parseAsync (/usr/app/node_modules/.pnpm/commander@9.5.0/node_modules/commander/lib/command.js:935:5)
Template render error: (unknown path) [Line 1, Column 36]
  expected name as lookup value, got }}
    at Object._prettifyError (/usr/app/node_modules/.pnpm/nunjucks@3.2.3_chokidar@3.6.0/node_modules/nunjucks/src/lib.js:36:11)
    at Template.render (/usr/app/node_modules/.pnpm/nunjucks@3.2.3_chokidar@3.6.0/node_modules/nunjucks/src/environment.js:538:21)
    at renderProfilesYml (/usr/app/packages/cli/dist/dbt/templating.js:25:31)
    at getDbtContext (/usr/app/packages/cli/dist/dbt/context.js:30:61)
    at async createProject (/usr/app/packages/cli/dist/handlers/createProject.js:63:21)
    at async Command.previewHandler (/usr/app/packages/cli/dist/handlers/preview.js:105:25)
    at async Command.parseAsync (/usr/app/node_modules/.pnpm/commander@9.5.0/node_modules/commander/lib/command.js:935:5)
 ```
 
These are likely caused by Jinja templates that either aren't valid (which we weren't trying to parse before) or have jinja features not supported by nunchucks. Heavy DBT users might have complex jinja macros in there. 

This fix does two things:
- Adds a try when trying to parse the template, with a catch the falls back to the raw file (like we had before)
- Move a profile-specific parse to its own function

To test it: 
- add templates to dbt_project
- preview and/or deploy

