### PR TITLE
fix: validation of sets for one-level nesting

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -420,7 +420,7 @@ function validateSets(
 
             // Validate one-level nesting: if this set references another set,
             // the referenced set cannot itself contain set references
-            if (isModelFieldName) {
+            if (!isModelFieldName && field.endsWith('*')) {
                 const referencedSetName = field.substring(0, field.length - 1);
                 const referencedSet = meta.sets?.[referencedSetName];
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/17386

### Description:

Fix set validation logic in translator.ts by correcting the condition for validating referenced sets. The previous implementation incorrectly checked for model field names, but the validation should actually apply to set references (fields ending with '*') that are not model field names.