### PR TITLE
feat: set fixed height for AI dashboard visualization cards

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
@@ -91,7 +91,13 @@ export const AiDashboardVisualization: FC<Props> = memo(
                     <Stack gap="md" style={{ minHeight: 'min-content' }}>
                         {dashboardConfig.visualizations.map(
                             (visualization, index) => (
-                                <Card key={index} withBorder p="md" radius="md">
+                                <Card
+                                    key={index}
+                                    withBorder
+                                    p="md"
+                                    radius="md"
+                                    h={400}
+                                >
                                     <ErrorBoundary>
                                         <AiDashboardVisualizationItem
                                             visualization={visualization}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17247

### Description:
Set a fixed height of 400px for AI dashboard visualization cards to ensure consistent sizing and improve the overall layout appearance.