### PR TITLE
fix: results table always loading when pivoting enabled

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -88,54 +88,10 @@ export const ExplorerResults = memo(() => {
     const resultsData = useMemo(() => {
         const isSqlPivotEnabled = !!useSqlPivotResults?.enabled;
         const hasUnpivotedQuery = !!unpivotedQuery?.data?.queryUuid;
-        const hasMainQuery = !!query.data?.queryUuid;
 
         // Only use unpivoted data when SQL pivot is enabled
         const shouldUseUnpivotedData =
             isSqlPivotEnabled && hasPivotConfig && hasUnpivotedQuery;
-
-        // Check if the main query is currently loading
-        const isMainQueryLoading =
-            query.isFetching ||
-            queryResults.isFetchingFirstPage ||
-            query.status === 'loading';
-
-        // Only check unpivoted query states if SQL pivot is enabled
-        if (isSqlPivotEnabled) {
-            // Check if we need to show loading for unpivoted data
-            const isUnpivotedQueryLoading =
-                unpivotedQuery.isFetching ||
-                unpivotedQueryResults.isFetchingFirstPage ||
-                unpivotedQuery.status === 'loading';
-
-            // Only consider needing unpivoted query if we actually expect it to run
-            const needsUnpivotedQuery =
-                hasPivotConfig &&
-                hasMainQuery &&
-                !hasUnpivotedQuery &&
-                !unpivotedQuery.isFetching &&
-                !unpivotedQuery.data &&
-                !isMainQueryLoading; // Don't show loading if main query is still running
-
-            const shouldShowLoadingForUnpivoted =
-                hasPivotConfig &&
-                hasMainQuery &&
-                !hasUnpivotedQuery &&
-                !isMainQueryLoading && // Don't show loading if main query is still running
-                (isUnpivotedQueryLoading || needsUnpivotedQuery);
-
-            if (shouldShowLoadingForUnpivoted) {
-                // Show loading state for pivoted charts waiting for unpivoted data
-                return {
-                    rows: undefined,
-                    totalResults: undefined,
-                    isFetchingRows: false,
-                    fetchMoreRows: () => {},
-                    status: 'loading' as const,
-                    apiError: null,
-                };
-            }
-        }
 
         if (shouldUseUnpivotedData) {
             return {

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -1,4 +1,3 @@
-// import { type FieldId } from '@lightdash/common';
 import { createSelector } from '@reduxjs/toolkit';
 import type { ExplorerStoreState } from '.';
 import { ExplorerSection } from '../../../providers/Explorer/types';
@@ -6,7 +5,7 @@ import { ExplorerSection } from '../../../providers/Explorer/types';
 // Base selectors
 const selectExplorerState = (state: ExplorerStoreState) => state.explorer;
 
-const selectUnsavedChartVersion = createSelector(
+export const selectUnsavedChartVersion = createSelector(
     [selectExplorerState],
     (explorer) => explorer.unsavedChartVersion,
 );

--- a/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
+++ b/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
@@ -1,5 +1,4 @@
 import {
-    ChartType,
     derivePivotConfigurationFromChart,
     getFieldsFromMetricQuery,
     type DateGranularity,
@@ -7,6 +6,7 @@ import {
     type FieldId,
     type MetricQuery,
     type ParametersValuesMap,
+    type SavedChartDAO,
 } from '@lightdash/common';
 import type { QueryResultsProps } from '../useQueryResults';
 
@@ -30,6 +30,7 @@ export function buildQueryArgs(options: {
         | { chartUuid: string; chartVersionUuid: string };
     dateZoomGranularity?: DateGranularity;
     minimal: boolean;
+    savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
 }): QueryResultsProps | null {
     const {
         activeFields,
@@ -56,15 +57,11 @@ export function buildQueryArgs(options: {
     if (useSqlPivotResults) {
         const items = getFieldsFromMetricQuery(computedMetricQuery, explore);
         pivotConfiguration = derivePivotConfigurationFromChart(
-            {
-                chartConfig: { type: ChartType.TABLE },
-                pivotConfig: undefined,
-            },
+            options.savedChart,
             computedMetricQuery,
             items,
         );
     }
-
     return {
         projectUuid,
         tableId: tableName,

--- a/packages/frontend/src/hooks/useExplorerQuery.ts
+++ b/packages/frontend/src/hooks/useExplorerQuery.ts
@@ -14,6 +14,7 @@ import {
     selectTableName,
     selectUnpivotedQueryArgs,
     selectUnpivotedQueryUuidHistory,
+    selectUnsavedChartVersion,
     selectValidQueryArgs,
     useExplorerDispatch,
     useExplorerSelector,
@@ -58,6 +59,7 @@ export const useExplorerQuery = (options?: {
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const validQueryArgs = useExplorerSelector(selectValidQueryArgs);
     const queryUuidHistory = useExplorerSelector(selectQueryUuidHistory);
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     const unpivotedQueryUuidHistory = useExplorerSelector(
         selectUnpivotedQueryUuidHistory,
     );
@@ -179,12 +181,14 @@ export const useExplorerQuery = (options?: {
             viewModeQueryArgs,
             dateZoomGranularity,
             minimal,
+            savedChart: unsavedChartVersion,
         });
 
         if (mainQueryArgs) {
             dispatch(explorerActions.setValidQueryArgs(mainQueryArgs));
         }
     }, [
+        unsavedChartVersion,
         activeFields,
         tableName,
         projectUuid,

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -1,5 +1,4 @@
 import {
-    ChartType,
     deepEqual,
     derivePivotConfigurationFromChart,
     FeatureFlags,
@@ -27,6 +26,7 @@ import {
     selectTableName,
     selectUnpivotedQueryArgs,
     selectUnpivotedQueryUuidHistory,
+    selectUnsavedChartVersion,
     selectValidQueryArgs,
     useExplorerDispatch,
     useExplorerSelector,
@@ -79,6 +79,7 @@ export const useExplorerQueryManager = (options?: {
     const unpivotedQueryUuidHistory = useExplorerSelector(
         selectUnpivotedQueryUuidHistory,
     );
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
     // Auto-fetch configuration
     const [autoFetchEnabled] = useLocalStorage({
@@ -135,16 +136,18 @@ export const useExplorerQueryManager = (options?: {
 
         const items = getFieldsFromMetricQuery(metricQuery, explore);
         const pivotConfiguration = derivePivotConfigurationFromChart(
-            {
-                chartConfig: { type: ChartType.TABLE }, // Default for detection
-                pivotConfig: undefined,
-            },
+            unsavedChartVersion,
             metricQuery,
             items,
         );
 
         return !!pivotConfiguration;
-    }, [useSqlPivotResults?.enabled, explore, metricQuery]);
+    }, [
+        useSqlPivotResults?.enabled,
+        explore,
+        metricQuery,
+        unsavedChartVersion,
+    ]);
 
     // Dispatch functions for query UUID history
     const setQueryUuidHistory = useCallback(
@@ -197,6 +200,7 @@ export const useExplorerQueryManager = (options?: {
             viewModeQueryArgs,
             dateZoomGranularity,
             minimal,
+            savedChart: unsavedChartVersion,
         });
 
         if (mainQueryArgs) {
@@ -221,6 +225,7 @@ export const useExplorerQueryManager = (options?: {
         viewModeQueryArgs,
         dateZoomGranularity,
         minimal,
+        unsavedChartVersion,
         dispatch,
     ]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#17264](https://github.com/lightdash/lightdash/issues/17264)

### Description:
Refactored the SQL pivot results handling in the Explorer component to improve performance and fix loading states. This PR:

- Simplified the loading state logic in `ExplorerResults.tsx` by removing redundant checks
- Properly passes the saved chart configuration to the pivot configuration derivation function
- Exported the `selectUnsavedChartVersion` selector for reuse across components
- Updated `buildQueryArgs` to use the actual chart configuration instead of hardcoded defaults
- Ensured the pivot configuration is properly derived based on the current chart settings

This change ensures that SQL pivot results are correctly generated based on the actual chart configuration rather than using default values, which improves the accuracy of pivoted data visualization.

**Note:** Test pivoted/normal tables and cartesian charts with/without group by