### PR TITLE
feat: log report on project compilation

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -193,13 +193,13 @@ const getMockedAsyncQueryService = (
         projectParametersModel: {} as ProjectParametersModel,
         organizationWarehouseCredentialsModel:
             {} as OrganizationWarehouseCredentialsModel,
-        projectCompileLogModel: {} as ProjectCompileLogModel,
         pivotTableService: new PivotTableService({
             lightdashConfig,
             s3Client: {} as S3Client,
             downloadFileModel: {} as DownloadFileModel,
         }),
         permissionsService: {} as PermissionsService,
+        projectCompileLogModel: {} as ProjectCompileLogModel,
         ...overrides,
     });
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -601,11 +601,11 @@ export class ServiceRepository
                         this.models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
                         this.models.getOrganizationWarehouseCredentialsModel(),
-                    projectCompileLogModel:
-                        this.models.getProjectCompileLogModel(),
                     pivotTableService: this.getPivotTableService(),
                     prometheusMetrics: this.prometheusMetrics,
                     permissionsService: this.getPermissionsService(),
+                    projectCompileLogModel:
+                        this.models.getProjectCompileLogModel(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17517

### Description:
Added compilation logging for dbt projects. This PR introduces a new feature that logs compilation results when projects are created, refreshed, or deployed via CLI. The logs include details such as the compilation source, connection types, and a report of successful and failed explores.

The implementation:
- Adds `ProjectCompileLogModel` to relevant services
- Tracks compilation source ('cli_deploy', 'refresh_dbt', or 'create_project')
- Captures job UUID and request method when available
- Generates compilation reports with metrics on explore counts and errors
- Logs this information when explores are saved to cache