### PR TITLE
feat: add generateDashboardV2 tool

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -15,7 +15,7 @@ import { getSystemPromptV2 } from '../prompts/systemV2';
 import { getFindContent } from '../tools/findContent';
 import { getFindExplores } from '../tools/findExplores';
 import { getFindFields } from '../tools/findFields';
-import { getGenerateDashboard } from '../tools/generateDashboard';
+import { getGenerateDashboardV2 } from '../tools/generateDashboardV2';
 import { getImproveContext } from '../tools/improveContext';
 import { getProposeChange } from '../tools/proposeChange';
 import { getRunQuery } from '../tools/runQuery';
@@ -168,15 +168,10 @@ const getAgentTools = (
         enableSelfImprovement: args.enableSelfImprovement,
     });
 
-    const generateDashboard = getGenerateDashboard({
+    const generateDashboard = getGenerateDashboardV2({
         getExplore: dependencies.getExplore,
-        updateProgress: dependencies.updateProgress,
-        runMiniMetricQuery: dependencies.runMiniMetricQuery,
         getPrompt: dependencies.getPrompt,
-        updatePrompt: dependencies.updatePrompt,
-        sendFile: dependencies.sendFile,
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
-        maxLimit: args.maxQueryLimit,
     });
 
     const improveContext = getImproveContext();

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
@@ -1,6 +1,7 @@
 import {
     isToolName,
     toolDashboardArgsSchema,
+    toolDashboardV2ArgsSchema,
     toolFindChartsArgsSchema,
     toolFindContentArgsSchema,
     toolFindDashboardsArgsSchema,
@@ -35,6 +36,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     generateBarVizConfig: 'vertical_bar_chart',
     runQuery: 'query_result',
     generateDashboard: 'generate_dashboard',
+    generateDashboardV2: 'generate_dashboard_v2',
     improveContext: 'improve_context',
     proposeChange: 'propose_change',
 } satisfies Record<ToolName, string>;
@@ -48,6 +50,7 @@ const TOOL_SCHEMAS = {
     generateTableVizConfig: toolTableVizArgsSchema,
     generateTimeSeriesVizConfig: toolTimeSeriesArgsSchema,
     generateDashboard: toolDashboardArgsSchema,
+    generateDashboardV2: toolDashboardV2ArgsSchema,
     findContent: toolFindContentArgsSchema,
     findDashboards: toolFindDashboardsArgsSchema,
     findCharts: toolFindChartsArgsSchema,

--- a/packages/backend/src/ee/services/ai/tools/generateDashboardV2.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDashboardV2.ts
@@ -1,0 +1,140 @@
+import {
+    toolDashboardV2ArgsSchema,
+    toolDashboardV2ArgsSchemaTransformed,
+    toolDashboardV2OutputSchema,
+    type ToolDashboardV2ArgsTransformed,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import type {
+    CreateOrUpdateArtifactFn,
+    GetExploreFn,
+    GetPromptFn,
+} from '../types/aiAgentDependencies';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+import { validateRunQueryTool } from './runQuery';
+
+type Dependencies = {
+    getExplore: GetExploreFn;
+    getPrompt: GetPromptFn;
+    createOrUpdateArtifact: CreateOrUpdateArtifactFn;
+};
+
+export const getGenerateDashboardV2 = ({
+    getExplore,
+    getPrompt,
+    createOrUpdateArtifact,
+}: Dependencies) =>
+    tool({
+        description: toolDashboardV2ArgsSchema.description,
+        inputSchema: toolDashboardV2ArgsSchema,
+        outputSchema: toolDashboardV2OutputSchema,
+        execute: async (toolArgs) => {
+            try {
+                const transformedToolArgs =
+                    toolDashboardV2ArgsSchemaTransformed.parse(toolArgs);
+
+                const errors: string[] = [];
+                const failedVisualizations: string[] = [];
+                const validIndices = new Set<number>();
+
+                const vizPromises = transformedToolArgs.visualizations.map(
+                    async (viz, index) => {
+                        try {
+                            const explore = await getExplore({
+                                exploreName: viz.queryConfig.exploreName,
+                            });
+
+                            validateRunQueryTool(viz, explore);
+                            validIndices.add(index);
+                            return viz;
+                        } catch (error) {
+                            const errorMessage = toolErrorHandler(
+                                error,
+                                `Validation failed for visualization ${
+                                    index + 1
+                                } (${viz.title})`,
+                            );
+                            errors.push(errorMessage);
+                            failedVisualizations.push(viz.title);
+                            return null;
+                        }
+                    },
+                );
+
+                const validatedVisualizations = await Promise.all(vizPromises);
+
+                // Filter out null values (failed validations)
+                const validVisualizations = validatedVisualizations.filter(
+                    (
+                        viz,
+                    ): viz is ToolDashboardV2ArgsTransformed['visualizations'][number] =>
+                        viz !== null,
+                );
+
+                // Check if we have at least one valid visualization
+                if (validVisualizations.length === 0) {
+                    return {
+                        result: `Dashboard generation failed - all visualizations had validation errors:\n${errors.join(
+                            '\n',
+                        )}
+                    Please fix these issues and try again.
+                    `,
+                        metadata: {
+                            status: 'error',
+                        },
+                    };
+                }
+
+                // Create dashboard with valid visualizations only
+                const prompt = await getPrompt();
+
+                // Store the original (untransformed) toolArgs, not the transformed version
+                // This is important because when reading from DB, we parse with the base schema
+                await createOrUpdateArtifact({
+                    threadUuid: prompt.threadUuid,
+                    promptUuid: prompt.promptUuid,
+                    artifactType: 'dashboard',
+                    title: toolArgs.title,
+                    description: toolArgs.description,
+                    vizConfig: {
+                        ...toolArgs,
+                        visualizations: toolArgs.visualizations.filter(
+                            (_, index) => validIndices.has(index),
+                        ),
+                    },
+                });
+
+                // Return appropriate message based on whether some visualizations failed
+                if (errors.length > 0) {
+                    return {
+                        result: `Dashboard created with ${
+                            validVisualizations.length
+                        } visualization${
+                            validVisualizations.length > 1 ? 's' : ''
+                        }.\n\nThe following visualizations were excluded due to validation errors:\n${failedVisualizations
+                            .map((title) => `- ${title}`)
+                            .join('\n')}\n\nErrors:\n${errors.join('\n')}`,
+                        metadata: {
+                            status: 'success',
+                        },
+                    };
+                }
+
+                return {
+                    result: `Success`,
+                    metadata: {
+                        status: 'success',
+                    },
+                };
+            } catch (e) {
+                return {
+                    result: toolErrorHandler(e, 'Error generating dashboard.'),
+                    metadata: {
+                        status: 'error',
+                    },
+                };
+            }
+        },
+        toModelOutput: (output) => toModelOutput(output),
+    });

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -51,7 +51,7 @@ type Dependencies = {
     enableSelfImprovement: boolean;
 };
 
-const validateQueryTool = (
+export const validateRunQueryTool = (
     queryTool: ToolRunQueryArgsTransformed,
     explore: Explore,
 ) => {
@@ -138,7 +138,7 @@ export const getRunQuery = ({
                     exploreName: queryTool.queryConfig.exploreName,
                 });
 
-                validateQueryTool(queryTool, explore);
+                validateRunQueryTool(queryTool, explore);
 
                 const prompt = await getPrompt();
 

--- a/packages/common/src/ee/AiAgent/followUpTools.ts
+++ b/packages/common/src/ee/AiAgent/followUpTools.ts
@@ -11,6 +11,7 @@ export const followUpToolsText: FollowUpToolsText = {
     [AiResultType.TIME_SERIES_RESULT]: 'Generate a Time Series Chart',
     [AiResultType.QUERY_RESULT]: 'Run Query',
     [AiResultType.DASHBOARD_RESULT]: 'Generate a Dashboard',
+    [AiResultType.DASHBOARD_V2_RESULT]: 'Generate a Dashboard (v2)',
     [AiResultType.IMPROVE_CONTEXT]: 'Improve Context',
     [AiResultType.PROPOSE_CHANGE]: 'Propose a Change',
 };

--- a/packages/common/src/ee/AiAgent/schemas/parser.ts
+++ b/packages/common/src/ee/AiAgent/schemas/parser.ts
@@ -1,6 +1,7 @@
 import assertUnreachable from '../../../utils/assertUnreachable';
 import {
     toolDashboardArgsSchemaTransformed,
+    toolDashboardV2ArgsSchemaTransformed,
     toolFindChartsArgsSchemaTransformed,
     toolFindContentArgsSchema,
     toolFindDashboardsArgsSchemaTransformed,
@@ -42,6 +43,8 @@ export const parseToolArgs = (toolName: ToolName, toolArgs: unknown) => {
             return toolTimeSeriesArgsSchemaTransformed.safeParse(toolArgs);
         case 'generateDashboard':
             return toolDashboardArgsSchemaTransformed.safeParse(toolArgs);
+        case 'generateDashboardV2':
+            return toolDashboardV2ArgsSchemaTransformed.safeParse(toolArgs);
         case 'findDashboards':
             return toolFindDashboardsArgsSchemaTransformed.safeParse(toolArgs);
         case 'findCharts':

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -1,4 +1,5 @@
 export * from './toolDashboardArgs';
+export * from './toolDashboardV2Args';
 export * from './toolFindChartsArgs';
 export * from './toolFindContentArgs';
 export * from './toolFindDashboardsArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardV2Args.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardV2Args.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+import { AiResultType } from '../../types';
+import { baseOutputMetadataSchema } from '../outputMetadata';
+import { createToolSchema } from '../toolSchemaBuilder';
+import {
+    toolRunQueryArgsSchema,
+    toolRunQueryArgsSchemaTransformed,
+} from './toolRunQueryArgs';
+
+export const TOOL_DASHBOARD_V2_DESCRIPTION = `
+
+Use this tool to generate multiple visualizations for a dashboard based on a specific theme.
+
+Instead of making multiple parallel tool calls for individual visualizations, this tool takes an array of visualization configurations and generates them all at once, ensuring thematic consistency and better performance.
+
+Dashboard Design Philosophy:
+Create "summary" or "executive" level dashboards that provide high-level overviews of specific topics (e.g., Support Dashboard, Revenue Performance, Sales Operations). These dashboards should be designed to monitor trends and key metric performance at a glance.
+
+Recommended Dashboard Structure:
+1. **Summary Metrics at the Top**: Start with key performance indicators (KPIs) as tables showing overall summary metrics
+2. **Time-Series Analysis**: Include time-series charts (line or area charts) to show how metrics trend over time
+3. **Categorical Comparisons**: Use bar or horizontal bar charts to compare metrics across categories
+4. **Proportional Analysis**: Use pie charts to show part-to-whole relationships (e.g., market share, revenue by segment)
+5. **Correlation Analysis**: Use scatter plots to explore relationships between two metrics
+6. **Conversion Flows**: Use funnel charts to visualize sequential conversion processes (e.g., sales funnel, user onboarding)
+7. **Detailed Breakdowns**: Add tables with more detail and specific line items that have the biggest impact on metrics
+`;
+
+// Dashboard visualization schema - use runQuery format for each visualization
+const dashboardV2VisualizationSchema = toolRunQueryArgsSchema;
+
+export type DashboardV2Visualization = z.infer<
+    typeof dashboardV2VisualizationSchema
+>;
+
+export const toolDashboardV2ArgsSchema = createToolSchema({
+    type: AiResultType.DASHBOARD_V2_RESULT,
+    description: TOOL_DASHBOARD_V2_DESCRIPTION,
+})
+    .extend({
+        title: z.string().describe('A descriptive title for the dashboard'),
+        description: z
+            .string()
+            .describe(
+                'A descriptive summary or explanation for the dashboard.',
+            ),
+        visualizations: z
+            .array(dashboardV2VisualizationSchema)
+            .min(2)
+            .max(15)
+            .describe(
+                'Array of visualization configurations to generate for this dashboard. Each should contribute to the overall theme and leverage the available chart types (table, bar, horizontal, line, scatter, pie, funnel).',
+            ),
+    })
+    .build();
+
+export type ToolDashboardV2Args = z.infer<typeof toolDashboardV2ArgsSchema>;
+
+export const toolDashboardV2ArgsSchemaTransformed =
+    toolDashboardV2ArgsSchema.transform((data) => ({
+        ...data,
+        visualizations: data.visualizations.map((viz) =>
+            toolRunQueryArgsSchemaTransformed.parse(viz),
+        ),
+    }));
+
+export type ToolDashboardV2ArgsTransformed = z.infer<
+    typeof toolDashboardV2ArgsSchemaTransformed
+>;
+
+export const toolDashboardV2OutputSchema = z.object({
+    result: z.string(),
+    metadata: baseOutputMetadataSchema,
+});
+
+export type ToolDashboardV2Output = z.infer<typeof toolDashboardV2OutputSchema>;

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -14,6 +14,7 @@ const VisualizationTools = [
 export const ToolNameSchema = z.enum([
     ...VisualizationTools,
     'generateDashboard',
+    'generateDashboardV2',
     'findContent',
     'findExplores',
     'findFields',
@@ -42,6 +43,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     generateTableVizConfig: 'Generating a table',
     generateTimeSeriesVizConfig: 'Generating a line chart',
     generateDashboard: 'Generating a dashboard',
+    generateDashboardV2: 'Generating a dashboard',
     findCharts: 'Finding relevant charts',
     improveContext: 'Improving context',
     runQuery: 'Running query',
@@ -58,6 +60,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         generateTableVizConfig: 'Generated a table',
         generateTimeSeriesVizConfig: 'Generated a line chart',
         generateDashboard: 'Generated a dashboard',
+        generateDashboardV2: 'Generated a dashboard',
         findCharts: 'Found relevant charts',
         improveContext: 'Improved context',
         runQuery: 'Ran query',

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -13,6 +13,7 @@ export enum AiResultType {
     TABLE_RESULT = 'table',
     QUERY_RESULT = 'query_result',
     DASHBOARD_RESULT = 'dashboard',
+    DASHBOARD_V2_RESULT = 'dashboard_v2',
     IMPROVE_CONTEXT = 'improve_context',
     PROPOSE_CHANGE = 'propose_change',
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -21,8 +21,8 @@ import {
     IconChartDots3,
     IconChartHistogram,
     IconChartLine,
-    IconDashboard,
     IconDatabase,
+    IconLayoutDashboard,
     IconPencil,
     IconSchool,
     IconSearch,
@@ -51,9 +51,10 @@ const getToolIcon = (toolName: ToolName) => {
             generateBarVizConfig: IconChartHistogram,
             generateTimeSeriesVizConfig: IconChartLine,
             generateTableVizConfig: IconTable,
-            generateDashboard: IconDashboard,
+            generateDashboard: IconLayoutDashboard,
+            generateDashboardV2: IconLayoutDashboard,
             findContent: IconSearch,
-            findDashboards: IconDashboard,
+            findDashboards: IconLayoutDashboard,
             findCharts: IconChartDots3,
             improveContext: IconSchool,
             proposeChange: IconPencil,
@@ -304,6 +305,7 @@ const ToolCallDescription: FC<{
                 </Text>
             );
         case AiResultType.DASHBOARD_RESULT:
+        case AiResultType.DASHBOARD_V2_RESULT:
             const dashboardToolArgs = toolArgs;
             return (
                 <Text c="dimmed" size="xs">

--- a/packages/frontend/src/ee/features/aiCopilot/utils/dashboardChartConverter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/dashboardChartConverter.ts
@@ -2,12 +2,13 @@ import {
     getWebAiChartConfig,
     type ApiAiAgentThreadMessageVizQuery,
     type CreateSavedChartVersion,
+    type DashboardV2Visualization,
     type DashboardVisualization,
 } from '@lightdash/common';
 
 function convertAiVisualizationToCreateSavedChartVersion(
     aiVizData: ApiAiAgentThreadMessageVizQuery,
-    dashboardVisualization: DashboardVisualization,
+    dashboardVisualization: DashboardVisualization | DashboardV2Visualization,
     options: {
         name: string;
         description?: string;
@@ -53,7 +54,7 @@ export function convertDashboardVisualizationsToChartData(
     dashboardConfig: {
         title: string;
         description: string;
-        visualizations: DashboardVisualization[];
+        visualizations: (DashboardVisualization | DashboardV2Visualization)[];
     },
     vizQueryResults: ApiAiAgentThreadMessageVizQuery[],
     options: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Added support for a new Dashboard V2 tool that enables richer chart types including pie charts, scatter plots, and funnel visualizations. This enhancement allows for more diverse data representation in dashboards.

The implementation includes:
- New `generateDashboardV2` tool with improved schema and validation
- Backward compatibility with the original dashboard tool
- Support for parsing both V1 and V2 dashboard configurations
- Updated frontend components to handle the new dashboard type

This enhancement provides users with more visualization options while maintaining compatibility with existing dashboards.

[CleanShot 2025-10-17 at 16.06.36.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/7eeea22b-14f2-4061-9e2e-8a8f21d712bb.mp4" />](https://app.graphite.dev/user-attachments/video/7eeea22b-14f2-4061-9e2e-8a8f21d712bb.mp4)

