### PR TITLE
fix: removing a sorted field causes a query error

### DIFF
--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -917,16 +917,30 @@ const ExplorerProvider: FC<
                     : ActionType.TOGGLE_METRIC,
                 payload: fieldId,
             });
+
+            // Remove it from the sort for an unsaved chart
+            const filteredSorts = unsavedChartVersion.metricQuery.sorts.filter(
+                (s) => s.fieldId !== fieldId,
+            );
+            reduxDispatch(explorerActions.setSortFields(filteredSorts));
         },
-        [],
+        [reduxDispatch, unsavedChartVersion.metricQuery.sorts],
     );
 
-    const removeActiveField = useCallback((fieldId: FieldId) => {
-        dispatch({
-            type: ActionType.REMOVE_FIELD,
-            payload: fieldId,
-        });
-    }, []);
+    const removeActiveField = useCallback(
+        (fieldId: FieldId) => {
+            dispatch({
+                type: ActionType.REMOVE_FIELD,
+                payload: fieldId,
+            });
+            // Remove it from the sort for an unsaved chart
+            const filteredSorts = unsavedChartVersion.metricQuery.sorts.filter(
+                (s) => s.fieldId !== fieldId,
+            );
+            reduxDispatch(explorerActions.setSortFields(filteredSorts));
+        },
+        [reduxDispatch, unsavedChartVersion.metricQuery.sorts],
+    );
 
     const setRowLimit = useCallback((limit: number) => {
         dispatch({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17300

### Description:

Removing a field from a saved chart causes an error when the chart is sorted by that field. This used to fall back to the default sort instead.

**Repro:**
Create a chart with a sort by dimension
Remove that dimension
Error

**Bug**
![bug](https://github.com/user-attachments/assets/030c541e-9793-4e5e-a416-c051ac6f4839)

**Fixed**
![Kapture 2025-10-08 at 13 53 05](https://github.com/user-attachments/assets/dc8d9222-b6cb-4e14-b216-75cdf810d3da)
