### PR TITLE
fix: handle deleted content in validation service

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -15,7 +15,9 @@ import {
     getFilterRules,
     getItemId,
     InlineErrorType,
+    isChartValidationError,
     isDashboardFieldTarget,
+    isDashboardValidationError,
     isExploreError,
     isSqlTableCalculation,
     isTemplateTableCalculation,
@@ -808,6 +810,21 @@ export class ValidationService extends BaseService {
         // Filter private content to developers
         return Promise.all(
             validations.map(async (validation) => {
+                const isDeleted =
+                    (isDashboardValidationError(validation) &&
+                        !validation.dashboardUuid) ||
+                    (isChartValidationError(validation) &&
+                        !validation.chartUuid);
+
+                if (isDeleted) {
+                    return {
+                        ...validation,
+                        chartUuid: undefined,
+                        dashboardUuid: undefined,
+                        name: 'Deleted content',
+                    };
+                }
+
                 const space = spaces.find(
                     (s) => s.uuid === validation.spaceUuid,
                 );

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -117,23 +117,9 @@ const TableValidationItem = forwardRef<
                         <Icon validationError={validationError} />
 
                         <Stack spacing={4}>
-                            {isDeleted(validationError) ? (
-                                <Tooltip
-                                    label={`This ${
-                                        isChartValidationError(validationError)
-                                            ? 'chart'
-                                            : 'dashboard'
-                                    } has been deleted`}
-                                >
-                                    <Text fw={600} color={'gray.6'}>
-                                        {getErrorName(validationError)}
-                                    </Text>
-                                </Tooltip>
-                            ) : (
-                                <Text fw={600}>
-                                    {getErrorName(validationError)}
-                                </Text>
-                            )}
+                            <Text fw={600}>
+                                {getErrorName(validationError)}
+                            </Text>
 
                             {(isChartValidationError(validationError) ||
                                 isDashboardValidationError(validationError)) &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Improved handling of deleted content in the validator table. Instead of showing deleted charts/dashboards with tooltips in the frontend, the backend now identifies deleted content and returns it with a standardized "Deleted content" name. This simplifies the frontend code by removing the need for conditional rendering and tooltips for deleted items.



![CleanShot 2025-10-22 at 19.16.17@2x.png](https://app.graphite.dev/user-attachments/assets/6a843456-90e8-47fd-9b33-734ec95d4cb1.png)

