### PR TITLE
fix: keep pivot dimensions when changing to table viz

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -390,7 +390,6 @@ const VisualizationCardOptions: FC = memo(() => {
                     }
                     icon={<MantineIcon icon={IconTable} />}
                     onClick={() => {
-                        setPivotDimensions(undefined);
                         setStacking(undefined);
                         setCartesianType(undefined);
                         setChartType(ChartType.TABLE);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Removed the `setPivotDimensions(undefined)` call when switching to table visualization type. This allows pivot dimensions to be preserved when toggling between table and other chart types.

This was already the case when going from `table` to `cartesian`, pivot dimensions were kept.


https://github.com/user-attachments/assets/9c8f257a-8f91-47ef-a40d-eae57825b171



