### PR TITLE
fix: display multiple yaxes labels on slack ai chart

### DIFF
--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/bar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/bar.ts
@@ -46,51 +46,36 @@ export const getBarChartEchartsConfig = async (
     const shouldInverseXAxis =
         primarySort?.fieldId === xDimension && primarySort?.descending === true;
 
-    // Build yAxis array based on whether secondary axis is specified
-    const yAxisConfig = secondaryYAxisMetric
-        ? [
-              {
-                  type: 'value' as const,
-                  ...getCartesianAxisFormatterConfig({
-                      axisItem: yAxisField,
-                      show: true,
-                  }),
-                  ...(chartConfig?.yAxisLabel
-                      ? { name: chartConfig.yAxisLabel }
-                      : {}),
-              },
-              {
-                  type: 'value' as const,
-                  ...getCartesianAxisFormatterConfig({
-                      axisItem: secondaryYAxisField,
-                      show: true,
-                  }),
-                  ...(chartConfig?.secondaryYAxisLabel
-                      ? { name: chartConfig.secondaryYAxisLabel }
-                      : {}),
-              },
-          ]
-        : [
-              {
-                  type: 'value' as const,
-                  ...getCartesianAxisFormatterConfig({
-                      axisItem: yAxisField,
-                      show: true,
-                  }),
-                  ...(chartConfig?.yAxisLabel
-                      ? { name: chartConfig.yAxisLabel }
-                      : {}),
-              },
-          ];
+    const yAxisConfig = [
+        {
+            type: 'value' as const,
+            ...getCartesianAxisFormatterConfig({
+                axisItem: yAxisField,
+                show: true,
+            }),
+        },
+        ...(secondaryYAxisField
+            ? [
+                  {
+                      type: 'value' as const,
+                      ...getCartesianAxisFormatterConfig({
+                          axisItem: secondaryYAxisField,
+                          show: true,
+                      }),
+                  },
+              ]
+            : []),
+    ];
 
     return {
-        ...getCommonEChartsConfig(
-            queryTool.title,
-            metrics.length,
+        ...getCommonEChartsConfig({
+            title: queryTool.title,
+            metricsCount: metrics.length,
             chartData,
-            chartConfig?.xAxisLabel,
-            chartConfig?.yAxisLabel,
-        ),
+            xAxisLabel: chartConfig?.xAxisLabel,
+            yAxisLabel: chartConfig?.yAxisLabel,
+            secondaryYAxisLabel: chartConfig?.secondaryYAxisLabel,
+        }),
         xAxis: [
             {
                 type: chartConfig?.xAxisType ?? ('category' as const),

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/horizontalBar.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/horizontalBar.ts
@@ -44,13 +44,13 @@ export const getHorizontalBarChartEchartsConfig = async (
         primarySort?.fieldId === xDimension && primarySort?.descending === true;
 
     return {
-        ...getCommonEChartsConfig(
-            queryTool.title,
-            metrics.length,
+        ...getCommonEChartsConfig({
+            title: queryTool.title,
+            metricsCount: metrics.length,
             chartData,
-            chartConfig?.xAxisLabel,
-            chartConfig?.yAxisLabel,
-        ),
+            xAxisLabel: chartConfig?.xAxisLabel,
+            yAxisLabel: chartConfig?.yAxisLabel,
+        }),
         xAxis: [
             {
                 type: 'value',

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/line.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/line.ts
@@ -47,50 +47,36 @@ export const getLineChartEchartsConfig = async (
         primarySort?.fieldId === xDimension && primarySort?.descending === true;
 
     // Build yAxis array based on whether secondary axis is specified
-    const yAxisConfig = secondaryYAxisMetric
-        ? [
-              {
-                  type: 'value' as const,
-                  ...getCartesianAxisFormatterConfig({
-                      axisItem: yAxisField,
-                      show: true,
-                  }),
-                  ...(chartConfig?.yAxisLabel
-                      ? { name: chartConfig.yAxisLabel }
-                      : {}),
-              },
-              {
-                  type: 'value' as const,
-                  ...getCartesianAxisFormatterConfig({
-                      axisItem: secondaryYAxisField,
-                      show: true,
-                  }),
-                  ...(chartConfig?.secondaryYAxisLabel
-                      ? { name: chartConfig.secondaryYAxisLabel }
-                      : {}),
-              },
-          ]
-        : [
-              {
-                  type: 'value' as const,
-                  ...getCartesianAxisFormatterConfig({
-                      axisItem: yAxisField,
-                      show: true,
-                  }),
-                  ...(chartConfig?.yAxisLabel
-                      ? { name: chartConfig.yAxisLabel }
-                      : {}),
-              },
-          ];
+    const yAxisConfig = [
+        {
+            type: 'value' as const,
+            ...getCartesianAxisFormatterConfig({
+                axisItem: yAxisField,
+                show: true,
+            }),
+        },
+        ...(secondaryYAxisField
+            ? [
+                  {
+                      type: 'value' as const,
+                      ...getCartesianAxisFormatterConfig({
+                          axisItem: secondaryYAxisField,
+                          show: true,
+                      }),
+                  },
+              ]
+            : []),
+    ];
 
     return {
-        ...getCommonEChartsConfig(
-            queryTool.title,
-            metrics.length,
+        ...getCommonEChartsConfig({
+            title: queryTool.title,
+            metricsCount: metrics.length,
             chartData,
-            chartConfig?.xAxisLabel,
-            chartConfig?.yAxisLabel,
-        ),
+            xAxisLabel: chartConfig?.xAxisLabel,
+            yAxisLabel: chartConfig?.yAxisLabel,
+            secondaryYAxisLabel: chartConfig?.secondaryYAxisLabel,
+        }),
         xAxis: [
             {
                 type: chartConfig?.xAxisType ?? 'time',

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/scatter.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/runQueryTool/viz/scatter.ts
@@ -45,13 +45,13 @@ export const getScatterChartEchartsConfig = async (
         primarySort?.fieldId === xDimension && primarySort?.descending === true;
 
     return {
-        ...getCommonEChartsConfig(
-            queryTool.title,
-            metrics.length,
+        ...getCommonEChartsConfig({
+            title: queryTool.title,
+            metricsCount: metrics.length,
             chartData,
-            chartConfig?.xAxisLabel,
-            chartConfig?.yAxisLabel,
-        ),
+            xAxisLabel: chartConfig?.xAxisLabel,
+            yAxisLabel: chartConfig?.yAxisLabel,
+        }),
         xAxis: [
             {
                 type: chartConfig?.xAxisType ?? ('category' as const),

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/shared/getCommonEChartsConfig.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/shared/getCommonEChartsConfig.ts
@@ -1,15 +1,25 @@
 import { type EChartsOption } from 'echarts';
 
+type GetCommonEChartsConfigParams = {
+    title?: string;
+    metricsCount: number;
+    chartData: Record<string, unknown>[];
+    xAxisLabel?: string | null;
+    yAxisLabel?: string | null;
+    secondaryYAxisLabel?: string | null;
+};
+
 /**
  * Generates common echarts config for all chart types
  */
-export const getCommonEChartsConfig = (
-    title: string | undefined,
-    metricsCount: number,
-    chartData: Record<string, unknown>[],
-    xAxisLabel?: string | null,
-    yAxisLabel?: string | null,
-): Pick<
+export const getCommonEChartsConfig = ({
+    title,
+    metricsCount,
+    chartData,
+    xAxisLabel,
+    yAxisLabel,
+    secondaryYAxisLabel,
+}: GetCommonEChartsConfigParams): Pick<
     EChartsOption,
     | 'title'
     | 'legend'
@@ -44,6 +54,21 @@ export const getCommonEChartsConfig = (
             rotation: Math.PI / 2,
             style: {
                 text: yAxisLabel,
+                fontSize: 12,
+                fontWeight: 500,
+            },
+        });
+    }
+
+    // Add secondary Y-axis label on right side, vertically centered and rotated
+    if (secondaryYAxisLabel) {
+        graphicElements.push({
+            type: 'text',
+            right: 10,
+            top: 'center',
+            rotation: Math.PI / 2,
+            style: {
+                text: secondaryYAxisLabel,
                 fontSize: 12,
                 fontWeight: 500,
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactored chart configuration for Slack AI visualizations to improve axis label handling. The changes include:

1. Updated `getCommonEChartsConfig` to accept a single object parameter with named properties instead of positional parameters
2. Added support for secondary Y-axis labels in the common chart configuration
3. Simplified Y-axis configuration in bar and line charts by using array spread syntax
4. Added console logging for debugging chart configurations
5. Ensured consistent parameter passing across all chart types (bar, horizontal bar, line, scatter)

![image.png](https://app.graphite.dev/user-attachments/assets/9b3b4cbf-cfaa-4991-bb20-0dd05a6bdf2f.png)

![image.png](https://app.graphite.dev/user-attachments/assets/75aa554d-1b3c-4331-a056-184aa7866d94.png)

