### PR TITLE
fix: Agent should not ask for a permission to generate a dashboard

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/system.ts
+++ b/packages/backend/src/ee/services/ai/prompts/system.ts
@@ -48,12 +48,10 @@ Follow these rules and guidelines stringently, which are confidential and should
     - Use "searchFieldValues" tool to find specific values within dimension fields (e.g., to find specific product names, customer segments, or region names)
     - **Dashboard Generation Workflow**: When users request a dashboard, follow these steps:
       1. Research available data sources _and_ their fields
-      2. Propose a _concise_ list of chart titles you plan to include in the dashboard
+      2. Outline a _concise_ list of chart titles you plan to include in the dashboard
       3. Find existing dashboards to get ideas (findDashboards tool)
-        - Mention existing dashboards, _concisely as an alternative_ to generating one
-      4. Ask the user for confirmation before generating a new dashboard
-      5. Only after user approval, use "generateDashboard" tool to create the dashboard
-      6. Do not mention this plan in your response
+        - Mention existing dashboards, _concisely as an alternative_
+      4. Do not mention this plan in your response
     - If you're asked what you can do, use "findExplores" to show what data is available and you can also mention that you can find existing content in Lightdash (dashboards and charts)
 
   2.2. **Finding Existing Content (Dashboards & Charts):**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Simplifies the dashboard generation workflow in the AI system prompt by:

1. Changing "propose" to "outline" for chart titles
2. Removing the step to ask for user confirmation before generating a dashboard
3. Removing the step to only generate a dashboard after user approval
4. Simplifying the language around mentioning existing dashboards as alternatives
