### PR TITLE
fix: dont render heavy modals on explorer load

### DIFF
--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -4,8 +4,10 @@ import { Stack } from '@mantine/core';
 import { memo, useEffect, useMemo, type FC } from 'react';
 import {
     explorerActions,
+    selectAdditionalMetricModal,
     selectColumnOrder,
     selectDimensions,
+    selectFormatModal,
     selectIsEditMode,
     selectMetricQuery,
     selectMetrics,
@@ -49,6 +51,13 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const parameterReferencesFromRedux = useExplorerSelector(
             selectParameterReferences,
         );
+
+        const { isOpen: isAdditionalMetricModalOpen } = useExplorerSelector(
+            selectAdditionalMetricModal,
+        );
+        const { isOpen: isFormatModalOpen } =
+            useExplorerSelector(selectFormatModal);
+
         const dispatch = useExplorerDispatch();
 
         const projectUuid = useProjectUuid();
@@ -166,12 +175,16 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                     </Can>
                 </Stack>
 
+                {/* These use the metricQueryDataProvider context */}
                 <UnderlyingDataModal />
                 <DrillDownModal />
-                <CustomMetricModal />
+
+                {/* These return safely when unopened */}
                 <CustomDimensionModal />
-                <FormatModal />
                 <WriteBackModal />
+
+                {isAdditionalMetricModalOpen && <CustomMetricModal />}
+                {isFormatModalOpen && <FormatModal />}
             </MetricQueryDataProvider>
         );
     },

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -361,3 +361,8 @@ export const selectFormatModal = createSelector(
     [selectModals],
     (modals) => modals?.format ?? { isOpen: false },
 );
+
+export const selectAdditionalMetricModal = createSelector(
+    [selectModals],
+    (modals) => modals?.additionalMetric ?? { isOpen: false },
+);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Changes a couple heavy modals in the explores page so that they don't mount on page load. The goal here is to improve initial explore load and this seems to make a measurable difference. 


