### PR TITLE
feat: improve messaging to user when ai is working

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
@@ -36,7 +36,6 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     generateBarVizConfig: 'vertical_bar_chart',
     runQuery: 'query_result',
     generateDashboard: 'generate_dashboard',
-    generateDashboardV2: 'generate_dashboard_v2',
     improveContext: 'improve_context',
     proposeChange: 'propose_change',
 } satisfies Record<ToolName, string>;
@@ -49,8 +48,8 @@ const TOOL_SCHEMAS = {
     generateBarVizConfig: toolVerticalBarArgsSchema,
     generateTableVizConfig: toolTableVizArgsSchema,
     generateTimeSeriesVizConfig: toolTimeSeriesArgsSchema,
-    generateDashboard: toolDashboardArgsSchema,
-    generateDashboardV2: toolDashboardV2ArgsSchema,
+    // TODO: agent needs to be v2 for this to work
+    generateDashboard: toolDashboardV2ArgsSchema,
     findContent: toolFindContentArgsSchema,
     findDashboards: toolFindDashboardsArgsSchema,
     findCharts: toolFindChartsArgsSchema,

--- a/packages/common/src/ee/AiAgent/schemas/parser.ts
+++ b/packages/common/src/ee/AiAgent/schemas/parser.ts
@@ -42,9 +42,13 @@ export const parseToolArgs = (toolName: ToolName, toolArgs: unknown) => {
         case 'generateTimeSeriesVizConfig':
             return toolTimeSeriesArgsSchemaTransformed.safeParse(toolArgs);
         case 'generateDashboard':
+            // try v2 then v1
+            const v2Result =
+                toolDashboardV2ArgsSchemaTransformed.safeParse(toolArgs);
+            if (v2Result.success) {
+                return v2Result;
+            }
             return toolDashboardArgsSchemaTransformed.safeParse(toolArgs);
-        case 'generateDashboardV2':
-            return toolDashboardV2ArgsSchemaTransformed.safeParse(toolArgs);
         case 'findDashboards':
             return toolFindDashboardsArgsSchemaTransformed.safeParse(toolArgs);
         case 'findCharts':

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -14,7 +14,6 @@ const VisualizationTools = [
 export const ToolNameSchema = z.enum([
     ...VisualizationTools,
     'generateDashboard',
-    'generateDashboardV2',
     'findContent',
     'findExplores',
     'findFields',
@@ -43,10 +42,9 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     generateTableVizConfig: 'Generating a table',
     generateTimeSeriesVizConfig: 'Generating a line chart',
     generateDashboard: 'Generating a dashboard',
-    generateDashboardV2: 'Generating a dashboard',
     findCharts: 'Finding relevant charts',
     improveContext: 'Improving context',
-    runQuery: 'Running query',
+    runQuery: 'Generating visualization',
 });
 
 // after-tool-call messages
@@ -60,10 +58,9 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         generateTableVizConfig: 'Generated a table',
         generateTimeSeriesVizConfig: 'Generated a line chart',
         generateDashboard: 'Generated a dashboard',
-        generateDashboardV2: 'Generated a dashboard',
         findCharts: 'Found relevant charts',
         improveContext: 'Improved context',
-        runQuery: 'Ran query',
+        runQuery: 'Generated visualization',
     });
 
 export const AVAILABLE_VISUALIZATION_TYPES = VisualizationTools;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ImproveContextToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ImproveContextToolCall.tsx
@@ -1,0 +1,109 @@
+import { Button, Group, Paper, Stack, Text } from '@mantine-8/core';
+import { IconSchool } from '@tabler/icons-react';
+import type { FC } from 'react';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
+import { useAppendInstructionMutation } from '../../../hooks/useProjectAiAgents';
+import { clearImproveContextNotification } from '../../../store/aiAgentThreadStreamSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../../store/hooks';
+
+type ImproveContextToolCallProps = {
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+};
+
+export const ImproveContextToolCall: FC<ImproveContextToolCallProps> = ({
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    promptUuid,
+}) => {
+    const improveContextNotification = useAiAgentStoreSelector((state) => {
+        const thread = state.aiAgentThreadStream[threadUuid];
+        if (thread?.messageUuid === promptUuid) {
+            return thread.improveContextNotification;
+        }
+        return null;
+    });
+    const dispatch = useAiAgentStoreDispatch();
+
+    const appendInstructionMutation = useAppendInstructionMutation(
+        projectUuid,
+        agentUuid,
+    );
+
+    if (!improveContextNotification) {
+        return null;
+    }
+
+    const handleSave = async () => {
+        if (!improveContextNotification) return;
+
+        await appendInstructionMutation.mutateAsync({
+            instruction: improveContextNotification.suggestedInstruction,
+        });
+
+        dispatch(
+            clearImproveContextNotification({
+                threadUuid,
+            }),
+        );
+    };
+
+    const handleDismiss = () => {
+        dispatch(
+            clearImproveContextNotification({
+                threadUuid,
+            }),
+        );
+    };
+
+    return (
+        <Paper bg="white" p="xs" mb="xs" withBorder>
+            <Group gap="xs" align="flex-start" wrap="nowrap">
+                <MantineIcon icon={IconSchool} size="md" color="indigo.6" />
+                <Stack gap="xs" style={{ flex: 1 }}>
+                    <Text fz="xs" fw={500} c="gray.9" lh="normal" m={0}>
+                        Save instruction to memory?
+                    </Text>
+
+                    <Text
+                        fz="xs"
+                        c="gray.7"
+                        bg="gray.0"
+                        p="xs"
+                        style={{
+                            borderRadius: '4px',
+                            fontStyle: 'italic',
+                        }}
+                    >
+                        {improveContextNotification.suggestedInstruction}
+                    </Text>
+                    <Group justify="flex-end" gap="xs">
+                        <Button
+                            size="compact-xs"
+                            variant="subtle"
+                            color="gray"
+                            onClick={handleDismiss}
+                            disabled={appendInstructionMutation.isLoading}
+                        >
+                            Dismiss
+                        </Button>
+                        <Button
+                            size="compact-xs"
+                            color="indigo"
+                            onClick={handleSave}
+                            loading={appendInstructionMutation.isLoading}
+                        >
+                            Save
+                        </Button>
+                    </Group>
+                </Stack>
+            </Group>
+        </Paper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallContainer.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallContainer.module.css
@@ -1,0 +1,37 @@
+@keyframes shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.streamingTitle {
+    background: linear-gradient(
+        90deg,
+        #94a3b8 0%,
+        #cbd5e1 25%,
+        #e2e8f0 50%,
+        #cbd5e1 75%,
+        #94a3b8 100%
+    );
+    background-size: 200% 100%;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    animation: shimmer 2s ease-in-out infinite;
+}
+
+.streamingIcon {
+    animation: spin 2s linear infinite;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallContainer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallContainer.tsx
@@ -1,0 +1,41 @@
+import { Box } from '@mantine-8/core';
+import { IconSparkles, type TablerIconsProps } from '@tabler/icons-react';
+import type { FC, JSX } from 'react';
+import classes from './ToolCallContainer.module.css';
+import { ToolCallPaper } from './ToolCallPaper';
+
+type ToolCallContainerProps = {
+    children: React.ReactNode;
+    defaultOpened?: boolean;
+    title: string;
+    isStreaming?: boolean;
+    icon?: (props: TablerIconsProps) => JSX.Element;
+};
+
+export const ToolCallContainer: FC<ToolCallContainerProps> = ({
+    children,
+    defaultOpened = true,
+    title,
+    isStreaming = false,
+    icon = IconSparkles,
+}) => {
+    return (
+        <ToolCallPaper
+            defaultOpened={defaultOpened}
+            variant="dashed"
+            icon={icon}
+            iconClassName={isStreaming ? classes.streamingIcon : undefined}
+            title={
+                isStreaming ? (
+                    <Box component="span" className={classes.streamingTitle}>
+                        {title}
+                    </Box>
+                ) : (
+                    title
+                )
+            }
+        >
+            {children}
+        </ToolCallPaper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallPaper.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallPaper.tsx
@@ -21,6 +21,7 @@ type ToolCallPaperProps = {
     variant?: 'default' | 'dashed';
     hasError?: boolean;
     rightAction?: ReactNode;
+    iconClassName?: string;
 };
 
 export const ToolCallPaper = ({
@@ -31,6 +32,7 @@ export const ToolCallPaper = ({
     variant = 'default',
     hasError,
     rightAction,
+    iconClassName,
 }: ToolCallPaperProps) => {
     const [opened, { toggle }] = useDisclosure(defaultOpened);
 
@@ -56,6 +58,7 @@ export const ToolCallPaper = ({
                             size="sm"
                             strokeWidth={1.2}
                             color={contentColor}
+                            className={iconClassName}
                         />
                         <Title order={6} c={contentColor} size="xs">
                             {title}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ContentSearchToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ContentSearchToolCallDescription.tsx
@@ -1,0 +1,40 @@
+import { type ToolFindContentArgsTransformed } from '@lightdash/common';
+import { Badge, rem, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type ContentSearchToolCallDescriptionProps = {
+    searchType: 'content' | 'dashboards' | 'charts';
+    searchQueries: NonNullable<ToolFindContentArgsTransformed>['searchQueries'];
+};
+
+export const ContentSearchToolCallDescription: FC<
+    ContentSearchToolCallDescriptionProps
+> = ({ searchType, searchQueries }) => {
+    const typeText = {
+        content: 'content',
+        dashboards: 'dashboards',
+        charts: 'charts',
+    }[searchType];
+
+    return (
+        <Text c="dimmed" size="xs">
+            Searched for {typeText}{' '}
+            {searchQueries.map((query) => (
+                <Badge
+                    key={query.label}
+                    color="gray"
+                    variant="light"
+                    size="xs"
+                    mx={rem(2)}
+                    radius="sm"
+                    style={{
+                        textTransform: 'none',
+                        fontWeight: 400,
+                    }}
+                >
+                    {query.label}
+                </Badge>
+            ))}
+        </Text>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/DashboardToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/DashboardToolCallDescription.tsx
@@ -1,0 +1,39 @@
+import {
+    type ToolDashboardArgsTransformed,
+    type ToolDashboardV2ArgsTransformed,
+} from '@lightdash/common';
+import { Group, Stack, Text, Tooltip } from '@mantine-8/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import type { FC } from 'react';
+import MantineIcon from '../../../../../../../components/common/MantineIcon';
+
+type DashboardToolCallDescriptionProps = Pick<
+    ToolDashboardV2ArgsTransformed | ToolDashboardArgsTransformed,
+    'title' | 'description'
+>;
+
+export const DashboardToolCallDescription: FC<
+    DashboardToolCallDescriptionProps
+> = ({ title, description }) => {
+    return (
+        <Stack gap="xs">
+            <Group gap="two">
+                <Text c="dimmed" size="xs">
+                    Built{' '}
+                    <Text span fw={500} c="gray.8">
+                        "{title}"
+                    </Text>
+                </Text>
+                {description && (
+                    <Tooltip label={description}>
+                        <MantineIcon
+                            icon={IconInfoCircle}
+                            color="gray.6"
+                            size="sm"
+                        />
+                    </Tooltip>
+                )}
+            </Group>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ExploreToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ExploreToolCallDescription.tsx
@@ -1,0 +1,32 @@
+import type { ToolFindExploresArgsTransformed } from '@lightdash/common';
+import { Badge, rem, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type ExploreToolCallDescriptionProps = {
+    exploreName: NonNullable<ToolFindExploresArgsTransformed>['exploreName'];
+};
+
+export const ExploreToolCallDescription: FC<
+    ExploreToolCallDescriptionProps
+> = ({ exploreName }) => {
+    return (
+        <Text c="dimmed" size="xs">
+            Searched relevant explores{' '}
+            {exploreName && (
+                <Badge
+                    color="gray"
+                    variant="light"
+                    size="xs"
+                    mx={rem(2)}
+                    radius="sm"
+                    style={{
+                        textTransform: 'none',
+                        fontWeight: 400,
+                    }}
+                >
+                    {exploreName}
+                </Badge>
+            )}
+        </Text>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/FieldSearchToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/FieldSearchToolCallDescription.tsx
@@ -1,0 +1,33 @@
+import { type ToolFindFieldsArgsTransformed } from '@lightdash/common';
+import { Badge, rem, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type FieldSearchToolCallDescriptionProps = {
+    searchQueries: NonNullable<ToolFindFieldsArgsTransformed>['fieldSearchQueries'];
+};
+
+export const FieldSearchToolCallDescription: FC<
+    FieldSearchToolCallDescriptionProps
+> = ({ searchQueries }) => {
+    return (
+        <Text c="dimmed" size="xs">
+            Searched for fields{' '}
+            {searchQueries.map((query) => (
+                <Badge
+                    key={query.label}
+                    color="gray"
+                    variant="light"
+                    size="xs"
+                    mx={rem(2)}
+                    radius="sm"
+                    style={{
+                        textTransform: 'none',
+                        fontWeight: 400,
+                    }}
+                >
+                    {query.label}
+                </Badge>
+            ))}
+        </Text>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/FieldValuesSearchToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/FieldValuesSearchToolCallDescription.tsx
@@ -1,0 +1,50 @@
+import { type ToolSearchFieldValuesArgsTransformed } from '@lightdash/common';
+import { Badge, rem, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type FieldValuesSearchToolCallDescriptionProps = Pick<
+    ToolSearchFieldValuesArgsTransformed,
+    'fieldId' | 'query'
+>;
+
+export const FieldValuesSearchToolCallDescription: FC<
+    FieldValuesSearchToolCallDescriptionProps
+> = ({ fieldId, query }) => {
+    return (
+        <Text c="dimmed" size="xs">
+            Searched for values in field{' '}
+            <Badge
+                color="gray"
+                variant="light"
+                size="xs"
+                mx={rem(2)}
+                radius="sm"
+                style={{
+                    textTransform: 'none',
+                    fontWeight: 400,
+                }}
+            >
+                {fieldId}
+            </Badge>
+            {query && (
+                <>
+                    {' '}
+                    matching{' '}
+                    <Badge
+                        color="gray"
+                        variant="light"
+                        size="xs"
+                        mx={rem(2)}
+                        radius="sm"
+                        style={{
+                            textTransform: 'none',
+                            fontWeight: 400,
+                        }}
+                    >
+                        "{query}"
+                    </Badge>
+                </>
+            )}
+        </Text>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/QueryResultToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/QueryResultToolCallDescription.tsx
@@ -1,0 +1,116 @@
+import { type ToolRunQueryArgsTransformed } from '@lightdash/common';
+import { Badge, Group, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+import { formatFieldName } from '../utils/formatFieldName';
+
+type QueryResultToolCallDescriptionProps = Pick<
+    ToolRunQueryArgsTransformed,
+    | 'title'
+    | 'queryConfig'
+    | 'chartConfig'
+    | 'customMetrics'
+    | 'tableCalculations'
+>;
+
+export const QueryResultToolCallDescription: FC<
+    QueryResultToolCallDescriptionProps
+> = ({ title, queryConfig, chartConfig, customMetrics, tableCalculations }) => {
+    const dimensions = queryConfig?.dimensions || [];
+    const metrics = queryConfig?.metrics || [];
+    const groupBy = chartConfig?.groupBy || [];
+    const customMetricsArray = customMetrics || [];
+    const tableCalculationsArray = tableCalculations || [];
+
+    // Separate dimensions into regular dimensions and groupBy dimensions
+    const regularDimensions = dimensions.filter(
+        (dim: string) => !groupBy.includes(dim),
+    );
+    const groupByDimensions = groupBy;
+
+    return (
+        <Group gap={4} wrap="wrap">
+            <Text c="dimmed" size="xs" fw={500}>
+                "{title}"
+            </Text>
+            {metrics.length > 0 && (
+                <>
+                    <Text c="dimmed" size="xs">
+                        shows
+                    </Text>
+                    {metrics.map((metric: string) => (
+                        <Badge
+                            key={metric}
+                            color="gray"
+                            variant="light"
+                            size="xs"
+                            radius="sm"
+                            style={{
+                                textTransform: 'none',
+                                fontWeight: 400,
+                            }}
+                        >
+                            {formatFieldName(metric)}
+                        </Badge>
+                    ))}
+                </>
+            )}
+            {regularDimensions.length > 0 && (
+                <>
+                    <Text c="dimmed" size="xs">
+                        by
+                    </Text>
+                    {regularDimensions.map((dim: string) => (
+                        <Badge
+                            key={dim}
+                            color="gray"
+                            variant="light"
+                            size="xs"
+                            radius="sm"
+                            style={{
+                                textTransform: 'none',
+                                fontWeight: 400,
+                            }}
+                        >
+                            {formatFieldName(dim)}
+                        </Badge>
+                    ))}
+                </>
+            )}
+            {groupByDimensions.length > 0 && (
+                <>
+                    <Text c="dimmed" size="xs">
+                        grouped by
+                    </Text>
+                    {groupByDimensions.map((dim: string) => (
+                        <Badge
+                            key={dim}
+                            color="gray"
+                            variant="light"
+                            size="xs"
+                            radius="sm"
+                            style={{
+                                textTransform: 'none',
+                                fontWeight: 400,
+                            }}
+                        >
+                            {formatFieldName(dim)}
+                        </Badge>
+                    ))}
+                </>
+            )}
+            {customMetricsArray.length > 0 && (
+                <Text c="dimmed" size="xs">
+                    with {customMetricsArray.length} custom metric
+                    {customMetricsArray.length !== 1 ? 's' : ''}
+                </Text>
+            )}
+            {tableCalculationsArray.length > 0 && (
+                <Text c="dimmed" size="xs">
+                    {customMetricsArray.length > 0 ? 'and' : 'with'}{' '}
+                    {tableCalculationsArray.length} calculation
+                    {tableCalculationsArray.length !== 1 ? 's' : ''}
+                </Text>
+            )}
+        </Group>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -1,0 +1,152 @@
+import {
+    AiResultType,
+    assertUnreachable,
+    parseToolArgs,
+    ToolNameSchema,
+} from '@lightdash/common';
+import type { FC } from 'react';
+import { AiChartGenerationToolCallDescription } from '../AiChartGenerationToolCallDescription';
+import type { ToolCallSummary } from '../utils/types';
+import { ContentSearchToolCallDescription } from './ContentSearchToolCallDescription';
+import { DashboardToolCallDescription } from './DashboardToolCallDescription';
+import { ExploreToolCallDescription } from './ExploreToolCallDescription';
+import { FieldSearchToolCallDescription } from './FieldSearchToolCallDescription';
+import { FieldValuesSearchToolCallDescription } from './FieldValuesSearchToolCallDescription';
+import { QueryResultToolCallDescription } from './QueryResultToolCallDescription';
+
+export const ToolCallDescription: FC<{
+    toolCall: ToolCallSummary;
+}> = ({ toolCall }) => {
+    const toolNameParsed = ToolNameSchema.safeParse(toolCall.toolName);
+
+    if (!toolNameParsed.success) {
+        console.error(
+            `Failed to parse tool name ${toolCall.toolName} ${toolCall.toolCallId}`,
+            toolNameParsed.error,
+        );
+        return null;
+    }
+
+    const toolName = toolNameParsed.data;
+    const toolArgsParsed = parseToolArgs(toolName, toolCall.toolArgs);
+
+    if (!toolArgsParsed.success) {
+        console.error(
+            `Failed to parse tool args for ${toolName} ${toolCall.toolCallId}`,
+            toolArgsParsed.error,
+        );
+        return null;
+    }
+
+    const toolArgs = toolArgsParsed.data;
+
+    switch (toolArgs.type) {
+        case 'find_explores':
+        case 'find_explores_v2':
+            return (
+                <ExploreToolCallDescription
+                    exploreName={toolArgs.exploreName}
+                />
+            );
+        case 'find_fields':
+            return (
+                <FieldSearchToolCallDescription
+                    searchQueries={toolArgs.fieldSearchQueries}
+                />
+            );
+        case 'search_field_values':
+            const searchFieldValuesArgs = toolArgs;
+            return (
+                <FieldValuesSearchToolCallDescription
+                    fieldId={searchFieldValuesArgs.fieldId}
+                    query={searchFieldValuesArgs.query}
+                />
+            );
+        case AiResultType.VERTICAL_BAR_RESULT:
+            const barVizConfigToolArgs = toolArgs;
+            return (
+                <AiChartGenerationToolCallDescription
+                    title={barVizConfigToolArgs.title}
+                    dimensions={[barVizConfigToolArgs.vizConfig.xDimension]}
+                    metrics={barVizConfigToolArgs.vizConfig.yMetrics}
+                    breakdownByDimension={
+                        barVizConfigToolArgs.vizConfig.breakdownByDimension
+                    }
+                />
+            );
+        case AiResultType.TABLE_RESULT:
+            const tableVizConfigToolArgs = toolArgs;
+            return (
+                <AiChartGenerationToolCallDescription
+                    title={tableVizConfigToolArgs.title}
+                    dimensions={
+                        tableVizConfigToolArgs.vizConfig.dimensions ?? []
+                    }
+                    metrics={tableVizConfigToolArgs.vizConfig.metrics}
+                />
+            );
+        case AiResultType.TIME_SERIES_RESULT:
+            const timeSeriesToolCallArgs = toolArgs;
+            return (
+                <AiChartGenerationToolCallDescription
+                    title={timeSeriesToolCallArgs.title}
+                    dimensions={[timeSeriesToolCallArgs.vizConfig.xDimension]}
+                    metrics={timeSeriesToolCallArgs.vizConfig.yMetrics}
+                    breakdownByDimension={
+                        timeSeriesToolCallArgs.vizConfig.breakdownByDimension
+                    }
+                />
+            );
+        case 'find_content':
+            const findContentToolArgs = toolArgs;
+            return (
+                <ContentSearchToolCallDescription
+                    searchType="content"
+                    searchQueries={findContentToolArgs.searchQueries}
+                />
+            );
+        case 'find_dashboards':
+            const findDashboardsToolArgs = toolArgs;
+            return (
+                <ContentSearchToolCallDescription
+                    searchType="dashboards"
+                    searchQueries={
+                        findDashboardsToolArgs.dashboardSearchQueries
+                    }
+                />
+            );
+        case 'find_charts':
+            const findChartsToolArgs = toolArgs;
+            return (
+                <ContentSearchToolCallDescription
+                    searchType="charts"
+                    searchQueries={findChartsToolArgs.chartSearchQueries}
+                />
+            );
+        case AiResultType.DASHBOARD_RESULT:
+        case AiResultType.DASHBOARD_V2_RESULT:
+            const dashboardToolArgs = toolArgs;
+            return (
+                <DashboardToolCallDescription
+                    title={dashboardToolArgs.title}
+                    description={dashboardToolArgs.description}
+                />
+            );
+        case AiResultType.QUERY_RESULT:
+            const queryToolArgs = toolArgs;
+            return (
+                <QueryResultToolCallDescription
+                    title={queryToolArgs.title}
+                    queryConfig={queryToolArgs.queryConfig}
+                    chartConfig={queryToolArgs.chartConfig}
+                    customMetrics={queryToolArgs.customMetrics}
+                    tableCalculations={queryToolArgs.tableCalculations}
+                />
+            );
+        case AiResultType.IMPROVE_CONTEXT:
+        case AiResultType.PROPOSE_CHANGE:
+            return <> </>;
+        default:
+            return assertUnreachable(toolArgs, `Unknown tool name ${toolName}`);
+    }
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/formatFieldName.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/formatFieldName.ts
@@ -1,0 +1,12 @@
+/**
+ * Format field names for display (remove table prefix, convert to readable format)
+ * e.g., "orders_order_date_month" -> "Order Date Month"
+ */
+export const formatFieldName = (fieldId: string): string => {
+    const parts = fieldId.split('_');
+    // Remove table prefix (first part) and capitalize remaining parts
+    return parts
+        .slice(1)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getContainerMetadata.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getContainerMetadata.ts
@@ -1,0 +1,92 @@
+import type { TablerIconsProps } from '@tabler/icons-react';
+import {
+    IconAnalyze,
+    IconChartLine,
+    IconLayoutDashboard,
+    IconSearch,
+    IconSparkles,
+} from '@tabler/icons-react';
+import type { JSX } from 'react';
+import type { ToolCallDisplayType, ToolCallSummary } from './types';
+
+type ContainerMetadata = {
+    title: string;
+    icon: (props: TablerIconsProps) => JSX.Element;
+};
+
+/**
+ * Determines the container title and icon based on the tool calls.
+ * This categorizes the tool calls once and returns both title and icon together.
+ */
+export const getContainerMetadata = (
+    toolCalls: ToolCallSummary[] | undefined,
+    type: ToolCallDisplayType,
+): ContainerMetadata => {
+    if (type === 'streaming') {
+        return {
+            title: 'Working on it...',
+            icon: IconAnalyze,
+        };
+    }
+
+    // Empty state
+    if (!toolCalls || toolCalls.length === 0) {
+        return {
+            title: 'Steps taken',
+            icon: IconSparkles,
+        };
+    }
+
+    const hasDashboardGeneration = toolCalls.some((tc) =>
+        ['generateDashboard'].includes(tc.toolName),
+    );
+
+    const hasVizGeneration = toolCalls.some((tc) =>
+        [
+            'generateBarVizConfig',
+            'generateTimeSeriesVizConfig',
+            'generateTableVizConfig',
+        ].includes(tc.toolName),
+    );
+
+    const hasQueryExecution = toolCalls.some(
+        (tc) => tc.toolName === 'runQuery',
+    );
+
+    const hasOnlySearches = toolCalls.every((tc) =>
+        [
+            'findExplores',
+            'findFields',
+            'searchFieldValues',
+            'findContent',
+            'findDashboards',
+            'findCharts',
+        ].includes(tc.toolName),
+    );
+
+    if (hasDashboardGeneration) {
+        return {
+            title: 'How this dashboard was built',
+            icon: IconLayoutDashboard,
+        };
+    }
+
+    if (hasVizGeneration || hasQueryExecution) {
+        return {
+            title: 'How this chart was built',
+            icon: IconChartLine,
+        };
+    }
+
+    if (hasOnlySearches) {
+        return {
+            title: 'Research steps',
+            icon: IconSearch,
+        };
+    }
+
+    return {
+        title: toolCalls.length === 1 ? 'Step taken' : 'Steps taken',
+        icon: IconSparkles,
+    };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -1,0 +1,36 @@
+import type { ToolName } from '@lightdash/common';
+import {
+    IconChartDots3,
+    IconChartHistogram,
+    IconChartLine,
+    IconDatabase,
+    IconLayoutDashboard,
+    IconPencil,
+    IconSchool,
+    IconSearch,
+    IconSelector,
+    IconTable,
+    type TablerIconsProps,
+} from '@tabler/icons-react';
+import type { JSX } from 'react';
+
+export const getToolIcon = (toolName: ToolName) => {
+    const iconMap: Record<ToolName, (props: TablerIconsProps) => JSX.Element> =
+        {
+            findExplores: IconDatabase,
+            findFields: IconSearch,
+            searchFieldValues: IconSelector,
+            generateBarVizConfig: IconChartHistogram,
+            generateTimeSeriesVizConfig: IconChartLine,
+            generateTableVizConfig: IconTable,
+            generateDashboard: IconLayoutDashboard,
+            findContent: IconSearch,
+            findDashboards: IconLayoutDashboard,
+            findCharts: IconChartDots3,
+            improveContext: IconSchool,
+            proposeChange: IconPencil,
+            runQuery: IconTable,
+        };
+
+    return iconMap[toolName];
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/types.ts
@@ -1,0 +1,10 @@
+export type ToolCallDisplayType =
+    | 'streaming'
+    | 'finished-streaming'
+    | 'persisted';
+
+export type ToolCallSummary = {
+    toolCallId: string;
+    toolName: string;
+    toolArgs: unknown;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -122,6 +122,7 @@ export function useAiAgentThreadStreamMutation() {
                                 case 'tool-improveContext':
                                 case 'tool-searchFieldValues':
                                 case 'tool-runQuery':
+                                case 'tool-generateDashboard':
                                     if (part.state !== 'input-available') break;
 
                                     const toolNameUnsafe =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1234

### Description:
Consolidates dashboard generation tools by removing `generateDashboardV2` and updating the `generateDashboard` tool to use V2 schema. This simplifies the API surface while maintaining backward compatibility by trying V2 schema parsing first, then falling back to V1 if needed.

The PR also significantly refactors the AI tool call UI components by:
1. Breaking down the monolithic `ToolCallDescription` component into smaller, specialized components
2. Adding dynamic container titles and icons based on tool call types
3. Improving visualization descriptions with better formatting
4. Adding loading animations for streaming tool calls
5. Updating tool display messages for better user experience

[CleanShot 2025-10-22 at 14.50.49.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/f10d6137-0796-4fc6-9355-5136ac41691a.mp4" />](https://app.graphite.dev/user-attachments/video/f10d6137-0796-4fc6-9355-5136ac41691a.mp4)

![Screenshot 2025-10-22 at 14.49.39.png](https://app.graphite.dev/user-attachments/assets/53fc9729-fc79-424f-8bbc-d4274a33552f.png)

![Screenshot 2025-10-22 at 14.49.29.png](https://app.graphite.dev/user-attachments/assets/e45e2fd3-54fb-4e06-91b8-6f0fdbcb9304.png)

![Screenshot 2025-10-22 at 14.49.17.png](https://app.graphite.dev/user-attachments/assets/e2dcc6c7-7199-4b91-90ad-0cac1d763a33.png)

