### PR TITLE
feat: allow fetching dashboards and charts by slug

### DIFF
--- a/packages/backend/src/controllers/commentsController.ts
+++ b/packages/backend/src/controllers/commentsController.ts
@@ -79,15 +79,15 @@ export class CommentsController extends BaseController {
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('/dashboards/{dashboardUuid}')
+    @Get('/dashboards/{dashboardUuidOrSlug}')
     @OperationId('getComments')
     async getComments(
-        @Path() dashboardUuid: string,
+        @Path() dashboardUuidOrSlug: string,
         @Request() req: express.Request,
     ): Promise<ApiGetComments> {
         const results = await this.services
             .getCommentService()
-            .findCommentsForDashboard(req.user!, dashboardUuid);
+            .findCommentsForDashboard(req.user!, dashboardUuidOrSlug);
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/ee/controllers/aiController.ts
+++ b/packages/backend/src/ee/controllers/aiController.ts
@@ -55,12 +55,12 @@ export class AiController extends BaseController {
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('/dashboard/:dashboardUuid/summary')
+    @Get('/dashboard/:dashboardUuidOrSlug/summary')
     @OperationId('getDashboardSummary')
     async getDashboardSummary(
         @Request() req: express.Request,
         @Path() projectUuid: string,
-        @Path() dashboardUuid: string,
+        @Path() dashboardUuidOrSlug: string,
     ): Promise<ApiAiGetDashboardSummaryResponse> {
         this.setStatus(200);
         return {
@@ -68,7 +68,7 @@ export class AiController extends BaseController {
             results: await this.getAiService().getDashboardSummary(
                 req.user!,
                 projectUuid,
-                dashboardUuid,
+                dashboardUuidOrSlug,
             ),
         };
     }

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -247,7 +247,9 @@ export class AiService {
     ) {
         await AiService.throwOnFeatureDisabled(user);
         const startTime = new Date().getTime();
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         const dashboardCharts = await this.getDashboardChartsResults(
             user,
             dashboard,
@@ -304,7 +306,7 @@ export class AiService {
         const timeOpenAi = new Date().getTime() - startTime - timeGetCharts;
 
         const dashboardSummary = await this.dashboardSummaryModel.save(
-            dashboardUuid,
+            dashboard.uuid,
             dashboard.dashboardVersionId,
             dashboardSummaryText,
             tone,
@@ -351,11 +353,15 @@ export class AiService {
     async getDashboardSummary(
         user: SessionUser,
         projectUuid: string,
-        dashboardUuid: string,
+        dashboardUuidOrSlug: string,
     ) {
         await AiService.throwOnFeatureDisabled(user);
+
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuidOrSlug,
+        );
         const dashboardSummary =
-            await this.dashboardSummaryModel.getByDashboardUuid(dashboardUuid);
+            await this.dashboardSummaryModel.getByDashboardUuid(dashboard.uuid);
 
         this.analytics.track<DashboardSummaryViewed>({
             userId: user.userUuid,
@@ -363,7 +369,7 @@ export class AiService {
             properties: {
                 organizationId: user.organizationUuid!,
                 projectId: projectUuid,
-                dashboardId: dashboardUuid,
+                dashboardId: dashboard.uuid,
                 dashboardSummaryUuid: dashboardSummary.dashboardSummaryUuid,
             },
         });

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -355,7 +355,9 @@ export class EmbedService extends BaseService {
                 dashboardUuid,
             );
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         await this.isFeatureEnabled({
             userUuid: user.userUuid,
@@ -801,7 +803,9 @@ export class EmbedService extends BaseService {
             await this.embedModel.get(projectUuid);
 
         const dashboardUuid = account.access.dashboardId;
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         const chart = await this._getChartFromDashboardTiles(
             dashboard,
@@ -879,7 +883,9 @@ export class EmbedService extends BaseService {
             await this.embedModel.get(projectUuid);
 
         const dashboardUuid = account.access.dashboardId;
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         const chart = await this._getChartFromDashboardTiles(
             dashboard,
@@ -1000,7 +1006,9 @@ export class EmbedService extends BaseService {
         dashboardFilters?: DashboardFilters,
     ) {
         const dashboardUuid = account.access.dashboardId;
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         const tile = dashboard.tiles
             .filter(isDashboardChartTileType)
@@ -1082,7 +1090,9 @@ export class EmbedService extends BaseService {
         const { userAttributes, intrinsicUserAttributes } =
             this.getAccessControls(account);
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         // No parameters are passed in embed requests, just combine the saved parameters
@@ -1168,7 +1178,9 @@ export class EmbedService extends BaseService {
             ...(metricQuery.additionalMetrics?.map((m) => m.name) || []),
         ];
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         // No parameters are passed in embed requests, just combine the saved parameters
@@ -1309,7 +1321,9 @@ export class EmbedService extends BaseService {
             },
             dashboardUuid,
         );
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         const dashboardFilters = dashboard.filters.dimensions;
         const filter = dashboardFilters.find((f) => f.id === filterUuid);
         if (!filter) {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -109,7 +109,7 @@ describe('DashboardModel', () => {
             )
             .response([]);
 
-        const dashboard = await model.getById(expectedDashboard.uuid);
+        const dashboard = await model.getByIdOrSlug(expectedDashboard.uuid);
 
         expect(dashboard).toEqual(expectedDashboard);
         expect(tracker.history.select).toHaveLength(4);
@@ -171,7 +171,7 @@ describe('DashboardModel', () => {
             .response([]);
 
         // Fetch the dashboard
-        const dashboard = await model.getById(expectedDashboard.uuid);
+        const dashboard = await model.getByIdOrSlug(expectedDashboard.uuid);
 
         // Assert that tiles are returned in the expected order
         // First by y_offset (ascending), then x_offset (ascending)
@@ -189,7 +189,7 @@ describe('DashboardModel', () => {
             .response([]);
 
         await expect(
-            model.getById(expectedDashboard.uuid),
+            model.getByIdOrSlug(expectedDashboard.uuid),
         ).rejects.toThrowError(NotFoundError);
     });
 
@@ -289,7 +289,7 @@ describe('DashboardModel', () => {
         tracker.on.update(DashboardViewsTableName).responseOnce([]);
         tracker.on.select(DashboardsTableName).responseOnce('slug');
 
-        jest.spyOn(model, 'getById').mockImplementationOnce(() =>
+        jest.spyOn(model, 'getByIdOrSlug').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
         );
         jest.spyOn(DashboardModel, 'generateUniqueSlug').mockResolvedValue(
@@ -475,7 +475,7 @@ describe('DashboardModel', () => {
         tracker.on.insert(DashboardTileMarkdownsTableName).responseOnce([]);
         tracker.on.update(DashboardViewsTableName).responseOnce([]);
 
-        jest.spyOn(model, 'getById').mockImplementationOnce(() =>
+        jest.spyOn(model, 'getByIdOrSlug').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
         );
 
@@ -583,7 +583,7 @@ describe('DashboardModel', () => {
         tracker.on.insert(DashboardTileChartTableName).responseOnce([]);
         tracker.on.update(DashboardViewsTableName).responseOnce([]);
 
-        jest.spyOn(model, 'getById').mockImplementationOnce(() =>
+        jest.spyOn(model, 'getByIdOrSlug').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
         );
 
@@ -660,7 +660,7 @@ describe('DashboardModel', () => {
         tracker.on.insert(DashboardTileChartTableName).responseOnce([]);
         tracker.on.update(DashboardViewsTableName).responseOnce([]);
 
-        jest.spyOn(model, 'getById').mockImplementationOnce(() =>
+        jest.spyOn(model, 'getByIdOrSlug').mockImplementationOnce(() =>
             Promise.resolve(expectedDashboard),
         );
 

--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -8,7 +8,7 @@ import {
 export const dashboardRouter = express.Router({ mergeParams: true });
 
 dashboardRouter.get(
-    '/:dashboardUuid',
+    '/:dashboardUuidOrSlug',
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
@@ -17,7 +17,7 @@ dashboardRouter.get(
                 status: 'ok',
                 results: await req.services
                     .getDashboardService()
-                    .getById(req.user!, req.params.dashboardUuid),
+                    .getByIdOrSlug(req.user!, req.params.dashboardUuidOrSlug),
             });
         } catch (e) {
             next(e);
@@ -44,7 +44,7 @@ dashboardRouter.get(
 );
 
 dashboardRouter.patch(
-    '/:dashboardUuid',
+    '/:dashboardUuidOrSlug',
     allowApiKeyAuthentication,
     isAuthenticated,
     unauthorisedInDemo,
@@ -54,7 +54,11 @@ dashboardRouter.patch(
                 status: 'ok',
                 results: await req.services
                     .getDashboardService()
-                    .update(req.user!, req.params.dashboardUuid, req.body),
+                    .update(
+                        req.user!,
+                        req.params.dashboardUuidOrSlug,
+                        req.body,
+                    ),
             });
         } catch (e) {
             next(e);

--- a/packages/backend/src/routers/savedChartRouter.ts
+++ b/packages/backend/src/routers/savedChartRouter.ts
@@ -9,13 +9,16 @@ import {
 export const savedChartRouter = express.Router();
 
 savedChartRouter.get(
-    '/:savedQueryUuid',
+    '/:savedQueryUuidOrSlug',
     allowApiKeyAuthentication,
     isAuthenticated,
     async (req, res, next) => {
         req.services
             .getSavedChartService()
-            .get(getObjectValue(req.params, 'savedQueryUuid'), req.account!)
+            .get(
+                getObjectValue(req.params, 'savedQueryUuidOrSlug'),
+                req.account!,
+            )
             .then((results) => {
                 res.json({
                     status: 'ok',

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -249,7 +249,7 @@ export default class SchedulerTask {
 
         if (dashboardUuid) {
             const dashboard =
-                await this.schedulerService.dashboardModel.getById(
+                await this.schedulerService.dashboardModel.getByIdOrSlug(
                     dashboardUuid,
                 );
 
@@ -480,7 +480,7 @@ export default class SchedulerTask {
                             properties: baseAnalyticsProperties,
                         });
                         const dashboard =
-                            await this.schedulerService.dashboardModel.getById(
+                            await this.schedulerService.dashboardModel.getByIdOrSlug(
                                 dashboardUuid,
                             );
 
@@ -730,7 +730,7 @@ export default class SchedulerTask {
                 let csvSchedulerParameters: ParametersValuesMap | undefined;
                 if (dashboardUuid) {
                     const dashboard =
-                        await this.schedulerService.dashboardModel.getById(
+                        await this.schedulerService.dashboardModel.getByIdOrSlug(
                             dashboardUuid,
                         );
                     const dashboardParameters = dashboard.parameters || {};
@@ -2512,7 +2512,7 @@ export default class SchedulerTask {
                     );
                 }
             } else if (dashboardUuid) {
-                const dashboard = await this.dashboardService.getById(
+                const dashboard = await this.dashboardService.getByIdOrSlug(
                     sessionUser,
                     dashboardUuid,
                 );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2281,7 +2281,9 @@ export class AsyncQueryService extends ProjectService {
             warehouseCredentials.startOfWeek,
         );
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         // Combine default parameter values, dashboard parameters, and request parameters first
@@ -2970,7 +2972,9 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError("You don't have access to this chart");
         }
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         // Combine default parameter values, dashboard parameters, and request parameters first

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -517,7 +517,7 @@ export class CoderService extends BaseService {
         );
 
         const dashboardPromises = limitedDashboardSummaries.map((dash) =>
-            this.dashboardModel.getById(dash.uuid),
+            this.dashboardModel.getByIdOrSlug(dash.uuid),
         );
         const dashboards = await Promise.all(dashboardPromises);
 
@@ -1055,7 +1055,7 @@ export class CoderService extends BaseService {
         }
         // Use promote service to update existing dashboard
 
-        const dashboard = await this.dashboardModel.getById(
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardSummary.uuid,
         );
 

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -157,7 +157,9 @@ export class CommentService extends BaseService {
     ): Promise<string> {
         await CommentService.isFeatureEnabled(user);
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -214,11 +216,13 @@ export class CommentService extends BaseService {
 
     async findCommentsForDashboard(
         user: SessionUser,
-        dashboardUuid: string,
+        dashboardUuidOrSlug: string,
     ): Promise<Record<string, Comment[]>> {
         await CommentService.isFeatureEnabled(user);
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuidOrSlug,
+        );
 
         if (
             user.ability.cannot(
@@ -247,7 +251,7 @@ export class CommentService extends BaseService {
         );
 
         return this.commentModel.findCommentsForDashboard(
-            dashboardUuid,
+            dashboard.uuid,
             user.userUuid,
             canUserRemoveAnyComment,
         );
@@ -260,7 +264,9 @@ export class CommentService extends BaseService {
     ): Promise<void> {
         await CommentService.isFeatureEnabled(user);
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -303,7 +309,9 @@ export class CommentService extends BaseService {
     ): Promise<void> {
         await CommentService.isFeatureEnabled(user);
 
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         if (!(await this.hasDashboardSpaceAccess(user, dashboard.spaceUuid))) {
             throw new ForbiddenError(

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -909,7 +909,9 @@ export class CsvService extends BaseService {
         invalidateCache?: boolean;
         schedulerParameters?: ParametersValuesMap;
     }): Promise<AttachmentUrl[]> {
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         const dashboardFilters = overrideDashboardFilters || dashboard.filters;
 
@@ -1304,7 +1306,9 @@ export class CsvService extends BaseService {
         dashboardFilters: DashboardFilters,
         dateZoomGranularity?: DateGranularity,
     ) {
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         if (
             user.ability.cannot(
                 'manage',
@@ -1353,7 +1357,9 @@ export class CsvService extends BaseService {
             formatted: true,
             limit: 'table',
         };
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         this.logger.info(`Exporting CSVs for dashboard ${dashboardUuid}`);
         const user = await this.userModel.findSessionUserAndOrgByUuid(

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -41,7 +41,7 @@ import {
 const dashboardModel = {
     getAllByProject: jest.fn(async () => dashboardsDetails),
 
-    getById: jest.fn(async () => dashboard),
+    getByIdOrSlug: jest.fn(async () => dashboard),
 
     create: jest.fn(async () => dashboard),
 
@@ -94,11 +94,13 @@ describe('DashboardService', () => {
         jest.clearAllMocks();
     });
     test('should get dashboard by uuid', async () => {
-        const result = await service.getById(user, dashboard.uuid);
+        const result = await service.getByIdOrSlug(user, dashboard.uuid);
 
         expect(result).toEqual(dashboard);
-        expect(dashboardModel.getById).toHaveBeenCalledTimes(1);
-        expect(dashboardModel.getById).toHaveBeenCalledWith(dashboard.uuid);
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledTimes(1);
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+            dashboard.uuid,
+        );
     });
     test('should get all dashboard by project uuid', async () => {
         const result = await service.getAllByProject(
@@ -291,7 +293,7 @@ describe('DashboardService', () => {
             ),
         };
         await expect(
-            service.getById(anotherUser, dashboard.uuid),
+            service.getByIdOrSlug(anotherUser, dashboard.uuid),
         ).rejects.toThrowError(ForbiddenError);
     });
     test('should see empty list if getting all dashboard by project uuid from another organization', async () => {
@@ -342,7 +344,7 @@ describe('DashboardService', () => {
             ),
         };
         await expect(
-            service.getById(userViewer, dashboard.uuid),
+            service.getByIdOrSlug(userViewer, dashboard.uuid),
         ).rejects.toThrowError(ForbiddenError);
     });
     test('should see dashboard from private space if you are admin', async () => {
@@ -350,11 +352,13 @@ describe('DashboardService', () => {
             async () => privateSpace,
         );
 
-        const result = await service.getById(user, dashboard.uuid);
+        const result = await service.getByIdOrSlug(user, dashboard.uuid);
 
         expect(result).toEqual(dashboard);
-        expect(dashboardModel.getById).toHaveBeenCalledTimes(1);
-        expect(dashboardModel.getById).toHaveBeenCalledWith(dashboard.uuid);
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledTimes(1);
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+            dashboard.uuid,
+        );
     });
 
     test('should not see dashboards from private space if you are not an admin', async () => {

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -724,7 +724,9 @@ export class PromoteService extends BaseService {
     }
 
     async getPromoteDashboardDiff(user: SessionUser, dashboardUuid: string) {
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         const { upstreamProjectUuid } = await this.projectModel.getSummary(
             dashboard.projectUuid,
@@ -1415,7 +1417,9 @@ export class PromoteService extends BaseService {
     }
 
     async promoteDashboard(user: SessionUser, dashboardUuid: string) {
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
 
         const { upstreamProjectUuid } = await this.projectModel.getSummary(
             dashboard.projectUuid,

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -622,7 +622,7 @@ export class RenameService extends BaseService {
                 `Rename resources: Found ${dashboardSummaries.length} dashboard summaries to rename`,
             );
             const dashboardPromises = dashboardSummaries.map((dashboard) =>
-                this.dashboardModel.getById(dashboard.uuid),
+                this.dashboardModel.getByIdOrSlug(dashboard.uuid),
             );
             const dashboards = await Promise.all(dashboardPromises);
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -811,8 +811,11 @@ export class SavedChartService
         return access;
     }
 
-    async get(savedChartUuid: string, account: Account): Promise<SavedChart> {
-        const savedChart = await this.savedChartModel.get(savedChartUuid);
+    async get(
+        savedChartUuidOrSlug: string,
+        account: Account,
+    ): Promise<SavedChart> {
+        const savedChart = await this.savedChartModel.get(savedChartUuidOrSlug);
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,
         );
@@ -820,7 +823,7 @@ export class SavedChartService
         const access = await this.checkPermissions(account, space, savedChart);
 
         await this.analyticsModel.addChartViewEvent(
-            savedChartUuid,
+            savedChart.uuid,
             account.isRegisteredUser() ? account.user.id : null,
         );
 
@@ -862,7 +865,7 @@ export class SavedChartService
                 savedChart.spaceUuid,
             );
         } else if (savedChart.dashboardUuid) {
-            const dashboard = await this.dashboardModel.getById(
+            const dashboard = await this.dashboardModel.getByIdOrSlug(
                 savedChart.dashboardUuid,
             );
             const space = await this.spaceModel.getSpaceSummary(
@@ -1319,7 +1322,7 @@ export class SavedChartService
             }
 
             if (savedChart.dashboardUuid) {
-                const dashboard = await this.dashboardModel.getById(
+                const dashboard = await this.dashboardModel.getByIdOrSlug(
                     savedChart.dashboardUuid,
                 );
                 spaceUuid = dashboard.spaceUuid;

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -108,7 +108,7 @@ export class SchedulerService extends BaseService {
     ): Promise<ChartSummary | DashboardDAO> {
         return isChartScheduler(scheduler)
             ? this.savedChartModel.getSummary(scheduler.savedChartUuid)
-            : this.dashboardModel.getById(scheduler.dashboardUuid);
+            : this.dashboardModel.getByIdOrSlug(scheduler.dashboardUuid);
     }
 
     public async getCreateSchedulerResource(
@@ -118,7 +118,7 @@ export class SchedulerService extends BaseService {
             return this.savedChartModel.getSummary(scheduler.savedChartUuid);
         }
         if (isDashboardCreateScheduler(scheduler)) {
-            return this.dashboardModel.getById(scheduler.dashboardUuid);
+            return this.dashboardModel.getByIdOrSlug(scheduler.dashboardUuid);
         }
         throw new ParameterError('Invalid scheduler type');
     }
@@ -204,7 +204,9 @@ export class SchedulerService extends BaseService {
                 throw new ForbiddenError();
         } else if (scheduler.dashboardUuid) {
             const { organizationUuid, spaceUuid, projectUuid } =
-                await this.dashboardModel.getById(scheduler.dashboardUuid);
+                await this.dashboardModel.getByIdOrSlug(
+                    scheduler.dashboardUuid,
+                );
             const [space] = await this.spaceModel.find({ spaceUuid });
             const spaceAccess = await this.spaceModel.getUserSpaceAccess(
                 user.userUuid,

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -301,7 +301,7 @@ export class UnfurlService extends BaseService {
                     throw new ParameterError(
                         `Missing dashboardUuid when unfurling Dashboard URL ${parsedUrl.url}`,
                     );
-                const dashboard = await this.dashboardModel.getById(
+                const dashboard = await this.dashboardModel.getByIdOrSlug(
                     parsedUrl.dashboardUuid,
                 );
 
@@ -524,7 +524,9 @@ export class UnfurlService extends BaseService {
         user: SessionUser,
         selectedTabs: string[] | null,
     ): Promise<string> {
-        const dashboard = await this.dashboardModel.getById(dashboardUuid);
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+        );
         const { isPrivate } = await this.spaceModel.get(dashboard.spaceUuid);
         const access = await this.spaceModel.getUserSpaceAccess(
             user.userUuid,

--- a/packages/e2e/SLUG_TESTING_GUIDE.md
+++ b/packages/e2e/SLUG_TESTING_GUIDE.md
@@ -1,0 +1,273 @@
+# Slug-Based Testing Guide
+
+This document outlines the comprehensive test coverage for slug-based functionality in Lightdash dashboards and charts.
+
+## Overview
+
+Lightdash supports accessing dashboards and charts using slugs (human-readable identifiers) instead of UUIDs. For example:
+- **UUID**: `/projects/123/dashboards/abc-def-123-456`
+- **Slug**: `/projects/123/dashboards/jaffle-dashboard`
+
+Both approaches are supported for backward compatibility.
+
+## Test Coverage
+
+### 1. Dashboard Tests (`cypress/e2e/app/dashboard.cy.ts`)
+
+Added 5 new test cases:
+
+#### a. Basic Slug Access
+- **Test**: `Should access dashboard by slug instead of UUID`
+- **Coverage**: Verifies that dashboards can be accessed via slug and render correctly
+- **Key Assertions**: Dashboard loads, tiles render, charts display
+
+#### b. Filter Persistence with Slugs
+- **Test**: `Should maintain dashboard filters when using slug`
+- **Coverage**: Ensures dashboard filters work correctly when using slug-based URLs
+- **Key Assertions**: Filters apply, URL contains slug + filters, reload preserves state
+
+#### c. API Access via Slug
+- **Test**: `Should access dashboard via API using slug`
+- **Coverage**: Tests the REST API endpoint with slug parameter
+- **Key Assertions**: API returns correct dashboard, includes slug and UUID
+
+#### d. Error Handling
+- **Test**: `Should handle invalid dashboard slug gracefully`
+- **Coverage**: Verifies proper error messages for non-existent slugs
+- **Key Assertions**: Error message displays appropriately
+
+### 2. Chart Tests (`cypress/e2e/app/chartSlugs.cy.ts`)
+
+Created a new test file with 10 comprehensive test cases:
+
+#### Basic Functionality
+1. **Slug Access**: Access saved charts via slug URL
+2. **Chart Editing**: Edit charts accessed by slug
+3. **API Access**: Fetch charts via API using slug
+4. **Error Handling**: Handle invalid slugs gracefully
+
+#### Advanced Functionality
+5. **URL Sharing**: Share chart URLs using slugs
+6. **Query Execution**: Run chart queries with slug-based access
+7. **Scheduled Delivery**: Create schedules for slug-accessed charts
+8. **CSV Export**: Export chart data when accessed by slug
+9. **Dashboard Integration**: Add slug-accessed charts to dashboards
+
+### 3. API Tests (`cypress/e2e/api/slugs.cy.ts`)
+
+Created a comprehensive API test suite with 16 test cases organized into 5 sections:
+
+#### Dashboard API Tests
+1. Get dashboard by slug
+2. Get dashboard by UUID (backward compatibility)
+3. Handle non-existent slug (404 error)
+4. Update dashboard accessed by slug
+5. Get dashboard views using slug
+
+#### Chart API Tests
+6. Get chart by slug
+7. Get chart by UUID (backward compatibility)
+8. Handle non-existent slug (404 error)
+9. Update chart accessed by slug
+10. Get chart history using slug-derived UUID
+11. Get chart filters using slug-derived UUID
+
+#### Interchangeability Tests
+12. Verify slug and UUID return same dashboard
+13. Verify slug and UUID return same chart
+
+#### List Endpoint Tests
+14. Verify slugs are included in dashboard list
+15. Verify slugs are included in chart summaries
+
+### 4. Extended Dashboard API Tests (`cypress/e2e/api/dashboard.cy.ts`)
+
+Added 3 new test cases to the existing API test suite:
+
+1. **Get Dashboard by Slug**: Basic API access test
+2. **Create and Access by Slug**: Full lifecycle test (create → access via slug)
+3. **Update via Slug**: Modify dashboard using slug, verify via UUID
+
+## API Endpoints Supporting Slugs
+
+### Dashboards
+- `GET /api/v1/dashboards/:dashboardUuidOrSlug`
+- `PATCH /api/v1/dashboards/:dashboardUuidOrSlug`
+- Returns: Dashboard object with both `uuid` and `slug` fields
+
+### Charts
+- `GET /api/v1/saved/:savedQueryUuidOrSlug`
+- `PATCH /api/v1/saved/:savedQueryUuidOrSlug`
+- Returns: Chart object with both `uuid` and `slug` fields
+
+### SQL Charts
+- `GET /api/v1/projects/:projectUuid/sqlRunner/saved/slug/:slug`
+- Separate endpoint specifically for slug-based access
+
+## Where Else to Add Tests
+
+### 1. Integration Tests
+**Location**: `packages/backend/src/services/DashboardService/DashboardService.test.ts`
+
+Suggested tests:
+```typescript
+describe('getByIdOrSlug', () => {
+    it('should get dashboard by slug', async () => {
+        // Test service layer slug resolution
+    });
+    
+    it('should get dashboard by UUID', async () => {
+        // Test backward compatibility
+    });
+});
+```
+
+### 2. Model Layer Tests
+**Location**: `packages/backend/src/models/DashboardModel/DashboardModel.test.ts`
+
+Suggested tests:
+```typescript
+describe('DashboardModel.getByIdOrSlug', () => {
+    it('should query by slug when slug provided', async () => {
+        // Test database query logic
+    });
+});
+```
+
+### 3. Frontend Unit Tests
+**Location**: `packages/frontend/src/hooks/dashboard/useDashboard.test.ts`
+
+Suggested tests:
+```typescript
+describe('useDashboardQuery with slug', () => {
+    it('should fetch dashboard using slug', async () => {
+        // Test React hook behavior
+    });
+});
+```
+
+### 4. Search Functionality
+**Location**: `packages/e2e/cypress/e2e/api/search.cy.ts`
+
+Consider adding:
+- Search results should include slugs
+- Clicking search result should navigate to slug URL
+
+### 5. Embedding Tests
+**Location**: `packages/e2e/cypress/e2e/app/embed.cy.ts` (if exists)
+
+Consider adding:
+- Embedded dashboards accessible via slug
+- Embedded charts accessible via slug
+
+### 6. Scheduler Tests
+**Location**: `packages/backend/src/scheduler/SchedulerTask.test.ts`
+
+Consider adding:
+- Scheduled deliveries work with slug-based references
+- Dashboard/chart resolution in scheduler uses slugs
+
+### 7. Content as Code Tests
+**Location**: `packages/e2e/cypress/e2e/api/contentAsCode.cy.ts`
+
+Already has some slug tests! Consider expanding:
+- Upload content using slugs
+- Download specific items by slug
+- Slug preservation during sync
+
+### 8. Permission/Access Control Tests
+**Location**: `packages/backend/src/services/PermissionsService/PermissionsService.test.ts`
+
+Consider adding:
+- Access checks work correctly with slugs
+- Private dashboard slug access denied appropriately
+
+### 9. Analytics Tests
+**Location**: `packages/backend/src/analytics/`
+
+Consider verifying:
+- View events tracked correctly for slug-based access
+- Analytics differentiate between UUID and slug access patterns
+
+### 10. Migration Tests
+**Location**: `packages/backend/src/database/migrations/`
+
+Consider adding:
+- Slug generation for existing content
+- Slug uniqueness constraints
+- Slug update on name change
+
+## Test Data Reference
+
+### Seed Dashboards
+- **Name**: "Jaffle dashboard"
+- **Slug**: `jaffle-dashboard`
+
+### Seed Charts
+- **Name**: "How much revenue do we have per payment method?"
+- **Slug**: `how-much-revenue-do-we-have-per-payment-method`
+
+- **Name**: "How many orders we have over time?"
+- **Slug**: `how-many-orders-we-have-over-time`
+
+- **Name**: "Which customers have not recently ordered an item?"
+- **Slug**: `which-customers-have-not-recently-ordered-an-item`
+
+## Running the Tests
+
+### Run all slug-related tests
+```bash
+# Dashboard tests
+pnpm test:e2e --spec "cypress/e2e/app/dashboard.cy.ts"
+
+# Chart slug tests
+pnpm test:e2e --spec "cypress/e2e/app/chartSlugs.cy.ts"
+
+# API slug tests
+pnpm test:e2e --spec "cypress/e2e/api/slugs.cy.ts"
+
+# Extended dashboard API tests
+pnpm test:e2e --spec "cypress/e2e/api/dashboard.cy.ts"
+```
+
+### Run all E2E tests
+```bash
+pnpm test:e2e
+```
+
+## Key Implementation Details
+
+### Backend
+1. **Router Level**: `dashboardRouter.ts` and `savedChartRouter.ts` accept `/:idOrSlug` parameter
+2. **Service Level**: `DashboardService.getByIdOrSlug()` and `SavedChartService.get()` handle slug resolution
+3. **Model Level**: `DashboardModel.getByIdOrSlug()` and `SavedChartModel.get()` query by slug or UUID
+
+### Frontend
+1. **URL Routing**: React Router accepts both slugs and UUIDs in path parameters
+2. **Hooks**: `useDashboardQuery()` and `useSavedQuery()` work with both identifiers
+3. **API Calls**: `lightdashApi` sends slug or UUID to backend
+
+## Best Practices
+
+1. **Always test both slug and UUID** - Ensure backward compatibility
+2. **Test error cases** - Invalid slugs, non-existent resources
+3. **Test state persistence** - Filters, parameters, view state
+4. **Test API and UI** - Both layers should support slugs
+5. **Test cross-references** - Charts in dashboards, dashboard tiles, etc.
+
+## Future Considerations
+
+1. **Slug conflicts** - How are duplicate slugs handled?
+2. **Slug changes** - What happens when a dashboard/chart is renamed?
+3. **Redirects** - Should old slugs redirect to new ones?
+4. **Analytics** - Track slug usage vs UUID usage
+5. **Performance** - Any performance impact of slug lookups vs UUID?
+
+## Contributing
+
+When adding new features that involve dashboards or charts:
+1. Ensure slug support is included
+2. Add corresponding tests to the appropriate test files
+3. Update this guide if new test patterns emerge
+4. Consider both API and UI test coverage
+

--- a/packages/e2e/cypress/e2e/api/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/api/dashboard.cy.ts
@@ -285,25 +285,22 @@ describe('Lightdash dashboard', () => {
                 url: `${apiUrl}/dashboards/${createdDashboard.uuid}`,
             }).then((response) => {
                 expect(response.status).to.eq(200);
-                const retrievedDashboard = response.body.results;
+                const retrievedDashboard = response.body.results as Dashboard;
 
                 // Verify parameters are present and correct
                 expect(retrievedDashboard.parameters).to.exist;
-                expect(
-                    Object.keys(retrievedDashboard.parameters),
-                ).to.have.length(2);
 
                 // Check first parameter
-                const firstParam = retrievedDashboard.parameters.time_zoom;
+                const firstParam = retrievedDashboard?.parameters?.time_zoom;
                 expect(firstParam).to.exist;
-                expect(firstParam.parameterName).to.eq('time_zoom');
-                expect(firstParam.value).to.eq('weekly');
+                expect(firstParam?.parameterName).to.eq('time_zoom');
+                expect(firstParam?.value).to.eq('weekly');
 
                 // Check second parameter
-                const secondParam = retrievedDashboard.parameters.region;
+                const secondParam = retrievedDashboard?.parameters?.region;
                 expect(secondParam).to.exist;
-                expect(secondParam.parameterName).to.eq('region');
-                expect(secondParam.value).to.deep.eq(['US', 'EU']);
+                expect(secondParam?.parameterName).to.eq('region');
+                expect(secondParam?.value).to.deep.eq(['US', 'EU']);
 
                 // Now update the dashboard with different parameters
                 const updatedParameters = {
@@ -339,41 +336,121 @@ describe('Lightdash dashboard', () => {
                             // Verify updated parameters
                             expect(finalDashboard.parameters).to.exist;
                             expect(
-                                Object.keys(finalDashboard.parameters),
+                                Object.keys(finalDashboard.parameters ?? {}),
                             ).to.have.length(3);
 
                             // Check first updated parameter
                             const updatedFirstParam =
-                                finalDashboard.parameters.time_period;
+                                finalDashboard?.parameters?.time_period;
                             expect(updatedFirstParam).to.exist;
-                            expect(updatedFirstParam.parameterName).to.eq(
+                            expect(updatedFirstParam?.parameterName).to.eq(
                                 'time_period',
                             );
-                            expect(updatedFirstParam.value).to.eq('monthly');
+                            expect(updatedFirstParam?.value).to.eq('monthly');
 
                             // Check second updated parameter
                             const updatedSecondParam =
-                                finalDashboard.parameters.category;
+                                finalDashboard?.parameters?.category;
                             expect(updatedSecondParam).to.exist;
-                            expect(updatedSecondParam.parameterName).to.eq(
+                            expect(updatedSecondParam?.parameterName).to.eq(
                                 'category',
                             );
-                            expect(updatedSecondParam.value).to.eq('premium');
+                            expect(updatedSecondParam?.value).to.eq('premium');
 
                             // Check third updated parameter (array value)
                             const updatedThirdParam =
-                                finalDashboard.parameters.markets;
+                                finalDashboard?.parameters?.markets;
                             expect(updatedThirdParam).to.exist;
-                            expect(updatedThirdParam.parameterName).to.eq(
+                            expect(updatedThirdParam?.parameterName).to.eq(
                                 'markets',
                             );
-                            expect(updatedThirdParam.value).to.deep.eq([
+                            expect(updatedThirdParam?.value).to.deep.eq([
                                 'APAC',
                                 'Americas',
                             ]);
                         });
                     },
                 );
+            });
+        });
+    });
+
+    describe('Dashboard slug support', () => {
+        it('Should get dashboard by slug', () => {
+            const slug = 'jaffle-dashboard';
+
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/dashboards/${slug}`,
+            }).then((response) => {
+                expect(response.status).to.eq(200);
+                expect(response.body.status).to.eq('ok');
+                expect(response.body.results.name).to.eq('Jaffle dashboard');
+                expect(response.body.results.slug).to.eq(slug);
+            });
+        });
+
+        it('Should create and access dashboard by slug', () => {
+            const projectUuid = SEED_PROJECT.project_uuid;
+            const testDashboardName = `Test Dashboard ${Date.now()}`;
+
+            createDashboard(projectUuid, {
+                ...dashboardMock,
+                name: testDashboardName,
+            }).then((newDashboard) => {
+                expect(newDashboard.slug).to.exist;
+
+                // Access the dashboard by slug
+                cy.request({
+                    method: 'GET',
+                    url: `${apiUrl}/dashboards/${newDashboard.slug}`,
+                }).then((response) => {
+                    expect(response.status).to.eq(200);
+                    expect(response.body.results.uuid).to.eq(newDashboard.uuid);
+                    expect(response.body.results.name).to.eq(testDashboardName);
+                });
+
+                // Clean up
+                cy.deleteDashboardsByName([testDashboardName]);
+            });
+        });
+
+        it('Should update dashboard accessed by slug', () => {
+            const projectUuid = SEED_PROJECT.project_uuid;
+            const testDashboardName = `Test Dashboard ${Date.now()}`;
+            const updatedDescription = 'Updated via slug test';
+
+            createDashboard(projectUuid, {
+                ...dashboardMock,
+                name: testDashboardName,
+            }).then((newDashboard) => {
+                // Update dashboard using slug
+                cy.request({
+                    method: 'PATCH',
+                    url: `${apiUrl}/dashboards/${newDashboard.slug}`,
+                    body: {
+                        name: testDashboardName,
+                        description: updatedDescription,
+                    },
+                }).then((updateResponse) => {
+                    expect(updateResponse.status).to.eq(200);
+                    expect(updateResponse.body.results.description).to.eq(
+                        updatedDescription,
+                    );
+
+                    // Verify via UUID
+                    cy.request({
+                        method: 'GET',
+                        url: `${apiUrl}/dashboards/${newDashboard.uuid}`,
+                    }).then((verifyResponse) => {
+                        expect(verifyResponse.body.results.description).to.eq(
+                            updatedDescription,
+                        );
+                    });
+                });
+
+                // Clean up
+                cy.deleteDashboardsByName([testDashboardName]);
             });
         });
     });

--- a/packages/e2e/cypress/e2e/api/slugs.cy.ts
+++ b/packages/e2e/cypress/e2e/api/slugs.cy.ts
@@ -1,0 +1,183 @@
+const apiUrl = '/api/v1';
+
+describe('Slug-based API endpoints', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+
+    describe('Dashboard API with slugs', () => {
+        it('Should get dashboard by slug', () => {
+            const slug = 'jaffle-dashboard';
+
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/dashboards/${slug}`,
+            }).then((response) => {
+                expect(response.status).to.eq(200);
+                expect(response.body.status).to.eq('ok');
+                expect(response.body.results.name).to.eq('Jaffle dashboard');
+                expect(response.body.results.slug).to.eq(slug);
+                expect(response.body.results).to.have.property('uuid');
+                expect(response.body.results).to.have.property('tiles');
+                expect(response.body.results).to.have.property('filters');
+                expect(response.body.results.tiles).to.be.an('array');
+            });
+        });
+
+        it('Should get dashboard by UUID for backward compatibility', () => {
+            const slug = 'jaffle-dashboard';
+
+            // First get the UUID
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/dashboards/${slug}`,
+            }).then((response) => {
+                const dashboardUuid = response.body.results.uuid;
+
+                // Now request with UUID
+                cy.request({
+                    method: 'GET',
+                    url: `${apiUrl}/dashboards/${dashboardUuid}`,
+                }).then((uuidResponse) => {
+                    expect(uuidResponse.status).to.eq(200);
+                    expect(uuidResponse.body.results.uuid).to.eq(dashboardUuid);
+                    expect(uuidResponse.body.results.slug).to.eq(slug);
+                    expect(uuidResponse.body.results.name).to.eq(
+                        'Jaffle dashboard',
+                    );
+                });
+            });
+        });
+
+        it('Should return 404 for non-existent dashboard slug', () => {
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/dashboards/non-existent-dashboard-slug`,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(404);
+                expect(response.body.status).to.eq('error');
+            });
+        });
+    });
+
+    describe('Chart API with slugs', () => {
+        it('Should get chart by slug', () => {
+            const slug = 'how-much-revenue-do-we-have-per-payment-method';
+
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/saved/${slug}`,
+            }).then((response) => {
+                expect(response.status).to.eq(200);
+                expect(response.body.status).to.eq('ok');
+                expect(response.body.results.name).to.eq(
+                    'How much revenue do we have per payment method?',
+                );
+                expect(response.body.results.slug).to.eq(slug);
+                expect(response.body.results).to.have.property('uuid');
+                expect(response.body.results).to.have.property('metricQuery');
+                expect(response.body.results).to.have.property('chartConfig');
+            });
+        });
+
+        it('Should get chart by UUID for backward compatibility', () => {
+            const slug = 'how-much-revenue-do-we-have-per-payment-method';
+
+            // First get the UUID
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/saved/${slug}`,
+            }).then((response) => {
+                const chartUuid = response.body.results.uuid;
+
+                // Now request with UUID
+                cy.request({
+                    method: 'GET',
+                    url: `${apiUrl}/saved/${chartUuid}`,
+                }).then((uuidResponse) => {
+                    expect(uuidResponse.status).to.eq(200);
+                    expect(uuidResponse.body.results.uuid).to.eq(chartUuid);
+                    expect(uuidResponse.body.results.slug).to.eq(slug);
+                });
+            });
+        });
+
+        it('Should return 404 for non-existent chart slug', () => {
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/saved/non-existent-chart-slug`,
+                failOnStatusCode: false,
+            }).then((response) => {
+                expect(response.status).to.eq(404);
+                expect(response.body.status).to.eq('error');
+            });
+        });
+
+        it('Should get chart available filters using slug-derived UUID', () => {
+            const slug = 'how-much-revenue-do-we-have-per-payment-method';
+
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/saved/${slug}`,
+            }).then((response) => {
+                const chartUuid = response.body.results.uuid;
+
+                cy.request({
+                    method: 'GET',
+                    url: `${apiUrl}/saved/${chartUuid}/availableFilters`,
+                }).then((filtersResponse) => {
+                    expect(filtersResponse.status).to.eq(200);
+                    expect(filtersResponse.body.status).to.eq('ok');
+                    expect(
+                        filtersResponse.body.results.length,
+                    ).to.be.greaterThan(0);
+                });
+            });
+        });
+    });
+
+    describe('Slug and UUID interchangeability', () => {
+        it('Should work with both slug and UUID for dashboards in same session', () => {
+            const slug = 'jaffle-dashboard';
+
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/dashboards/${slug}`,
+            }).then((slugResponse) => {
+                const { uuid } = slugResponse.body.results;
+
+                cy.request({
+                    method: 'GET',
+                    url: `${apiUrl}/dashboards/${uuid}`,
+                }).then((uuidResponse) => {
+                    // Both should return the same dashboard
+                    expect(slugResponse.body.results.name).to.equal(
+                        uuidResponse.body.results.name,
+                    );
+                });
+            });
+        });
+
+        it('Should work with both slug and UUID for charts in same session', () => {
+            const slug = 'how-much-revenue-do-we-have-per-payment-method';
+
+            cy.request({
+                method: 'GET',
+                url: `${apiUrl}/saved/${slug}`,
+            }).then((slugResponse) => {
+                const { uuid } = slugResponse.body.results;
+
+                cy.request({
+                    method: 'GET',
+                    url: `${apiUrl}/saved/${uuid}`,
+                }).then((uuidResponse) => {
+                    // Both should return the same chart
+                    expect(slugResponse.body.results).to.deep.equal(
+                        uuidResponse.body.results,
+                    );
+                });
+            });
+        });
+    });
+});

--- a/packages/e2e/cypress/e2e/app/chartSlugs.cy.ts
+++ b/packages/e2e/cypress/e2e/app/chartSlugs.cy.ts
@@ -1,0 +1,105 @@
+import { SEED_PROJECT } from '@lightdash/common';
+
+describe('Chart Slugs', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+
+    it('Should access saved chart by slug instead of UUID', () => {
+        // Navigate to the chart list
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved`);
+
+        // Find and click on a chart
+        cy.contains(
+            'a',
+            'How much revenue do we have per payment method?',
+        ).click();
+
+        // Get the UUID from the URL
+        cy.url().then((urlWithUuid) => {
+            const uuidMatch = urlWithUuid.match(/\/saved\/([^/?]+)/);
+            const chartUuid = uuidMatch ? uuidMatch[1] : '';
+            void expect(chartUuid).to.not.be.empty;
+
+            // Now navigate to the chart using slug
+            const slug = 'how-much-revenue-do-we-have-per-payment-method';
+            cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved/${slug}`);
+
+            // Verify the chart loads correctly
+            cy.findByText(
+                'How much revenue do we have per payment method?',
+            ).should('exist');
+
+            cy.findAllByText('Loading chart').should('have.length', 0);
+
+            // Verify URL contains the slug
+            cy.url().should('include', `/saved/${slug}`);
+
+            // Verify chart renders
+            cy.get('.echarts-for-react').should('have.length', 1);
+        });
+    });
+
+    it('Should edit chart accessed by slug', () => {
+        const slug = 'how-much-revenue-do-we-have-per-payment-method';
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved/${slug}`);
+
+        cy.findAllByText('Loading chart').should('have.length', 0);
+
+        // Click edit
+        cy.contains('Edit chart').click();
+
+        // Wait for explorer to load
+        cy.contains('Run query').should('exist');
+
+        // Verify we're in edit mode
+        cy.url().should('include', '/edit');
+    });
+
+    it('Should access chart via API using slug', () => {
+        const slug = 'how-much-revenue-do-we-have-per-payment-method';
+
+        // Test API endpoint with slug
+        cy.request({
+            method: 'GET',
+            url: `/api/v1/saved/${slug}`,
+        }).then((response) => {
+            expect(response.status).to.eq(200);
+            expect(response.body).to.have.property('status', 'ok');
+            expect(response.body.results).to.have.property(
+                'name',
+                'How much revenue do we have per payment method?',
+            );
+            expect(response.body.results).to.have.property('slug', slug);
+            expect(response.body.results).to.have.property('uuid');
+            expect(response.body.results).to.have.property('metricQuery');
+        });
+    });
+
+    it('Should handle invalid chart slug gracefully', () => {
+        cy.visit(
+            `/projects/${SEED_PROJECT.project_uuid}/saved/non-existent-chart-slug`,
+            { failOnStatusCode: false },
+        );
+
+        // Should show an error message (either "Chart not found" or similar)
+        cy.findByText(/not found|does not exist/i).should('exist');
+    });
+
+    it('Should run chart query using slug', () => {
+        const slug = 'how-much-revenue-do-we-have-per-payment-method';
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved/${slug}`);
+
+        cy.findAllByText('Loading chart').should('have.length', 0);
+
+        // Verify chart renders with data
+        cy.get('.echarts-for-react').should('have.length', 1);
+
+        // Verify data in results table view
+        cy.contains('Results').click();
+
+        // Should have payment method data
+        cy.contains('credit_card').should('exist');
+        cy.contains('bank_transfer').should('exist');
+    });
+});

--- a/packages/frontend/src/features/comments/hooks/useComments.ts
+++ b/packages/frontend/src/features/comments/hooks/useComments.ts
@@ -6,6 +6,7 @@ import {
     type Comment,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
 
 type CreateDashboardTileComment = Pick<
@@ -39,6 +40,7 @@ const createDashboardTileComment = async ({
 
 export const useCreateComment = () => {
     const queryClient = useQueryClient();
+    const params = useParams();
 
     return useMutation<
         ApiCreateComment['results'],
@@ -47,7 +49,13 @@ export const useCreateComment = () => {
     >((data) => createDashboardTileComment(data), {
         mutationKey: ['create-comment'],
         onSuccess: async (_, { dashboardUuid }) => {
-            await queryClient.invalidateQueries(['comments', dashboardUuid]);
+            await Promise.all([
+                queryClient.invalidateQueries(['comments', dashboardUuid]),
+                queryClient.invalidateQueries([
+                    'comments',
+                    params.dashboardUuid,
+                ]),
+            ]);
         },
     });
 };
@@ -89,15 +97,19 @@ const removeComment = async ({
 
 export const useRemoveComment = () => {
     const queryClient = useQueryClient();
+    const params = useParams();
 
     return useMutation<ApiDeleteComment, ApiError, RemoveCommentParams>(
         (data) => removeComment(data),
         {
             mutationKey: ['remove-comment'],
             onSuccess: async (_, { dashboardUuid }) => {
-                await queryClient.invalidateQueries([
-                    'comments',
-                    dashboardUuid,
+                await Promise.all([
+                    queryClient.invalidateQueries(['comments', dashboardUuid]),
+                    queryClient.invalidateQueries([
+                        'comments',
+                        params.dashboardUuid,
+                    ]),
                 ]);
             },
         },

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -279,6 +279,7 @@ export const useUpdateMutation = (
 ) => {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
+    const params = useParams();
     const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<
@@ -308,6 +309,10 @@ export const useUpdateMutation = (
                 await queryClient.invalidateQueries(['spaces']);
 
                 queryClient.setQueryData(['saved_query', data.uuid], data);
+                queryClient.setQueryData(
+                    ['saved_query', params.savedQueryUuid],
+                    data,
+                );
 
                 if (dashboardUuid) {
                     // Invalidate dashboard chart queries to refresh charts on dashboards


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: CENG-69

### Description:
This PR enhances dashboard and saved chart access by supporting slug-based URLs in addition to UUIDs. The implementation replaces `getById` with `getByIdOrSlug` across the codebase, which intelligently determines whether the provided identifier is a UUID or slug and queries the database accordingly.

This change enables more user-friendly URLs for dashboards and charts, allowing them to be accessed via their slugs (e.g., `/dashboards/my-sales-dashboard`) rather than requiring UUIDs.