### PR TITLE
feat: see compilation raw information

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -105,6 +105,7 @@ import {
     type CreatePersonalAccessToken,
     type PersonalAccessToken,
 } from './personalAccessToken';
+import { type ApiProjectCompileLogsResults } from './projectCompileLogs';
 import { type ProjectMemberProfile } from './projectMemberProfile';
 import { type ProjectMemberRole } from './projectMemberRole';
 import {
@@ -171,7 +172,6 @@ import type {
 import type { PivotValuesColumn } from '../visualizations/types';
 import type { ResultsPaginationMetadata } from './paginateResults';
 import { type PivotConfiguration } from './pivot';
-import { type ApiProjectCompileLogsResults } from './projectCompileLogs';
 import { type QueryHistoryStatus } from './queryHistory';
 
 export enum RequestMethod {

--- a/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../hooks/useProjectCompileLogs';
 import MantineIcon from '../common/MantineIcon';
 import { CompilationHistoryTopToolbar } from './CompilationHistoryTopToolbar';
+import { CompilationLogDrawer } from './CompilationLogDrawer';
 import { CompilationSourceBadge } from './CompilationSourceBadge';
 
 type CompilationSource = 'cli_deploy' | 'refresh_dbt' | 'create_project';
@@ -68,6 +69,21 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
 
     const [selectedSource, setSelectedSource] =
         useState<CompilationSource | null>(null);
+
+    const [drawerOpened, setDrawerOpened] = useState(false);
+    const [selectedLog, setSelectedLog] = useState<ProjectCompileLog | null>(
+        null,
+    );
+
+    const handleRowClick = useCallback((log: ProjectCompileLog) => {
+        setSelectedLog(log);
+        setDrawerOpened(true);
+    }, []);
+
+    const handleDrawerClose = useCallback(() => {
+        setDrawerOpened(false);
+        setSelectedLog(null);
+    }, []);
 
     const sortBy = useMemo(() => {
         if (sorting.length === 0) return undefined;
@@ -312,6 +328,10 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
             highlightOnHover: true,
             withColumnBorders: false,
         },
+        mantineTableBodyRowProps: ({ row }) => ({
+            onClick: () => handleRowClick(row.original),
+            style: { cursor: 'pointer' },
+        }),
         mantineTableHeadCellProps: {
             h: '3xl',
             pos: 'relative',
@@ -389,7 +409,16 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
         return null;
     }
 
-    return <MantineReactTable table={table} />;
+    return (
+        <>
+            <MantineReactTable table={table} />
+            <CompilationLogDrawer
+                opened={drawerOpened}
+                onClose={handleDrawerClose}
+                log={selectedLog}
+            />
+        </>
+    );
 };
 
 export default CompilationHistoryTable;

--- a/packages/frontend/src/components/CompilationHistory/CompilationLogDrawer.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationLogDrawer.tsx
@@ -1,0 +1,84 @@
+import {
+    ActionIcon,
+    Box,
+    CopyButton,
+    Drawer,
+    Group,
+    ScrollArea,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconCheck, IconCopy } from '@tabler/icons-react';
+import { type FC } from 'react';
+import ReactJson from 'react-json-view';
+import { type ProjectCompileLog } from '../../hooks/useProjectCompileLogs';
+import MantineIcon from '../common/MantineIcon';
+
+type CompilationLogDrawerProps = {
+    opened: boolean;
+    onClose: () => void;
+    log: ProjectCompileLog | null;
+};
+
+export const CompilationLogDrawer: FC<CompilationLogDrawerProps> = ({
+    opened,
+    onClose,
+    log,
+}) => {
+    return (
+        <Drawer
+            opened={opened}
+            onClose={onClose}
+            position="right"
+            size="lg"
+            title={
+                <Group justify="space-between" w="100%">
+                    <Text fw={600} fz="lg">
+                        Compilation Log Details
+                    </Text>
+                    {log && (
+                        <CopyButton
+                            value={JSON.stringify(log, null, 2)}
+                            timeout={2000}
+                        >
+                            {({ copied, copy }) => (
+                                <Tooltip
+                                    label={copied ? 'Copied' : 'Copy JSON'}
+                                    withinPortal
+                                    variant="xs"
+                                >
+                                    <ActionIcon
+                                        color={copied ? 'teal' : 'gray'}
+                                        onClick={copy}
+                                        variant="subtle"
+                                    >
+                                        <MantineIcon
+                                            icon={copied ? IconCheck : IconCopy}
+                                        />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </CopyButton>
+                    )}
+                </Group>
+            }
+        >
+            <ScrollArea h="calc(100vh - 80px)">
+                <Stack gap="md">
+                    {log && (
+                        <Box>
+                            <ReactJson
+                                src={log as Record<string, unknown>}
+                                enableClipboard={false}
+                                displayDataTypes={false}
+                                collapsed={1}
+                                name={null}
+                            />
+                        </Box>
+                    )}
+                </Stack>
+            </ScrollArea>
+        </Drawer>
+    );
+};


### PR DESCRIPTION

### Description:
Added a compilation log details drawer to the Compilation History Table. Users can now click on any row in the table to view detailed information about the compilation log in a side drawer. The drawer includes a copy button to easily copy the JSON data and uses ReactJson for a collapsible, formatted display of the log details.

![image.png](https://app.graphite.dev/user-attachments/assets/72e514f7-9110-4070-93a8-f3e8b40c1c0e.png)

