### PR TITLE
fix: prevent blank message flash in AI agent responses

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -383,7 +383,8 @@ const createOptimisticMessages = (
             role: 'assistant' as const,
             uuid: promptUuid,
             threadUuid,
-            message: '',
+            // Non-empty message to avoid brief flash of blank message
+            message: ' ',
             createdAt: new Date().toISOString(),
             user: {
                 name: agent?.name ?? 'Unknown',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Prevents a brief flash of blank message in AI Copilot by initializing the message with a space character instead of an empty string. This provides a better user experience while waiting for the assistant's response to load.
