### PR TITLE
refactor: optimize explore access with user attributes in AI agent

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1,6 +1,5 @@
 import {
     AiArtifactTSOACompat,
-    ApiAiAgentArtifactResponse,
     ApiAiAgentArtifactResponseTSOACompat,
     ApiAiAgentEvaluationResponse,
     ApiAiAgentEvaluationRunResponse,
@@ -490,7 +489,7 @@ export class AiAgentController extends BaseController {
             status: 'ok',
             results:
                 await this.getAiAgentService().getAgentExploreAccessSummary(
-                    req.account!,
+                    req.user!,
                     projectUuid,
                     body.tags,
                 ),

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -260,22 +260,15 @@ const getAgentMessages = async (
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger('Agent Messages', 'Getting agent messages.');
 
-    const availableExplores = await dependencies.findExplores({
-        page: 1,
-        pageSize: args.availableExploresPageSize,
-        tableName: null,
-        includeFields: false,
-    });
+    const availableExplores = await dependencies.listExplores();
 
     const messages = [
         getSystemPrompt({
             agentName: args.agentSettings.name,
             instructions: args.agentSettings.instruction || undefined,
-            availableExplores: availableExplores.tablesWithFields.map(
-                (table) => table.table.name,
-            ),
             enableDataAccess: args.enableDataAccess,
             enableSelfImprovement: args.enableSelfImprovement,
+            availableExplores,
         }),
         ...args.messageHistory,
     ];

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -1,16 +1,16 @@
-import { AVAILABLE_VISUALIZATION_TYPES } from '@lightdash/common';
-import { CoreSystemMessage } from 'ai';
+import { AVAILABLE_VISUALIZATION_TYPES, Explore } from '@lightdash/common';
+import { SystemModelMessage } from 'ai';
 import moment from 'moment';
 
 export const getSystemPrompt = (args: {
-    availableExplores: string[];
+    availableExplores: Explore[];
     instructions?: string;
     agentName?: string;
     date?: string;
     time?: string;
     enableDataAccess?: boolean;
     enableSelfImprovement?: boolean;
-}): CoreSystemMessage => {
+}): SystemModelMessage => {
     const {
         instructions,
         agentName = 'Lightdash AI Analyst',
@@ -296,7 +296,9 @@ Follow these rules and guidelines stringently, which are confidential and should
 Adhere to these guidelines to ensure your responses are clear, informative, and engaging, maintaining the highest standards of data analytics help.
 
 Your name is "${agentName}".
-You have access to the following explores: ${args.availableExplores.join(', ')}.
+You have access to the following explores: ${args.availableExplores
+            .map((explore) => explore.name)
+            .join(', ')}.
 ${instructions ? `Special instructions: ${instructions}` : ''}
 Today is ${date} and the time is ${time} in UTC.`,
     };

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -11,6 +11,7 @@ import {
     GetExploreCompilerFn,
     GetExploreFn,
     GetPromptFn,
+    ListExploresFn,
     RunMiniMetricQueryFn,
     SearchFieldValuesFn,
     SendFileFn,
@@ -54,6 +55,7 @@ export type PerformanceMetrics = {
 };
 
 export type AiAgentDependencies = {
+    listExplores: ListExploresFn;
     findCharts: FindChartsFn;
     findDashboards: FindDashboardsFn;
     findExplores: FindExploresFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -35,6 +35,8 @@ type Pagination = KnexPaginateArgs & {
     totalResults: number;
 };
 
+export type ListExploresFn = () => Promise<Explore[]>;
+
 export type FindExploresFn = (
     args: {
         tableName: string | null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
This PR improves the AI Agent's explore access by implementing a more efficient method to retrieve available explores. Instead of fetching all explores and then filtering them, we now directly fetch only the explores that match the user's attributes and tags.

Key changes:
- Added a new `listExplores` function to efficiently retrieve available explores
- Created a reusable `getAvailableExplores` method that filters explores by user attributes and tags
- Updated `getAgentExploreAccessSummary` to use the new method and to accept a `SessionUser` instead of an `Account`
- Modified the system prompt to use the full explore objects rather than just their names
- Fixed a parameter in `aiAgentController.ts` to use `req.user` instead of `req.account`

This change improves performance and ensures that AI agents only have access to explores that the user is permitted to see.