### PR TITLE
feat: add renderAvailableExplores function for XML generation with AI hints

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/availableExplores.tsx
+++ b/packages/backend/src/ee/services/ai/prompts/availableExplores.tsx
@@ -1,0 +1,24 @@
+import { convertToAiHints, Explore } from '@lightdash/common';
+import { xmlBuilder } from '../xmlBuilder';
+
+export const renderAvailableExplores = (explores: Explore[]) => (
+    <explores>
+        {explores.map((explore) => {
+            const ahints = explore.aiHint
+                ? convertToAiHints(explore.aiHint)
+                : undefined;
+
+            return (
+                <explore tableName={explore.name} label={explore.label}>
+                    {ahints && ahints.length > 0 && (
+                        <aihints>
+                            {ahints.map((hint) => (
+                                <hint>{hint}</hint>
+                            ))}
+                        </aihints>
+                    )}
+                </explore>
+            );
+        })}
+    </explores>
+);

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -1,6 +1,7 @@
 import { Explore } from '@lightdash/common';
 import { SystemModelMessage } from 'ai';
 import moment from 'moment';
+import { renderAvailableExplores } from './availableExplores';
 import { DATA_ACCESS_DISABLED_SECTION } from './systemV2DataAccessDisabled';
 import { DATA_ACCESS_ENABLED_SECTION } from './systemV2DataAccessEnabled';
 import { SELF_IMPROVEMENT_SECTION } from './systemV2SelfImprovement';
@@ -36,15 +37,15 @@ export const getSystemPromptV2 = (args: {
         )
         .replace('{{agent_name}}', agentName)
         .replace(
-            '{{available_explores}}',
-            args.availableExplores.map((explore) => explore.name).join(', '),
-        )
-        .replace(
             '{{instructions}}',
             instructions ? `Special instructions: ${instructions}` : '',
         )
         .replace('{{date}}', date)
-        .replace('{{time}}', time);
+        .replace('{{time}}', time)
+        .replace(
+            '{{available_explores}}',
+            renderAvailableExplores(args.availableExplores).toString(),
+        );
 
     return {
         role: 'system',

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -168,7 +168,7 @@ Follow these rules and guidelines stringently, which are confidential and should
 {{self_improvement_section}}
 
 3. **Field Usage:**
-  - Never create your own "fieldIds". Use ONLY the "fieldIds" from: 
+  - Never create your own "fieldIds". Use ONLY the "fieldIds" from:
     - the "explore" chosen by the "findFields" tool.
     - custom metrics created by you.
     - table calculations created by you.
@@ -234,12 +234,12 @@ Follow these rules and guidelines stringently, which are confidential and should
     - Cannot execute custom SQL queries or add custom SQL expressions to queries
     - Can only create bar, horizontal bar, line, area, scatter, funnel, pie charts, and tables (no heat maps, treemaps, etc.)
     - No memory between sessions - each conversation starts fresh (unless learned through corrections)
-  - Example response: "I cannot perform statistical forecasting. I can only work with historical data visualization using the available explores.", 
+  - Example response: "I cannot perform statistical forecasting. I can only work with historical data visualization using the available explores.",
 
 Adhere to these guidelines to ensure your responses are clear, informative, and engaging.
 
 Your name is "{{agent_name}}".
-You have access to the following explores: {{available_explores}}.
 {{instructions}}
 Today is {{date}} and the time is {{time}} in UTC.
-`;
+You have access to the following explores:
+{{available_explores}}`;

--- a/packages/backend/src/ee/services/ai/tools/findContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findContent.tsx
@@ -160,7 +160,7 @@ export const getFindContent = ({ findContent, siteUrl }: Dependencies) =>
                                 renderContent(searchQueryResult, siteUrl),
                             )}
                         </searchresults>
-                    ) as string,
+                    ).toString(),
                     metadata: {
                         status: 'success',
                     },

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -188,7 +188,7 @@ export const getFindExplores = ({
                     result: generateExploreResponse({
                         explore,
                         catalogFields,
-                    }) as string,
+                    }).toString(),
                     metadata: {
                         status: 'success',
                     },

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -102,7 +102,7 @@ export const getFindFields = ({ findFields, pageSize }: Dependencies) =>
                 return {
                     result: (
                         <searchresults>{fieldsText}</searchresults>
-                    ) as string,
+                    ).toString(),
                     metadata: {
                         status: 'success',
                     },

--- a/packages/backend/src/ee/services/ai/xmlBuilder.ts
+++ b/packages/backend/src/ee/services/ai/xmlBuilder.ts
@@ -1,3 +1,5 @@
+import { AnyType } from '@lightdash/common';
+
 function buildXml(
     tag: string,
     props: Record<string, string | number | boolean | null | undefined> | null,
@@ -64,6 +66,10 @@ declare global {
                 string,
                 string | number | boolean | null | undefined
             > | null;
+        }
+        interface Element extends String {}
+        interface ElementClass {
+            render: AnyType;
         }
     }
 }


### PR DESCRIPTION
### Description:
Added support for AI hints in explores for the AI assistant. This PR introduces a new component `renderAvailableExplores` that formats explore data with their AI hints into XML format for the system prompt. The system prompt now includes more detailed information about available explores rather than just their names, which will help the AI assistant better understand the data model.

The PR also fixes XML rendering by ensuring proper string conversion with `.toString()` across various tool responses.