### PR TITLE
feat: display slack message when AI Agent is not found for channel

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -3140,6 +3140,10 @@ export class AiAgentService {
 
             if (e instanceof AiAgentNotFoundError) {
                 Logger.debug('Failed to find ai agent:', e);
+                await say({
+                    text: `🤔 It seems like there is no AI agent configured for this channel. Please check if the integration is set up correctly or visit ${this.lightdashConfig.siteUrl}/ai-agents to configure one.`,
+                    thread_ts: event.ts,
+                });
                 return;
             }
 


### PR DESCRIPTION

### Description:
Reply with message when an AI agent is not found for a Slack channel instead of no response 

![image.png](https://app.graphite.dev/user-attachments/assets/302f3139-5f59-436f-8298-ac946981597c.png)

