### PR TITLE
fix: improve labels,legend,title position on slack ai charts

### DIFF
--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/bar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/bar.ts
@@ -38,13 +38,16 @@ export const getBarChartEchartsConfig = async (
     const yAxisField = queryMetrics[0] ? fieldsMap[queryMetrics[0]] : undefined;
 
     return {
-        ...getCommonEChartsConfig(queryTool.title, metrics.length, chartData),
+        ...getCommonEChartsConfig(
+            queryTool.title,
+            metrics.length,
+            chartData,
+            chartConfig?.xAxisLabel,
+            chartConfig?.yAxisLabel,
+        ),
         xAxis: [
             {
                 type: chartConfig?.xAxisType ?? ('category' as const),
-                ...(chartConfig?.xAxisLabel
-                    ? { name: chartConfig.xAxisLabel }
-                    : {}),
                 ...getCartesianAxisFormatterConfig({
                     axisItem: xAxisField,
                     show: true,
@@ -54,9 +57,6 @@ export const getBarChartEchartsConfig = async (
         yAxis: [
             {
                 type: 'value',
-                ...(chartConfig?.yAxisLabel
-                    ? { name: chartConfig.yAxisLabel }
-                    : {}),
                 ...getCartesianAxisFormatterConfig({
                     axisItem: yAxisField,
                     show: true,

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/horizontalBar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/horizontalBar.ts
@@ -39,13 +39,16 @@ export const getHorizontalBarChartEchartsConfig = async (
     const xAxisField = queryMetrics[0] ? fieldsMap[queryMetrics[0]] : undefined; // Value axis
 
     return {
-        ...getCommonEChartsConfig(queryTool.title, metrics.length, chartData),
+        ...getCommonEChartsConfig(
+            queryTool.title,
+            metrics.length,
+            chartData,
+            chartConfig?.xAxisLabel,
+            chartConfig?.yAxisLabel,
+        ),
         xAxis: [
             {
                 type: 'value',
-                ...(chartConfig?.xAxisLabel
-                    ? { name: chartConfig.xAxisLabel }
-                    : {}),
                 ...getCartesianAxisFormatterConfig({
                     axisItem: xAxisField,
                     show: true,
@@ -55,9 +58,6 @@ export const getHorizontalBarChartEchartsConfig = async (
         yAxis: [
             {
                 type: chartConfig?.xAxisType ?? ('category' as const),
-                ...(chartConfig?.yAxisLabel
-                    ? { name: chartConfig.yAxisLabel }
-                    : {}),
                 ...getCartesianAxisFormatterConfig({
                     axisItem: yAxisField,
                     show: true,

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/line.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/line.ts
@@ -38,13 +38,16 @@ export const getLineChartEchartsConfig = async (
     const yAxisField = queryMetrics[0] ? fieldsMap[queryMetrics[0]] : undefined;
 
     return {
-        ...getCommonEChartsConfig(queryTool.title, metrics.length, chartData),
+        ...getCommonEChartsConfig(
+            queryTool.title,
+            metrics.length,
+            chartData,
+            chartConfig?.xAxisLabel,
+            chartConfig?.yAxisLabel,
+        ),
         xAxis: [
             {
                 type: chartConfig?.xAxisType ?? 'time',
-                ...(chartConfig?.xAxisLabel
-                    ? { name: chartConfig.xAxisLabel }
-                    : {}),
                 ...getCartesianAxisFormatterConfig({
                     axisItem: xAxisField,
                     show: true,
@@ -54,9 +57,6 @@ export const getLineChartEchartsConfig = async (
         yAxis: [
             {
                 type: 'value',
-                ...(chartConfig?.yAxisLabel
-                    ? { name: chartConfig.yAxisLabel }
-                    : {}),
                 ...getCartesianAxisFormatterConfig({
                     axisItem: yAxisField,
                     show: true,

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/scatter.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/scatter.ts
@@ -40,13 +40,16 @@ export const getScatterChartEchartsConfig = async (
     const yAxisField = queryMetrics[0] ? fieldsMap[queryMetrics[0]] : undefined;
 
     return {
-        ...getCommonEChartsConfig(queryTool.title, metrics.length, chartData),
+        ...getCommonEChartsConfig(
+            queryTool.title,
+            metrics.length,
+            chartData,
+            chartConfig?.xAxisLabel,
+            chartConfig?.yAxisLabel,
+        ),
         xAxis: [
             {
                 type: chartConfig?.xAxisType ?? ('category' as const),
-                ...(chartConfig?.xAxisLabel
-                    ? { name: chartConfig.xAxisLabel }
-                    : {}),
                 ...getCartesianAxisFormatterConfig({
                     axisItem: xAxisField,
                     show: true,
@@ -56,9 +59,6 @@ export const getScatterChartEchartsConfig = async (
         yAxis: [
             {
                 type: 'value',
-                ...(chartConfig?.yAxisLabel
-                    ? { name: chartConfig.yAxisLabel }
-                    : {}),
                 ...getCartesianAxisFormatterConfig({
                     axisItem: yAxisField,
                     show: true,

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/shared/getCommonEChartsConfig.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/shared/getCommonEChartsConfig.ts
@@ -7,52 +7,100 @@ export const getCommonEChartsConfig = (
     title: string | undefined,
     metricsCount: number,
     chartData: Record<string, unknown>[],
+    xAxisLabel?: string | null,
+    yAxisLabel?: string | null,
 ): Pick<
     EChartsOption,
-    'title' | 'legend' | 'grid' | 'animation' | 'backgroundColor' | 'dataset'
-> => ({
-    ...(title
-        ? {
-              title: {
-                  text: title,
-                  left: 'center',
-                  top: 10,
-                  textStyle: {
-                      fontSize: 16,
-                      fontWeight: 'bold' as const,
+    | 'title'
+    | 'legend'
+    | 'grid'
+    | 'animation'
+    | 'backgroundColor'
+    | 'dataset'
+    | 'graphic'
+> => {
+    const graphicElements = [];
+
+    // Add X-axis label at bottom center
+    if (xAxisLabel) {
+        graphicElements.push({
+            type: 'text',
+            left: 'center',
+            bottom: 10,
+            style: {
+                text: xAxisLabel,
+                fontSize: 12,
+                fontWeight: 500,
+            },
+        });
+    }
+
+    // Add Y-axis label on left side, vertically centered and rotated
+    if (yAxisLabel) {
+        graphicElements.push({
+            type: 'text',
+            left: 10,
+            top: 'center',
+            rotation: Math.PI / 2,
+            style: {
+                text: yAxisLabel,
+                fontSize: 12,
+                fontWeight: 500,
+            },
+        });
+    }
+
+    return {
+        ...(title
+            ? {
+                  title: {
+                      text: title,
+                      left: 'center',
+                      top: 10,
+                      textStyle: {
+                          fontSize: 16,
+                          fontWeight: 'bold' as const,
+                      },
                   },
-              },
-          }
-        : {}),
-    legend: {
-        show: metricsCount > 1,
-        type: 'scroll' as const,
-        orient: 'horizontal' as const,
-        bottom: 10,
-        left: 'center' as const,
-        padding: [5, 10],
-        itemGap: 15,
-        itemWidth: 25,
-        itemHeight: 14,
-        textStyle: {
-            fontSize: 11,
+              }
+            : {}),
+        legend: {
+            show: metricsCount > 1,
+            type: 'scroll' as const,
+            orient: 'horizontal' as const,
+            top: title ? 40 : 10, // Position below title if exists, otherwise at top
+            left: 'center' as const,
+            padding: [5, 10],
+            itemGap: 15,
+            itemWidth: 25,
+            itemHeight: 14,
+            textStyle: {
+                fontSize: 11,
+            },
+            pageIconSize: 12,
+            pageTextStyle: {
+                fontSize: 11,
+            },
         },
-        pageIconSize: 12,
-        pageTextStyle: {
-            fontSize: 11,
+        grid: {
+            containLabel: true, // Ensures labels are within grid bounds to prevent cutoff
+            left: '5%', // Increased from 3% to give more space for Y-axis labels
+            right: '5%', // Increased from 3% to give more space for labels on right
+            // Account for title + legend at top
+            top: (() => {
+                if (title && metricsCount > 1) return 90; // Title + legend both present
+                if (title) return 60; // Only title
+                if (metricsCount > 1) return 50; // Only legend
+                return 30; // Neither
+            })(),
+            bottom: 60, // Fixed bottom spacing for x-axis labels
         },
-    },
-    grid: {
-        containLabel: true,
-        left: '3%',
-        right: '3%',
-        top: title ? 50 : 20,
-        bottom: metricsCount > 1 ? 70 : 50,
-    },
-    animation: false,
-    backgroundColor: '#fff',
-    dataset: {
-        source: chartData,
-        dimensions: Object.keys(chartData[0] || {}),
-    },
-});
+        animation: false,
+        backgroundColor: '#fff',
+        dataset: {
+            source: chartData,
+            dimensions: Object.keys(chartData[0] || {}),
+        },
+        ...(graphicElements.length > 0 ? { graphic: graphicElements } : {}),
+    };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:

Improved chart axis labels in ECharts configurations for Slack visualizations. The changes:

1. Refactored axis label handling by moving it from individual chart types to the common ECharts config
2. Added proper positioning for X and Y axis labels as graphic elements
3. Improved grid layout to accommodate axis labels and prevent cutoff
4. Adjusted spacing and positioning of chart elements (title, legend, grid) for better visual hierarchy

This enhancement provides a more consistent and visually appealing way to display axis labels across all chart types (bar, horizontal bar, line, and scatter).



before

![image.png](https://app.graphite.dev/user-attachments/assets/e30e9da9-5e31-41f4-8b48-571ad5d0956a.png)



after



![image.png](https://app.graphite.dev/user-attachments/assets/07308d02-db00-4e4c-b221-5b094573ee42.png)

![image.png](https://app.graphite.dev/user-attachments/assets/56ea4658-056f-4c57-8ae2-73d239ecb9d9.png)



