### PR TITLE
fix: prevent unnecessary navigation when URL params haven't changed

### DIFF
--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -435,6 +435,7 @@ const DashboardProvider: React.FC<
             return;
         }
 
+        const currentParams = new URLSearchParams(search);
         const newParams = new URLSearchParams(search);
         if (dateZoomGranularity === undefined) {
             newParams.delete('dateZoom');
@@ -442,13 +443,18 @@ const DashboardProvider: React.FC<
             newParams.set('dateZoom', dateZoomGranularity.toLowerCase());
         }
 
-        void navigate(
-            {
-                pathname,
-                search: newParams.toString(),
-            },
-            { replace: true },
-        );
+        const currentSearch = currentParams.toString();
+        const newSearch = newParams.toString();
+
+        if (currentSearch !== newSearch) {
+            void navigate(
+                {
+                    pathname,
+                    search: newParams.toString(),
+                },
+                { replace: true },
+            );
+        }
     }, [dateZoomGranularity, search, navigate, pathname, embed.mode]);
 
     const {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17508

### Description:
Optimize URL navigation in DashboardProvider by only triggering navigation when the search parameters actually change. This prevents unnecessary re-renders when the dateZoomGranularity is updated but results in the same URL parameters.