### PR TITLE
fix: preview from cli can copy organization warehouse credentials

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/dbt_project.yml
+++ b/examples/full-jaffle-shop-demo/dbt/dbt_project.yml
@@ -12,7 +12,7 @@ seed-paths:
   - data
 macro-paths:
   - macros
-target-path: "{{ env_var('DBT_ENV__TARGET_FOLDER', 'target') }}"
+target-path: target
 clean-targets:
   - target
   - dbt_modules

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1121,6 +1121,18 @@ export class ProjectService extends BaseService {
         await this.validateProjectCreationPermissions(user, data);
 
         const newProjectData = data;
+
+        // If type preview and has upstream project, we first link the preview to the same organization warehouse credentials (if exists)
+        if (
+            newProjectData.type === ProjectType.PREVIEW &&
+            newProjectData.upstreamProjectUuid
+        ) {
+            const upstreamProject = data.upstreamProjectUuid
+                ? await this.projectModel.get(data.upstreamProjectUuid)
+                : undefined;
+            newProjectData.organizationWarehouseCredentialsUuid =
+                upstreamProject?.organizationWarehouseCredentialsUuid;
+        }
         if (
             newProjectData.type === ProjectType.PREVIEW &&
             data.copyWarehouseConnectionFromUpstreamProject &&
@@ -5143,6 +5155,8 @@ export class ProjectService extends BaseService {
                 data.dbtConnectionOverrides ?? {},
             ),
             upstreamProjectUuid: data.copyContent ? projectUuid : undefined,
+            organizationWarehouseCredentialsUuid:
+                project.organizationWarehouseCredentialsUuid,
             dbtVersion: project.dbtVersion,
         };
 
@@ -5151,6 +5165,7 @@ export class ProjectService extends BaseService {
             previewData,
             context,
         );
+
         // Since the project is new, and we have copied some permissions,
         // it is possible that the user `abilities` are not uptodate
         // Before we check permissions on scheduleCompileProject


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-63/apply-this-to-previews-on-ui-and-cli-copy-the-org-uuid-credentials-on

<img width="942" height="600" alt="Screenshot from 2025-10-13 09-33-17" src="https://github.com/user-attachments/assets/f20678ed-9fad-4fbb-85fd-8f26e522bb01" />

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
