### PR TITLE
feat: avoid layout jump when loading new results using ai search box

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -47,10 +47,15 @@ export const SearchDropdown: FC<Props> = ({
     });
 
     const [debouncedQuery] = useDebouncedValue(value, 200);
-    const { data: searchResults, isSuccess } = useSearch(
+    const {
+        data: searchResults,
+        isSuccess,
+        isFetching,
+    } = useSearch({
         projectUuid,
-        debouncedQuery,
-    );
+        query: debouncedQuery,
+        keepPreviousData: true,
+    });
 
     const allSearchItemsGrouped = useMemo(
         () =>
@@ -93,6 +98,9 @@ export const SearchDropdown: FC<Props> = ({
                         value={value}
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                             handleInputChange(e.currentTarget.value)
+                        }
+                        rightSection={
+                            isFetching && <Loader size={12} color="gray" />
                         }
                     />
                 </Combobox.EventsTarget>

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -70,11 +70,11 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     const [focusedItemIndex, setFocusedItemIndex] =
         useState<FocusedItemIndex>();
 
-    const { data: searchResults, isFetching } = useSearch(
+    const { data: searchResults, isFetching } = useSearch({
         projectUuid,
-        debouncedValue,
-        searchFilters,
-    );
+        query: debouncedValue,
+        filters: searchFilters,
+    });
 
     const [isOmnibarOpen, { open: openOmnibar, close: closeOmnibar }] =
         useDisclosure(false);

--- a/packages/frontend/src/features/omnibar/hooks/useSearch.ts
+++ b/packages/frontend/src/features/omnibar/hooks/useSearch.ts
@@ -3,24 +3,27 @@ import {
     type SearchFilters,
     type SearchResults,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { getSearchResults } from '../api/search';
 import { type SearchResultMap } from '../types/searchResultMap';
 import { getSearchItemMap } from '../utils/getSearchItemMap';
 
 export const OMNIBAR_MIN_QUERY_LENGTH = 3;
 
-const useSearch = (
-    projectUuid: string,
-    query: string = '',
-    filters?: SearchFilters,
-) =>
+type Params = UseQueryOptions<SearchResults, ApiError, SearchResultMap> & {
+    projectUuid: string;
+    query?: string;
+    filters?: SearchFilters;
+};
+
+const useSearch = ({ projectUuid, query = '', filters, ...params }: Params) =>
     useQuery<SearchResults, ApiError, SearchResultMap>({
-        queryKey: ['search', filters ?? 'all', query],
+        queryKey: [projectUuid, 'search', filters ?? 'all', query],
         queryFn: () => getSearchResults({ projectUuid, query, filters }),
         retry: false,
         enabled: query.length >= OMNIBAR_MIN_QUERY_LENGTH,
         select: (data) => getSearchItemMap(data, projectUuid),
+        ...params,
     });
 
 export default useSearch;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Improved search UX when using the AI Search box by using the `keepPreviousData` flag when doing requests. Instead of cleaning the list of results while fetching, we now keep it and display a loader in the input to avoid layout jumps.

_Before_
[Screen Recording 2025-10-14 at 14.55.54.mov](https://app.graphite.dev/user-attachments/video/07ab6f7f-726e-48da-aff9-058b471b12dc.mov)

_After_
[Screen Recording 2025-10-14 at 14.55.06.mov](https://app.graphite.dev/user-attachments/video/54ca92cf-ca53-4a1e-832f-2ed826530946.mov)

(Extra latency was added into the requests to better display the loading state)