### PR TITLE
fix: use pre-formatted date values to avoid timezone issues

### DIFF
--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -1,4 +1,5 @@
 import {
+    DimensionType,
     formatItemValue,
     getItemMap,
     isAdditionalMetric,
@@ -227,6 +228,18 @@ export const useColumns = (): TableColumn[] => {
                         if (!cellValue) return '-';
                         // Use item from meta to ensure we get the latest version with overrides
                         const currentItem = info.column.columnDef.meta?.item;
+
+                        // For DATE types, use the pre-formatted value from backend to avoid
+                        // timezone issues when re-parsing UTC date strings on the frontend
+                        if (
+                            isField(currentItem) &&
+                            currentItem.type === DimensionType.DATE
+                        ) {
+                            return cellValue.value.formatted;
+                        }
+
+                        // For everything else (metrics, numbers, etc.), format on frontend
+                        // to support metric overrides and other client-side formatting
                         return formatItemValue(
                             currentItem,
                             cellValue.value.raw,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17450

### Description:
Fix date formatting in table cells to prevent timezone issues by using pre-formatted values from the backend for DATE type dimensions. This change ensures dates are displayed consistently without being affected by client-side timezone conversions when parsing UTC date strings.

For non-date values (metrics, numbers, etc.), the existing client-side formatting is maintained to support metric overrides and other frontend formatting requirements.