### PR TITLE
feat: add 100% stacking option to cartesian charts

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3035,6 +3035,14 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                stack: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -5937,11 +5945,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -5956,11 +5964,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -5975,11 +5983,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -5994,11 +6002,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6013,11 +6021,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6032,11 +6040,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6051,11 +6059,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6070,11 +6078,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6089,11 +6097,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6108,11 +6116,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10615,6 +10623,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                stack: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'boolean' },
+                    ],
+                },
                 sortBy: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'VizSortBy' },
@@ -10694,12 +10709,20 @@ const models: TsoaRoute.Models = {
         enums: [0, 1],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    StackType: {
+        dataType: 'refEnum',
+        enums: ['none', 'stack', 'stack100'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CartesianChartDisplay: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                stack: { dataType: 'boolean' },
+                stack: {
+                    dataType: 'union',
+                    subSchemas: [{ dataType: 'boolean' }, { ref: 'StackType' }],
+                },
                 legend: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -15128,7 +15151,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15138,7 +15161,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15148,7 +15171,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -15161,7 +15184,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3300,6 +3300,16 @@
                     },
                     "showYAxis": {
                         "type": "boolean"
+                    },
+                    "stack": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "boolean"
+                            }
+                        ]
                     }
                 },
                 "type": "object",
@@ -6585,34 +6595,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "success",
                                                             "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "error",
