### PR TITLE
feat: add organization warehouse credentials feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -251,6 +251,9 @@ export const lightdashConfigMock: LightdashConfig = {
     serviceAccount: {
         enabled: false,
     },
+    organizationWarehouseCredentials: {
+        enabled: false,
+    },
     googleCloudPlatform: {
         projectId: 'test-project-id',
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -766,6 +766,9 @@ export type LightdashConfig = {
     serviceAccount: {
         enabled: boolean;
     };
+    organizationWarehouseCredentials: {
+        enabled: boolean;
+    };
     github: {
         appName: string;
         redirectDomain: string;
@@ -1582,6 +1585,11 @@ export const parseConfig = (): LightdashConfig => {
         },
         serviceAccount: {
             enabled: process.env.SERVICE_ACCOUNT_ENABLED === 'true',
+        },
+        organizationWarehouseCredentials: {
+            enabled:
+                process.env.ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED ===
+                'true',
         },
         github: {
             appName: process.env.GITHUB_APP_NAME || 'lightdash-app-dev',

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -92,6 +92,7 @@ export const BaseResponse: HealthState = {
         overrideColorPaletteName: undefined,
     },
     isServiceAccountEnabled: false,
+    isOrganizationWarehouseCredentialsEnabled: false,
     isCustomRolesEnabled: false,
     embedding: { enabled: false, events: undefined },
     ai: {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -171,6 +171,8 @@ export class HealthService extends BaseService {
             hasMicrosoftTeams: this.lightdashConfig.microsoftTeams.enabled,
             isServiceAccountEnabled:
                 this.lightdashConfig.serviceAccount.enabled,
+            isOrganizationWarehouseCredentialsEnabled:
+                this.lightdashConfig.organizationWarehouseCredentials.enabled,
             isCustomRolesEnabled:
                 this.isEnterpriseEnabled() &&
                 this.lightdashConfig.customRoles.enabled,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1055,6 +1055,7 @@ export type HealthState = {
     hasEmailClient: boolean;
     hasMicrosoftTeams: boolean;
     isServiceAccountEnabled: boolean;
+    isOrganizationWarehouseCredentialsEnabled: boolean;
     latest: {
         version?: string;
     };

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -148,9 +148,14 @@ const Settings: FC = () => {
     const isServiceAccountsEnabled =
         health?.isServiceAccountEnabled || isServiceAccountFeatureFlagEnabled;
 
-    const isWarehouseCredentialsEnabled = useFeatureFlagEnabled(
+    const isWarehouseCredentialsFeatureFlagEnabled = useFeatureFlagEnabled(
         CommercialFeatureFlags.OrganizationWarehouseCredentials,
     );
+
+    // This allows us to enable organization warehouse credentials in the UI for on-premise installations
+    const isWarehouseCredentialsEnabled =
+        (health?.isOrganizationWarehouseCredentialsEnabled ?? false) ||
+        isWarehouseCredentialsFeatureFlagEnabled;
 
     const routes = useMemo<RouteObject[]>(() => {
         const allowedRoutes: RouteObject[] = [

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -90,6 +90,7 @@ export default function mockHealthResponse(
             overrideColorPaletteName: undefined,
         },
         isServiceAccountEnabled: false,
+        isOrganizationWarehouseCredentialsEnabled: false,
         isCustomRolesEnabled: false,
         embedding: {
             enabled: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Added configuration for organization warehouse credentials, allowing on-premise installations to enable this feature through environment variables. The feature can now be enabled either through the `ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED` environment variable or through feature flags.

This PR also adds the AI Agent feature flag to the commercial feature flag model, which enables the "Ask AI" button when configured.