### PR TITLE
chore: remove unnecessary changeset row copy when create/delete

### DIFF
--- a/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
+++ b/packages/frontend/src/features/changesets/components/ProjectChangesets.tsx
@@ -71,9 +71,8 @@ const extractChangeValue = (
 ): string | { path: string; value: string }[] => {
     switch (change.type) {
         case 'create':
-            return 'Create new item';
         case 'delete':
-            return 'Delete item';
+            return '';
         case 'update':
             return change.payload.patches.map((patch) => ({
                 path: patch.path.replace('/', ''),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:

Removes the default text values for 'create' and 'delete' change types in the `extractChangeValue` function, returning an empty string instead. This change affects how changeset information is displayed in the UI.