### PR TITLE
refactor: remove AgentToolCallArgsSchema & AgentToolCallArgsSchemav2

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
@@ -1,7 +1,18 @@
 import {
-    AgentToolCallArgsSchema,
     isToolName,
-    ToolName,
+    toolDashboardArgsSchema,
+    toolFindChartsArgsSchema,
+    toolFindDashboardsArgsSchema,
+    toolFindExploresArgsSchemaV2,
+    toolFindFieldsArgsSchema,
+    toolImproveContextArgsSchema,
+    type ToolName,
+    toolProposeChangeArgsSchema,
+    toolRunQueryArgsSchema,
+    toolSearchFieldValuesArgsSchema,
+    toolTableVizArgsSchema,
+    toolTimeSeriesArgsSchema,
+    toolVerticalBarArgsSchema,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { JSONDiff } from 'autoevals';
@@ -26,22 +37,31 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     proposeChange: 'propose_change',
 } satisfies Record<ToolName, string>;
 
+// Explicit mapping of tool names to their schemas
+const TOOL_SCHEMAS = {
+    findExplores: toolFindExploresArgsSchemaV2,
+    findFields: toolFindFieldsArgsSchema,
+    searchFieldValues: toolSearchFieldValuesArgsSchema,
+    generateBarVizConfig: toolVerticalBarArgsSchema,
+    generateTableVizConfig: toolTableVizArgsSchema,
+    generateTimeSeriesVizConfig: toolTimeSeriesArgsSchema,
+    generateDashboard: toolDashboardArgsSchema,
+    findDashboards: toolFindDashboardsArgsSchema,
+    findCharts: toolFindChartsArgsSchema,
+    improveContext: toolImproveContextArgsSchema,
+    proposeChange: toolProposeChangeArgsSchema,
+    runQuery: toolRunQueryArgsSchema,
+} satisfies Record<ToolName, z.ZodSchema>;
+
 const getToolInfo = (toolName: string) => {
     if (!isToolName(toolName)) {
         throw new Error(`Tool ${toolName} is not a valid tool`);
     }
-    const tool = AgentToolCallArgsSchema.options.find(
-        (schema) =>
-            schema.shape.type.value === TOOL_NAME_TO_DB_TOOL_NAME[toolName],
-    );
-    if (!tool) {
-        throw new Error(`Tool info not found for tool: ${toolName}`);
-    }
-    return tool;
+    return TOOL_SCHEMAS[toolName];
 };
 
