### PR TITLE
feat: publish events for embed when location changes

### DIFF
--- a/packages/frontend/src/ee/features/embed/events/types.ts
+++ b/packages/frontend/src/ee/features/embed/events/types.ts
@@ -2,6 +2,7 @@
  * Enum of all supported Lightdash embed event types
  */
 export enum LightdashEventType {
+    LocationChanged = 'locationChanged',
     FilterChanged = 'filterChanged',
     TabChanged = 'tabChanged',
     Error = 'error',
@@ -48,11 +49,18 @@ export type AllTilesLoadedPayload = {
     loadTimeMs: number;
 };
 
+export type LocationChangedPayload = {
+    pathname: string;
+    search: string;
+    href: string;
+};
+
 export type LightdashEventPayload =
     | FilterChangedPayload
     | TabChangedPayload
     | ErrorPayload
-    | AllTilesLoadedPayload;
+    | AllTilesLoadedPayload
+    | LocationChangedPayload;
 
 /**
  * Generic event structure for all Lightdash events


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Now that we update the embed app's URL with each UI change, we need to publish an event with the new location fields. 