### PR TITLE
fix: move role from connection to authentication options in Snowflake client

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -206,7 +206,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 );
             }
             authenticationOptions = {
-                // Do not include username when doing SSO authentication
+                // Do not include username or role when doing SSO authentication
                 token: credentials.token,
                 authenticator: 'OAUTH',
             };
@@ -218,6 +218,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             if (!credentials.privateKeyPass) {
                 authenticationOptions = {
                     username: credentials.user,
+                    role: credentials.role,
                     privateKey: credentials.privateKey,
                     authenticator: 'SNOWFLAKE_JWT',
                 };
@@ -239,6 +240,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
 
                 authenticationOptions = {
                     username: credentials.user,
+                    role: credentials.role,
                     privateKey: privateKey.toString(),
                     authenticator: 'SNOWFLAKE_JWT',
                 };
@@ -246,6 +248,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         } else if (credentials.password) {
             authenticationOptions = {
                 username: credentials.user,
+                role: credentials.role,
                 password: credentials.password,
                 authenticator: 'SNOWFLAKE',
             };
@@ -253,7 +256,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
 
         this.connectionOptions = {
             account: credentials.account,
-            role: credentials.role,
             ...authenticationOptions,
             database: credentials.database,
             schema: credentials.schema,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Reverts lightdash/lightdash#17524

But keeps extra logs, and simplified user/role logic


Before
<img width="504" height="182" alt="Screenshot from 2025-10-17 14-37-01" src="https://github.com/user-attachments/assets/58a32916-a92d-4b0a-8fde-325ea04c0c1f" />

After

<img width="1101" height="354" alt="image" src="https://github.com/user-attachments/assets/e1a74767-8e0a-4462-ba3b-a6fd6ca12408" />



### Description:
This PR updates the Snowflake authentication logic to include the role parameter directly in the authentication options rather than in the connection options. This change ensures the role is properly applied during authentication for JWT, password, and private key authentication methods, while correctly excluding it for SSO authentication.