### PR TITLE
fix: enable quoted CSV output in PivotTableService

### DIFF
--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -225,6 +225,7 @@ export class PivotTableService extends BaseService {
                 csvResults,
                 {
                     delimiter: ',',
+                    quoted: true,
                 },
                 (err, output) => {
                     if (err) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17255

### Description:
Enables quote wrapping for CSV exports in the PivotTableService by setting the `quoted` parameter to `true`. This ensures that all fields in exported CSV files are properly quoted, which helps prevent parsing issues when fields contain special characters like commas or newlines.