### PR TITLE
fix: merge warehouse credentials when creating preview projects

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -252,6 +252,34 @@ export const maybeOverrideWarehouseConnection = <
     };
 };
 
+/**
+ * Merges new warehouse credentials with base credentials, preserving advanced settings
+ * like requireUserCredentials from the base credentials.
+ *
+ * This is useful when creating preview projects where we want to use new connection details
+ * (like from dbt profiles) but preserve advanced configuration from the parent project.
+ */
+export const mergeWarehouseCredentials = <T extends CreateWarehouseCredentials>(
+    baseCredentials: T,
+    newCredentials: T,
+): T => {
+    // If types don't match, return newCredentials as-is (can't merge different warehouse types)
+    if (baseCredentials.type !== newCredentials.type) {
+        return newCredentials;
+    }
+
+    // Merge credentials, with newCredentials taking precedence for connection details
+    // but baseCredentials providing advanced settings like requireUserCredentials
+    const merged = {
+        ...baseCredentials,
+        ...newCredentials,
+        // Keep requireUserCredentials from base credentials, since this is a security setting and should not be overridden
+        requireUserCredentials: baseCredentials.requireUserCredentials,
+    };
+
+    return merged as T;
+};
+
 export interface DbtProjectConfigBase {
     type: DbtProjectType;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-59/previews-to-have-the-require-user-credentials-as-the-main-project

This should be compatible with the upcoming organization configuration settings feature  https://github.com/lightdash/lightdash/pull/17223


Before

<img width="935" height="759" alt="image" src="https://github.com/user-attachments/assets/514bd782-7a88-4bc6-825e-e7d3fdc31257" />

After

<img width="935" height="759" alt="Screenshot from 2025-10-06 16-32-31" src="https://github.com/user-attachments/assets/165dee09-39db-4c17-919d-57411d41b648" />


### Description:
Added functionality to merge warehouse credentials when creating preview projects from CLI. This preserves advanced settings like `requireUserCredentials` from the upstream project while using the connection details provided by the CLI. 

The implementation adds a new `mergeWarehouseCredentials` utility function in the common package and updates the project creation logic to use this function when creating preview projects with custom warehouse credentials.