### PR TITLE
feat: add ability to revert changes in project changesets

### DIFF
--- a/packages/frontend/src/features/changesets/hooks/index.ts
+++ b/packages/frontend/src/features/changesets/hooks/index.ts
@@ -1,1 +1,3 @@
 export { useActiveChangesets } from './useActiveChangesets';
+export { useRevertAllChanges } from './useRevertAllChanges';
+export { useRevertChange } from './useRevertChange';

--- a/packages/frontend/src/features/changesets/hooks/useActiveChangesets.ts
+++ b/packages/frontend/src/features/changesets/hooks/useActiveChangesets.ts
@@ -15,4 +15,7 @@ export const useActiveChangesets = (projectUuid: string) =>
         queryKey: ['activeChangesets', projectUuid],
         queryFn: () => getActiveChangesets(projectUuid),
         enabled: !!projectUuid,
+        staleTime: 5 * 60 * 1000,
+        refetchOnWindowFocus: true,
+        refetchOnMount: true,
     });

--- a/packages/frontend/src/features/changesets/hooks/useRevertAllChanges.ts
+++ b/packages/frontend/src/features/changesets/hooks/useRevertAllChanges.ts
@@ -1,0 +1,24 @@
+import { type ApiError, type ApiRevertChangeResponse } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const revertAllChanges = async (projectUuid: string) =>
+    lightdashApi<ApiRevertChangeResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/changesets/revert-all`,
+        method: 'POST',
+        body: undefined,
+    });
+
+export const useRevertAllChanges = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+
+    return useMutation<ApiRevertChangeResponse['results'], ApiError>({
+        mutationFn: () => revertAllChanges(projectUuid),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: ['activeChangesets', projectUuid],
+            });
+        },
+    });
+};

--- a/packages/frontend/src/features/changesets/hooks/useRevertChange.ts
+++ b/packages/frontend/src/features/changesets/hooks/useRevertChange.ts
@@ -1,0 +1,28 @@
+import { type ApiError, type ApiRevertChangeResponse } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const revertChange = async (projectUuid: string, changeUuid: string) =>
+    lightdashApi<ApiRevertChangeResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/changesets/changes/${changeUuid}/revert`,
+        method: 'POST',
+        body: undefined,
+    });
+
+export const useRevertChange = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+
+    return useMutation<
+        ApiRevertChangeResponse['results'],
+        ApiError,
+        { changeUuid: string }
+    >({
+        mutationFn: ({ changeUuid }) => revertChange(projectUuid, changeUuid),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: ['activeChangesets', projectUuid],
+            });
+        },
+    });
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
Added the ability to revert changes in the Project Changesets UI. Users can now:

- Revert individual changes by clicking the new "Revert" button in the last row
- Revert all changes at once using the new "Revert All" button
- Confirmation modals prevent accidental reverts
- Success/error toasts provide feedback on revert operations

This implementation includes two new hooks:
- `useRevertChange` for reverting a single change
- `useRevertAllChanges` for reverting all changes at once