### PR TITLE
feat: send email notification when schedule fails

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3023,6 +3023,43 @@ export default class SchedulerTask {
                 },
             });
 
+            // Send failure notification email to scheduler creator
+            try {
+                const user = await this.userService.getSessionByUserUuid(
+                    scheduler.createdBy,
+                );
+                if (user.email) {
+                    const schedulerUrlParam = setUuidParam(
+                        'scheduler_uuid',
+                        schedulerUuid,
+                    );
+                    const schedulerUrl =
+                        scheduler.savedChartUuid || scheduler.dashboardUuid
+                            ? `${this.lightdashConfig.siteUrl}/projects/${
+                                  schedulerPayload.projectUuid
+                              }/${
+                                  scheduler.savedChartUuid
+                                      ? 'saved'
+                                      : 'dashboards'
+                              }/${
+                                  scheduler.savedChartUuid ||
+                                  scheduler.dashboardUuid
+                              }/view?${schedulerUrlParam}`
+                            : this.lightdashConfig.siteUrl;
+
+                    await this.emailClient.sendScheduledDeliveryFailureEmail(
+                        user.email,
+                        scheduler.name,
+                        schedulerUrl,
+                        getErrorMessage(e),
+                    );
+                }
+            } catch (emailError) {
+                Logger.error(
+                    `Failed to send scheduled delivery failure email: ${emailError}`,
+                );
+                // Don't throw - we still want to handle the original error
+            }
             if (e instanceof NotEnoughResults) {
                 Logger.warn(
                     `Scheduler ${schedulerUuid} did not return enough results for threshold alert`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #7961

### Description:

Added email notifications for scheduled delivery failures. When a scheduled delivery fails, the system now sends an email to the scheduler creator with details about the error and a link to the scheduler settings. This helps users quickly identify and fix issues with their scheduled deliveries.

The implementation includes:
- A new `sendScheduledDeliveryFailureEmail` method in the EmailClient
- Error handling in the SchedulerTask to capture failures and trigger the notification
- Proper URL construction to direct users to the relevant scheduler settings

![Screenshot 2025-10-07 at 11.14.32.png](https://app.graphite.dev/user-attachments/assets/4cde1280-c5f5-42ad-adf0-773a8019b8fd.png)

You can test this by adding this to `UnfurlService`

`throw new Error('Testing notification error');`

![image.png](https://app.graphite.dev/user-attachments/assets/3547a540-86fb-40da-808b-44db63f8f541.png)

