### PR TITLE
feat: create ai_organization_settings table

### DIFF
--- a/packages/backend/src/ee/database/migrations/20251009132725_add_ai_organization_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20251009132725_add_ai_organization_settings.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+const aiOrganizationSettings = 'ai_organization_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(aiOrganizationSettings, (table) => {
+        table
+            .uuid('organization_uuid')
+            .primary()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        table.boolean('ai_agents_visible').notNullable().defaultTo(true);
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(aiOrganizationSettings);
+}


### PR DESCRIPTION


### Description:
Adds a new database migration to create the `ai_organization_settings` table. This table will store organization-level settings for AI features, including a boolean flag `ai_agents_visible` that controls whether AI features are visible to users within an organization.
