### PR TITLE
fix: update react query cache on ai dashboard chart change

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardSaveModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardSaveModal.tsx
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import {
     type AiArtifact,
-    type ApiAiAgentThreadMessageVizQuery,
     type Dashboard,
     type ToolDashboardArgs,
 } from '@lightdash/common';
@@ -32,7 +31,10 @@ import {
     getAiAgentDashboardChartVizQueryKey,
     useUpdateArtifactVersion,
 } from '../../hooks/useProjectAiAgents';
-import { convertDashboardVisualizationsToChartData } from '../../utils/dashboardChartConverter';
+import {
+    convertDashboardVisualizationsToChartData,
+    type VizQueryWithOverrides,
+} from '../../utils/dashboardChartConverter';
 
 enum ModalStep {
     InitialInfo = 'initialInfo',
@@ -124,7 +126,7 @@ export const AiDashboardSaveModal: FC<Props> = ({
 
     // Read cached viz-query results from react-query client using exported key
     const getCachedVizQueries = useCallback(() => {
-        const results: (ApiAiAgentThreadMessageVizQuery | undefined)[] = [];
+        const results: (VizQueryWithOverrides | undefined)[] = [];
         for (let i = 0; i < dashboardConfig.visualizations.length; i++) {
             const key = getAiAgentDashboardChartVizQueryKey({
                 projectUuid,
@@ -133,8 +135,7 @@ export const AiDashboardSaveModal: FC<Props> = ({
                 versionUuid: artifactData.versionUuid,
                 chartIndex: i,
             });
-            const data =
-                queryClient.getQueryData<ApiAiAgentThreadMessageVizQuery>(key);
+            const data = queryClient.getQueryData<VizQueryWithOverrides>(key);
             results.push(data);
         }
         return results;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Adds the ability to customize chart types and configurations in AI dashboard visualizations. This enhancement allows users to:

1. Change chart types directly in the dashboard view
2. Customize chart configurations which persist when saving to a dashboard
3. Maintain these customizations when converting AI visualizations to saved charts

The implementation adds callback handlers to the `AiVisualizationRenderer` component that update the query cache with the user's chart type and configuration preferences, ensuring these customizations are preserved throughout the application.

