### PR TITLE
refactor: update findExplores tool to use versioned schema

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -19,8 +19,8 @@ import {
     toolFindChartsArgsSchema,
     ToolFindDashboardsArgs,
     toolFindDashboardsArgsSchema,
-    ToolFindExploresArgs,
-    toolFindExploresArgsSchema,
+    toolFindExploresArgsSchemaV2,
+    ToolFindExploresArgsV2,
     ToolFindFieldsArgs,
     toolFindFieldsArgsSchema,
     ToolRunMetricQueryArgs,
@@ -237,13 +237,13 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             McpToolName.FIND_EXPLORES,
             {
-                description: toolFindExploresArgsSchema.description,
+                description: toolFindExploresArgsSchemaV2.description,
                 inputSchema: this.getMcpCompatibleSchema(
-                    toolFindExploresArgsSchema,
+                    toolFindExploresArgsSchemaV2,
                 ) as AnyType,
             },
             async (_args, context) => {
-                const args = _args as ToolFindExploresArgs;
+                const args = _args as ToolFindExploresArgsV2;
 
                 const projectUuid = await this.resolveProjectUuid(
                     context as McpProtocolContext,
@@ -836,7 +836,7 @@ export class McpService extends BaseService {
     }
 
     async getFindExploresFunction(
-        toolArgs: ToolFindExploresArgs & { projectUuid: string },
+        toolArgs: ToolFindExploresArgsV2 & { projectUuid: string },
         context: McpProtocolContext,
     ): Promise<FindExploresFn> {
         const { user, account } = context.authInfo!.extra;

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -4,7 +4,7 @@ import {
     CompiledMetric,
     convertToAiHints,
     getItemId,
-    toolFindExploresArgsSchema,
+    toolFindExploresArgsSchemaV2,
     toolFindExploresOutputSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -176,8 +176,8 @@ export const getFindExplores = ({
     fieldSearchSize,
 }: Dependencies) =>
     tool({
-        description: toolFindExploresArgsSchema.description,
-        inputSchema: toolFindExploresArgsSchema,
+        description: toolFindExploresArgsSchemaV2.description,
+        inputSchema: toolFindExploresArgsSchemaV2,
         outputSchema: toolFindExploresOutputSchema,
         execute: async (args) => {
             try {

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -6,7 +6,8 @@ import {
     type ToolFindChartsOutput,
     toolFindDashboardsArgsSchema,
     type ToolFindDashboardsOutput,
-    toolFindExploresArgsSchema,
+    toolFindExploresArgsSchemaV1,
+    toolFindExploresArgsSchemaV2,
     type ToolFindExploresOutput,
     toolFindFieldsArgsSchema,
     type ToolFindFieldsOutput,
@@ -43,7 +44,8 @@ export const AgentToolCallArgsSchema = z.discriminatedUnion('type', [
     toolVerticalBarArgsSchema,
     toolTableVizArgsSchema,
     toolTimeSeriesArgsSchema,
-    toolFindExploresArgsSchema,
+    toolFindExploresArgsSchemaV1,
+    toolFindExploresArgsSchemaV2,
 ]);
 
 export type AgentToolCallArgs = z.infer<typeof AgentToolCallArgsSchema>;

--- a/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
@@ -48,15 +48,48 @@ const toolSchemaBuilder = <$Schema extends z.ZodRawShape>(
     schema,
 });
 
-export const createToolSchema = <
+function createToolSchema<
     $Type extends string,
     $Description extends string,
->(
-    /** The type of the tool. This will be used as differentiator for the union with other tool schemas  */
-    type: $Type,
-    /** Description of the tool. This will be used to help the LLM to understand the tool and its capabilities. Be as clear and concise as possible. */
-    description: $Description,
-) =>
-    toolSchemaBuilder(
-        z.object({ type: z.literal(type) }).describe(description),
+>(args: {
+    type: $Type;
+    description: $Description;
+}): ReturnType<typeof toolSchemaBuilder<{ type: z.ZodLiteral<$Type> }>>;
+function createToolSchema<
+    $Type extends string,
+    $Description extends string,
+    $Version extends number,
+>(args: {
+    type: $Type;
+    description: $Description;
+    version: $Version;
+}): ReturnType<
+    typeof toolSchemaBuilder<{ type: z.ZodLiteral<`${$Type}_v${$Version}`> }>
+>;
+function createToolSchema<
+    $Type extends string,
+    $Description extends string,
+    $Version extends number,
+>({
+    type,
+    description,
+    version,
+}: {
+    type: $Type;
+    description: $Description;
+    version?: $Version;
+}) {
+    return toolSchemaBuilder(
+        z
+            .object({
+                type: z.literal(
+                    version !== undefined
+                        ? (`${type}_v${version}` as const)
+                        : type,
+                ),
+            })
+            .describe(description),
     );
+}
+
+export { createToolSchema };

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardArgs.ts
@@ -81,10 +81,10 @@ export type DashboardVisualization = z.infer<
     typeof dashboardVisualizationSchema
 >;
 
-export const toolDashboardArgsSchema = createToolSchema(
-    AiResultType.DASHBOARD_RESULT,
-    TOOL_DASHBOARD_DESCRIPTION,
-)
+export const toolDashboardArgsSchema = createToolSchema({
+    type: AiResultType.DASHBOARD_RESULT,
+    description: TOOL_DASHBOARD_DESCRIPTION,
+})
     .extend({
         title: z.string().describe('A descriptive title for the dashboard'),
         description: z

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindChartsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindChartsArgs.ts
@@ -15,10 +15,10 @@ Usage tips:
 - Returns chart URLs when available
 `;
 
-export const toolFindChartsArgsSchema = createToolSchema(
-    'find_charts',
-    TOOL_FIND_CHARTS_DESCRIPTION,
-)
+export const toolFindChartsArgsSchema = createToolSchema({
+    type: 'find_charts',
+    description: TOOL_FIND_CHARTS_DESCRIPTION,
+})
     .extend({
         chartSearchQueries: z.array(
             z.object({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindDashboardsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindDashboardsArgs.ts
@@ -17,10 +17,10 @@ Usage tips:
 - It doesn't provide a dashboard summary yet, so don't suggest this capability
 `;
 
-export const toolFindDashboardsArgsSchema = createToolSchema(
-    'find_dashboards',
-    TOOL_FIND_DASHBOARDS_DESCRIPTION,
-)
+export const toolFindDashboardsArgsSchema = createToolSchema({
+    type: 'find_dashboards',
+    description: TOOL_FIND_DASHBOARDS_DESCRIPTION,
+})
     .extend({
         dashboardSearchQueries: z.array(
             z.object({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -12,16 +12,43 @@ Usage Tips:
 - All fields are returned as well as their field ids, descriptions labels and ai hints.
 `;
 
-export const toolFindExploresArgsSchema = createToolSchema(
-    'find_explores',
-    TOOL_FIND_EXPLORES_DESCRIPTION,
-)
+export const toolFindExploresArgsSchemaV1 = createToolSchema({
+    type: 'find_explores',
+    description: TOOL_FIND_EXPLORES_DESCRIPTION,
+})
+    .extend({
+        exploreName: z
+            .string()
+            .nullable()
+            .describe('Name of the explore that you have access to'),
+    })
+    .withPagination()
+    .build();
+
+export type ToolFindExploresArgsV1 = z.infer<
+    typeof toolFindExploresArgsSchemaV1
+>;
+
+export const toolFindExploresArgsSchemaV2 = createToolSchema({
+    type: 'find_explores',
+    description: TOOL_FIND_EXPLORES_DESCRIPTION,
+    version: 2,
+})
     .extend({
         exploreName: z
             .string()
             .describe('Name of the explore that you have access to'),
     })
     .build();
+
+export type ToolFindExploresArgsV2 = z.infer<
+    typeof toolFindExploresArgsSchemaV2
+>;
+
+export const toolFindExploresArgsSchema = z.discriminatedUnion('type', [
+    toolFindExploresArgsSchemaV1,
+    toolFindExploresArgsSchemaV2,
+]);
 
 export type ToolFindExploresArgs = z.infer<typeof toolFindExploresArgsSchema>;
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
@@ -16,10 +16,10 @@ Usage tips:
 - Results are paginated — use the next page token to get more results if needed.
 `;
 
-export const toolFindFieldsArgsSchema = createToolSchema(
-    'find_fields',
-    TOOL_FIND_FIELDS_DESCRIPTION,
-)
+export const toolFindFieldsArgsSchema = createToolSchema({
+    type: 'find_fields',
+    description: TOOL_FIND_FIELDS_DESCRIPTION,
+})
     .extend({
         table: z.string().describe('The table to search in.'),
         fieldSearchQueries: z.array(

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolImproveContext.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolImproveContext.ts
@@ -22,10 +22,10 @@ Captures learnings from user corrections, clarifications, and guidance to improv
 - Instructions should be specific and context-aware (not overly generic)
 `;
 
-export const toolImproveContextArgsSchema = createToolSchema(
-    AiResultType.IMPROVE_CONTEXT,
-    TOOL_IMPROVE_CONTEXT_DESCRIPTION,
-)
+export const toolImproveContextArgsSchema = createToolSchema({
+    type: AiResultType.IMPROVE_CONTEXT,
+    description: TOOL_IMPROVE_CONTEXT_DESCRIPTION,
+})
     .extend({
         originalQuery: z
             .string()

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolProposeChange.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolProposeChange.ts
@@ -152,10 +152,10 @@ const changeSchema = z.discriminatedUnion('entityType', [
 // Tool Schema Export
 // ============================================================================
 
-export const toolProposeChangeArgsSchema = createToolSchema(
-    AiResultType.PROPOSE_CHANGE,
-    TOOL_PROPOSE_CHANGE_DESCRIPTION,
-)
+export const toolProposeChangeArgsSchema = createToolSchema({
+    type: AiResultType.PROPOSE_CHANGE,
+    description: TOOL_PROPOSE_CHANGE_DESCRIPTION,
+})
     .extend({
         entityTableName: z
             .string()

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunMetricQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunMetricQueryArgs.ts
@@ -18,10 +18,10 @@ Usage Tips:
 - The query respects the same limits and permissions as other visualization tools
 `;
 
-export const toolRunMetricQueryArgsSchema = createToolSchema(
-    'run_metric_query',
-    TOOL_RUN_METRIC_QUERY_DESCRIPTION,
-)
+export const toolRunMetricQueryArgsSchema = createToolSchema({
+    type: 'run_metric_query',
+    description: TOOL_RUN_METRIC_QUERY_DESCRIPTION,
+})
     .extend({
         vizConfig: tableVizConfigSchema,
         customMetrics: customMetricsSchema,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
@@ -16,10 +16,10 @@ Usage Tips:
 - Results are returned as a list of unique field values (limited to 100)
 `;
 
-export const toolSearchFieldValuesArgsSchema = createToolSchema(
-    'search_field_values',
-    TOOL_SEARCH_FIELD_VALUES_DESCRIPTION,
-)
+export const toolSearchFieldValuesArgsSchema = createToolSchema({
+    type: 'search_field_values',
+    description: TOOL_SEARCH_FIELD_VALUES_DESCRIPTION,
+})
     .extend({
         table: z.string().describe('The table to search in.'),
         fieldId: getFieldIdSchema({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -14,10 +14,10 @@ import { tableVizConfigSchema } from '../visualizations';
 
 export const TOOL_TABLE_VIZ_DESCRIPTION = `Use this tool to query data to display in a table or summarized if limit is set to 1.`;
 
-export const toolTableVizArgsSchema = createToolSchema(
-    AiResultType.TABLE_RESULT,
-    TOOL_TABLE_VIZ_DESCRIPTION,
-)
+export const toolTableVizArgsSchema = createToolSchema({
+    type: AiResultType.TABLE_RESULT,
+    description: TOOL_TABLE_VIZ_DESCRIPTION,
+})
     .extend({
         ...visualizationMetadataSchema.shape,
         customMetrics: customMetricsSchema,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -14,10 +14,10 @@ import { timeSeriesMetricVizConfigSchema } from '../visualizations/timeSeriesViz
 
 export const TOOL_TIME_SERIES_VIZ_DESCRIPTION = `Use this tool to generate a Time Series Chart.`;
 
-export const toolTimeSeriesArgsSchema = createToolSchema(
-    AiResultType.TIME_SERIES_RESULT,
-    TOOL_TIME_SERIES_VIZ_DESCRIPTION,
-)
+export const toolTimeSeriesArgsSchema = createToolSchema({
+    type: AiResultType.TIME_SERIES_RESULT,
+    description: TOOL_TIME_SERIES_VIZ_DESCRIPTION,
+})
     .extend({
         ...visualizationMetadataSchema.shape,
         customMetrics: customMetricsSchema,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -14,10 +14,10 @@ import { verticalBarMetricVizConfigSchema } from '../visualizations';
 
 export const TOOL_VERTICAL_BAR_VIZ_DESCRIPTION = `Use this tool to generate a Bar Chart Visualization.`;
 
-export const toolVerticalBarArgsSchema = createToolSchema(
-    AiResultType.VERTICAL_BAR_RESULT,
-    TOOL_VERTICAL_BAR_VIZ_DESCRIPTION,
-)
+export const toolVerticalBarArgsSchema = createToolSchema({
+    type: AiResultType.VERTICAL_BAR_RESULT,
+    description: TOOL_VERTICAL_BAR_VIZ_DESCRIPTION,
+})
     .extend({
         ...visualizationMetadataSchema.shape,
         customMetrics: customMetricsSchema,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -106,9 +106,25 @@ const ToolCallDescription: FC<{
 
     switch (toolArgs.type) {
         case 'find_explores':
+        case 'find_explores_v2':
             return (
                 <Text c="dimmed" size="xs">
-                    Searched relevant explores
+                    Searched relevant explores{' '}
+                    {toolArgs.exploreName && (
+                        <Badge
+                            color="gray"
+                            variant="light"
+                            size="xs"
+                            mx={rem(2)}
+                            radius="sm"
+                            style={{
+                                textTransform: 'none',
+                                fontWeight: 400,
+                            }}
+                        >
+                            {toolArgs.exploreName}
+                        </Badge>
+                    )}
                 </Text>
             );
         case 'find_fields':


### PR DESCRIPTION
### Description:
This PR updates the `find_explores` tool to support versioning. It introduces a new version (V2) of the tool schema that makes the `exploreName` parameter required, while maintaining backward compatibility with the original schema (now V1) where this parameter was nullable.

The PR also enhances the `createToolSchema` function to support versioned tool schemas and updates the UI to display the explore name in the tool call description when available.