### PR TITLE
fix: remove timeInterval check from isValidNonCustomDimension

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2487,10 +2487,7 @@ export class AsyncQueryService extends ProjectService {
 
         const isValidNonCustomDimension = (
             dimension: CustomDimension | CompiledDimension,
-        ) =>
-            !isCustomDimension(dimension) &&
-            !dimension.timeInterval &&
-            !dimension.hidden;
+        ) => !isCustomDimension(dimension) && !dimension.hidden;
 
         const availableDimensions = allDimensions.filter(
             (dimension) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Removed the `!dimension.timeInterval` condition from the `isValidNonCustomDimension` function in AsyncQueryService. This change allows dimensions with time intervals to be available in underlying data modals.

More context in slack: https://lightdash.slack.com/archives/C08L4N6GU1J/p1759490878379839?thread_ts=1759415257.164239&cid=C08L4N6GU1J