### PR TITLE
refactor: convert findFields tool to use JSX for XML generation

### DIFF
--- a/packages/backend/src/ee/services/ai/xmlBuilder.ts
+++ b/packages/backend/src/ee/services/ai/xmlBuilder.ts
@@ -1,7 +1,7 @@
 function buildXml(
     tag: string,
-    props: Record<string, string | number | boolean> | null,
-    children: (string | null | undefined | boolean)[],
+    props: Record<string, string | number | boolean | null | undefined> | null,
+    children: (string | number | boolean | null | undefined)[],
     level: number,
 ): string {
     const indent = '  '.repeat(level);
@@ -17,10 +17,9 @@ function buildXml(
 
     const filteredChildren = children
         .flat()
-        .filter(
-            (child): child is string =>
-                typeof child === 'string' && child.trim().length > 0,
-        );
+        .filter((c) => c !== null && c !== undefined && c !== false)
+        .map((c) => String(c))
+        .filter((c) => c.trim().length > 0);
 
     if (filteredChildren.length === 0) {
         return `${indent}<${tag}${attributeString}/>`;
@@ -51,8 +50,8 @@ function buildXml(
 
 export function xmlBuilder(
     tag: string,
-    props: Record<string, string | number | boolean> | null,
-    ...children: (string | null | undefined | boolean)[]
+    props: Record<string, string | number | boolean | null | undefined> | null,
+    ...children: (string | number | boolean | null | undefined)[]
 ): string {
     return buildXml(tag, props, children, 0);
 }
@@ -63,7 +62,7 @@ declare global {
         interface IntrinsicElements {
             [elemName: string]: Record<
                 string,
-                string | number | boolean
+                string | number | boolean | null | undefined
             > | null;
         }
     }


### PR DESCRIPTION
### Description:
Refactored the `findFields` tool to use JSX syntax for XML generation. This change leverages the `xmlBuilder` utility to create more readable and maintainable XML output. The implementation now uses React-like component syntax instead of string concatenation, making the code cleaner and less error-prone.

The XML structure was also improved with better tag naming and organization, while maintaining the same functional output. The `xmlBuilder` utility was enhanced to handle more data types including null and undefined values.