### PR TITLE
style: uniform schedule & logs table heights

### DIFF
--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -607,7 +607,7 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
         },
         mantineTableContainerProps: {
             ref: tableContainerRef,
-            style: { maxHeight: 'calc(100dvh - 500px)' },
+            style: { maxHeight: 'calc(100dvh - 420px)' },
             onScroll: (event: UIEvent<HTMLDivElement>) =>
                 fetchMoreOnBottomReached(event.target as HTMLDivElement),
         },

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -592,7 +592,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({ projectUuid }) => {
         },
         mantineTableContainerProps: {
             ref: tableContainerRef,
-            style: { maxHeight: '600px' },
+            style: { maxHeight: 'calc(100dvh - 420px)' },
             onScroll: (event: UIEvent<HTMLDivElement>) =>
                 fetchMoreOnBottomReached(event.target as HTMLDivElement),
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Improves the table height consistency in the Schedulers view by setting both the LogsTable and SchedulersTable to use the same dynamic height calculation (`calc(100dvh - 420px)`). This replaces the previous fixed height of 600px for the SchedulersTable and adjusts the LogsTable from `-500px` to `-420px`, ensuring a more consistent UI experience.