### PR TITLE
fix: custom metrics validation

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -51,7 +51,12 @@ export const getRunMetricQuery = ({
             vizTool.vizConfig.dimensions,
             'dimension',
         );
-        validateFieldEntityType(explore, vizTool.vizConfig.metrics, 'metric');
+        validateFieldEntityType(
+            explore,
+            vizTool.vizConfig.metrics,
+            'metric',
+            vizTool.customMetrics,
+        );
         validateCustomMetricsDefinition(explore, vizTool.customMetrics);
         validateFilterRules(explore, filterRules, vizTool.customMetrics);
         validateMetricDimensionFilterPlacement(

--- a/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
@@ -23,7 +23,12 @@ export const validateBarVizConfig = (
         vizTool.vizConfig.breakdownByDimension,
     ].filter((x) => typeof x === 'string');
     validateFieldEntityType(explore, selectedDimensions, 'dimension');
-    validateFieldEntityType(explore, vizTool.vizConfig.yMetrics, 'metric');
+    validateFieldEntityType(
+        explore,
+        vizTool.vizConfig.yMetrics,
+        'metric',
+        vizTool.customMetrics,
+    );
     validateCustomMetricsDefinition(explore, vizTool.customMetrics);
     validateFilterRules(explore, filterRules, vizTool.customMetrics);
     validateMetricDimensionFilterPlacement(

--- a/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
@@ -19,7 +19,12 @@ export const validateTableVizConfig = (
 ) => {
     const filterRules = getTotalFilterRules(vizTool.filters);
     validateFieldEntityType(explore, vizTool.vizConfig.dimensions, 'dimension');
-    validateFieldEntityType(explore, vizTool.vizConfig.metrics, 'metric');
+    validateFieldEntityType(
+        explore,
+        vizTool.vizConfig.metrics,
+        'metric',
+        vizTool.customMetrics,
+    );
     validateCustomMetricsDefinition(explore, vizTool.customMetrics);
     validateFilterRules(explore, filterRules, vizTool.customMetrics);
     validateMetricDimensionFilterPlacement(

--- a/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
@@ -23,7 +23,12 @@ export const validateTimeSeriesVizConfig = (
         vizTool.vizConfig.breakdownByDimension,
     ].filter((x) => typeof x === 'string');
     validateFieldEntityType(explore, selectedDimensions, 'dimension');
-    validateFieldEntityType(explore, vizTool.vizConfig.yMetrics, 'metric');
+    validateFieldEntityType(
+        explore,
+        vizTool.vizConfig.yMetrics,
+        'metric',
+        vizTool.customMetrics,
+    );
     validateCustomMetricsDefinition(explore, vizTool.customMetrics);
     validateFilterRules(explore, filterRules, vizTool.customMetrics);
     validateMetricDimensionFilterPlacement(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated field validation to properly handle custom metrics in visualization configurations. The `validateFieldEntityType` function now accepts custom metrics as an additional parameter and validates fields against both explore fields and custom metrics. Error messages have been enhanced to provide more detailed information about field sources and types, making it easier to debug validation issues.
