### PR TITLE
fix: include non grouped dimensions in index

### DIFF
--- a/packages/common/src/pivot/derivePivotConfigFromChart.mock.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.mock.ts
@@ -9,6 +9,19 @@ import { ChartType, type CartesianChartConfig } from '../types/savedCharts';
 
 // Items (fields) map derived from issue description
 export const mockItems: ItemsMap = {
+    customers_customer_id: {
+        sql: '${TABLE}.customer_id',
+        name: 'customer_id',
+        type: DimensionType.STRING,
+        index: 1,
+        label: 'Customer ID',
+        table: 'customers',
+        groups: [],
+        hidden: false,
+        fieldType: FieldType.DIMENSION,
+        tableLabel: 'Customers',
+        description: 'Unique identifier for each customer',
+    },
     payments_payment_method: {
         sql: '${TABLE}.payment_method',
         name: 'payment_method',
@@ -60,6 +73,27 @@ export const mockItems: ItemsMap = {
 export const mockMetricQuery: MetricQuery = {
     exploreName: 'payments',
     dimensions: ['payments_payment_method', 'orders_status'],
+    metrics: ['payments_total_revenue'],
+    filters: {},
+    sorts: [
+        {
+            fieldId: 'payments_payment_method',
+            descending: false,
+        },
+    ],
+    limit: 500,
+    tableCalculations: [],
+    additionalMetrics: [],
+    metricOverrides: {},
+};
+
+export const mockMetricQueryWithMultipleIndexColumns: MetricQuery = {
+    exploreName: 'payments',
+    dimensions: [
+        'payments_payment_method',
+        'orders_status',
+        'customers_customer_id',
+    ],
     metrics: ['payments_total_revenue'],
     filters: {},
     sorts: [

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -13,6 +13,7 @@ import {
     mockCartesianChartConfig,
     mockItems,
     mockMetricQuery,
+    mockMetricQueryWithMultipleIndexColumns,
 } from './derivePivotConfigFromChart.mock';
 
 // Jest provides describe/it/expect globals
@@ -43,10 +44,54 @@ describe('derivePivotConfigurationFromChart', () => {
         );
 
         expect(result).toEqual({
-            indexColumn: {
-                reference: 'payments_payment_method',
-                type: VizIndexType.CATEGORY,
+            indexColumn: [
+                {
+                    reference: 'payments_payment_method',
+                    type: VizIndexType.CATEGORY,
+                },
+            ],
+            valuesColumns: [
+                {
+                    reference: 'payments_total_revenue',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ],
+            groupByColumns: [{ reference: 'orders_status' }],
+            sortBy: [
+                {
+                    reference: 'payments_payment_method',
+                    direction: SortByDirection.ASC,
+                },
+            ],
+        });
+    });
+
+    it('derives pivot configuration for Cartesian charts with pivot config and multiple index columns', () => {
+        const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
+            chartConfig: mockCartesianChartConfig,
+            pivotConfig: {
+                columns: ['orders_status'],
             },
+        };
+
+        const result = derivePivotConfigurationFromChart(
+            savedChart,
+            mockMetricQueryWithMultipleIndexColumns,
+            mockItems,
+        );
+
+        expect(result).toEqual({
+            indexColumn: [
+                {
+                    reference: 'payments_payment_method',
+                    type: VizIndexType.CATEGORY,
+                },
+                // added by derivePivotConfigurationFromChart since this is not being pivoted on
+                {
+                    reference: 'customers_customer_id',
+                    type: VizIndexType.CATEGORY,
+                },
+            ],
             valuesColumns: [
                 {
                     reference: 'payments_total_revenue',
@@ -220,10 +265,12 @@ describe('derivePivotConfigurationFromChart', () => {
         const result = derivePivotConfigurationFromChart(savedChart, mq, items);
 
         expect(result).toEqual({
-            indexColumn: {
-                reference: 'amount_range',
-                type: VizIndexType.CATEGORY,
-            },
+            indexColumn: [
+                {
+                    reference: 'amount_range',
+                    type: VizIndexType.CATEGORY,
+                },
+            ],
             valuesColumns: [
                 {
                     reference: 'payments_total_revenue',

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -88,54 +88,10 @@ export const ExplorerResults = memo(() => {
     const resultsData = useMemo(() => {
         const isSqlPivotEnabled = !!useSqlPivotResults?.enabled;
         const hasUnpivotedQuery = !!unpivotedQuery?.data?.queryUuid;
-        const hasMainQuery = !!query.data?.queryUuid;
 
         // Only use unpivoted data when SQL pivot is enabled
         const shouldUseUnpivotedData =
             isSqlPivotEnabled && hasPivotConfig && hasUnpivotedQuery;
-
-        // Check if the main query is currently loading
-        const isMainQueryLoading =
-            query.isFetching ||
-            queryResults.isFetchingFirstPage ||
-            query.status === 'loading';
-
-        // Only check unpivoted query states if SQL pivot is enabled
-        if (isSqlPivotEnabled) {
-            // Check if we need to show loading for unpivoted data
-            const isUnpivotedQueryLoading =
-                unpivotedQuery.isFetching ||
-                unpivotedQueryResults.isFetchingFirstPage ||
-                unpivotedQuery.status === 'loading';
-
-            // Only consider needing unpivoted query if we actually expect it to run
-            const needsUnpivotedQuery =
-                hasPivotConfig &&
-                hasMainQuery &&
-                !hasUnpivotedQuery &&
-                !unpivotedQuery.isFetching &&
-                !unpivotedQuery.data &&
-                !isMainQueryLoading; // Don't show loading if main query is still running
-
-            const shouldShowLoadingForUnpivoted =
-                hasPivotConfig &&
-                hasMainQuery &&
-                !hasUnpivotedQuery &&
-                !isMainQueryLoading && // Don't show loading if main query is still running
-                (isUnpivotedQueryLoading || needsUnpivotedQuery);
-
-            if (shouldShowLoadingForUnpivoted) {
-                // Show loading state for pivoted charts waiting for unpivoted data
-                return {
-                    rows: undefined,
-                    totalResults: undefined,
-                    isFetchingRows: false,
-                    fetchMoreRows: () => {},
-                    status: 'loading' as const,
-                    apiError: null,
-                };
-            }
-        }
 
         if (shouldUseUnpivotedData) {
             return {

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -1,4 +1,3 @@
-// import { type FieldId } from '@lightdash/common';
 import { createSelector } from '@reduxjs/toolkit';
 import type { ExplorerStoreState } from '.';
 import { ExplorerSection } from '../../../providers/Explorer/types';
@@ -6,7 +5,7 @@ import { ExplorerSection } from '../../../providers/Explorer/types';
 // Base selectors
 const selectExplorerState = (state: ExplorerStoreState) => state.explorer;
 
-const selectUnsavedChartVersion = createSelector(
+export const selectUnsavedChartVersion = createSelector(
     [selectExplorerState],
     (explorer) => explorer.unsavedChartVersion,
 );

--- a/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
+++ b/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
@@ -1,5 +1,4 @@
 import {
-    ChartType,
     derivePivotConfigurationFromChart,
     getFieldsFromMetricQuery,
     type DateGranularity,
@@ -7,6 +6,7 @@ import {
     type FieldId,
     type MetricQuery,
     type ParametersValuesMap,
+    type SavedChartDAO,
 } from '@lightdash/common';
 import type { QueryResultsProps } from '../useQueryResults';
 
@@ -30,6 +30,7 @@ export function buildQueryArgs(options: {
         | { chartUuid: string; chartVersionUuid: string };
     dateZoomGranularity?: DateGranularity;
     minimal: boolean;
+    savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
 }): QueryResultsProps | null {
     const {
         activeFields,
@@ -56,15 +57,11 @@ export function buildQueryArgs(options: {
     if (useSqlPivotResults) {
         const items = getFieldsFromMetricQuery(computedMetricQuery, explore);
         pivotConfiguration = derivePivotConfigurationFromChart(
-            {
-                chartConfig: { type: ChartType.TABLE },
-                pivotConfig: undefined,
-            },
+            options.savedChart,
             computedMetricQuery,
             items,
         );
     }
-
     return {
         projectUuid,
         tableId: tableName,

--- a/packages/frontend/src/hooks/useExplorerQuery.ts
+++ b/packages/frontend/src/hooks/useExplorerQuery.ts
@@ -14,6 +14,7 @@ import {
     selectTableName,
     selectUnpivotedQueryArgs,
     selectUnpivotedQueryUuidHistory,
+    selectUnsavedChartVersion,
     selectValidQueryArgs,
     useExplorerDispatch,
     useExplorerSelector,
@@ -58,6 +59,7 @@ export const useExplorerQuery = (options?: {
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const validQueryArgs = useExplorerSelector(selectValidQueryArgs);
     const queryUuidHistory = useExplorerSelector(selectQueryUuidHistory);
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     const unpivotedQueryUuidHistory = useExplorerSelector(
         selectUnpivotedQueryUuidHistory,
     );
@@ -179,12 +181,14 @@ export const useExplorerQuery = (options?: {
             viewModeQueryArgs,
             dateZoomGranularity,
             minimal,
+            savedChart: unsavedChartVersion,
         });
 
         if (mainQueryArgs) {
             dispatch(explorerActions.setValidQueryArgs(mainQueryArgs));
         }
     }, [
+        unsavedChartVersion,
         activeFields,
         tableName,
         projectUuid,

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -1,5 +1,4 @@
 import {
-    ChartType,
     deepEqual,
     derivePivotConfigurationFromChart,
     FeatureFlags,
@@ -27,6 +26,7 @@ import {
     selectTableName,
     selectUnpivotedQueryArgs,
     selectUnpivotedQueryUuidHistory,
+    selectUnsavedChartVersion,
     selectValidQueryArgs,
     useExplorerDispatch,
     useExplorerSelector,
@@ -79,6 +79,7 @@ export const useExplorerQueryManager = (options?: {
     const unpivotedQueryUuidHistory = useExplorerSelector(
         selectUnpivotedQueryUuidHistory,
     );
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
     // Auto-fetch configuration
     const [autoFetchEnabled] = useLocalStorage({
@@ -135,16 +136,18 @@ export const useExplorerQueryManager = (options?: {
 
         const items = getFieldsFromMetricQuery(metricQuery, explore);
         const pivotConfiguration = derivePivotConfigurationFromChart(
-            {
-                chartConfig: { type: ChartType.TABLE }, // Default for detection
-                pivotConfig: undefined,
-            },
+            unsavedChartVersion,
             metricQuery,
             items,
         );
 
         return !!pivotConfiguration;
-    }, [useSqlPivotResults?.enabled, explore, metricQuery]);
+    }, [
+        useSqlPivotResults?.enabled,
+        explore,
+        metricQuery,
+        unsavedChartVersion,
+    ]);
 
     // Dispatch functions for query UUID history
     const setQueryUuidHistory = useCallback(
@@ -197,6 +200,7 @@ export const useExplorerQueryManager = (options?: {
             viewModeQueryArgs,
             dateZoomGranularity,
             minimal,
+            savedChart: unsavedChartVersion,
         });
 
         if (mainQueryArgs) {
@@ -221,6 +225,7 @@ export const useExplorerQueryManager = (options?: {
         viewModeQueryArgs,
         dateZoomGranularity,
         minimal,
+        unsavedChartVersion,
         dispatch,
     ]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17018

### Description:
Refactored pivot configuration logic by extracting the `getIndexColumn` function to reduce code duplication between table and cartesian pivot configurations. This improves maintainability and ensures consistent behavior when determining index columns for different chart types.

The PR also removes an unused import (`VizIndexType`) and simplifies the cartesian pivot configuration by using the same index column determination logic as tables.

**Before**
<img width="2125" height="1081" alt="image" src="https://github.com/user-attachments/assets/172eb8a5-35fa-43ef-bd15-f45d494ab8e0" />

**After**
<img width="2112" height="1062" alt="image" src="https://github.com/user-attachments/assets/48d8771f-5426-431e-b205-3877572e94af" />

**Steps to test**
1. Create chart with group by
2. Sort by a column not included in either the X axis or group by
3. Sort should be respected

