### PR TITLE
fix: move artifact creation after error handling in dashboard generation

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/generateDashboard.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDashboard.ts
@@ -123,20 +123,6 @@ export const getGenerateDashboard = ({
                 // Create dashboard with valid visualizations only
                 const prompt = await getPrompt();
 
-                await createOrUpdateArtifact({
-                    threadUuid: prompt.threadUuid,
-                    promptUuid: prompt.promptUuid,
-                    artifactType: 'dashboard',
-                    title: toolArgs.title,
-                    description: toolArgs.description,
-                    vizConfig: {
-                        ...toolArgs,
-                        visualizations: toolArgs.visualizations.filter(
-                            (_, index) => validIndices.has(index),
-                        ),
-                    },
-                });
-
                 // Return appropriate message based on whether some visualizations failed
                 if (errors.length > 0) {
                     return {
@@ -152,6 +138,20 @@ export const getGenerateDashboard = ({
                         },
                     };
                 }
+
+                await createOrUpdateArtifact({
+                    threadUuid: prompt.threadUuid,
+                    promptUuid: prompt.promptUuid,
+                    artifactType: 'dashboard',
+                    title: toolArgs.title,
+                    description: toolArgs.description,
+                    vizConfig: {
+                        ...toolArgs,
+                        visualizations: toolArgs.visualizations.filter(
+                            (_, index) => validIndices.has(index),
+                        ),
+                    },
+                });
 
                 return {
                     result: `Success`,


### PR DESCRIPTION

### Description:
Reordered the artifact creation logic in the dashboard generation process to ensure it only occurs after successful validation. This change moves the `createOrUpdateArtifact` call after the error handling logic, preventing artifacts from being created when there are validation errors.