### PR TITLE
fix: apply changeset when retrieving catalog search item

### DIFF
--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -262,6 +262,10 @@ export class CatalogService<
         fullTextSearchOperator?: 'OR' | 'AND';
         filteredExplore?: Explore;
     }): Promise<KnexPaginatedData<CatalogItem[]>> {
+        const changeset =
+            await this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
+                args.projectUuid,
+            );
         return wrapSentryTransaction(
             'CatalogService.searchCatalog',
             {
@@ -281,6 +285,7 @@ export class CatalogService<
                     () =>
                         this.catalogModel.search({
                             projectUuid: args.projectUuid,
+                            changeset,
                             catalogSearch: args.catalogSearch,
                             paginateArgs: args.paginateArgs,
                             userAttributes: args.userAttributes,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:

Apply active changeset to catalog search results to ensure that catalog items reflect the latest changes from the active changeset. This modification allows users to see catalog items with pending changes that haven't been committed yet.

> [!IMPORTANT]
> This is so `parseCatalog` doesn't throw a field-not-found error. To test you can: create a metric (proposeChange tool) and then ask ai to explore the explore the new metric belongs to.

The implementation:
1. Fetches the active changeset with changes for the project in the CatalogService
2. Passes the changeset to the CatalogModel's search method
3. Applies the changeset to each explore in the catalog search results before returning them