### PR TITLE
feat: add chart embedding support to JWT authentication

### DIFF
--- a/examples/api/embedding.http
+++ b/examples/api/embedding.http
@@ -68,3 +68,61 @@ Content-Type: application/json
         "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3"
     }
 }
+
+### Generate embed url for chart - use the chartUuid you want to embed
+
+@chartUuid = 0854611a-9842-4937-9cab-37fb3557e852
+@projectUuid = 3675b69e-8324-4110-bdca-059031aa8da3
+
+POST http://localhost:8080/api/v1/embed/3675b69e-8324-4110-bdca-059031aa8da3/get-embed-url
+Content-Type: application/json
+
+{
+    "user": {
+        "externalId": "chart-user@example.com",
+        "email": "chart-user@example.com"
+    },
+    "content": {
+        "type": "chart",
+        "contentId": "{{chartUuid}}",
+        "scopes": ["view:Chart"],
+        "canExportCsv": true,
+        "canExportImages": false,
+        "canViewUnderlyingData": true,
+        "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3"
+    },
+    "expiresIn": "24h"
+}
+
+
+# We can use JWT token to call some endpoints that support `account` parameters. 
+
+### Get chart results using JWT token
+GET http://localhost:8080/api/v1/saved/{{chartUuid}}
+Lightdash-Embed-Token: {{chartJwtToken}}
+
+# This endpoint should not work, since the chart is not the one in the JWT token
+### Get another chart results using JWT token
+GET http://localhost:8080/api/v1/saved/868d7c41-2184-4d1d-b5f8-33e00ae1ae96
+Lightdash-Embed-Token: {{chartJwtToken}}
+
+
+### Run SQL query using JWT token
+POST http://localhost:8080/api/v1/projects/{{projectUuid}}/sqlQuery
+Lightdash-Embed-Token: {{chartJwtToken}}
+Content-Type: application/json
+
+{
+   "sql": "SELECT * FROM postgres.jaffle.orders LIMIT 10"
+}
+   
+
+# This calculate total endpoint does not support chart JWT token, only dashboard
+@chartJwtToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImV4dGVybmFsSWQiOiJjaGFydC11c2VyQGV4YW1wbGUuY29tIiwiZW1haWwiOiJjaGFydC11c2VyQGV4YW1wbGUuY29tIn0sImNvbnRlbnQiOnsidHlwZSI6ImNoYXJ0IiwiY29udGVudElkIjoiMDg1NDYxMWEtOTg0Mi00OTM3LTljYWItMzdmYjM1NTdlODUyIiwic2NvcGVzIjpbInZpZXc6Q2hhcnQiXSwiY2FuRXhwb3J0Q3N2Ijp0cnVlLCJjYW5FeHBvcnRJbWFnZXMiOmZhbHNlLCJjYW5WaWV3VW5kZXJseWluZ0RhdGEiOnRydWUsInByb2plY3RVdWlkIjoiMzY3NWI2OWUtODMyNC00MTEwLWJkY2EtMDU5MDMxYWE4ZGEzIn0sImlhdCI6MTc2MTIxNDgxNCwiZXhwIjoxNzYxMzAxMjE0fQ.h1bv99NPtjIICpsmQ0QqZPDJOJYtJ7iJ4-urQqNDXP8
+POST http://localhost:8080/api/v1/embed/{{projectUuid}}/chart/{{chartUuid}}/calculate-total
+Lightdash-Embed-Token: {{chartJwtToken}}
+Content-Type: application/json
+
+{
+    "invalidateCache": false
+}

