### PR TITLE
fix: use fieldsWithOverrides instead of fields in AsyncQueryService

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2106,6 +2106,7 @@ export class AsyncQueryService extends ProjectService {
 
         const {
             sql,
+            fields: fieldsWithOverrides,
             warnings,
             parameterReferences,
             missingParameterReferences,
@@ -2129,7 +2130,7 @@ export class AsyncQueryService extends ProjectService {
                 queryTags,
                 invalidateCache,
                 metricQuery: metricQueryWithLimit,
-                fields,
+                fields: fieldsWithOverrides,
                 sql,
                 originalColumns: undefined,
                 missingParameterReferences,
@@ -2142,7 +2143,7 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             cacheMetadata,
             metricQuery: metricQueryWithLimit,
-            fields,
+            fields: fieldsWithOverrides,
             warnings,
             parameterReferences,
             usedParametersValues: usedParameters,

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -196,10 +196,13 @@ export const useColumns = (): TableColumn[] => {
             ...(resultsFields || {}),
         };
 
-        // Apply metric overrides and remove legacy format properties
-        // to ensure formatItemValue uses new formatOptions instead of old format expressions
         return Object.fromEntries(
             Object.entries(mergedMap).map(([key, value]) => {
+                const isFromResults = resultsFields && key in resultsFields;
+                if (isFromResults) {
+                    return [key, value];
+                }
+
                 if (!metricOverrides?.[key]) return [key, value];
                 const itemWithoutLegacyFormat = omit(value, [
                     'format',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fix field overrides not being applied to query results. This PR ensures that field overrides from the SQL compiler are properly passed to the query results, and prevents overriding fields that come directly from query results in the frontend.