### PR TITLE
fix: unsaved chart share link not working

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -10,6 +10,7 @@ import {
     selectIsValidQuery,
     selectQueryLimit,
     selectTimezone,
+    selectUnsavedChartVersion,
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
@@ -48,9 +49,7 @@ const ExplorerHeader: FC = memo(() => {
     const savedChart = useExplorerContext(
         (context) => context.state.savedChart,
     );
-    const unsavedChartVersion = useExplorerContext(
-        (context) => context.state.unsavedChartVersion,
-    );
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     const setTimeZone = useExplorerContext(
         (context) => context.actions.setTimeZone,
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17406

### Description:
Refactored the `ExplorerHeader` component to use the `selectUnsavedChartVersion` selector from the Redux store instead of accessing the state directly through context. 