### PR TITLE
feat: add bar chart display style for table columns

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -154,6 +154,7 @@ export type ColumnProperties = {
     visible?: boolean;
     name?: string;
     frozen?: boolean;
+    displayStyle?: 'text' | 'bar';
 };
 
 export type TableChart = {

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -189,6 +189,12 @@ export type VizColumnConfig = {
     frozen: boolean;
     order?: number;
     aggregation?: VizAggregationOptions;
+    displayStyle?: 'text' | 'bar';
+    barConfig?: {
+        min?: number; // Default: auto-calculate from column
+        max?: number; // Default: auto-calculate from column
+        color?: string; // Default: '#5470c6'
+    };
 };
 
 export type VizColumnsConfig = { [key: string]: VizColumnConfig };

--- a/packages/frontend/src/components/DataViz/utils/columnStats.ts
+++ b/packages/frontend/src/components/DataViz/utils/columnStats.ts
@@ -1,0 +1,44 @@
+import { type RawResultRow } from '@lightdash/common';
+
+export type ColumnStats = {
+    min: number;
+    max: number;
+};
+
+export type ColumnStatsMap = Record<string, ColumnStats>;
+
+/**
+ * Calculate min/max statistics for numeric columns
+ * Used for scaling bar chart displays
+ */
+export function calculateColumnStats(
+    rows: RawResultRow[],
+    columnReferences: string[],
+): ColumnStatsMap {
+    const stats: ColumnStatsMap = {};
+
+    if (rows.length === 0) return stats;
+
+    // Initialize with first row values
+    columnReferences.forEach((colRef) => {
+        // Initialize stats for all columns with default values
+        stats[colRef] = { min: Infinity, max: -Infinity };
+    });
+
+    // Scan all rows to find min/max
+    rows.forEach((row) => {
+        columnReferences.forEach((colRef) => {
+            const value = Number(row[colRef]);
+            if (!Number.isNaN(value) && stats[colRef]) {
+                if (value < stats[colRef].min) {
+                    stats[colRef].min = value;
+                }
+                if (value > stats[colRef].max) {
+                    stats[colRef].max = value;
+                }
+            }
+        });
+    });
+
+    return stats;
+}

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -61,6 +61,16 @@ export const ExplorerResults = memo(() => {
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
     const tableCalculations = useExplorerSelector(selectTableCalculations);
 
+    // Get chart config for column properties
+    const chartConfig = useExplorerContext(
+        (context) => context.state.unsavedChartVersion.chartConfig,
+    );
+    const columnProperties =
+        chartConfig.type === 'table' && chartConfig.config?.columns
+            ? chartConfig.config.columns
+            : undefined;
+
+    // Get query state from new hook
     const {
         query,
         queryResults,
@@ -254,6 +264,7 @@ export const ExplorerResults = memo(() => {
                     pagination={pagination}
                     footer={footer}
                     showSubtotals={false}
+                    columnProperties={columnProperties}
                 />
                 <JsonViewerModal
                     heading={`Field: ${expandData.name}`}

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -238,6 +238,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 showSubtotals={showSubtotals}
                 conditionalFormattings={conditionalFormattings}
                 minMaxMap={minMaxMap}
+                columnProperties={
+                    visualizationConfig.chartConfig.columnProperties
+                }
                 footer={pagination}
                 headerContextMenu={headerContextMenu}
                 cellContextMenu={cellContextMenu}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/BarChartDisplay.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/BarChartDisplay.tsx
@@ -1,0 +1,86 @@
+import {
+    getItemId,
+    isFilterableItem,
+    isNumericItem,
+    type FilterableItem,
+} from '@lightdash/common';
+import { Checkbox, Stack, Text } from '@mantine/core';
+import { useMemo, type FC } from 'react';
+import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import { Config } from '../common/Config';
+
+export const BarChartDisplay: FC = () => {
+    const { itemsMap, resultsData, visualizationConfig } =
+        useVisualizationContext();
+
+    const chartConfig = useMemo(() => {
+        if (!isTableVisualizationConfig(visualizationConfig)) return undefined;
+        return visualizationConfig.chartConfig;
+    }, [visualizationConfig]);
+
+    const activeFields = useMemo(() => {
+        if (!resultsData?.metricQuery) return new Set<string>();
+        return new Set([
+            ...resultsData.metricQuery.dimensions,
+            ...resultsData.metricQuery.metrics,
+            ...resultsData.metricQuery.tableCalculations.map((tc) => tc.name),
+        ]);
+    }, [resultsData]);
+
+    const numericFields = useMemo<FilterableItem[]>(() => {
+        if (!itemsMap) return [];
+        return Object.values(itemsMap)
+            .filter((field) => activeFields.has(getItemId(field)))
+            .filter(
+                (field) => isNumericItem(field) && isFilterableItem(field),
+            ) as FilterableItem[];
+    }, [itemsMap, activeFields]);
+
+    if (!chartConfig) {
+        return null;
+    }
+
+    if (numericFields.length === 0) {
+        return (
+            <Text c="dimmed" size="sm">
+                No numeric columns available for bar chart display
+            </Text>
+        );
+    }
+
+    return (
+        <Config>
+            <Config.Section>
+                <Config.Heading>Bar chart columns</Config.Heading>
+                <Stack spacing="md">
+                    <Text size="sm" c="dimmed">
+                        Display numeric values as bar charts
+                    </Text>
+
+                    {numericFields.map((field) => {
+                        const fieldId = getItemId(field);
+                        const isBarChart =
+                            chartConfig.columnProperties[fieldId]
+                                ?.displayStyle === 'bar';
+
+                        return (
+                            <Checkbox
+                                key={fieldId}
+                                label={field.name}
+                                checked={isBarChart}
+                                onChange={(e) => {
+                                    chartConfig.updateColumnProperty(fieldId, {
+                                        displayStyle: e.currentTarget.checked
+                                            ? 'bar'
+                                            : 'text',
+                                    });
+                                }}
+                            />
+                        );
+                    })}
+                </Stack>
+            </Config.Section>
+        </Config>
+    );
+};

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
@@ -1,6 +1,7 @@
 import { MantineProvider, Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
 import { themeOverride } from '../mantineTheme';
+import { BarChartDisplay } from './BarChartDisplay';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
 
@@ -14,6 +15,9 @@ export const ConfigTabs: FC = memo(() => (
                 <Tabs.Tab px="sm" value="conditional-formatting">
                     Conditional formatting
                 </Tabs.Tab>
+                <Tabs.Tab px="sm" value="bar-chart">
+                    Bar display
+                </Tabs.Tab>
             </Tabs.List>
 
             <Tabs.Panel value="general">
@@ -21,6 +25,9 @@ export const ConfigTabs: FC = memo(() => (
             </Tabs.Panel>
             <Tabs.Panel value="conditional-formatting">
                 <ConditionalFormattingList />
+            </Tabs.Panel>
+            <Tabs.Panel value="bar-chart">
+                <BarChartDisplay />
             </Tabs.Panel>
         </Tabs>
     </MantineProvider>

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -52,6 +52,8 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
         columnOrder,
         fetchMoreRows,
         pagination,
+        columnProperties,
+        minMaxMap,
     } = rest;
     const [grouping, setGrouping] = useState<GroupingState>([]);
     const [columnVisibility, setColumnVisibility] = useState({});
@@ -164,6 +166,10 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
                 ],
             },
             pagination: paginationState,
+        },
+        meta: {
+            columnProperties,
+            minMaxMap,
         },
         enableColumnPinning: true,
         onColumnVisibilityChange: setColumnVisibility,

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -1,4 +1,5 @@
 import type {
+    ColumnProperties,
     ConditionalFormattingConfig,
     ConditionalFormattingMinMaxMap,
     CustomDimension,
@@ -68,6 +69,7 @@ export type ProviderProps = {
     showColumnCalculation?: boolean;
     conditionalFormattings?: ConditionalFormattingConfig[];
     minMaxMap?: ConditionalFormattingMinMaxMap;
+    columnProperties?: Record<string, ColumnProperties>;
     footer?: {
         show?: boolean;
     };

--- a/packages/frontend/src/hooks/barChartDisplay.tsx
+++ b/packages/frontend/src/hooks/barChartDisplay.tsx
@@ -1,0 +1,53 @@
+/**
+ * Renders a bar chart display for positive numeric values in table cells.
+ */
+import { type ReactElement } from 'react';
+
+type BarChartDisplayProps = {
+    value: number;
+    formatted: string;
+    min: number;
+    max: number;
+    color?: string;
+};
+
+export const renderBarChartDisplay = ({
+    value,
+    formatted,
+    min,
+    max,
+    color = '#5470c6',
+}: BarChartDisplayProps): ReactElement => {
+    // Calculate bar width percentage
+    const range = max - min;
+    const percentage =
+        range > 0
+            ? Math.max(0, Math.min(100, ((value - min) / range) * 100))
+            : 0;
+
+    // Only show bar for positive numbers
+    const showBar = value > 0;
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+            }}
+        >
+            {showBar && (
+                <div
+                    style={{
+                        width: `${percentage}%`,
+                        minWidth: '2px', // Always show visible bar for positive values
+                        height: '20px',
+                        backgroundColor: color,
+                        borderRadius: '2px',
+                    }}
+                />
+            )}
+            <span style={{ whiteSpace: 'nowrap' }}>{formatted}</span>
+        </div>
+    );
+};

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -6,6 +6,7 @@ import {
     isDimension,
     isField,
     isNumericItem,
+    isResultValue,
     itemsInMetricQuery,
     type AdditionalMetric,
     type CustomDimension,
@@ -43,6 +44,7 @@ import {
     selectTableName,
     useExplorerSelector,
 } from '../features/explorer/store';
+import { renderBarChartDisplay } from './barChartDisplay';
 import { useCalculateTotal } from './useCalculateTotal';
 import { useExplore } from './useExplore';
 import { useExplorerQuery } from './useExplorerQuery';
@@ -62,12 +64,80 @@ export const formatCellContent = (data?: { value: ResultValue }) => {
     return data?.value.formatted ?? '-';
 };
 
+const isBarDisplay = (
+    info:
+        | CellContext<ResultRow, { value: ResultValue }>
+        | CellContext<RawResultRow, string>,
+) => {
+    const minMaxMap = info.table?.options.meta?.minMaxMap;
+    const columnProperties = info.table?.options.meta?.columnProperties;
+    const displayStyle = columnProperties?.[info.column.id]?.displayStyle;
+    return minMaxMap && displayStyle === 'bar';
+};
+
+const formatBarDisplayCell = (
+    info:
+        | CellContext<ResultRow, { value: ResultValue }>
+        | CellContext<RawResultRow, string>,
+) => {
+    const cellValue = info.getValue();
+    const columnId = info.column.id;
+
+    const minMaxMap = info.table?.options.meta?.minMaxMap;
+
+    let formatted, value: number;
+
+    if (isResultValue(cellValue)) {
+        // Parse value - numeric metrics may return strings from the database (e.g., "1" for count_distinct)
+        const rawValue = cellValue.value.raw;
+        value = typeof rawValue === 'number' ? rawValue : Number(rawValue);
+        formatted = cellValue.value.formatted;
+
+        // Only render bar if value is a valid number
+        if (Number.isNaN(value)) {
+            return formatCellContent(cellValue);
+        }
+    } else {
+        value = Number(cellValue);
+        formatted = formatRowValueFromWarehouse(cellValue);
+    }
+
+    // Get min/max from minMaxMap (same as conditional formatting)
+    const min = minMaxMap[columnId]?.min ?? 0;
+    const max = minMaxMap[columnId]?.max ?? 100;
+
+    return renderBarChartDisplay({
+        value,
+        formatted,
+        min,
+        max,
+    });
+};
+
 export const getFormattedValueCell = (
     info: CellContext<ResultRow, { value: ResultValue }>,
-) => formatCellContent(info.getValue());
+) => {
+    const cellValue = info.getValue();
+
+    try {
+        if (isBarDisplay(info)) return formatBarDisplayCell(info);
+    } catch (error) {
+        console.error(`Unable to format value for bar display cell ${error}`);
+    }
+
+    return formatCellContent(cellValue);
+};
 
 export const getValueCell = (info: CellContext<RawResultRow, string>) => {
     const value = info.getValue();
+
+    try {
+        if (isBarDisplay(info)) return formatBarDisplayCell(info);
+    } catch (error) {
+        console.error(`Unable to get value for bar display cell ${error}`);
+    }
+
+    // Default text rendering
     const formatted = formatRowValueFromWarehouse(value);
     return <span>{formatted}</span>;
 };

--- a/packages/frontend/src/types/@tanstack-react-table.d.ts
+++ b/packages/frontend/src/types/@tanstack-react-table.d.ts
@@ -1,5 +1,10 @@
-import { type ItemsMap, type PivotReference } from '@lightdash/common';
+import {
+    type ItemsMap,
+    type PivotReference,
+    type VizColumnsConfig,
+} from '@lightdash/common';
 import { type MouseEventHandler } from 'react';
+import { type ColumnStatsMap } from '../components/DataViz/utils/columnStats';
 import { type Sort } from '../components/common/Table/types';
 
 declare module '@tanstack/react-table' {
@@ -18,5 +23,11 @@ declare module '@tanstack/react-table' {
         onHeaderClick?: MouseEventHandler<HTMLTableHeaderCellElement>;
         type?: string;
         headerInfo?: Record<string, any>;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+    interface TableMeta<_TData extends RowData> {
+        columnStats?: ColumnStatsMap;
+        columnsConfig?: VizColumnsConfig;
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-64/cell-visualization-bar-in-table

This is a POC: the currenct configuration is very simple, just a list of fields, in the future, we can add different color, values, etc. 

PR for making this work with pivot tables https://github.com/lightdash/lightdash/pull/17366

Compatible with charts as code
Can be visualized in dashboards too

<img width="777" height="789" alt="Screenshot from 2025-10-09 09-10-47" src="https://github.com/user-attachments/assets/f451e47d-926b-4198-a5bf-5473d9bc4de9" />

<img width="1709" height="649" alt="Screenshot from 2025-10-09 09-17-13" src="https://github.com/user-attachments/assets/127c18a9-189f-4ec7-ad21-142a6714b6f2" />

<img width="1755" height="710" alt="Screenshot from 2025-10-09 09-09-55" src="https://github.com/user-attachments/assets/feaf6bdc-2aa9-44ea-b0ef-0ab987d3580e" />

Negative numbers simply don't show up (I think that works for now), we can change this later

<img width="1300" height="612" alt="image" src="https://github.com/user-attachments/assets/a0ba445a-5748-4b92-b320-2957bdf20928" />


### Description:
Added bar chart display style for table columns. This feature allows numeric columns to be visualized as horizontal bars alongside their text values.

Key changes:
- Extended `VizColumnConfig` type to include `displayStyle` option ('text' or 'bar')
- Added bar configuration options for customizing min/max values and colors
- Implemented column statistics calculation to automatically determine appropriate scaling
- Enhanced cell rendering to support bar visualization while preserving the numeric value

![Bar chart in table columns](https://placeholder-for-screenshot.png)