### PR TITLE
fix: do not override credentials for preview for different warehouse

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -269,6 +269,16 @@ export const mergeWarehouseCredentials = <T extends CreateWarehouseCredentials>(
         return newCredentials;
     }
 
+    // Edge case: if the warehouse is snowflake but with a different warehouse, return newCredentials as-is
+    // This is to avoid enforcing requireUserCredentials on a different snowflake warehouse that might not have SSO enabled or different roles
+    if (
+        baseCredentials.type === WarehouseTypes.SNOWFLAKE &&
+        newCredentials.type === WarehouseTypes.SNOWFLAKE &&
+        baseCredentials.warehouse !== newCredentials.warehouse
+    ) {
+        return newCredentials;
+    }
+
     // We will use new credentials for connection, this might contain new authentication method
     // do not include all baseCredentials here, to avoid conflicts on authentication (that will cause a mix of serviceaccounts/sso/passwords)
     const merged = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added an edge case in `mergeWarehouseCredentials` function to handle Snowflake connections with different warehouses. When connecting to a different Snowflake warehouse, we now return the new credentials as-is instead of merging them with base credentials. This prevents enforcing `requireUserCredentials` on different Snowflake warehouses that might not have SSO enabled or might have different roles.