### PR TITLE
feat: add API key authentication to MCP

### DIFF
--- a/examples/api/mcp.http
+++ b/examples/api/mcp.http
@@ -7,7 +7,8 @@ Accept: application/json"
     "email": "demo@lightdash.com",
     "password": "demo_password!"
 }
-
+### Logout
+GET http://localhost:8080/api/v1/logout
 
 ### List available tools
 POST http://localhost:3000/api/v1/mcp
@@ -26,6 +27,8 @@ Accept: application/json, text/event-stream
 POST http://localhost:3000/api/v1/mcp
 Content-Type: application/json
 Accept: application/json, text/event-stream
+Authorization: ApiKey ldpat_ff90d7cb9e1f374e2fd8b3678128c6bf
+
 
 {
     "jsonrpc": "2.0",

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1,6 +1,7 @@
 import {
     Account,
     AnyType,
+    ApiKeyAccount,
     CatalogFilter,
     CatalogType,
     CommercialFeatureFlags,
@@ -94,7 +95,10 @@ type McpServiceArguments = {
     featureFlagService: FeatureFlagService;
 };
 
-export type ExtraContext = { user: SessionUser; account: OauthAccount };
+export type ExtraContext = {
+    user: SessionUser;
+    account: OauthAccount | ApiKeyAccount;
+};
 type McpProtocolContext = {
     authInfo?: AuthInfo & {
         extra: ExtraContext;
@@ -1250,11 +1254,12 @@ export class McpService extends BaseService {
 
         const user = context.authInfo.extra?.user;
         const account = context.authInfo.extra?.account;
-        const { scopes } = account.authentication;
 
         // TODO replace with CASL ability check
         // Do not enforce client scopes for now until more MCP clients support this
         /*
+        //const { scopes } = account.authentication;
+
         if (
             !scopes.includes(OAuthScope.MCP_READ) &&
             !scopes.includes(OAuthScope.MCP_WRITE)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

Before:

<img width="1009" height="403" alt="Screenshot from 2025-10-13 11-09-29" src="https://github.com/user-attachments/assets/cd9751de-0e03-464e-bd37-09b71ee1721f" />

After

<img width="1269" height="402" alt="Screenshot from 2025-10-13 11-22-04" src="https://github.com/user-attachments/assets/3304b9af-de6d-4688-aff7-f1bf54aacf38" />


Thread: https://lightdash.slack.com/archives/C03MCQ08UKS/p1759524309233049


### Description:
Add API key authentication support for MCP endpoints. This allows users to authenticate with personal access tokens (PATs) when making MCP API calls, in addition to the existing OAuth authentication method.

The changes include:
- Updated the MCP router to accept API key authentication
- Modified the ExtraContext type to support both OAuth and API key accounts
- Added authorization header example in the mcp.http file
- Added a logout endpoint example in the API documentation

API keys are now properly handled with appropriate scopes ('mcp:read', 'mcp:write') for MCP operations.