### PR TITLE
fix: claude sonnet default name fix

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const DEFAULT_OPENAI_MODEL_NAME = 'gpt-4.1-2025-04-14';
-export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-4-sonnet-20250514';
+export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-20250514';
 export const DEFAULT_DEFAULT_AI_PROVIDER = 'openai';
 export const DEFAULT_OPENROUTER_MODEL_NAME = 'openai/gpt-4.1-2025-04-14';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Updated the default Anthropic model name from `claude-4-sonnet-20250514` to `claude-sonnet-4-20250514` to match the correct naming convention.