### PR TITLE
fix: update scim/v2/Schemas and scim/v2/ResourceTypes to return a ListResponse and add scim/v2/Schemas/{schemaId} endpoint

### DIFF
--- a/packages/backend/src/ee/controllers/scimRootController.ts
+++ b/packages/backend/src/ee/controllers/scimRootController.ts
@@ -1,5 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import {
+    ScimListResponse,
     ScimResourceType,
     ScimSchema,
     ScimServiceProviderConfig,
@@ -56,9 +57,34 @@ export class ScimRootController extends BaseController {
      */
     @Get('/Schemas')
     @OperationId('GetScimSchemas')
-    @Response<ScimSchema[]>('200', 'Success')
-    async getSchemas(@Request() req: express.Request): Promise<ScimSchema[]> {
+    @Response<ScimListResponse<ScimSchema>>('200', 'Success')
+    async getSchemas(
+        @Request() req: express.Request,
+    ): Promise<ScimListResponse<ScimSchema>> {
         return ScimService.getSchemas();
+    }
+
+    /**
+     * Get individual SCIM schema
+     * @param req express request
+     * @param schemaId schema identifier
+     */
+    @Get('/Schemas/{schemaId}')
+    @OperationId('GetScimSchema')
+    @Response<ScimSchema>('200', 'Success')
+    async getSchema(
+        @Request() req: express.Request,
+        @Path() schemaId: string,
+    ): Promise<ScimSchema> {
+        const schemasResponse = ScimService.getSchemas();
+        const schema = schemasResponse.Resources.find((s) => s.id === schemaId);
+
+        if (!schema) {
+            this.setStatus(404);
+            throw new Error(`Schema ${schemaId} not found`);
+        }
+
+        return schema;
     }
 
     /**
@@ -67,10 +93,10 @@ export class ScimRootController extends BaseController {
      */
     @Get('/ResourceTypes')
     @OperationId('GetScimResourceTypes')
-    @Response<ScimResourceType[]>('200', 'Success')
+    @Response<ScimListResponse<ScimResourceType>>('200', 'Success')
     async getResourceTypes(
         @Request() req: express.Request,
-    ): Promise<ScimResourceType[]> {
+    ): Promise<ScimListResponse<ScimResourceType>> {
         return ScimService.getResourceTypes();
     }
 
@@ -86,8 +112,8 @@ export class ScimRootController extends BaseController {
         @Request() req: express.Request,
         @Path() resourceTypeId: string,
     ): Promise<ScimResourceType> {
-        const resourceTypes = ScimService.getResourceTypes();
-        const resourceType = resourceTypes.find(
+        const resourceTypesResponse = ScimService.getResourceTypes();
+        const resourceType = resourceTypesResponse.Resources.find(
             (rt) => rt.id === resourceTypeId,
         );
 

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -480,10 +480,16 @@ describe('ScimService', () => {
 
         describe('getSchemas', () => {
             test('should return correct schemas array', async () => {
-                const schemas = ScimService.getSchemas();
+                const schemasResponse = ScimService.getSchemas();
 
-                expect(schemas).toHaveLength(5);
-                expect(schemas.map((s) => s.id)).toEqual([
+                expect(schemasResponse.schemas).toEqual([
+                    ScimSchemaType.LIST_RESPONSE,
+                ]);
+                expect(schemasResponse.totalResults).toBe(5);
+                expect(schemasResponse.itemsPerPage).toBe(5);
+                expect(schemasResponse.startIndex).toBe(1);
+                expect(schemasResponse.Resources).toHaveLength(5);
+                expect(schemasResponse.Resources.map((s) => s.id)).toEqual([
                     ScimSchemaType.USER,
                     ScimSchemaType.GROUP,
                     ScimSchemaType.LIGHTDASH_USER_EXTENSION,
@@ -492,7 +498,7 @@ describe('ScimService', () => {
                 ]);
 
                 // Test User schema
-                const userSchema = schemas.find(
+                const userSchema = schemasResponse.Resources.find(
                     (s) => s.id === ScimSchemaType.USER,
                 );
                 expect(userSchema).toBeDefined();
@@ -507,7 +513,7 @@ describe('ScimService', () => {
                 );
 
                 // Test Group schema
-                const groupSchema = schemas.find(
+                const groupSchema = schemasResponse.Resources.find(
                     (s) => s.id === ScimSchemaType.GROUP,
                 );
                 expect(groupSchema).toBeDefined();
@@ -521,7 +527,7 @@ describe('ScimService', () => {
                 );
 
                 // Test Lightdash extension schema
-                const extensionSchema = schemas.find(
+                const extensionSchema = schemasResponse.Resources.find(
                     (s) => s.id === ScimSchemaType.LIGHTDASH_USER_EXTENSION,
                 );
                 expect(extensionSchema).toBeDefined();
@@ -540,9 +546,10 @@ describe('ScimService', () => {
                 );
 
                 // Test ServiceProviderConfig schema
-                const serviceProviderConfigSchema = schemas.find(
-                    (s) => s.id === ScimSchemaType.SERVICE_PROVIDER_CONFIG,
-                );
+                const serviceProviderConfigSchema =
+                    schemasResponse.Resources.find(
+                        (s) => s.id === ScimSchemaType.SERVICE_PROVIDER_CONFIG,
+                    );
                 expect(serviceProviderConfigSchema).toBeDefined();
                 expect(serviceProviderConfigSchema!.name).toBe(
                     'Service Provider Configuration',
@@ -556,7 +563,7 @@ describe('ScimService', () => {
                 );
 
                 // Test ResourceType schema
-                const resourceTypeSchema = schemas.find(
+                const resourceTypeSchema = schemasResponse.Resources.find(
                     (s) => s.id === ScimSchemaType.RESOURCE_TYPE,
                 );
                 expect(resourceTypeSchema).toBeDefined();
@@ -573,12 +580,18 @@ describe('ScimService', () => {
 
         describe('getResourceTypes', () => {
             test('should return correct resource types as array', async () => {
-                const resourceTypes = ScimService.getResourceTypes();
+                const resourceTypesResponse = ScimService.getResourceTypes();
 
-                expect(resourceTypes).toHaveLength(2);
+                expect(resourceTypesResponse.schemas).toEqual([
+                    ScimSchemaType.LIST_RESPONSE,
+                ]);
+                expect(resourceTypesResponse.totalResults).toBe(2);
+                expect(resourceTypesResponse.itemsPerPage).toBe(2);
+                expect(resourceTypesResponse.startIndex).toBe(1);
+                expect(resourceTypesResponse.Resources).toHaveLength(2);
 
                 // Test User resource type
-                const userResourceType = resourceTypes.find(
+                const userResourceType = resourceTypesResponse.Resources.find(
                     (rt) => rt.name === 'User',
                 );
                 expect(userResourceType).toEqual({
@@ -603,7 +616,7 @@ describe('ScimService', () => {
                 });
 
                 // Test Group resource type
-                const groupResourceType = resourceTypes.find(
+                const groupResourceType = resourceTypesResponse.Resources.find(
                     (rt) => rt.name === 'Group',
                 );
                 expect(groupResourceType).toEqual({

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1442,7 +1442,7 @@ export class ScimService extends BaseService {
         return Object.values(fieldAttributeMap);
     }
 
-    static getSchemas(): ScimSchema[] {
+    static getSchemas(): ScimListResponse<ScimSchema> {
         const userSchema: ScimSchema = {
             schemas: [ScimSchemaType.SCHEMA],
             id: ScimSchemaType.USER,
@@ -1936,20 +1936,28 @@ export class ScimService extends BaseService {
             ],
         };
 
-        return [
+        const schemas = [
             userSchema,
             groupSchema,
             lightdashUserExtensionSchema,
             serviceProviderConfigSchema,
             resourceTypeSchema,
         ];
+
+        return {
+            schemas: [ScimSchemaType.LIST_RESPONSE],
+            totalResults: schemas.length,
+            itemsPerPage: schemas.length,
+            startIndex: 1,
+            Resources: schemas,
+        };
     }
 
-    static getResourceTypes(): ScimResourceType[] {
+    static getResourceTypes(): ScimListResponse<ScimResourceType> {
         // Get base URL from environment or use default
         const baseUrl = process.env.SITE_URL || 'http://localhost:8080';
 
-        return [
+        const resources: ScimResourceType[] = [
             {
                 schemas: [ScimSchemaType.RESOURCE_TYPE],
                 id: 'User',
@@ -1981,5 +1989,13 @@ export class ScimService extends BaseService {
                 },
             },
         ];
+
+        return {
+            schemas: [ScimSchemaType.LIST_RESPONSE],
+            totalResults: resources.length,
+            itemsPerPage: resources.length,
+            startIndex: 1,
+            Resources: resources,
+        };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -738,6 +738,29 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimListResponse_ScimSchema_: {
+        dataType: 'refObject',
+        properties: {
+            schemas: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refEnum',
+                    ref: 'ScimSchemaType.LIST_RESPONSE',
+                },
+                required: true,
+            },
+            totalResults: { dataType: 'double', required: true },
+            itemsPerPage: { dataType: 'double', required: true },
+            startIndex: { dataType: 'double', required: true },
+            Resources: {
+                dataType: 'array',
+                array: { dataType: 'refObject', ref: 'ScimSchema' },
+                required: true,
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ScimSchemaType.RESOURCE_TYPE': {
         dataType: 'refEnum',
         enums: ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
@@ -778,6 +801,29 @@ const models: TsoaRoute.Models = {
                         schema: { dataType: 'string', required: true },
                     },
                 },
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimListResponse_ScimResourceType_: {
+        dataType: 'refObject',
+        properties: {
+            schemas: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refEnum',
+                    ref: 'ScimSchemaType.LIST_RESPONSE',
+                },
+                required: true,
+            },
+            totalResults: { dataType: 'double', required: true },
+            itemsPerPage: { dataType: 'double', required: true },
+            startIndex: { dataType: 'double', required: true },
+            Resources: {
+                dataType: 'array',
+                array: { dataType: 'refObject', ref: 'ScimResourceType' },
+                required: true,
             },
         },
         additionalProperties: true,
@@ -3654,6 +3700,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                displayStyle: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['text'] },
+                        { dataType: 'enum', enums: ['bar'] },
+                    ],
+                },
                 frozen: { dataType: 'boolean' },
                 name: { dataType: 'string' },
                 visible: { dataType: 'boolean' },
@@ -5190,7 +5243,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_':
+    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -5262,6 +5315,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'boolean',
                         required: true,
                     },
+                    version: { dataType: 'double', required: true },
                 },
                 validators: {},
             },
@@ -5270,7 +5324,7 @@ const models: TsoaRoute.Models = {
     AiAgentSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_',
+            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_',
             validators: {},
         },
     },
@@ -5336,7 +5390,7 @@ const models: TsoaRoute.Models = {
         type: { ref: 'AiAgentUserPreferences', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -5408,6 +5462,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'boolean',
                         required: true,
                     },
+                    version: { dataType: 'double', required: true },
                 },
                 validators: {},
             },
@@ -5416,7 +5471,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_',
             validators: {},
         },
     },
@@ -5445,7 +5500,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_':
+    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -5513,6 +5568,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'boolean',
                         required: true,
                     },
+                    version: { dataType: 'double', required: true },
                 },
                 validators: {},
             },
@@ -5521,12 +5577,12 @@ const models: TsoaRoute.Models = {
     ApiCreateAiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_',
+            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__':
         {
             dataType: 'refAlias',
             type: {
@@ -5630,6 +5686,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    version: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                 },
                 validators: {},
             },
@@ -5641,7 +5704,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -5810,6 +5873,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['findDashboards'] },
                 { dataType: 'enum', enums: ['findCharts'] },
                 { dataType: 'enum', enums: ['improveContext'] },
+                { dataType: 'enum', enums: ['runQuery'] },
             ],
             validators: {},
         },
@@ -5933,6 +5997,25 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['error'],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
                                                     required: true,
                                                 },
                                             },
@@ -6585,6 +6668,7 @@ const models: TsoaRoute.Models = {
             'time_series_chart',
             'vertical_bar_chart',
             'table',
+            'query_result',
             'dashboard',
             'improve_context',
             'propose_change',
@@ -10618,6 +10702,11 @@ const models: TsoaRoute.Models = {
         enums: ['line'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    StackType: {
+        dataType: 'refEnum',
+        enums: ['none', 'stack', 'stack100'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PivotChartLayout: {
         dataType: 'refAlias',
         type: {
@@ -10625,10 +10714,7 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 stack: {
                     dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'boolean' },
-                    ],
+                    subSchemas: [{ dataType: 'boolean' }, { ref: 'StackType' }],
                 },
                 sortBy: {
                     dataType: 'array',
@@ -10707,11 +10793,6 @@ const models: TsoaRoute.Models = {
     AxisSide: {
         dataType: 'refEnum',
         enums: [0, 1],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    StackType: {
-        dataType: 'refEnum',
-        enums: ['none', 'stack', 'stack100'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CartesianChartDisplay: {
@@ -10891,6 +10972,21 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                barConfig: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        color: { dataType: 'string' },
+                        max: { dataType: 'double' },
+                        min: { dataType: 'double' },
+                    },
+                },
+                displayStyle: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['text'] },
+                        { dataType: 'enum', enums: ['bar'] },
+                    ],
+                },
                 aggregation: { ref: 'VizAggregationOptions' },
                 order: { dataType: 'double' },
                 frozen: { dataType: 'boolean', required: true },
@@ -15260,6 +15356,7 @@ const models: TsoaRoute.Models = {
                 nestedProperties: {
                     name: { dataType: 'string', required: true },
                     updatedAt: { dataType: 'datetime', required: true },
+                    version: { dataType: 'double', required: true },
                     slug: { dataType: 'string', required: true },
                     tableName: { dataType: 'string', required: true },
                     pivotConfig: {
@@ -15297,7 +15394,6 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
-                    version: { dataType: 'double', required: true },
                     spaceSlug: { dataType: 'string', required: true },
                     downloadedAt: {
                         dataType: 'union',
@@ -15339,13 +15435,13 @@ const models: TsoaRoute.Models = {
                 nestedProperties: {
                     name: { dataType: 'string', required: true },
                     updatedAt: { dataType: 'datetime', required: true },
+                    version: { dataType: 'double', required: true },
                     slug: { dataType: 'string', required: true },
                     tabs: {
                         dataType: 'array',
                         array: { dataType: 'refAlias', ref: 'DashboardTab' },
                         required: true,
                     },
-                    version: { dataType: 'double', required: true },
                     spaceSlug: { dataType: 'string', required: true },
                     downloadedAt: {
                         dataType: 'union',
@@ -21024,6 +21120,66 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getSchemas',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsScimRootController_getSchema: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        schemaId: {
+            in: 'path',
+            name: 'schemaId',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/scim/v2/Schemas/:schemaId',
+        ...fetchMiddlewares<RequestHandler>(ScimRootController),
+        ...fetchMiddlewares<RequestHandler>(
+            ScimRootController.prototype.getSchema,
+        ),
+
+        async function ScimRootController_getSchema(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsScimRootController_getSchema,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ScimRootController>(
+                    ScimRootController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getSchema',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -711,6 +711,43 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "ScimListResponse_ScimSchema_": {
+                "properties": {
+                    "schemas": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaType.LIST_RESPONSE"
+                        },
+                        "type": "array"
+                    },
+                    "totalResults": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "itemsPerPage": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "startIndex": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "Resources": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchema"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "schemas",
+                    "totalResults",
+                    "itemsPerPage",
+                    "startIndex",
+                    "Resources"
+                ],
+                "type": "object",
+                "additionalProperties": true
+            },
             "ScimSchemaType.RESOURCE_TYPE": {
                 "enum": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
                 "type": "string"
@@ -777,6 +814,43 @@
                     }
                 },
                 "required": ["schemas", "id", "name", "endpoint", "schema"],
+                "type": "object",
+                "additionalProperties": true
+            },
+            "ScimListResponse_ScimResourceType_": {
+                "properties": {
+                    "schemas": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaType.LIST_RESPONSE"
+                        },
+                        "type": "array"
+                    },
+                    "totalResults": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "itemsPerPage": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "startIndex": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "Resources": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimResourceType"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "schemas",
+                    "totalResults",
+                    "itemsPerPage",
+                    "startIndex",
+                    "Resources"
+                ],
                 "type": "object",
                 "additionalProperties": true
             },
@@ -3931,6 +4005,10 @@
             },
             "ColumnProperties": {
                 "properties": {
+                    "displayStyle": {
+                        "type": "string",
+                        "enum": ["text", "bar"]
+                    },
                     "frozen": {
                         "type": "boolean"
                     },
@@ -5829,7 +5907,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_": {
+            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -5900,6 +5978,10 @@
                     },
                     "enableSelfImprovement": {
                         "type": "boolean"
+                    },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
                     }
                 },
                 "required": [
@@ -5916,13 +5998,14 @@
                     "groupAccess",
                     "userAccess",
                     "enableDataAccess",
-                    "enableSelfImprovement"
+                    "enableSelfImprovement",
+                    "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgentSummary": {
-                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_"
+                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_"
             },
             "ApiAiAgentSummaryResponse": {
                 "properties": {
@@ -5980,7 +6063,7 @@
             "ApiUpdateUserAgentPreferences": {
                 "$ref": "#/components/schemas/AiAgentUserPreferences"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -6051,6 +6134,10 @@
                     },
                     "enableSelfImprovement": {
                         "type": "boolean"
+                    },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
                     }
                 },
                 "required": [
@@ -6067,13 +6154,14 @@
                     "groupAccess",
                     "userAccess",
                     "enableDataAccess",
-                    "enableSelfImprovement"
+                    "enableSelfImprovement",
+                    "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -6103,7 +6191,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_": {
+            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -6160,6 +6248,10 @@
                     },
                     "enableSelfImprovement": {
                         "type": "boolean"
+                    },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
                     }
                 },
                 "required": [
@@ -6172,15 +6264,16 @@
                     "groupAccess",
                     "userAccess",
                     "enableDataAccess",
-                    "enableSelfImprovement"
+                    "enableSelfImprovement",
+                    "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ApiCreateAiAgent": {
-                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement_"
+                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_"
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -6237,6 +6330,10 @@
                     },
                     "enableSelfImprovement": {
                         "type": "boolean"
+                    },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
                     }
                 },
                 "type": "object",
@@ -6245,7 +6342,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__"
                     },
                     {
                         "properties": {
@@ -6465,7 +6562,8 @@
                     "searchFieldValues",
                     "findDashboards",
                     "findCharts",
-                    "improveContext"
+                    "improveContext",
+                    "runQuery"
                 ],
                 "description": "Exclude from T those types that are assignable to U"
             },
@@ -7027,6 +7125,7 @@
                     "time_series_chart",
                     "vertical_bar_chart",
                     "table",
+                    "query_result",
                     "dashboard",
                     "improve_context",
                     "propose_change"
@@ -11021,15 +11120,19 @@
                 "enum": ["line"],
                 "type": "string"
             },
+            "StackType": {
+                "enum": ["none", "stack", "stack100"],
+                "type": "string"
+            },
             "PivotChartLayout": {
                 "properties": {
                     "stack": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "boolean"
                             },
                             {
-                                "type": "boolean"
+                                "$ref": "#/components/schemas/StackType"
                             }
                         ]
                     },
@@ -11097,10 +11200,6 @@
             "AxisSide": {
                 "enum": [0, 1],
                 "type": "number"
-            },
-            "StackType": {
-                "enum": ["none", "stack", "stack100"],
-                "type": "string"
             },
             "CartesianChartDisplay": {
                 "properties": {
@@ -11266,6 +11365,26 @@
             },
             "VizColumnConfig": {
                 "properties": {
+                    "barConfig": {
+                        "properties": {
+                            "color": {
+                                "type": "string"
+                            },
+                            "max": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "min": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "displayStyle": {
+                        "type": "string",
+                        "enum": ["text", "bar"]
+                    },
                     "aggregation": {
                         "$ref": "#/components/schemas/VizAggregationOptions"
                     },
@@ -15956,6 +16075,10 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "slug": {
                         "type": "string"
                     },
@@ -15989,10 +16112,6 @@
                     "dashboardSlug": {
                         "type": "string"
                     },
-                    "version": {
-                        "type": "number",
-                        "format": "double"
-                    },
                     "spaceSlug": {
                         "type": "string"
                     },
@@ -16004,10 +16123,10 @@
                 "required": [
                     "name",
                     "updatedAt",
+                    "version",
                     "slug",
                     "tableName",
                     "tableConfig",
-                    "version",
                     "spaceSlug"
                 ],
                 "type": "object",
@@ -16040,6 +16159,10 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "slug": {
                         "type": "string"
                     },
@@ -16048,10 +16171,6 @@
                             "$ref": "#/components/schemas/DashboardTab"
                         },
                         "type": "array"
-                    },
-                    "version": {
-                        "type": "number",
-                        "format": "double"
                     },
                     "spaceSlug": {
                         "type": "string"
@@ -16064,9 +16183,9 @@
                 "required": [
                     "name",
                     "updatedAt",
+                    "version",
                     "slug",
                     "tabs",
-                    "version",
                     "spaceSlug"
                 ],
                 "type": "object",
@@ -20851,7 +20970,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2078.1",
+        "version": "0.2086.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
This PR updates the SCIM API to return list responses in the standard SCIM format. The changes include:

1. Modified `getSchemas()` and `getResourceTypes()` methods to return a `ScimListResponse` object instead of arrays
2. Added a new endpoint `/Schemas/{schemaId}` to fetch individual schemas by ID
3. Updated controller methods and tests to work with the new response format

These changes improve compliance with the SCIM 2.0 specification by properly formatting list responses with metadata like totalResults, itemsPerPage, and startIndex.