### PR TITLE
fix: show retry option when assistant has no response

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -74,6 +74,9 @@ const AssistantBubbleContent: FC<{
 
     const hasStreamingError =
         streamingState?.error && streamingState?.messageUuid === message.uuid;
+    const hasNoResponse = !isStreaming && !message.message;
+    const shouldShowRetry = hasStreamingError || hasNoResponse;
+
     const messageContent =
         isStreaming && streamingState
             ? streamingState.content
@@ -106,7 +109,7 @@ const AssistantBubbleContent: FC<{
 
     return (
         <>
-            {hasStreamingError && (
+            {shouldShowRetry && (
                 <Paper
                     withBorder
                     radius="md"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a retry button for chat messages with no response. Previously, the retry button was only shown when there was a streaming error. Now it will also appear when a message has no content, allowing users to retry failed or empty messages.
