### PR TITLE
fix: take parameters into account for google sheet sync

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -119,6 +119,7 @@ import {
 } from '../services/CsvService/CsvService';
 import { DashboardService } from '../services/DashboardService/DashboardService';
 import { ExcelService } from '../services/ExcelService/ExcelService';
+import { getDashboardParametersValuesMap } from '../services/ProjectService/parameters';
 import { ProjectService } from '../services/ProjectService/ProjectService';
 import { RenameService } from '../services/RenameService/RenameService';
 import { SchedulerService } from '../services/SchedulerService/SchedulerService';
@@ -2575,6 +2576,11 @@ export default class SchedulerTask {
                 Logger.debug(
                     `Uploading dashboard with ${chartUuids.length} charts to Google Sheets`,
                 );
+
+                // Get the dashboard parameters to override the saved chart parameters
+                const dashboardParameters =
+                    getDashboardParametersValuesMap(dashboard);
+
                 // We want to process all charts in sequence, so we don't load all chart results in memory
                 chartUuids
                     .reduce(async (promise, chartUuid) => {
@@ -2588,6 +2594,7 @@ export default class SchedulerTask {
                                 account!,
                                 chartUuid,
                                 QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
+                                dashboardParameters,
                             );
                         const explore = await this.projectService.getExplore(
                             account!,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2633,6 +2633,7 @@ export class ProjectService extends BaseService {
         account: Account,
         chartUuid: string,
         context: QueryExecutionContext,
+        dashboardParameters?: ParametersValuesMap,
     ): Promise<{
         rows: Record<string, AnyType>[];
         cacheMetadata: CacheMetadata;
@@ -2645,7 +2646,7 @@ export class ProjectService extends BaseService {
             },
             async () => {
                 const chart = await this.savedChartModel.get(chartUuid);
-                const { metricQuery } = chart;
+                const { metricQuery, parameters: savedChartParameters } = chart;
                 const exploreId = chart.tableName;
                 const queryTags: RunQueryTags = {
                     ...this.getUserQueryTags(account),
@@ -2654,6 +2655,20 @@ export class ProjectService extends BaseService {
                     explore_name: exploreId,
                     query_context: context,
                 };
+
+                // Parameter overrides are the dashboard parameters
+                const explore = await this.getExplore(
+                    account,
+                    chart.projectUuid,
+                    exploreId,
+                );
+
+                const parameters = await this.combineParameters(
+                    chart.projectUuid,
+                    explore,
+                    undefined,
+                    dashboardParameters ?? savedChartParameters, // Dashboard parameters go in place of saved chart parameters
+                );
 
                 return this.runMetricQuery({
                     account,
@@ -2664,6 +2679,8 @@ export class ProjectService extends BaseService {
                     context,
                     chartUuid,
                     queryTags,
+                    parameters,
+                    explore, // Passing in explore to avoid fetching it again
                 });
             },
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17456

### Description:
This PR adds support for dashboard parameters in scheduled Google Sheets exports. Previously, when exporting a dashboard to Google Sheets, the saved chart parameters were used instead of the dashboard parameters. Now, the dashboard parameters are properly passed to override the saved chart parameters when exporting to Google Sheets.

The implementation:
1. Gets dashboard parameters using `getDashboardParametersValuesMap`
2. Passes these parameters to `getChartResultsWithCache`
3. Uses dashboard parameters instead of saved chart parameters when running the metric query

This ensures that scheduled Google Sheets exports respect dashboard parameter values, providing consistent results between dashboard views and exports.