### PR TITLE
fix: prevent authentication method conflicts when merging warehouse credentials

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -268,10 +268,9 @@ export const mergeWarehouseCredentials = <T extends CreateWarehouseCredentials>(
         return newCredentials;
     }
 
-    // Merge credentials, with newCredentials taking precedence for connection details
-    // but baseCredentials providing advanced settings like requireUserCredentials
+    // We will use new credentials for connection, this might contain new authentication method
+    // do not include all baseCredentials here, to avoid conflicts on authentication (that will cause a mix of serviceaccounts/sso/passwords)
     const merged = {
-        ...baseCredentials,
         ...newCredentials,
         // Keep requireUserCredentials from base credentials, since this is a security setting and should not be overridden
         requireUserCredentials: baseCredentials.requireUserCredentials,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/17301

### Description:
Refactored the `mergeWarehouseCredentials` function to prevent authentication method conflicts. The function now only uses new credentials for connection details instead of merging all base credentials, which could cause issues when mixing different authentication methods (service accounts, SSO, passwords). The security setting `requireUserCredentials` is still preserved from the base credentials.