### PR TITLE
chore: hide dropdown if one agent

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/CompactAgentSelector.tsx
@@ -30,6 +30,7 @@ export const CompactAgentSelector = ({
         onDropdownClose: () => combobox.resetSelectedOption(),
     });
     const agentOptions = getAgentOptions(agents);
+    const isSingleAgent = agentOptions.length === 1;
 
     return (
         <Combobox
@@ -48,6 +49,7 @@ export const CompactAgentSelector = ({
                     variant="light"
                     color="gray"
                     p={0}
+                    disabled={isSingleAgent}
                 >
                     <Group gap="xxs">
                         <LightdashUserAvatar
@@ -55,7 +57,10 @@ export const CompactAgentSelector = ({
                             name={selectedAgent.name}
                             src={selectedAgent.imageUrl}
                         />
-                        <MantineIcon icon={IconChevronDown} />
+
+                        {!isSingleAgent && (
+                            <MantineIcon icon={IconChevronDown} />
+                        )}
                     </Group>
                 </UnstyledButton>
             </Combobox.Target>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17405

### Description:
Disables the agent selector dropdown when only one agent is available. This improves the user experience by preventing users from clicking on the dropdown when there's only a single option. Additionally, the chevron icon is now only displayed when multiple agents are available, providing a clearer visual indication of when the selector is interactive.

