### PR TITLE
fix: error when filtering by metric with fanout

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -866,9 +866,34 @@ export class MetricQueryBuilder {
                 joinedTables,
             });
 
+        // Get metrics from selected fields
         const metricsObjects = metrics.map((field) =>
             getMetricFromId(field, explore, compiledMetricQuery),
         );
+
+        // Also include metrics that are only used in filters (not selected for display)
+        const metricsFromFilters = getFilterRulesFromGroup(
+            compiledMetricQuery.filters.metrics,
+        ).reduce<CompiledMetric[]>((acc, filter) => {
+            const metricInSelect = metrics.find(
+                (metric) => metric === filter.target.fieldId,
+            );
+            if (metricInSelect !== undefined) {
+                return acc; // Already in selected metrics
+            }
+            const metric = getMetricFromId(
+                filter.target.fieldId,
+                explore,
+                compiledMetricQuery,
+            );
+            // Avoid duplicates
+            const alreadyIncluded = acc.find(
+                (m) => getItemId(m) === getItemId(metric),
+            );
+            return alreadyIncluded ? acc : [...acc, metric];
+        }, []);
+
+        const allMetricsObjects = [...metricsObjects, ...metricsFromFilters];
         const metricsWithCteReferences: Array<CompiledMetric> = [];
         const referencedMetricObjects = metricsObjects.reduce<CompiledMetric[]>(
             (acc, metricObject) => {
@@ -1092,7 +1117,7 @@ export class MetricQueryBuilder {
         });
         if (ctes.length > 0) {
             const unaffectedMetrics = [
-                ...metricsObjects,
+                ...allMetricsObjects,
                 ...referencedMetricObjects,
             ].filter((metric) => {
                 const notInMetricCtes = !metricCtes.some((metricCte) =>
@@ -1216,6 +1241,10 @@ export class MetricQueryBuilder {
             ctes,
             finalSelectParts,
             warnings,
+            metricCtes,
+            dimensionSelects,
+            metricsObjects,
+            fieldQuoteChar,
         };
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17014 
Relates to: #16829 

### Description:

There is a SQL when filtering by a metric not included in the query with fanouts protection.

Repro:
- Select a dimension
- Select a metric from a joined table
- Filter by a metric from the joined table, but don't select it
- Run the query
- Error

There are a couple localhost repros that match customer issues:
[Repro 1](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/fanouts_accounts?create_saved_chart_version=%7B%22tableName%22%3A%22fanouts_accounts%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22fanouts_accounts%22%2C%22dimensions%22%3A%5B%5D%2C%22metrics%22%3A%5B%22fanouts_accounts_inflated_industry_count%22%5D%2C%22filters%22%3A%7B%22metrics%22%3A%7B%22id%22%3A%22b836ed72-c9cc-438b-91c6-0dacb35591d7%22%2C%22and%22%3A%5B%7B%22id%22%3A%22a5e8a611-24b8-4a98-98aa-e9d5e762fb52%22%2C%22target%22%3A%7B%22fieldId%22%3A%22fanouts_deals_inflated_deal_count%22%7D%2C%22operator%22%3A%22notNull%22%2C%22values%22%3A%5B%5D%7D%5D%7D%7D%2C%22sorts%22%3A%5B%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22fanouts_accounts_inflated_industry_count%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22big_number%22%2C%22config%22%3A%7B%22selectedField%22%3A%22fanouts_accounts_inflated_industry_count%22%2C%22showBigNumberLabel%22%3Atrue%2C%22showComparison%22%3Afalse%2C%22comparisonFormat%22%3A%22raw%22%2C%22flipColors%22%3Afalse%7D%7D%7D)

[Repro 2](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/payments?create_saved_chart_version=%7B%22tableName%22%3A%22payments%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22payments%22%2C%22dimensions%22%3A%5B%22payments_payment_method%22%5D%2C%22metrics%22%3A%5B%22orders_average_order_size%22%5D%2C%22filters%22%3A%7B%22metrics%22%3A%7B%22id%22%3A%22a7b827bb-650a-458f-b3c7-2a5a0a9ca30d%22%2C%22and%22%3A%5B%7B%22id%22%3A%22fbba786c-309f-4170-9c9b-071b305847a2%22%2C%22target%22%3A%7B%22fieldId%22%3A%22payments_total_revenue%22%7D%2C%22operator%22%3A%22notNull%22%2C%22values%22%3A%5B%5D%7D%5D%7D%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22payments_payment_method%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22payments_payment_method%22%2C%22orders_average_order_size%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22payments_payment_method%22%2C%22yField%22%3A%5B%22orders_average_order_size%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22payments_payment_method%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_average_order_size%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%7D)

Should be fixed in this PR. The change is to include filtered fields in the selects in the `cte_unaffected`. With the bug we were not including filtered fields:
```
cte_unaffected AS (
  SELECT "payments".payment_method AS "payments_payment_method"
  FROM "postgres"."jaffle"."payments" AS "payments"
    LEFT OUTER JOIN "postgres"."jaffle"."orders" AS "orders" ON ("orders".order_id) = ("payments".order_id)
  GROUP BY 1
),
```
And now they will be added:
```
cte_unaffected AS (
  SELECT "payments".payment_method AS "payments_payment_method",
    SUM("payments".amount) AS "payments_total_revenue"
  FROM "postgres"."jaffle"."payments" AS "payments"
    LEFT OUTER JOIN "postgres"."jaffle"."orders" AS "orders" ON ("orders".order_id) = ("payments".order_id)
  GROUP BY 1
),
```

This does not fix the issue on dashboards. Working on that next. 
