### PR TITLE
feat: enable ai chart pivot when running version 2

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/renderRunQueryChart.ts
+++ b/packages/backend/src/ee/services/ai/utils/renderRunQueryChart.ts
@@ -24,10 +24,8 @@ const getBarChartEchartsConfig = (
     let metrics: (string | PivotReference)[] = queryMetrics;
     let chartData = rows;
 
-    // Determine if we should pivot based on chartConfig.pivot or auto-detect from dimensions
-    const shouldPivot = chartConfig?.pivot ?? dimensions.length > 1;
-    const breakdownDimension =
-        shouldPivot && dimensions.length > 1 ? dimensions[1] : null;
+    // Determine if we should pivot based on chartConfig.groupBy
+    const breakdownDimension = chartConfig?.groupBy?.[0] ?? null;
 
     // If we should pivot and have a breakdown dimension, pivot the data
     if (breakdownDimension) {
@@ -116,10 +114,8 @@ const getLineChartEchartsConfig = (
     let metrics: (string | PivotReference)[] = queryMetrics;
     let chartData = rows;
 
-    // Determine if we should pivot based on chartConfig.pivot or auto-detect from dimensions
-    const shouldPivot = chartConfig?.pivot ?? dimensions.length > 1;
-    const breakdownDimension =
-        shouldPivot && dimensions.length > 1 ? dimensions[1] : null;
+    // Determine if we should pivot based on chartConfig.groupBy
+    const breakdownDimension = chartConfig?.groupBy?.[0] ?? null;
 
     // If we should pivot and have a breakdown dimension, pivot the data
     if (breakdownDimension) {
@@ -209,10 +205,8 @@ const getHorizontalBarChartEchartsConfig = (
     let metrics: (string | PivotReference)[] = queryMetrics;
     let chartData = rows;
 
-    // Determine if we should pivot based on chartConfig.pivot or auto-detect from dimensions
-    const shouldPivot = chartConfig?.pivot ?? dimensions.length > 1;
-    const breakdownDimension =
-        shouldPivot && dimensions.length > 1 ? dimensions[1] : null;
+    // Determine if we should pivot based on chartConfig.groupBy
+    const breakdownDimension = chartConfig?.groupBy?.[0] ?? null;
 
     // If we should pivot and have a breakdown dimension, pivot the data
     if (breakdownDimension) {
@@ -301,10 +295,8 @@ const getScatterChartEchartsConfig = (
     let metrics: (string | PivotReference)[] = queryMetrics;
     let chartData = rows;
 
-    // Determine if we should pivot based on chartConfig.pivot or auto-detect from dimensions
-    const shouldPivot = chartConfig?.pivot ?? dimensions.length > 1;
-    const breakdownDimension =
-        shouldPivot && dimensions.length > 1 ? dimensions[1] : null;
+    // Determine if we should pivot based on chartConfig.groupBy
+    const breakdownDimension = chartConfig?.groupBy?.[0] ?? null;
 
     // If we should pivot and have a breakdown dimension, pivot the data
     if (breakdownDimension) {

--- a/packages/backend/src/ee/services/ai/visualizations/vizVerticalBar.ts
+++ b/packages/backend/src/ee/services/ai/visualizations/vizVerticalBar.ts
@@ -2,7 +2,6 @@ import {
     AiMetricQueryWithFilters,
     AiResultType,
     MetricQuery,
-    metricQueryVerticalBarViz,
     ToolVerticalBarArgsTransformed,
 } from '@lightdash/common';
 import { ProjectService } from '../../../../services/ProjectService/ProjectService';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -55,11 +55,11 @@ const chartConfigSchema = z
             .describe('The default visualization type to render'),
 
         // Series creation control
-        pivot: z
-            .boolean()
+        groupBy: z
+            .array(getFieldIdSchema({ additionalDescription: null }))
             .nullable()
             .describe(
-                'Controls how multiple dimensions are rendered in charts. Set to true to create one series per value in dimensions[1] (e.g., "show revenue by month, split by region"). Set to false or omit for simple grouping. Only applies when you have 2+ dimensions.',
+                'Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts.',
             ),
 
         // Bar and horizontal bar chart specific
@@ -73,7 +73,7 @@ const chartConfigSchema = z
             .boolean()
             .nullable()
             .describe(
-                'If using pivot then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.',
+                'If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.',
             ),
 
         // Line chart specific
@@ -120,12 +120,11 @@ Chart Type Selection Guide:
 
 Configuration Tips:
 - Specify exploreName, dimensions (for grouping/x-axis), and metrics (for y-axis values)
-- dimensions[0] is the primary grouping (x-axis for charts)
-- dimensions[1+] create additional grouping levels
+- First dimension is the x-axis; additional dimensions can be used for series breakdown via groupBy
 - At least one metric is required for all chart types except table
-- Set chartConfig.pivot to true to create one series per value in dimensions[1] (only when 2+ dimensions)
+- chartConfig.groupBy: Use to split data into multiple series (e.g., one line per region). Do NOT include the x-axis dimension. Only include dimensions for series breakdown. Leave null for simple single-series charts.
 - For bar/horizontal charts: use xAxisType 'category' for strings or 'time' for dates/timestamps
-- For bar/horizontal charts: stackBars (when pivoted) stacks bars instead of placing them side by side
+- For bar/horizontal charts: stackBars (when groupBy is provided) stacks bars instead of placing them side by side
 - For line charts: use lineType 'area' to fill the area under the line
 - For scatter charts: each point represents one row of data
 - For funnel charts: set funnelDataInput to 'row' (each row = stage) or 'column' (multiple funnels)

--- a/packages/common/src/ee/AiAgent/utils/chartConfigUtils.ts
+++ b/packages/common/src/ee/AiAgent/utils/chartConfigUtils.ts
@@ -1,7 +1,6 @@
 import type { ItemsMap } from '../../../types/field';
 import { friendlyName, isField } from '../../../types/field';
 import type { MetricQuery } from '../../../types/metricQuery';
-import type { ResultRow } from '../../../types/results';
 import type {
     CartesianChartConfig,
     ChartConfig,
@@ -16,7 +15,6 @@ import {
 } from '../../../types/savedCharts';
 import { formatItemValue } from '../../../utils/formatting';
 import { getItemLabelWithoutTableName } from '../../../utils/item';
-import { getPivotedData } from '../../../utils/pivotData';
 import type { ToolRunQueryArgsTransformed } from '../schemas/tools/toolRunQueryArgs';
 
 // Axis type from echarts - defined inline since echarts is not a dependency of common
@@ -117,39 +115,18 @@ export const formatPivotValueLabel = (
 const getBarChartConfig = ({
     queryTool,
     metricQuery,
-    rows,
     fieldsMap,
     chartConfig,
     metadata,
 }: {
     queryTool: ToolRunQueryArgsTransformed;
     metricQuery: MetricQuery;
-    rows: Record<string, unknown>[];
     fieldsMap: ItemsMap;
     chartConfig: ToolRunQueryArgsTransformed['chartConfig'] | null | undefined;
     metadata: { title: string; description: string };
 }): CartesianChartConfig => {
-    const { dimensions } = queryTool.queryConfig;
+    const { dimensions, metrics } = queryTool.queryConfig;
     const xDimension = dimensions[0];
-
-    const { metrics: queryMetrics } = metricQuery;
-    let metrics: (string | PivotReference)[] = queryMetrics;
-
-    // Determine if we should pivot based on chartConfig.pivot or auto-detect from dimensions
-    const shouldPivot = chartConfig?.pivot ?? dimensions.length > 1;
-    const breakdownDimension =
-        shouldPivot && dimensions.length > 1 ? dimensions[1] : null;
-
-    // If we should pivot and have a breakdown dimension, pivot the data
-    if (breakdownDimension) {
-        const pivot = getPivotedData(
-            rows as ResultRow[],
-            [breakdownDimension],
-            metricQuery.metrics,
-            [], // No pivoted dimensions
-        );
-        metrics = Object.values(pivot.rowKeyMap);
-    }
 
     return {
         type: ChartType.CARTESIAN,
@@ -162,7 +139,7 @@ const getBarChartConfig = ({
                 ...(metadata.title ? { title: { text: metadata.title } } : {}),
                 legend: {
                     show: true,
-                    type: 'plain',
+                    type: 'scroll',
                 },
                 grid: { containLabel: true },
                 xAxis: [
@@ -206,9 +183,6 @@ const getBarChartConfig = ({
                             xRef: { field: xDimension },
                             yRef: metric,
                         },
-                        ...(chartConfig?.stackBars && {
-                            stack: metric.field,
-                        }),
                     };
                 }),
             },
@@ -222,39 +196,18 @@ const getBarChartConfig = ({
 const getLineChartConfig = ({
     queryTool,
     metricQuery,
-    rows,
     fieldsMap,
     chartConfig,
     metadata,
 }: {
     queryTool: ToolRunQueryArgsTransformed;
     metricQuery: MetricQuery;
-    rows: Record<string, unknown>[];
     fieldsMap: ItemsMap;
     chartConfig: ToolRunQueryArgsTransformed['chartConfig'] | null | undefined;
     metadata: { title: string; description: string };
 }): CartesianChartConfig => {
-    const { dimensions } = queryTool.queryConfig;
+    const { dimensions, metrics } = queryTool.queryConfig;
     const xDimension = dimensions[0];
-
-    const { metrics: queryMetrics } = metricQuery;
-    let metrics: (string | PivotReference)[] = queryMetrics;
-
-    // Determine if we should pivot based on chartConfig.pivot or auto-detect from dimensions
-    const shouldPivot = chartConfig?.pivot ?? dimensions.length > 1;
-    const breakdownDimension =
-        shouldPivot && dimensions.length > 1 ? dimensions[1] : null;
-
-    // If we should pivot and have a breakdown dimension, pivot the data
-    if (breakdownDimension) {
-        const pivoted = getPivotedData(
-            rows as ResultRow[],
-            [breakdownDimension],
-            metricQuery.metrics,
-            [], // No pivoted dimensions
-        );
-        metrics = Object.values(pivoted.rowKeyMap);
-    }
 
     return {
         type: ChartType.CARTESIAN,
@@ -267,7 +220,7 @@ const getLineChartConfig = ({
                 ...(metadata.title ? { title: { text: metadata.title } } : {}),
                 legend: {
                     show: true,
-                    type: 'plain',
+                    type: 'scroll',
                 },
                 grid: { containLabel: true },
                 xAxis: [
@@ -326,39 +279,18 @@ const getLineChartConfig = ({
 const getHorizontalBarChartConfig = ({
     queryTool,
     metricQuery,
-    rows,
     fieldsMap,
     chartConfig,
     metadata,
 }: {
     queryTool: ToolRunQueryArgsTransformed;
     metricQuery: MetricQuery;
-    rows: Record<string, unknown>[];
     fieldsMap: ItemsMap;
     chartConfig: ToolRunQueryArgsTransformed['chartConfig'] | null | undefined;
     metadata: { title: string; description: string };
 }): CartesianChartConfig => {
-    const { dimensions } = queryTool.queryConfig;
+    const { dimensions, metrics } = queryTool.queryConfig;
     const xDimension = dimensions[0];
-
-    const { metrics: queryMetrics } = metricQuery;
-    let metrics: (string | PivotReference)[] = queryMetrics;
-
-    // Determine if we should pivot based on chartConfig.pivot or auto-detect from dimensions
-    const shouldPivot = chartConfig?.pivot ?? dimensions.length > 1;
-    const breakdownDimension =
-        shouldPivot && dimensions.length > 1 ? dimensions[1] : null;
-
-    // If we should pivot and have a breakdown dimension, pivot the data
-    if (breakdownDimension) {
-        const pivot = getPivotedData(
-            rows as ResultRow[],
-            [breakdownDimension],
-            metricQuery.metrics,
-            [], // No pivoted dimensions
-        );
-        metrics = Object.values(pivot.rowKeyMap);
-    }
 
     return {
         type: ChartType.CARTESIAN,
@@ -372,7 +304,7 @@ const getHorizontalBarChartConfig = ({
                 ...(metadata.title ? { title: { text: metadata.title } } : {}),
                 legend: {
                     show: true,
-                    type: 'plain',
+                    type: 'scroll',
                 },
                 grid: { containLabel: true },
                 xAxis: [
@@ -415,9 +347,6 @@ const getHorizontalBarChartConfig = ({
                             xRef: { field: xDimension },
                             yRef: metric,
                         },
-                        ...(chartConfig?.stackBars && {
-                            stack: metric.field,
-                        }),
                     };
                 }),
             },
@@ -431,39 +360,18 @@ const getHorizontalBarChartConfig = ({
 const getScatterChartConfig = ({
     queryTool,
     metricQuery,
-    rows,
     fieldsMap,
     chartConfig,
     metadata,
 }: {
     queryTool: ToolRunQueryArgsTransformed;
     metricQuery: MetricQuery;
-    rows: Record<string, unknown>[];
     fieldsMap: ItemsMap;
     chartConfig: ToolRunQueryArgsTransformed['chartConfig'] | null | undefined;
     metadata: { title: string; description: string };
 }): CartesianChartConfig => {
-    const { dimensions } = queryTool.queryConfig;
+    const { dimensions, metrics } = queryTool.queryConfig;
     const xDimension = dimensions[0];
-
-    const { metrics: queryMetrics } = metricQuery;
-    let metrics: (string | PivotReference)[] = queryMetrics;
-
-    // Determine if we should pivot based on chartConfig.pivot or auto-detect from dimensions
-    const shouldPivot = chartConfig?.pivot ?? dimensions.length > 1;
-    const breakdownDimension =
-        shouldPivot && dimensions.length > 1 ? dimensions[1] : null;
-
-    // If we should pivot and have a breakdown dimension, pivot the data
-    if (breakdownDimension) {
-        const pivoted = getPivotedData(
-            rows as ResultRow[],
-            [breakdownDimension],
-            metricQuery.metrics,
-            [], // No pivoted dimensions
-        );
-        metrics = Object.values(pivoted.rowKeyMap);
-    }
 
     return {
         type: ChartType.CARTESIAN,
@@ -476,7 +384,7 @@ const getScatterChartConfig = ({
                 ...(metadata.title ? { title: { text: metadata.title } } : {}),
                 legend: {
                     show: true,
-                    type: 'plain',
+                    type: 'scroll',
                 },
                 grid: { containLabel: true },
                 xAxis: [
@@ -537,8 +445,6 @@ const getPieChartConfig = ({
 }: {
     queryTool: ToolRunQueryArgsTransformed;
     metricQuery: MetricQuery;
-    rows: Record<string, unknown>[];
-    fieldsMap: ItemsMap;
 }): PieChartConfig => {
     const { dimensions } = queryTool.queryConfig;
     const { metrics } = metricQuery;
@@ -563,8 +469,6 @@ const getFunnelChartConfig = ({
 }: {
     queryTool: ToolRunQueryArgsTransformed;
     metricQuery: MetricQuery;
-    rows: Record<string, unknown>[];
-    fieldsMap: ItemsMap;
 }): FunnelChartConfig => {
     const { metrics } = metricQuery;
     const { chartConfig } = queryTool;
@@ -590,13 +494,11 @@ const getFunnelChartConfig = ({
 export const getChartConfigFromRunQuery = ({
     queryTool,
     metricQuery,
-    rows,
     fieldsMap,
     overrideChartType,
 }: {
     queryTool: ToolRunQueryArgsTransformed;
     metricQuery: MetricQuery;
-    rows: Record<string, unknown>[];
     fieldsMap: ItemsMap;
     overrideChartType?: ChartTypeOption;
 }): ChartConfig => {
@@ -610,8 +512,8 @@ export const getChartConfigFromRunQuery = ({
 
     const { chartConfig } = queryTool;
     const metadata = {
-        title: queryTool.title as string,
-        description: queryTool.description as string,
+        title: queryTool.title,
+        description: queryTool.description,
     };
 
     switch (chartType) {
@@ -622,7 +524,6 @@ export const getChartConfigFromRunQuery = ({
             return getBarChartConfig({
                 queryTool,
                 metricQuery,
-                rows,
                 fieldsMap,
                 chartConfig,
                 metadata,
@@ -632,7 +533,6 @@ export const getChartConfigFromRunQuery = ({
             return getHorizontalBarChartConfig({
                 queryTool,
                 metricQuery,
-                rows,
                 fieldsMap,
                 chartConfig,
                 metadata,
@@ -642,7 +542,6 @@ export const getChartConfigFromRunQuery = ({
             return getLineChartConfig({
                 queryTool,
                 metricQuery,
-                rows,
                 fieldsMap,
                 chartConfig,
                 metadata,
@@ -652,7 +551,6 @@ export const getChartConfigFromRunQuery = ({
             return getScatterChartConfig({
                 queryTool,
                 metricQuery,
-                rows,
                 fieldsMap,
                 chartConfig,
                 metadata,
@@ -662,16 +560,12 @@ export const getChartConfigFromRunQuery = ({
             return getPieChartConfig({
                 queryTool,
                 metricQuery,
-                rows,
-                fieldsMap,
             });
 
         case 'funnel':
             return getFunnelChartConfig({
                 queryTool,
                 metricQuery,
-                rows,
-                fieldsMap,
             });
 
         default:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationChartTypeSwitcher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationChartTypeSwitcher.tsx
@@ -19,6 +19,7 @@ type Props = {
     metricQuery: MetricQuery;
     selectedChartType: ChartTypeOption;
     onChartTypeChange: (chartType: ChartTypeOption) => void;
+    hasGroupByDimensions: boolean;
 };
 
 const CHART_TYPE_ICONS: Record<ChartTypeOption, typeof IconTable> = {
@@ -35,6 +36,7 @@ export const AgentVisualizationChartTypeSwitcher: FC<Props> = ({
     metricQuery,
     selectedChartType,
     onChartTypeChange,
+    hasGroupByDimensions,
 }) => {
     const availableChartTypes = getAvailableChartTypes(metricQuery);
 
@@ -47,19 +49,32 @@ export const AgentVisualizationChartTypeSwitcher: FC<Props> = ({
         <SegmentedControl
             value={selectedChartType}
             onChange={(value) => onChartTypeChange(value as ChartTypeOption)}
-            data={availableChartTypes.map((chartType) => ({
-                value: chartType,
-                label: (
-                    <MantineIcon
-                        icon={CHART_TYPE_ICONS[chartType]}
-                        size="sm"
-                        style={{
-                            rotate:
-                                chartType === 'horizontal' ? '90deg' : '0deg',
-                        }}
-                    />
-                ),
-            }))}
+            data={availableChartTypes
+                .filter((chartType) => {
+                    // Pie and funnel charts are not supported with group by dimensions, they're meant to be used with a single dimension
+                    if (
+                        (hasGroupByDimensions && chartType === 'pie') ||
+                        chartType === 'funnel'
+                    ) {
+                        return false;
+                    }
+                    return true;
+                })
+                .map((chartType) => ({
+                    value: chartType,
+                    label: (
+                        <MantineIcon
+                            icon={CHART_TYPE_ICONS[chartType]}
+                            size="sm"
+                            style={{
+                                rotate:
+                                    chartType === 'horizontal'
+                                        ? '90deg'
+                                        : '0deg',
+                            }}
+                        />
+                    ),
+                }))}
             color="indigo"
             size="xs"
         />

--- a/packages/frontend/src/ee/features/aiCopilot/utils/echarts.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/echarts.ts
@@ -312,7 +312,6 @@ export const getChartConfigFromAiAgentVizConfig = ({
                 echartsConfig: getChartConfigFromRunQuery({
                     queryTool: parsedConfig.vizTool,
                     metricQuery,
-                    rows,
                     fieldsMap,
                     overrideChartType,
                 }),

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -121,7 +121,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 userAccess: agent.userAccess ?? [],
                 enableDataAccess: agent.enableDataAccess ?? false,
                 enableSelfImprovement: agent.enableSelfImprovement ?? false,
-                version: 1, // TODO: Update to 2 when v2 is ready or allow version to be passed in
+                version: agent.version ?? 1, // TODO: Update to 2 when v2 is ready or allow version to be passed in
             };
             form.setValues(values);
             form.resetDirty(values);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Replaced chart pivoting mechanism with a more intuitive `groupBy` approach for AI-generated visualizations. This change:

- Replaces the `pivot` boolean with a `groupBy` array that explicitly specifies which dimensions should be used to create separate series
- Updates the chart rendering logic to use the new `groupBy` parameter instead of auto-detecting from dimensions
- Improves the chart type switcher to filter out incompatible chart types when using `groupBy`
- Enhances chart rendering with proper series generation based on the `groupBy` dimensions
- Updates documentation and tooltips to better explain how to use the new `groupBy` functionality

This change makes it more intuitive for users (and AI) to understand how to create multi-series charts, as they can explicitly specify which dimensions should be used for breaking down the data rather than relying on dimension order.