### PR TITLE
fix: cancelling a chart edit should reset editing

### DIFF
--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -891,7 +891,11 @@ const ExplorerProvider: FC<
             type: ActionType.RESET,
             payload: initialState || defaultStateWithConfig,
         });
-    }, [defaultStateWithConfig, initialState]);
+        // Reset Redux state as well
+        reduxDispatch(
+            explorerActions.reset(initialState || defaultStateWithConfig),
+        );
+    }, [defaultStateWithConfig, initialState, reduxDispatch]);
 
     const setTableName = useCallback(
         (tableName: string) => {


### PR DESCRIPTION
### Description:

Fixes a bug where editing a chart, then cancelling keeps the edited unsavedChartVersion

To repro:
- Save a chart
- Edit it, make changes
- Cancel
- Edit again
- You will see the previously edited version

Note on implementation: I added the redux reset to the context instead of bringing redux into the Saved Chart Header. I did it this was because the header doesn't use redux yet. We could put the redux reset in the header instead, but it seems a little more prone to getting out of sync. Probably we should just migrate the header component to use all redux soon. 


