### PR TITLE
fix: error when removing sort by metric

### DIFF
--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -863,6 +863,15 @@ const ExplorerProvider: FC<
         );
     }, [unsavedChartVersion.metricQuery.tableCalculations, reduxDispatch]);
 
+    // Keep Redux sorts in sync with Context sorts
+    useEffect(() => {
+        reduxDispatch(
+            explorerActions.setSortFields(
+                unsavedChartVersion.metricQuery.sorts,
+            ),
+        );
+    }, [unsavedChartVersion.metricQuery.sorts, reduxDispatch]);
+
     // END TRANSITIONAL SYNC CODE
 
     const [activeFields, isValidQuery] = useMemo<
@@ -917,30 +926,16 @@ const ExplorerProvider: FC<
                     : ActionType.TOGGLE_METRIC,
                 payload: fieldId,
             });
-
-            // Remove it from the sort for an unsaved chart
-            const filteredSorts = unsavedChartVersion.metricQuery.sorts.filter(
-                (s) => s.fieldId !== fieldId,
-            );
-            reduxDispatch(explorerActions.setSortFields(filteredSorts));
         },
-        [reduxDispatch, unsavedChartVersion.metricQuery.sorts],
+        [],
     );
 
-    const removeActiveField = useCallback(
-        (fieldId: FieldId) => {
-            dispatch({
-                type: ActionType.REMOVE_FIELD,
-                payload: fieldId,
-            });
-            // Remove it from the sort for an unsaved chart
-            const filteredSorts = unsavedChartVersion.metricQuery.sorts.filter(
-                (s) => s.fieldId !== fieldId,
-            );
-            reduxDispatch(explorerActions.setSortFields(filteredSorts));
-        },
-        [reduxDispatch, unsavedChartVersion.metricQuery.sorts],
-    );
+    const removeActiveField = useCallback((fieldId: FieldId) => {
+        dispatch({
+            type: ActionType.REMOVE_FIELD,
+            payload: fieldId,
+        });
+    }, []);
 
     const setRowLimit = useCallback((limit: number) => {
         dispatch({


### PR DESCRIPTION
### Description:

Fixes another error that occurs when a field being sorted by is removed from a query. I tried to fix a very similar thing yesterday, the solution I put in was incomplete. This more closely follows the existing patterns for keeping state in sync. 

To repro the bug:
- Start a new explore
- Select a dimension and a metric
- Run the query
- Remove the metric
- You will see an error

This should fix that. 
