### PR TITLE
feat(frontend): add project compilation log in project settings

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -171,6 +171,7 @@ import type {
 import type { PivotValuesColumn } from '../visualizations/types';
 import type { ResultsPaginationMetadata } from './paginateResults';
 import { type PivotConfiguration } from './pivot';
+import { type ApiProjectCompileLogsResults } from './projectCompileLogs';
 import { type QueryHistoryStatus } from './queryHistory';
 
 export enum RequestMethod {
@@ -809,7 +810,8 @@ type ApiResults =
     | ApiAppendInstructionResponse['results']
     | ApiGetChangeResponse['results']
     | ApiAiOrganizationSettingsResponse['results']
-    | ApiUpdateAiOrganizationSettingsResponse['results'];
+    | ApiUpdateAiOrganizationSettingsResponse['results']
+    | ApiProjectCompileLogsResults;
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'
 

--- a/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
@@ -1,0 +1,395 @@
+import {
+    Box,
+    Group,
+    Loader,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
+import {
+    IconAlertTriangleFilled,
+    IconArrowDown,
+    IconArrowsSort,
+    IconArrowUp,
+    IconCircleCheckFilled,
+    IconClock,
+    IconHash,
+    IconProgress,
+    IconRadar,
+    IconUser,
+} from '@tabler/icons-react';
+import { format } from 'date-fns';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_SortingState,
+    type MRT_Virtualizer,
+} from 'mantine-react-table';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+    type UIEvent,
+} from 'react';
+import { useProject } from '../../hooks/useProject';
+import {
+    useProjectCompileLogs,
+    type ProjectCompileLog,
+} from '../../hooks/useProjectCompileLogs';
+import MantineIcon from '../common/MantineIcon';
+import { CompilationHistoryTopToolbar } from './CompilationHistoryTopToolbar';
+import { CompilationSourceBadge } from './CompilationSourceBadge';
+
+type CompilationSource = 'cli_deploy' | 'refresh_dbt' | 'create_project';
+
+type CompilationHistoryTableProps = {
+    projectUuid: string;
+};
+
+const fetchSize = 25;
+
+const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
+    projectUuid,
+}) => {
+    const theme = useMantineTheme();
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const rowVirtualizerInstanceRef =
+        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+
+    const { data: project } = useProject(projectUuid);
+
+    const [sorting, setSorting] = useState<MRT_SortingState>([
+        { id: 'createdAt', desc: true },
+    ]);
+
+    const [selectedSource, setSelectedSource] =
+        useState<CompilationSource | null>(null);
+
+    const sortBy = useMemo(() => {
+        if (sorting.length === 0) return undefined;
+        const sortField = sorting[0].id;
+        return sortField === 'createdAt' ? 'created_at' : undefined;
+    }, [sorting]);
+
+    const sortDirection = useMemo(() => {
+        if (sorting.length === 0) return undefined;
+        return sorting[0].desc ? 'desc' : 'asc';
+    }, [sorting]);
+
+    const hasActiveFilters = selectedSource !== null;
+
+    const resetFilters = useCallback(() => {
+        setSelectedSource(null);
+    }, []);
+
+    const { data, fetchNextPage, isError, isFetching, isLoading } =
+        useProjectCompileLogs({
+            projectUuid,
+            paginateArgs: { page: 1, pageSize: fetchSize },
+            sortBy,
+            sortDirection,
+            source: selectedSource ?? undefined,
+        });
+
+    const compileLogs = useMemo(() => {
+        if (!data?.pages) return [];
+        return data.pages.flatMap((page) => page.data || []);
+    }, [data]);
+
+    const totalDBRowCount = data?.pages?.[0]?.pagination?.totalResults ?? 0;
+    const totalFetched = compileLogs.length;
+
+    // Callback to fetch more data when scrolling
+    const fetchMoreOnBottomReached = useCallback(
+        (containerRefElement?: HTMLDivElement | null) => {
+            if (containerRefElement) {
+                const { scrollHeight, scrollTop, clientHeight } =
+                    containerRefElement;
+                // Fetch more when within 400px of bottom
+                if (
+                    scrollHeight - scrollTop - clientHeight < 400 &&
+                    !isFetching &&
+                    totalFetched < totalDBRowCount
+                ) {
+                    void fetchNextPage();
+                }
+            }
+        },
+        [fetchNextPage, isFetching, totalFetched, totalDBRowCount],
+    );
+
+    useEffect(() => {
+        fetchMoreOnBottomReached(tableContainerRef.current);
+    }, [fetchMoreOnBottomReached]);
+
+    const columns: MRT_ColumnDef<ProjectCompileLog>[] = useMemo(
+        () => [
+            {
+                accessorKey: 'createdAt',
+                header: 'Timestamp',
+                enableSorting: true,
+                size: 180,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconClock} color="gray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Text c="dimmed" size="xs">
+                        {format(row.original.createdAt, 'yyyy/MM/dd hh:mm a')}
+                    </Text>
+                ),
+            },
+            {
+                accessorKey: 'compilationSource',
+                header: 'Source',
+                enableSorting: false,
+                size: 140,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconRadar} color="gray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <CompilationSourceBadge
+                        source={row.original.compilationSource}
+                    />
+                ),
+            },
+            {
+                accessorKey: 'userName',
+                header: 'Triggered by user',
+                enableSorting: false,
+                size: 200,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconUser} color="gray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => row.original.userName,
+            },
+            {
+                accessorKey: 'report',
+                header: 'Explores',
+                enableSorting: false,
+                size: 100,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconHash} color="gray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) =>
+                    row.original.report.successfulExploresCount ?? 0,
+            },
+            {
+                accessorKey: 'report.metricsCount',
+                header: 'Metrics',
+                enableSorting: false,
+                size: 100,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconHash} color="gray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => row.original.report.metricsCount ?? 0,
+            },
+            {
+                accessorKey: 'report.dimensionsCount',
+                header: 'Dimensions',
+                enableSorting: false,
+                size: 120,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconHash} color="gray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => row.original.report.dimensionsCount ?? 0,
+            },
+            {
+                accessorKey: 'compilationStatus',
+                header: 'Status',
+                enableSorting: false,
+                size: 100,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconProgress} color="gray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const { report } = row.original;
+                    const { label, color, icon } = report.errorExploresCount
+                        ? {
+                              label: report.exploresWithErrors
+                                  .map(
+                                      (explore) =>
+                                          `${explore.name} (${explore.errors
+                                              .map((e) => e.message)
+                                              .join(', ')})`,
+                                  )
+                                  .join('\n'),
+                              color: theme.colors.red[6],
+                              icon: IconAlertTriangleFilled,
+                          }
+                        : {
+                              label: 'Compilation successful',
+                              color: theme.colors.green[6],
+                              icon: IconCircleCheckFilled,
+                          };
+                    return (
+                        <Tooltip label={label}>
+                            <MantineIcon icon={icon} style={{ color: color }} />
+                        </Tooltip>
+                    );
+                },
+            },
+        ],
+        [theme],
+    );
+
+    const table = useMantineReactTable({
+        columns,
+        data: compileLogs,
+        enableColumnResizing: false,
+        enableRowNumbers: false,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        enableSorting: true,
+        enableMultiSort: false,
+        manualSorting: true,
+        enableRowVirtualization: true,
+        enableTopToolbar: true,
+        enableBottomToolbar: true,
+        enableRowActions: false,
+        renderTopToolbar: () => (
+            <CompilationHistoryTopToolbar
+                selectedSource={selectedSource}
+                setSelectedSource={setSelectedSource}
+                isFetching={isFetching || isLoading}
+                currentResultsCount={totalFetched}
+                hasActiveFilters={hasActiveFilters}
+                resetFilters={resetFilters}
+            />
+        ),
+        mantinePaperProps: {
+            shadow: undefined,
+            style: {
+                border: `1px solid ${theme.colors.gray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableHeadRowProps: {
+            sx: {
+                boxShadow: 'none',
+            },
+        },
+        mantineTableContainerProps: {
+            ref: tableContainerRef,
+            style: { maxHeight: 'calc(100dvh - 370px)' },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.target as HTMLDivElement),
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: false,
+        },
+        mantineTableHeadCellProps: {
+            h: '3xl',
+            pos: 'relative',
+            style: {
+                padding: `${theme.spacing.xs} ${theme.spacing.md}`,
+                backgroundColor: theme.colors.gray[0],
+                fontWeight: 600,
+                fontSize: theme.fontSizes.xs,
+                justifyContent: 'center',
+            },
+            sx: {
+                // Removing mantine table borders for last cell
+                '&:last-of-type': {
+                    borderLeft: 'none!important',
+                },
+            },
+        },
+        mantineTableBodyCellProps: {
+            sx: {
+                // Removing mantine table borders for last cell
+                '&:last-of-type': {
+                    borderLeft: 'none!important',
+                },
+            },
+            style: {
+                padding: `${theme.spacing.xs} ${theme.spacing.md}`,
+                fontSize: theme.fontSizes.xs,
+                color: theme.colors.gray[7],
+            },
+        },
+
+        icons: {
+            IconArrowsSort: () => (
+                <MantineIcon icon={IconArrowsSort} size="md" color="gray.5" />
+            ),
+            IconSortAscending: () => (
+                <MantineIcon icon={IconArrowUp} size="md" color="blue.6" />
+            ),
+            IconSortDescending: () => (
+                <MantineIcon icon={IconArrowDown} size="md" color="blue.6" />
+            ),
+        },
+        rowVirtualizerInstanceRef,
+        rowVirtualizerProps: { overscan: 10 },
+        state: {
+            isLoading,
+            showAlertBanner: isError,
+            showProgressBars: isFetching,
+            density: 'md',
+            sorting,
+        },
+        onSortingChange: setSorting,
+        renderBottomToolbar: () => (
+            <Box>
+                <Group gap="xs" px="md" py="xs">
+                    {isFetching ? (
+                        <>
+                            <Loader size={14} c="gray" />{' '}
+                            <Text size="xs" c="dimmed">
+                                Loading...
+                            </Text>
+                        </>
+                    ) : (
+                        <Text size="xs" c="dimmed">
+                            Showing {totalFetched} of {totalDBRowCount} log
+                            {totalDBRowCount === 1 ? '' : 's'}
+                        </Text>
+                    )}
+                </Group>
+            </Box>
+        ),
+    });
+
+    if (!project) {
+        return null;
+    }
+
+    return <MantineReactTable table={table} />;
+};
+
+export default CompilationHistoryTable;

--- a/packages/frontend/src/components/CompilationHistory/CompilationHistoryTopToolbar.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationHistoryTopToolbar.tsx
@@ -1,0 +1,52 @@
+import { ActionIcon, Group, Tooltip } from '@mantine-8/core';
+import { IconFilter, IconTrash } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+import CompilationSourceFilter from './SourceFilter';
+import { type CompilationSource } from './types';
+
+type CompilationHistoryTopToolbarProps = {
+    selectedSource: CompilationSource | null;
+    setSelectedSource: (source: CompilationSource | null) => void;
+    isFetching: boolean;
+    currentResultsCount: number;
+    hasActiveFilters: boolean;
+    resetFilters: () => void;
+};
+
+export const CompilationHistoryTopToolbar: FC<
+    CompilationHistoryTopToolbarProps
+> = ({ selectedSource, setSelectedSource, hasActiveFilters, resetFilters }) => {
+    return (
+        <Group
+            justify="space-between"
+            px="sm"
+            py="md"
+            wrap="nowrap"
+            style={(theme) => ({
+                borderBottom: `1px solid ${theme.colors.gray[2]}`,
+            })}
+        >
+            <Group gap="xs" wrap="nowrap">
+                <MantineIcon icon={IconFilter} color="gray" />
+                <CompilationSourceFilter
+                    selectedSource={selectedSource}
+                    setSelectedSource={setSelectedSource}
+                />
+            </Group>
+            {hasActiveFilters && (
+                <Tooltip label="Clear all filters">
+                    <ActionIcon
+                        variant="subtle"
+                        size="sm"
+                        color="gray"
+                        onClick={resetFilters}
+                        style={{ flexShrink: 0 }}
+                    >
+                        <MantineIcon icon={IconTrash} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+        </Group>
+    );
+};

--- a/packages/frontend/src/components/CompilationHistory/CompilationSourceBadge.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationSourceBadge.tsx
@@ -1,0 +1,38 @@
+import { Badge, type DefaultMantineColor } from '@mantine-8/core';
+import { SOURCE_LABELS } from './types';
+
+const SOURCE_COLORS: Record<string, DefaultMantineColor> = {
+    refresh_dbt: 'indigo',
+    cli_deploy: 'pink',
+    create_project: 'cyan',
+} as const;
+
+type CompilationSourceBadgeProps = {
+    source: string;
+};
+
+export const CompilationSourceBadge = ({
+    source,
+}: CompilationSourceBadgeProps) => {
+    const color = SOURCE_COLORS[source] ?? 'gray';
+
+    return (
+        <Badge
+            color={color}
+            variant="light"
+            size="sm"
+            radius="md"
+            py={10}
+            h={24}
+            style={(theme) => ({
+                border: `1px solid ${theme.colors[color][2]}`,
+                textTransform: 'none',
+                boxShadow: '0px -1px 0px 0px rgba(4, 4, 4, 0.04) inset',
+            })}
+        >
+            {source in SOURCE_LABELS
+                ? SOURCE_LABELS[source as keyof typeof SOURCE_LABELS]
+                : source}
+        </Badge>
+    );
+};

--- a/packages/frontend/src/components/CompilationHistory/SourceFilter.module.css
+++ b/packages/frontend/src/components/CompilationHistory/SourceFilter.module.css
@@ -1,0 +1,21 @@
+.filterButton {
+    border: 1px dashed var(--mantine-color-gray-3);
+    background: var(--mantine-color-white);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButton:hover {
+    border: 1px dashed var(--mantine-color-gray-4);
+    background: var(--mantine-color-gray-0);
+}
+
+.filterButtonSelected {
+    border: 1px solid var(--mantine-color-indigo-2);
+    background: var(--mantine-color-indigo-0);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButtonSelected:hover {
+    border: 1px solid var(--mantine-color-indigo-3);
+    background: var(--mantine-color-indigo-1);
+}

--- a/packages/frontend/src/components/CompilationHistory/SourceFilter.tsx
+++ b/packages/frontend/src/components/CompilationHistory/SourceFilter.tsx
@@ -1,0 +1,97 @@
+import {
+    Badge,
+    Button,
+    Popover,
+    Radio,
+    ScrollArea,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { type FC } from 'react';
+import classes from './SourceFilter.module.css';
+import { ALL_SOURCES, SOURCE_LABELS, type CompilationSource } from './types';
+
+type CompilationSourceFilterProps = {
+    selectedSource: CompilationSource | null;
+    setSelectedSource: (source: CompilationSource | null) => void;
+};
+
+const CompilationSourceFilter: FC<CompilationSourceFilterProps> = ({
+    selectedSource,
+    setSelectedSource,
+}) => {
+    const hasSelectedSource = selectedSource !== null;
+
+    const handleSourceChange = (value: string) => {
+        setSelectedSource(value as CompilationSource);
+    };
+
+    return (
+        <Popover width={250} position="bottom-start">
+            <Popover.Target>
+                <Tooltip
+                    withinPortal
+                    variant="xs"
+                    label="Filter logs by source"
+                >
+                    <Button
+                        h={32}
+                        c="gray.7"
+                        fw={500}
+                        fz="sm"
+                        variant="default"
+                        radius="md"
+                        px="sm"
+                        className={
+                            hasSelectedSource
+                                ? classes.filterButtonSelected
+                                : classes.filterButton
+                        }
+                        rightSection={
+                            hasSelectedSource ? (
+                                <Badge
+                                    size="xs"
+                                    variant="filled"
+                                    color="indigo.6"
+                                    circle
+                                >
+                                    1
+                                </Badge>
+                            ) : null
+                        }
+                    >
+                        Source
+                    </Button>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown p="sm">
+                <Stack gap={4}>
+                    <Text fz="xs" c="dark.3" fw={600}>
+                        Filter by source:
+                    </Text>
+
+                    <ScrollArea.Autosize mah={200} type="always" scrollbars="y">
+                        <Radio.Group
+                            value={selectedSource ?? ''}
+                            onChange={handleSourceChange}
+                        >
+                            <Stack gap="xs">
+                                {ALL_SOURCES.map((source) => (
+                                    <Radio
+                                        key={source}
+                                        value={source}
+                                        label={SOURCE_LABELS[source]}
+                                        size="xs"
+                                    />
+                                ))}
+                            </Stack>
+                        </Radio.Group>
+                    </ScrollArea.Autosize>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+export default CompilationSourceFilter;

--- a/packages/frontend/src/components/CompilationHistory/index.tsx
+++ b/packages/frontend/src/components/CompilationHistory/index.tsx
@@ -1,0 +1,76 @@
+import {
+    ActionIcon,
+    Card,
+    Group,
+    LoadingOverlay,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconRefresh } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FC } from 'react';
+import useToaster from '../../hooks/toaster/useToaster';
+import { useProject } from '../../hooks/useProject';
+import MantineIcon from '../common/MantineIcon';
+import CompilationHistoryTable from './CompilationHistoryTable';
+
+type CompilationHistoryProps = {
+    projectUuid: string;
+};
+
+const CompilationHistory: FC<CompilationHistoryProps> = ({ projectUuid }) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess } = useToaster();
+    const { isLoading: isLoadingProject } = useProject(projectUuid);
+
+    const handleRefresh = async () => {
+        await queryClient.invalidateQueries([
+            'projectCompileLogs',
+            projectUuid,
+        ]);
+        showToastSuccess({
+            title: 'Compilation history refreshed successfully',
+        });
+    };
+
+    return (
+        <>
+            <LoadingOverlay visible={isLoadingProject} />
+
+            <Card>
+                <Stack gap="md">
+                    <Group justify="space-between">
+                        <Stack gap={2}>
+                            <Title order={5}>Compilation History</Title>
+                            <Text c="dimmed" size="xs">
+                                View the history of all dbt compilations for
+                                this project, including CLI deploys and UI
+                                refreshes.
+                            </Text>
+                        </Stack>
+                        <Group gap="xs"></Group>
+                        <Tooltip label="Click to refresh the compilation history">
+                            <ActionIcon
+                                onClick={handleRefresh}
+                                variant="subtle"
+                                size="md"
+                            >
+                                <MantineIcon
+                                    icon={IconRefresh}
+                                    color="gray.6"
+                                    stroke={2}
+                                />
+                            </ActionIcon>
+                        </Tooltip>
+                    </Group>
+
+                    <CompilationHistoryTable projectUuid={projectUuid} />
+                </Stack>
+            </Card>
+        </>
+    );
+};
+
+export default CompilationHistory;

--- a/packages/frontend/src/components/CompilationHistory/types.ts
+++ b/packages/frontend/src/components/CompilationHistory/types.ts
@@ -1,0 +1,13 @@
+export type CompilationSource = 'cli_deploy' | 'refresh_dbt' | 'create_project';
+
+export const SOURCE_LABELS: Record<CompilationSource, string> = {
+    cli_deploy: 'CLI Deploy',
+    refresh_dbt: 'Refresh dbt',
+    create_project: 'Create Project',
+};
+
+export const ALL_SOURCES: CompilationSource[] = [
+    'cli_deploy',
+    'refresh_dbt',
+    'create_project',
+];

--- a/packages/frontend/src/hooks/useProjectCompileLogs.ts
+++ b/packages/frontend/src/hooks/useProjectCompileLogs.ts
@@ -1,0 +1,94 @@
+import {
+    type ApiError,
+    type ApiProjectCompileLogsResponse,
+    type KnexPaginateArgs,
+    type ProjectCompileLog,
+} from '@lightdash/common';
+import {
+    useInfiniteQuery,
+    type UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+export type { ProjectCompileLog };
+
+const getProjectCompileLogs = async (
+    projectUuid: string,
+    paginateArgs: KnexPaginateArgs,
+    sortBy?: 'created_at',
+    sortDirection?: 'asc' | 'desc',
+    source?: 'cli_deploy' | 'refresh_dbt' | 'create_project',
+): Promise<ApiProjectCompileLogsResponse['results']> => {
+    const params = new URLSearchParams({
+        page: paginateArgs.page.toString(),
+        pageSize: paginateArgs.pageSize.toString(),
+    });
+
+    if (sortBy) {
+        params.append('sortBy', sortBy);
+    }
+    if (sortDirection) {
+        params.append('sortDirection', sortDirection);
+    }
+    if (source) {
+        params.append('source', source);
+    }
+
+    return lightdashApi<ApiProjectCompileLogsResponse['results']>({
+        url: `/projects/${projectUuid}/compile-logs?${params.toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useProjectCompileLogs = ({
+    projectUuid,
+    paginateArgs,
+    sortBy,
+    sortDirection,
+    source,
+}: {
+    projectUuid: string;
+    paginateArgs?: KnexPaginateArgs;
+    sortBy?: 'created_at';
+    sortDirection?: 'asc' | 'desc';
+    source?: 'cli_deploy' | 'refresh_dbt' | 'create_project';
+}): UseInfiniteQueryResult<
+    ApiProjectCompileLogsResponse['results'],
+    ApiError
+> => {
+    return useInfiniteQuery<ApiProjectCompileLogsResponse['results'], ApiError>(
+        {
+            queryKey: [
+                'projectCompileLogs',
+                projectUuid,
+                paginateArgs,
+                sortBy,
+                sortDirection,
+                source,
+            ],
+            queryFn: async ({ pageParam = 0 }) => {
+                return getProjectCompileLogs(
+                    projectUuid,
+                    {
+                        page: (pageParam as number) + 1,
+                        pageSize: paginateArgs?.pageSize || 25,
+                    },
+                    sortBy,
+                    sortDirection,
+                    source,
+                );
+            },
+            getNextPageParam: (_lastGroup, groups) => {
+                const currentPage = groups.length - 1;
+                const totalPages = _lastGroup.pagination?.totalPageCount ?? 0;
+                return currentPage < totalPages - 1
+                    ? currentPage + 1
+                    : undefined;
+            },
+            keepPreviousData: true,
+            refetchOnWindowFocus: false,
+            enabled: !!projectUuid,
+        },
+    );
+};

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -1,6 +1,7 @@
 import { Stack } from '@mantine/core';
 import { useMemo, type FC } from 'react';
 import { Navigate, useParams, useRoutes, type RouteObject } from 'react-router';
+import CompilationHistory from '../components/CompilationHistory';
 import { DataOps } from '../components/DataOps';
 import ProjectUserAccess from '../components/ProjectAccess';
 import { UpdateProjectConnection } from '../components/ProjectConnection';
@@ -65,6 +66,10 @@ const ProjectSettings: FC = () => {
             {
                 path: `/parameters`,
                 element: <ProjectParameters projectUuid={projectUuid} />,
+            },
+            {
+                path: `/compilationHistory`,
+                element: <CompilationHistory projectUuid={projectUuid} />,
             },
             {
                 path: '*',

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -16,6 +16,7 @@ import {
     IconLock,
     IconPalette,
     IconPlug,
+    IconRefresh,
     IconReportAnalytics,
     IconTableOptions,
     IconUserCircle,
@@ -421,6 +422,12 @@ const Settings: FC = () => {
                     path: '/generalSettings/projectManagement/:projectUuid/scheduledDeliveries',
                 },
                 location.pathname,
+            ) &&
+            !matchPath(
+                {
+                    path: '/generalSettings/projectManagement/:projectUuid/compilationHistory',
+                },
+                location.pathname,
             )
         );
     }, [location.pathname]);
@@ -731,6 +738,15 @@ const Settings: FC = () => {
                                         to={`/generalSettings/projectManagement/${project.projectUuid}/changesets`}
                                         icon={
                                             <MantineIcon icon={IconHistory} />
+                                        }
+                                    />
+
+                                    <RouterNavLink
+                                        label="Compilation history"
+                                        exact
+                                        to={`/generalSettings/projectManagement/${project.projectUuid}/compilationHistory`}
+                                        icon={
+                                            <MantineIcon icon={IconRefresh} />
                                         }
                                     />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17518

### Description:
This PR adds a new Compilation History feature to the project settings, allowing users to view the history of all dbt compilations for a project. The implementation includes:

- A new table component that displays compilation logs with details like timestamp, source, triggered user, and status
- Filtering capabilities by compilation source (CLI Deploy, Refresh dbt, Create Project)
- Sorting functionality for timestamps and sources
- Infinite scrolling to load more logs as the user scrolls down
- Visual indicators for successful and failed compilations
- A refresh button to manually update the compilation history

The feature is accessible through a new "Compilation history" tab in the project settings navigation.

![image.png](https://app.graphite.dev/user-attachments/assets/9261d4b7-1eea-4703-a24f-2daa745fa3bf.png)

