### PR TITLE
feat: add table calculation validation in filter placement

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -66,8 +66,9 @@ export const getRunMetricQuery = ({
         );
         validateMetricDimensionFilterPlacement(
             explore,
-            vizTool.filters,
             vizTool.customMetrics,
+            vizTool.tableCalculations,
+            vizTool.filters,
         );
         validateSelectedFieldsExistence(
             explore,

--- a/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
@@ -38,8 +38,9 @@ export const validateBarVizConfig = (
     );
     validateMetricDimensionFilterPlacement(
         explore,
-        vizTool.filters,
         vizTool.customMetrics,
+        vizTool.tableCalculations,
+        vizTool.filters,
     );
     // validate sort fields exist
     validateSelectedFieldsExistence(

--- a/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
@@ -34,8 +34,9 @@ export const validateTableVizConfig = (
     );
     validateMetricDimensionFilterPlacement(
         explore,
-        vizTool.filters,
         vizTool.customMetrics,
+        vizTool.tableCalculations,
+        vizTool.filters,
     );
     // validate sort fields exist
     validateSelectedFieldsExistence(

--- a/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
@@ -38,8 +38,9 @@ export const validateTimeSeriesVizConfig = (
     );
     validateMetricDimensionFilterPlacement(
         explore,
-        vizTool.filters,
         vizTool.customMetrics,
+        vizTool.tableCalculations,
+        vizTool.filters,
     );
     // validate sort fields exist
     validateSelectedFieldsExistence(


### PR DESCRIPTION
### Description:
Enhanced filter validation to properly handle table calculations in visualization configurations. The `validateMetricDimensionFilterPlacement` function now validates that:

- Dimension filters only contain dimension fields
- Metric filters only contain metric fields
- Custom metric filters only contain custom metric fields
- Table calculation filters only contain table calculation fields

This prevents users from placing fields in incorrect filter groups and provides clear error messages when validation fails.