### PR TITLE
feat: display more info on create metric change

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6060,11 +6060,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -21012,7 +21012,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2096.0",
+        "version": "0.2101.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/index.tsx
@@ -57,10 +57,12 @@ export const AiProposeChangeToolCall = ({
     const isSuccessResult = metadata?.status === 'success';
     const changeUuid = isSuccessResult ? metadata.changeUuid : undefined;
 
-    const { isLoading: isLoadingChange, error: changeError } = useChange(
-        projectUuid,
-        changeUuid,
-    );
+    // Fetch the full compiled change data from backend (source of truth)
+    const {
+        isLoading: isLoadingChange,
+        error: changeError,
+        data: changeData,
+    } = useChange(projectUuid, changeUuid);
 
     const isChangeDeleted = changeError?.error?.statusCode === 404;
     const isRejectedByMetadata =
@@ -125,8 +127,13 @@ export const AiProposeChangeToolCall = ({
             }
         >
             <Stack gap="xs" mt="xs">
+                {/*
+                    ChangeRenderer uses changeData as primary source when available,
+                    and falls back to proposedChange (AI proposal) for loading/error states
+                */}
                 <ChangeRenderer
-                    change={change}
+                    changeData={changeData}
+                    proposedChange={change}
                     entityTableName={entityTableName}
                 />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Refactored the AI Copilot's change proposal rendering to better handle compiled metric data from the backend. The implementation now:

1. Prioritizes backend-compiled change data as the source of truth
2. Uses AI proposals as fallbacks during loading/error states
3. Removes the need for manual data merging by clearly separating responsibilities
4. Improves the display of metric creation with a dedicated fallback component

This change enhances reliability by ensuring we always show the most accurate data when available, while maintaining a good user experience during transitional states.