### PR TITLE
feat: implement catalog revert functionality for changeset changes

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -101,6 +101,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     userModel: models.getUserModel(),
                     aiAgentModel: models.getAiAgentModel(),
                     changesetModel: models.getChangesetModel(),
+                    catalogModel: models.getCatalogModel(),
                     groupsModel: models.getGroupsModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     slackClient: clients.getSlackClient(),

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -928,6 +928,7 @@ export class ProjectModel {
         projectUuid: string,
         key: 'name' | 'uuid',
         exploreNamesWithDuplicates?: string[],
+        { applyChangeset = true }: { applyChangeset?: boolean } = {},
     ): Promise<{ [exploreNameOrUuid: string]: Explore | ExploreError }> {
         // dedupe values
         const exploreNames = exploreNamesWithDuplicates
@@ -949,7 +950,7 @@ export class ProjectModel {
                 const cachedExplores = this.exploreCache?.getExplores(
                     projectUuid,
                     exploreNames,
-                    changeset?.updatedAt,
+                    applyChangeset ? changeset?.updatedAt : undefined,
                 );
                 // NOTE: Explores are cached with the name key, so we don't need to return the cached explores if the key is uuid
                 if (cachedExplores && key === 'name') {
@@ -979,20 +980,20 @@ export class ProjectModel {
                     return acc;
                 }, {});
 
-                if (changeset) {
+                if (changeset && applyChangeset) {
                     finalExplores = await ChangesetUtils.applyChangeset(
                         changeset,
                         finalExplores,
                     );
                 }
 
-                // Store in cache
                 this.exploreCache?.setExplores(
                     projectUuid,
                     exploreNames,
-                    changeset?.updatedAt,
+                    applyChangeset ? changeset?.updatedAt : undefined,
                     finalExplores,
                 );
+
                 return finalExplores;
             },
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Implemented proper reversion of catalog changes when reverting changesets. This PR adds a new `indexCatalogReverts` method to the `CatalogModel` that reconstructs the state of fields before a change was applied, allowing for accurate restoration when changes are reverted.

Key improvements:

- Added chronological ordering to changes to ensure they're applied in the correct sequence
- Created a state map to track the catalog state before each change
- Implemented logic to handle different revert scenarios (create, update, delete)
- Added option to skip changeset application when retrieving explores to avoid cache pollution
- Modified the `applyChangeset` utility to support non-mutating document updates
