### PR TITLE
fix: make filtersSchemaAndFilterRulesTransformed nullable

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/filters/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/index.ts
@@ -70,10 +70,12 @@ const filtersSchemaAndFilterRulesTransformedV2 =
         tableCalculations: z.array(filterRuleSchemaTransformed).nullable(),
     });
 
-const filtersSchemaAndFilterRulesTransformed = z.union([
-    filtersSchemaAndFilterRulesTransformedV2,
-    filtersSchemaAndFilterRulesTransformedV1,
-]);
+const filtersSchemaAndFilterRulesTransformed = z
+    .union([
+        filtersSchemaAndFilterRulesTransformedV2,
+        filtersSchemaAndFilterRulesTransformedV1,
+    ])
+    .nullable();
 
 export const filtersSchemaTransformed =
     filtersSchemaAndFilterRulesTransformed.transform((data): Filters => {


### PR DESCRIPTION
### Description:
Make `filtersSchemaAndFilterRulesTransformed` nullable to handle cases where filter data might be null. This change ensures proper type validation when dealing with potentially missing filter configurations.