### PR TITLE
feat: improve error ui when fetching branches in preview project creation

### DIFF
--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -490,15 +490,18 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
                                     placeholder={
                                         branches.isLoading
                                             ? 'Loading branches...'
+                                            : branches.isError
+                                            ? 'Failed to load branches'
                                             : 'Select branch'
                                     }
                                     searchable
                                     value={selectedBranch}
                                     readOnly={isPreviewCreating}
                                     disabled={
-                                        branches.isSuccess &&
-                                        (!branches.data ||
-                                            branches.data.length <= 0)
+                                        branches.isError ||
+                                        (branches.isSuccess &&
+                                            (!branches.data ||
+                                                branches.data.length <= 0))
                                     }
                                     data={branches.data ?? []}
                                     onChange={(value) => {
@@ -508,6 +511,38 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
                                         branches.isFetching && (
                                             <Loader size="xs" color="gray" />
                                         )
+                                    }
+                                    error={
+                                        branches.isError ? (
+                                            <Group spacing="xs" align="center">
+                                                <Text size="xs">
+                                                    The project will use the
+                                                    default branch.
+                                                </Text>
+                                                <Tooltip
+                                                    withinPortal
+                                                    label={
+                                                        branches.error?.error
+                                                            ?.message ||
+                                                        'Failed to fetch branches'
+                                                    }
+                                                    multiline
+                                                    w={250}
+                                                >
+                                                    <ActionIcon
+                                                        size="xs"
+                                                        color="red"
+                                                        variant="transparent"
+                                                    >
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconHelpCircle
+                                                            }
+                                                        />
+                                                    </ActionIcon>
+                                                </Tooltip>
+                                            </Group>
+                                        ) : undefined
                                     }
                                 />{' '}
                                 {/* only show if branch changed + change label based on warehouse type? + get value from dbt cloud api */}


### PR DESCRIPTION
### Description

Improved error handling when creating preview projects and fetching branches from repository fails:

![image.png](https://app.graphite.dev/user-attachments/assets/7f5d1b72-9ede-440b-b7c2-e420289fef15.png)

![image.png](https://app.graphite.dev/user-attachments/assets/f90d438d-39c1-4bb1-89c3-a637cd503e5e.png)

