### PR TITLE
fix: configure ESLint import resolver to handle TypeScript extensions

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -11,6 +11,13 @@ module.exports = {
         'airbnb-typescript/base',
         'prettier',
     ],
+    settings: {
+        'import/resolver': {
+            node: {
+                extensions: ['.js', '.jsx', '.ts', '.tsx']
+            }
+        }
+    },
     rules: {
         'import/prefer-default-export': 'off',
         '@typescript-eslint/no-unused-vars': 'off',

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -60,7 +60,6 @@ import { wrapSentryTransaction } from '../../../utils';
 import { VERSION } from '../../../version';
 import { getFindCharts } from '../ai/tools/findCharts';
 import { getFindDashboards } from '../ai/tools/findDashboards';
-// eslint-disable-next-line import/extensions
 import { getFindExplores } from '../ai/tools/findExplores';
 import { getFindFields } from '../ai/tools/findFields';
 import { getRunMetricQuery } from '../ai/tools/runMetricQuery';

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -7,7 +7,6 @@ import {
     smoothStream,
     stepCountIs,
     streamText,
-    Tool,
     ToolCallRepairFunction,
     ToolSet,
 } from 'ai';
@@ -15,7 +14,6 @@ import Logger from '../../../../logging/logger';
 import { getSystemPrompt } from '../prompts/system';
 import { getFindCharts } from '../tools/findCharts';
 import { getFindDashboards } from '../tools/findDashboards';
-// eslint-disable-next-line import/extensions
 import { getFindExplores } from '../tools/findExplores';
 import { getFindFields } from '../tools/findFields';
 import { getGenerateBarVizConfig } from '../tools/generateBarVizConfig';


### PR DESCRIPTION
### Description:
Fixed ESLint configuration to properly resolve TypeScript imports by adding an import resolver setting. This eliminates the need for `// eslint-disable-next-line import/extensions` comments which have been removed from McpService.ts and agent.ts files.