### PR TITLE
fix: use fieldsWithOverrides instead of fields in AsyncQueryService

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2371,6 +2371,7 @@ export class AsyncQueryService extends ProjectService {
 
         const {
             sql,
+            fields: fieldsWithOverrides,
             parameterReferences,
             missingParameterReferences,
             usedParameters,
@@ -2395,7 +2396,7 @@ export class AsyncQueryService extends ProjectService {
                 queryTags,
                 invalidateCache,
                 dateZoom,
-                fields,
+                fields: fieldsWithOverrides,
                 sql,
                 originalColumns: undefined,
                 missingParameterReferences,
@@ -2409,7 +2410,7 @@ export class AsyncQueryService extends ProjectService {
             cacheMetadata,
             appliedDashboardFilters,
             metricQuery: metricQueryWithLimit,
-            fields,
+            fields: fieldsWithOverrides,
             parameterReferences,
             usedParametersValues: usedParameters,
         };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17537

### Description:
This PR fixes a bug in the AsyncQueryService where field overrides were not being properly passed through to the query results. The issue was that the `fields` variable was being used directly instead of the `fieldsWithOverrides` that contains any field customizations. This ensures that any field customizations made by users are correctly reflected in the query results.