### PR TITLE
feat: add table calculations to filter rule validation

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.test.ts
@@ -467,6 +467,7 @@ describe('McpSchemaCompatLayer', () => {
                             fieldFilterType: 'date',
                         },
                     ],
+                    tableCalculations: null,
                 },
                 tableCalculations: null,
             });

--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -53,7 +53,12 @@ export const getRunMetricQuery = ({
         );
         validateFieldEntityType(explore, vizTool.vizConfig.metrics, 'metric');
         validateCustomMetricsDefinition(explore, vizTool.customMetrics);
-        validateFilterRules(explore, filterRules, vizTool.customMetrics);
+        validateFilterRules(
+            explore,
+            filterRules,
+            vizTool.customMetrics,
+            vizTool.tableCalculations,
+        );
         validateMetricDimensionFilterPlacement(
             explore,
             vizTool.filters,

--- a/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
@@ -25,7 +25,12 @@ export const validateBarVizConfig = (
     validateFieldEntityType(explore, selectedDimensions, 'dimension');
     validateFieldEntityType(explore, vizTool.vizConfig.yMetrics, 'metric');
     validateCustomMetricsDefinition(explore, vizTool.customMetrics);
-    validateFilterRules(explore, filterRules, vizTool.customMetrics);
+    validateFilterRules(
+        explore,
+        filterRules,
+        vizTool.customMetrics,
+        vizTool.tableCalculations,
+    );
     validateMetricDimensionFilterPlacement(
         explore,
         vizTool.filters,

--- a/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
@@ -21,7 +21,12 @@ export const validateTableVizConfig = (
     validateFieldEntityType(explore, vizTool.vizConfig.dimensions, 'dimension');
     validateFieldEntityType(explore, vizTool.vizConfig.metrics, 'metric');
     validateCustomMetricsDefinition(explore, vizTool.customMetrics);
-    validateFilterRules(explore, filterRules, vizTool.customMetrics);
+    validateFilterRules(
+        explore,
+        filterRules,
+        vizTool.customMetrics,
+        vizTool.tableCalculations,
+    );
     validateMetricDimensionFilterPlacement(
         explore,
         vizTool.filters,

--- a/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
@@ -25,7 +25,12 @@ export const validateTimeSeriesVizConfig = (
     validateFieldEntityType(explore, selectedDimensions, 'dimension');
     validateFieldEntityType(explore, vizTool.vizConfig.yMetrics, 'metric');
     validateCustomMetricsDefinition(explore, vizTool.customMetrics);
-    validateFilterRules(explore, filterRules, vizTool.customMetrics);
+    validateFilterRules(
+        explore,
+        filterRules,
+        vizTool.customMetrics,
+        vizTool.tableCalculations,
+    );
     validateMetricDimensionFilterPlacement(
         explore,
         vizTool.filters,

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -4,6 +4,7 @@ import {
     booleanFilterSchema,
     CompiledField,
     convertAdditionalMetric,
+    convertAiTableCalcsSchemaToTableCalcs,
     CustomMetricBase,
     dateFilterSchema,
     Explore,
@@ -19,15 +20,17 @@ import {
     isAdditionalMetric,
     isDimension,
     isMetric,
-    Metric,
+    isTableCalculation,
     MetricType,
     numberFilterSchema,
     renderFilterRuleSql,
     renderFilterRuleSqlFromField,
+    renderTableCalculationFilterRuleSql,
     stringFilterSchema,
     SupportedDbtAdapter,
     TableCalcSchema,
     TableCalcsSchema,
+    TableCalculation,
     ToolSortField,
     WeekDay,
 } from '@lightdash/common';
@@ -145,8 +148,12 @@ export function validateCustomMetricsDefinition(
 
 function validateFilterRule(
     filterRule: FilterRule,
-    field: CompiledField | AdditionalMetric,
+    field: CompiledField | AdditionalMetric | TableCalculation,
 ) {
+    if (!field.type) {
+        throw new Error('Field type is required');
+    }
+
     const filterType = getFilterTypeFromItemType(field.type);
 
     switch (filterType) {
@@ -231,6 +238,17 @@ function validateFilterRule(
                 WeekDay.SUNDAY,
                 SupportedDbtAdapter.BIGQUERY,
             );
+        } else if (isTableCalculation(field)) {
+            renderTableCalculationFilterRuleSql(
+                filterRule,
+                field,
+                // ! The following args are used to actually render the SQL, we don't care about the ouput, just that it doesn't throw
+                '"',
+                "'",
+                (string: string) => string.replaceAll('\\', '\\\\'),
+                SupportedDbtAdapter.BIGQUERY,
+                WeekDay.SUNDAY,
+            );
         } else {
             renderFilterRuleSqlFromField(
                 filterRule,
@@ -259,13 +277,21 @@ export function validateFilterRules(
     explore: Explore,
     filterRules: FilterRule[],
     customMetrics?: CustomMetricBase[] | null,
+    tableCalculations?: TableCalcsSchema | null,
 ) {
     const exploreFields = getFields(explore);
     const customMetricFields = populateCustomMetricsSQL(
         customMetrics || [],
         explore,
     );
-    const allFields = [...exploreFields, ...customMetricFields];
+    const tableCalcFields = tableCalculations
+        ? convertAiTableCalcsSchemaToTableCalcs(tableCalculations)
+        : [];
+    const allFields = [
+        ...exploreFields,
+        ...customMetricFields,
+        ...tableCalcFields,
+    ];
     const allFieldIds = allFields.map(getItemId);
     const filterRuleErrors: string[] = [];
 

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -10,7 +10,7 @@ import {
     isMetric,
     type CompiledCustomSqlDimension,
     type CompiledField,
-    type CompiledTableCalculation,
+    type TableCalculation,
 } from '../types/field';
 import {
     FilterOperator,
@@ -413,7 +413,7 @@ const escapeStringValuesOnFilterRule = (
 
 export const renderTableCalculationFilterRuleSql = (
     filterRule: FilterRule<FilterOperator, unknown>,
-    field: CompiledTableCalculation | undefined,
+    field: TableCalculation | undefined,
     fieldQuoteChar: string,
     stringQuoteChar: string,
     escapeString: (string: string) => string,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardArgs.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import assertUnreachable from '../../../../utils/assertUnreachable';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
-import { filtersSchema } from '../filters';
+import { filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
@@ -24,7 +24,7 @@ Create "summary" or "executive" level dashboards that provide high-level overvie
 Recommended Dashboard Structure:
 1. **Summary Metrics at the Top**: Start with key performance indicators (KPIs) as tables showing overall summary metrics
 2. **Time-Series Analysis**: Include time-series charts with appropriate granularities to show how metrics trend over time:
-   - Use line charts for smaller granularities (daily, weekly) 
+   - Use line charts for smaller granularities (daily, weekly)
    - Use bar charts for more grouped data (monthly, quarterly)
 3. **Detailed Breakdowns**: Add tables with more detail and specific line items that have the biggest impact on metrics
    - Show problematic areas that need attention (e.g., longest response times, highest churn segments)
@@ -46,7 +46,7 @@ const baseVisualizationSchema = z.object({
     ...visualizationMetadataSchema.shape,
     customMetrics: customMetricsSchema,
     tableCalculations: tableCalcsSchema,
-    filters: filtersSchema
+    filters: filtersSchemaV2
         .nullable()
         .describe(
             'Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunMetricQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunMetricQueryArgs.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { customMetricsSchema } from '../customMetrics';
-import { filtersSchema, filtersSchemaTransformed } from '../filters';
+import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
@@ -26,7 +26,7 @@ export const toolRunMetricQueryArgsSchema = createToolSchema(
         vizConfig: tableVizConfigSchema,
         customMetrics: customMetricsSchema,
         tableCalculations: tableCalcsSchema,
-        filters: filtersSchema
+        filters: filtersSchemaV2
             .nullable()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { getFieldIdSchema } from '../fieldId';
-import { filtersSchema, filtersSchemaTransformed } from '../filters';
+import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { createToolSchema } from '../toolSchemaBuilder';
 
@@ -29,7 +29,7 @@ export const toolSearchFieldValuesArgsSchema = createToolSchema(
             .string()
             .describe('Query string to filter field values')
             .nullable(),
-        filters: filtersSchema
+        filters: filtersSchemaV2
             .nullable()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -5,7 +5,7 @@ import {
 } from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
-import { filtersSchema, filtersSchemaTransformed } from '../filters';
+import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
@@ -23,7 +23,7 @@ export const toolTableVizArgsSchema = createToolSchema(
         customMetrics: customMetricsSchema,
         tableCalculations: tableCalcsSchema,
         vizConfig: tableVizConfigSchema,
-        filters: filtersSchema
+        filters: filtersSchemaV2
             .nullable()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.',
@@ -56,10 +56,10 @@ export const toolTableVizArgsSchemaTransformed = toolTableVizArgsSchema
                 z.literal(LegacyFollowUpTools.GENERATE_TIME_SERIES_VIZ),
             ]),
         ),
+        filters: filtersSchemaTransformed,
     })
     .transform((data) => ({
         ...data,
-        filters: filtersSchemaTransformed.parse(data.filters),
         followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -5,7 +5,7 @@ import {
 } from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
-import { filtersSchema, filtersSchemaTransformed } from '../filters';
+import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
@@ -23,7 +23,7 @@ export const toolTimeSeriesArgsSchema = createToolSchema(
         customMetrics: customMetricsSchema,
         tableCalculations: tableCalcsSchema,
         vizConfig: timeSeriesMetricVizConfigSchema,
-        filters: filtersSchema
+        filters: filtersSchemaV2
             .nullable()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.',
@@ -61,10 +61,10 @@ export const toolTimeSeriesArgsSchemaTransformed = toolTimeSeriesArgsSchema
                 z.literal(LegacyFollowUpTools.GENERATE_BAR_VIZ),
             ]),
         ),
+        filters: filtersSchemaTransformed,
     })
     .transform((data) => ({
         ...data,
-        filters: filtersSchemaTransformed.parse(data.filters),
         followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -5,7 +5,7 @@ import {
 } from '../../followUpTools';
 import { AiResultType } from '../../types';
 import { customMetricsSchema } from '../customMetrics';
-import { filtersSchema, filtersSchemaTransformed } from '../filters';
+import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
@@ -23,7 +23,7 @@ export const toolVerticalBarArgsSchema = createToolSchema(
         customMetrics: customMetricsSchema,
         tableCalculations: tableCalcsSchema,
         vizConfig: verticalBarMetricVizConfigSchema,
-        filters: filtersSchema
+        filters: filtersSchemaV2
             .nullable()
             .describe(
                 'Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.',
@@ -56,10 +56,10 @@ export const toolVerticalBarArgsSchemaTransformed = toolVerticalBarArgsSchema
                 z.literal(LegacyFollowUpTools.GENERATE_TIME_SERIES_VIZ),
             ]),
         ),
+        filters: filtersSchemaTransformed,
     })
     .transform((data) => ({
         ...data,
-        filters: filtersSchemaTransformed.parse(data.filters),
         followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 


### PR DESCRIPTION
### Description:
Added support for table calculation filters in AI tools. The `validateFilterRules` function now accepts table calculations as a parameter and validates filter rules against them. Updated filter schemas to include table calculations and modified the filter transformation logic to handle them properly. This ensures that AI-generated visualizations can properly filter on table calculations.