### PR TITLE
fix: use columnOrder instead of selectedItemIds for table visualization

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -310,7 +310,7 @@ const VisualizationProvider: FC<
         resultsData: lastValidResultsData,
         isLoading,
         apiErrorDetail,
-        columnOrder,
+        columnOrder: defaultColumnOrder,
         itemsMap,
         setStacking,
         setCartesianType,

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -84,13 +84,13 @@ const getDataAndColumns = ({
     totals,
     groupedSubtotals,
 }: Args): Array<TableHeader | TableColumn> => {
-    return selectedItemIds.reduce<Array<TableHeader | TableColumn>>(
+    return columnOrder.reduce<Array<TableHeader | TableColumn>>(
         (acc, itemId) => {
             const item = itemsMap[itemId] as
                 | typeof itemsMap[number]
                 | undefined;
 
-            if (!columnOrder.includes(itemId)) {
+            if (!selectedItemIds.includes(itemId)) {
                 return acc;
             }
             const headerOverride = getFieldLabelOverride(itemId);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17589

### Description:
Fixed a bug in table visualization where columns were being filtered incorrectly. The code was using `selectedItemIds` to generate columns but then filtering out items not in `columnOrder`. This PR reverses the approach by starting with `columnOrder` and filtering out items not in `selectedItemIds`, ensuring that columns appear in the correct order while respecting the user's selection.