### PR TITLE
fix: remove resize calc from vega-lite to depend on css only

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -90,7 +90,6 @@ const CustomVisualization: FC<Props> = (props) => {
                     }}
                     config={{
                         autosize: {
-                            resize: true,
                             type: 'fit',
                         },
                     }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17337

### Description:

Removed the `resize: true` property from the `autosize` configuration in the CustomVisualization component. This change maintains the `type: 'fit'` setting while eliminating the resize behavior.

The visualization will now use only the 'fit' type for autosizing without automatic resizing.

To test with both main and this branch: 
1. create bar chart custom vis 
2. play with collapsing and expanding sibling cards and then hover on the vis
3. You will see on `main` that there's some weird resizing going on. 
4. on this branch that's fixed because the autosize isn't necessary - the parent div gets the correct sizing already through styles. 

http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/campaigns?create_saved_chart_version=%7B%22uuid%22%3A%2264c8b7c7-568b-41d1-8326-1b2c808452bf%22%2C%22projectUuid%22%3A%223675b69e-8324-4110-bdca-059031aa8da3%22%2C%22name%22%3A%22asdasd%22%2C%22description%22%3A%22%22%2C%22tableName%22%3A%22campaigns%22%2C%22updatedAt%22%3A%222025-10-09T13%3A14%3A36.051Z%22%2C%22updatedByUser%22%3A%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%7D%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22campaigns%22%2C%22dimensions%22%3A%5B%22campaigns_audience_segment%22%2C%22campaigns_campaign_id%22%5D%2C%22metrics%22%3A%5B%22campaigns_max_budget%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22campaigns_max_budget%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22metricOverrides%22%3A%7B%7D%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22custom%22%2C%22config%22%3A%7B%22spec%22%3A%7B%22mark%22%3A%22bar%22%2C%22%24schema%22%3A%22https%3A%2F%2Fvega.github.io%2Fschema%2Fvega-lite%2Fv5.json%22%2C%22encoding%22%3A%7B%22x%22%3A%7B%22axis%22%3A%7B%22tickColor%22%3A%22%236e7079%22%2C%22labelColor%22%3A%22%236e7079%22%2C%22labelFontSize%22%3A50%7D%2C%22type%22%3A%22ordinal%22%2C%22field%22%3A%22campaigns_audience_segment%22%7D%2C%22y%22%3A%7B%22axis%22%3A%7B%22tickColor%22%3A%22%236e7079%22%2C%22labelColor%22%3A%22%236e7079%22%7D%2C%22type%22%3A%22quantitative%22%2C%22field%22%3A%22campaigns_max_budget%22%7D%2C%22tooltip%22%3A%5B%7B%22type%22%3A%22ordinal%22%2C%22field%22%3A%22campaigns_audience_segment%22%2C%22title%22%3A%22Audience+Segment%22%7D%2C%7B%22type%22%3A%22quantitative%22%2C%22field%22%3A%22campaigns_max_budget%22%2C%22title%22%3A%22Max+Budget%22%7D%5D%7D%7D%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22campaigns_audience_segment%22%2C%22campaigns_campaign_id%22%2C%22campaigns_max_budget%22%5D%7D%2C%22organizationUuid%22%3A%22172a2270-000f-42be-9c68-c4752c23ae51%22%2C%22spaceUuid%22%3A%22f14fe9d7-77f1-450b-9f27-31242b93a262%22%2C%22spaceName%22%3A%22Parent+Space+5%22%2C%22pinnedListUuid%22%3Anull%2C%22pinnedListOrder%22%3Anull%2C%22dashboardUuid%22%3Anull%2C%22dashboardName%22%3Anull%2C%22colorPalette%22%3A%5B%22%2333ffb1%22%2C%22%23ff33e1%22%2C%22%2333e6ff%22%2C%22%23ffdd8a%22%2C%22%23ffdefa%22%2C%22%2373c0de%22%2C%22%23ff8178%22%2C%22%239a60b4%22%2C%22%23ea7ccc%22%2C%22%2333ff7d%22%2C%22%2333ffb1%22%2C%22%2333ffe6%22%2C%22%2333e6ff%22%2C%22%2333b1ff%22%2C%22%23337dff%22%2C%22%233349ff%22%2C%22%235e33ff%22%2C%22%239233ff%22%2C%22%23c633ff%22%2C%22%23ff33e1%22%5D%2C%22slug%22%3A%22asdasd%22%2C%22isPrivate%22%3Atrue%2C%22access%22%3A%5B%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%2C%22email%22%3A%22demo%40lightdash.com%22%2C%22role%22%3A%22admin%22%2C%22hasDirectAccess%22%3Atrue%2C%22inheritedRole%22%3A%22admin%22%2C%22inheritedFrom%22%3A%22organization%22%2C%22projectRole%22%3A%22admin%22%7D%5D%7D

Before

[CleanShot 2025-10-09 at 14.22.34.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/5e17e166-1809-415b-8011-4a315b11ad51.mp4" />](https://app.graphite.dev/user-attachments/video/5e17e166-1809-415b-8011-4a315b11ad51.mp4)

After

[CleanShot 2025-10-09 at 14.22.00.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/73d26605-8d63-4a3a-a457-418a30055ae0.mp4" />](https://app.graphite.dev/user-attachments/video/73d26605-8d63-4a3a-a457-418a30055ae0.mp4)

