### PR TITLE
feat: add charts to embedding table

### DIFF
--- a/examples/api/embedding.http
+++ b/examples/api/embedding.http
@@ -9,6 +9,9 @@ Content-Type: application/json
     "password": "demo_password!"
 }
 
+### Logout
+GET http://localhost:8080/api/v1/logout
+
 ### Get project config
 GET http://localhost:8080/api/v1/embed/3675b69e-8324-4110-bdca-059031aa8da3/config
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -154,7 +154,7 @@
     },
     "scripts": {
         "generate-api": "tsoa spec-and-routes --configuration tsoa.yml",
-        "generate-api-dev": "chokidar './src/controllers/**/*.ts' -c 'pnpm run generate-api'",
+        "generate-api-dev": "chokidar './src/**/controllers/**/*.ts' -c 'pnpm run generate-api'",
         "dev": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false --inspect=0.0.0.0:9229 src/index.ts",
         "build": "tsc --build tsconfig.json",
         "build-sourcemaps": "tsc --build tsconfig.sentry.json",

--- a/packages/backend/src/auth/account/account.mock.ts
+++ b/packages/backend/src/auth/account/account.mock.ts
@@ -94,6 +94,8 @@ export function buildAccount({
         encodedSecret: 'test-encoded-secret',
         dashboardUuids: ['test-dashboard-uuid'],
         allowAllDashboards: false,
+        chartUuids: [],
+        allowAllCharts: false,
         createdAt: '2021-01-01',
         user: {
             userUuid: 'test-user-uuid',
@@ -109,6 +111,8 @@ export function buildAccount({
             projectUuid: 'test-project-uuid',
             dashboardUuids: ['test-dashboard-uuid'],
             allowAllDashboards: false,
+            chartUuids: [],
+            allowAllCharts: false,
             createdAt: '2024-01-01',
             encodedSecret: 'test-encoded-secret',
             user: {

--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -22,6 +22,8 @@ describe('account', () => {
             encodedSecret: 'test-encoded-secret',
             dashboardUuids: ['test-dashboard-uuid'],
             allowAllDashboards: false,
+            chartUuids: [],
+            allowAllCharts: false,
             createdAt: '2021-01-01',
             user: {
                 userUuid: 'test-user-uuid',

--- a/packages/backend/src/database/migrations/20251022131031_add_chart_fields_to_embeddings.ts
+++ b/packages/backend/src/database/migrations/20251022131031_add_chart_fields_to_embeddings.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+const EMBEDDING_TABLE_NAME = 'embedding';
+const fields = {
+    chart_uuids: 'chart_uuids',
+    allow_all_charts: 'allow_all_charts',
+};
+export async function up(knex: Knex): Promise<void> {
+    if (
+        !(await knex.schema.hasColumn(EMBEDDING_TABLE_NAME, fields.chart_uuids))
+    ) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            table
+                .specificType(fields.chart_uuids, 'text[]')
+                .notNullable()
+                .defaultTo('{}');
+        });
+    }
+    if (
+        !(await knex.schema.hasColumn(
+            EMBEDDING_TABLE_NAME,
+            fields.allow_all_charts,
+        ))
+    ) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            table.boolean(fields.allow_all_charts).defaultTo(false);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(EMBEDDING_TABLE_NAME, fields.chart_uuids)) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            table.dropColumn(fields.chart_uuids);
+        });
+    }
+    if (
+        await knex.schema.hasColumn(
+            EMBEDDING_TABLE_NAME,
+            fields.allow_all_charts,
+        )
+    ) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            table.dropColumn(fields.allow_all_charts);
+        });
+    }
+}

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -8,6 +8,7 @@ import {
     ApiExecuteAsyncDashboardChartQueryResults,
     ApiSuccessEmpty,
     assertEmbeddedAuth,
+    assertSessionAuth,
     CacheMetadata,
     CreateEmbedJwt,
     CreateEmbedRequestBody,
@@ -102,10 +103,11 @@ export class EmbedController extends BaseController {
         @Path() projectUuid: string,
     ): Promise<ApiEmbedConfigResponse> {
         this.setStatus(200);
+        assertSessionAuth(req.account);
         return {
             status: 'ok',
             results: await this.getEmbedService().getConfig(
-                req.user!,
+                req.account.user,
                 projectUuid,
             ),
         };
@@ -121,10 +123,11 @@ export class EmbedController extends BaseController {
         @Body() body: CreateEmbedRequestBody,
     ): Promise<ApiEmbedConfigResponse> {
         this.setStatus(201);
+        assertSessionAuth(req.account);
         return {
             status: 'ok',
-            results: await this.getEmbedService().saveConfig(
-                req.user!,
+            results: await this.getEmbedService().createConfig(
+                req.account.user,
                 projectUuid,
                 body,
             ),
@@ -135,14 +138,38 @@ export class EmbedController extends BaseController {
     @SuccessResponse('200', 'Success')
     @Patch('/config/dashboards')
     @OperationId('updateEmbeddedDashboards')
+    @Deprecated()
     async updateEmbeddedDashboards(
         @Request() req: express.Request,
         @Path() projectUuid: string,
         @Body() body: UpdateEmbed,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
+        assertSessionAuth(req.account);
         await this.getEmbedService().updateDashboards(
-            req.user!,
+            req.account,
+            projectUuid,
+            body,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Patch('/config')
+    @OperationId('updateEmbedConfig')
+    async updateEmbedConfig(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: UpdateEmbed,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+        assertSessionAuth(req.account);
+        await this.getEmbedService().updateConfig(
+            req.account,
             projectUuid,
             body,
         );
@@ -162,10 +189,11 @@ export class EmbedController extends BaseController {
         @Body() body: CreateEmbedJwt,
     ): Promise<ApiEmbedUrlResponse> {
         this.setStatus(200);
+        assertSessionAuth(req.account);
         return {
             status: 'ok',
             results: await this.getEmbedService().getEmbedUrl(
-                req.user!,
+                req.account,
                 projectUuid,
                 body,
             ),

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.mock.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.mock.ts
@@ -1,0 +1,116 @@
+import { Ability } from '@casl/ability';
+import {
+    OrganizationMemberRole,
+    PossibleAbilities,
+    SessionAccount,
+} from '@lightdash/common';
+import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
+import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
+import { OrganizationModel } from '../../../models/OrganizationModel';
+import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../../models/SavedChartModel';
+import { UserAttributesModel } from '../../../models/UserAttributesModel';
+import { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import { ProjectService } from '../../../services/ProjectService/ProjectService';
+import { EncryptionUtil } from '../../../utils/EncryptionUtil/EncryptionUtil';
+import { EmbedModel } from '../../models/EmbedModel';
+import { EmbedService } from './EmbedService';
+
+export const mockProjectUuid = 'project-123';
+export const mockOrganizationUuid = 'org-456';
+export const mockUserUuid = 'user-789';
+
+// Mock account with permission to update projects
+export const mockAccountWithPermission: SessionAccount = {
+    organization: {
+        organizationUuid: mockOrganizationUuid,
+        name: 'Test Org',
+        createdAt: new Date(),
+    },
+    authentication: {
+        type: 'session',
+        source: 'mock-session',
+    },
+    user: {
+        type: 'registered',
+        id: mockUserUuid,
+        userUuid: mockUserUuid,
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        isSetupComplete: true,
+        userId: 1,
+        role: OrganizationMemberRole.ADMIN,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        abilityRules: [],
+        ability: new Ability<PossibleAbilities>([
+            { subject: 'Project', action: ['update', 'view'] },
+        ]),
+    },
+    isAuthenticated: jest.fn().mockReturnValue(true),
+    isRegisteredUser: jest.fn().mockReturnValue(true),
+    isAnonymousUser: jest.fn().mockReturnValue(false),
+    isSessionUser: jest.fn().mockReturnValue(true),
+    isJwtUser: jest.fn().mockReturnValue(false),
+    isServiceAccount: jest.fn().mockReturnValue(false),
+    isPatUser: jest.fn().mockReturnValue(false),
+    isOauthUser: jest.fn().mockReturnValue(false),
+};
+
+// Mock account without permission
+export const mockAccountWithoutPermission: SessionAccount = {
+    ...mockAccountWithPermission,
+    user: {
+        ...mockAccountWithPermission.user,
+        role: OrganizationMemberRole.VIEWER,
+        ability: new Ability<PossibleAbilities>([]),
+    },
+};
+
+// Only mock what updateConfig actually uses
+const projectModelMock = {
+    getSummary: jest.fn().mockResolvedValue({
+        projectUuid: mockProjectUuid,
+        organizationUuid: mockOrganizationUuid,
+        name: 'Test Project',
+    }),
+} as unknown as ProjectModel;
+
+const featureFlagModelMock = {
+    get: jest.fn().mockResolvedValue({ enabled: true }),
+} as unknown as FeatureFlagModel;
+
+const organizationModelMock = {
+    get: jest.fn().mockResolvedValue({
+        organizationUuid: mockOrganizationUuid,
+        name: 'Test Org',
+    }),
+} as unknown as OrganizationModel;
+
+const embedModelMock = {
+    updateConfig: jest.fn().mockResolvedValue(undefined),
+} as unknown as EmbedModel;
+
+// Constructor dependencies - minimal mocks since updateConfig doesn't use them
+export const EmbedServiceArgumentsMock: ConstructorParameters<
+    typeof EmbedService
+>[0] = {
+    lightdashConfig: lightdashConfigMock,
+    analytics: {} as LightdashAnalytics,
+    encryptionUtil: {} as EncryptionUtil,
+    embedModel: embedModelMock,
+    dashboardModel: {} as DashboardModel,
+    savedChartModel: {} as SavedChartModel,
+    projectModel: projectModelMock,
+    userAttributesModel: {} as UserAttributesModel,
+    projectService: {} as ProjectService,
+    asyncQueryService: {} as AsyncQueryService,
+    featureFlagModel: featureFlagModelMock,
+    organizationModel: organizationModelMock,
+};

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -1,0 +1,262 @@
+import { ForbiddenError, ParameterError } from '@lightdash/common';
+import { EmbedService } from './EmbedService';
+import {
+    EmbedServiceArgumentsMock,
+    mockAccountWithoutPermission,
+    mockAccountWithPermission,
+    mockProjectUuid,
+} from './EmbedService.mock';
+
+describe('EmbedService', () => {
+    let service: EmbedService;
+
+    beforeEach(() => {
+        service = new EmbedService(EmbedServiceArgumentsMock);
+        jest.clearAllMocks();
+    });
+
+    describe('updateConfig', () => {
+        const validDashboardUpdate = {
+            dashboardUuids: ['dashboard-1', 'dashboard-2'],
+            allowAllDashboards: false,
+            chartUuids: [],
+            allowAllCharts: false,
+        };
+
+        const validChartUpdate = {
+            dashboardUuids: [],
+            allowAllDashboards: false,
+            chartUuids: ['chart-1', 'chart-2'],
+            allowAllCharts: false,
+        };
+
+        const validBothUpdate = {
+            dashboardUuids: ['dashboard-1'],
+            allowAllDashboards: false,
+            chartUuids: ['chart-1'],
+            allowAllCharts: false,
+        };
+
+        describe('successful updates', () => {
+            test('should successfully update config with dashboards', async () => {
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    validDashboardUpdate,
+                );
+
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(mockProjectUuid, validDashboardUpdate);
+            });
+
+            test('should successfully update config with charts only', async () => {
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    validChartUpdate,
+                );
+
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(mockProjectUuid, validChartUpdate);
+            });
+
+            test('should successfully update config with both dashboards and charts', async () => {
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    validBothUpdate,
+                );
+
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(mockProjectUuid, validBothUpdate);
+            });
+
+            test('should successfully update config with allowAllDashboards enabled', async () => {
+                const allowAllDashboardsUpdate = {
+                    dashboardUuids: [],
+                    allowAllDashboards: true,
+                    chartUuids: [],
+                    allowAllCharts: false,
+                };
+
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    allowAllDashboardsUpdate,
+                );
+
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(
+                    mockProjectUuid,
+                    allowAllDashboardsUpdate,
+                );
+            });
+
+            test('should successfully update config with allowAllCharts enabled', async () => {
+                const allowAllChartsUpdate = {
+                    dashboardUuids: [],
+                    allowAllDashboards: false,
+                    chartUuids: [],
+                    allowAllCharts: true,
+                };
+
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    allowAllChartsUpdate,
+                );
+
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(mockProjectUuid, allowAllChartsUpdate);
+            });
+
+            test('should successfully update when both allowAll flags are true', async () => {
+                const updateWithBothAllowAll = {
+                    dashboardUuids: [],
+                    allowAllDashboards: true,
+                    chartUuids: [],
+                    allowAllCharts: true,
+                };
+
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    updateWithBothAllowAll,
+                );
+
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(mockProjectUuid, updateWithBothAllowAll);
+            });
+        });
+
+        describe('validation errors', () => {
+            test('should throw ParameterError when no dashboards or charts specified', async () => {
+                const invalidUpdate = {
+                    dashboardUuids: [],
+                    allowAllDashboards: false,
+                    chartUuids: [],
+                    allowAllCharts: false,
+                };
+
+                await expect(
+                    service.updateConfig(
+                        mockAccountWithPermission,
+                        mockProjectUuid,
+                        invalidUpdate,
+                    ),
+                ).rejects.toThrow(ParameterError);
+
+                await expect(
+                    service.updateConfig(
+                        mockAccountWithPermission,
+                        mockProjectUuid,
+                        invalidUpdate,
+                    ),
+                ).rejects.toThrow(
+                    'At least one dashboard or chart must be specified for embedding',
+                );
+            });
+
+            test('should throw ParameterError when chartUuids is undefined and no dashboards', async () => {
+                const invalidUpdate = {
+                    dashboardUuids: [],
+                    allowAllDashboards: false,
+                    chartUuids: undefined,
+                    allowAllCharts: false,
+                };
+
+                await expect(
+                    service.updateConfig(
+                        mockAccountWithPermission,
+                        mockProjectUuid,
+                        invalidUpdate,
+                    ),
+                ).rejects.toThrow(ParameterError);
+            });
+        });
+
+        describe('permission errors', () => {
+            test('should throw ForbiddenError when user lacks update permission', async () => {
+                await expect(
+                    service.updateConfig(
+                        mockAccountWithoutPermission,
+                        mockProjectUuid,
+                        validDashboardUpdate,
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+
+                // Verify embedModel.updateConfig was NOT called
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('should throw ForbiddenError when embedding feature is disabled', async () => {
+                // Mock feature flag as disabled for this test
+                const featureFlagGet = EmbedServiceArgumentsMock
+                    .featureFlagModel.get as jest.Mock;
+                featureFlagGet.mockResolvedValueOnce({ enabled: false });
+
+                await expect(
+                    service.updateConfig(
+                        mockAccountWithPermission,
+                        mockProjectUuid,
+                        validDashboardUpdate,
+                    ),
+                ).rejects.toThrow('Feature not enabled');
+            });
+        });
+
+        describe('edge cases', () => {
+            test('should handle chartUuids being undefined when dashboards are provided', async () => {
+                const updateWithUndefinedCharts = {
+                    dashboardUuids: ['dashboard-1'],
+                    allowAllDashboards: false,
+                    chartUuids: undefined,
+                    allowAllCharts: false,
+                };
+
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    updateWithUndefinedCharts,
+                );
+
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(
+                    mockProjectUuid,
+                    updateWithUndefinedCharts,
+                );
+            });
+
+            test('should handle allowAllCharts being undefined when dashboards are provided', async () => {
+                const updateWithUndefinedAllowAllCharts = {
+                    dashboardUuids: ['dashboard-1'],
+                    allowAllDashboards: false,
+                    chartUuids: ['chart-1'],
+                    allowAllCharts: undefined,
+                };
+
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    updateWithUndefinedAllowAllCharts,
+                );
+
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(
+                    mockProjectUuid,
+                    updateWithUndefinedAllowAllCharts,
+                );
+            });
+        });
+    });
+});

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1052,6 +1052,12 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 allowAllDashboards: { dataType: 'boolean', required: true },
+                chartUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                allowAllCharts: { dataType: 'boolean', required: true },
                 createdAt: { dataType: 'string', required: true },
                 user: {
                     ref: 'Pick_LightdashUser.userUuid-or-firstName-or-lastName_',
@@ -1108,10 +1114,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                chartUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
                 dashboardUuids: {
                     dataType: 'array',
                     array: { dataType: 'string' },
-                    required: true,
                 },
             },
             validators: {},
@@ -1123,6 +1132,11 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                allowAllCharts: { dataType: 'boolean' },
+                chartUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
                 allowAllDashboards: { dataType: 'boolean', required: true },
                 dashboardUuids: {
                     dataType: 'array',
@@ -22687,6 +22701,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateEmbeddedDashboards',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsEmbedController_updateEmbedConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: { in: 'body', name: 'body', required: true, ref: 'UpdateEmbed' },
+    };
+    app.patch(
+        '/api/v1/embed/:projectUuid/config',
+        ...fetchMiddlewares<RequestHandler>(EmbedController),
+        ...fetchMiddlewares<RequestHandler>(
+            EmbedController.prototype.updateEmbedConfig,
+        ),
+
+        async function EmbedController_updateEmbedConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsEmbedController_updateEmbedConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<EmbedController>(
+                    EmbedController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateEmbedConfig',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -555,8 +555,8 @@ export class InstanceConfigurationService extends BaseService {
                 await this.embedModel.save(
                     projectUuid,
                     encodedSecret,
-                    [],
                     userUuid,
+                    [],
                     allowAllDashboards ?? false,
                 );
                 this.logger.info(

--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -44,6 +44,8 @@ const embed: OssEmbed = {
     encodedSecret: 'encoded-secret',
     dashboardUuids: ['dashboard-uuid-1'],
     allowAllDashboards: false,
+    chartUuids: [],
+    allowAllCharts: false,
     createdAt: '2021-01-01',
     user: {
         firstName: 'John',

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -10,14 +10,19 @@ export type DecodedEmbed = Omit<Embed, 'encodedSecret'> & {
     secret: string;
 };
 
-// tsoa can't differentiate betwen CreateEmbed and CreatedEmbedJwt so we opt for a more unique name
+// tsoa can't differentiate between CreateEmbed and CreatedEmbedJwt so we opt for a more unique name
+// At least one of dashboardUuids or chartUuids must be provided
 export type CreateEmbedRequestBody = {
-    dashboardUuids: string[];
+    dashboardUuids?: string[];
+    chartUuids?: string[];
 };
 
 export type UpdateEmbed = {
     dashboardUuids: string[];
     allowAllDashboards: boolean;
+    // TODO: Make these required in Settings UI PR
+    chartUuids?: string[];
+    allowAllCharts?: boolean;
 };
 
 export enum FilterInteractivityValues {

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -63,6 +63,8 @@ export type OssEmbed = {
     encodedSecret: string;
     dashboardUuids: string[];
     allowAllDashboards: boolean;
+    chartUuids: string[];
+    allowAllCharts: boolean;
     createdAt: string;
     user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'>;
 };

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedDashboardsForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedDashboardsForm.tsx
@@ -24,6 +24,8 @@ const EmbedDashboardsForm: FC<{
         onSave({
             dashboardUuids: values.dashboardUuids,
             allowAllDashboards: values.allowAllDashboards,
+            chartUuids: [],
+            allowAllCharts: false,
         });
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,12 +20,6 @@
         {
             "path": "./packages/warehouses"
         },
-        {
-            "path": "./packages/e2e"
-        },
-        {
-            "path": "./packages/sdk-test-app"
-        }
     ],
     "exclude": [
         "dist",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: CENG-99<!-- reference the related issue e.g. #150 -->

### Description: 

This is the first PR in making embed charts available in Lightdash. 

The migration adds two new columns to the embedding table to allow configuring a chart for embedding. While this isn't a great long-term solution (adding more `*_uuids`​ fields), this is a bridge solution until we have a stronger long-term solution for sharing content. 

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->