### PR TITLE
fix: use activity to render filters card

### DIFF
--- a/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
@@ -9,7 +9,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
-import { useCallback, type FC, type Ref } from 'react';
+import { Activity, useCallback, type FC, type Ref } from 'react';
 import MantineIcon from './../MantineIcon';
 import { COLLAPSIBLE_CARD_GAP_SIZE } from './constants';
 
@@ -152,7 +152,7 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                 )}
             </Flex>
 
-            {isOpen && (
+            <Activity mode={isOpen ? 'visible' : 'hidden'}>
                 <Flex
                     direction="column"
                     style={shouldExpand ? { minHeight, flex: 1 } : undefined}
@@ -190,7 +190,7 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                         children
                     )}
                 </Flex>
-            )}
+            </Activity>
         </Card>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Replace conditional rendering with React's `Activity` component in `CollapsableCard`. This maintains the component in the DOM when collapsed, improving performance by avoiding remounting and preserving state.

The change wraps the card content in an `Activity` component that toggles between 'visible' and 'hidden' modes based on the `isOpen` state, rather than conditionally rendering the content.

**Before**

**After**

[after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/e45dc2ac-e4e7-43e1-b68b-84a45f4e14f0.mov" />](https://app.graphite.dev/user-attachments/video/e45dc2ac-e4e7-43e1-b68b-84a45f4e14f0.mov)

