### PR TITLE
fix: improve explore table and modal render perf

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/index.tsx
@@ -1,9 +1,10 @@
 import { isCustomBinDimension, isDimension } from '@lightdash/common';
+import { memo } from 'react';
 import { useExplorerSelector } from '../../../features/explorer/store';
 import { CustomBinDimensionModal } from './CustomBinDimensionModal';
 import { CustomSqlDimensionModal } from './CustomSqlDimensionModal';
 
-export const CustomDimensionModal = () => {
+export const CustomDimensionModal = memo(() => {
     const { isOpen, isEditing, table, item } = useExplorerSelector(
         (state) => state.explorer.modals.customDimension,
     );
@@ -37,4 +38,4 @@ export const CustomDimensionModal = () => {
     }
 
     return null;
-};
+});

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -26,7 +26,7 @@ import {
     Title,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { type ValueOf } from 'type-fest';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -48,7 +48,7 @@ import {
     prepareCustomMetricData,
 } from './utils';
 
-export const CustomMetricModal = () => {
+export const CustomMetricModal = memo(() => {
     const {
         isOpen,
         isEditing,
@@ -293,6 +293,10 @@ export const CustomMetricModal = () => {
         value: ValueOf<CustomFormat>,
     ) => form.setFieldValue(`format.${path}`, value);
 
+    if (!isOpen) {
+        return null;
+    }
+
     return item ? (
         <Modal
             size="xl"
@@ -394,4 +398,4 @@ export const CustomMetricModal = () => {
             </form>
         </Modal>
     ) : null;
-};
+});

--- a/packages/frontend/src/components/Explorer/FormatModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatModal/index.tsx
@@ -10,7 +10,7 @@ import {
 import { Button, Group, Modal, Stack, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import isEqual from 'lodash/isEqual';
-import { useCallback, useEffect } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 import { type ValueOf } from 'type-fest';
 import {
     explorerActions,
@@ -31,7 +31,7 @@ const DEFAULT_FORMAT: CustomFormat = {
     suffix: undefined,
 };
 
-export const FormatModal = () => {
+export const FormatModal = memo(() => {
     const dispatch = useExplorerDispatch();
     const { isOpen, metric } = useExplorerSelector(selectFormatModal);
     const metricQuery = useExplorerSelector(selectMetricQuery);
@@ -136,4 +136,4 @@ export const FormatModal = () => {
             </form>
         </Modal>
     ) : null;
-};
+});

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -18,7 +18,7 @@ import {
 import { Prism } from '@mantine/prism';
 import { IconGitBranch, IconInfoCircle } from '@tabler/icons-react';
 import * as yaml from 'js-yaml';
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
 import {
@@ -495,7 +495,7 @@ const MultipleItemsModalContent = ({
     );
 };
 
-export const WriteBackModal = () => {
+export const WriteBackModal = memo(() => {
     const { isOpen, items } = useExplorerSelector(
         (state) => state.explorer.modals.writeBack,
     );
@@ -533,4 +533,4 @@ export const WriteBackModal = () => {
             items={items}
         />
     );
-};
+});

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -60,6 +60,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
     const [isMenuOpen, { toggle: toggleMenu }] = useDisclosure(false);
     const [isTooltipOpen, { open: openTooltip, close: closeTooltip }] =
         useDisclosure(false);
+    const [elementBounds, setElementBounds] = useState<DOMRect | null>(null);
 
     const canHaveMenu = !!cellContextMenu && hasData;
     const canHaveTooltip = !!tooltipContent && !minimal;
@@ -72,6 +73,16 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
         isTooltipOpen &&
         elementRef.current &&
         !shouldRenderMenu;
+
+    // Calculate bounds when menu/tooltip opens, not during every render
+    useEffect(() => {
+        if ((shouldRenderMenu || shouldRenderTooltip) && elementRef.current) {
+            setElementBounds(elementRef.current.getBoundingClientRect());
+        } else if (!isMenuOpen && !isTooltipOpen) {
+            // Clear bounds when closed to free memory
+            setElementBounds(null);
+        }
+    }, [shouldRenderMenu, shouldRenderTooltip, isMenuOpen, isTooltipOpen]);
 
     const displayValue = useMemo(() => {
         if (!hasData) return null;
@@ -145,9 +156,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                 <CellMenu
                     cell={cell as Cell<ResultRow, ResultRow[0]>}
                     menuItems={cellContextMenu}
-                    elementBounds={
-                        elementRef.current?.getBoundingClientRect() ?? null
-                    }
+                    elementBounds={elementBounds}
                     onClose={toggleMenu}
                 />
             ) : null}
@@ -156,9 +165,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                 <CellTooltip
                     position="top"
                     label={tooltipContent}
-                    elementBounds={
-                        elementRef.current?.getBoundingClientRect() ?? null
-                    }
+                    elementBounds={elementBounds}
                 />
             ) : null}
         </>


### PR DESCRIPTION
### Description:

Small improvements to render perf on explores page
- Don't call getBoundingClientRect 2x for every cell in the table (actually seems to make a difference)
- Memoize modals
