### PR TITLE
feat: add percent rank table calculation template

### DIFF
--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -84,6 +84,10 @@ const compileTableCalculationFromTemplate = (
             return `SUM(${quotedFieldId}) OVER (ORDER BY ${quotedFieldId} DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`;
         }
 
+        case TableCalculationTemplateType.PERCENT_RANK: {
+            return `PERCENT_RANK() OVER (${orderByClause})`;
+        }
+
         default:
             return assertUnreachable(
                 templateType,

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentRank.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentRank.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { getFieldIdSchema } from '../fieldId';
+import {
+    baseTableCalcSchema,
+    orderBySchema,
+    orderBySchemaDescription,
+} from './tableCalcBaseSchemas';
+
+export const tableCalcPercentRankSchema = baseTableCalcSchema.extend({
+    type: z.literal('percent_rank'),
+    fieldId: getFieldIdSchema({
+        additionalDescription: 'Field to calculate percent rank for',
+    }),
+    orderBy: z.array(orderBySchema).min(1).describe(orderBySchemaDescription),
+});
+
+export type TableCalcPercentRankSchema = z.infer<
+    typeof tableCalcPercentRankSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.ts
@@ -10,6 +10,7 @@ import assertUnreachable from '../../../../utils/assertUnreachable';
 import { tableCalcPercentChangeFromPreviousSchema } from './tableCalcPercentChangeFromPrevious';
 import { tableCalcPercentOfColumnTotalSchema } from './tableCalcPercentOfColumnTotal';
 import { tableCalcPercentOfPreviousValueSchema } from './tableCalcPercentOfPreviousValue';
+import { tableCalcPercentRankSchema } from './tableCalcPercentRank';
 import { tableCalcRankInColumnSchema } from './tableCalcRankInColumn';
 import { tableCalcRunningTotalSchema } from './tableCalcRunningTotal';
 
@@ -19,6 +20,7 @@ const tableCalcSchema = z.discriminatedUnion('type', [
     tableCalcPercentOfColumnTotalSchema,
     tableCalcRankInColumnSchema,
     tableCalcRunningTotalSchema,
+    tableCalcPercentRankSchema,
 ]);
 
 export type TableCalcSchema = z.infer<typeof tableCalcSchema>;
@@ -47,6 +49,10 @@ Create table calculations when:
 - User requests running total
   Examples: "Show cumulative revenue over time", "Running sum of orders by month"
   Recommended visualization type: Line chart for the table calculation as Y axis and time as X axis
+
+- User requests percent rank (relative position as a percentage)
+  Examples: "Show percentile ranking of sales", "What percentile is each product in revenue distribution"
+  Recommended visualization type: Table, Bar chart
 `);
 
 export type TableCalcsSchema = z.infer<typeof tableCalcsSchema>;
@@ -123,6 +129,19 @@ function convertTableCalcSchemaToTableCalc(
                 },
                 format: {
                     type: CustomFormatType.NUMBER,
+                    separator: NumberSeparator.DEFAULT,
+                },
+            };
+        case 'percent_rank':
+            return {
+                ...baseCalc,
+                template: {
+                    type: TableCalculationTemplateType.PERCENT_RANK,
+                    fieldId,
+                    orderBy: tableCalc.orderBy,
+                },
+                format: {
+                    type: CustomFormatType.PERCENT,
                     separator: NumberSeparator.DEFAULT,
                 },
             };

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -319,6 +319,7 @@ export enum TableCalculationTemplateType {
     PERCENT_OF_COLUMN_TOTAL = 'percent_of_column_total',
     RANK_IN_COLUMN = 'rank_in_column',
     RUNNING_TOTAL = 'running_total',
+    PERCENT_RANK = 'percent_rank',
 }
 
 export type TableCalculationTemplate =
@@ -349,6 +350,14 @@ export type TableCalculationTemplate =
     | {
           type: TableCalculationTemplateType.RUNNING_TOTAL;
           fieldId: string;
+      }
+    | {
+          type: TableCalculationTemplateType.PERCENT_RANK;
+          fieldId: string;
+          orderBy: {
+              fieldId: string;
+              order: 'asc' | 'desc' | null;
+          }[];
       };
 
 export type TableCalculation = {

--- a/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
@@ -40,6 +40,11 @@ const getFormatForQuickCalculation = (
                 type: CustomFormatType.NUMBER,
                 round: 2,
             };
+        case TableCalculationTemplateType.PERCENT_RANK:
+            return {
+                type: CustomFormatType.PERCENT,
+                round: 2,
+            };
         default:
             assertUnreachable(
                 templateType,
@@ -70,6 +75,7 @@ const isCalculationAvailable = (
         case TableCalculationTemplateType.RUNNING_TOTAL:
             return numericTypes.includes(item.type);
         case TableCalculationTemplateType.RANK_IN_COLUMN:
+        case TableCalculationTemplateType.PERCENT_RANK:
             return true; // any type
 
         default:

--- a/packages/frontend/src/components/Explorer/ResultsCard/tableCalculationTemplateGenerator.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/tableCalculationTemplateGenerator.ts
@@ -66,6 +66,13 @@ export function generateTableCalculationTemplate(
                 fieldId,
             };
 
+        case TableCalculationTemplateType.PERCENT_RANK:
+            return {
+                type: TableCalculationTemplateType.PERCENT_RANK,
+                fieldId,
+                orderBy: mapSortsToOrderBy(currentSorts),
+            };
+
         default:
             return assertUnreachable(type, `Unknown template type`);
     }

--- a/packages/frontend/src/features/tableCalculation/utils/templateFormatting.ts
+++ b/packages/frontend/src/features/tableCalculation/utils/templateFormatting.ts
@@ -13,6 +13,7 @@ export const TemplateTypeLabels: Record<TableCalculationTemplateType, string> =
             'Percent of column total',
         [TableCalculationTemplateType.RANK_IN_COLUMN]: 'Rank in column',
         [TableCalculationTemplateType.RUNNING_TOTAL]: 'Running total',
+        [TableCalculationTemplateType.PERCENT_RANK]: 'Percent rank',
     };
 
 export const formatTemplateType = (
@@ -35,6 +36,8 @@ export const getTemplateDescription = (
             return 'Ranks values within the column from highest to lowest.';
         case TableCalculationTemplateType.RUNNING_TOTAL:
             return 'Calculates a cumulative sum across rows.';
+        case TableCalculationTemplateType.PERCENT_RANK:
+            return 'Calculates the percentile rank of values (0-1 scale).';
         default:
             return assertUnreachable(type, `Unknown template type`);
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added a new "Percent Rank" table calculation that calculates the percentile rank of values on a 0-1 scale. This calculation can be used when users want to see the relative position of each value as a percentage within a distribution.

The implementation includes:
- New table calculation template type `PERCENT_RANK`
- SQL compilation support using `PERCENT_RANK() OVER` window function
- Schema definition for AI agent integration
- Appropriate formatting as percentage values
- Documentation and UI labels

