### PR TITLE
fix: optimize SQL query processing and preserve whitespace in table cells

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -484,16 +484,12 @@ export const removeCommentsAndOuterLimitOffset = (sql: string): string => {
         .replace(limitOffsetRegex, '');
     // remove semicolon from the end of the query
     sqlWithoutLimit = sqlWithoutLimit.trim().replace(/;+$/g, '');
-    // restore strings
-    let sqlRestored = restoreStringsFromPlaceholders(
-        sqlWithoutLimit,
-        placeholders,
-    );
     // normalize multiple spaces to a single space
-    sqlRestored = sqlRestored.replace(/\s+/g, ' ');
+    sqlWithoutLimit = sqlWithoutLimit.replace(/\s+/g, ' ');
     // remove any trailing semicolons, including those preceded by whitespace
-    sqlRestored = sqlRestored.replace(/\s*;+\s*$/g, '').trim();
-    return sqlRestored;
+    sqlWithoutLimit = sqlWithoutLimit.replace(/\s*;+\s*$/g, '').trim();
+    // restore strings
+    return restoreStringsFromPlaceholders(sqlWithoutLimit, placeholders);
 };
 
 // Apply a limit (and optional offset) to a SQL query

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -149,7 +149,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                 onMouseEnter={canHaveTooltip ? openTooltip : undefined}
                 onMouseLeave={canHaveTooltip ? closeTooltip : undefined}
             >
-                <span>{children}</span>
+                <span style={{ whiteSpace: 'pre' }}>{children}</span>
             </Td>
 
             {shouldRenderMenu ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17608

### Description:

This PR makes two improvements:

1. Makes sure the string values are kept intact (white spaces remain)
2. Preserves whitespace in table cells by adding `whiteSpace: 'pre'` style to the span element in `BodyCell.tsx`. This ensures that spaces, tabs, and other whitespace characters in cell content are displayed as intended.

![CleanShot 2025-10-23 at 15.11.30@2x.png](https://app.graphite.dev/user-attachments/assets/841d344f-eecb-45a1-a821-95ccd097c0aa.png)