### PR TITLE
fix(sqlRunner): reset limit when switching to SQL tab

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -160,6 +160,10 @@ export const ContentPanel: FC = () => {
 
     const queryResults = useAppSelector(selectSqlQueryResults);
 
+    const defaultQueryLimit = useMemo(() => {
+        return health.data?.query.defaultLimit ?? DEFAULT_SQL_LIMIT;
+    }, [health]);
+
     const handleRunQuery = useCallback(
         async (sqlToUse: string) => {
             if (!sqlToUse || !limit) return;
@@ -167,13 +171,23 @@ export const ContentPanel: FC = () => {
             await dispatch(
                 runSqlQuery({
                     sql: sqlToUse,
-                    limit,
+                    limit:
+                        activeEditorTab === EditorTabs.SQL
+                            ? defaultQueryLimit
+                            : limit,
                     projectUuid,
                     parameterValues,
                 }),
             );
         },
-        [dispatch, projectUuid, limit, parameterValues],
+        [
+            dispatch,
+            projectUuid,
+            limit,
+            parameterValues,
+            activeEditorTab,
+            defaultQueryLimit,
+        ],
     );
 
     useEffect(() => {
@@ -286,10 +300,6 @@ export const ContentPanel: FC = () => {
             setPanelSizes([50, 50]);
         }
     }, [queryResults, panelSizes]);
-
-    const defaultQueryLimit = useMemo(() => {
-        return health.data?.query.defaultLimit ?? DEFAULT_SQL_LIMIT;
-    }, [health]);
 
     useEffect(() => {
         if (!limit) {


### PR DESCRIPTION
# Use default query limit when running SQL from the SQL tab

This PR modifies the SQL Runner to use the default query limit when executing queries from the SQL tab, while maintaining the user-specified limit for other tabs. This ensures a consistent experience when users switch between tabs, preventing unexpected query result limitations.

The change moves the `defaultQueryLimit` calculation earlier in the component and updates the `handleRunQuery` function to conditionally apply the appropriate limit based on the active tab.