### PR TITLE
fix: display base dimension name in proposed metric label

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
@@ -80,7 +80,7 @@ const CreateMetric = ({ change }: CreateMetricProps) => {
                 {metric.label}
             </Text>
             <Text size="xs" fw={600} c="dimmed">
-                ({friendlyName(metric.type)})
+                ({friendlyName(metric.type)} of {metric.baseDimensionName})
             </Text>
         </Paper>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Enhanced the display of metric information in the AI Copilot's ChangeRenderer component by adding the base dimension name to the metric type label. This provides users with more context about the metric being created or modified.
