### PR TITLE
fix: validate pat expiration when on dst transition

### DIFF
--- a/packages/backend/src/services/PersonalAccessTokenService.ts
+++ b/packages/backend/src/services/PersonalAccessTokenService.ts
@@ -42,9 +42,11 @@ export class PersonalAccessTokenService extends BaseService {
 
         const { maxExpirationTimeInDays } = this.lightdashConfig.auth.pat;
         if (maxExpirationTimeInDays) {
-            const maxDate: Date = new Date(
-                Date.now() + maxExpirationTimeInDays * 24 * 60 * 60 * 1000,
-            );
+            // Use calendar days to avoid DST issues
+            const maxDate = new Date();
+            maxDate.setDate(maxDate.getDate() + maxExpirationTimeInDays);
+            maxDate.setHours(23, 59, 59, 999); // End of day to be more lenient
+
             if (!expiresAtDate || expiresAtDate.getTime() > maxDate.getTime()) {
                 throw new ParameterError(
                     `Expiration time can't be greater than ${maxExpirationTimeInDays} days`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

To test here: 

![image.png](https://app.graphite.dev/user-attachments/assets/6074f4c3-297d-4374-9509-e7e5b43a130b.png)

Fixes the Personal Access Token expiration date calculation to use calendar days instead of milliseconds to avoid issues with Daylight Saving Time (DST). The new implementation:

1. Uses `setDate()` to properly add calendar days to the current date
2. Sets the expiration time to the end of the day (23:59:59.999) to be more lenient with users

This ensures that token expiration dates are calculated consistently regardless of DST changes.

> [!IMPORTANT]
> Set env var  PAT_MAX_EXPIRATION_TIME_IN_DAYS: "60",

```
  Before (Buggy - Milliseconds):
  // October 7, 2025 12:00 BST + (60 × 24 hours in ms)
  // = December 6, 2025 11:00 GMT (lost 1 hour to BST→GMT)
  const maxDate = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000);

  After (Fixed - Calendar Days):
  // October 7, 2025 + 60 calendar days
  // = December 6, 2025 23:59:59 GMT (DST-aware)
  const maxDate = new Date();
  maxDate.setDate(maxDate.getDate() + 60);
  maxDate.setHours(23, 59, 59, 999);
```