### PR TITLE
fix: properly track charts with date zoom in useEffect hook

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -144,13 +144,15 @@ export const useDashboardChartReadyQuery = (
     }, [parameterValues, tileParameterReferences, tileUuid]);
 
     useEffect(() => {
+        if (!chartUuid) return;
+
         setChartsWithDateZoomApplied((prev) => {
             if (hasADateDimension) {
                 const nextSet = new Set(prev ?? []);
                 if (granularity) {
-                    nextSet.add(chartUuid!);
+                    nextSet.add(chartUuid);
                 } else {
-                    nextSet.delete(chartUuid!);
+                    nextSet.delete(chartUuid);
                 }
                 return nextSet;
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fix date zoom state management in dashboard charts by properly handling the addition and removal of charts with date dimensions. The implementation now uses `useEffect` to manage the state updates, ensuring that charts are correctly added to or removed from the set based on whether they have a granularity setting.

This prevents the issue where the set of charts with date zoom applied was being cleared incorrectly, which could cause unexpected behavior when interacting with multiple charts on a dashboard.