### PR TITLE
style: render ai textarea within portal

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Button, Flex, Group, Loader, Text } from '@mantine/core';
+import { Group, Loader, Stack, Text } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';
@@ -10,8 +10,8 @@ import DocumentationHelpButton from '../../../DocumentationHelpButton';
 import { isCustomVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../../common/Config';
-import { GenerateVizWithAi } from './components/CustomVisAi';
-import { SelectTemplate } from './components/CustomVisTemplate';
+import { GenerateVisWithAi } from './components/CustomVisAi';
+import { CustomVisTemplate } from './components/CustomVisTemplate';
 import { type Schema } from './types/types';
 
 const MONACO_DEFAULT_OPTIONS: EditorProps['options'] = {
@@ -205,62 +205,58 @@ export const ConfigTabs: React.FC = memo(() => {
     const isEditorEmpty = (editorConfig || '')?.length === 0;
 
     return (
-        <>
+        <Stack>
             <Config>
                 <Config.Section>
                     <Config.Group>
                         <Config.Heading>
-                            <Flex justify="space-between" gap="xs">
-                                <Text>Vega-Lite JSON</Text>
+                            <Group gap="two">
+                                <Text fw={500} fz="sm">
+                                    Vega-Lite JSON
+                                </Text>
                                 <DocumentationHelpButton
                                     pos="relative"
                                     top="2px"
                                     href="https://docs.lightdash.com/references/custom-charts#custom-charts"
                                 />
-                            </Flex>
+                            </Group>
                         </Config.Heading>
 
-                        <Button.Group>
-                            <SelectTemplate
+                        <Group gap="0">
+                            <CustomVisTemplate
                                 itemsMap={itemsMap}
                                 isCustomConfig={isCustomConfig}
                                 isEditorEmpty={isEditorEmpty}
                                 setEditorConfig={setEditorConfig}
+                                isInGroup={isAiEnabled}
                             />
 
                             {isAiEnabled && (
-                                <GenerateVizWithAi
+                                <GenerateVisWithAi
                                     itemsMap={itemsMap}
                                     sampleResults={series.slice(0, 3)}
                                     setEditorConfig={setEditorConfig}
                                     editorConfig={editorConfig}
                                 />
                             )}
-                        </Button.Group>
+                        </Group>
                     </Config.Group>
                 </Config.Section>
             </Config>
-            <Group
-                h="calc(100vh - 300px)"
-                align="top"
-                mt="4px"
-                sx={{
-                    borderTop: '0.125rem solid #dee2e6',
-                }}
-            >
+            <Group h="calc(100vh - 300px)" align="top">
                 {/* Hack to show a monaco placeholder */}
                 {isEditorEmpty ? (
                     <Text
                         pos="absolute"
                         w="330px"
-                        color="gray.5"
-                        sx={{
+                        c="gray.5"
+                        fz="xs"
+                        lh="19px"
+                        ml="35px" // Style to match Monaco text
+                        ff="monospace"
+                        style={{
                             pointerEvents: 'none',
                             zIndex: 100,
-                            fontFamily: 'monospace',
-                            marginLeft: '35px', // Stye to match Monaco text
-                            fontSize: '12px',
-                            lineHeight: '19px',
                             letterSpacing: '0px',
                         }}
                     >
@@ -299,6 +295,6 @@ export const ConfigTabs: React.FC = memo(() => {
                     }}
                 />
             </Group>
-        </>
+        </Stack>
     );
 });

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
@@ -1,12 +1,12 @@
 import { type ItemsMap } from '@lightdash/common';
-import { Button, Popover, Textarea } from '@mantine/core';
+import { Button, Group, Popover, Stack, Textarea } from '@mantine-8/core';
 import { IconSparkles } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import MantineIcon from '../../../../common/MantineIcon';
 import { useCustomVis } from '../hooks/useCustomVisAi';
 
-export const GenerateVizWithAi = ({
+export const GenerateVisWithAi = ({
     itemsMap,
     sampleResults,
     editorConfig,
@@ -29,6 +29,7 @@ export const GenerateVizWithAi = ({
     useEffect(() => {
         if (data) setEditorConfig(data);
     }, [data, setEditorConfig]);
+
     const handleSubmit = useCallback(() => {
         if (isLoading) return;
 
@@ -50,44 +51,62 @@ export const GenerateVizWithAi = ({
     ]);
 
     return (
-        <Popover width="400px" position="bottom" withArrow shadow="md">
+        <Popover
+            width="400px"
+            position="bottom"
+            withArrow
+            shadow="md"
+            withinPortal
+        >
             <Popover.Target>
                 <Button
-                    compact
+                    size="compact-sm"
                     variant="default"
                     fz="xs"
-                    leftIcon={<MantineIcon icon={IconSparkles} />}
+                    leftSection={<MantineIcon icon={IconSparkles} />}
+                    styles={{
+                        root: {
+                            borderTopLeftRadius: 0,
+                            borderBottomLeftRadius: 0,
+                            borderLeftColor: 'transparent',
+                        },
+                    }}
                 >
                     AI
                 </Button>
             </Popover.Target>
 
             <Popover.Dropdown>
-                <Textarea
-                    placeholder="Create a heatmap with detailed tooltips and clear values for fast insights"
-                    autosize
-                    autoFocus={true}
-                    minRows={1}
-                    maxRows={20}
-                    onChange={(event) => {
-                        setPrompt(event.currentTarget.value);
-                    }}
-                    onKeyDown={(event) => {
-                        if (event.key === 'Enter' && !event.shiftKey) {
-                            event.preventDefault();
-                            handleSubmit();
-                        }
-                    }}
-                />
+                <Stack gap="xs">
+                    <Textarea
+                        placeholder="Create a heatmap with detailed tooltips and clear values for fast insights"
+                        autosize
+                        radius="md"
+                        autoFocus={true}
+                        minRows={1}
+                        maxRows={20}
+                        onChange={(event) => {
+                            setPrompt(event.currentTarget.value);
+                        }}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter' && !event.shiftKey) {
+                                event.preventDefault();
+                                handleSubmit();
+                            }
+                        }}
+                    />
 
-                <Button
-                    mt="sm"
-                    type="submit"
-                    disabled={isLoading}
-                    onClick={handleSubmit}
-                >
-                    {isLoading ? 'Generating...' : 'Generate'}
-                </Button>
+                    <Group justify="flex-end">
+                        <Button
+                            type="submit"
+                            size="compact-sm"
+                            loading={isLoading}
+                            onClick={handleSubmit}
+                        >
+                            {isLoading ? 'Generating...' : 'Generate'}
+                        </Button>
+                    </Group>
+                </Stack>
             </Popover.Dropdown>
         </Popover>
     );

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisTemplate.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisTemplate.tsx
@@ -3,7 +3,7 @@ import {
     sortedItemsForXAxis,
     sortedItemsForYAxis,
 } from '@lightdash/common';
-import { Button, Menu } from '@mantine/core';
+import { Button, Menu } from '@mantine-8/core';
 import {
     IconChartBar,
     IconChartBubble,
@@ -14,7 +14,6 @@ import {
     IconWorld,
 } from '@tabler/icons-react';
 import { useCallback } from 'react';
-import { COLLAPSABLE_CARD_POPOVER_PROPS } from '../../../../common/CollapsableCard/constants';
 import MantineIcon from '../../../../common/MantineIcon';
 import { generateVegaTemplate } from '../utils/templates';
 import { TemplateType } from '../utils/vegaTemplates';
@@ -34,18 +33,19 @@ const getTemplateIcon = (template: TemplateType) => {
         case TemplateType.MAP:
             return IconWorld;
     }
-
-    return IconChartBar;
 };
-export const SelectTemplate = ({
+
+export const CustomVisTemplate = ({
     itemsMap,
     isCustomConfig,
     setEditorConfig,
+    isInGroup,
 }: {
     itemsMap: ItemsMap | undefined;
     isCustomConfig: boolean;
     isEditorEmpty: boolean;
     setEditorConfig: (config: string) => void;
+    isInGroup: boolean;
 }) => {
     const loadTemplate = useCallback(
         (template: TemplateType) => {
@@ -66,30 +66,38 @@ export const SelectTemplate = ({
     );
 
     return (
-        <Menu {...COLLAPSABLE_CARD_POPOVER_PROPS} width={183} closeOnItemClick>
+        <Menu closeOnItemClick>
             <Menu.Dropdown>
                 {Object.values(TemplateType).map((template) => (
                     <Menu.Item
                         key={template}
                         onClick={() => loadTemplate(template)}
-                        icon={<MantineIcon icon={getTemplateIcon(template)} />}
+                        leftSection={
+                            <MantineIcon icon={getTemplateIcon(template)} />
+                        }
                     >
                         {template}
                     </Menu.Item>
                 ))}
                 <Menu.Divider />
-                <Menu.Label>
+                <Menu.Label w="150" fz="xs">
                     Selecting a new template will reset the config. Use "ctrl+z"
                     to undo.
                 </Menu.Label>
             </Menu.Dropdown>
             <Menu.Target>
                 <Button
-                    size="sm"
+                    size="compact-sm"
                     variant="default"
-                    compact
                     fz="xs"
-                    leftIcon={<MantineIcon icon={IconPlus} />}
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    styles={{
+                        root: {
+                            borderTopRightRadius: isInGroup ? 0 : undefined,
+                            borderBottomRightRadius: isInGroup ? 0 : undefined,
+                            borderRightRadius: isInGroup ? 0 : undefined,
+                        },
+                    }}
                 >
                     Insert template
                 </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:

Upgraded the Custom Visualization UI components to use Mantine 8 and improved the overall layout and styling:

- Migrated from `@mantine/core` to `@mantine-8/core` for all components
- Renamed `GenerateVizWithAi` to `GenerateVisWithAi` for consistency
- Renamed `SelectTemplate` to `CustomVisTemplate` for better clarity
- Improved button styling with proper border radius handling when grouped
- Enhanced the AI generation popover with better spacing and layout
- Replaced `Flex` with `Stack` and `Group` components for more consistent spacing
- Updated styling to use Mantine's shorthand props (e.g., `c` instead of `color`)
- Improved the editor placeholder text styling
- Added `withinPortal` to the AI popover for better rendering

before

![CleanShot 2025-10-09 at 11.27.34.gif](https://app.graphite.dev/user-attachments/assets/41ac9f0c-bbf7-4447-a67b-d564f1955c14.gif)

after

![CleanShot 2025-10-09 at 11.25.30.gif](https://app.graphite.dev/user-attachments/assets/bfa197a8-9588-43e5-a98a-69b555d11d1c.gif)