--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -70,9 +70,11 @@ describe('account', () => {
 
             expect(result.organization).toEqual(mockEmbed.organization);
 
-            expect(result.access.dashboardId).toBe('test-dashboard-uuid');
+            expect(result.access.contentId).toBe('test-dashboard-uuid');
             expect(result.access.filtering).toEqual(
-                mockDecodedToken.content.dashboardFiltersInteractivity,
+                mockDecodedToken.content.type === 'dashboard'
+                    ? mockDecodedToken.content.dashboardFiltersInteractivity
+                    : undefined,
             );
             expect(result.access.controls).toBe(mockUserAttributes);
 

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -9,6 +9,7 @@ import {
     ApiSuccessEmpty,
     assertEmbeddedAuth,
     CacheMetadata,
+    CommonEmbedJwtContent,
     CreateEmbedJwt,
     CreateEmbedRequestBody,
     Dashboard,
@@ -54,7 +55,7 @@ export type ApiEmbedDashboardResponse = {
     status: 'ok';
     results: Dashboard & {
         // declare type as TSOA doesn't understand zod type InteractivityOptions
-        dashboardFiltersInteractivity?: CreateEmbedJwt['content']['dashboardFiltersInteractivity'];
+        dashboardFiltersInteractivity?: CommonEmbedJwtContent['dashboardFiltersInteractivity'];
         canExportCsv?: boolean;
         canExportImages?: boolean;
     };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1238,6 +1238,57 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CommonChartEmbedJwtContent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                canViewUnderlyingData: { dataType: 'boolean' },
+                canExportImages: { dataType: 'boolean' },
+                canExportCsv: { dataType: 'boolean' },
+                scopes: { dataType: 'array', array: { dataType: 'string' } },
+                isPreview: { dataType: 'boolean' },
+                projectUuid: { dataType: 'string' },
+                type: { dataType: 'enum', enums: ['chart'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmbedJwtContentChartUuid: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CommonChartEmbedJwtContent' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        contentId: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmbedJwtContentChartSlug: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CommonChartEmbedJwtContent' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        contentId: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CreateEmbedJwt: {
         dataType: 'refAlias',
         type: {
@@ -1263,6 +1314,8 @@ const models: TsoaRoute.Models = {
                     subSchemas: [
                         { ref: 'EmbedJwtContentDashboardUuid' },
                         { ref: 'EmbedJwtContentDashboardSlug' },
+                        { ref: 'EmbedJwtContentChartUuid' },
+                        { ref: 'EmbedJwtContentChartSlug' },
                     ],
                     required: true,
                 },
@@ -1913,10 +1966,19 @@ const models: TsoaRoute.Models = {
                                         enabled: {
                                             dataType: 'union',
                                             subSchemas: [
-                                                {
-                                                    ref: 'FilterInteractivityValues',
-                                                },
                                                 { dataType: 'boolean' },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['some'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['all'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['none'],
+                                                },
                                             ],
                                             required: true,
                                         },
@@ -6065,11 +6127,106 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6179,106 +6336,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15323,7 +15385,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15333,7 +15395,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15343,7 +15405,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -15356,7 +15418,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1290,6 +1290,70 @@
                     }
                 ]
             },
+            "CommonChartEmbedJwtContent": {
+                "properties": {
+                    "canViewUnderlyingData": {
+                        "type": "boolean"
+                    },
+                    "canExportImages": {
+                        "type": "boolean"
+                    },
+                    "canExportCsv": {
+                        "type": "boolean"
+                    },
+                    "scopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "isPreview": {
+                        "type": "boolean"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["chart"],
+                        "nullable": false
+                    }
+                },
+                "required": ["type"],
+                "type": "object"
+            },
+            "EmbedJwtContentChartUuid": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CommonChartEmbedJwtContent"
+                    },
+                    {
+                        "properties": {
+                            "contentId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["contentId"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "EmbedJwtContentChartSlug": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CommonChartEmbedJwtContent"
+                    },
+                    {
+                        "properties": {
+                            "contentId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["contentId"],
+                        "type": "object"
+                    }
+                ]
+            },
             "CreateEmbedJwt": {
                 "properties": {
                     "exp": {
@@ -1328,6 +1392,12 @@
                             },
                             {
                                 "$ref": "#/components/schemas/EmbedJwtContentDashboardSlug"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EmbedJwtContentChartUuid"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EmbedJwtContentChartSlug"
                             }
                         ]
                     }
@@ -2039,10 +2109,15 @@
                                             "enabled": {
                                                 "anyOf": [
                                                     {
-                                                        "$ref": "#/components/schemas/FilterInteractivityValues"
+                                                        "type": "boolean"
                                                     },
                                                     {
-                                                        "type": "boolean"
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "some",
+                                                            "all",
+                                                            "none"
+                                                        ]
                                                     }
                                                 ]
                                             }
@@ -6711,19 +6786,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -16028,22 +16090,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -21012,7 +21074,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2104.0",
+        "version": "0.2104.5",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/PermissionsService/PermissionsService.ts
+++ b/packages/backend/src/services/PermissionsService/PermissionsService.ts
@@ -20,11 +20,17 @@ export class PermissionsService extends BaseService {
     ) {
         const { projectUuid, dashboardUuids, allowAllDashboards } =
             account.embed;
-        const dashboardUuid = account.access.dashboardId;
+        const dashboardUuid = account.access.contentId;
 
         if (!projectUuid) {
             throw new ForbiddenError(
                 'Project UUID is required to check embed permissions',
+            );
+        }
+
+        if (!dashboardUuid) {
+            throw new ForbiddenError(
+                'Dashboard ID is required to check embed permissions',
             );
         }
 

--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -58,7 +58,14 @@ const defineAbilityForEmbedUser = (
 ): MemberAbility => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     const externalId = 'external-id-1';
-    applyEmbeddedAbility(embedUser, dashboardUuid, embed, externalId, builder);
+    applyEmbeddedAbility(
+        embedUser,
+        dashboardUuid,
+        'dashboard',
+        embed,
+        externalId,
+        builder,
+    );
     return builder.build();
 };
 

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -1,12 +1,13 @@
 import { type AbilityBuilder } from '@casl/ability';
 import flow from 'lodash/flow';
-import { type CreateEmbedJwt } from '../ee';
+import { isDashboardContent, type CreateEmbedJwt } from '../ee';
 import type { OssEmbed } from '../types/auth';
 import type { MemberAbility } from './types';
 
 type EmbeddedAbilityBuilderPayload = {
     embedUser: CreateEmbedJwt;
-    dashboardUuid: string;
+    contentUuid: string;
+    contentType: 'dashboard' | 'chart';
     embed: OssEmbed;
     builder: Pick<AbilityBuilder<MemberAbility>, 'can'>;
     externalId: string;
@@ -18,42 +19,79 @@ type EmbeddedAbilityBuilder = (
 
 const dashboardAbilities: EmbeddedAbilityBuilder = ({
     embedUser,
-    dashboardUuid,
+    contentUuid,
+    contentType,
     embed,
     externalId,
     builder,
 }) => {
     const { organization } = embed;
     const { can } = builder;
-    can('view', 'Dashboard', {
-        dashboardUuid,
-        organizationUuid: organization.organizationUuid,
-    });
 
-    if (embedUser.content.canDateZoom) {
+    if (contentType === 'dashboard') {
         can('view', 'Dashboard', {
-            dateZoom: true,
+            dashboardUuid: contentUuid,
             organizationUuid: organization.organizationUuid,
+        });
+
+        if (
+            embedUser.content.type === 'dashboard' &&
+            embedUser.content.canDateZoom
+        ) {
+            can('view', 'Dashboard', {
+                dateZoom: true,
+                organizationUuid: organization.organizationUuid,
+            });
+        }
+
+        can('view', 'SavedChart', {
+            organizationUuid: organization.organizationUuid,
+            projectUuid: embed.projectUuid,
+            isPrivate: false,
         });
     }
 
-    can('view', 'SavedChart', {
-        organizationUuid: organization.organizationUuid,
-        projectUuid: embed.projectUuid,
-        isPrivate: false,
-    });
-
+    // Grant project view for both content types
     can('view', 'Project', {
         organizationUuid: organization.organizationUuid,
         projectUuid: embed.projectUuid,
     });
 
-    return { embedUser, dashboardUuid, embed, builder, externalId };
+    return { embedUser, contentUuid, contentType, embed, builder, externalId };
+};
+
+const chartAbilities: EmbeddedAbilityBuilder = ({
+    embedUser,
+    contentUuid,
+    contentType,
+    embed,
+    externalId,
+    builder,
+}) => {
+    const { organization } = embed;
+    const { can } = builder;
+
+    if (contentType === 'chart') {
+        can('view', 'SavedChart', {
+            uuid: contentUuid,
+            organizationUuid: organization.organizationUuid,
+            projectUuid: embed.projectUuid,
+        });
+    }
+
+    // Grant project view for both content types
+    can('view', 'Project', {
+        organizationUuid: organization.organizationUuid,
+        projectUuid: embed.projectUuid,
+    });
+
+    return { embedUser, contentUuid, contentType, embed, builder, externalId };
 };
 
 const exploreAbilities: EmbeddedAbilityBuilder = ({
     embedUser,
-    dashboardUuid,
+    contentUuid,
+    contentType,
     embed,
     externalId,
     builder,
@@ -62,26 +100,33 @@ const exploreAbilities: EmbeddedAbilityBuilder = ({
     const { organization } = embed;
     const { can } = builder;
 
-    if (content.canExplore || content.canViewUnderlyingData) {
+    const canExplore = 'canExplore' in content ? content.canExplore : undefined;
+    const canViewUnderlyingData =
+        'canViewUnderlyingData' in content
+            ? content.canViewUnderlyingData
+            : undefined;
+
+    if (canExplore || canViewUnderlyingData) {
         can('view', 'UnderlyingData', {
             organizationUuid: organization.organizationUuid,
             projectUuid: embed.projectUuid,
         });
     }
 
-    if (content.canExplore) {
+    if (canExplore) {
         can('view', 'Explore', {
             organizationUuid: organization.organizationUuid,
             projectUuid: embed.projectUuid,
         });
     }
 
-    return { embedUser, dashboardUuid, embed, externalId, builder };
+    return { embedUser, contentUuid, contentType, embed, externalId, builder };
 };
 
 const exportAbilities: EmbeddedAbilityBuilder = ({
     embedUser,
-    dashboardUuid,
+    contentUuid,
+    contentType,
     embed,
     externalId,
     builder,
@@ -90,48 +135,65 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
     const { organization } = embed;
     const { can } = builder;
 
-    if (content.canExportCsv) {
-        can('export', 'Dashboard', {
+    const subjectType: 'Dashboard' | 'SavedChart' =
+        contentType === 'dashboard' ? 'Dashboard' : 'SavedChart';
+
+    // Common abilities for both dashboard and chart
+    if (content.canExportImages) {
+        can('export', subjectType, {
             organizationUuid: organization.organizationUuid,
             type: 'csv',
         });
+    }
 
+    if (content.canExportCsv) {
+        can('export', subjectType, {
+            organizationUuid: organization.organizationUuid,
+            type: 'csv',
+        });
         can('view', 'JobStatus', {
             organizationUuid: organization.organizationUuid,
             projectUuid: embed.projectUuid,
             createdByUserUuid: externalId,
         });
     }
-
-    if (content.canExportPagePdf) {
-        can('export', 'Dashboard', {
-            organizationUuid: organization.organizationUuid,
-            type: 'pdf',
-        });
+    // Dashboard specific abilities
+    if (isDashboardContent(content)) {
+        if (content.canExportPagePdf) {
+            can('export', 'Dashboard', {
+                organizationUuid: organization.organizationUuid,
+                type: 'pdf',
+            });
+        }
     }
 
-    if (content.canExportImages) {
-        can('export', 'Dashboard', {
-            organizationUuid: organization.organizationUuid,
-            type: 'images',
-        });
-    }
-
-    return { embedUser, dashboardUuid, embed, externalId, builder };
+    return { embedUser, contentUuid, contentType, embed, externalId, builder };
 };
 
 const applyAbilities = flow(
     dashboardAbilities,
+    chartAbilities,
     exportAbilities,
     exploreAbilities,
 );
 
 export function applyEmbeddedAbility(
     embedUser: CreateEmbedJwt,
-    dashboardUuid: string,
+    contentUuid: string | undefined,
+    contentType: 'dashboard' | 'chart',
     embed: OssEmbed,
     externalId: string,
     builder: AbilityBuilder<MemberAbility>,
 ) {
-    applyAbilities({ embedUser, dashboardUuid, embed, externalId, builder });
+    if (!contentUuid) {
+        throw new Error('Content UUID is required');
+    }
+    applyAbilities({
+        embedUser,
+        contentUuid,
+        contentType,
+        embed,
+        externalId,
+        builder,
+    });
 }

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -79,9 +79,11 @@ export type UserAccessControls = {
     intrinsicUserAttributes: IntrinsicUserAttributes;
 };
 
-export type DashboardAccess = {
-    /** The dashboard ID the account has access to */
-    dashboardId: string;
+export type EmbedAccess = {
+    /** The content ID the account has access to (dashboard or chart) */
+    contentId?: string;
+    /** The type of content (dashboard or chart) */
+    contentType?: 'dashboard' | 'chart';
     /** Dashboard filtering options for interactivity */
     filtering?: DashboardFilterInteractivityOptions;
     /** User-specific access controls */
@@ -137,7 +139,7 @@ export type AnonymousAccount = BaseAccountWithHelpers & {
     authentication: JwtAuth;
     user: ExternalUser;
     /** The access permissions the account has */
-    access: DashboardAccess;
+    access: EmbedAccess;
     /** The embed configuration associated with the JWT */
     embed: OssEmbed;
 };

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -1,6 +1,7 @@
 import {
     FilterInteractivityValues,
     getFilterInteractivityValue,
+    isDashboardContent,
     isDashboardUuidContent,
     type CreateEmbedJwt,
 } from '@lightdash/common';
@@ -197,7 +198,10 @@ const getCodeSnippet = (
         siteUrl: string;
         data: CreateEmbedJwt;
     },
-) => {
+): string => {
+    if (!isDashboardContent(data.content)) {
+        return `Unsupported embedded content type ${data.content} snippet`;
+    }
     return codeTemplates[language]
         .replace('{{projectUuid}}', projectUuid)
         .replace('{{siteUrl}}', siteUrl)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-102/update-jwt-to-accept-chart

Creating jwt for chart
<img width="1159" height="553" alt="Screenshot from 2025-10-23 10-56-36" src="https://github.com/user-attachments/assets/923a04c1-9a3e-4dc4-af3b-23b279993651" />


Attempt to use it . we don't support it on the method yet, but at least it knows it is not a dashboard.


<img width="1158" height="328" alt="Screenshot from 2025-10-23 10-56-25" src="https://github.com/user-attachments/assets/c5a1da9f-e25c-4882-8663-2a20fe3a6a5c" />


### Description:
Add support for chart embedding in the API. This enhancement allows users to generate embed URLs for individual charts, similar to how dashboard embedding works. The implementation includes:

- New JWT content types for chart embedding with appropriate scopes and permissions
- Updated authentication middleware to handle chart content types
- Modified ability checks to properly handle chart-specific permissions
- Added HTTP examples for generating chart embed URLs and calculating chart totals

This change maintains backward compatibility with existing dashboard embedding while extending the embedding functionality to individual charts.