### PR TITLE
fix: wrap in config and do not duplicate meta

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -98,10 +98,8 @@ const generateModelYml = ({
         description: '',
         ...(includeMeta
             ? wrapInConfig(dbtVersion, {
-                  meta: {
-                      dimension: {
-                          type: dimensionType,
-                      },
+                  dimension: {
+                      type: dimensionType,
                   },
               })
             : {}),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:

### Description:

Fixes a bug in `lightdash generate` where column metadata was being double-wrapped with `meta`, causing:

```
  - dbt 1.9: Generated YAMLs with meta: { meta: { dimension: ... } } instead of meta: { dimension: ... }
  - dbt 1.10: Generated YAMLs with config: { meta: { meta: { dimension: ... } } } instead of config: { meta: { dimension: ... } }
```

This caused errors when deploying metrics that referenced these incorrectly nested fields.

:bulb: Used this: `node ./packages/cli/dist/index.js generate -s orders --project-dir ./examples/full-jaffle-shop-demo/dbt --profiles-dir ./examples/full-jaffle-shop-demo/profiles`​

## Root Cause

In `/packages/cli/src/dbt/models.ts`, the `generateModelYml` function was passing an extra meta wrapper to the `wrapInConfig` helper:

```
  wrapInConfig(dbtVersion, {
      meta: {  // ← Extra meta key!
          dimension: {
              type: dimensionType,
          },
      },
  })
```

The `wrapInConfig` function already handles wrapping the metadata structure based on dbt version:

- dbt 1.9: { meta:  }
- dbt 1.10+: { config: { meta:  } }

By passing { meta: { dimension: ... } }, we were creating duplicate nesting.

Changes

File: packages/cli/src/dbt/models.ts:100-104

Removed the extra meta wrapper:

```
    wrapInConfig(dbtVersion, {
  -     meta: {
  -         dimension: {
  -             type: dimensionType,
  -         },
  -     },
  +     dimension: {
  +         type: dimensionType,
  +     },
    })
```

Before (Buggy) vs After (Fixed)

**dbt 1.9**

Before ❌:

```
  columns:
    - name: order_id
      description: ''
      meta:
        meta:           # ← DUPLICATE!
          dimension:
            type: number
```

After ✅:

```
  columns:
    - name: order_id
      description: ''
      meta:
        dimension:
          type: number
```

**dbt 1.10+**

Before ❌:

```
  columns:
    - name: order_id
      description: ''
      config:
        meta:
          meta:         # ← DUPLICATE!
            dimension:
              type: number
```

After ✅:

```
  columns:
    - name: order_id
      description: ''
      config:
        meta:
          dimension:
            type: number

```