### PR TITLE
fix: metric formating is not applied after saving

### DIFF
--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -4,6 +4,7 @@ import {
     type AdditionalMetric,
     type ChartConfig,
     type CustomDimension,
+    type CustomFormat,
     type Dimension,
     type FieldId,
     type Item,
@@ -578,6 +579,23 @@ const explorerSlice = createSlice({
                 state.unsavedChartVersion.tableConfig.columnOrder.filter(
                     (fieldId) => fieldId !== metricIdToRemove,
                 );
+        },
+
+        updateMetricFormat: (
+            state,
+            action: PayloadAction<{
+                metric: Metric;
+                formatOptions: CustomFormat | undefined;
+            }>,
+        ) => {
+            const { metric, formatOptions } = action.payload;
+            const metricId = getItemId(metric);
+            if (!state.unsavedChartVersion.metricQuery.metricOverrides) {
+                state.unsavedChartVersion.metricQuery.metricOverrides = {};
+            }
+            state.unsavedChartVersion.metricQuery.metricOverrides[metricId] = {
+                formatOptions,
+            };
         },
 
         setValidQueryArgs: (

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -120,6 +120,11 @@ export const selectMetrics = createSelector(
     (metricQuery) => metricQuery.metrics,
 );
 
+export const selectMetricOverrides = createSelector(
+    [selectMetricQuery],
+    (metricQuery) => metricQuery.metricOverrides || {},
+);
+
 // Parameter selectors
 export const selectParameters = createSelector(
     [selectUnsavedChartVersion],

--- a/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
+++ b/packages/frontend/src/providers/Explorer/ExplorerProvider.tsx
@@ -1049,8 +1049,9 @@ const ExplorerProvider: FC<
                 type: ActionType.UPDATE_METRIC_FORMAT,
                 payload: args,
             });
+            reduxDispatch(explorerActions.updateMetricFormat(args));
         },
-        [],
+        [reduxDispatch],
     );
 
     const replaceFields = useCallback(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17389

### Description:
Fixes metric format overrides in the Explorer

- Added the missing redux slice (prev `updateMetricFormat` in old react context)
- Apply the metric overrides to items using the `useColumns` hook


[Screen Recording 2025-10-13 at 15.55.34.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/d017e104-4ad8-4db3-aa1b-01c48edf51d3.mov" />](https://app.graphite.dev/user-attachments/video/d017e104-4ad8-4db3-aa1b-01c48edf51d3.mov)

