### PR TITLE
feat: Display field labels instead of IDs in funnel chart

### DIFF
--- a/packages/frontend/src/hooks/useFunnelChartConfig.ts
+++ b/packages/frontend/src/hooks/useFunnelChartConfig.ts
@@ -98,7 +98,7 @@ const useFunnelChartConfig: FunnelChartConfigFn = (
     );
 
     const allNumericFieldIds = useMemo(
-        () => Object.keys(numericFields),
+        () => (numericFields ? Object.keys(numericFields) : []),
         [numericFields],
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #10672 



### Description:
<!-- Add a description of the changes proposed in the pull request. -->
This PR fixes the issue where field IDs were displayed instead of field labels in funnel charts by importing the method `getItemLabelWithoutTableName` from common and uses it to retrieve the proper field label when building funnel chart data points. Additionally, a null check was added for `numericFields` to prevent a crash that occurred when switching from other chart types to funnel charts, where `numericFields` could be undefined during the initial render transition.

<!-- Even better add a screenshot / gif / loom -->
#### Screenshot
<img width="1278" height="652" alt="image" src="https://github.com/user-attachments/assets/87794b1c-e7ac-4277-9744-4c9118d414dc" />