-                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -11039,6 +11023,16 @@
             },
             "PivotChartLayout": {
                 "properties": {
+                    "stack": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "boolean"
+                            }
+                        ]
+                    },
                     "sortBy": {
                         "items": {
                             "$ref": "#/components/schemas/VizSortBy"
@@ -11104,10 +11098,21 @@
                 "enum": [0, 1],
                 "type": "number"
             },
+            "StackType": {
+                "enum": ["none", "stack", "stack100"],
+                "type": "string"
+            },
             "CartesianChartDisplay": {
                 "properties": {
                     "stack": {
-                        "type": "boolean"
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "$ref": "#/components/schemas/StackType"
+                            }
+                        ]
                     },
                     "legend": {
                         "properties": {
@@ -15862,22 +15867,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -20846,7 +20851,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2077.1",
+        "version": "0.2078.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -343,6 +343,7 @@ export * from './utils/timeFrames';
 export * from './utils/virtualView';
 export * from './utils/warehouse';
 export * from './visualizations/CartesianChartDataModel';
+export * from './visualizations/chartTransformations';
 export * from './visualizations/PieChartDataModel';
 export * from './visualizations/TableDataModel';
 export * from './visualizations/types';

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -338,6 +338,7 @@ export type CompleteCartesianChartLayout = {
     showGridY?: boolean | undefined;
     showXAxis?: boolean | undefined;
     showYAxis?: boolean | undefined;
+    stack?: boolean | string | undefined; // Support both old boolean and new StackType string for backward compatibility
 };
 
 export type CartesianChartLayout = Partial<CompleteCartesianChartLayout>;

--- a/packages/common/src/visualizations/chartTransformations.ts
+++ b/packages/common/src/visualizations/chartTransformations.ts
@@ -1,0 +1,155 @@
+import toNumber from 'lodash/toNumber';
+
+/**
+ * ECharts tooltip parameter types
+ * These represent the structure of params passed to tooltip formatters
+ */
+export interface TooltipParam {
+    seriesName?: string;
+    marker?: string;
+    encode?: {
+        x?: string | number | (string | number)[];
+        y?: string | number | (string | number)[];
+    };
+    dimensionNames?: string[];
+    data?: Record<string, unknown>;
+    value?: Record<string, unknown> | unknown[];
+    axisValue?: string | number;
+    axisValueLabel?: string | number;
+}
+
+type TooltipParams = TooltipParam | TooltipParam[];
+
+type GetDimensionNameFn = (param: TooltipParam) => string | undefined;
+
+/**
+ * Creates a tooltip formatter for 100% stacked charts
+ * This formatter shows both the percentage and the original count value
+ *
+ * @param originalValues - Map of x-axis values to their original y-values
+ * @param getDimensionName - Function to extract the dimension name from a param
+ * @returns A formatter function compatible with ECharts tooltip
+ *
+ * @example
+ * // SQL Runner usage
+ * const formatter = createStack100TooltipFormatter(
+ *     originalValues,
+ *     (param) => {
+ *         const { encode, dimensionNames } = param;
+ *         const yFieldIndex = Array.isArray(encode.y) ? encode.y[0] : encode.y;
+ *         return dimensionNames?.[yFieldIndex];
+ *     }
+ * );
+ *
+ * @example
+ * // Explorer usage with flip axes
+ * const formatter = createStack100TooltipFormatter(
+ *     originalValues,
+ *     (param) => {
+ *         const { encode, dimensionNames } = param;
+ *         if (!dimensionNames || !encode) return undefined;
+ *         return flipAxes ? dimensionNames[1] : dimensionNames[encode.y?.[0]];
+ *     }
+ * );
+ */
+export function createStack100TooltipFormatter(
+    originalValues: Map<string, Map<string, number>>,
+    getDimensionName: GetDimensionNameFn,
+) {
+    return (params: TooltipParams) => {
+        if (!Array.isArray(params)) return '';
+
+        const xValue = String(
+            params[0]?.axisValueLabel || params[0]?.axisValue || '',
+        );
+        let result = `<strong>${xValue}</strong><br/>`;
+
+        params.forEach((param) => {
+            const { seriesName = '', marker = '' } = param;
+            const dimensionName = getDimensionName(param);
+
+            if (dimensionName) {
+                // Access value - try both data and value for compatibility
+                // SQL Runner uses 'data', Explorer uses 'value'
+                const valueObject =
+                    param.data ||
+                    (typeof param.value === 'object' &&
+                    !Array.isArray(param.value)
+                        ? param.value
+                        : undefined);
+
+                if (valueObject && typeof valueObject === 'object') {
+                    const percentage = valueObject[dimensionName];
+                    const originalValue =
+                        originalValues?.get(xValue)?.get(dimensionName) || 0;
+
+                    result += `${marker} ${seriesName}: ${Number(
+                        percentage,
+                    ).toFixed(1)}%, count: ${originalValue}<br/>`;
+                }
+            }
+        });
+
+        return result;
+    };
+}
+
+/**
+ * Transform data for 100% stacked charts
+ *
+ * Converts absolute values to percentages where each stacked group totals 100%.
+ * Also preserves original values for tooltip display.
+ *
+ * @param rows - Array of data rows to transform
+ * @param xAxisField - Field reference for the x-axis (grouping key)
+ * @param yFieldRefs - Array of field references for y-axis values to convert to percentages
+ * @returns Object containing transformed data and original values map
+ */
+export function transformToPercentageStacking<
+    T extends Record<string, unknown>,
+>(
+    rows: T[],
+    xAxisField: string,
+    yFieldRefs: string[],
+): {
+    transformedResults: T[];
+    originalValues: Map<string, Map<string, number>>;
+} {
+    const originalValues = new Map<string, Map<string, number>>();
+    const totals = new Map<string, number>();
+
+    // Calculate totals for each x-axis value
+    rows.forEach((row) => {
+        const xValue = String(row[xAxisField]);
+        let total = 0;
+
+        yFieldRefs.forEach((yField) => {
+            const value = toNumber(row[yField]) || 0;
+            total += value;
+
+            // Store original value
+            if (!originalValues.has(xValue)) {
+                originalValues.set(xValue, new Map());
+            }
+            originalValues.get(xValue)!.set(yField, value);
+        });
+
+        totals.set(xValue, total);
+    });
+
+    // Transform data to percentages
+    const transformedResults = rows.map((row) => {
+        const xValue = String(row[xAxisField]);
+        const total = totals.get(xValue) || 1; // Avoid division by zero
+        const newRow = { ...row };
+
+        yFieldRefs.forEach((yField) => {
+            const value = toNumber(row[yField]) || 0;
+            (newRow as Record<string, unknown>)[yField] = (value / total) * 100;
+        });
+
+        return newRow;
+    });
+
+    return { transformedResults, originalValues };
+}

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -47,6 +47,12 @@ export enum AxisSide {
     RIGHT,
 }
 
+export enum StackType {
+    NONE = 'none',
+    NORMAL = 'stack',
+    PERCENT = 'stack100',
+}
+
 export function getColumnAxisType(dimensionType: DimensionType): VizIndexType {
     switch (dimensionType) {
         case DimensionType.DATE:
@@ -151,6 +157,7 @@ export type PivotChartLayout = {
     }[];
     groupBy: { reference: string }[] | undefined;
     sortBy?: VizSortBy[];
+    stack?: boolean | StackType; // StackType enum or boolean for backward compatibility
 };
 
 export const isPivotChartLayout = (

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -1,6 +1,7 @@
 import {
     ECHARTS_DEFAULT_COLORS,
     friendlyName,
+    StackType,
     type AxisSide,
     type CartesianChartDisplay,
     type ChartKind,
@@ -165,15 +166,34 @@ export const CartesianChartSeries = ({
                                         value: 'Stacked',
                                         label: 'Stacked',
                                     },
+                                    {
+                                        value: '100%',
+                                        label: '100%',
+                                    },
                                 ]}
-                                value={
-                                    currentConfig?.display?.stack
-                                        ? 'Stacked'
-                                        : 'None'
-                                }
+                                value={(() => {
+                                    const stackValue =
+                                        currentConfig?.display?.stack;
+                                    if (stackValue === StackType.PERCENT) {
+                                        return '100%';
+                                    }
+                                    if (
+                                        stackValue === StackType.NORMAL ||
+                                        stackValue === true
+                                    ) {
+                                        return 'Stacked';
+                                    }
+                                    return 'None';
+                                })()}
                                 onChange={(value) =>
                                     dispatch(
-                                        actions.setStacked(value === 'Stacked'),
+                                        actions.setStacked(
+                                            value === 'Stacked'
+                                                ? StackType.NORMAL
+                                                : value === '100%'
+                                                ? StackType.PERCENT
+                                                : StackType.NONE,
+                                        ),
                                     )
                                 }
                             />

--- a/packages/frontend/src/components/DataViz/store/barChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/barChartSlice.ts
@@ -43,7 +43,8 @@ export const barChartConfigSlice = createSlice({
             if (!state.fieldConfig && action.payload.config.fieldConfig) {
                 state.fieldConfig = action.payload.config.fieldConfig;
             }
-            if (!state.display && action.payload.config.display) {
+            // Always load display config when available (don't skip if display already exists)
+            if (action.payload.config.display) {
                 state.display = action.payload.config.display;
             }
 

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -2,6 +2,7 @@
 // Not needed when viewing a cartesian chart on a dashboard
 import {
     ChartKind,
+    StackType,
     VIZ_DEFAULT_AGGREGATION,
     VizAggregationOptions,
     isFormat,
@@ -287,12 +288,23 @@ export const cartesianChartConfigSlice = createSlice({
             }
         },
 
-        setStacked: ({ display }, action: PayloadAction<boolean>) => {
-            if (!display) return;
+        setStacked: (state, action: PayloadAction<boolean | StackType>) => {
+            if (!state.fieldConfig) return;
 
-            display = display || {};
+            // Support both old boolean format and new StackType string format
+            const stackValue =
+                typeof action.payload === 'boolean'
+                    ? action.payload
+                        ? StackType.NORMAL
+                        : StackType.NONE
+                    : action.payload;
 
-            display.stack = action.payload;
+            // Set in both fieldConfig and display for consistency
+            state.fieldConfig.stack = stackValue;
+
+            // Also set in display for backward compatibility
+            state.display = state.display || {};
+            state.display.stack = stackValue;
         },
 
         setYAxisFormat: (

--- a/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/lineChartSlice.ts
@@ -43,7 +43,8 @@ export const lineChartConfigSlice = createSlice({
             if (!state.fieldConfig && action.payload.config.fieldConfig) {
                 state.fieldConfig = action.payload.config.fieldConfig;
             }
-            if (!state.display && action.payload.config.display) {
+            // Always load display config when available (don't skip if display already exists)
+            if (action.payload.config.display) {
                 state.display = action.payload.config.display;
             }
 

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -11,6 +11,7 @@ import {
     type ParametersValuesMap,
     type PivotValue,
     type Series,
+    type StackType,
     type TableCalculationMetadata,
 } from '@lightdash/common';
 import type EChartsReact from 'echarts-for-react';
@@ -140,7 +141,7 @@ const VisualizationProvider: FC<
         useChartColorConfig({ colorPalette });
 
     // cartesian config related
-    const [stacking, setStacking] = useState<boolean>();
+    const [stacking, setStacking] = useState<boolean | StackType>();
     const [cartesianType, setCartesianType] = useState<CartesianTypeOptions>();
     // --
 

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -1,9 +1,10 @@
-import {
-    type ApiErrorDetail,
-    type ChartConfig,
-    type ChartType,
-    type ItemsMap,
-    type MetricQuery,
+import type {
+    ApiErrorDetail,
+    ChartConfig,
+    ChartType,
+    ItemsMap,
+    MetricQuery,
+    StackType,
 } from '@lightdash/common';
 import type EChartsReact from 'echarts-for-react';
 import { createContext, type RefObject } from 'react';
@@ -30,7 +31,7 @@ type VisualizationContext = {
     itemsMap: ItemsMap | undefined;
     visualizationConfig: VisualizationConfig;
     // cartesian config related
-    setStacking: (value: boolean | undefined) => void;
+    setStacking: (value: boolean | StackType | undefined) => void;
     setCartesianType(args: CartesianTypeOptions | undefined): void;
     // --
     onSeriesContextMenu?: (

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -7,6 +7,7 @@ import {
     type Metric,
     type MetricQuery,
     type ParametersValuesMap,
+    type StackType,
     type TableCalculation,
     type TableCalculationMetadata,
 } from '@lightdash/common';
@@ -71,7 +72,7 @@ export const isCartesianVisualizationConfig = (
 export type VisualizationCartesianConfigProps =
     VisualizationConfigCommon<VisualizationConfigCartesian> & {
         itemsMap: ItemsMap | undefined;
-        stacking: boolean | undefined;
+        stacking: boolean | StackType | undefined;
         cartesianType: CartesianTypeOptions | undefined;
         columnOrder: string[];
         validPivotDimensions: string[] | undefined;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/1582
Closes: https://linear.app/lightdash/issue/CENG-71/100percent-stacked-bar-charts

Also works in dashboards

Not tested: charts as code (should work out of the box, but not 100% sure)

## Explorer

Stack

<img width="1479" height="749" alt="image" src="https://github.com/user-attachments/assets/1b4aaccf-b512-46f2-a2d1-aa69fd8c553f" />

100%

<img width="1479" height="749" alt="image" src="https://github.com/user-attachments/assets/379206bd-06a1-4153-be4d-d573dc96496c" />

100% tooltip

<img width="517" height="452" alt="image" src="https://github.com/user-attachments/assets/9534595a-77bd-4774-8707-c34911cef705" />

## Sql runner

Stack

<img width="1479" height="749" alt="image" src="https://github.com/user-attachments/assets/e165e37b-e609-4920-85d0-19c7c04f3a0c" />

100 %

<img width="1479" height="749" alt="image" src="https://github.com/user-attachments/assets/c6df5ddd-59bc-43a4-9be3-f47ce885d5b6" />

tooltip 

<img width="1286" height="734" alt="image" src="https://github.com/user-attachments/assets/f5793c01-6230-4116-a3a8-fd109c388eb7" />


### Description:
Added support for 100% stacked charts in cartesian visualizations. This enhancement allows users to display data as percentages of the total for each category, making it easier to compare proportional contributions across different groups.

The implementation includes:
- A new `StackType` enum with options for `NONE`, `NORMAL`, and `PERCENT` (100%)
- Updated UI controls in the chart configuration panel with a segmented control for stack type selection
- Data transformation logic to convert values to percentages for 100% stacking
- Custom tooltip formatting to show both percentage and original values
- Y-axis formatting to display percentage values with % symbol
- Backward compatibility with the existing boolean stacking implementation

![image](https://github.com/lightdash/lightdash/assets/12345678/abcd1234-5678-9abc-def0-123456789abc)