### PR TITLE
feat: add no results retry prompt for AI visualization tools

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/noResultsRetry.ts
+++ b/packages/backend/src/ee/services/ai/prompts/noResultsRetry.ts
@@ -1,0 +1,2 @@
+export const NO_RESULTS_RETRY_PROMPT = `No results were returned for your query.
+This may be due to the use of filter values. If you're filtering by specific values and aren't sure they exist in the data, use the "searchFieldValues`;

--- a/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateBarVizConfig.ts
@@ -7,6 +7,7 @@ import {
     toolVerticalBarOutputSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
+import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
 import type {
     CreateOrUpdateArtifactFn,
     GetExploreFn,
@@ -103,11 +104,21 @@ export const getGenerateBarVizConfig = ({
                         vizTool.tableCalculations,
                     ),
                 });
+
                 const queryResults = await runMiniMetricQuery(
                     metricQuery,
                     maxLimit,
                     populateCustomMetricsSQL(vizTool.customMetrics, explore),
                 );
+
+                if (queryResults.rows.length === 0) {
+                    return {
+                        result: NO_RESULTS_RETRY_PROMPT,
+                        metadata: {
+                            status: 'success',
+                        },
+                    };
+                }
 
                 await createOrUpdateArtifactHook();
 

--- a/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateTimeSeriesVizConfig.ts
@@ -7,6 +7,7 @@ import {
     toolTimeSeriesOutputSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
+import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
 import type {
     CreateOrUpdateArtifactFn,
     GetExploreFn,
@@ -103,11 +104,21 @@ export const getGenerateTimeSeriesVizConfig = ({
                         vizTool.tableCalculations,
                     ),
                 });
+
                 const queryResults = await runMiniMetricQuery(
                     metricQuery,
                     maxLimit,
                     populateCustomMetricsSQL(vizTool.customMetrics, explore),
                 );
+
+                if (queryResults.rows.length === 0) {
+                    return {
+                        result: NO_RESULTS_RETRY_PROMPT,
+                        metadata: {
+                            status: 'success',
+                        },
+                    };
+                }
 
                 await createOrUpdateArtifactHook();
 

--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -12,6 +12,7 @@ import {
 import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
 import { CsvService } from '../../../../services/CsvService/CsvService';
+import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
 import type {
     GetExploreFn,
     RunMiniMetricQueryFn,
@@ -100,6 +101,15 @@ export const getRunMetricQuery = ({
                     maxLimit,
                     populateCustomMetricsSQL(vizTool.customMetrics, explore),
                 );
+
+                if (results.rows.length === 0) {
+                    return {
+                        result: NO_RESULTS_RETRY_PROMPT,
+                        metadata: {
+                            status: 'success',
+                        },
+                    };
+                }
 
                 const fieldIds = results.rows[0]
                     ? Object.keys(results.rows[0])


### PR DESCRIPTION
Improves AI query error handling by adding a standardized message when queries return no results. The message prompts users to check their query and filters when no data is returned, providing clearer guidance for troubleshooting. This consistent message has been implemented across all visualization tools (bar, table, time series) and metric queries.