### PR TITLE
fix: downloading pivoted results for cartesian charts

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -79,6 +79,14 @@ const ResultsCard: FC = memo(() => {
         }
     };
 
+    // ResultsCard always downloads raw unpivoted results
+    const getResultsCardDownloadQueryUuid = useCallback(
+        (limit: number | null) => {
+            return getDownloadQueryUuid(limit, false);
+        },
+        [getDownloadQueryUuid],
+    );
+
     return (
         <CollapsableCard
             title="Results"
@@ -134,7 +142,7 @@ const ResultsCard: FC = memo(() => {
                                         projectUuid={projectUuid}
                                         totalResults={totalResults}
                                         getDownloadQueryUuid={
-                                            getDownloadQueryUuid
+                                            getResultsCardDownloadQueryUuid
                                         }
                                         getGsheetLink={getGsheetLink}
                                         columnOrder={columnOrder}

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     DownloadFileType,
     formatDate,
+    type DownloadOptions,
     type PivotConfig,
 } from '@lightdash/common';
 import {
@@ -95,7 +96,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         limit,
                     );
 
-                    const downloadOptions = {
+                    const downloadOptions: DownloadOptions = {
                         fileType,
                         onlyRaw: format === Values.RAW,
                         columnOrder,

--- a/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
+++ b/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
@@ -1,11 +1,4 @@
-import {
-    type PivotConfig,
-    isField,
-    isMetric,
-    isTableCalculation,
-} from '@lightdash/common';
 import JsPDF from 'jspdf';
-import { type VisualizationConfigTable } from '../../LightdashVisualization/types';
 
 const FILE_NAME = 'lightdash_chart';
 
@@ -93,36 +86,3 @@ export function downloadPdf(base64: string, width: number, height: number) {
     });
     doc.save(FILE_NAME);
 }
-
-/**
- * Creates a PivotConfig from table visualization context data.
- * This is similar to the `getPivotConfig` function in common, but works with
- * visualization config instead of saved chart version data.
- *
- * @param visualizationConfig - The table visualization configuration
- * @param pivotDimensions - Array of dimension field IDs to pivot by
- * @returns PivotConfig object for use with pivot table downloads
- */
-export const createPivotConfigFromVisualization = (
-    visualizationConfig: VisualizationConfigTable,
-    pivotDimensions: string[],
-): PivotConfig => ({
-    pivotDimensions,
-    metricsAsRows: visualizationConfig.chartConfig.metricsAsRows ?? false,
-    hiddenMetricFieldIds:
-        visualizationConfig.chartConfig.selectedItemIds?.filter(
-            (fieldId: string) => {
-                const field = visualizationConfig.chartConfig.getField(fieldId);
-                return (
-                    !visualizationConfig.chartConfig.isColumnVisible(fieldId) &&
-                    field &&
-                    ((isField(field) && isMetric(field)) ||
-                        isTableCalculation(field))
-                );
-            },
-        ),
-    columnOrder: visualizationConfig.chartConfig.columnOrder,
-    rowTotals: visualizationConfig.chartConfig.showRowCalculation ?? false,
-    columnTotals:
-        visualizationConfig.chartConfig.showColumnCalculation ?? false,
-});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17346

### Description:
Refactored pivot configuration handling to support both table and cartesian chart types. The `getPivotConfig` function now handles different chart types with specific configuration functions.

Added support for downloading both raw and pivoted results:
- `ResultsCard` now explicitly downloads raw unpivoted results
- `ChartDownloadMenu` downloads pivoted results when available
- Updated `getDownloadQueryUuid` to accept a parameter controlling whether to export pivoted results

Fixed the query UUID selection logic to properly handle pivoted vs unpivoted results based on the export requirements.

**Steps to test**
- Explorer
    - download from results table should download unpivoted results on all export sizes
- Chart view
    - download from results table should download unpivoted results for all export sizes
    - download from viz (table only) should download pivoted results if table is pivoted for all export sizes
- Dashboard chart tile
    - should download pivoted results if table is pivoted or chart has group by for all export sizes
- Embed dashboard tile
    - should download pivoted results if table is pivoted or chart has group by, only size available is results in table
- SQL Runner
    - No changes here, should behave as normal

Include tests for when `USE_SQL_PIVOT_RESULTS` is disabled to ensure this is backwards compatible
