### PR TITLE
fix: pass xAxisField to stack100TooltipFormatter for correct value lookup

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -685,6 +685,7 @@ export class CartesianChartDataModel {
                             return undefined;
                         return dimensionNames[yFieldIndex];
                     },
+                    xAxisReference,
                 ),
             };
         } else if (xAxisType === VizIndexType.TIME && xAxisReference) {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2089,6 +2089,7 @@ const useEchartsCartesianConfig = (
                                     : undefined;
                             }
                         },
+                        xFieldId,
                     )(params as TooltipParam[]);
                     return s;
                 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/pull/17434

Before:

<img width="883" height="560" alt="Screenshot from 2025-10-20 15-24-44" src="https://github.com/user-attachments/assets/935c83d8-3df9-4c61-a16a-68c37eff6d78" />

After:

<img width="649" height="455" alt="image" src="https://github.com/user-attachments/assets/ee4c6ca6-9aae-4024-bd37-d18aa2053439" />


### Description:
Fixed stack100 tooltip formatter to correctly display original values by passing the x-axis field reference to the formatter function. Previously, the formatter was using the formatted display value as a key to look up original values, which could cause mismatches. Now it properly extracts the raw x-axis value from the data object for accurate lookups in the originalValues map.