### PR TITLE
feat: add description field to custom metric schema

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -12,6 +12,11 @@ export const customMetricBaseSchema = z.object({
         .describe(
             'Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")',
         ),
+    description: z
+        .string()
+        .describe(
+            'Brief explanation of what the metric represents, how it is calculated, and why it matters. Example: "Calculates the total revenue by summing all transaction amounts in the sales table."',
+        ),
     baseDimensionName: z
         .string()
         .describe(


### PR DESCRIPTION
### Description:
Added a new `description` field to the custom metric base schema. This field allows users to provide a brief explanation of what the metric represents, how it's calculated, and why it matters. The description includes an example to guide users: "Calculates the total revenue by summing all transaction amounts in the sales table."