### PR TITLE
fix: [LD-14576] - Prevent infinite re-render loop in <TrackPage> component

### DIFF
--- a/packages/frontend/src/providers/Tracking/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/Tracking/TrackingProvider.tsx
@@ -178,11 +178,14 @@ export const TrackPage: FC<React.PropsWithChildren<PageData>> = ({
 }) => {
     const { page } = useTracking();
 
-    const pageData = useMemo(() => rest, [
-        rest.name,
-        rest.category,
-        rest.type,
-    ]);
+    const pageData = useMemo(
+        () => ({
+            name: rest.name,
+            category: rest.category,
+            type: rest.type,
+        }),
+        [rest.name, rest.category, rest.type],
+    );
 
     useEffect(() => {
         page(pageData);


### PR DESCRIPTION
Closes: [Error: Maximum update depth exceeded. #14576
](https://github.com/lightdash/lightdash/issues/14576)

### 🐛 Bug Fix: React Infinite Re-render Loop (Error #185)

This PR resolves an issue where the `<TrackPage>` component could trigger an infinite re-render loop, leading to the "Maximum update depth exceeded" error (React Minified Error #185) on certain pages, particularly dashboards.

The issue occurred because the `useEffect` hook inside `<TrackPage>` was using the object destructured from props (`...rest`) as a dependency:

```typescript
useEffect(() => {
    page(rest);
}, [page, rest]); // 👈 'rest' is a new object on every re-render
```

<img width="1699" height="994" alt="Screenshot 2025-10-22 at 11 56 00" src="https://github.com/user-attachments/assets/b80a02da-5751-479d-8f02-b0c9715e0a62" />
<img width="1699" height="994" alt="Screenshot 2025-10-22 at 11 55 54" src="https://github.com/user-attachments/assets/b3644fb2-8a48-4d21-b021-bf233b0c52a1" />
