### PR TITLE
feat: display more information on creation of metric

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/changeDataMerger.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/changeDataMerger.ts
@@ -1,0 +1,51 @@
+import type { Change, CompiledMetric } from '@lightdash/common';
+import { FieldType } from '@lightdash/common';
+import type { CreateMetric } from './types';
+
+/**
+ * Extended metric type that includes UI-specific fields from the AI proposal
+ */
+export type MergedMetric = CompiledMetric & {
+    baseDimensionName: string;
+};
+
+/**
+ * Merges the AI's proposed metric change with the backend's compiled metric data.
+ */
+export function mergeCreateMetricData(
+    aiProposal: CreateMetric,
+    changePayload: Change['payload'] | undefined,
+): MergedMetric | null {
+    // Type guard to check if changePayload exists and is a metric type
+    if (
+        !changePayload ||
+        !('type' in changePayload) ||
+        changePayload.type !== 'metric'
+    ) {
+        return null;
+    }
+
+    const { metric: proposedMetric } = aiProposal.value;
+    const compiledData = changePayload.value;
+
+    return {
+        // Base fields from AI proposal
+        name: proposedMetric.name,
+        type: proposedMetric.type,
+        label: proposedMetric.label,
+        table: proposedMetric.table,
+        description: proposedMetric.description,
+        baseDimensionName: proposedMetric.baseDimensionName,
+
+        // Compiled fields from backend
+        fieldType: FieldType.METRIC,
+        tableLabel: compiledData.tableLabel,
+        sql: compiledData.sql,
+        compiledSql: compiledData.compiledSql,
+        hidden: compiledData.hidden,
+
+        // Optional fields from backend (if they exist)
+        tablesReferences: compiledData.tablesReferences,
+        tablesRequiredAttributes: compiledData.tablesRequiredAttributes,
+    };
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
@@ -57,10 +57,11 @@ export const AiProposeChangeToolCall = ({
     const isSuccessResult = metadata?.status === 'success';
     const changeUuid = isSuccessResult ? metadata.changeUuid : undefined;
 
-    const { isLoading: isLoadingChange, error: changeError } = useChange(
-        projectUuid,
-        changeUuid,
-    );
+    const {
+        isLoading: isLoadingChange,
+        error: changeError,
+        data: changeData,
+    } = useChange(projectUuid, changeUuid);
 
     const isChangeDeleted = changeError?.error?.statusCode === 404;
     const isRejectedByMetadata =
@@ -127,6 +128,7 @@ export const AiProposeChangeToolCall = ({
             <Stack gap="xs" mt="xs">
                 <ChangeRenderer
                     change={change}
+                    changePayload={changeData?.payload}
                     entityTableName={entityTableName}
                 />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Enhances the AI Copilot's metric creation functionality by adding a `compiledSql` field to the metric schema and improving the metric display UI. The changes include:

1. Updated the `MetricChangeSchema` to include a required `compiledSql` string field
2. Redesigned the metric display component with a collapsible interface that shows:
   - Metric label with icon
   - Aggregation type with badge styling
   - Base dimension name
   - Description (when available)
   - SQL code display



![CleanShot 2025-10-09 at 19.29.22.gif](https://app.graphite.dev/user-attachments/assets/a8ed8db2-8914-4a1c-b857-4b8bf621efb3.gif)

