### PR TITLE
fix(mcp): retain table calculations in metric query

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1148,7 +1148,6 @@ export class McpService extends BaseService {
                 projectUuid,
                 metricQuery: {
                     ...metricQuery,
-                    tableCalculations: [],
                     additionalMetrics: additionalMetrics ?? [],
                 },
                 exploreName: metricQuery.exploreName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removed the forced empty `tableCalculations` array from the metric query in the McpService. This allows table calculations to be properly passed through when querying metrics.
