### PR TITLE
feat: ai feature visibility defaults to true

### DIFF
--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -48,7 +48,7 @@ export class AiOrganizationSettingsService {
         if (!settings) {
             return {
                 organizationUuid: user.organizationUuid,
-                aiAgentsVisible: false,
+                aiAgentsVisible: true,
             };
         }
 


### PR DESCRIPTION
### Description:
Changes the default value of `aiAgentsVisible` from `false` to `true` in the `AiOrganizationSettingsService` when no settings exist for a user's organization.

> [!NOTE]
> AI Feature enablement still requires the copilot environment variable. This change makes the visibility of AI Ask / AI search box true by default to all orgs with AI enabled already