### PR TITLE
fix: use conditional formatting object as key instead of index

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -136,7 +136,7 @@ const ConditionalFormattingList = ({}) => {
                 >
                     {activeConfigs.map((conditionalFormatting, index) => (
                         <ConditionalFormattingItem
-                            key={index}
+                            key={JSON.stringify(conditionalFormatting)}
                             isOpen={openItems.includes(`${index}`)}
                             addNewItem={addNewItem}
                             removeItem={removeItem}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17390

### Description:
Fixed a React key issue in the ConditionalFormattingList component by using the stringified conditional formatting object as the key instead of the array index. This ensures proper component re-rendering when items are added or removed from the list.