### PR TITLE
chore: add json schemas for content-as-code

### DIFF
--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -1,0 +1,436 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.lightdash.com/lightdash/chart-as-code.json",
+    "title": "Lightdash Chart as Code",
+    "description": "Schema for defining Lightdash charts in YAML format for version control",
+    "type": "object",
+    "required": [
+        "name",
+        "tableName",
+        "metricQuery",
+        "slug",
+        "spaceSlug",
+        "version"
+    ],
+    "properties": {
+        "version": {
+            "type": "number",
+            "description": "Schema version for this chart configuration",
+            "const": 1
+        },
+        "name": {
+            "type": "string",
+            "description": "Display name of the chart",
+            "minLength": 1
+        },
+        "description": {
+            "type": "string",
+            "description": "Optional description of what this chart displays"
+        },
+        "slug": {
+            "type": "string",
+            "description": "Unique identifier slug for this chart",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "spaceSlug": {
+            "type": "string",
+            "description": "Path to the space containing this chart (e.g., 'sales/reports' or 'marketing')"
+        },
+        "tableName": {
+            "type": "string",
+            "description": "The explore/table name this chart queries from"
+        },
+        "dashboardSlug": {
+            "type": ["string", "null"],
+            "description": "Optional dashboard slug if this chart is saved within a dashboard",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the chart was last updated (readonly)"
+        },
+        "downloadedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when this chart was downloaded from Lightdash (readonly)"
+        },
+        "metricQuery": {
+            "type": "object",
+            "description": "The query configuration defining what data to fetch",
+            "required": ["exploreName"],
+            "properties": {
+                "exploreName": {
+                    "type": "string",
+                    "description": "The name of the explore to query"
+                },
+                "dimensions": {
+                    "type": "array",
+                    "description": "List of dimension field IDs to include",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "metrics": {
+                    "type": "array",
+                    "description": "List of metric field IDs to include",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "filters": {
+                    "type": "object",
+                    "description": "Filter rules to apply to the query using 'and'/'or' filter groups",
+                    "properties": {
+                        "dimensions": {
+                            "type": "object",
+                            "description": "Dimension filter group",
+                            "properties": {
+                                "and": {
+                                    "type": "array",
+                                    "description": "Array of filters combined with AND logic",
+                                    "items": {
+                                        "type": "object",
+                                        "required": ["target", "operator"],
+                                        "properties": {
+                                            "target": {
+                                                "type": "object",
+                                                "required": ["fieldId"],
+                                                "properties": {
+                                                    "fieldId": {
+                                                        "type": "string",
+                                                        "description": "Field ID to filter on"
+                                                    }
+                                                }
+                                            },
+                                            "operator": {
+                                                "type": "string",
+                                                "description": "Filter operator",
+                                                "enum": [
+                                                    "equals",
+                                                    "notEquals",
+                                                    "isNull",
+                                                    "notNull",
+                                                    "startsWith",
+                                                    "endsWith",
+                                                    "include",
+                                                    "doesNotInclude",
+                                                    "lessThan",
+                                                    "lessThanOrEqual",
+                                                    "greaterThan",
+                                                    "greaterThanOrEqual",
+                                                    "inThePast",
+                                                    "notInThePast",
+                                                    "inTheNext",
+                                                    "inTheCurrent",
+                                                    "notInTheCurrent",
+                                                    "inBetween",
+                                                    "notInBetween"
+                                                ]
+                                            },
+                                            "values": {
+                                                "type": "array",
+                                                "description": "Values to filter by"
+                                            },
+                                            "required": {
+                                                "type": "boolean",
+                                                "description": "Whether this filter is required"
+                                            }
+                                        }
+                                    }
+                                },
+                                "or": {
+                                    "type": "array",
+                                    "description": "Array of filters combined with OR logic",
+                                    "items": {
+                                        "$ref": "#/properties/metricQuery/properties/filters/properties/dimensions/properties/and/items"
+                                    }
+                                }
+                            }
+                        },
+                        "metrics": {
+                            "type": "object",
+                            "description": "Metric filter group",
+                            "properties": {
+                                "and": {
+                                    "$ref": "#/properties/metricQuery/properties/filters/properties/dimensions/properties/and"
+                                },
+                                "or": {
+                                    "$ref": "#/properties/metricQuery/properties/filters/properties/dimensions/properties/or"
+                                }
+                            }
+                        },
+                        "tableCalculations": {
+                            "type": "object",
+                            "description": "Table calculation filter group",
+                            "properties": {
+                                "and": {
+                                    "$ref": "#/properties/metricQuery/properties/filters/properties/dimensions/properties/and"
+                                },
+                                "or": {
+                                    "$ref": "#/properties/metricQuery/properties/filters/properties/dimensions/properties/or"
+                                }
+                            }
+                        }
+                    }
+                },
+                "sorts": {
+                    "type": "array",
+                    "description": "Sort configuration for query results",
+                    "items": {
+                        "type": "object",
+                        "required": ["fieldId", "descending"],
+                        "properties": {
+                            "fieldId": {
+                                "type": "string",
+                                "description": "Field ID to sort by"
+                            },
+                            "descending": {
+                                "type": "boolean",
+                                "description": "Sort in descending order"
+                            }
+                        }
+                    }
+                },
+                "limit": {
+                    "type": "number",
+                    "description": "Maximum number of rows to return",
+                    "minimum": 1
+                },
+                "metricOverrides": {
+                    "type": "object",
+                    "description": "Override formatting and display options for existing metrics",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "formatOptions": {
+                                "type": "object",
+                                "description": "Formatting configuration for the metric",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "default",
+                                            "currency",
+                                            "number",
+                                            "percent"
+                                        ],
+                                        "description": "Format type"
+                                    },
+                                    "round": {
+                                        "type": "number",
+                                        "description": "Number of decimal places"
+                                    },
+                                    "currency": {
+                                        "type": "string",
+                                        "description": "Currency code (e.g., USD, GBP, EUR)"
+                                    },
+                                    "separator": {
+                                        "type": "string",
+                                        "enum": [
+                                            "default",
+                                            "commaPeriod",
+                                            "spacePeriod",
+                                            "periodComma",
+                                            "spaceComma"
+                                        ],
+                                        "description": "Thousands separator style"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "tableCalculations": {
+                    "type": "array",
+                    "description": "Custom calculations to perform on query results (like window functions)",
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "displayName", "sql"],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Internal name of the table calculation"
+                            },
+                            "displayName": {
+                                "type": "string",
+                                "description": "Display name shown in the UI"
+                            },
+                            "sql": {
+                                "type": "string",
+                                "description": "SQL expression for the calculation (can reference fields with ${table.field})"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["string", "number", "date", "boolean"],
+                                "description": "Data type of the calculation result"
+                            },
+                            "format": {
+                                "type": "object",
+                                "description": "Formatting options for the calculation",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "default",
+                                            "currency",
+                                            "number",
+                                            "percent"
+                                        ],
+                                        "description": "Format type"
+                                    },
+                                    "round": {
+                                        "type": "number",
+                                        "description": "Number of decimal places"
+                                    },
+                                    "currency": {
+                                        "type": "string",
+                                        "description": "Currency code (e.g., USD, GBP, EUR)"
+                                    },
+                                    "separator": {
+                                        "type": "string",
+                                        "enum": [
+                                            "default",
+                                            "commaPeriod",
+                                            "spacePeriod",
+                                            "periodComma",
+                                            "spaceComma"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "additionalMetrics": {
+                    "type": "array",
+                    "description": "Custom metrics defined inline (ad-hoc metrics not in the dbt model)",
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "label", "sql", "table", "type"],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Internal name of the metric"
+                            },
+                            "label": {
+                                "type": "string",
+                                "description": "Display label for the metric"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description of what the metric measures"
+                            },
+                            "sql": {
+                                "type": "string",
+                                "description": "SQL expression (e.g., ${TABLE}.column_name)"
+                            },
+                            "table": {
+                                "type": "string",
+                                "description": "Table name the metric belongs to"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "count",
+                                    "count_distinct",
+                                    "sum",
+                                    "average",
+                                    "min",
+                                    "max"
+                                ],
+                                "description": "Aggregation type"
+                            },
+                            "baseDimensionName": {
+                                "type": "string",
+                                "description": "Name of the base dimension/column this metric aggregates"
+                            },
+                            "formatOptions": {
+                                "type": "object",
+                                "description": "Formatting configuration",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "default",
+                                            "currency",
+                                            "number",
+                                            "percent"
+                                        ]
+                                    },
+                                    "separator": {
+                                        "type": "string",
+                                        "enum": [
+                                            "default",
+                                            "commaPeriod",
+                                            "spacePeriod",
+                                            "periodComma",
+                                            "spaceComma"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customDimensions": {
+                    "type": "array",
+                    "description": "Custom dimensions defined inline",
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            }
+        },
+        "chartConfig": {
+            "type": "object",
+            "description": "Visualization configuration for the chart",
+            "required": ["type"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Type of chart visualization",
+                    "enum": [
+                        "cartesian",
+                        "pie",
+                        "table",
+                        "big_number",
+                        "funnel",
+                        "treemap",
+                        "custom"
+                    ]
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Chart-specific configuration (varies by chart type)"
+                }
+            }
+        },
+        "tableConfig": {
+            "type": "object",
+            "description": "Table view configuration",
+            "properties": {
+                "columnOrder": {
+                    "type": "array",
+                    "description": "Order of columns in table view",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "pivotConfig": {
+            "type": "object",
+            "description": "Pivot table configuration",
+            "properties": {
+                "columns": {
+                    "type": "array",
+                    "description": "Fields to use as pivot columns",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -1,0 +1,349 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.lightdash.com/lightdash/dashboard-as-code.json",
+    "title": "Lightdash Dashboard as Code",
+    "description": "Schema for defining Lightdash dashboards in YAML format for version control",
+    "type": "object",
+    "required": [
+        "name",
+        "slug",
+        "spaceSlug",
+        "version",
+        "tiles",
+        "filters",
+        "tabs"
+    ],
+    "properties": {
+        "version": {
+            "type": "number",
+            "description": "Schema version for this dashboard configuration",
+            "const": 1
+        },
+        "name": {
+            "type": "string",
+            "description": "Display name of the dashboard",
+            "minLength": 1
+        },
+        "description": {
+            "type": "string",
+            "description": "Optional description of what this dashboard displays"
+        },
+        "slug": {
+            "type": "string",
+            "description": "Unique identifier slug for this dashboard",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "spaceSlug": {
+            "type": "string",
+            "description": "Path to the space containing this dashboard (e.g., 'sales/reports' or 'marketing')"
+        },
+        "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the dashboard was last updated (readonly)"
+        },
+        "downloadedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when this dashboard was downloaded from Lightdash (readonly)"
+        },
+        "tiles": {
+            "type": "array",
+            "description": "Array of tiles (charts, markdown, loom videos) positioned on the dashboard",
+            "items": {
+                "type": "object",
+                "required": ["type", "x", "y", "h", "w"],
+                "properties": {
+                    "uuid": {
+                        "type": "string",
+                        "description": "Optional UUID for the tile (generated if not provided)"
+                    },
+                    "tileSlug": {
+                        "type": "string",
+                        "description": "Optional slug identifier for the tile"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Type of dashboard tile",
+                        "enum": ["saved_chart", "markdown", "loom"]
+                    },
+                    "x": {
+                        "type": "number",
+                        "description": "Horizontal position in grid units",
+                        "minimum": 0
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "Vertical position in grid units",
+                        "minimum": 0
+                    },
+                    "h": {
+                        "type": "number",
+                        "description": "Height in grid units",
+                        "minimum": 1
+                    },
+                    "w": {
+                        "type": "number",
+                        "description": "Width in grid units",
+                        "minimum": 1
+                    },
+                    "tabUuid": {
+                        "type": ["string", "null"],
+                        "description": "UUID of the tab this tile belongs to, or null for default tab"
+                    },
+                    "properties": {
+                        "type": "object",
+                        "description": "Tile-specific properties (varies by tile type)",
+                        "oneOf": [
+                            {
+                                "description": "Properties for a saved chart tile",
+                                "properties": {
+                                    "title": {
+                                        "type": "string",
+                                        "description": "Optional custom title override for the chart"
+                                    },
+                                    "hideTitle": {
+                                        "type": "boolean",
+                                        "description": "Whether to hide the chart title"
+                                    },
+                                    "chartSlug": {
+                                        "type": "string",
+                                        "description": "Slug of the chart to display"
+                                    },
+                                    "chartName": {
+                                        "type": "string",
+                                        "description": "Name of the chart"
+                                    }
+                                },
+                                "required": ["chartSlug"]
+                            },
+                            {
+                                "description": "Properties for a markdown tile",
+                                "properties": {
+                                    "title": {
+                                        "type": "string",
+                                        "description": "Title of the markdown tile"
+                                    },
+                                    "hideTitle": {
+                                        "type": "boolean",
+                                        "description": "Whether to hide the markdown tile title"
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "description": "Markdown content to display"
+                                    }
+                                },
+                                "required": ["title", "content"]
+                            },
+                            {
+                                "description": "Properties for a Loom video tile",
+                                "properties": {
+                                    "title": {
+                                        "type": "string",
+                                        "description": "Title of the Loom tile"
+                                    },
+                                    "hideTitle": {
+                                        "type": "boolean",
+                                        "description": "Whether to hide the tile title"
+                                    },
+                                    "url": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "URL of the Loom video"
+                                    }
+                                },
+                                "required": ["title", "url"]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "tabs": {
+            "type": "array",
+            "description": "Dashboard tabs for organizing tiles into separate views",
+            "items": {
+                "type": "object",
+                "required": ["uuid", "name", "order"],
+                "properties": {
+                    "uuid": {
+                        "type": "string",
+                        "description": "Unique identifier for the tab"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Display name of the tab",
+                        "minLength": 1
+                    },
+                    "order": {
+                        "type": "number",
+                        "description": "Sort order of the tab (lower numbers appear first)",
+                        "minimum": 0
+                    }
+                }
+            }
+        },
+        "filters": {
+            "type": "object",
+            "description": "Dashboard-level filters that can be applied across all tiles",
+            "required": ["dimensions"],
+            "properties": {
+                "dimensions": {
+                    "type": "array",
+                    "description": "Dimension filters applied to the dashboard",
+                    "items": {
+                        "type": "object",
+                        "required": ["operator", "target"],
+                        "properties": {
+                            "operator": {
+                                "type": "string",
+                                "description": "Filter operator determining how values are compared",
+                                "enum": [
+                                    "isNull",
+                                    "notNull",
+                                    "equals",
+                                    "notEquals",
+                                    "startsWith",
+                                    "endsWith",
+                                    "include",
+                                    "doesNotInclude",
+                                    "lessThan",
+                                    "lessThanOrEqual",
+                                    "greaterThan",
+                                    "greaterThanOrEqual",
+                                    "inThePast",
+                                    "notInThePast",
+                                    "inTheNext",
+                                    "inTheCurrent",
+                                    "notInTheCurrent",
+                                    "inBetween",
+                                    "notInBetween"
+                                ]
+                            },
+                            "values": {
+                                "type": "array",
+                                "description": "Values to filter by (varies by operator)",
+                                "items": {}
+                            },
+                            "target": {
+                                "type": "object",
+                                "description": "Field to apply the filter to",
+                                "required": ["fieldId", "tableName"],
+                                "properties": {
+                                    "fieldId": {
+                                        "type": "string",
+                                        "description": "ID of the field to filter (e.g., 'orders_status')"
+                                    },
+                                    "fieldName": {
+                                        "type": "string",
+                                        "description": "Human-readable name of the field (e.g., 'status')"
+                                    },
+                                    "tableName": {
+                                        "type": "string",
+                                        "description": "Table containing the field (e.g., 'orders')"
+                                    },
+                                    "isSqlColumn": {
+                                        "type": "boolean",
+                                        "description": "Whether the fieldId refers to a SQL column name"
+                                    },
+                                    "fallbackType": {
+                                        "type": "string",
+                                        "description": "Fallback type when field is not available",
+                                        "enum": [
+                                            "string",
+                                            "number",
+                                            "boolean",
+                                            "date",
+                                            "timestamp"
+                                        ]
+                                    }
+                                }
+                            },
+                            "settings": {
+                                "type": "object",
+                                "description": "Additional settings for date/time filters",
+                                "properties": {
+                                    "unitOfTime": {
+                                        "type": "string",
+                                        "enum": [
+                                            "milliseconds",
+                                            "seconds",
+                                            "minutes",
+                                            "hours",
+                                            "days",
+                                            "weeks",
+                                            "months",
+                                            "quarters",
+                                            "years"
+                                        ]
+                                    },
+                                    "completed": {
+                                        "type": "boolean",
+                                        "description": "For date filters, whether to include completed periods"
+                                    }
+                                }
+                            },
+                            "disabled": {
+                                "type": "boolean",
+                                "description": "Whether this filter is currently disabled"
+                            },
+                            "required": {
+                                "type": "boolean",
+                                "description": "Whether this filter must be set by users"
+                            },
+                            "tileTargets": {
+                                "type": "object",
+                                "description": "Per-tile filter configuration (tile UUID -> field mapping or false to disable)",
+                                "additionalProperties": {
+                                    "oneOf": [
+                                        {
+                                            "type": "boolean",
+                                            "const": false
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "fieldId",
+                                                "tableName"
+                                            ],
+                                            "properties": {
+                                                "fieldId": {
+                                                    "type": "string"
+                                                },
+                                                "tableName": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "label": {
+                                "type": ["string", "null"],
+                                "description": "Custom label for the filter"
+                            },
+                            "singleValue": {
+                                "type": "boolean",
+                                "description": "Whether the filter only accepts a single value"
+                            }
+                        }
+                    }
+                },
+                "metrics": {
+                    "type": "array",
+                    "description": "Metric filters applied to the dashboard",
+                    "items": {
+                        "$ref": "#/properties/filters/properties/dimensions/items"
+                    }
+                },
+                "tableCalculations": {
+                    "type": "array",
+                    "description": "Table calculation filters applied to the dashboard",
+                    "items": {
+                        "$ref": "#/properties/filters/properties/dimensions/items"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Add JSON schema definitions for Chart-as-Code and Dashboard-as-Code features. These schemas define the structure for YAML-based version control of Lightdash charts and dashboards.

The schemas include:
- `chart-as-code-1.0.json`: Defines the structure for charts with properties for queries, visualization settings, and metadata
- `dashboard-as-code-1.0.json`: Defines the structure for dashboards with properties for tiles, tabs, filters, and layout

These schemas will enable validation of chart and dashboard YAML files, providing a standardized format for version-controlled analytics assets.

chart-as-code validation:

![image.png](https://app.graphite.dev/user-attachments/assets/92cbec3a-961c-4d70-aed0-75711e20a24f.png)

dashboard-as-code validation:

![image.png](https://app.graphite.dev/user-attachments/assets/3a99568a-03f9-41a4-90ad-9c1df44cb895.png)

ℹ️ how to test:

download Red hat yaml extension
go to vscode/cursor's JSON settings: 

have something like this 

```
 "yaml.schemas": {
   "FULLPATH.../lightdash/packages/common/src/schemas/json/chart-as-code-1.0.json": [
      "/examples/lightdash/charts/*.yml"
    ],
    "FULLPATH.../lightdash/packages/common/src/schemas/json/dashboard-as-code-1.0.json": [
      "/examples/lightdash/dashboards/*.yml"
    ]
}
```

you will then reload the window (> + reload window) 

Then on a chart example you will see the schema loaded and you can hover on the properties. 
