### PR TITLE
fix(perf): add experimental explore summary fetching to

### DIFF
--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -134,7 +134,12 @@ export class CatalogService<
             if (isExploreError(explore)) {
                 return acc;
             }
-            if (doesExploreMatchRequiredAttributes(explore, userAttributes)) {
+            if (
+                doesExploreMatchRequiredAttributes(
+                    explore.tables[explore.baseTable].requiredAttributes,
+                    userAttributes,
+                )
+            ) {
                 const fields: CatalogField[] = Object.values(
                     explore.tables,
                 ).flatMap((t) => parseFieldsFromCompiledTable(t));
@@ -214,7 +219,12 @@ export class CatalogService<
             ) {
                 return acc;
             }
-            if (doesExploreMatchRequiredAttributes(explore, userAttributes)) {
+            if (
+                doesExploreMatchRequiredAttributes(
+                    explore.tables[explore.baseTable].requiredAttributes,
+                    userAttributes,
+                )
+            ) {
                 return [
                     ...acc,
                     {
@@ -327,7 +337,10 @@ export class CatalogService<
                     return [...acc, explore];
                 }
                 if (
-                    !doesExploreMatchRequiredAttributes(explore, userAttributes)
+                    !doesExploreMatchRequiredAttributes(
+                        explore.tables[explore.baseTable].requiredAttributes,
+                        userAttributes,
+                    )
                 ) {
                     return acc;
                 }
@@ -676,7 +689,12 @@ export class CatalogService<
                 userUuid: user.userUuid,
             });
 
-        if (!doesExploreMatchRequiredAttributes(explore, userAttributes)) {
+        if (
+            !doesExploreMatchRequiredAttributes(
+                explore.tables[explore.baseTable].requiredAttributes,
+                userAttributes,
+            )
+        ) {
             throw new ForbiddenError(
                 `You don't have access to the explore ${explore.name}`,
             );

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
@@ -19,13 +19,17 @@ describe('doesExploreMatchUserAttributes', () => {
     test('should be true if there are no required attributes', () => {
         expect(
             doesExploreMatchRequiredAttributes(
-                EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES,
+                EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables[
+                    EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.baseTable
+                ].requiredAttributes,
                 {},
             ),
         ).toStrictEqual(true);
         expect(
             doesExploreMatchRequiredAttributes(
-                EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES,
+                EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables[
+                    EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.baseTable
+                ].requiredAttributes,
                 { test: ['1'] },
             ),
         ).toStrictEqual(true);
@@ -33,7 +37,9 @@ describe('doesExploreMatchUserAttributes', () => {
     test('should be true if required attribute value match', () => {
         expect(
             doesExploreMatchRequiredAttributes(
-                EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES,
+                EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.baseTable
+                ].requiredAttributes,
                 { access_level: ['2'] },
             ),
         ).toStrictEqual(true);
@@ -41,13 +47,17 @@ describe('doesExploreMatchUserAttributes', () => {
     test('should be false if required attributes dont match', () => {
         expect(
             doesExploreMatchRequiredAttributes(
-                EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES,
+                EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.baseTable
+                ].requiredAttributes,
                 {},
             ),
         ).toStrictEqual(false);
         expect(
             doesExploreMatchRequiredAttributes(
-                EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES,
+                EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.baseTable
+                ].requiredAttributes,
                 { access_level: ['1'] },
             ),
         ).toStrictEqual(false);

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -43,20 +43,24 @@ export const exploreHasFilteredAttribute = (explore: Explore) =>
     );
 
 export const doesExploreMatchRequiredAttributes = (
-    explore: Explore,
+    exploreAttributes:
+        | Explore['tables'][string]['requiredAttributes']
+        | undefined,
     userAttributes: UserAttributeValueMap,
 ) =>
-    explore.tables[explore.baseTable].requiredAttributes === undefined ||
-    hasUserAttributes(
-        explore.tables[explore.baseTable].requiredAttributes,
-        userAttributes,
-    );
+    exploreAttributes === undefined ||
+    hasUserAttributes(exploreAttributes, userAttributes);
 
 export const getFilteredExplore = (
     explore: Explore,
     userAttributes: UserAttributeValueMap,
 ): Explore => {
-    if (!doesExploreMatchRequiredAttributes(explore, userAttributes)) {
+    if (
+        !doesExploreMatchRequiredAttributes(
+            explore.tables[explore.baseTable].requiredAttributes,
+            userAttributes,
+        )
+    ) {
         throw new AuthorizationError(
             "You don't have authorization to access this explore",
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16772

### Description:
Optimized explore summaries by implementing a new method that directly extracts only the required fields from the database using PostgreSQL JSON operators instead of fetching the entire explore JSON.

The implementation:
1. Added `getAllExploreSummaries()` method in ProjectModel that uses PostgreSQL JSON operators to extract only needed fields
2. Created a feature flag `EXPERIMENTAL_EXPLORE_SUMMARIES` to toggle between the optimized and legacy implementations
3. Refactored `doesExploreMatchRequiredAttributes()` to accept the required attributes directly instead of the entire explore object
4. Updated all calls to `doesExploreMatchRequiredAttributes()` throughout the codebase

This optimization significantly reduces the amount of data transferred from the database when fetching explore summaries, improving performance for projects with many explores.

**Test data**
To test this accurately I had to create and seed around 200 models that were quite complex. The complexity of the models was quite important as that meant the json blobs saved in the database were bigger

**Scenarios to test**
- User attributes and required attributes still need to work
- Models with errors also need to be shown in the list as they currently are

**EXPERIMENTAL_EXPLORE_SUMMARIES=false**

![legacy.png](https://app.graphite.dev/user-attachments/assets/46a68a5b-7a6a-4062-9f59-3ba309a884c0.png)

**EXPERIMENTAL_EXPLORE_SUMMARIES=true**

![experimental.png](https://app.graphite.dev/user-attachments/assets/8ce80958-1210-42f7-8d42-c3bdd6d6c553.png)

test-frontend
