### PR TITLE
fix: error when filtering by metric with fanout

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_accounts.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_accounts.sql
@@ -2,6 +2,7 @@ select
     account_id,
     account_name,
     industry,
-    segment
+    segment, 
+    100 AS estimated_annual_recurring_revenue 
 from 
     {{ ref('accounts_raw') }}

--- a/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_accounts.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_accounts.yml
@@ -1,189 +1,122 @@
 version: 2
 models:
   - name: fanouts_accounts
-    description: |
-      This model demonstrates all three common join patterns that cause metric inflation:
-      1. Simple 1-to-many: Accounts → Deals OR Accounts -> Users
-      2. Chained 1-to-many: Accounts → Users → Events  
-      3. Multiple 1-to-many: Accounts → Deals AND Accounts → Users
-
-      When these tables are joined, each account record gets multiplied by:
-      - Number of deals it has
-      - Number of users it has  
-      - Number of events each user has
-
-      This creates a "fanout" effect that inflates COUNT metrics but leaves COUNT_DISTINCT safe.
-      Note with the way we currently implement joins in Lightdash, tables/models are only added to 
-      a join if we select dimesions or metrics from them. 
-      This means we can use the same models to demonstrate all the joins. 
-
     meta:
-      required_attributes: 
-        is_admin_saas_demo: 'true'
       primary_key: account_id
+      # This filter means that unless you are an admin, you can't see Enterprise account
       sql_filter: ${lightdash.attributes.is_admin_saas_demo} = 'true' or segment !=
         'Enterprise'
+      description: List of all customer and prospective customer fanouts_accounts pulled from
+        our CRM
       joins:
-        # 🚨 INTENTIONAL METRICS INFLATION DEMO 🚨
-
-        # Simple 1-to-many: Accounts → Deals (runs parallel to deals join)
         - join: fanouts_deals
-          relationship: one-to-many
           sql_on: ${fanouts_accounts.account_id} = ${fanouts_deals.account_id}
           type: left
+          relationship: one-to-many
           fields:
             [
               deal_id,
-              unique_deal_count,
+              unique_deals,
+              new_deals,
+              won_deals,
+              lost_deals,
               stage,
-              amount,
-              inflated_total_deal_value,
-              inflated_average_deal_value,
-              inflated_deal_count,
-              max_deal_value,
-              min_deal_value,
-              median_deal_value, 
-              created_date
+              average_amount,
+              total_amount,
+              total_deal_value,
+              total_won_amount,
+              seats
             ]
-
-        # Multiple 1-to-many: Accounts → Users (runs parallel to deals join)
         - join: fanouts_users
-          relationship: one-to-many
-          sql_on: ${fanouts_accounts.account_id} = ${fanouts_users.account_id}
+          relationship: many-to-many
+          sql_on: ${fanouts_accounts.account_id} = ${fanouts_users.account_id} and ${fanouts_deals.stage} = 'Won'
           type: left
           fields:
             [
               user_id,
               unique_user_count,
-              inflated_user_count,
               job_title,
               is_marketing_opted_in,
               unique_job_title_count,
-              inflated_job_title_count,
               email,
               created_at,
-              first_logged_in_at
+              first_logged_in_at,
+              experience_in_years,
+              average_experience_in_years
             ]
-
-        # Chained 1-to-many: Users → Events (builds on the users join above)
         - join: fanouts_tracks
           relationship: one-to-many
           sql_on: ${fanouts_users.user_id} = ${fanouts_tracks.user_id}
           type: left
