### PR TITLE
fix: resolve sorting and pivot issues in Slack AI charts

### DIFF
--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/bar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/bar.ts
@@ -37,6 +37,10 @@ export const getBarChartEchartsConfig = async (
     const xAxisField = fieldsMap[xDimension];
     const yAxisField = queryMetrics[0] ? fieldsMap[queryMetrics[0]] : undefined;
 
+    const primarySort = sorts?.[0];
+    const shouldInverseXAxis =
+        primarySort?.fieldId === xDimension && primarySort?.descending === true;
+
     return {
         ...getCommonEChartsConfig(queryTool.title, metrics.length, chartData),
         xAxis: [
@@ -49,6 +53,7 @@ export const getBarChartEchartsConfig = async (
                     axisItem: xAxisField,
                     show: true,
                 }),
+                ...(shouldInverseXAxis ? { inverse: true } : {}),
             },
         ],
         yAxis: [

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/horizontalBar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/horizontalBar.ts
@@ -38,6 +38,10 @@ export const getHorizontalBarChartEchartsConfig = async (
     const yAxisField = fieldsMap[xDimension]; // Category axis
     const xAxisField = queryMetrics[0] ? fieldsMap[queryMetrics[0]] : undefined; // Value axis
 
+    const primarySort = sorts?.[0];
+    const shouldInverseYAxis =
+        primarySort?.fieldId === xDimension && primarySort?.descending === true;
+
     return {
         ...getCommonEChartsConfig(queryTool.title, metrics.length, chartData),
         xAxis: [
@@ -62,6 +66,7 @@ export const getHorizontalBarChartEchartsConfig = async (
                     axisItem: yAxisField,
                     show: true,
                 }),
+                ...(shouldInverseYAxis ? { inverse: true } : {}),
             },
         ],
         series: metrics.map((metric) => ({

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/line.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/line.ts
@@ -37,6 +37,10 @@ export const getLineChartEchartsConfig = async (
     const xAxisField = fieldsMap[xDimension];
     const yAxisField = queryMetrics[0] ? fieldsMap[queryMetrics[0]] : undefined;
 
+    const primarySort = sorts?.[0];
+    const shouldInverseXAxis =
+        primarySort?.fieldId === xDimension && primarySort?.descending === true;
+
     return {
         ...getCommonEChartsConfig(queryTool.title, metrics.length, chartData),
         xAxis: [
@@ -49,6 +53,7 @@ export const getLineChartEchartsConfig = async (
                     axisItem: xAxisField,
                     show: true,
                 }),
+                ...(shouldInverseXAxis ? { inverse: true } : {}),
             },
         ],
         yAxis: [

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/scatter.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/scatter.ts
@@ -39,6 +39,10 @@ export const getScatterChartEchartsConfig = async (
     const xAxisField = fieldsMap[xDimension];
     const yAxisField = queryMetrics[0] ? fieldsMap[queryMetrics[0]] : undefined;
 
+    const primarySort = sorts?.[0];
+    const shouldInverseXAxis =
+        primarySort?.fieldId === xDimension && primarySort?.descending === true;
+
     return {
         ...getCommonEChartsConfig(queryTool.title, metrics.length, chartData),
         xAxis: [
@@ -51,6 +55,7 @@ export const getScatterChartEchartsConfig = async (
                     axisItem: xAxisField,
                     show: true,
                 }),
+                ...(shouldInverseXAxis ? { inverse: true } : {}),
             },
         ],
         yAxis: [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

**Backend fixes (getPivotedResults)**

- Add explicit GROUP BY clause before ORDER BY in DuckDB PIVOT queries https://duckdb.org/docs/stable/sql/statements/pivot#pivot-on-using-and-group-by
- Filter invalid sorts: only allow sorting by GROUP BY columns (not metrics after aggregation)
- Convert BigInt values to Numbers for ECharts serialization

**Frontend Fixes (bar.ts, line.ts, scatter.ts, horizontalBar.ts):**

- Add automatic axis inversion when descending sort is specified
- Fixes ECharts auto-sorting behavior for time-based axes
- Ensures visual ordering matches the requested sort direction

Previously, DuckDB PIVOT queries would fail or produce incorrect results because:

1. ORDER BY without GROUP BY is invalid in PIVOT syntax
2. Attempting to sort by aggregated metric columns after pivoting
3. ECharts time axes would ignore dataset order and auto-sort chronologically