### PR TITLE
refactor: remove exploreCacheMap dependency in catalog search

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -600,7 +600,6 @@ export class CatalogModel {
         sortArgs,
         context,
         fullTextSearchOperator = 'AND',
-        exploreCacheMap,
         filteredExplore,
     }: {
         projectUuid: string;
@@ -613,7 +612,6 @@ export class CatalogModel {
         sortArgs?: ApiSort;
         context: CatalogSearchContext;
         fullTextSearchOperator?: 'OR' | 'AND';
-        exploreCacheMap: { [exploreUuid: string]: Explore | ExploreError };
         filteredExplore?: Explore;
     }): Promise<KnexPaginatedData<CatalogItem[]>> {
         let catalogItemsQuery = this.database(CatalogTableName)
@@ -896,7 +894,6 @@ export class CatalogModel {
                 paginatedCatalogItems.data.map((item) =>
                     parseCatalog({
                         ...item,
-                        explore: exploreCacheMap[item.explore.name] as Explore,
                         catalog_tags:
                             tagsPerItem[item.catalog_search_uuid] ?? [],
                     }),

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -87,7 +87,7 @@ export const parseCatalog = (
         return {
             catalogSearchUuid: dbCatalog.catalog_search_uuid,
             name: dbCatalog.name,
-            label: dbCatalog.explore.label,
+            label: dbCatalog.label ?? dbCatalog.explore.label,
             groupLabel: dbCatalog.explore.groupLabel,
             description: dbCatalog.description || undefined,
             type: CatalogType.Table,

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -270,11 +270,6 @@ export class CatalogService<
                 searchQuery: args.catalogSearch.searchQuery,
             },
             async () => {
-                const exploreCacheMap =
-                    await this.projectModel.findExploresFromCache(
-                        args.projectUuid,
-                        'name',
-                    );
                 const tablesConfiguration =
                     await this.projectModel.getTablesConfiguration(
                         args.projectUuid,
@@ -294,7 +289,6 @@ export class CatalogService<
                             tablesConfiguration,
                             excludeUnmatched: args.excludeUnmatched,
                             fullTextSearchOperator: args.fullTextSearchOperator,
-                            exploreCacheMap,
                             filteredExplore: args.filteredExplore,
                         }),
                 );
@@ -1310,10 +1304,6 @@ export class CatalogService<
         ) {
             throw new ForbiddenError();
         }
-        const exploreCacheMap = await this.projectModel.findExploresFromCache(
-            projectUuid,
-            'name',
-        );
 
         const userAttributes =
             await this.userAttributesModel.getAttributeValuesForOrgMember({
@@ -1332,7 +1322,6 @@ export class CatalogService<
             tablesConfiguration: await this.projectModel.getTablesConfiguration(
                 projectUuid,
             ),
-            exploreCacheMap,
         });
 
         const filteredMetrics = allCatalogMetrics.data.filter(
@@ -1372,10 +1361,9 @@ export class CatalogService<
             throw new ForbiddenError();
         }
 
-        const exploreCacheMap = await this.projectModel.findExploresFromCache(
+        const explore = await this.projectModel.getExploreFromCache(
             projectUuid,
-            'name',
-            [tableName],
+            tableName,
         );
 
         const userAttributes =
@@ -1396,15 +1384,10 @@ export class CatalogService<
             tablesConfiguration: await this.projectModel.getTablesConfiguration(
                 projectUuid,
             ),
-            exploreCacheMap,
         });
 
         const allDimensions = catalogDimensions.data
-            .map(
-                (d) =>
-                    exploreCacheMap[tableName]?.tables?.[tableName]
-                        ?.dimensions?.[d.name],
-            )
+            .map((d) => explore?.tables?.[tableName]?.dimensions?.[d.name])
             .filter((d): d is CompiledDimension => d !== undefined);
 
         return getAvailableSegmentDimensions(allDimensions);


### PR DESCRIPTION
### Description:
Removed the `exploreCacheMap` parameter from the CatalogModel's search method and related functions, simplifying the code by eliminating the need to pass around the entire explore cache. Instead, the code now uses the explore data that's already available in the catalog items or fetches specific explores as needed.

Also added a fallback to use the catalog item's label property if available, before using the explore label.