### PR TITLE
fix: use correct minio image

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -84,7 +84,7 @@ x-lightdash-base: &lightdash-base
 
 services:
     minio:
-        image: bitnami/minio:latest
+        image: minio/minio:latest
         ports:
             - '9000:9000'
             - '9001:9001' # for minio console


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17392 

### Description:

The bitnami/minio image no longer provides tags in the Docker registry
Hence i have switched to `minio/minio:latest` 

<img width="652" height="191" alt="Screenshot from 2025-10-13 01-34-57" src="https://github.com/user-attachments/assets/1052b619-177e-4652-8a7d-9eb88e78b7cc" />
