### PR TITLE
refactor: delay artifact creation until after data processing in viz tools

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -66,14 +66,16 @@ export const getGenerateBarVizConfig = ({
 
                 const prompt = await getPrompt();
 
-                await createOrUpdateArtifact({
-                    threadUuid: prompt.threadUuid,
-                    promptUuid: prompt.promptUuid,
-                    artifactType: 'chart',
-                    title: toolArgs.title,
-                    description: toolArgs.description,
-                    vizConfig: toolArgs,
-                });
+                const createOrUpdateArtifactHook = () =>
+                    createOrUpdateArtifact({
+                        threadUuid: prompt.threadUuid,
+                        promptUuid: prompt.promptUuid,
+                        artifactType: 'chart',
+                        title: toolArgs.title,
+                        description: toolArgs.description,
+                        vizConfig: toolArgs,
+                    });
+
                 const selfImprovementResultFollowUp =
                     enableSelfImprovement &&
                     vizTool.customMetrics &&
@@ -82,6 +84,8 @@ export const getGenerateBarVizConfig = ({
                         : '';
 
                 if (!enableDataAccess && !isSlackPrompt(prompt)) {
+                    await createOrUpdateArtifactHook();
+
                     return {
                         result: `Success`,
                         metadata: {
@@ -104,6 +108,8 @@ export const getGenerateBarVizConfig = ({
                     maxLimit,
                     populateCustomMetricsSQL(vizTool.customMetrics, explore),
                 );
+
+                await createOrUpdateArtifactHook();
 
                 if (isSlackPrompt(prompt)) {
                     const { chartOptions } = await renderVerticalBarViz({

--- a/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTableVizConfig.ts
@@ -66,15 +66,15 @@ export const getGenerateTableVizConfig = ({
 
                 const prompt = await getPrompt();
 
-                // Create or update artifact
-                await createOrUpdateArtifact({
-                    threadUuid: prompt.threadUuid,
-                    promptUuid: prompt.promptUuid,
-                    artifactType: 'chart',
-                    title: toolArgs.title,
-                    description: toolArgs.description,
-                    vizConfig: toolArgs,
-                });
+                const createOrUpdateArtifactHook = () =>
+                    createOrUpdateArtifact({
+                        threadUuid: prompt.threadUuid,
+                        promptUuid: prompt.promptUuid,
+                        artifactType: 'chart',
+                        title: toolArgs.title,
+                        description: toolArgs.description,
+                        vizConfig: toolArgs,
+                    });
 
                 const selfImprovementResultFollowUp =
                     enableSelfImprovement &&
@@ -101,6 +101,8 @@ export const getGenerateTableVizConfig = ({
 
                 const rowCount = queryResults.rows.length;
                 const csv = convertQueryResultsToCsv(queryResults);
+
+                await createOrUpdateArtifactHook();
 
                 // Always send CSV file to Slack if it's a Slack prompt, unless there are no results
                 if (isSlackPrompt(prompt) && rowCount > 0) {

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -66,15 +66,15 @@ export const getGenerateTimeSeriesVizConfig = ({
 
                 const prompt = await getPrompt();
 
-                // Create or update artifact
-                await createOrUpdateArtifact({
-                    threadUuid: prompt.threadUuid,
-                    promptUuid: prompt.promptUuid,
-                    artifactType: 'chart',
-                    title: toolArgs.title,
-                    description: toolArgs.description,
-                    vizConfig: toolArgs,
-                });
+                const createOrUpdateArtifactHook = () =>
+                    createOrUpdateArtifact({
+                        threadUuid: prompt.threadUuid,
+                        promptUuid: prompt.promptUuid,
+                        artifactType: 'chart',
+                        title: toolArgs.title,
+                        description: toolArgs.description,
+                        vizConfig: toolArgs,
+                    });
 
                 const selfImprovementResultFollowUp =
                     enableSelfImprovement &&
@@ -84,6 +84,8 @@ export const getGenerateTimeSeriesVizConfig = ({
                         : '';
 
                 if (!enableDataAccess && !isSlackPrompt(prompt)) {
+                    await createOrUpdateArtifactHook();
+
                     return {
                         result: `Success`,
                         metadata: {
@@ -106,6 +108,8 @@ export const getGenerateTimeSeriesVizConfig = ({
                     maxLimit,
                     populateCustomMetricsSQL(vizTool.customMetrics, explore),
                 );
+
+                await createOrUpdateArtifactHook();
 
                 if (isSlackPrompt(prompt)) {
                     const { chartOptions } = await renderTimeSeriesViz({


### PR DESCRIPTION
### Description:
Refactored chart artifact creation in visualization tools to ensure artifacts are created after data is fetched. This fixes a bug where artifacts were being created before data was available, resulting in incomplete chart data.

The change extracts the `createOrUpdateArtifact` call into a function and moves its execution to after data fetching in the bar, table, and time series visualization generators.