### PR TITLE
fix: support validation for additional explores

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -28,6 +28,17 @@ models:
         default_time_dimension:
           field: order_date
           interval: MONTH
+        explores:
+          completed_orders:
+            label: Completed Orders
+            description: Analysis of completed orders with customer information
+            group_label: Sales Analysis
+            joins:
+              - join: customers
+                sql_on: ${customers.customer_id} = ${orders.customer_id}
+                relationship: many-to-one
+            required_filters:
+              - is_completed: "true"
     columns:
       - name: order_id
         tests:

--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -274,6 +274,25 @@ export const exploreWithJoin: Explore = {
     },
 };
 
+// Additional explore with different name but same baseTable and fields as base explore
+export const additionalExplore: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'additional_explore',
+    label: 'Additional Explore',
+    tags: [],
+    baseTable: 'table', // Same baseTable as explore
+    joinedTables: [],
+    tables: explore.tables, // Same fields as base explore
+};
+
+export const chartForValidationWithAdditionalExplore: Awaited<
+    ReturnType<SavedChartModel['findChartsForValidation']>
+>[number] = {
+    ...chartForValidation,
+    name: 'Chart using additional explore',
+    tableName: 'additional_explore', // References the additional explore by name
+};
+
 export const exploreError: ExploreError = {
     name: 'valid_explore',
     label: 'valid_explore',

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -13,7 +13,9 @@ import { ValidationModel } from '../../models/ValidationModel/ValidationModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { ValidationService } from './ValidationService';
 import {
+    additionalExplore,
     chartForValidation,
+    chartForValidationWithAdditionalExplore,
     chartForValidationWithCustomMetricFilters,
     chartForValidationWithJoinedField,
     config,
@@ -347,6 +349,28 @@ describe('validation', () => {
             new Set([ValidationTarget.CHARTS]),
         );
 
+        expect(errors.length).toEqual(0);
+    });
+
+    it('Should validate charts using additional explores', async () => {
+        (
+            projectModel.findExploresFromCache as jest.Mock
+        ).mockImplementationOnce(async () => [explore, additionalExplore]);
+
+        (
+            savedChartModel.findChartsForValidation as jest.Mock
+        ).mockImplementationOnce(async () => [
+            chartForValidationWithAdditionalExplore,
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.CHARTS]),
+        );
+
+        // Chart uses "additional_explore" as tableName but has same fields as base "table"
+        // Should validate without errors because fields are indexed by both baseTable and explore name
         expect(errors.length).toEqual(0);
     });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17585

### Description:

Added support for additional explores in the validation service. The service now validates charts that use additional explores by matching both the base table name and the explore name. This enables the use of custom explores defined in YAML, such as the new "completed_orders" explore added to the jaffle-shop demo.

The implementation indexes field data by both the base table name and the explore name, allowing charts to reference either one while maintaining proper validation.
