### PR TITLE
fix: table calculation e2e test

### DIFF
--- a/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
+++ b/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
@@ -47,7 +47,7 @@ describe('Table calculations', () => {
         cy.findByTestId('SQL-card-expand').click();
 
         const sqlLines = [
-            `SUM("payments_total_revenue") OVER ( ORDER BY "payments_total_revenue" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW )`,
+            `SUM("payments_total_revenue") OVER ( ORDER BY "payments_payment_method" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW )`,
             `AS "running_total_of_total_revenue"`,
             `FROM metrics`,
         ];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the SQL query in the table calculation test to order by `payments_payment_method` in ascending order instead of ordering by `payments_total_revenue` in descending order. This change ensures the running total calculation is performed based on payment method rather than revenue amount.
