### PR TITLE
feat: add search to ai search box

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -1,0 +1,150 @@
+import {
+    Combobox,
+    Loader,
+    ScrollArea,
+    TextInput,
+    useCombobox,
+    type TextInputProps,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { useMemo, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import OmnibarItem from '../../../../features/omnibar/components/OmnibarItem';
+import { getSearchResultsGroupsSorted } from '../../../../features/omnibar/components/utils';
+import useSearch, {
+    OMNIBAR_MIN_QUERY_LENGTH,
+} from '../../../../features/omnibar/hooks/useSearch';
+import { type SearchItem } from '../../../../features/omnibar/types/searchItem';
+import { getSearchItemLabel } from '../../../../features/omnibar/utils/getSearchItemLabel';
+import { useValidationUserAbility } from '../../../../hooks/validation/useValidation';
+// eslint-disable-next-line css-modules/no-unused-class
+import styles from './aiSearchBox.module.css';
+
+type Props = {
+    projectUuid: string;
+    value: string;
+    onChange: (value: string) => void;
+    onSearchItemSelect?: (item: SearchItem) => void;
+    placeholder?: string;
+    footer?: React.ReactNode;
+    inputProps?: TextInputProps;
+};
+
+export const SearchDropdown: FC<Props> = ({
+    projectUuid,
+    value,
+    onChange,
+    onSearchItemSelect,
+    placeholder,
+    inputProps,
+    footer,
+}) => {
+    const navigate = useNavigate();
+    const canUserManageValidation = useValidationUserAbility(projectUuid);
+    const combobox = useCombobox({
+        onDropdownClose: () => combobox.resetSelectedOption(),
+    });
+
+    const [debouncedQuery] = useDebouncedValue(value, 200);
+    const { data: searchResults, isSuccess } = useSearch(
+        projectUuid,
+        debouncedQuery,
+    );
+
+    const allSearchItemsGrouped = useMemo(
+        () =>
+            searchResults ? getSearchResultsGroupsSorted(searchResults) : [],
+        [searchResults],
+    );
+
+    const allSearchItems: SearchItem[] = useMemo(() => {
+        if (!searchResults) return [];
+        return Object.values(searchResults).flat();
+    }, [searchResults]);
+
+    const handleSearchItemClick = (item: SearchItem) => {
+        void navigate(item.location.pathname + (item.location.search || ''));
+        onSearchItemSelect?.(item);
+        combobox.closeDropdown();
+    };
+
+    const handleInputChange = (newValue: string) => {
+        onChange(newValue);
+        if (newValue.length >= OMNIBAR_MIN_QUERY_LENGTH) {
+            combobox.openDropdown();
+        } else {
+            combobox.closeDropdown();
+        }
+    };
+
+    return (
+        <Combobox
+            store={combobox}
+            classNames={{
+                option: styles.comboboxOption,
+            }}
+        >
+            <Combobox.Target>
+                <Combobox.EventsTarget>
+                    <TextInput
+                        {...inputProps}
+                        placeholder={placeholder}
+                        value={value}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                            handleInputChange(e.currentTarget.value)
+                        }
+                        rightSection={
+                            value.length >= OMNIBAR_MIN_QUERY_LENGTH &&
+                            !isSuccess && <Loader size={12} color="gray" />
+                        }
+                    />
+                </Combobox.EventsTarget>
+            </Combobox.Target>
+
+            <Combobox.Dropdown>
+                <Combobox.Options>
+                    <ScrollArea.Autosize
+                        maw="100%"
+                        mah={300}
+                        type="scroll"
+                        scrollbars="y"
+                        className={styles.searchDropdownScrollContent}
+                    >
+                        {allSearchItems.length === 0 && (
+                            <Combobox.Empty>Nothing found</Combobox.Empty>
+                        )}
+                        {allSearchItemsGrouped.map(([groupType, items], i) => (
+                            <Combobox.Group
+                                key={groupType}
+                                label={getSearchItemLabel(groupType)}
+                            >
+                                {items.map((item, j) => (
+                                    <Combobox.Option
+                                        key={`${i}-${j}`}
+                                        value={`${item.type}-${item.title}`}
+                                        onClick={() =>
+                                            handleSearchItemClick(item)
+                                        }
+                                    >
+                                        <OmnibarItem
+                                            projectUuid={projectUuid}
+                                            canUserManageValidation={
+                                                canUserManageValidation
+                                            }
+                                            item={item}
+                                        />
+                                    </Combobox.Option>
+                                ))}
+                            </Combobox.Group>
+                        ))}
+                    </ScrollArea.Autosize>
+                </Combobox.Options>
+                {footer && (
+                    <Combobox.Footer p={0} style={{ overflow: 'hidden' }}>
+                        {footer}
+                    </Combobox.Footer>
+                )}
+            </Combobox.Dropdown>
+        </Combobox>
+    );
+};

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
@@ -1,0 +1,27 @@
+.askAiFooter {
+    border-bottom-left-radius: var(--mantine-radius-md);
+    border-bottom-right-radius: var(--mantine-radius-md);
+    overflow: hidden;
+    background: linear-gradient(
+        90deg,
+        var(--mantine-color-grape-0) 0%,
+        var(--mantine-color-violet-0) 40%,
+        var(--mantine-color-indigo-0) 100%
+    );
+    width: 100%;
+}
+
+.searchDropdownInput {
+    flex: 1;
+}
+
+.searchDropdownScrollContent > div {
+    max-width: 100%;
+}
+
+.comboboxOption:hover > div,
+.comboboxOption[data-combobox-selected],
+.comboboxOption[data-combobox-selected] > div {
+    background-color: var(--mantine-color-gray-0);
+    color: inherit;
+}

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/index.ts
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AiSearchBox';

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
@@ -1,4 +1,10 @@
-import { Combobox, Group, UnstyledButton, useCombobox } from '@mantine-8/core';
+import {
+    Combobox,
+    type ComboboxProps,
+    Group,
+    UnstyledButton,
+    useCombobox,
+} from '@mantine-8/core';
 import { IconChevronDown } from '@tabler/icons-react';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -8,7 +14,7 @@ import {
     renderSelectOption,
 } from './AgentSelectorUtils';
 
-type Props = {
+type Props = ComboboxProps & {
     agents: Agent[];
     selectedAgent: Agent;
     onSelect: (val: string) => void;
@@ -18,6 +24,7 @@ export const CompactAgentSelector = ({
     agents,
     selectedAgent,
     onSelect,
+    ...props
 }: Props) => {
     const combobox = useCombobox({
         onDropdownClose: () => combobox.resetSelectedOption(),
@@ -26,6 +33,7 @@ export const CompactAgentSelector = ({
 
     return (
         <Combobox
+            {...props}
             store={combobox}
             width={230}
             position="bottom-start"

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -1,9 +1,7 @@
 import {
-    getSearchItemTypeFromResultKey,
     getSearchResultId,
     type SearchFilters,
     type SearchItemType,
-    type SearchResults,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -49,6 +47,7 @@ import OmnibarFilters from './OmnibarFilters';
 import OmnibarItemGroups from './OmnibarItemGroups';
 import { OmnibarKeyboardNav } from './OmnibarKeyboardNav';
 import OmnibarTarget from './OmnibarTarget';
+import { getSearchResultsGroupsSorted } from './utils';
 
 interface Props {
     projectUuid: string;
@@ -166,25 +165,11 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     const hasSearchResults =
         searchResults && !isSearchResultEmpty(searchResults);
 
-    const sortedGroupEntries = useMemo(() => {
-        return searchResults
-            ? Object.entries(searchResults)
-                  .map((items) => {
-                      return [
-                          getSearchItemTypeFromResultKey(
-                              items[0] as keyof SearchResults,
-                          ),
-                          items[1],
-                      ] as [SearchItemType, SearchItem[]];
-                  })
-                  .filter(([_type, items]) => items.length > 0)
-                  .sort(
-                      ([_a, itemsA], [_b, itemsB]) =>
-                          (itemsB[0].searchRank ?? 0) -
-                          (itemsA[0].searchRank ?? 0),
-                  )
-            : [];
-    }, [searchResults]);
+    const sortedGroupEntries = useMemo(
+        () =>
+            searchResults ? getSearchResultsGroupsSorted(searchResults) : [],
+        [searchResults],
+    );
     useEffect(() => {
         setFocusedItemIndex(undefined);
     }, [query, searchFilters]);

--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
@@ -39,7 +39,7 @@ type Props = {
     classNames?: Record<string, string>;
     hovered?: boolean;
     scrollRef?: MutableRefObject<HTMLDivElement>;
-    onClick: (e: React.MouseEvent) => void;
+    onClick?: (e: React.MouseEvent) => void;
 };
 
 const itemHasValidationError = (searchItem: SearchItem) =>

--- a/packages/frontend/src/features/omnibar/components/utils.ts
+++ b/packages/frontend/src/features/omnibar/components/utils.ts
@@ -1,7 +1,9 @@
 import {
-    SearchItemType,
     assertUnreachable,
+    getSearchItemTypeFromResultKey,
+    SearchItemType,
     type SavedChartSearchResult,
+    type SearchResults,
 } from '@lightdash/common';
 import {
     Icon123,
@@ -14,6 +16,7 @@ import {
 } from '@tabler/icons-react';
 import { getChartIcon } from '../../../components/common/ResourceIcon/utils';
 import { type SearchItem } from '../types/searchItem';
+import { type SearchResultMap } from '../types/searchResultMap';
 
 export const getOmnibarItemColor = (itemType: SearchItemType) => {
     switch (itemType) {
@@ -71,3 +74,17 @@ export const getOmnibarItemIcon = (item: SearchItem) => {
             );
     }
 };
+
+export const getSearchResultsGroupsSorted = (results: SearchResultMap) =>
+    Object.entries(results)
+        .map((items) => {
+            return [
+                getSearchItemTypeFromResultKey(items[0] as keyof SearchResults),
+                items[1],
+            ] as [SearchItemType, SearchItem[]];
+        })
+        .filter(([_type, items]) => items.length > 0)
+        .sort(
+            ([_a, itemsA], [_b, itemsB]) =>
+                (itemsB[0].searchRank ?? 0) - (itemsA[0].searchRank ?? 0),
+        );


### PR DESCRIPTION
Closes: #17285

Enhanced the AI Search Box with a combined search functionality that allows users to search data and ask AI questions from the same input. 

Key improvements:
- Added a dropdown search component that displays search results as users type
- Implemented a more intuitive UI with a dedicated "Ask AI" footer option
- Fixed agent selection logic to properly handle preferences and default agents
- Added styling for search results and the AI question interface
- Improved UX with debounced search and better loading states

[Screen Recording 2025-10-09 at 14.33.41.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/0c22bcf9-cdae-4687-96c8-69b88b078cc8.mov" />](https://app.graphite.dev/user-attachments/video/0c22bcf9-cdae-4687-96c8-69b88b078cc8.mov)
