### PR TITLE
fix: allow stacking on run query tool

### DIFF
--- a/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/viz/bar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/viz/bar.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../../../../types/savedCharts';
 import { type ToolRunQueryArgsTransformed } from '../../../../schemas';
 import { formatFieldLabel } from '../../../shared/formatFieldLabel';
-import { formatPivotValueLabel } from '../../shared/formatPivotValueLabel';
 
 export const getBarChartConfig = ({
     queryTool,
@@ -31,6 +30,7 @@ export const getBarChartConfig = ({
             layout: {
                 xField: xDimension,
                 yField: metricQuery.metrics,
+                stack: !!chartConfig?.stackBars,
             },
             eChartsConfig: {
                 ...(metadata.title ? { title: { text: metadata.title } } : {}),
@@ -53,33 +53,18 @@ export const getBarChartConfig = ({
                             : {}),
                     },
                 ],
-                series: metrics.map((metric) => {
-                    const defaultProperties = {
-                        type: CartesianSeriesType.BAR,
-                        yAxisIndex: 0,
-                        // ...(chartConfig?.stackBars && { stack: 'total' }),
-                    };
-
-                    if (typeof metric === 'string') {
-                        return {
-                            ...defaultProperties,
-                            name: formatFieldLabel(metric, fieldsMap),
-                            encode: {
-                                xRef: { field: xDimension },
-                                yRef: { field: metric },
-                            },
-                        };
-                    }
-
-                    return {
-                        ...defaultProperties,
-                        name: formatPivotValueLabel(metric, fieldsMap),
-                        encode: {
-                            xRef: { field: xDimension },
-                            yRef: metric,
-                        },
-                    };
-                }),
+                series: metrics.map((metric) => ({
+                    type: CartesianSeriesType.BAR,
+                    yAxisIndex: 0,
+                    ...(chartConfig?.stackBars && {
+                        stack: metric,
+                    }),
+                    encode: {
+                        xRef: { field: xDimension },
+                        yRef: { field: metric },
+                    },
+                    name: formatFieldLabel(metric, fieldsMap),
+                })),
             },
         },
     };

--- a/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/viz/horizontalBar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/viz/horizontalBar.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../../../../types/savedCharts';
 import { type ToolRunQueryArgsTransformed } from '../../../../schemas';
 import { formatFieldLabel } from '../../../shared/formatFieldLabel';
-import { formatPivotValueLabel } from '../../shared/formatPivotValueLabel';
 
 export const getHorizontalBarChartConfig = ({
     queryTool,
@@ -54,32 +53,18 @@ export const getHorizontalBarChartConfig = ({
                             : {}),
                     },
                 ],
-                series: metrics.map((metric) => {
-                    const defaultProperties = {
-                        type: CartesianSeriesType.BAR,
-                        yAxisIndex: 0,
-                    };
-
-                    if (typeof metric === 'string') {
-                        return {
-                            ...defaultProperties,
-                            name: formatFieldLabel(metric, fieldsMap),
-                            encode: {
-                                xRef: { field: xDimension },
-                                yRef: { field: metric },
-                            },
-                        };
-                    }
-
-                    return {
-                        ...defaultProperties,
-                        name: formatPivotValueLabel(metric, fieldsMap),
-                        encode: {
-                            xRef: { field: xDimension },
-                            yRef: metric,
-                        },
-                    };
-                }),
+                series: metrics.map((metric) => ({
+                    type: CartesianSeriesType.BAR,
+                    yAxisIndex: 0,
+                    ...(chartConfig?.stackBars && {
+                        stack: metric,
+                    }),
+                    encode: {
+                        xRef: { field: xDimension },
+                        yRef: { field: metric },
+                    },
+                    name: formatFieldLabel(metric, fieldsMap),
+                })),
             },
         },
     };

--- a/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/viz/line.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/runQueryTool/viz/line.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../../../../types/savedCharts';
 import { type ToolRunQueryArgsTransformed } from '../../../../schemas';
 import { formatFieldLabel } from '../../../shared/formatFieldLabel';
-import { formatPivotValueLabel } from '../../shared/formatPivotValueLabel';
 
 export const getLineChartConfig = ({
     queryTool,
@@ -53,35 +52,20 @@ export const getLineChartConfig = ({
                             : {}),
                     },
                 ],
-                series: metrics.map((metric) => {
-                    const defaultProperties = {
-                        type: CartesianSeriesType.LINE,
-                        yAxisIndex: 0,
-                        ...(chartConfig?.lineType === 'area' && {
-                            areaStyle: {},
-                        }),
-                    };
-
-                    if (typeof metric === 'string') {
-                        return {
-                            ...defaultProperties,
-                            name: formatFieldLabel(metric, fieldsMap),
-                            encode: {
-                                xRef: { field: xDimension },
-                                yRef: { field: metric },
-                            },
-                        };
-                    }
-
-                    return {
-                        ...defaultProperties,
-                        name: formatPivotValueLabel(metric, fieldsMap),
-                        encode: {
-                            xRef: { field: xDimension },
-                            yRef: metric,
-                        },
-                    };
-                }),
+                series: metrics.map((metric) => ({
+                    type: CartesianSeriesType.LINE,
+                    yAxisIndex: 0,
+                    ...(chartConfig?.lineType === 'area' && {
+                        areaStyle: {},
+                    }),
+                    name: formatFieldLabel(metric, fieldsMap),
+                    encode: {
+                        xRef: { field: xDimension },
+                        yRef: { field: metric },
+                    },
+                    stack:
+                        chartConfig?.lineType === 'area' ? 'total' : undefined,
+                })),
             },
         },
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Enables stacking functionality for bar, horizontal bar, and line charts by adding the `stack` property with value `'stack-all-series'` when the `stackBars` configuration option is enabled. This uncomments and improves the previously commented-out stacking implementation in bar charts and extends the same functionality to horizontal bar and line charts

![image.png](https://app.graphite.dev/user-attachments/assets/372a5f42-7756-4bae-b7c8-25b41d610a6e.png)