-          fields:
-            [
-              unique_event_count,
-              inflated_event_count,
-              event_name,
-              timestamp,
-              event_id
-            ]
-
-        - join: fanouts_addresses
-          relationship: one-to-one
-          sql_on: ${fanouts_users.user_id} = ${fanouts_addresses.user_id} AND ${fanouts_addresses.valid_to} IS NULL
-          type: left
-          fields: [ street_address, city, state, postal_code, country_iso_code, valid_from, valid_to, unique_city_count, inflated_city_count ]
-
-        - join: fanouts_countries
-          relationship: many-to-one
-          sql_on: ${fanouts_addresses.country_iso_code} = ${fanouts_countries.iso_code}
-          type: left
-          fields: [ country_name, unique_country_count, inflated_country_count ]
-
-        - join: fanouts_sales_targets
-          alias: fanouts_industry_sales_targets
-          relationship: many-to-one 
-          sql_on: |
-            ${fanouts_deals.created_date} BETWEEN ${fanouts_industry_sales_targets.quarter_start_date} AND ${fanouts_industry_sales_targets.quarter_end_date} 
-            AND  
-              (
-                (${fanouts_deals.stage} = 'Won' AND ${fanouts_accounts.industry} = ${fanouts_industry_sales_targets.target_value} AND ${fanouts_industry_sales_targets.target_type} = 'industry')
-              )
-          type: left
-          fields:
-            [
-              target_deals,
-              target_amount,
-              quarter_start_date,
-              total_target_deal_count,
-              total_target_deal_amount
-            ]
-        - join: fanouts_sales_targets
-          alias: fanouts_segment_sales_targets
-          relationship: many-to-one # Many deals to one target
-          sql_on: |
-            ${fanouts_deals.created_date} BETWEEN ${fanouts_segment_sales_targets.quarter_start_date} AND ${fanouts_segment_sales_targets.quarter_end_date} 
-            AND  
-              (
-                (${fanouts_deals.stage} = 'Won' AND ${fanouts_accounts.segment} = ${fanouts_segment_sales_targets.target_value} AND ${fanouts_segment_sales_targets.target_type} = 'segment')
-              )
-          type: left # Since this is a LEFT JOIN, deals that are not 'Won' will appear with NULL sales target data
-          fields:
-            [
-              target_deals,
-              target_amount,
-              quarter_start_date,
-              total_target_deal_count,
-              total_target_deal_amount
-            ]
+          fields: [ id, user_id, event_count, name, timestamp, days_since_user_created, event_count]
     columns:
       - name: account_id
         description: "The Account ID from our database"
         meta:
           dimension:
             type: string
+            urls:
+              - label: 'Open in CRM'
+                url: https://demo_saas.com/example/account/${ value.raw }
           metrics:
+            deals_seats_metric:
+              type: sum
+              description: "Sum of all deal seats for this account"
+              sql: ${fanouts_deals.seats}
             unique_accounts:
               type: count_distinct
-              label: "✅ FANOUT SAFE Unique Account Count"
-              description: "✅ CORRECT: Uses count_distinct so won't inflate"
-
-            # 🚨 INFLATION DEMO METRICS 🚨
-            inflated_account_count:
-              type: count
-              label: "🚨 INFLATED Account Count"
-              description: "❌ WRONG: Uses COUNT instead of COUNT_DISTINCT - will inflate based
-                on the grain of the data"
-
+              description: The unique number of fanouts_accounts based on distinct Account IDs
+              spotlight:
+                visibility: show
+            unique_smb_accounts:
+              label: Unique SMB fanouts_accounts
+              type: count_distinct
+              description: The unique number of fanouts_accounts based on distinct Account IDs for
+                fanouts_accounts in the SMB Segment
+              filters:
+                - segment: 'SMB'
+            unique_midmarket_accounts:
+              label: Unique Midmarket fanouts_accounts
+              type: count_distinct
+              description: The unique number of Midmarket fanouts_accounts based on distinct Account
+                IDs for fanouts_accounts in the Midmarket Segment
+              filters:
+                - segment: 'Midmarket'
+            unique_enterprise_accounts:
+              label: Unique Enterprise Accounts
+              type: count_distinct
+              description: The unique number of accounts based on distinct Account IDs for
+                accounts in the Enterprise Segment
+              filters:
+                - segment: 'Enterprise'
       - name: account_name
         description: "Name of this company account"
         meta:
           dimension:
             type: string
-
       - name: industry
         description: "Stock market industry for this account"
         meta:
           dimension:
             type: string
