### PR TITLE
chore: add debugger launch.json config for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Backend",
+            "port": 9229,
+            "restart": true,
+            "skipFiles": ["<node_internals>/**"],
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/usr/app"
+        }
+    ]
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -155,8 +155,7 @@
     "scripts": {
         "generate-api": "tsoa spec-and-routes --configuration tsoa.yml",
         "generate-api-dev": "chokidar './src/controllers/**/*.ts' -c 'pnpm run generate-api'",
-        "dev": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false src/index.ts",
-        "debug": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false --inspect-brk=0.0.0.0:9229 src/index.ts",
+        "dev": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false --inspect=0.0.0.0:9229 src/index.ts",
         "build": "tsc --build tsconfig.json",
         "build-sourcemaps": "tsc --build tsconfig.sentry.json",
         "typecheck": "tsc --project tsconfig.json --noEmit",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added VSCode debugging configuration for the backend service and simplified the npm scripts by combining the `dev` and `debug` commands. Now developers can attach to the backend process using VSCode's debugger while running the standard development command.

The PR:
1. Adds a `.vscode/launch.json` file with an "Attach to Backend" configuration
2. Modifies the `dev` script to include the `--inspect` flag, enabling the debugger
3. Removes the separate `debug` script as it's now redundant


https://github.com/user-attachments/assets/3adf13b9-3d94-43a4-8e89-9ae09c4ea83b

