### PR TITLE
fix: new post-calculation metric types were incorrectly plotted as category

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -128,6 +128,9 @@ export const getAxisTypeFromField = (
             case MetricType.SUM:
             case MetricType.MIN:
             case MetricType.MAX:
+            case MetricType.PERCENT_OF_PREVIOUS:
+            case MetricType.PERCENT_OF_TOTAL:
+            case MetricType.RUNNING_TOTAL:
                 return 'value';
             case DimensionType.TIMESTAMP:
             case MetricType.TIMESTAMP:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/17437

### Description:
Added support for new metric types in the `getAxisTypeFromField` function. The function now handles `PERCENT_OF_PREVIOUS`, `PERCENT_OF_TOTAL`, and `RUNNING_TOTAL` metric types, returning 'value' as the axis type for these metrics.

**Before**
![image.png](https://app.graphite.dev/user-attachments/assets/e3ba0825-2fc2-4267-97e9-ba2685a63d3f.png)

**After**
![image.png](https://app.graphite.dev/user-attachments/assets/d90d791b-2199-4660-b16e-80253096e10c.png)

**Steps to test**
1. Create chart with dimension and post-calculation metric type
2. Run query
3. Open chart

