### PR TITLE
fix: use pre-formatted values for both DATE and TIMESTAMP types

### DIFF
--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -314,11 +314,12 @@ export const useColumns = (): TableColumn[] => {
                         // Use item from meta to ensure we get the latest version with overrides
                         const currentItem = info.column.columnDef.meta?.item;
 
-                        // For DATE types, use the pre-formatted value from backend to avoid
-                        // timezone issues when re-parsing UTC date strings on the frontend
+                        // For DATE and TIMESTAMP types, use the pre-formatted value from backend
+                        // to avoid timezone issues when re-parsing UTC date strings on the frontend
                         if (
                             isField(currentItem) &&
-                            currentItem.type === DimensionType.DATE
+                            (currentItem.type === DimensionType.DATE ||
+                                currentItem.type === DimensionType.TIMESTAMP)
                         ) {
                             return cellValue.value.formatted;
                         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17496

### Description:
Fix timezone issues for TIMESTAMP type fields by using pre-formatted values from the backend, similar to how DATE type fields are already handled. This prevents incorrect date/time display when parsing UTC date strings on the frontend.