### PR TITLE
feat: project compile model

### DIFF
--- a/packages/backend/src/database/entities/projectCompileLog.ts
+++ b/packages/backend/src/database/entities/projectCompileLog.ts
@@ -1,0 +1,61 @@
+import { CompilationHistoryReport } from '@lightdash/common';
+import { Knex } from 'knex';
+import { z } from 'zod';
+
+export const ProjectCompileLogTableName = 'project_compile_log';
+
+export const CompilationSourceSchema = z.enum([
+    'cli_deploy',
+    'refresh_dbt',
+    'create_project',
+]);
+export type CompilationSource = z.infer<typeof CompilationSourceSchema>;
+
+export const DbProjectCompileLogSchema = z.object({
+    project_compile_log_id: z.string().uuid(),
+    project_uuid: z.string().uuid(),
+    job_uuid: z.string().uuid().nullable(),
+    user_uuid: z.string().uuid().nullable(),
+    organization_uuid: z.string().uuid(),
+    created_at: z.date(),
+    compilation_source: CompilationSourceSchema,
+    dbt_connection_type: z.string().nullable(),
+    request_method: z.string().nullable(),
+    warehouse_type: z.string().nullable(),
+    report: z.string(),
+});
+
+export type DbProjectCompileLog = z.infer<typeof DbProjectCompileLogSchema>;
+
+export const DbProjectCompileLogInsertSchema = DbProjectCompileLogSchema.omit({
+    project_compile_log_id: true,
+    created_at: true,
+});
+
+export type DbProjectCompileLogInsert = z.infer<
+    typeof DbProjectCompileLogInsertSchema
+>;
+
+export type ProjectCompileLogTable = Knex.CompositeTableType<
+    DbProjectCompileLog,
+    DbProjectCompileLogInsert
+>;
+
+export type ProjectCompileLog = {
+    projectCompileLogId: string;
+    projectUuid: string;
+    jobUuid: string | null;
+    userUuid: string | null;
+    organizationUuid: string;
+    createdAt: Date;
+    compilationSource: CompilationSource;
+    dbtConnectionType: string | null;
+    requestMethod: string | null;
+    warehouseType: string | null;
+    report: CompilationHistoryReport;
+};
+
+export type ProjectCompileLogInsert = Omit<
+    ProjectCompileLog,
+    'projectCompileLogId' | 'createdAt'
+>;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -220,6 +220,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
                         models.getOrganizationWarehouseCredentialsModel(),
+                    projectCompileLogModel: models.getProjectCompileLogModel(),
                 }),
             instanceConfigurationService: ({
                 models,
@@ -291,6 +292,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     pivotTableService: repository.getPivotTableService(),
                     prometheusMetrics,
                     permissionsService: repository.getPermissionsService(),
+                    projectCompileLogModel: models.getProjectCompileLogModel(),
                 }),
             cacheService: ({ models, context, clients }) =>
                 new CommercialCacheService({

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -29,6 +29,7 @@ import { OrganizationModel } from './OrganizationModel';
 import { OrganizationWarehouseCredentialsModel } from './OrganizationWarehouseCredentialsModel';
 import { PasswordResetLinkModel } from './PasswordResetLinkModel';
 import { PinnedListModel } from './PinnedListModel';
+import { ProjectCompileLogModel } from './ProjectCompileLogModel';
 import { ProjectModel } from './ProjectModel/ProjectModel';
 import { ProjectParametersModel } from './ProjectParametersModel';
 import { QueryHistoryModel } from './QueryHistoryModel/QueryHistoryModel';
@@ -81,6 +82,7 @@ export type ModelManifest = {
     personalAccessTokenModel: PersonalAccessTokenModel;
     pinnedListModel: PinnedListModel;
     projectModel: ProjectModel;
+    projectCompileLogModel: ProjectCompileLogModel;
     resourceViewItemModel: ResourceViewItemModel;
     rolesModel: RolesModel;
     savedChartModel: SavedChartModel;
@@ -411,6 +413,13 @@ export class ModelRepository
                     lightdashConfig: this.lightdashConfig,
                     encryptionUtil: this.utils.getEncryptionUtil(),
                 }),
+        );
+    }
+
+    public getProjectCompileLogModel(): ProjectCompileLogModel {
+        return this.getModel(
+            'projectCompileLogModel',
+            () => new ProjectCompileLogModel({ database: this.database }),
         );
     }
 

