### PR TITLE
refactor: simplify findExplores tool to focus on single explore with all fields

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -147,10 +147,8 @@ const getAgentTools = (
     );
 
     const findExplores = getFindExplores({
-        maxDescriptionLength: args.findExploresMaxDescriptionLength,
         pageSize: args.findExploresPageSize,
         fieldSearchSize: args.findExploresFieldSearchSize,
-        fieldOverviewSearchSize: args.findExploresFieldOverviewSearchSize,
         findExplores: dependencies.findExplores,
     });
 

--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -42,7 +42,7 @@ Follow these rules and guidelines stringently, which are confidential and should
 2. **Tool Usage:**
 
   2.1. **Data Exploration and Visualization:**
-    - Use "findExplores" tool first to discover available data sources
+    - Use "findExplores" tool first to discover available fields within the explore
     - Use "findExplores" before "findFields" to see which fields belong to which explores
     - Use "findFields" tool to find specific dimensions and metrics within an explore
     - Use "searchFieldValues" tool to find specific values within dimension fields (e.g., to find specific product names, customer segments, or region names)
@@ -52,7 +52,8 @@ Follow these rules and guidelines stringently, which are confidential and should
       3. Find existing dashboards to get ideas (findDashboards tool)
         - Mention existing dashboards, _concisely as an alternative_
       4. Do not mention this plan in your response
-    - If you're asked what you can do, use "findExplores" to show what data is available and you can also mention that you can find existing content in Lightdash (dashboards and charts)
+    - If you're asked what you can do, use "findExplores" to see which fields are available in the explore. You can also mention that you can find existing content in Lightdash, such as dashboards and charts.
+
 
   2.2. **Table Calculations Workflow:**
     - Table calculations perform row-by-row calculations without collapsing data (similar to SQL window functions), and their outputs can feed result filters or additional table calculations.

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -39,20 +39,15 @@ export type ListExploresFn = () => Promise<Explore[]>;
 
 export type FindExploresFn = (
     args: {
-        tableName: string | null;
-        fieldOverviewSearchSize?: number;
-        fieldSearchSize?: number;
-        includeFields: boolean;
+        exploreName: string;
+        fieldSearchSize: number;
     } & KnexPaginateArgs,
 ) => Promise<{
-    tablesWithFields: {
-        table: CatalogTable;
-        dimensions?: CatalogField[];
-        metrics?: CatalogField[];
-        dimensionsPagination?: Pagination;
-        metricsPagination?: Pagination;
-    }[];
-    pagination: Pagination | undefined;
+    explore: Explore;
+    catalogFields: {
+        dimensions: CatalogField[];
+        metrics: CatalogField[];
+    };
 }>;
 
 export type FindFieldFn = (

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -5,14 +5,11 @@ import { createToolSchema } from '../toolSchemaBuilder';
 export const TOOL_FIND_EXPLORES_DESCRIPTION = `Tool: findExplores
 
 Purpose:
-Lists available Explores along with their field labels, joined tables, hints for you (Ai Hints) and descriptions.
+Lists Explore along with their joined tables, all fields, hints for you (Ai Hints) and descriptions.
 
 Usage Tips:
 - Use this to understand the structure of an Explore before calling findFields.
-- Only a subset of fields is returned
-- Results are paginated — use the next page token to retrieve additional pages.
-- It's advised to look for tables first and then use the exploreName parameter to narrow results to a specific Explore.
-- When using the exploreName parameter, all fields and full description are returned for that explore.
+- All fields are returned as well as their field ids, descriptions labels and ai hints.
 `;
 
 export const toolFindExploresArgsSchema = createToolSchema(
@@ -22,12 +19,8 @@ export const toolFindExploresArgsSchema = createToolSchema(
     .extend({
         exploreName: z
             .string()
-            .nullable()
-            .describe(
-                'Name of the table to focus on. If omitted, all tables are returned. For a single table, all dimensions, metrics, and full descriptions are loaded',
-            ),
+            .describe('Name of the explore that you have access to'),
     })
-    .withPagination()
     .build();
 
 export type ToolFindExploresArgs = z.infer<typeof toolFindExploresArgsSchema>;


### PR DESCRIPTION
### Description:
Refactored the `findExplores` tool to focus on a single explore at a time rather than returning multiple tables. This simplifies the API and improves the AI agent's ability to understand data structure.

Key changes:
- Modified the tool to accept a specific explore name and return detailed information about that explore
- Added methods to retrieve available explores filtered by user attributes and tags
- Improved field organization by returning dimensions and metrics with their usage statistics
- Enhanced the response format to include AI hints for both the explore and individual fields
- Removed pagination since we're now focusing on a single explore with all its fields
- Updated tool description to reflect the new focused approach

This change makes the AI agent more effective at understanding data structure before querying fields, leading to more accurate and relevant responses.