### PR TITLE
fix: use exploreWithOverride and pass dateZoom parameter

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1506,7 +1506,10 @@ export class AsyncQueryService extends ProjectService {
             availableParameters,
         });
 
-        return getFieldsFromMetricQuery(compiledMetricQuery, explore);
+        return getFieldsFromMetricQuery(
+            compiledMetricQuery,
+            exploreWithOverride,
+        );
     }
 
     private async prepareMetricQueryAsyncQueryArgs({
@@ -2355,6 +2358,7 @@ export class AsyncQueryService extends ProjectService {
             explore,
             warehouseSqlBuilder,
             projectUuid,
+            dateZoom,
         });
 
         const pivotConfiguration = pivotResults


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17508

### Description:
Fixed a bug in the AsyncQueryService where the `exploreWithOverride` was not being passed to `getFieldsFromMetricQuery()`, causing incorrect field resolution. Also added the missing `dateZoom` parameter to the function call that prepares metric query arguments.