### PR TITLE
fix: useDebouncedValue for number input

### DIFF
--- a/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
+++ b/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
@@ -145,6 +145,7 @@ describe('Table calculations', () => {
         cy.contains('greater than').click(); // If the type is string, this option will not be available and it will fail when running the query
 
         cy.findByPlaceholderText('Enter value(s)').clear().type('2000');
+        cy.wait(300); // Wait for the debounce to complete
         cy.get('button').contains('Run query').click();
 
         // Check valid results`

--- a/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
@@ -9,7 +9,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
-import { useCallback, type FC, type Ref } from 'react';
+import { Activity, useCallback, useMemo, type FC, type Ref } from 'react';
 import MantineIcon from './../MantineIcon';
 import { COLLAPSIBLE_CARD_GAP_SIZE } from './constants';
 
@@ -57,7 +57,10 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
         [onToggle],
     );
 
-    const shouldExpand = isOpen && isVisualizationCard;
+    const shouldExpand = useMemo(
+        () => isOpen && isVisualizationCard,
+        [isOpen, isVisualizationCard],
+    );
 
     /**
      * Collapsible cards can be toggled via the heading, in which case we need to
@@ -152,7 +155,7 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                 )}
             </Flex>
 
-            {isOpen && (
+            <Activity mode={isOpen ? 'visible' : 'hidden'}>
                 <Flex
                     direction="column"
                     style={shouldExpand ? { minHeight, flex: 1 } : undefined}
@@ -190,7 +193,7 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                         children
                     )}
                 </Flex>
-            )}
+            </Activity>
         </Card>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: https://linear.app/lightdash/issue/GLITCH-49/number-inputs-in-filters-are-super-slow-in-huge-explores

### Description:
Implemented debouncing for the FilterNumberInput component to improve performance and user experience. Instead of triggering the onChange callback on every keystroke, the component now waits 300ms after the user stops typing before processing the input value.

Key changes:
- Added `useDebouncedValue` hook from Mantine to handle debouncing
- Moved the value parsing logic from the change handler to a useEffect that watches the debounced value
- Used a ref to store the latest onChange callback to avoid stale closures
- Separated the input change handler from the value processing logic

This change prevents excessive re-renders and filter operations while users are still typing numbers, making the filtering experience smoother.