### PR TITLE
fix: table calculations not being taken into account when on x-axis

### DIFF
--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -1,4 +1,4 @@
-import { DimensionType } from '../../types/field';
+import { DimensionType, TableCalculationType } from '../../types/field';
 import { type PivotConfiguration } from '../../types/pivot';
 import { type RawResultRow } from '../../types/results';
 import { ChartKind } from '../../types/savedCharts';
@@ -55,6 +55,18 @@ export function getColumnAxisType(dimensionType: DimensionType): VizIndexType {
         case DimensionType.BOOLEAN:
         case DimensionType.NUMBER:
         case DimensionType.STRING:
+        default:
+            return VizIndexType.CATEGORY;
+    }
+}
+
+export function getTableCalculationAxisType(
+    tableCalculationType: TableCalculationType,
+): VizIndexType {
+    switch (tableCalculationType) {
+        case TableCalculationType.DATE:
+        case TableCalculationType.TIMESTAMP:
+            return VizIndexType.TIME;
         default:
             return VizIndexType.CATEGORY;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17409

### Description:
Fixes a bug where table calculations weren't being recognized as valid axis columns in pivoted cartesian charts, causing them to be excluded from the visualization.

#### Changes

  - Extended `getIndexColumn()` to include table calculations alongside dimensions and metrics if those are not group by OR values columns
  - Added `getTableCalculationAxisType()` helper to map table calculation types to appropriate axis types (date/timestamp → time, others → category)
  - Refactored `getIndexColumn()` parameters to use groupByColumns and valuesColumns for more precise filtering

This ensures that table calculations can be properly displayed as index columns in visualizations, particularly for date and timestamp types which are now correctly mapped to the time axis type.

**Before**

![image.png](https://app.graphite.dev/user-attachments/assets/3fdf4191-3b30-4cc1-9bf3-c75692e95964.png)

**After**

![image.png](https://app.graphite.dev/user-attachments/assets/5086bb07-fb51-4484-aa0c-26a0aa08ecc3.png)

**How to test**
1. Follow steps in #17409
