### PR TITLE
chore: make S3ResultsFileStorageClient logs provider agnostic

### DIFF
--- a/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
@@ -77,11 +77,11 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
                 passThrough.end(); // signal EOF
                 await upload.done(); // wait for upload to finish
                 Logger.debug(
-                    `Successfully closed upload stream to s3://${this.configuration.bucket}/${fileName}`,
+                    `Successfully closed upload stream to ${this.configuration.bucket}/${fileName}`,
                 );
             } catch (error) {
                 Logger.error(
-                    `Error closing upload stream to s3://${
+                    `Error closing upload stream to ${
                         this.configuration.bucket
                     }/${fileName}: ${getErrorMessage(error)}`,
                 );
@@ -247,7 +247,7 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
         try {
             await upload.done();
             Logger.debug(
-                `Successfully uploaded file to s3://${this.configuration.bucket}/${fileName}`,
+                `Successfully uploaded file to ${this.configuration.bucket}/${fileName}`,
             );
 
             // Determine file extension for URL generation
@@ -256,7 +256,7 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
             return await this.getFileUrl(fileName, fileExtension);
         } catch (error) {
             Logger.error(
-                `Failed to upload file to s3://${
+                `Failed to upload file to ${
                     this.configuration.bucket
                 }/${fileName}: ${getErrorMessage(error)}`,
             );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17272

### Description:
Removes the `s3://` prefix from log messages in the S3ResultsFileStorageClient to make the logs more generic and compatible with different S3-compatible storage providers.

The change ensures that log messages don't incorrectly suggest an S3-specific URL format when the storage might be using a different S3-compatible service.