-          metrics:
-            unique_industry_count:
-              type: count_distinct
-              label: "✅ SAFE Unique Industry Count"
-              description: "✅ CORRECT: Uses count_distinct so won't inflate regardless of the
-                grain of the data"
-            inflated_industry_count:
-              type: count
-              label: "🚨 ALWAYS INFLATED Industry Count"
-              description: "❌ WRONG: Uses COUNT instead of COUNT_DISTINCT - will always return
-                inflated count because multiple accounts can fall into the same
-                industry."
-
       - name: segment
         description: "The market Segment for this account (SMB, Midmarket, Enterprise)"
         meta:
           dimension:
             type: string
+      - name: estimated_annual_recurring_revenue
+        description: "Estimated annual recurring revenue for this business"
+        meta:
+          dimension:
+            type: number
           metrics:
-            unique_segment_count:
-              type: count_distinct
-              label: "✅ SAFE Unique Segment Count"
-              description: "✅ CORRECT: Uses count_distinct so won't inflate regardless of the
-                grain of the data."
-            inflated_segment_count:
-              type: count
-              label: "🚨 ALWAYS INFLATED Segment Count"
-              description: "❌ WRONG: Uses COUNT instead of COUNT_DISTINCT - will always return
-                inflated count because multiple accounts can fall into the same
-                segment."
+            total_estimated_annual_recurring_revenue:
+              type: sum
+              label: "Total Estimated Annual Recurring Revenue"
+              description: "Sum of all estimated annual recurring revenue"
+              format: 'usd'
+      - name: numeric_dim
+        description: "A numeric dimension for testing purposes"
+        meta:
+          dimension:
+            type: number

--- a/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_deals.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_deals.yml
@@ -41,17 +41,16 @@ models:
           dimension:
             type: number
           metrics:
-            inflated_total_deal_value:
-              label: "🚨 INFLATED Total Deal Value"
-              description: "❌ WRONG: Deal amounts get multiplied by (users × events). A $1000
-                deal becomes $1000 × users × events!"
+            total_deal_value:
+              label: "Total Deal Value"
+              description: ""
               format: 'usd'
               type: sum
 
-            inflated_average_deal_value:
+            average_deal_value:
               type: average
-              label: "🚨 INFLATED Average Deal Value"
-              description: "❌ WRONG: Average is calculated on inflated rows, not actual deals"
+              label: ""
+              description: ""
               format: 'usd'
 
             max_deal_value:

--- a/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_tracks.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_tracks.yml
@@ -21,11 +21,9 @@ models:
               type: count_distinct
               label: "✅ FANOUT SAFE Unique Event Count"
               description: "✅ CORRECT: Uses count_distinct so won't inflate"
-            inflated_event_count:
+            event_count:
               type: count
