### PR TITLE
chore: improve filter card loading time

### DIFF
--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -18,7 +18,14 @@ import {
     Tooltip,
     type SelectProps,
 } from '@mantine/core';
-import { forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+    forwardRef,
+    memo,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+} from 'react';
 import FieldIcon from '../Filters/FieldIcon';
 import { FILTER_SELECT_LIMIT } from '../Filters/constants';
 
@@ -87,7 +94,7 @@ const getLabel = (item: Item, hasGrouping: boolean) => {
         : getItemLabel(item);
 };
 
-const FieldSelect = <T extends Item = Item>({
+const FieldSelectComponent = <T extends Item = Item>({
     item,
     items,
     onChange,
@@ -260,5 +267,8 @@ const FieldSelect = <T extends Item = Item>({
         />
     );
 };
+
+// Memoize with generic type support
+const FieldSelect = memo(FieldSelectComponent) as typeof FieldSelectComponent;
 
 export default FieldSelect;

--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -28,7 +28,7 @@ import {
     Text,
 } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
-import React, { useCallback, useMemo, useState, type FC } from 'react';
+import React, { memo, useCallback, useMemo, useState, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import MantineIcon from '../MantineIcon';
 import FilterRuleForm from './FilterRuleForm';
@@ -47,226 +47,238 @@ type Props = {
 
 const ALLOW_CONVERT_TO_GROUP_UP_TO_DEPTH = 2;
 
-const FilterGroupForm: FC<Props> = ({
-    hideButtons,
-    hideLine,
-    groupDepth = 0,
-    fields,
-    filterGroup,
-    isEditMode,
-    onChange,
-    onDelete,
-}) => {
-    const items = getItemsFromFilterGroup(filterGroup);
-    const [conditionLabel, setConditionLabel] = useState('');
+const FilterGroupForm: FC<Props> = memo(
+    ({
+        hideButtons,
+        hideLine,
+        groupDepth = 0,
+        fields,
+        filterGroup,
+        isEditMode,
+        onChange,
+        onDelete,
+    }) => {
+        const items = getItemsFromFilterGroup(filterGroup);
+        const [conditionLabel, setConditionLabel] = useState('');
 
-    const [dimensions, metrics, tableCalculations] = useMemo<
-        [
-            Array<FilterableDimension | CustomSqlDimension>,
-            Metric[],
-            TableCalculation[],
-        ]
-    >(() => {
-        return [
+        const [dimensions, metrics, tableCalculations] = useMemo<
             [
-                ...fields.filter(isDimension),
-                ...fields.filter(isCustomSqlDimension),
-            ],
-            fields.filter(isMetric),
-            fields.filter(isTableCalculation),
-        ];
-    }, [fields]);
+                Array<FilterableDimension | CustomSqlDimension>,
+                Metric[],
+                TableCalculation[],
+            ]
+        >(() => {
+            return [
+                [
+                    ...fields.filter(isDimension),
+                    ...fields.filter(isCustomSqlDimension),
+                ],
+                fields.filter(isMetric),
+                fields.filter(isTableCalculation),
+            ];
+        }, [fields]);
 
-    const availableFieldsForGroupRules = useMemo<FilterableField[]>(() => {
-        // If the group is an AND group, we can use all fields
-        if (isAndFilterGroup(filterGroup)) {
-            return [...dimensions, ...metrics, ...tableCalculations];
-        }
+        const availableFieldsForGroupRules = useMemo<FilterableField[]>(() => {
+            // If the group is an AND group, we can use all fields
+            if (isAndFilterGroup(filterGroup)) {
+                return [...dimensions, ...metrics, ...tableCalculations];
+            }
 
-        // If the group is an OR group, we can only use fields that are of the same type
-        const filters = getFiltersFromGroup(filterGroup, fields);
-        if (filters.dimensions) {
-            setConditionLabel('dimension');
-            return dimensions;
-        }
+            // If the group is an OR group, we can only use fields that are of the same type
+            const filters = getFiltersFromGroup(filterGroup, fields);
+            if (filters.dimensions) {
+                setConditionLabel('dimension');
+                return dimensions;
+            }
 
-        if (filters.metrics) {
-            setConditionLabel('metric');
-            return metrics;
-        }
+            if (filters.metrics) {
+                setConditionLabel('metric');
+                return metrics;
+            }
 
-        if (filters.tableCalculations) {
-            setConditionLabel('table calculation');
-            return tableCalculations;
-        }
+            if (filters.tableCalculations) {
+                setConditionLabel('table calculation');
+                return tableCalculations;
+            }
 
-        return [];
-    }, [dimensions, fields, filterGroup, metrics, tableCalculations]);
+            return [];
+        }, [dimensions, fields, filterGroup, metrics, tableCalculations]);
 
-    const onDeleteItem = useCallback(
-        (index: number) => {
-            if (items.length <= 1) {
-                onDelete();
-            } else {
+        const onDeleteItem = useCallback(
+            (index: number) => {
+                if (items.length <= 1) {
+                    onDelete();
+                } else {
+                    onChange({
+                        ...filterGroup,
+                        [getFilterGroupItemsPropertyName(filterGroup)]: [
+                            ...items.slice(0, index),
+                            ...items.slice(index + 1),
+                        ],
+                    });
+                }
+            },
+            [filterGroup, items, onChange, onDelete],
+        );
+
+        const onChangeItem = useCallback(
+            (index: number, item: FilterRule | FilterGroup) => {
                 onChange({
                     ...filterGroup,
                     [getFilterGroupItemsPropertyName(filterGroup)]: [
                         ...items.slice(0, index),
+                        item,
                         ...items.slice(index + 1),
                     ],
                 });
+            },
+            [filterGroup, items, onChange],
+        );
+
+        const onAddFilterRule = useCallback(() => {
+            if (availableFieldsForGroupRules.length > 0) {
+                onChange({
+                    ...filterGroup,
+                    [getFilterGroupItemsPropertyName(filterGroup)]: [
+                        ...items,
+                        createFilterRuleFromField(
+                            availableFieldsForGroupRules[0],
+                        ),
+                    ],
+                });
             }
-        },
-        [filterGroup, items, onChange, onDelete],
-    );
+        }, [availableFieldsForGroupRules, filterGroup, items, onChange]);
 
-    const onChangeItem = useCallback(
-        (index: number, item: FilterRule | FilterGroup) => {
-            onChange({
-                ...filterGroup,
-                [getFilterGroupItemsPropertyName(filterGroup)]: [
-                    ...items.slice(0, index),
-                    item,
-                    ...items.slice(index + 1),
-                ],
-            });
-        },
-        [filterGroup, items, onChange],
-    );
+        const onChangeOperator = useCallback(
+            (value: FilterGroupOperator) => {
+                onChange({
+                    id: filterGroup.id,
+                    [value]: items,
+                } as FilterGroup);
+            },
+            [filterGroup, items, onChange],
+        );
 
-    const onAddFilterRule = useCallback(() => {
-        if (availableFieldsForGroupRules.length > 0) {
-            onChange({
-                ...filterGroup,
-                [getFilterGroupItemsPropertyName(filterGroup)]: [
-                    ...items,
-                    createFilterRuleFromField(availableFieldsForGroupRules[0]),
-                ],
-            });
-        }
-    }, [availableFieldsForGroupRules, filterGroup, items, onChange]);
-
-    const onChangeOperator = useCallback(
-        (value: FilterGroupOperator) => {
-            onChange({
-                id: filterGroup.id,
-                [value]: items,
-            } as FilterGroup);
-        },
-        [filterGroup, items, onChange],
-    );
-
-    return (
-        <Stack pos="relative" spacing="sm" mb="xxs">
-            {!hideLine && (
-                <Divider
-                    orientation="vertical"
-                    pos="absolute"
-                    h="100%"
-                    top={0}
-                    left={18}
-                    style={{ zIndex: 1 }}
-                />
-            )}
-
-            <Group spacing="xs">
-                <Box bg="white" pos="relative" style={{ zIndex: 3 }}>
-                    <Select
-                        limit={FILTER_SELECT_LIMIT}
-                        size="xs"
-                        w={70}
-                        withinPortal
-                        disabled={!isEditMode}
-                        data={[
-                            {
-                                value: FilterGroupOperator.and,
-                                label: 'All',
-                            },
-                            {
-                                value: FilterGroupOperator.or,
-                                label: 'Any',
-                            },
-                        ]}
-                        value={
-                            isAndFilterGroup(filterGroup)
-                                ? FilterGroupOperator.and
-                                : FilterGroupOperator.or
-                        }
-                        onChange={(operator: FilterGroupOperator) =>
-                            onChangeOperator(operator)
-                        }
+        return (
+            <Stack pos="relative" spacing="sm" mb="xxs">
+                {!hideLine && (
+                    <Divider
+                        orientation="vertical"
+                        pos="absolute"
+                        h="100%"
+                        top={0}
+                        left={18}
+                        style={{ zIndex: 1 }}
                     />
-                </Box>
-
-                <Text color="dimmed" size="xs">
-                    of the following {conditionLabel} conditions match:
-                </Text>
-            </Group>
-
-            <Stack
-                spacing="xs"
-                pl={36}
-                style={{ flexGrow: 1, overflowY: 'auto' }}
-            >
-                {items.map((item, index) => (
-                    <React.Fragment key={item.id}>
-                        {!isFilterGroup(item) ? (
-                            <FilterRuleForm
-                                filterRule={item}
-                                fields={availableFieldsForGroupRules}
-                                isEditMode={isEditMode}
-                                onChange={(value) => onChangeItem(index, value)}
-                                onDelete={() => onDeleteItem(index)}
-                                onConvertToGroup={
-                                    ALLOW_CONVERT_TO_GROUP_UP_TO_DEPTH >
-                                    groupDepth
-                                        ? () =>
-                                              onChangeItem(
-                                                  index,
-                                                  // create new group with opposite operator
-                                                  isAndFilterGroup(filterGroup)
-                                                      ? {
-                                                            id: uuidv4(),
-                                                            or: [item],
-                                                        }
-                                                      : {
-                                                            id: uuidv4(),
-                                                            and: [item],
-                                                        },
-                                              )
-                                        : undefined
-                                }
-                            />
-                        ) : (
-                            <FilterGroupForm
-                                groupDepth={groupDepth + 1}
-                                isEditMode={isEditMode}
-                                filterGroup={item}
-                                fields={availableFieldsForGroupRules}
-                                onChange={(value) => onChangeItem(index, value)}
-                                onDelete={() => onDeleteItem(index)}
-                            />
-                        )}
-                    </React.Fragment>
-                ))}
-            </Stack>
-
-            {isEditMode &&
-                !hideButtons &&
-                availableFieldsForGroupRules.length > 0 && (
-                    <Box bg="white" pos="relative" style={{ zIndex: 2 }}>
-                        <Button
-                            variant="outline"
-                            size="xs"
-                            leftIcon={<MantineIcon icon={IconPlus} />}
-                            onClick={onAddFilterRule}
-                        >
-                            Add group rule
-                        </Button>
-                    </Box>
                 )}
-        </Stack>
-    );
-};
+
+                <Group spacing="xs">
+                    <Box bg="white" pos="relative" style={{ zIndex: 3 }}>
+                        <Select
+                            limit={FILTER_SELECT_LIMIT}
+                            size="xs"
+                            w={70}
+                            withinPortal
+                            disabled={!isEditMode}
+                            data={[
+                                {
+                                    value: FilterGroupOperator.and,
+                                    label: 'All',
+                                },
+                                {
+                                    value: FilterGroupOperator.or,
+                                    label: 'Any',
+                                },
+                            ]}
+                            value={
+                                isAndFilterGroup(filterGroup)
+                                    ? FilterGroupOperator.and
+                                    : FilterGroupOperator.or
+                            }
+                            onChange={(operator: FilterGroupOperator) =>
+                                onChangeOperator(operator)
+                            }
+                        />
+                    </Box>
+
+                    <Text color="dimmed" size="xs">
+                        of the following {conditionLabel} conditions match:
+                    </Text>
+                </Group>
+
+                <Stack
+                    spacing="xs"
+                    pl={36}
+                    style={{ flexGrow: 1, overflowY: 'auto' }}
+                >
+                    {items.map((item, index) => (
+                        <React.Fragment key={item.id}>
+                            {!isFilterGroup(item) ? (
+                                <FilterRuleForm
+                                    filterRule={item}
+                                    fields={availableFieldsForGroupRules}
+                                    isEditMode={isEditMode}
+                                    onChange={(value) =>
+                                        onChangeItem(index, value)
+                                    }
+                                    onDelete={() => onDeleteItem(index)}
+                                    onConvertToGroup={
+                                        ALLOW_CONVERT_TO_GROUP_UP_TO_DEPTH >
+                                        groupDepth
+                                            ? () =>
+                                                  onChangeItem(
+                                                      index,
+                                                      // create new group with opposite operator
+                                                      isAndFilterGroup(
+                                                          filterGroup,
+                                                      )
+                                                          ? {
+                                                                id: uuidv4(),
+                                                                or: [item],
+                                                            }
+                                                          : {
+                                                                id: uuidv4(),
+                                                                and: [item],
+                                                            },
+                                                  )
+                                            : undefined
+                                    }
+                                />
+                            ) : (
+                                <FilterGroupForm
+                                    groupDepth={groupDepth + 1}
+                                    isEditMode={isEditMode}
+                                    filterGroup={item}
+                                    fields={availableFieldsForGroupRules}
+                                    onChange={(value) =>
+                                        onChangeItem(index, value)
+                                    }
+                                    onDelete={() => onDeleteItem(index)}
+                                />
+                            )}
+                        </React.Fragment>
+                    ))}
+                </Stack>
+
+                {isEditMode &&
+                    !hideButtons &&
+                    availableFieldsForGroupRules.length > 0 && (
+                        <Box bg="white" pos="relative" style={{ zIndex: 2 }}>
+                            <Button
+                                variant="outline"
+                                size="xs"
+                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                onClick={onAddFilterRule}
+                            >
+                                Add group rule
+                            </Button>
+                        </Box>
+                    )}
+            </Stack>
+        );
+    },
+);
+
+FilterGroupForm.displayName = 'FilterGroupForm';
 
 export default FilterGroupForm;

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -10,7 +10,7 @@ import {
 } from '@lightdash/common';
 import { ActionIcon, Box, Group, Menu, Select, Tooltip } from '@mantine/core';
 import { IconDots, IconX } from '@tabler/icons-react';
-import { useCallback, useMemo, type FC } from 'react';
+import { memo, useCallback, useMemo, type FC } from 'react';
 import FieldSelect from '../FieldSelect';
 import MantineIcon from '../MantineIcon';
 import { FILTER_SELECT_LIMIT } from './constants';
@@ -27,190 +27,194 @@ type Props = {
     onConvertToGroup?: () => void;
 };
 
-const FilterRuleForm: FC<Props> = ({
-    fields,
-    filterRule,
-    isEditMode,
-    onChange,
-    onDelete,
-    onConvertToGroup,
-}) => {
-    const { popoverProps, baseTable } = useFiltersContext();
-    const activeField = useMemo(() => {
-        return fields.find(
-            (field) => getItemId(field) === filterRule.target.fieldId,
-        );
-    }, [fields, filterRule.target.fieldId]);
-
-    const filterType = useMemo(() => {
-        return activeField
-            ? getFilterTypeFromItem(activeField)
-            : FilterType.STRING;
-    }, [activeField]);
-
-    const filterOperatorOptions = useMemo(() => {
-        return getFilterOperatorOptions(filterType);
-    }, [filterType]);
-
-    const onFieldChange = useCallback(
-        (fieldId: string) => {
-            const selectedField = fields.find(
-                (field) => getItemId(field) === fieldId,
+const FilterRuleForm: FC<Props> = memo(
+    ({
+        fields,
+        filterRule,
+        isEditMode,
+        onChange,
+        onDelete,
+        onConvertToGroup,
+    }) => {
+        const { popoverProps, baseTable } = useFiltersContext();
+        const activeField = useMemo(() => {
+            return fields.find(
+                (field) => getItemId(field) === filterRule.target.fieldId,
             );
-            if (selectedField && activeField) {
-                if (selectedField.type === activeField.type) {
-                    const newFilterRuleBase = {
-                        ...filterRule,
-                        target: {
-                            fieldId,
-                        },
-                    };
+        }, [fields, filterRule.target.fieldId]);
 
-                    const newFilterRule = isDateItem(selectedField)
-                        ? // If the field is the same type but different field, we need to update the filter rule with the new time frames
-                          getFilterRuleFromFieldWithDefaultValue(
-                              selectedField,
-                              newFilterRuleBase,
-                              filterRule.values,
-                          )
-                        : newFilterRuleBase;
+        const filterType = useMemo(() => {
+            return activeField
+                ? getFilterTypeFromItem(activeField)
+                : FilterType.STRING;
+        }, [activeField]);
 
-                    onChange(newFilterRule);
-                } else {
-                    onChange(createFilterRuleFromField(selectedField));
-                }
-            }
-        },
-        [activeField, fields, filterRule, onChange],
-    );
-    const isRequired = filterRule.required;
-    const isRequiredLabel = isRequired
-        ? "This filter is a required filter.\n It can't be deleted, but the value can be changed."
-        : '';
+        const filterOperatorOptions = useMemo(() => {
+            return getFilterOperatorOptions(filterType);
+        }, [filterType]);
 
-    if (!activeField) {
-        return null;
-    }
-
-    return (
-        <Group
-            noWrap
-            align="start"
-            spacing="xs"
-            data-testid="FilterRuleForm/filter-rule"
-        >
-            <FieldSelect
-                size="xs"
-                disabled={!isEditMode}
-                withinPortal={popoverProps?.withinPortal}
-                onDropdownOpen={popoverProps?.onOpen}
-                onDropdownClose={popoverProps?.onClose}
-                hasGrouping
-                item={activeField}
-                items={fields}
-                onChange={(field) => {
-                    if (!field) return;
-                    onFieldChange(getItemId(field));
-                }}
-                baseTable={baseTable}
-            />
-            <Select
-                limit={FILTER_SELECT_LIMIT}
-                size="xs"
-                w="175px"
-                sx={{ flexShrink: 0 }}
-                withinPortal={popoverProps?.withinPortal}
-                onDropdownOpen={popoverProps?.onOpen}
-                onDropdownClose={popoverProps?.onClose}
-                disabled={!isEditMode}
-                value={filterRule.operator}
-                data={filterOperatorOptions}
-                onChange={(value) => {
-                    if (!value) return;
-                    onChange(
-                        getFilterRuleFromFieldWithDefaultValue(
-                            activeField,
-                            {
-                                ...filterRule,
-                                operator: value as FilterRule['operator'],
+        const onFieldChange = useCallback(
+            (fieldId: string) => {
+                const selectedField = fields.find(
+                    (field) => getItemId(field) === fieldId,
+                );
+                if (selectedField && activeField) {
+                    if (selectedField.type === activeField.type) {
+                        const newFilterRuleBase = {
+                            ...filterRule,
+                            target: {
+                                fieldId,
                             },
-                            filterRule.values ?? [],
-                        ),
-                    );
-                }}
-            />
+                        };
 
-            <FilterInputComponent
-                filterType={filterType}
-                field={activeField}
-                rule={filterRule}
-                onChange={onChange}
-                disabled={!isEditMode}
-                popoverProps={popoverProps}
-            />
+                        const newFilterRule = isDateItem(selectedField)
+                            ? // If the field is the same type but different field, we need to update the filter rule with the new time frames
+                              getFilterRuleFromFieldWithDefaultValue(
+                                  selectedField,
+                                  newFilterRuleBase,
+                                  filterRule.values,
+                              )
+                            : newFilterRuleBase;
 
-            {isEditMode &&
-                (!onConvertToGroup ? (
-                    <Tooltip
-                        label={isRequiredLabel}
-                        disabled={!isRequired}
-                        withinPortal
-                        variant="xs"
-                        multiline
-                    >
-                        <span>
-                            <ActionIcon
-                                onClick={onDelete}
-                                disabled={isRequired}
-                                data-testid="delete-filter-rule-button"
-                            >
-                                <MantineIcon icon={IconX} size="sm" />
-                            </ActionIcon>
-                        </span>
-                    </Tooltip>
-                ) : (
-                    <Menu
-                        position="bottom-end"
-                        shadow="md"
-                        closeOnItemClick
-                        withArrow
-                        arrowPosition="center"
-                        withinPortal
-                    >
-                        <Menu.Target>
-                            <Box>
-                                <ActionIcon variant="subtle">
-                                    <IconDots size="20" />
+                        onChange(newFilterRule);
+                    } else {
+                        onChange(createFilterRuleFromField(selectedField));
+                    }
+                }
+            },
+            [activeField, fields, filterRule, onChange],
+        );
+        const isRequired = filterRule.required;
+        const isRequiredLabel = isRequired
+            ? "This filter is a required filter.\n It can't be deleted, but the value can be changed."
+            : '';
+
+        if (!activeField) {
+            return null;
+        }
+
+        return (
+            <Group
+                noWrap
+                align="start"
+                spacing="xs"
+                data-testid="FilterRuleForm/filter-rule"
+            >
+                <FieldSelect
+                    size="xs"
+                    disabled={!isEditMode}
+                    withinPortal={popoverProps?.withinPortal}
+                    onDropdownOpen={popoverProps?.onOpen}
+                    onDropdownClose={popoverProps?.onClose}
+                    hasGrouping
+                    item={activeField}
+                    items={fields}
+                    onChange={(field) => {
+                        if (!field) return;
+                        onFieldChange(getItemId(field));
+                    }}
+                    baseTable={baseTable}
+                />
+                <Select
+                    limit={FILTER_SELECT_LIMIT}
+                    size="xs"
+                    w="175px"
+                    sx={{ flexShrink: 0 }}
+                    withinPortal={popoverProps?.withinPortal}
+                    onDropdownOpen={popoverProps?.onOpen}
+                    onDropdownClose={popoverProps?.onClose}
+                    disabled={!isEditMode}
+                    value={filterRule.operator}
+                    data={filterOperatorOptions}
+                    onChange={(value) => {
+                        if (!value) return;
+                        onChange(
+                            getFilterRuleFromFieldWithDefaultValue(
+                                activeField,
+                                {
+                                    ...filterRule,
+                                    operator: value as FilterRule['operator'],
+                                },
+                                filterRule.values ?? [],
+                            ),
+                        );
+                    }}
+                />
+
+                <FilterInputComponent
+                    filterType={filterType}
+                    field={activeField}
+                    rule={filterRule}
+                    onChange={onChange}
+                    disabled={!isEditMode}
+                    popoverProps={popoverProps}
+                />
+
+                {isEditMode &&
+                    (!onConvertToGroup ? (
+                        <Tooltip
+                            label={isRequiredLabel}
+                            disabled={!isRequired}
+                            withinPortal
+                            variant="xs"
+                            multiline
+                        >
+                            <span>
+                                <ActionIcon
+                                    onClick={onDelete}
+                                    disabled={isRequired}
+                                    data-testid="delete-filter-rule-button"
+                                >
+                                    <MantineIcon icon={IconX} size="sm" />
                                 </ActionIcon>
-                            </Box>
-                        </Menu.Target>
+                            </span>
+                        </Tooltip>
+                    ) : (
+                        <Menu
+                            position="bottom-end"
+                            shadow="md"
+                            closeOnItemClick
+                            withArrow
+                            arrowPosition="center"
+                            withinPortal
+                        >
+                            <Menu.Target>
+                                <Box>
+                                    <ActionIcon variant="subtle">
+                                        <IconDots size="20" />
+                                    </ActionIcon>
+                                </Box>
+                            </Menu.Target>
 
-                        <Menu.Dropdown>
-                            <Menu.Item onClick={onConvertToGroup}>
-                                Convert to group
-                            </Menu.Item>
-                            <Tooltip
-                                label={isRequiredLabel}
-                                disabled={!isRequired}
-                                withinPortal
-                                variant="xs"
-                                multiline
-                            >
-                                <span>
-                                    <Menu.Item
-                                        color="red"
-                                        disabled={isRequired}
-                                        onClick={onDelete}
-                                    >
-                                        Remove
-                                    </Menu.Item>
-                                </span>
-                            </Tooltip>
-                        </Menu.Dropdown>
-                    </Menu>
-                ))}
-        </Group>
-    );
-};
+                            <Menu.Dropdown>
+                                <Menu.Item onClick={onConvertToGroup}>
+                                    Convert to group
+                                </Menu.Item>
+                                <Tooltip
+                                    label={isRequiredLabel}
+                                    disabled={!isRequired}
+                                    withinPortal
+                                    variant="xs"
+                                    multiline
+                                >
+                                    <span>
+                                        <Menu.Item
+                                            color="red"
+                                            disabled={isRequired}
+                                            onClick={onDelete}
+                                        >
+                                            Remove
+                                        </Menu.Item>
+                                    </span>
+                                </Tooltip>
+                            </Menu.Dropdown>
+                        </Menu>
+                    ))}
+            </Group>
+        );
+    },
+);
+
+FilterRuleForm.displayName = 'FilterRuleForm';
 
 export default FilterRuleForm;

--- a/packages/frontend/src/components/common/Filters/SimplifiedFilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/SimplifiedFilterGroupForm.tsx
@@ -1,6 +1,6 @@
 import { type FilterableField, type FilterRule } from '@lightdash/common';
 import { Stack, Text, Tooltip } from '@mantine/core';
-import { useCallback, type FC } from 'react';
+import { memo, useCallback, type FC } from 'react';
 import FilterRuleForm from './FilterRuleForm';
 
 type Props = {
@@ -10,59 +10,58 @@ type Props = {
     onChange: (value: FilterRule[]) => void;
 };
 
-const SimplifiedFilterGroupForm: FC<Props> = ({
-    isEditMode,
-    fields,
-    filterRules,
-    onChange,
-}) => {
-    const onDeleteItem = useCallback(
-        (index: number) => {
-            onChange([
-                ...filterRules.slice(0, index),
-                ...filterRules.slice(index + 1),
-            ]);
-        },
-        [filterRules, onChange],
-    );
+const SimplifiedFilterGroupForm: FC<Props> = memo(
+    ({ isEditMode, fields, filterRules, onChange }) => {
+        const onDeleteItem = useCallback(
+            (index: number) => {
+                onChange([
+                    ...filterRules.slice(0, index),
+                    ...filterRules.slice(index + 1),
+                ]);
+            },
+            [filterRules, onChange],
+        );
 
-    const onChangeItem = useCallback(
-        (index: number, item: FilterRule) => {
-            onChange([
-                ...filterRules.slice(0, index),
-                item,
-                ...filterRules.slice(index + 1),
-            ]);
-        },
-        [filterRules, onChange],
-    );
+        const onChangeItem = useCallback(
+            (index: number, item: FilterRule) => {
+                onChange([
+                    ...filterRules.slice(0, index),
+                    item,
+                    ...filterRules.slice(index + 1),
+                ]);
+            },
+            [filterRules, onChange],
+        );
 
-    return (
-        <Stack style={{ flexGrow: 1 }}>
-            <Tooltip
-                label="You can only use the 'and' operator when combining metrics & dimensions"
-                disabled={filterRules.length > 1}
-                arrowPosition="center"
-            >
-                <Text color="dimmed" size="xs">
-                    All of the following conditions match:
-                </Text>
-            </Tooltip>
+        return (
+            <Stack style={{ flexGrow: 1 }}>
+                <Tooltip
+                    label="You can only use the 'and' operator when combining metrics & dimensions"
+                    disabled={filterRules.length > 1}
+                    arrowPosition="center"
+                >
+                    <Text color="dimmed" size="xs">
+                        All of the following conditions match:
+                    </Text>
+                </Tooltip>
 
-            <Stack spacing="sm">
-                {filterRules.map((item, index) => (
-                    <FilterRuleForm
-                        isEditMode={isEditMode}
-                        key={item.id}
-                        filterRule={item}
-                        fields={fields}
-                        onChange={(value) => onChangeItem(index, value)}
-                        onDelete={() => onDeleteItem(index)}
-                    />
-                ))}
+                <Stack spacing="sm">
+                    {filterRules.map((item, index) => (
+                        <FilterRuleForm
+                            isEditMode={isEditMode}
+                            key={item.id}
+                            filterRule={item}
+                            fields={fields}
+                            onChange={(value) => onChangeItem(index, value)}
+                            onDelete={() => onDeleteItem(index)}
+                        />
+                    ))}
+                </Stack>
             </Stack>
-        </Stack>
-    );
-};
+        );
+    },
+);
+
+SimplifiedFilterGroupForm.displayName = 'SimplifiedFilterGroupForm';
 
 export default SimplifiedFilterGroupForm;

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -24,7 +24,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconAlertCircle, IconPlus, IconX } from '@tabler/icons-react';
-import { useCallback, useMemo, type FC } from 'react';
+import { memo, useCallback, useMemo, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -60,7 +60,7 @@ const getInvalidFilterRules = (
         return accumulator;
     }, []);
 
-const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
+const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
     const { itemsMap, baseTable } = useFiltersContext<FieldsWithSuggestions>();
     const [isOpen, toggleFieldInput] = useToggle(false);
     const fields = useMemo<FieldWithSuggestions[]>(() => {
@@ -302,6 +302,8 @@ const FiltersForm: FC<Props> = ({ filters, setFilters, isEditMode }) => {
             )}
         </Stack>
     );
-};
+});
+
+FiltersForm.displayName = 'FiltersForm';
 
 export default FiltersForm;


### PR DESCRIPTION
### Description:

This improves load time of the explores page by optimising the filters card load a bit better. Everything in here seems kind of small, but it has a noticeable effect on load times from dashboard -> edit chart. 

To test:
- I've been using [this chart (localhost)](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/generated_a?create_saved_chart_version=%7B%22uuid%22%3A%225d612927-8322-418c-ae38-820dfd8e426b%22%2C%22projectUuid%22%3A%223675b69e-8324-4110-bdca-059031aa8da3%22%2C%22name%22%3A%22GenA%22%2C%22description%22%3A%22%22%2C%22tableName%22%3A%22generated_a%22%2C%22updatedAt%22%3A%222025-10-17T07%3A58%3A10.657Z%22%2C%22updatedByUser%22%3A%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%7D%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22generated_a%22%2C%22dimensions%22%3A%5B%22generated_a_numberrange3%22%2C%22join_16_alphanumeric%22%2C%22generated_a_numberrange6%22%2C%22join_16_text1%22%2C%22join_19_address1%22%2C%22join_19_date5%22%2C%22join_3_address%22%2C%22join_3_date6%22%2C%22join_3_time%22%2C%22join_5_numberrange8%22%2C%22join_5_phone%22%2C%22join_6_phone1%22%2C%22join_6_numberrange6%22%2C%22join_7_numberrange12%22%2C%22join_7_numberrange2%22%2C%22join_7_numberrange4%22%2C%22join_7_text1%22%5D%2C%22metrics%22%3A%5B%5D%2C%22filters%22%3A%7B%22dimensions%22%3A%7B%22id%22%3A%22ac86ea68-3f56-4278-9d64-8515e34c4b04%22%2C%22and%22%3A%5B%7B%22id%22%3A%22837d67d0-85bf-43b9-a9fa-4df6016fd19c%22%2C%22target%22%3A%7B%22fieldId%22%3A%22join_7_numberrange2%22%7D%2C%22values%22%3A%5B%223%22%5D%2C%22operator%22%3A%22equals%22%2C%22required%22%3Afalse%7D%2C%7B%22id%22%3A%22ff127aa4-d62e-4842-b0bc-d6d32dc035a3%22%2C%22target%22%3A%7B%22fieldId%22%3A%22join_7_text1%22%7D%2C%22values%22%3A%5B%22a%2C+dui.+Cras+pellentesque.+Sed+dictum.+Proin+eget+odio.+Aliquam%22%5D%2C%22operator%22%3A%22notEquals%22%2C%22required%22%3Afalse%7D%5D%7D%2C%22metrics%22%3A%7B%22id%22%3A%22e92be23a-4202-4586-9fe6-03f6bef01d82%22%2C%22and%22%3A%5B%5D%7D%2C%22tableCalculations%22%3A%7B%22id%22%3A%2208263106-dc90-4f23-a284-8665ce7b0b05%22%2C%22and%22%3A%5B%7B%22id%22%3A%226b7ad902-af9d-4ee7-9ee9-1a4b8cb60e37%22%2C%22target%22%3A%7B%22fieldId%22%3A%22a%22%7D%2C%22values%22%3A%5B3%5D%2C%22operator%22%3A%22lessThan%22%7D%5D%7D%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22generated_a_numberrange3%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A1000%2C%22metricOverrides%22%3A%7B%7D%2C%22tableCalculations%22%3A%5B%7B%22name%22%3A%22a%22%2C%22displayName%22%3A%22a%22%2C%22sql%22%3A%22%24%7Bgenerated_a.numberrange3%7D%22%2C%22format%22%3A%7B%22type%22%3A%22default%22%2C%22separator%22%3A%22default%22%7D%2C%22type%22%3A%22number%22%7D%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22table%22%2C%22config%22%3A%7B%22columns%22%3A%7B%7D%2C%22metricsAsRows%22%3Afalse%2C%22showSubtotals%22%3Afalse%2C%22hideRowNumbers%22%3Afalse%2C%22showTableNames%22%3Atrue%2C%22showResultsTotal%22%3Afalse%2C%22showRowCalculation%22%3Afalse%2C%22showColumnCalculation%22%3Afalse%2C%22conditionalFormattings%22%3A%5B%5D%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22generated_a_numberrange3%22%2C%22join_16_alphanumeric%22%2C%22generated_a_numberrange6%22%2C%22join_16_text1%22%2C%22join_19_address1%22%2C%22join_19_date5%22%2C%22join_3_address%22%2C%22join_3_date6%22%2C%22join_3_time%22%2C%22join_5_numberrange8%22%2C%22join_5_phone%22%2C%22join_6_phone1%22%2C%22join_6_numberrange6%22%2C%22join_7_numberrange12%22%2C%22join_7_numberrange2%22%2C%22join_7_numberrange4%22%2C%22join_7_text1%22%2C%22a%22%5D%7D%2C%22organizationUuid%22%3A%22172a2270-000f-42be-9c68-c4752c23ae51%22%2C%22spaceUuid%22%3A%22cdf2d309-17e3-4451-b09f-8d9ec1125504%22%2C%22spaceName%22%3A%22Jaffle+shop%22%2C%22pinnedListUuid%22%3Anull%2C%22pinnedListOrder%22%3Anull%2C%22dashboardUuid%22%3Anull%2C%22dashboardName%22%3Anull%2C%22colorPalette%22%3A%5B%22%235470c6%22%2C%22%23fc8452%22%2C%22%2391cc75%22%2C%22%23fac858%22%2C%22%23ee6666%22%2C%22%2373c0de%22%2C%22%233ba272%22%2C%22%239a60b4%22%2C%22%23ea7ccc%22%5D%2C%22slug%22%3A%22gena%22%2C%22isPrivate%22%3Afalse%2C%22access%22%3A%5B%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%2C%22email%22%3A%22demo%40lightdash.com%22%2C%22role%22%3A%22admin%22%2C%22hasDirectAccess%22%3Atrue%2C%22inheritedRole%22%3A%22admin%22%2C%22inheritedFrom%22%3A%22organization%22%2C%22projectRole%22%3A%22admin%22%7D%5D%7D)
- Save it to a dashbaord
- Click the edit chart button
- Page load is slow, but this helps
- Also: do all of the fitler features still work? (I think so)

**Whats in here specifically?**

Not a lot of logic changes.

Changes:
  - Memoize filter components (FiltersForm, FilterGroupForm, FilterRuleForm,
  SimplifiedFilterGroupForm, FieldSelect) to prevent unnecessary re-renders
  - Implement lazy mounting for FiltersForm - only renders after first open
  - Cache visibleFields calculation in useMemo to avoid repeated expensive operations
  - Consolidate filter processing logic inline to reduce function overhead
  - Remove redundant URL search param comparison in DashboardProvider
  - Clean up embed dashboard filter and header components


