### PR TITLE
feat: update URL for embed dashboard interactions

### DIFF
--- a/packages/frontend/sdk/index.test.tsx
+++ b/packages/frontend/sdk/index.test.tsx
@@ -1,0 +1,325 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock react-router hooks
+const mockNavigate = vi.fn();
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual('react-router');
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    };
+});
+
+// Mock API calls
+vi.mock('../src/hooks/dashboard/useDashboard', () => ({
+    useDashboardQuery: () => ({
+        data: {
+            uuid: 'test-dashboard-uuid',
+            name: 'Test Dashboard',
+            description: '',
+            tiles: [],
+            tabs: [
+                { uuid: 'tab-1', name: 'Tab 1', order: 0 },
+                { uuid: 'tab-2', name: 'Tab 2', order: 1 },
+            ],
+            filters: { dimensions: [], metrics: [], tableCalculations: [] },
+            updatedAt: new Date(),
+            projectUuid: 'test-project-uuid',
+            organizationUuid: 'test-org-uuid',
+            spaceUuid: 'test-space-uuid',
+            pinnedListUuid: null,
+            views: 0,
+            firstViewedAt: null,
+            slug: 'test-dashboard',
+        },
+        isInitialLoading: false,
+        error: null,
+    }),
+    useDashboardsAvailableFilters: () => ({
+        isInitialLoading: false,
+        isFetching: false,
+        data: {
+            allFilterableFields: [],
+            savedQueryFilters: {},
+        },
+    }),
+    useDashboardVersionRefresh: () => ({
+        mutateAsync: vi.fn(),
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../src/hooks/user/useAccount', () => ({
+    useAccount: () => ({
+        data: {
+            user: {
+                userUuid: 'test-user',
+                email: 'test@example.com',
+                firstName: 'Test',
+                lastName: 'User',
+                organizationUuid: 'test-org',
+                organizationName: 'Test Org',
+                isTrackingAnonymized: false,
+                isMarketingOptedIn: false,
+                isSetupComplete: true,
+                abilityRules: [],
+            },
+        },
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../src/ee/features/embed/EmbedDashboard/hooks', () => ({
+    useEmbedDashboard: () => ({
+        data: {
+            uuid: 'test-dashboard-uuid',
+            name: 'Test Dashboard',
+            description: '',
+            tiles: [],
+            tabs: [
+                { uuid: 'tab-1', name: 'Tab 1', order: 0 },
+                { uuid: 'tab-2', name: 'Tab 2', order: 1 },
+            ],
+            filters: { dimensions: [], metrics: [], tableCalculations: [] },
+            updatedAt: new Date(),
+            projectUuid: 'test-project-uuid',
+            organizationUuid: 'test-org-uuid',
+            spaceUuid: 'test-space-uuid',
+            pinnedListUuid: null,
+            views: 0,
+            firstViewedAt: null,
+            slug: 'test-dashboard',
+            canExportCsv: true,
+            canExportImages: true,
+        },
+        error: null,
+    }),
+}));
+
+// Mock AbilityProvider
+vi.mock('../src/providers/Ability/AbilityProvider', () => ({
+    default: ({ children }: { children: React.ReactNode }) => (
+        <div>{children}</div>
+    ),
+}));
+
+vi.mock('../src/providers/Ability/useAbilityContext', () => ({
+    useAbilityContext: () => ({
+        update: vi.fn(),
+        can: vi.fn(() => true),
+    }),
+}));
+
+vi.mock('../src/features/parameters', () => ({
+    useParameters: () => ({
+        data: {},
+    }),
+}));
+
+vi.mock('../src/features/comments', () => ({
+    useGetComments: () => ({
+        data: {},
+    }),
+}));
+
+import { FilterOperator } from '@lightdash/common';
+import { Dashboard } from './index';
+
+describe('SDK Dashboard - URL Sync Behavior', () => {
+    const mockToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250ZW50Ijp7InByb2plY3RVdWlkIjoidGVzdC1wcm9qZWN0LXV1aWQifX0.test';
+    const mockInstanceUrl = 'http://localhost:3000';
+    const originalLocation = window.location;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Store initial window.location
+        window.location = {
+            ...window.location,
+            pathname: '/test',
+            search: '',
+            hash: '',
+        };
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        window.location = originalLocation;
+    });
+
+    it('should pass mode="sdk" to EmbedProvider', async () => {
+        const { container } = render(
+            <Dashboard
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                filters={[]}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(container).toBeTruthy();
+        });
+
+        // SDK mode should be set, which will prevent URL syncing
+        // We verify this indirectly by checking that navigate is never called
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('should NOT sync URL when filters change in SDK mode', async () => {
+        const filters: Array<{
+            model: string;
+            field: string;
+            operator: FilterOperator;
+            value: string;
+        }> = [];
+
+        const { rerender } = render(
+            <Dashboard
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                filters={filters}
+            />,
+        );
+
+        const initialPathname = window.location.pathname;
+        const initialSearch = window.location.search;
+
+        // Update filters
+        const newFilters = [
+            {
+                model: 'payments',
+                field: 'payment_method',
+                operator: FilterOperator.EQUALS,
+                value: 'credit_card',
+            },
+        ];
+
+        rerender(
+            <Dashboard
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                filters={newFilters}
+            />,
+        );
+
+        await waitFor(() => {
+            // Verify navigate was NOT called
+            expect(mockNavigate).not.toHaveBeenCalled();
+        });
+
+        // Verify window.location hasn't changed
+        expect(window.location.pathname).toBe(initialPathname);
+        expect(window.location.search).toBe(initialSearch);
+    });
+
+    it('should NOT sync URL when dateZoom changes in SDK mode', async () => {
+        render(
+            <Dashboard
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                filters={[]}
+            />,
+        );
+
+        const initialPathname = window.location.pathname;
+        const initialSearch = window.location.search;
+
+        // In a real scenario, dateZoom would be changed through the DashboardProvider context
+        // Since we're in SDK mode, any dateZoom changes should NOT trigger URL updates
+
+        await waitFor(() => {
+            // Verify navigate was NOT called
+            expect(mockNavigate).not.toHaveBeenCalled();
+        });
+
+        // Verify window.location hasn't changed
+        expect(window.location.pathname).toBe(initialPathname);
+        expect(window.location.search).toBe(initialSearch);
+    });
+
+    it('should NOT sync URL when tabs change in SDK mode', async () => {
+        render(
+            <Dashboard
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                filters={[]}
+            />,
+        );
+
+        const initialPathname = window.location.pathname;
+        const initialSearch = window.location.search;
+
+        // In a real scenario, tab switching would trigger navigation
+        // In SDK mode, this should NOT update the browser URL
+
+        await waitFor(() => {
+            // Verify navigate was NOT called
+            expect(mockNavigate).not.toHaveBeenCalled();
+        });
+
+        // Verify window.location hasn't changed
+        expect(window.location.pathname).toBe(initialPathname);
+        expect(window.location.search).toBe(initialSearch);
+    });
+
+    it('should use MemoryRouter which does not affect browser URL', async () => {
+        const { container } = render(
+            <Dashboard
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                filters={[]}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(container).toBeTruthy();
+        });
+
+        // MemoryRouter keeps routing state in memory
+        // Any navigation within the SDK should not affect window.location
+        expect(window.location.pathname).toBe('/test');
+        expect(window.location.search).toBe('');
+    });
+
+    it('should accept async token provider', async () => {
+        const asyncToken = Promise.resolve(mockToken);
+
+        const { container } = render(
+            <Dashboard
+                token={asyncToken}
+                instanceUrl={mockInstanceUrl}
+                filters={[]}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(container).toBeTruthy();
+        });
+
+        // Verify navigate was not called even with async token
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('should handle explore navigation without syncing URL', async () => {
+        const mockOnExplore = vi.fn();
+
+        render(
+            <Dashboard
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                filters={[]}
+                onExplore={mockOnExplore}
+            />,
+        );
+
+        // Simulate explore navigation
+        // In SDK mode, this should call onExplore callback but not update browser URL
+
+        await waitFor(() => {
+            // Browser URL should not change
+            expect(window.location.pathname).toBe('/test');
+        });
+    });
+});

--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/index.tsx
@@ -231,6 +231,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
             {!isEditMode && haveFiltersChanged && (
                 <Tooltip label="Reset all filters">
                     <Button
+                        aria-label="Reset all filters"
                         size="xs"
                         variant="default"
                         radius="md"

--- a/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/components/DashboardFilter/FilterConfiguration/index.tsx
@@ -492,6 +492,7 @@ const FilterConfiguration: FC<Props> = ({
                             position="left"
                         >
                             <Button
+                                aria-label="Reset filter to original value"
                                 size="xs"
                                 variant="default"
                                 color="gray"

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -31,6 +31,14 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
                 ),
             },
             {
+                path: '/embed/:projectUuid/tabs/:tabUuid',
+                element: (
+                    <TrackPage name={PageName.EMBED_DASHBOARD}>
+                        <EmbedDashboard />
+                    </TrackPage>
+                ),
+            },
+            {
                 path: '/embed/:projectUuid/explore/:exploreId',
                 element: (
                     <TrackPage name={PageName.EMBED_EXPLORE}>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
@@ -1,62 +1,27 @@
-import {
-    FilterInteractivityValues,
-    getFilterInteractivityValue,
-    type Dashboard,
-    type DashboardFilterInteractivityOptions,
-    type DashboardFilters,
-} from '@lightdash/common';
+import { type Dashboard } from '@lightdash/common';
 import { Flex } from '@mantine/core';
-import mapValues from 'lodash/mapValues';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useState, type FC } from 'react';
 import ActiveFilters from '../../../../../components/DashboardFilter/ActiveFilters';
 import FiltersProvider from '../../../../../components/common/Filters/FiltersProvider';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 
 type Props = {
-    dashboardFilters: DashboardFilters;
     dashboardTiles: Dashboard['tiles'];
-    filterInteractivityOptions: DashboardFilterInteractivityOptions;
 };
 
-const EmbedDashboardFilters: FC<Props> = ({
-    dashboardFilters,
-    dashboardTiles,
-    filterInteractivityOptions,
-}) => {
+const EmbedDashboardFilters: FC<Props> = ({ dashboardTiles }) => {
     const [openPopoverId, setPopoverId] = useState<string>();
 
-    const setDashboardFilters = useDashboardContext(
-        (c) => c.setDashboardFilters,
+    const resetDashboardFilters = useDashboardContext(
+        (c) => c.resetDashboardFilters,
     );
-
-    const allowedFilters = useMemo(() => {
-        const filterInteractivityValue = getFilterInteractivityValue(
-            filterInteractivityOptions.enabled,
-        );
-
-        if (filterInteractivityValue === FilterInteractivityValues.all) {
-            return dashboardFilters;
-        }
-
-        return mapValues(dashboardFilters, (filters) => {
-            return filters.filter((filter) =>
-                filterInteractivityOptions.allowedFilters?.includes(filter.id),
-            );
-        });
-    }, [dashboardFilters, filterInteractivityOptions]);
 
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
     const projectUuid = useDashboardContext((c) => c.projectUuid);
 
     useEffect(() => {
-        setDashboardFilters(allowedFilters);
         setDashboardTiles(dashboardTiles);
-    }, [
-        allowedFilters,
-        setDashboardFilters,
-        setDashboardTiles,
-        dashboardTiles,
-    ]);
+    }, [setDashboardTiles, dashboardTiles]);
 
     const handlePopoverOpen = useCallback((id: string) => {
         setPopoverId(id);
@@ -80,9 +45,7 @@ const EmbedDashboardFilters: FC<Props> = ({
                     onPopoverClose={handlePopoverClose}
                     openPopoverId={openPopoverId}
                     activeTabUuid={undefined}
-                    onResetDashboardFilters={() => {
-                        setDashboardFilters(allowedFilters);
-                    }}
+                    onResetDashboardFilters={resetDashboardFilters}
                 />
             </Flex>
         </FiltersProvider>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
@@ -29,6 +29,10 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid }) => {
             />
         );
     }
+
+    const isFilteringEnabled =
+        dashboard.dashboardFiltersInteractivity &&
+        isFilterInteractivityEnabled(dashboard.dashboardFiltersInteractivity);
     return (
         <Flex
             justify="flex-end"
@@ -39,18 +43,9 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid }) => {
             gap="sm"
             style={{ flexGrow: 1 }}
         >
-            {dashboard.dashboardFiltersInteractivity &&
-                isFilterInteractivityEnabled(
-                    dashboard.dashboardFiltersInteractivity,
-                ) && (
-                    <EmbedDashboardFilters
-                        dashboardFilters={dashboard.filters}
-                        dashboardTiles={dashboard.tiles}
-                        filterInteractivityOptions={
-                            dashboard.dashboardFiltersInteractivity
-                        }
-                    />
-                )}
+            {isFilteringEnabled && (
+                <EmbedDashboardFilters dashboardTiles={dashboard.tiles} />
+            )}
             {dashboard.canDateZoom && <DateZoom isEditMode={false} />}
 
             {dashboard.canExportPagePdf && (

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../utils/inMemoryStorage';
 import { type SdkFilter } from '../../features/embed/EmbedDashboard/types';
 import EmbedProviderContext from './context';
-import { EMBED_KEY, type InMemoryEmbed } from './types';
+import { EMBED_KEY, type EmbedMode, type InMemoryEmbed } from './types';
 
 type Props = {
     embedToken?: string;
@@ -25,7 +25,7 @@ type Props = {
 
 const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     children,
-    embedToken = window.location.hash.replace('#', ''),
+    embedToken: encodedToken,
     filters,
     projectUuid: projectUuidFromProps,
     contentOverrides,
@@ -33,6 +33,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     onBackToDashboard,
     savedChart,
 }) => {
+    const embedToken = encodedToken || window.location.hash.replace('#', '');
     const [isInitialized, setIsInitialized] = useState(false);
     const embed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
     const { data: account, isLoading } = useAccount();
@@ -71,6 +72,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             onExplore,
             savedChart,
             onBackToDashboard,
+            mode: (encodedToken ? 'sdk' : 'direct') as EmbedMode,
         };
     }, [
         embed?.projectUuid,
@@ -82,6 +84,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         onExplore,
         savedChart,
         onBackToDashboard,
+        encodedToken,
     ]);
 
     return (

--- a/packages/frontend/src/ee/providers/Embed/context.ts
+++ b/packages/frontend/src/ee/providers/Embed/context.ts
@@ -11,6 +11,7 @@ const EmbedProviderContext = createContext<EmbedContext>({
     onExplore: (_options: { chart: SavedChart }) => {},
     savedChart: undefined,
     onBackToDashboard: undefined,
+    mode: 'direct',
 });
 
 export default EmbedProviderContext;

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -8,6 +8,8 @@ export type InMemoryEmbed = {
     token?: string;
 };
 
+export type EmbedMode = 'sdk' | 'direct';
+
 export interface EmbedContext {
     // The JWT token used to authenticate the user
     embedToken?: string;
@@ -25,4 +27,6 @@ export interface EmbedContext {
     onBackToDashboard?: () => void;
     // The chart that the user is exploring
     savedChart?: SavedChart;
+    // The mode of the embed: 'sdk' when embedded via SDK (no URL sync), 'direct' when navigating directly to /embed (sync URL)
+    mode: EmbedMode;
 }

--- a/packages/frontend/src/ee/providers/Embed/useEmbed.ts
+++ b/packages/frontend/src/ee/providers/Embed/useEmbed.ts
@@ -28,6 +28,7 @@ function useEmbed(): EmbedContext {
             languageMap: undefined,
             onExplore: (_options: { chart: SavedChart }) => {},
             t: (_input: string) => undefined,
+            mode: 'direct',
         };
     }
 

--- a/packages/sdk-test-app/src/App.tsx
+++ b/packages/sdk-test-app/src/App.tsx
@@ -2,7 +2,7 @@ import Lightdash from '@lightdash/sdk';
 import '@lightdash/sdk/sdk.css';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SavedChart } from '../../common/src';
+import { FilterOperator, SavedChart } from '../../common/src';
 
 // NOTE: add an embed url here for persistence
 const EMBED_URL = '';
@@ -245,6 +245,13 @@ function App() {
                                         'translation',
                                     )}
                                     onExplore={handleExploreClick}
+                                    // This replaces the embedded dashboard filters
+                                    // filters={[{
+                                    //     model: 'orders',
+                                    //     field: 'is_completed',
+                                    //     operator: FilterOperator.EQUALS,
+                                    //     value: [true],
+                                    // },]}
                                 />
                             )}
                         </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: CENG-80

### Description:

This PR improves URL synchronization in embedded dashboards by:

1. Adding URL sync support for dashboard filters, date zoom, and tabs in direct embed mode
2. Preventing URL sync in SDK mode to avoid affecting the parent application's URL

The implementation:

- Updates the `EmbedProvider` to support a new `mode` parameter ('direct' or 'sdk')
- Adds tab URL support with a new route `/embed/:projectUuid/tabs/:tabUuid`
- Adds comprehensive E2E tests for URL syncing in direct embed mode
- Adds unit tests for SDK mode to verify it doesn't affect browser URLs

This ensures that:

- Users can share links with specific filters, tabs, and date zoom settings in direct embed mode
- SDK embeddings don't interfere with the parent application's URL state

## To Test

### iframe

#### URL Update

1. Use embed preview or Generate Embed URL
2. Go to embedding and use interactivity: filters, tabs, datezoom
3. URL should update to reflect UI state

#### URL init

1. Copy filter from previous test
2. Use embed preview or Generate Embed URL
3. Append filter ?SearchParam
4. UI should apply URL overrides without user changing the filter

### SDK

1. URLs should not change when using interactivity
2. Passing filters to the SDK should replace embed filters only as a sub-set of the filters configured in the embedding