-              label: "🚨 INFLATED Event Count"
-              description: "❌ WRONG: If grain of data is not at event/track level then this
-                will be inflated"
+              description: ""
       - name: event_name
         description: ""
         meta:

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1769,11 +1769,12 @@ export class MetricQueryBuilder {
 
             // Get filter-only metrics to exclude from final SELECT
             const { metrics, filters } = compiledMetricQuery;
-            const fieldQuoteChar =
-                this.args.warehouseSqlBuilder.getFieldQuoteChar();
             const filterOnlyMetricIds = getFilterRulesFromGroup(filters.metrics)
                 .map((filter) => filter.target.fieldId)
                 .filter((metricId) => !metrics.includes(metricId));
+
+            const fieldQuoteChar =
+                this.args.warehouseSqlBuilder.getFieldQuoteChar();
 
             // Build explicit column list excluding filter-only metrics
             const finalSelectColumns =
@@ -1789,10 +1790,14 @@ export class MetricQueryBuilder {
                               (metricId) =>
                                   `  ${fieldQuoteChar}${metricId}${fieldQuoteChar}`,
                           ),
-                          // Include table calcs if inlined
-                          ...(shouldInlineSimpleCalcs
-                              ? simpleTableCalculationSelects
-                              : []),
+                          ...interdependentTableCalcs.map(
+                              (tableCalc) =>
+                                  `  ${fieldQuoteChar}${tableCalc.name}${fieldQuoteChar}`,
+                          ),
+                          ...simpleTableCalcs.map(
+                              (tableCalc) =>
+                                  `${fieldQuoteChar}${tableCalc.name}${fieldQuoteChar}`,
+                          ),
                       ]
                     : [
                           '  *',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17014

### Description:

WIP at the moment, but getting closer, I think. We had an incomplete fix before, here is some background

**The basic problem**
There is a SQL when filtering by a metric not included in the query with fanouts protection.

Repro:

Select a dimension
Select a metric from a joined table
Filter by a metric from the joined table, but don't select it
Run the query
Error
There are a couple localhost repros that match customer issues, one with a fanned out join, one without:

[Repro 1](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/fanouts_accounts?create_saved_chart_version=%7B%22tableName%22%3A%22fanouts_accounts%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22fanouts_accounts%22%2C%22dimensions%22%3A%5B%5D%2C%22metrics%22%3A%5B%22fanouts_accounts_inflated_industry_count%22%5D%2C%22filters%22%3A%7B%22metrics%22%3A%7B%22id%22%3A%22b836ed72-c9cc-438b-91c6-0dacb35591d7%22%2C%22and%22%3A%5B%7B%22id%22%3A%22a5e8a611-24b8-4a98-98aa-e9d5e762fb52%22%2C%22target%22%3A%7B%22fieldId%22%3A%22fanouts_deals_inflated_deal_count%22%7D%2C%22operator%22%3A%22notNull%22%2C%22values%22%3A%5B%5D%7D%5D%7D%7D%2C%22sorts%22%3A%5B%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22fanouts_accounts_inflated_industry_count%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22big_number%22%2C%22config%22%3A%7B%22selectedField%22%3A%22fanouts_accounts_inflated_industry_count%22%2C%22showBigNumberLabel%22%3Atrue%2C%22showComparison%22%3Afalse%2C%22comparisonFormat%22%3A%22raw%22%2C%22flipColors%22%3Afalse%7D%7D%7D) - repro on main, the fields don't exist in this branch if you sync DBT

[Repro 2](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/payments?create_saved_chart_version=%7B%22tableName%22%3A%22payments%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22payments%22%2C%22dimensions%22%3A%5B%22payments_payment_method%22%5D%2C%22metrics%22%3A%5B%22orders_average_order_size%22%5D%2C%22filters%22%3A%7B%22metrics%22%3A%7B%22id%22%3A%22a7b827bb-650a-458f-b3c7-2a5a0a9ca30d%22%2C%22and%22%3A%5B%7B%22id%22%3A%22fbba786c-309f-4170-9c9b-071b305847a2%22%2C%22target%22%3A%7B%22fieldId%22%3A%22payments_total_revenue%22%7D%2C%22operator%22%3A%22notNull%22%2C%22values%22%3A%5B%5D%7D%5D%7D%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22payments_payment_method%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22payments_payment_method%22%2C%22orders_average_order_size%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22payments_payment_method%22%2C%22yField%22%3A%5B%22orders_average_order_size%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22payments_payment_method%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_average_order_size%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%7D) - this repro uses a fitler from a joined table that doesn't fan out. We add the filter field to the unaffected CTE

In the previous fix, @jesshitchcock gave a good explanation of why we need to do more to avoid inflation from metrics included from filters: [details](https://github.com/lightdash/lightdash/pull/17356#issuecomment-3389934622)

This attempts to solve the problem by doing what was suggested and adding fanout protection for the joined tables that we are referencing just for a filter, but not selecting the metrics in the final select. This adds a `cte_keys_fanouts_<table>` and `cte_metrics_fanouts_<table>` for the filter table. Then we don't select the fitler metric in the final select. 

Since we are no longer selecting all fields, I tested including
- A dimension
- A metric
- A custom dimension
- A custom metric
- A TC based on a dimension
- A TC based on the first one
- A TC not related to the first two

Are there any other field types we need to include?

