### PR TITLE
chore: validate groupby dimensions on runQuery

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -32,6 +32,7 @@ import {
     validateCustomMetricsDefinition,
     validateFieldEntityType,
     validateFilterRules,
+    validateGroupByFields,
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
     validateSortFieldsAreSelected,
@@ -77,6 +78,13 @@ const validateQueryTool = (
         queryTool.customMetrics,
         queryTool.tableCalculations,
         queryTool.filters,
+    );
+
+    // Validate groupBy fields
+    validateGroupByFields(
+        explore,
+        queryTool.chartConfig?.groupBy,
+        queryTool.queryConfig.dimensions,
     );
 
     // Validate sort fields exist


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #[issue number]

### Description:
Added validation for groupBy fields in AI query tools to ensure they are valid dimensions that exist in the explore and are selected in the query. This prevents errors when users try to use invalid fields for series breakdown in charts.

The validation checks that:
- groupBy fields must be valid dimensions from the explore
- groupBy fields must be included in the query's dimensions array
- Only dimensions can be used for series breakdown

The implementation includes detailed error messages to help users understand and fix issues with their groupBy configuration.