### PR TITLE
fix: return entire explore when AI tags are empty instead of undefined

### DIFF
--- a/packages/common/src/ee/AiAgent/filterExploreByTags.test.ts
+++ b/packages/common/src/ee/AiAgent/filterExploreByTags.test.ts
@@ -44,28 +44,29 @@ describe('AiService', () => {
         ).toBeDefined();
     });
 
-    test('should return undefined when AI tags are configured but empty', async () => {
+    test('should return entire explore when AI tags are configured but empty', async () => {
+        const explore = {
+            baseTable: 'customers',
+            tags: [],
+            tables: {
+                customers: {
+                    dimensions: {
+                        customer_name: {
+                            tags: ['pii'],
+                        },
+                    },
+                    metrics: {
+                        revenue: {},
+                    },
+                },
+            },
+        };
         expect(
             filterExploreByTags({
                 availableTags: [],
-                explore: {
-                    baseTable: 'customers',
-                    tags: [],
-                    tables: {
-                        customers: {
-                            dimensions: {
-                                customer_name: {
-                                    tags: ['pii'],
-                                },
-                            },
-                            metrics: {
-                                revenue: {},
-                            },
-                        },
-                    },
-                },
+                explore,
             }),
-        ).toBeUndefined();
+        ).toStrictEqual(explore);
     });
 
     test('should return undefined when explore and fields have no matching AI tags', async () => {

--- a/packages/common/src/ee/AiAgent/filterExploreByTags.ts
+++ b/packages/common/src/ee/AiAgent/filterExploreByTags.ts
@@ -79,7 +79,7 @@ function hasMatchingTags<
  *
  * | Scenario                                        | Result                                    |
  * |-------------------------------------------------|-------------------------------------------|
- * | No tags configured (availableTags = null)       | Everything is visible                     |
+ * | No tags configured (availableTags = null/[])    | Everything is visible                     |
  * | Explore tagged, no field tags                   | All tables/fields visible (explore-level) |
  * | Explore tagged, some fields tagged              | Per-table: field-level or explore-level   |
  * | No explore tag, base table fields tagged        | Only matching fields visible              |
@@ -93,7 +93,7 @@ export function filterExploreByTags<E extends FilterableExplore>({
     explore: E;
     availableTags: string[] | null;
 }) {
-    if (!availableTags) {
+    if (!availableTags || availableTags.length === 0) {
         return explore;
     }
 


### PR DESCRIPTION
### Description:
Fix behavior when AI tags are configured but empty. Previously, the function would return `undefined` when `availableTags` was an empty array, but now it correctly returns the entire explore object, maintaining consistency with the documented behavior that "Everything is visible" when no tags are configured.

The test has been updated to reflect this change, now asserting that the explore object is returned unchanged rather than expecting `undefined`.