### PR TITLE
feat: add secondary y-axis support for charts

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/validateAxisFields.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateAxisFields.test.ts
@@ -157,6 +157,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             expect(() =>
@@ -180,6 +182,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             expect(() =>
@@ -205,6 +209,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = ['orders_order_date'];
@@ -231,6 +237,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = [
@@ -263,6 +271,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = ['orders_order_date'];
@@ -293,6 +303,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = ['orders_order_date'];
@@ -323,6 +335,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const tableCalculations: TableCalcsSchema = [
@@ -359,6 +373,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const tableCalculations: TableCalcsSchema = [
@@ -404,6 +420,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: 'Date',
                 yAxisLabel: 'Revenue & Count',
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = ['orders_order_date'];
@@ -435,6 +453,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = ['orders_order_date'];
@@ -463,6 +483,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = ['orders_order_date'];
@@ -491,6 +513,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = ['orders_order_date'];
@@ -519,6 +543,8 @@ describe('validateAxisFields', () => {
                 funnelDataInput: null,
                 xAxisLabel: null,
                 yAxisLabel: null,
+                secondaryYAxisMetric: null,
+                secondaryYAxisLabel: null,
             };
 
             const selectedDimensions = ['orders_order_date'];

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -1037,7 +1037,8 @@ export function validateYAxisMetrics(
 }
 
 /**
- * Validates that xAxisDimension and yAxisMetrics are in selected fields
+ * Validates that xAxisDimension and yAxisMetrics are properly specified
+ * @param explore - The explore containing field definitions
  * @param chartConfig - Chart configuration with axis field definitions
  * @param selectedDimensions - Array of selected dimension field IDs in the query
  * @param selectedMetrics - Array of selected metric field IDs in the query
@@ -1063,6 +1064,15 @@ export function validateAxisFields(
         selectedMetrics,
         tableCalculations,
     );
+    if (chartConfig.secondaryYAxisMetric) {
+        yAxisErrors.push(
+            ...validateYAxisMetrics(
+                [chartConfig.secondaryYAxisMetric],
+                selectedMetrics,
+                tableCalculations,
+            ),
+        );
+    }
 
     const errors = [...xAxisErrors, ...yAxisErrors];
 

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/bar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/bar.ts
@@ -20,6 +20,7 @@ export const getBarChartEchartsConfig = async (
     const { chartConfig } = queryTool;
     const xDimension = chartConfig?.xAxisDimension || dimensions[0];
     const yMetrics = chartConfig?.yAxisMetrics || queryMetrics;
+    const secondaryYAxisMetric = chartConfig?.secondaryYAxisMetric;
     let metrics: string[] = yMetrics;
     let chartData = rows;
 
@@ -37,10 +38,50 @@ export const getBarChartEchartsConfig = async (
 
     const xAxisField = fieldsMap[xDimension];
     const yAxisField = yMetrics[0] ? fieldsMap[yMetrics[0]] : undefined;
+    const secondaryYAxisField = secondaryYAxisMetric
+        ? fieldsMap[secondaryYAxisMetric]
+        : undefined;
 
     const primarySort = sorts?.[0];
     const shouldInverseXAxis =
         primarySort?.fieldId === xDimension && primarySort?.descending === true;
+
+    // Build yAxis array based on whether secondary axis is specified
+    const yAxisConfig = secondaryYAxisMetric
+        ? [
+              {
+                  type: 'value' as const,
+                  ...getCartesianAxisFormatterConfig({
+                      axisItem: yAxisField,
+                      show: true,
+                  }),
+                  ...(chartConfig?.yAxisLabel
+                      ? { name: chartConfig.yAxisLabel }
+                      : {}),
+              },
+              {
+                  type: 'value' as const,
+                  ...getCartesianAxisFormatterConfig({
+                      axisItem: secondaryYAxisField,
+                      show: true,
+                  }),
+                  ...(chartConfig?.secondaryYAxisLabel
+                      ? { name: chartConfig.secondaryYAxisLabel }
+                      : {}),
+              },
+          ]
+        : [
+              {
+                  type: 'value' as const,
+                  ...getCartesianAxisFormatterConfig({
+                      axisItem: yAxisField,
+                      show: true,
+                  }),
+                  ...(chartConfig?.yAxisLabel
+                      ? { name: chartConfig.yAxisLabel }
+                      : {}),
+              },
+          ];
 
     return {
         ...getCommonEChartsConfig(
@@ -60,26 +101,38 @@ export const getBarChartEchartsConfig = async (
                 ...(shouldInverseXAxis ? { inverse: true } : {}),
             },
         ],
-        yAxis: [
-            {
-                type: 'value',
-                ...getCartesianAxisFormatterConfig({
-                    axisItem: yAxisField,
-                    show: true,
-                }),
-            },
+        yAxis: yAxisConfig,
+        series: [
+            ...metrics.map((metric) => ({
+                type: 'bar' as const,
+                yAxisIndex: 0,
+                // Use formatted label for non-pivoted metrics, otherwise use the metric name as-is (already formatted by pivot)
+                name: yMetrics.includes(metric)
+                    ? formatFieldLabel(metric, fieldsMap)
+                    : metric,
+                encode: {
+                    x: xDimension,
+                    y: metric,
+                },
+                ...(chartConfig?.stackBars ? { stack: 'stack' } : {}),
+            })),
+            ...(secondaryYAxisMetric
+                ? [
+                      {
+                          type: 'bar' as const,
+                          yAxisIndex: 1,
+                          name: formatFieldLabel(
+                              secondaryYAxisMetric,
+                              fieldsMap,
+                          ),
+                          encode: {
+                              x: xDimension,
+                              y: secondaryYAxisMetric,
+                          },
+                          ...(chartConfig?.stackBars ? { stack: 'stack' } : {}),
+                      },
+                  ]
+                : []),
         ],
-        series: metrics.map((metric) => ({
-            type: 'bar',
-            // Use formatted label for non-pivoted metrics, otherwise use the metric name as-is (already formatted by pivot)
-            name: yMetrics.includes(metric)
-                ? formatFieldLabel(metric, fieldsMap)
-                : metric,
-            encode: {
-                x: xDimension,
-                y: metric,
-            },
-            ...(chartConfig?.stackBars ? { stack: 'stack' } : {}),
-        })),
     };
 };

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/line.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/line.ts
@@ -20,6 +20,7 @@ export const getLineChartEchartsConfig = async (
     const { chartConfig } = queryTool;
     const xDimension = chartConfig?.xAxisDimension || dimensions[0];
     const yMetrics = chartConfig?.yAxisMetrics || queryMetrics;
+    const secondaryYAxisMetric = chartConfig?.secondaryYAxisMetric;
     let metrics: string[] = yMetrics;
     let chartData = rows;
 
@@ -37,10 +38,50 @@ export const getLineChartEchartsConfig = async (
 
     const xAxisField = fieldsMap[xDimension];
     const yAxisField = yMetrics[0] ? fieldsMap[yMetrics[0]] : undefined;
+    const secondaryYAxisField = secondaryYAxisMetric
+        ? fieldsMap[secondaryYAxisMetric]
+        : undefined;
 
     const primarySort = sorts?.[0];
     const shouldInverseXAxis =
         primarySort?.fieldId === xDimension && primarySort?.descending === true;
+
+    // Build yAxis array based on whether secondary axis is specified
+    const yAxisConfig = secondaryYAxisMetric
+        ? [
+              {
+                  type: 'value' as const,
+                  ...getCartesianAxisFormatterConfig({
+                      axisItem: yAxisField,
+                      show: true,
+                  }),
+                  ...(chartConfig?.yAxisLabel
+                      ? { name: chartConfig.yAxisLabel }
+                      : {}),
+              },
+              {
+                  type: 'value' as const,
+                  ...getCartesianAxisFormatterConfig({
+                      axisItem: secondaryYAxisField,
+                      show: true,
+                  }),
+                  ...(chartConfig?.secondaryYAxisLabel
+                      ? { name: chartConfig.secondaryYAxisLabel }
+                      : {}),
+              },
+          ]
+        : [
+              {
+                  type: 'value' as const,
+                  ...getCartesianAxisFormatterConfig({
+                      axisItem: yAxisField,
+                      show: true,
+                  }),
+                  ...(chartConfig?.yAxisLabel
+                      ? { name: chartConfig.yAxisLabel }
+                      : {}),
+              },
+          ];
 
     return {
         ...getCommonEChartsConfig(
@@ -60,29 +101,44 @@ export const getLineChartEchartsConfig = async (
                 ...(shouldInverseXAxis ? { inverse: true } : {}),
             },
         ],
-        yAxis: [
-            {
-                type: 'value',
-                ...getCartesianAxisFormatterConfig({
-                    axisItem: yAxisField,
-                    show: true,
+        yAxis: yAxisConfig,
+        series: [
+            ...metrics.map((metric) => ({
+                type: 'line' as const,
+                yAxisIndex: 0,
+                // Use formatted label for non-pivoted metrics, otherwise use the metric name as-is (already formatted by pivot)
+                name: yMetrics.includes(metric)
+                    ? formatFieldLabel(metric, fieldsMap)
+                    : metric,
+                encode: {
+                    x: xDimension,
+                    y: metric,
+                },
+                ...(chartConfig?.lineType === 'area' && {
+                    areaStyle: {},
                 }),
-            },
+                showSymbol: true,
+            })),
+            ...(secondaryYAxisMetric
+                ? [
+                      {
+                          type: 'line' as const,
+                          yAxisIndex: 1,
+                          name: formatFieldLabel(
+                              secondaryYAxisMetric,
+                              fieldsMap,
+                          ),
+                          encode: {
+                              x: xDimension,
+                              y: secondaryYAxisMetric,
+                          },
+                          ...(chartConfig?.lineType === 'area' && {
+                              areaStyle: {},
+                          }),
+                          showSymbol: true,
+                      },
+                  ]
+                : []),
         ],
-        series: metrics.map((metric) => ({
-            type: 'line',
-            // Use formatted label for non-pivoted metrics, otherwise use the metric name as-is (already formatted by pivot)
-            name: yMetrics.includes(metric)
-                ? formatFieldLabel(metric, fieldsMap)
-                : metric,
-            encode: {
-                x: xDimension,
-                y: metric,
-            },
-            ...(chartConfig?.lineType === 'area' && {
-                areaStyle: {},
-            }),
-            showSymbol: true,
-        })),
     };
 };

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -115,6 +115,16 @@ const chartConfigSchema = z
             .string()
             .nullable()
             .describe('A helpful label to explain the y-axis'),
+        secondaryYAxisMetric: z
+            .string()
+            .nullable()
+            .describe(
+                '(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).',
+            ),
+        secondaryYAxisLabel: z
+            .string()
+            .nullable()
+            .describe('A helpful label for the secondary y-axis'),
     })
     .nullable();
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -242,6 +242,8 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
         return null;
     }
 
+    console.log(unsavedChartVersion.chartConfig);
+
     return (
         <ErrorBoundary>
             <VisualizationProvider

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -124,6 +124,12 @@ export const AiVisualizationRenderer: FC<Props> = ({
         );
     }
 
+    console.log(
+        'chartConfigFromAiAgentVizConfig',
+        chartConfigFromAiAgentVizConfig.echartsConfig,
+        groupByDimensions,
+    );
+
     return (
         <MetricQueryDataProvider
             metricQuery={metricQuery}

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiVisualizationRenderer/getComputedSeries.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiVisualizationRenderer/getComputedSeries.ts
@@ -57,5 +57,6 @@ export const getComputedSeries = ({
         expectedSeriesMap,
         existingSeries: echartsConfig.config?.eChartsConfig?.series || [],
     });
+    console.log('newSeries', newSeries);
     return newSeries;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added support for secondary Y-axis in charts to handle metrics with different scales. This feature allows users to specify a single metric to display on a secondary (right) Y-axis with its own scale and label.

The implementation includes:

- Added `secondaryYAxisMetric` and `secondaryYAxisLabel` fields to chart configuration
- Created validation logic to ensure the secondary axis metric is properly specified
- Updated bar and line chart rendering to support the secondary Y-axis in both web and Slack visualizations
- Added test coverage for the new validation logic
