### PR TITLE
style: display messaging when trying ai

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -18,6 +18,7 @@ import { Link, useNavigate } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { CompactAgentSelector } from '../../../features/aiCopilot/components/AgentSelector';
 import { useAiAgentPermission } from '../../../features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiOrganizationSettings } from '../../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
@@ -33,12 +34,6 @@ type Props = {
     projectUuid: string;
 };
 
-const MOCK_LIGHTDASH_AGENT = {
-    uuid: 'MOCK_LIGHTDASH_AGENT',
-    name: 'Lightdash',
-    imageUrl: '/favicon-32x32.png',
-};
-
 const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     const navigate = useNavigate();
 
@@ -46,6 +41,10 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
         projectUuid,
         redirectOnUnauthorized: false,
     });
+    const organizationSettingsQuery = useAiOrganizationSettings();
+    const isTrial =
+        organizationSettingsQuery.isSuccess &&
+        organizationSettingsQuery.data?.isTrial;
     const {
         data: userAgentPreferences,
         isLoading: isLoadingUserAgentPreferences,
@@ -122,14 +121,7 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
             <Box p="md">
                 <form onSubmit={handleSubmit}>
                     <Group>
-                        {noAgentsAvailable ? (
-                            <CompactAgentSelector
-                                agents={[MOCK_LIGHTDASH_AGENT]}
-                                selectedAgent={MOCK_LIGHTDASH_AGENT}
-                                onSelect={() => {}}
-                                disabled
-                            />
-                        ) : (
+                        {noAgentsAvailable ? null : (
                             <CompactAgentSelector
                                 agents={agents}
                                 selectedAgent={selectedAgent ?? agents[0]}
@@ -208,32 +200,64 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                 <>
                     <Divider color="gray.2" />
                     <Box bg="gray.0" py="xs" px="md">
-                        <Group>
-                            {noAgentsAvailable && (
-                                <Group gap={4}>
-                                    <MantineIcon
-                                        icon={IconSparkles}
-                                        color="violet.5"
-                                        fill="violet.5"
-                                    />
-                                    <Text size="xs" c="gray.8">
-                                        Set up your first agent
-                                    </Text>
-                                </Group>
-                            )}
-                            <Group flex={1} justify="flex-end">
-                                <Button
-                                    size="compact-xs"
-                                    variant="subtle"
-                                    leftSection={
-                                        <MantineIcon icon={IconSettings} />
-                                    }
-                                    component={Link}
-                                    to="/ai-agents/admin/threads"
-                                >
-                                    Admin Settings
-                                </Button>
+                        <Group
+                            flex={1}
+                            justify={isTrial ? 'space-between' : 'flex-end'}
+                        >
+                            <Group gap={2}>
+                                {noAgentsAvailable ? (
+                                    <Button
+                                        size="compact-xs"
+                                        variant="subtle"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconSparkles}
+                                                color="violet.5"
+                                                fill="violet.5"
+                                            />
+                                        }
+                                        component={Link}
+                                        to="/ai-agents"
+                                    >
+                                        <Group gap={2}>
+                                            {isTrial && (
+                                                <Text size="xs" c="gray.8">
+                                                    You are trialing the AI
+                                                    Agents feature.
+                                                </Text>
+                                            )}{' '}
+                                            <Text size="xs" fw={500}>
+                                                Set up your first agent to get
+                                                started
+                                            </Text>
+                                        </Group>
+                                    </Button>
+                                ) : isTrial ? (
+                                    <Group gap="xs">
+                                        <MantineIcon
+                                            icon={IconSparkles}
+                                            color="violet.5"
+                                            fill="violet.5"
+                                        />
+                                        <Text size="xs" c="gray.8">
+                                            You are trialing the AI Agents
+                                            feature.
+                                        </Text>
+                                    </Group>
+                                ) : null}
                             </Group>
+
+                            <Button
+                                size="compact-xs"
+                                variant="subtle"
+                                leftSection={
+                                    <MantineIcon icon={IconSettings} />
+                                }
+                                component={Link}
+                                to="/ai-agents/admin/agents"
+                            >
+                                Admin Settings
+                            </Button>
                         </Group>
                     </Box>
                 </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminEnableFeatureToggle.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminEnableFeatureToggle.tsx
@@ -1,4 +1,6 @@
 import {
+    Badge,
+    Group,
     HoverCard,
     List,
     Paper,
@@ -7,7 +9,12 @@ import {
     Text,
     Title,
 } from '@mantine-8/core';
-import { useUpdateAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
+import { IconSparkles } from '@tabler/icons-react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import {
+    useAiOrganizationSettings,
+    useUpdateAiOrganizationSettings,
+} from '../../hooks/useAiOrganizationSettings';
 
 type Props = {
     enabled: boolean | undefined;
@@ -17,6 +24,12 @@ export const AiAgentsAdminEnableFeatureToggle = ({ enabled }: Props) => {
     const { mutateAsync: updateAiOrganizationSettings, isLoading } =
         useUpdateAiOrganizationSettings();
 
+    const organizationSettingsQuery = useAiOrganizationSettings();
+
+    const isTrial =
+        organizationSettingsQuery.isSuccess &&
+        organizationSettingsQuery.data?.isTrial;
+
     return (
         <HoverCard>
             <HoverCard.Target>
@@ -25,7 +38,33 @@ export const AiAgentsAdminEnableFeatureToggle = ({ enabled }: Props) => {
                         size="xs"
                         withThumbIndicator={false}
                         labelPosition="left"
-                        label="Enable AI features for users"
+                        label={
+                            isTrial ? (
+                                <Group gap="xs">
+                                    <Badge
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconSparkles}
+                                                size={12}
+                                            />
+                                        }
+                                        radius="sm"
+                                        variant="light"
+                                        color="indigo"
+                                        size="xs"
+                                        tt="none"
+                                        fw={500}
+                                    >
+                                        Free trial
+                                    </Badge>
+                                    <Text fw={500} fz="xs">
+                                        Enable AI features for users
+                                    </Text>
+                                </Group>
+                            ) : (
+                                'Enable AI features for users'
+                            )
+                        }
                         checked={enabled}
                         onChange={(event) =>
                             updateAiOrganizationSettings({

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
@@ -141,10 +141,11 @@ export const AiAgentsAdminLayout = () => {
                                 icon={<IconInfoCircle />}
                                 radius="md"
                                 variant="outline"
-                                color="orange"
+                                color="orange.6"
+                                bg="orange.0"
                                 title="AI Features Currently Disabled for All Users"
                             >
-                                <Text c="gray.7" size="sm">
+                                <Text c="gray.7" size="xs">
                                     AI features on the homepage and navbar are
                                     turned off. Users cannot interact with AI
                                     Agents until you re-enable this feature

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
@@ -12,6 +12,7 @@ import {
     type UseQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
 
 const getAiOrganizationSettings = async () => {
     return lightdashApi<ApiAiOrganizationSettingsResponse['results']>({
@@ -53,6 +54,7 @@ export const useUpdateAiOrganizationSettings = (
     >,
 ) => {
     const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
 
     return useMutation<
         ApiUpdateAiOrganizationSettingsResponse['results'],
@@ -61,9 +63,18 @@ export const useUpdateAiOrganizationSettings = (
     >({
         mutationFn: updateAiOrganizationSettings,
         onSuccess: async (data, variables, context) => {
+            showToastSuccess({
+                title: 'Success! AI organization settings updated',
+            });
             queryClient.setQueryData(['ai-organization-settings'], data);
             await queryClient.invalidateQueries(['ai-organization-settings']);
             mutationOptions?.onSuccess?.(data, variables, context);
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update AI organization settings',
+                apiError: error,
+            });
         },
         ...mutationOptions,
     });

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,6 +1,7 @@
 import { type AiAgent, type AiAgentThreadSummary } from '@lightdash/common';
 import {
     ActionIcon,
+    Alert,
     Box,
     Button,
     Group,
@@ -19,8 +20,10 @@ import {
     IconChevronDown,
     IconCirclePlus,
     IconDots,
+    IconInfoCircle,
     IconPlus,
     IconSettings,
+    IconSparkles,
 } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
 import { Link, Navigate, Outlet, useParams } from 'react-router';
@@ -29,6 +32,7 @@ import { AgentSelector } from '../../features/aiCopilot/components/AgentSelector
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { SidebarButton } from '../../features/aiCopilot/components/AiAgentPageLayout/SidebarButton';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
     useProjectAiAgent as useAiAgent,
     useAiAgentThreads,
@@ -82,6 +86,10 @@ const AgentSidebar: FC<{
     threadUuid?: string;
     isAgentSidebarCollapsed: boolean;
 }> = ({ agent, projectUuid, threadUuid, isAgentSidebarCollapsed }) => {
+    const organizationSettingsQuery = useAiOrganizationSettings();
+    const isTrial =
+        organizationSettingsQuery.isSuccess &&
+        organizationSettingsQuery.data?.isTrial;
     const { data: threads } = useAiAgentThreads(projectUuid, agent.uuid);
     const [showMaxItems, setShowMaxItems] = useState(INITIAL_MAX_THREADS);
 
@@ -172,6 +180,36 @@ const AgentSidebar: FC<{
                         )}
                     </Box>
                 </Stack>
+            )}
+            {isTrial && (
+                <Alert
+                    icon={<MantineIcon icon={IconSparkles} />}
+                    variant="outline"
+                    color="indigo.6"
+                    bg="indigo.0"
+                    fz="xs"
+                    p="xs"
+                    title={
+                        <Text size="xs" fw={500}>
+                            You're currently using Lightdash AI Agents in free
+                            trial mode
+                        </Text>
+                    }
+                >
+                    <Button
+                        size="compact-xs"
+                        variant="light"
+                        color="indigo"
+                        leftSection={
+                            <MantineIcon icon={IconInfoCircle} size="sm" />
+                        }
+                        component={Link}
+                        to="https://docs.lightdash.com/guides/ai-agents"
+                        target="_blank"
+                    >
+                        Learn more
+                    </Button>
+                </Alert>
             )}
         </Stack>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17408

### Description:

This PR adds UI elements to indicate when users are in a trial mode for AI Agents. Key changes include:

- Added trial mode indicators in the AI search box on the homepage
- Updated the admin settings toggle to show a "Free trial" badge when in trial mode
- Added an alert in the Agent sidebar informing users they're in trial mode with a "Learn more" button
- Improved the "Set up your first agent" button with clearer messaging for trial users
- Fixed the admin settings link to point to "/ai-agents/admin/agents" instead of "/threads"
- Removed the mock Lightdash agent that was displayed when no agents were available
- Added success and error toasts for AI organization settings updates

![AI Agents Trial UI](https://example.com/screenshot.png)