-const availableTools = AgentToolCallArgsSchema.options.map((schema) => ({
-    name: schema.shape.type.value,
+const availableTools = Object.entries(TOOL_SCHEMAS).map(([name, schema]) => ({
+    name: TOOL_NAME_TO_DB_TOOL_NAME[name as ToolName],
     description: schema.description,
 }));
 

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -1,71 +1,26 @@
-import { z } from 'zod';
 import {
-    toolDashboardArgsSchema,
     type ToolDashboardOutput,
-    toolFindChartsArgsSchema,
     type ToolFindChartsOutput,
-    toolFindDashboardsArgsSchema,
     type ToolFindDashboardsOutput,
-    toolFindExploresArgsSchemaV1,
-    toolFindExploresArgsSchemaV2,
     type ToolFindExploresOutput,
-    toolFindFieldsArgsSchema,
     type ToolFindFieldsOutput,
-    toolImproveContextArgsSchema,
     type ToolImproveContextOutput,
-    toolProposeChangeArgsSchema,
     type ToolProposeChangeOutput,
-    toolRunQueryArgsSchema,
     type ToolRunQueryOutput,
-    toolSearchFieldValuesArgsSchema,
     type ToolSearchFieldValuesOutput,
-    toolTableVizArgsSchema,
     type ToolTableVizOutput,
-    toolTimeSeriesArgsSchema,
     type ToolTimeSeriesOutput,
-    toolVerticalBarArgsSchema,
     type ToolVerticalBarOutput,
 } from './tools';
 
 export * from './customMetrics';
 export * from './filters';
 export * from './outputMetadata';
+export * from './parser';
 export * from './sortField';
 export * from './tableCalcs/tableCalcs';
 export * from './tools';
 export * from './visualizations';
-
-export const AgentToolCallArgsSchema = z.discriminatedUnion('type', [
-    toolDashboardArgsSchema,
-    toolFindChartsArgsSchema,
-    toolFindDashboardsArgsSchema,
-    toolFindFieldsArgsSchema,
-    toolImproveContextArgsSchema,
-    toolProposeChangeArgsSchema,
-    toolSearchFieldValuesArgsSchema,
-    toolVerticalBarArgsSchema,
-    toolTableVizArgsSchema,
-    toolTimeSeriesArgsSchema,
-    toolFindExploresArgsSchemaV1,
-    toolFindExploresArgsSchemaV2,
-]);
-
-export const AgentToolCallArgsSchemaV2 = z.discriminatedUnion('type', [
-    toolDashboardArgsSchema,
-    toolFindChartsArgsSchema,
-    toolFindDashboardsArgsSchema,
-    toolFindFieldsArgsSchema,
-    toolImproveContextArgsSchema,
-    toolProposeChangeArgsSchema,
-    toolRunQueryArgsSchema,
-    toolSearchFieldValuesArgsSchema,
-    toolFindExploresArgsSchemaV2,
-]);
-
-// TODO: Remove usage of this schema and use switch case instead where it's used
-export type AgentToolCallArgs = z.infer<
-    typeof AgentToolCallArgsSchema | typeof AgentToolCallArgsSchemaV2
->;
 
 export type AgentToolOutput =
     | ToolDashboardOutput

--- a/packages/common/src/ee/AiAgent/schemas/parser.ts
+++ b/packages/common/src/ee/AiAgent/schemas/parser.ts
@@ -1,0 +1,58 @@
+import assertUnreachable from '../../../utils/assertUnreachable';
+import {
+    toolDashboardArgsSchemaTransformed,
+    toolFindChartsArgsSchemaTransformed,
+    toolFindDashboardsArgsSchemaTransformed,
+    toolFindExploresArgsSchemaTransformed,
+    toolFindFieldsArgsSchemaTransformed,
+    toolImproveContextArgsSchema,
+    toolProposeChangeArgsSchema,
+    toolRunQueryArgsSchemaTransformed,
+    toolSearchFieldValuesArgsSchemaTransformed,
+    toolTableVizArgsSchemaTransformed,
+    toolTimeSeriesArgsSchemaTransformed,
+    toolVerticalBarArgsSchemaTransformed,
+} from './tools';
+import { type ToolName } from './visualizations';
+
+/**
+ * Parse the tool args using the specific schema for each tool name
+ * @param toolName - The name of the tool to parse
+ * @param toolArgs - The tool args to parse
+ * @returns The parsed tool args
+ */
+export const parseToolArgs = (toolName: ToolName, toolArgs: unknown) => {
+    switch (toolName) {
+        case 'findExplores':
+            return toolFindExploresArgsSchemaTransformed.safeParse(toolArgs);
+        case 'findFields':
+            return toolFindFieldsArgsSchemaTransformed.safeParse(toolArgs);
+        case 'searchFieldValues':
+            return toolSearchFieldValuesArgsSchemaTransformed.safeParse(
+                toolArgs,
+            );
+        case 'generateBarVizConfig':
+            return toolVerticalBarArgsSchemaTransformed.safeParse(toolArgs);
+        case 'generateTableVizConfig':
+            return toolTableVizArgsSchemaTransformed.safeParse(toolArgs);
+        case 'generateTimeSeriesVizConfig':
+            return toolTimeSeriesArgsSchemaTransformed.safeParse(toolArgs);
+        case 'generateDashboard':
+            return toolDashboardArgsSchemaTransformed.safeParse(toolArgs);
+        case 'findDashboards':
+            return toolFindDashboardsArgsSchemaTransformed.safeParse(toolArgs);
+        case 'findCharts':
+            return toolFindChartsArgsSchemaTransformed.safeParse(toolArgs);
+        case 'improveContext':
+            return toolImproveContextArgsSchema.safeParse(toolArgs);
+        case 'proposeChange':
+            return toolProposeChangeArgsSchema.safeParse(toolArgs);
+        case 'runQuery':
+            return toolRunQueryArgsSchemaTransformed.safeParse(toolArgs);
+        default:
+            return assertUnreachable(
+                toolName,
+                `Unknown tool name: ${toolName}`,
+            );
+    }
+};

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -1,10 +1,10 @@
-import { type AgentToolCallArgs, type ToolName } from '@lightdash/common';
+import { type ToolName } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 type ToolCall = {
     toolCallId: string;
     toolName: ToolName;
-    toolArgs: AgentToolCallArgs;
+    toolArgs: unknown;
 };
 
 export interface AiAgentThreadStreamingState {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

- Replaced the generic `AgentToolCallArgsSchema` with individual tool schemas

Also fixes this error  


```
 "code": "invalid_union_discriminator",
    "options": [
      "dashboard",
      "find_charts",
      "find_dashboards",…
```



But main reason was to avoid: 

```
TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
```