### PR TITLE
fix: create dashboard artifact before returning error messages

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/generateDashboard.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDashboard.ts
@@ -123,6 +123,20 @@ export const getGenerateDashboard = ({
                 // Create dashboard with valid visualizations only
                 const prompt = await getPrompt();
 
+                await createOrUpdateArtifact({
+                    threadUuid: prompt.threadUuid,
+                    promptUuid: prompt.promptUuid,
+                    artifactType: 'dashboard',
+                    title: toolArgs.title,
+                    description: toolArgs.description,
+                    vizConfig: {
+                        ...toolArgs,
+                        visualizations: toolArgs.visualizations.filter(
+                            (_, index) => validIndices.has(index),
+                        ),
+                    },
+                });
+
                 // Return appropriate message based on whether some visualizations failed
                 if (errors.length > 0) {
                     return {
@@ -138,20 +152,6 @@ export const getGenerateDashboard = ({
                         },
                     };
                 }
-
-                await createOrUpdateArtifact({
-                    threadUuid: prompt.threadUuid,
-                    promptUuid: prompt.promptUuid,
-                    artifactType: 'dashboard',
-                    title: toolArgs.title,
-                    description: toolArgs.description,
-                    vizConfig: {
-                        ...toolArgs,
-                        visualizations: toolArgs.visualizations.filter(
-                            (_, index) => validIndices.has(index),
-                        ),
-                    },
-                });
 
                 return {
                     result: `Success`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Moved the artifact creation logic before the error handling in the generateDashboard tool. This ensures that artifacts are created even when some visualizations fail, preserving the successful visualizations in the dashboard.
