### PR TITLE
feat: add roles attribute to SCIM User schema

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -246,6 +246,20 @@ const models: TsoaRoute.Models = {
         enums: ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                primary: { dataType: 'boolean' },
+                type: { dataType: 'enum', enums: ['organization'] },
+                display: { dataType: 'string' },
+                value: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     LightdashScimExtension: {
         dataType: 'refObject',
         properties: {
@@ -291,6 +305,10 @@ const models: TsoaRoute.Models = {
                         value: { dataType: 'string', required: true },
                     },
                 },
+            },
+            roles: {
+                dataType: 'array',
+                array: { dataType: 'refAlias', ref: 'ScimRole' },
             },
             'urn:lightdash:params:scim:schemas:extension:2.0:User': {
                 ref: 'LightdashScimExtension',
@@ -430,6 +448,16 @@ const models: TsoaRoute.Models = {
                                     },
                                 },
                             },
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                roles: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'ScimRole' },
                         },
                         { dataType: 'undefined' },
                     ],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -143,6 +143,26 @@
                 "enum": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
                 "type": "string"
             },
+            "ScimRole": {
+                "properties": {
+                    "primary": {
+                        "type": "boolean"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["organization"],
+                        "nullable": false
+                    },
+                    "display": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "required": ["value"],
+                "type": "object"
+            },
             "LightdashScimExtension": {
                 "properties": {
                     "role": {
@@ -214,6 +234,12 @@
                             },
                             "required": ["value"],
                             "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "roles": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimRole"
                         },
                         "type": "array"
                     },
@@ -343,6 +369,12 @@
                             },
                             "required": ["value"],
                             "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "roles": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimRole"
                         },
                         "type": "array"
                     },

--- a/packages/common/src/ee/scim/types.ts
+++ b/packages/common/src/ee/scim/types.ts
@@ -16,6 +16,13 @@ export interface ScimResource {
     };
 }
 
+export type ScimRole = {
+    value: string;
+    display?: string;
+    type?: 'organization'; // todo: soon 'project' will be added
+    primary?: boolean; // true is an alias for 'org' type
+};
+
 export interface LightdashScimExtension {
     role?: string;
 }
@@ -32,6 +39,7 @@ export interface ScimUser extends ScimResource {
         value: string;
         primary?: boolean;
     }[];
+    roles?: ScimRole[];
     [ScimSchemaType.LIGHTDASH_USER_EXTENSION]?: LightdashScimExtension;
 }
 

--- a/packages/common/src/types/organizationMemberProfile.ts
+++ b/packages/common/src/types/organizationMemberProfile.ts
@@ -10,6 +10,18 @@ export enum OrganizationMemberRole {
     ADMIN = 'admin',
 }
 
+export const OrganizationMemberRoleLabels: Record<
+    OrganizationMemberRole,
+    string
+> = {
+    [OrganizationMemberRole.MEMBER]: 'Member',
+    [OrganizationMemberRole.VIEWER]: 'Viewer',
+    [OrganizationMemberRole.INTERACTIVE_VIEWER]: 'Interactive Viewer',
+    [OrganizationMemberRole.EDITOR]: 'Editor',
+    [OrganizationMemberRole.DEVELOPER]: 'Developer',
+    [OrganizationMemberRole.ADMIN]: 'Admin',
+} as const;
+
 export const isOrganizationMemberRole = (
     x: string,
 ): x is OrganizationMemberRole =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #SCIM-123

### Description:
Added support for the standard SCIM `roles` attribute in the User schema, allowing SCIM clients to set user roles using the standard SCIM attribute rather than relying solely on our custom extension schema.

Key changes:
- Added `roles` attribute to the SCIM User schema with proper validation
- Implemented logic to extract organization roles from both standard `roles` and extension schema
- Added role display names via `OrganizationMemberRoleLabels`
- Prioritized `roles` over extension schema when both are present
- Updated tests to verify the new functionality

This change maintains backward compatibility with clients using our extension schema while providing a more standards-compliant approach for new integrations.