### PR TITLE
fix: allow area charts to be stacked

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -47,8 +47,7 @@ export const Layout: FC<Props> = ({ items }) => {
 
     const canBeStacked =
         cartesianType !== CartesianSeriesType.LINE &&
-        cartesianType !== CartesianSeriesType.SCATTER &&
-        cartesianType !== CartesianSeriesType.AREA;
+        cartesianType !== CartesianSeriesType.SCATTER;
 
     // Initialize stacking mode from saved configuration
     const initialStackMode = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

<img width="1539" height="734" alt="image" src="https://github.com/user-attachments/assets/8afc4cca-e61b-4bcf-8914-657ce7db191a" />

### Description:
Allow area charts to be stacked by removing the restriction that prevented area charts from being stacked in the chart configuration panel.