### PR TITLE
feat: improve loading state ai search box

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -1,5 +1,6 @@
 import {
     Combobox,
+    Group,
     Loader,
     ScrollArea,
     TextInput,
@@ -93,10 +94,6 @@ export const SearchDropdown: FC<Props> = ({
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             handleInputChange(e.currentTarget.value)
                         }
-                        rightSection={
-                            value.length >= OMNIBAR_MIN_QUERY_LENGTH &&
-                            !isSuccess && <Loader size={12} color="gray" />
-                        }
                     />
                 </Combobox.EventsTarget>
             </Combobox.Target>
@@ -110,9 +107,19 @@ export const SearchDropdown: FC<Props> = ({
                         scrollbars="y"
                         className={styles.searchDropdownScrollContent}
                     >
-                        {allSearchItems.length === 0 && (
-                            <Combobox.Empty>Nothing found</Combobox.Empty>
+                        {!isSuccess ? (
+                            <Combobox.Empty>
+                                <Group align="center" justify="center" gap="xs">
+                                    <Loader size={12} color="gray" />
+                                    Loading results
+                                </Group>
+                            </Combobox.Empty>
+                        ) : (
+                            allSearchItems.length === 0 && (
+                                <Combobox.Empty>Nothing found</Combobox.Empty>
+                            )
                         )}
+
                         {allSearchItemsGrouped.map(([groupType, items], i) => (
                             <Combobox.Group
                                 key={groupType}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:

The previous loading state was not visible enough, making it look like there were no results while the query was still running.


[Screen Recording 2025-10-10 at 14.19.51.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/95d3eaa7-8941-457f-8c1c-077f0997bf48.mov" />](https://app.graphite.dev/user-attachments/video/95d3eaa7-8941-457f-8c1c-077f0997bf48.mov)

