### PR TITLE
feat: use avatar light version for ai agents

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
@@ -190,7 +190,6 @@ const AgentsFilter: FC<AgentsFilterProps> = ({
                                                                         size={
                                                                             16
                                                                         }
-                                                                        variant="filled"
                                                                         name={
                                                                             agent.name
                                                                         }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -142,7 +142,6 @@ const AiAgentAdminAgentsTable = () => {
                             <Group gap="two" wrap="nowrap">
                                 <LightdashUserAvatar
                                     size={16}
-                                    variant="filled"
                                     name={agent.name}
                                     src={agent.imageUrl}
                                 />

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -236,7 +236,6 @@ const AiAgentAdminThreadsTable = ({
                         <Group gap="two" wrap="nowrap">
                             <LightdashUserAvatar
                                 size={12}
-                                variant="filled"
                                 name={thread.agent.name}
                                 src={thread.agent.imageUrl}
                             />

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelector.tsx
@@ -40,7 +40,6 @@ export const AgentSelector = ({
             leftSection={
                 <LightdashUserAvatar
                     size={22}
-                    variant="filled"
                     name={selectedAgent.name}
                     src={selectedAgent.imageUrl}
                 />

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.tsx
@@ -20,7 +20,6 @@ export const renderSelectOption = ({
     <Group gap="xs" wrap="nowrap" miw={0} flex={1}>
         <LightdashUserAvatar
             size={20}
-            variant="filled"
             name={option.label}
             src={option.imageUrl}
         />

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
@@ -52,7 +52,6 @@ export const CompactAgentSelector = ({
                     <Group gap="xxs">
                         <LightdashUserAvatar
                             size="md"
-                            variant="filled"
                             name={selectedAgent.name}
                             src={selectedAgent.imageUrl}
                         />

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -42,7 +42,6 @@ const AiAgentNewThreadPage = () => {
                     <Stack align="center" gap="xxs">
                         <LightdashUserAvatar
                             size="lg"
-                            variant="filled"
                             name={agent.name || 'AI'}
                             src={agent.imageUrl}
                         />

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -247,7 +247,6 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                         </Group>
                         <LightdashUserAvatar
                             name={isCreateMode ? '+' : form.values.name}
-                            variant="filled"
                             src={
                                 !isCreateMode ? form.values.imageUrl : undefined
                             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17317

### Description:
Removed the `variant="filled"` prop from all `LightdashUserAvatar` components across AI Copilot features. This change ensures consistent avatar styling throughout the application by removing the filled variant that was previously applied to agent avatars in the admin tables, agent selectors, and thread pages.

CC: @PriPatel 

_before_

![image.png](https://app.graphite.dev/user-attachments/assets/de0d8dbe-4af4-4dbb-b24e-10027edce012.png)

_after_
![image.png](https://app.graphite.dev/user-attachments/assets/6941f9a1-ac9f-4abc-9134-4b503e80fc92.png)

