### PR TITLE
chore: track search on ai vs omnibar

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -720,6 +720,7 @@ type ProjectSearch = BaseTrack & {
         tablesResultsCount: number;
         fieldsResultsCount: number;
         dashboardTabsResultsCount: number;
+        source: 'omnibar' | 'ai_search_box';
     };
 };
 type DashboardUpdateMultiple = BaseTrack & {

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -56,6 +56,7 @@ projectRouter.get(
                     req.user!,
                     getObjectValue(req.params, 'projectUuid'),
                     getObjectValue(req.params, 'query'),
+                    req.query.source as 'omnibar' | 'ai_search_box' | undefined,
                     {
                         type: type?.toString(),
                         fromDate: fromDate?.toString(),

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -54,6 +54,7 @@ export class SearchService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         query: string,
+        source: 'omnibar' | 'ai_search_box' = 'omnibar',
         filters?: SearchFilters,
     ): Promise<SearchResults> {
         const { organizationUuid } = await this.projectModel.getSummary(
@@ -240,6 +241,7 @@ export class SearchService extends BaseService {
                 tablesResultsCount: filteredResults.tables.length,
                 fieldsResultsCount: filteredResults.fields.length,
                 dashboardTabsResultsCount: filteredResults.dashboardTabs.length,
+                source,
             },
         });
 

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -55,6 +55,7 @@ export const SearchDropdown: FC<Props> = ({
         projectUuid,
         query: debouncedQuery,
         keepPreviousData: true,
+        source: 'ai_search_box',
     });
 
     const allSearchItemsGrouped = useMemo(

--- a/packages/frontend/src/features/omnibar/api/search.ts
+++ b/packages/frontend/src/features/omnibar/api/search.ts
@@ -7,20 +7,23 @@ export const getSearchResults = async ({
     projectUuid,
     query,
     filters,
+    source,
 }: {
     projectUuid: string;
     query: string;
+    source: 'omnibar' | 'ai_search_box';
     filters?: SearchFilters;
 }) => {
     const sanitisedFilters = omitBy(filters, isNil);
-    const searchParams = sanitisedFilters
-        ? new URLSearchParams(sanitisedFilters).toString()
-        : undefined;
+    const params = new URLSearchParams({
+        ...(sanitisedFilters || {}),
+        source,
+    });
 
     return lightdashApi<SearchResults>({
-        url: `/projects/${projectUuid}/search/${encodeURIComponent(query)}${
-            searchParams ? `?${searchParams}` : ''
-        }`,
+        url: `/projects/${projectUuid}/search/${encodeURIComponent(
+            query,
+        )}?${params.toString()}`,
         method: 'GET',
         body: undefined,
     });

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -74,6 +74,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
         projectUuid,
         query: debouncedValue,
         filters: searchFilters,
+        source: 'omnibar',
     });
 
     const [isOmnibarOpen, { open: openOmnibar, close: closeOmnibar }] =

--- a/packages/frontend/src/features/omnibar/hooks/useSearch.ts
+++ b/packages/frontend/src/features/omnibar/hooks/useSearch.ts
@@ -14,12 +14,20 @@ type Params = UseQueryOptions<SearchResults, ApiError, SearchResultMap> & {
     projectUuid: string;
     query?: string;
     filters?: SearchFilters;
+    source: 'omnibar' | 'ai_search_box';
 };
 
-const useSearch = ({ projectUuid, query = '', filters, ...params }: Params) =>
+const useSearch = ({
+    projectUuid,
+    query = '',
+    filters,
+    source,
+    ...params
+}: Params) =>
     useQuery<SearchResults, ApiError, SearchResultMap>({
         queryKey: [projectUuid, 'search', filters ?? 'all', query],
-        queryFn: () => getSearchResults({ projectUuid, query, filters }),
+        queryFn: () =>
+            getSearchResults({ projectUuid, query, filters, source }),
         retry: false,
         enabled: query.length >= OMNIBAR_MIN_QUERY_LENGTH,
         select: (data) => getSearchItemMap(data, projectUuid),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17415

### Description:
Added a `source` parameter to track whether search queries come from the omnibar or AI search box. This allows us to differentiate between search origins in analytics tracking.

The changes include:
- Added a new `source` field to the `ProjectSearch` analytics type
- Updated the search API endpoint to accept and pass the source parameter
- Modified the SearchService to include the source in analytics events
- Updated frontend components to specify their source when making search requests

This will help us better understand how users are interacting with different search interfaces in the application.

![Screenshot 2025-10-15 at 18.09.26.png](https://app.graphite.dev/user-attachments/assets/277d944e-1187-46f4-9109-3a84001e5463.png)

![Screenshot 2025-10-15 at 18.09.49.png](https://app.graphite.dev/user-attachments/assets/7f9d067c-a8c2-47aa-8bb6-34deb17a8b87.png)