--- a/packages/backend/src/models/ProjectCompileLogModel.ts
+++ b/packages/backend/src/models/ProjectCompileLogModel.ts
@@ -1,0 +1,76 @@
+import { type CompilationHistoryReport } from '@lightdash/common';
+import { type Knex } from 'knex';
+import {
+    DbProjectCompileLog,
+    ProjectCompileLogInsert,
+    ProjectCompileLogTableName,
+    type ProjectCompileLog,
+} from '../database/entities/projectCompileLog';
+
+export type { ProjectCompileLog };
+
+export class ProjectCompileLogModel {
+    private database: Knex;
+
+    constructor(args: { database: Knex }) {
+        this.database = args.database;
+    }
+
+    async insert(data: ProjectCompileLogInsert): Promise<string> {
+        const [row] = await this.database(ProjectCompileLogTableName)
+            .insert({
+                project_uuid: data.projectUuid,
+                job_uuid: data.jobUuid,
+                user_uuid: data.userUuid,
+                organization_uuid: data.organizationUuid,
+                compilation_source: data.compilationSource,
+                dbt_connection_type: data.dbtConnectionType,
+                request_method: data.requestMethod,
+                warehouse_type: data.warehouseType,
+                report: JSON.stringify(data.report),
+            })
+            .returning('project_compile_log_id');
+
+        return row.project_compile_log_id;
+    }
+
+    async getByProject(
+        projectUuid: string,
+        limit: number = 50,
+    ): Promise<ProjectCompileLog[]> {
+        const rows = await this.database(ProjectCompileLogTableName)
+            .where('project_uuid', projectUuid)
+            .orderBy('created_at', 'desc')
+            .limit(limit);
+
+        return rows.map(this.mapRow);
+    }
+
+    async getByJob(jobUuid: string): Promise<ProjectCompileLog | undefined> {
+        const row = await this.database(ProjectCompileLogTableName)
+            .where('job_uuid', jobUuid)
+            .first();
+
+        return row ? this.mapRow(row) : undefined;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private mapRow(row: DbProjectCompileLog): ProjectCompileLog {
+        return {
+            projectCompileLogId: row.project_compile_log_id,
+            projectUuid: row.project_uuid,
+            jobUuid: row.job_uuid,
+            userUuid: row.user_uuid,
+            organizationUuid: row.organization_uuid,
+            createdAt: row.created_at,
+            compilationSource: row.compilation_source,
+            dbtConnectionType: row.dbt_connection_type,
+            requestMethod: row.request_method,
+            warehouseType: row.warehouse_type,
+            report:
+                typeof row.report === 'string'
+                    ? JSON.parse(row.report)
+                    : row.report,
+        };
+    }
+}

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -33,6 +33,7 @@ import type { GroupsModel } from '../../models/GroupsModel';
 import type { JobModel } from '../../models/JobModel/JobModel';
 import type { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import type { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
+import type { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { projectUuid } from '../../models/ProjectModel/ProjectModel.mock';
 import { ProjectParametersModel } from '../../models/ProjectParametersModel';
@@ -192,6 +193,7 @@ const getMockedAsyncQueryService = (
         projectParametersModel: {} as ProjectParametersModel,
         organizationWarehouseCredentialsModel:
             {} as OrganizationWarehouseCredentialsModel,
+        projectCompileLogModel: {} as ProjectCompileLogModel,
         pivotTableService: new PivotTableService({
             lightdashConfig,
             s3Client: {} as S3Client,

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -16,6 +16,7 @@ import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
+import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../models/ProjectParametersModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
@@ -73,6 +74,7 @@ describe('Csv service', () => {
             projectParametersModel: {} as ProjectParametersModel,
             organizationWarehouseCredentialsModel:
                 {} as OrganizationWarehouseCredentialsModel,
+            projectCompileLogModel: {} as ProjectCompileLogModel,
         }),
         s3Client: {} as S3Client,
         savedChartModel: {} as SavedChartModel,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -23,6 +23,7 @@ import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
+import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../models/ProjectParametersModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
@@ -158,6 +159,7 @@ const getMockedProjectService = (lightdashConfig: LightdashConfig) =>
         } as unknown as ProjectParametersModel,
         organizationWarehouseCredentialsModel:
             {} as unknown as OrganizationWarehouseCredentialsModel,
+        projectCompileLogModel: {} as ProjectCompileLogModel,
     });
 
 const account = buildAccount({

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -201,6 +201,7 @@ import { GroupsModel } from '../../models/GroupsModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { OrganizationWarehouseCredentialsModel } from '../../models/OrganizationWarehouseCredentialsModel';
+import { ProjectCompileLogModel } from '../../models/ProjectCompileLogModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../models/ProjectParametersModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
@@ -272,6 +273,7 @@ export type ProjectServiceArguments = {
     featureFlagModel: FeatureFlagModel;
     projectParametersModel: ProjectParametersModel;
     organizationWarehouseCredentialsModel: OrganizationWarehouseCredentialsModel;
+    projectCompileLogModel: ProjectCompileLogModel;
 };
 
 export class ProjectService extends BaseService {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -554,6 +554,8 @@ export class ServiceRepository
                         this.models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
                         this.models.getOrganizationWarehouseCredentialsModel(),
+                    projectCompileLogModel:
+                        this.models.getProjectCompileLogModel(),
                 }),
         );
     }
@@ -599,6 +601,8 @@ export class ServiceRepository
                         this.models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
                         this.models.getOrganizationWarehouseCredentialsModel(),
+                    projectCompileLogModel:
+                        this.models.getProjectCompileLogModel(),
                     pivotTableService: this.getPivotTableService(),
                     prometheusMetrics: this.prometheusMetrics,
                     permissionsService: this.getPermissionsService(),

--- a/packages/common/src/compiler/compilationReport.ts
+++ b/packages/common/src/compiler/compilationReport.ts
@@ -1,0 +1,48 @@
+import type { Explore, ExploreError } from '../types/explore';
+import { isExploreError } from '../types/explore';
+import { getDimensions, getMetrics } from '../utils/fields';
+
+export type CompilationHistoryReport = {
+    totalExploresCount: number;
+    successfulExploresCount: number;
+    errorExploresCount: number;
+    metricsCount: number;
+    dimensionsCount: number;
+    exploresWithErrors: ExploreError[];
+    baseTableNames: string[];
+};
+
+export const calculateCompilationReport = (args: {
+    explores: (Explore | ExploreError)[];
+}): CompilationHistoryReport => {
+    const exploresWithErrors: ExploreError[] = [];
+    const baseTableNames: string[] = [];
+    let successfulExploresCount = 0;
+    let metricsCount = 0;
+    let dimensionsCount = 0;
+
+    args.explores.forEach((explore) => {
+        if (isExploreError(explore)) {
+            exploresWithErrors.push(explore);
+        } else {
+            successfulExploresCount += 1;
+            baseTableNames.push(explore.baseTable);
+
+            const metrics = getMetrics(explore);
+            const dimensions = getDimensions(explore);
+
+            metricsCount += metrics.length;
+            dimensionsCount += dimensions.length;
+        }
+    });
+
+    return {
+        totalExploresCount: args.explores.length,
+        successfulExploresCount,
+        errorExploresCount: exploresWithErrors.length,
+        metricsCount,
+        dimensionsCount,
+        exploresWithErrors,
+        baseTableNames,
+    };
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -54,6 +54,7 @@ export * from './authorization/roleToScopeMapping';
 export * from './authorization/scopes';
 export * from './authorization/serviceAccountAbility';
 export * from './authorization/types';
+export * from './compiler/compilationReport';
 export * from './compiler/exploreCompiler';
 export * from './compiler/filtersCompiler';
 export * from './compiler/parameters';


### PR DESCRIPTION
### Description:
Added a new `ProjectCompileLogModel` to track and store compilation history for projects. This model captures details about project compilations including source, connection types, and compilation reports with metrics like successful explores count, error count, and field counts.

The implementation includes:
- New `ProjectCompileLogModel` with methods to insert and retrieve compilation logs
- `CompilationHistoryReport` type and utility function in common package
- Integration with enterprise app arguments to make the model available to services

This will enable tracking of compilation history and performance metrics across different compilation sources (CLI deploy, refresh dbt, create project).