### PR TITLE
fix: add progress updates to findExplores and findFields tools

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -263,6 +263,7 @@ export class McpService extends BaseService {
 
                 const findExploresTool = getFindExplores({
                     findExplores,
+                    updateProgress: async () => {}, // No-op for MCP context
                     fieldSearchSize: 200,
                 });
                 const result = await findExploresTool.execute!(
@@ -314,6 +315,7 @@ export class McpService extends BaseService {
 
                 const findFieldsTool = getFindFields({
                     findFields,
+                    updateProgress: async () => {}, // No-op for MCP context
                     pageSize: 15,
                 });
                 const result = await findFieldsTool.execute!(argsWithProject, {

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -147,10 +147,12 @@ const getAgentTools = (
     const findExplores = getFindExplores({
         fieldSearchSize: args.findExploresFieldSearchSize,
         findExplores: dependencies.findExplores,
+        updateProgress: dependencies.updateProgress,
     });
 
     const findFields = getFindFields({
         findFields: dependencies.findFields,
+        updateProgress: dependencies.updateProgress,
         pageSize: args.findFieldsPageSize,
     });
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -144,10 +144,12 @@ const getAgentTools = (
     const findExplores = getFindExplores({
         fieldSearchSize: args.findExploresFieldSearchSize,
         findExplores: dependencies.findExplores,
+        updateProgress: dependencies.updateProgress,
     });
 
     const findFields = getFindFields({
         findFields: dependencies.findFields,
+        updateProgress: dependencies.updateProgress,
         pageSize: args.findFieldsPageSize,
     });
 

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -8,7 +8,10 @@ import {
     toolFindExploresOutputSchema,
 } from '@lightdash/common';
 import { tool } from 'ai';
-import type { FindExploresFn } from '../types/aiAgentDependencies';
+import type {
+    FindExploresFn,
+    UpdateProgressFn,
+} from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import { xmlBuilder } from '../xmlBuilder';
@@ -16,6 +19,7 @@ import { xmlBuilder } from '../xmlBuilder';
 type Dependencies = {
     fieldSearchSize: number;
     findExplores: FindExploresFn;
+    updateProgress: UpdateProgressFn;
 };
 
 function getCatalogChartUsage(
@@ -171,6 +175,7 @@ const generateExploreResponse = ({
 };
 export const getFindExplores = ({
     findExplores,
+    updateProgress,
     fieldSearchSize,
 }: Dependencies) =>
     tool({
@@ -179,6 +184,10 @@ export const getFindExplores = ({
         outputSchema: toolFindExploresOutputSchema,
         execute: async (args) => {
             try {
+                await updateProgress(
+                    `🔍 Searching explore: \`${args.exploreName}\`...`,
+                );
+
                 const { explore, catalogFields } = await findExplores({
                     exploreName: args.exploreName,
                     fieldSearchSize,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added progress updates for AI agent tools to improve user feedback during query processing. The `findExplores` and `findFields` tools now report their current operation status through the `updateProgress` function, showing when they're searching for explores or fields. For the MCP context, a no-op function is provided since progress updates aren't needed in that environment.
