### PR TITLE
fix: improve auto-refresh UI

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -105,6 +105,7 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
                 <Tooltip
                     withinPortal
                     position="bottom"
+                    disabled={isOpen}
                     label={
                         <Text>
                             Last refreshed at:{' '}
@@ -172,7 +173,7 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
                         </Button>
                     </Menu.Target>
                     <Menu.Dropdown>
-                        <Menu.Label>Auto-refresh</Menu.Label>
+                        <Menu.Label>Auto-refresh while viewing</Menu.Label>
                         <Menu.Item
                             fz="xs"
                             onClick={() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17229

### Description:

Auto-refresh was confusing with cache enabled. It just said `Auto-refresh` next to the cache-refresh time. This changes the text to make it clear that it's only while viewing the dashboard. 

Also fixes the tooltip opening behind the menu
<img width="290" height="284" alt="Screenshot 2025-10-03 at 14 30 28" src="https://github.com/user-attachments/assets/7edeec9c-3c87-4b78-95fd-56361cc004da" />

