### PR TITLE
feat: ai organization settings crud

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -4,14 +4,19 @@ import {
     ApiAiAgentAdminConversationsResponse,
     ApiAiAgentResponse,
     ApiAiAgentSummaryResponse,
+    ApiAiOrganizationSettingsResponse,
     ApiErrorPayload,
+    ApiUpdateAiOrganizationSettingsResponse,
     KnexPaginateArgs,
+    UpdateAiOrganizationSettings,
 } from '@lightdash/common';
 import {
+    Body,
     Get,
     Hidden,
     Middlewares,
     OperationId,
+    Patch,
     Query,
     Request,
     Response,
@@ -25,6 +30,7 @@ import {
 } from '../../controllers/authentication';
 import { BaseController } from '../../controllers/baseController';
 import { type AiAgentAdminService } from '../services/AiAgentAdminService';
+import { type AiOrganizationSettingsService } from '../services/AiOrganizationSettingsService';
 
 @Route('/api/v1/aiAgents/admin')
 @Hidden()
@@ -127,7 +133,59 @@ export class AiAgentAdminController extends BaseController {
         };
     }
 
+    /**
+     * Get AI organization settings
+     * @summary Get AI settings
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Retrieved AI organization settings')
+    @Get('/settings')
+    @OperationId('getAiOrganizationSettings')
+    async getSettings(
+        @Request() req: express.Request,
+    ): Promise<ApiAiOrganizationSettingsResponse> {
+        const settings =
+            await this.getAiOrganizationSettingsService().getSettings(
+                req.user!,
+            );
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: settings,
+        };
+    }
+
+    /**
+     * Update AI organization settings
+     * @summary Update AI settings
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Updated AI organization settings')
+    @Patch('/settings')
+    @OperationId('upsertAiOrganizationSettings')
+    async upsertSettings(
+        @Request() req: express.Request,
+        @Body() body: UpdateAiOrganizationSettings,
+    ): Promise<ApiUpdateAiOrganizationSettingsResponse> {
+        const settings =
+            await this.getAiOrganizationSettingsService().upsertSettings(
+                req.user!,
+                body,
+            );
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: settings,
+        };
+    }
+
     protected getAiAgentAdminService() {
         return this.services.getAiAgentAdminService<AiAgentAdminService>();
+    }
+
+    protected getAiOrganizationSettingsService() {
+        return this.services.getAiOrganizationSettingsService<AiOrganizationSettingsService>();
     }
 }

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -179,3 +179,18 @@ export type AiAgentToolResultTable = Knex.CompositeTableType<
         Partial<Pick<DbAiAgentToolResult, 'metadata'>>,
     Partial<Pick<DbAiAgentToolResult, 'metadata'>>
 >;
+
+export const AiOrganizationSettingsTableName = 'ai_organization_settings';
+
+export type DbAiOrganizationSettings = {
+    organization_uuid: string;
+    ai_agents_visible: boolean;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiOrganizationSettingsTable = Knex.CompositeTableType<
+    DbAiOrganizationSettings,
+    Pick<DbAiOrganizationSettings, 'organization_uuid' | 'ai_agents_visible'>,
+    Partial<Pick<DbAiOrganizationSettings, 'ai_agents_visible'>>
+>;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -13,6 +13,7 @@ import LicenseClient from './clients/License/LicenseClient';
 import OpenAi from './clients/OpenAi';
 import { CommercialSlackClient } from './clients/Slack/SlackClient';
 import { AiAgentModel } from './models/AiAgentModel';
+import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
 import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel';
 import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuthenticationModel';
 import { DashboardSummaryModel } from './models/DashboardSummaryModel';
@@ -22,6 +23,7 @@ import { CommercialSchedulerClient } from './scheduler/SchedulerClient';
 import { CommercialSchedulerWorker } from './scheduler/SchedulerWorker';
 import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentService } from './services/AiAgentService';
+import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
 import { AiService } from './services/AiService/AiService';
 import { CommercialCacheService } from './services/CommercialCacheService';
 import { CommercialSlackIntegrationService } from './services/CommercialSlackIntegrationService';
@@ -124,6 +126,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiAgentAdminService({
                     aiAgentModel: models.getAiAgentModel(),
                     lightdashConfig: context.lightdashConfig,
+                }),
+            aiOrganizationSettingsService: ({ models }) =>
+                new AiOrganizationSettingsService({
+                    aiOrganizationSettingsModel:
+                        models.getAiOrganizationSettingsModel(),
                 }),
             scimService: ({ models, context }) =>
                 new ScimService({
@@ -307,6 +314,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
         },
         modelProviders: {
             aiAgentModel: ({ database }) => new AiAgentModel({ database }),
+            aiOrganizationSettingsModel: ({ database }) =>
+                new AiOrganizationSettingsModel({ database }),
             embedModel: ({ database }) => new EmbedModel({ database }),
             mcpContextModel: ({ database }) => new McpContextModel(database),
             dashboardSummaryModel: ({ database }) =>

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
@@ -1,0 +1,120 @@
+import {
+    AiOrganizationSettings,
+    CreateAiOrganizationSettings,
+    NotFoundError,
+    UpdateAiOrganizationSettings,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    AiOrganizationSettingsTable,
+    AiOrganizationSettingsTableName,
+    DbAiOrganizationSettings,
+} from '../database/entities/ai';
+
+type Dependencies = {
+    database: Knex;
+};
+
+export class AiOrganizationSettingsModel {
+    private database: Knex;
+
+    constructor(dependencies: Dependencies) {
+        this.database = dependencies.database;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private mapDbToEntity(
+        db: DbAiOrganizationSettings,
+    ): AiOrganizationSettings {
+        return {
+            organizationUuid: db.organization_uuid,
+            aiAgentsVisible: db.ai_agents_visible,
+            createdAt: db.created_at,
+            updatedAt: db.updated_at,
+        };
+    }
+
+    async findByOrganizationUuid(
+        organizationUuid: string,
+    ): Promise<AiOrganizationSettings | null> {
+        const row = await this.database
+            .select<DbAiOrganizationSettings>()
+            .from(AiOrganizationSettingsTableName)
+            .where('organization_uuid', organizationUuid)
+            .first();
+
+        return row ? this.mapDbToEntity(row) : null;
+    }
+
+    async getByOrganizationUuid(
+        organizationUuid: string,
+    ): Promise<AiOrganizationSettings> {
+        const settings = await this.findByOrganizationUuid(organizationUuid);
+        if (!settings) {
+            throw new NotFoundError(
+                `AI organization settings not found for organization ${organizationUuid}`,
+            );
+        }
+        return settings;
+    }
+
+    async create(
+        data: CreateAiOrganizationSettings,
+    ): Promise<AiOrganizationSettings> {
+        const [row] = await this.database<AiOrganizationSettingsTable>(
+            AiOrganizationSettingsTableName,
+        )
+            .insert({
+                organization_uuid: data.organizationUuid,
+                ai_agents_visible: data.aiAgentsVisible,
+            })
+            .returning('*');
+
+        return this.mapDbToEntity(row);
+    }
+
+    async update(
+        organizationUuid: string,
+        data: UpdateAiOrganizationSettings,
+    ): Promise<AiOrganizationSettings> {
+        const [row] = await this.database<AiOrganizationSettingsTable>(
+            AiOrganizationSettingsTableName,
+        )
+            .where('organization_uuid', organizationUuid)
+            .update({
+                ai_agents_visible: data.aiAgentsVisible,
+            })
+            .returning('*');
+
+        if (!row) {
+            throw new NotFoundError(
+                `AI organization settings not found for organization ${organizationUuid}`,
+            );
+        }
+
+        return this.mapDbToEntity(row);
+    }
+
+    async upsert(
+        organizationUuid: string,
+        data: UpdateAiOrganizationSettings,
+    ): Promise<AiOrganizationSettings> {
+        const existing = await this.findByOrganizationUuid(organizationUuid);
+
+        if (existing) {
+            return this.update(organizationUuid, data);
+        }
+        return this.create({
+            organizationUuid,
+            aiAgentsVisible: data.aiAgentsVisible,
+        });
+    }
+
+    async delete(organizationUuid: string): Promise<void> {
+        await this.database<AiOrganizationSettingsTable>(
+            AiOrganizationSettingsTableName,
+        )
+            .where('organization_uuid', organizationUuid)
+            .delete();
+    }
+}

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -1,0 +1,91 @@
+import { subject } from '@casl/ability';
+import {
+    AiOrganizationSettings,
+    ForbiddenError,
+    UpdateAiOrganizationSettings,
+    type SessionUser,
+} from '@lightdash/common';
+import { AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
+
+type AiOrganizationSettingsServiceDependencies = {
+    aiOrganizationSettingsModel: AiOrganizationSettingsModel;
+};
+
+export class AiOrganizationSettingsService {
+    private readonly aiOrganizationSettingsModel: AiOrganizationSettingsModel;
+
+    constructor(dependencies: AiOrganizationSettingsServiceDependencies) {
+        this.aiOrganizationSettingsModel =
+            dependencies.aiOrganizationSettingsModel;
+    }
+
+    private static checkManageAiAgentAccess(user: SessionUser): void {
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid: user.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to manage AI agent settings',
+            );
+        }
+    }
+
+    async getSettings(user: SessionUser): Promise<AiOrganizationSettings> {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError('User must belong to an organization');
+        }
+
+        AiOrganizationSettingsService.checkManageAiAgentAccess(user);
+
+        const settings =
+            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+                user.organizationUuid,
+            );
+
+        // Return default settings if none exist
+        if (!settings) {
+            return {
+                organizationUuid: user.organizationUuid,
+                aiAgentsVisible: false,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            };
+        }
+
+        return settings;
+    }
+
+    async upsertSettings(
+        user: SessionUser,
+        data: UpdateAiOrganizationSettings,
+    ): Promise<AiOrganizationSettings> {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError('User must belong to an organization');
+        }
+
+        AiOrganizationSettingsService.checkManageAiAgentAccess(user);
+
+        return this.aiOrganizationSettingsModel.upsert(
+            user.organizationUuid,
+            data,
+        );
+    }
+
+    /**
+     * Check if AI agents are visible for an organization
+     * This is used internally by other services to check if AI features should be available
+     */
+    async areAiAgentsVisible(organizationUuid: string): Promise<boolean> {
+        const settings =
+            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+                organizationUuid,
+            );
+
+        // Default to false if no settings exist (AI agents not visible by default)
+        return settings?.aiAgentsVisible ?? false;
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -105,6 +105,7 @@ export type ModelManifest = {
     changesetModel: ChangesetModel;
     /** An implementation signature for these models are not available at this stage */
     aiAgentModel: unknown;
+    aiOrganizationSettingsModel: unknown;
     embedModel: unknown;
     dashboardSummaryModel: unknown;
     serviceAccountModel: unknown;
@@ -567,6 +568,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getAiOrganizationSettingsModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiOrganizationSettingsModel');
     }
 
     public getEmbedModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -105,6 +105,7 @@ interface ServiceManifest {
     aiService: unknown;
     aiAgentService: unknown;
     aiAgentAdminService: unknown;
+    aiOrganizationSettingsService: unknown;
     scimService: unknown;
     supportService: unknown;
     cacheService: unknown;
@@ -935,6 +936,12 @@ export class ServiceRepository
         AiAgentAdminServiceImplT,
     >(): AiAgentAdminServiceImplT {
         return this.getService('aiAgentAdminService');
+    }
+
+    public getAiOrganizationSettingsService<
+        AiOrganizationSettingsServiceImplT,
+    >(): AiOrganizationSettingsServiceImplT {
+        return this.getService('aiOrganizationSettingsService');
     }
 
     public getRolesService(): RolesService {

--- a/packages/common/src/ee/AiOrganizationSettings/index.ts
+++ b/packages/common/src/ee/AiOrganizationSettings/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/common/src/ee/AiOrganizationSettings/types.ts
+++ b/packages/common/src/ee/AiOrganizationSettings/types.ts
@@ -1,0 +1,25 @@
+export type AiOrganizationSettings = {
+    organizationUuid: string;
+    aiAgentsVisible: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type CreateAiOrganizationSettings = {
+    organizationUuid: string;
+    aiAgentsVisible: boolean;
+};
+
+export type UpdateAiOrganizationSettings = {
+    aiAgentsVisible: boolean;
+};
+
+export type ApiAiOrganizationSettingsResponse = {
+    status: 'ok';
+    results: AiOrganizationSettings;
+};
+
+export type ApiUpdateAiOrganizationSettingsResponse = {
+    status: 'ok';
+    results: AiOrganizationSettings;
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -1,4 +1,5 @@
 export * from './AiAgent';
+export * from './AiOrganizationSettings';
 export * from './commercialFeatureFlags';
 export * from './embed';
 export * from './scim/errors';


### PR DESCRIPTION

### Description:
Adds organization-level AI settings to control AI agent visibility. This PR introduces:

- New `AiOrganizationSettings` model and service to manage AI visibility settings
- API endpoints to get and update organization AI settings
- Default behavior where AI agents are hidden unless explicitly enabled
- Permission checks to ensure only users with proper access can manage AI settings
