### PR TITLE
chore: set embed dashboard tiles in EmbedDashboard

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -128,6 +128,7 @@ const EmbedDashboard: FC<{
     const projectUuid = useDashboardContext((c) => c.projectUuid);
     const activeTab = useDashboardContext((c) => c.activeTab);
     const setActiveTab = useDashboardContext((c) => c.setActiveTab);
+    const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
 
     const { embedToken, mode } = useEmbed();
     const navigate = useNavigate();
@@ -139,6 +140,12 @@ const EmbedDashboard: FC<{
 
     const { data: dashboard, error: dashboardError } =
         useEmbedDashboard(projectUuid);
+
+    useEffect(() => {
+        if (dashboard) {
+            setDashboardTiles(dashboard.tiles);
+        }
+    }, [dashboard, setDashboardTiles]);
 
     const setEmbedDashboard = useDashboardContext((c) => c.setEmbedDashboard);
     useEffect(() => {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
@@ -1,27 +1,17 @@
-import { type Dashboard } from '@lightdash/common';
 import { Flex } from '@mantine/core';
-import { useCallback, useEffect, useState, type FC } from 'react';
+import { useCallback, useState, type FC } from 'react';
 import ActiveFilters from '../../../../../components/DashboardFilter/ActiveFilters';
 import FiltersProvider from '../../../../../components/common/Filters/FiltersProvider';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 
-type Props = {
-    dashboardTiles: Dashboard['tiles'];
-};
-
-const EmbedDashboardFilters: FC<Props> = ({ dashboardTiles }) => {
+const EmbedDashboardFilters: FC = () => {
     const [openPopoverId, setPopoverId] = useState<string>();
 
     const resetDashboardFilters = useDashboardContext(
         (c) => c.resetDashboardFilters,
     );
 
-    const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
     const projectUuid = useDashboardContext((c) => c.projectUuid);
-
-    useEffect(() => {
-        setDashboardTiles(dashboardTiles);
-    }, [setDashboardTiles, dashboardTiles]);
 
     const handlePopoverOpen = useCallback((id: string) => {
         setPopoverId(id);

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
@@ -43,9 +43,7 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid }) => {
             gap="sm"
             style={{ flexGrow: 1 }}
         >
-            {isFilteringEnabled && (
-                <EmbedDashboardFilters dashboardTiles={dashboard.tiles} />
-            )}
+            {isFilteringEnabled && <EmbedDashboardFilters />}
             {dashboard.canDateZoom && <DateZoom isEditMode={false} />}
 
             {dashboard.canExportPagePdf && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

[Pointed out](https://app.graphite.dev/github/pr/lightdash/lightdash/17387/feat-update-URL-for-embed-dashboard-interactions?utm_source=gt-slack-notif#comment-PRRC_kwDOFNL_E86RCT8S) by @ZeRego that it's odd we were setting dashboard tiles in EmbeddedFilters. 

This just sets tiles in the Dashboard similar to the main Dashboard. Long-term, we could probably have DashboardProvider handle this logic. We should refactor that component eventually to implement a reducer pattern to manage all of its state. 
