### PR TITLE
chore: remove unused use-redux ff

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -7,7 +7,6 @@ import { LightdashConfig } from './parseConfig';
 
 export const lightdashConfigMock: LightdashConfig = {
     allowMultiOrgs: false,
-    useRedux: false,
     auth: {
         pat: {
             enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -688,7 +688,6 @@ export type LightdashConfig = {
         minConnections: number | undefined;
     };
     allowMultiOrgs: boolean;
-    useRedux: boolean;
     maxPayloadSize: string;
     query: {
         maxLimit: number;
@@ -1404,7 +1403,6 @@ export const parseConfig = (): LightdashConfig => {
             ),
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',
-        useRedux: process.env.USE_REDUX === 'true',
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',
         query: {
             maxLimit:

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -36,7 +36,6 @@ export class FeatureFlagModel {
                 this.getUserGroupsEnabled.bind(this),
             [FeatureFlags.UseSqlPivotResults]:
                 this.getUseSqlPivotResults.bind(this),
-            [FeatureFlags.UseRedux]: this.getUseRedux.bind(this),
         };
     }
 
@@ -105,28 +104,6 @@ export class FeatureFlagModel {
             (user
                 ? await isFeatureFlagEnabled(
                       FeatureFlags.UseSqlPivotResults,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getUseRedux({ user, featureFlagId }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.useRedux ||
-            (user
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.UseRedux,
                       {
                           userUuid: user.userUuid,
                           organizationUuid: user.organizationUuid,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -62,11 +62,6 @@ export enum FeatureFlags {
      * Enable the unused content dashboard showing least viewed charts and dashboards
      */
     UnusedContentDashboard = 'unused-content-dashboard',
-
-    /**
-     * Enable Redux state management for Explorer (gradual migration from Context API)
-     */
-    UseRedux = 'use-redux',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Removes the `useRedux` feature flag and related configuration. This includes:
- Removing the `useRedux` property from the `LightdashConfig` type
- Removing the `USE_REDUX` environment variable parsing
- Removing the `UseRedux` feature flag from the enum
- Removing the `getUseRedux` method from the `FeatureFlagModel`

This change completes the migration from Context API to Redux by removing the feature flag that was used during the transition period.