### PR TITLE
feat: parameter support to embedded dashboards backend

### DIFF
--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -108,6 +108,7 @@ export const fromJwt = ({
         access: {
             dashboardId: dashboardUuid,
             filtering: decodedToken.content.dashboardFiltersInteractivity,
+            canChangeParameters: decodedToken.content.canChangeParameters,
             controls: userAttributes,
         },
         // Create the fields we're able to set from the JWT

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -22,6 +22,7 @@ import {
     FieldValueSearchResult,
     Item,
     MetricQueryResponse,
+    ParametersValuesMap,
     SavedChart,
     SavedChartsInfoForDashboardAvailableFilters,
     SortField,
@@ -227,6 +228,7 @@ export class EmbedController extends BaseController {
             dashboardFilters?: DashboardFilters;
             dateZoomGranularity?: DateGranularity;
             dashboardSorts?: SortField[];
+            parameters?: ParametersValuesMap;
         },
     ): Promise<ApiEmbedChartAndResultsResponse> {
         this.setStatus(200);
@@ -242,6 +244,7 @@ export class EmbedController extends BaseController {
                 body.dashboardFilters,
                 body.dateZoomGranularity,
                 body.dashboardSorts,
+                body.parameters,
             ),
         };
     }
@@ -299,6 +302,7 @@ export class EmbedController extends BaseController {
         @Body()
         body: {
             dashboardFilters?: AnyType; // DashboardFilters; temp disable validation
+            parameters?: ParametersValuesMap;
             invalidateCache?: boolean;
         },
     ): Promise<ApiCalculateTotalResponse> {
@@ -313,6 +317,7 @@ export class EmbedController extends BaseController {
                 projectUuid,
                 savedChartUuid,
                 body.dashboardFilters,
+                body.parameters,
                 body.invalidateCache,
             ),
         };
@@ -328,6 +333,7 @@ export class EmbedController extends BaseController {
         @Body()
         body: {
             dashboardFilters?: DashboardFilters;
+            parameters?: ParametersValuesMap;
             columnOrder: string[];
             pivotDimensions?: string[];
             invalidateCache?: boolean;
@@ -345,6 +351,7 @@ export class EmbedController extends BaseController {
                     projectUuid,
                     savedChartUuid,
                     body.dashboardFilters,
+                    body.parameters,
                     body.columnOrder,
                     body.pivotDimensions,
                     body.invalidateCache,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -882,6 +882,7 @@ export class EmbedService extends BaseService {
         dashboardFilters?: DashboardFilters,
         dateZoomGranularity?: DateGranularity,
         dashboardSorts?: SortField[],
+        userParameters?: ParametersValuesMap,
         checkPermissions: boolean = true,
     ) {
         const { dashboardUuids, allowAllDashboards, user } =
@@ -959,11 +960,14 @@ export class EmbedService extends BaseService {
 
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
-        // No parameters are passed in embed requests, just combine the saved parameters
+        const acceptedUserParameters =
+            account.access.canChangeParameters && userParameters
+                ? userParameters
+                : {};
         const combinedParameters = await this.projectService.combineParameters(
             projectUuid,
             explore,
-            {},
+            acceptedUserParameters,
             dashboardParameters,
         );
 
@@ -1077,6 +1081,7 @@ export class EmbedService extends BaseService {
         projectUuid: string,
         savedChartUuid: string,
         dashboardFilters?: DashboardFilters,
+        userParameters?: ParametersValuesMap,
         invalidateCache?: boolean,
     ) {
         const { dashboardUuid, chart, explore, metricQuery } =
@@ -1100,11 +1105,14 @@ export class EmbedService extends BaseService {
         );
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
-        // No parameters are passed in embed requests, just combine the saved parameters
+        const acceptedUserParameters =
+            account.access.canChangeParameters && userParameters
+                ? userParameters
+                : {};
         const combinedParameters = await this.projectService.combineParameters(
             projectUuid,
             explore,
-            {},
+            acceptedUserParameters,
             dashboardParameters,
         );
 
@@ -1164,6 +1172,7 @@ export class EmbedService extends BaseService {
         projectUuid: string,
         savedChartUuid: string,
         dashboardFilters?: DashboardFilters,
+        userParameters?: ParametersValuesMap,
         columnOrder?: string[],
         pivotDimensions?: string[],
         invalidateCache?: boolean,
@@ -1188,11 +1197,14 @@ export class EmbedService extends BaseService {
         );
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
-        // No parameters are passed in embed requests, just combine the saved parameters
+        const acceptedUserParameters =
+            account.access.canChangeParameters && userParameters
+                ? userParameters
+                : {};
         const combinedParameters = await this.projectService.combineParameters(
             projectUuid,
             explore,
-            {},
+            acceptedUserParameters,
             dashboardParameters,
         );
 

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -45,6 +45,7 @@ export type DashboardFilterInteractivityOptions = z.infer<
 export const InteractivityOptionsSchema = z.object({
     dashboardFiltersInteractivity:
         DashboardFilterInteractivityOptionsSchema.optional(),
+    canChangeParameters: z.boolean().optional(),
     canExportCsv: z.boolean().optional(),
     canExportImages: z.boolean().optional(),
     canExportPagePdf: z.boolean().optional(),
@@ -100,6 +101,7 @@ type CommonEmbedJwtContent = {
         enabled: FilterInteractivityValues | boolean;
         allowedFilters?: string[] | null;
     };
+    canChangeParameters?: boolean;
     canExportCsv?: boolean;
     canExportImages?: boolean;
     canDateZoom?: boolean;

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -86,6 +86,8 @@ export type DashboardAccess = {
     filtering?: DashboardFilterInteractivityOptions;
     /** User-specific access controls */
     controls?: UserAccessControls;
+    /** Whether users can change dashboard parameters in embedded dashboards */
+    canChangeParameters?: boolean;
 };
 
 export type AccountHelpers = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #16595

### Description:
Adds support for changing parameters in embedded dashboards. This PR introduces a new `canChangeParameters` flag in the JWT content that controls whether users can modify parameters in embedded dashboards. When enabled, user-provided parameters are accepted and combined with dashboard parameters in the embed service.

The implementation includes:
- Adding `canChangeParameters` to the account access object
- Updating the embed controller to accept parameters in API requests
- Modifying the embed service to respect the parameter permissions
- Adding parameter support to chart results, totals, and results table endpoints

This enhancement gives more flexibility to embedded dashboard users while maintaining proper permission controls.