### PR TITLE
feat: display compilation log on job details drawer

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -105,7 +105,11 @@ import {
     type CreatePersonalAccessToken,
     type PersonalAccessToken,
 } from './personalAccessToken';
-import { type ApiProjectCompileLogsResults } from './projectCompileLogs';
+
+import {
+    type ApiProjectCompileLogResponse,
+    type ApiProjectCompileLogsResponse,
+} from './projectCompileLogs';
 import { type ProjectMemberProfile } from './projectMemberProfile';
 import { type ProjectMemberRole } from './projectMemberRole';
 import {
@@ -811,7 +815,8 @@ type ApiResults =
     | ApiGetChangeResponse['results']
     | ApiAiOrganizationSettingsResponse['results']
     | ApiUpdateAiOrganizationSettingsResponse['results']
-    | ApiProjectCompileLogsResults;
+    | ApiProjectCompileLogsResponse['results']
+    | ApiProjectCompileLogResponse['results'];
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'
 

--- a/packages/frontend/src/components/JobDetailsDrawer/ProjectCompileLog.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/ProjectCompileLog.tsx
@@ -1,0 +1,57 @@
+import { Box, Button } from '@mantine-8/core';
+import { IconExternalLink } from '@tabler/icons-react';
+import { type FC } from 'react';
+import ReactJson from 'react-json-view';
+import { useProjectCompileLogByJob } from '../../hooks/useProjectCompileLogs';
+import MantineIcon from '../common/MantineIcon';
+import { CollapsablePaper } from './../common/CollapsablePaper';
+
+type ProjectCompileLogProps = {
+    projectUuid: string;
+    jobUuid: string;
+};
+
+const ProjectCompileLog: FC<ProjectCompileLogProps> = ({
+    projectUuid,
+    jobUuid,
+}) => {
+    const { data: compileLog } = useProjectCompileLogByJob({
+        projectUuid,
+        jobUuid,
+    });
+
+    if (!compileLog) {
+        return null;
+    }
+
+    return (
+        <CollapsablePaper
+            title="Compilation log"
+            rightAction={
+                <Button
+                    variant="subtle"
+                    color="gray"
+                    size="compact-xs"
+                    rightSection={<MantineIcon icon={IconExternalLink} />}
+                    component="a"
+                    target="_blank"
+                    href={`/generalSettings/${projectUuid}/compilationHistory`}
+                >
+                    See history
+                </Button>
+            }
+        >
+            <Box>
+                <ReactJson
+                    style={{ fontSize: '12px' }}
+                    src={compileLog}
+                    enableClipboard={true}
+                    displayDataTypes={false}
+                    collapsed={2}
+                />
+            </Box>
+        </CollapsablePaper>
+    );
+};
+
+export default ProjectCompileLog;

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../hooks/useRefreshServer';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
 import MantineIcon from '../common/MantineIcon';
+import ProjectCompileLog from './ProjectCompileLog';
 
 dayjs.extend(duration);
 dayjs.extend(utc);
@@ -151,6 +152,8 @@ const JobDetailsDrawer: FC = () => {
     }
 
     const hasSteps = !!activeJob?.steps.length;
+    const isJobDone = activeJob.jobStatus === JobStatusType.DONE;
+
     return (
         <Drawer
             trapFocus
@@ -308,6 +311,12 @@ const JobDetailsDrawer: FC = () => {
                         </Stack>
                     </Group>
                 ))}
+                {isJobDone && activeJob.projectUuid && (
+                    <ProjectCompileLog
+                        projectUuid={activeJob.projectUuid}
+                        jobUuid={activeJob.jobUuid}
+                    />
+                )}
             </Stack>
         </Drawer>
     );

--- a/packages/frontend/src/components/common/CollapsablePaper.tsx
+++ b/packages/frontend/src/components/common/CollapsablePaper.tsx
@@ -1,0 +1,58 @@
+import { Collapse, Group, Paper, Title, UnstyledButton } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
+import { IconSelector } from '@tabler/icons-react';
+import { type PropsWithChildren } from 'react';
+import MantineIcon, { type MantineIconProps } from './MantineIcon';
+
+type CollapsablePaperProps = PropsWithChildren<{
+    title: string;
+    defaultOpened?: boolean;
+    icon?: MantineIconProps['icon'];
+    rightAction?: React.ReactNode;
+}>;
+
+export const CollapsablePaper = ({
+    title,
+    children,
+    defaultOpened = true,
+    icon,
+    rightAction,
+}: CollapsablePaperProps) => {
+    const [opened, { toggle }] = useDisclosure(defaultOpened);
+
+    return (
+        <Paper
+            withBorder
+            p="xs"
+            radius="md"
+            shadow={opened ? 'none' : undefined}
+        >
+            <UnstyledButton onClick={toggle} w="100%" h="18px">
+                <Group justify="space-between" w="100%" h="100%">
+                    <Group gap="xs">
+                        {icon && (
+                            <MantineIcon
+                                icon={icon}
+                                size="sm"
+                                strokeWidth={1.2}
+                                color={'gray.6'}
+                            />
+                        )}
+                        <Title order={6} c={'gray.6'} size="xs">
+                            {title}
+                        </Title>
+                    </Group>
+                    <Group gap="xs">
+                        {rightAction}
+                        <MantineIcon
+                            icon={IconSelector}
+                            size={12}
+                            color="gray.6"
+                        />
+                    </Group>
+                </Group>
+            </UnstyledButton>
+            <Collapse in={opened}>{children}</Collapse>
+        </Paper>
+    );
+};

--- a/packages/frontend/src/hooks/useProjectCompileLogs.ts
+++ b/packages/frontend/src/hooks/useProjectCompileLogs.ts
@@ -1,12 +1,15 @@
 import {
     type ApiError,
+    type ApiProjectCompileLogResponse,
     type ApiProjectCompileLogsResponse,
     type KnexPaginateArgs,
     type ProjectCompileLog,
 } from '@lightdash/common';
 import {
     useInfiniteQuery,
+    useQuery,
     type UseInfiniteQueryResult,
+    type UseQueryResult,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 
@@ -91,4 +94,32 @@ export const useProjectCompileLogs = ({
             enabled: !!projectUuid,
         },
     );
+};
+
+const getProjectCompileLogByJob = async (
+    projectUuid: string,
+    jobUuid: string,
+): Promise<ProjectCompileLog | undefined> => {
+    const response = await lightdashApi<
+        ApiProjectCompileLogResponse['results']
+    >({
+        url: `/projects/${projectUuid}/compile-logs/job/${jobUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+    return response.log;
+};
+
+export const useProjectCompileLogByJob = ({
+    projectUuid,
+    jobUuid,
+}: {
+    projectUuid: string;
+    jobUuid: string;
+}): UseQueryResult<ProjectCompileLog | undefined, ApiError> => {
+    return useQuery<ProjectCompileLog | undefined, ApiError>({
+        queryKey: ['projectCompileLogByJob', projectUuid, jobUuid],
+        queryFn: () => getProjectCompileLogByJob(projectUuid, jobUuid),
+    });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17520

### Description:
Added a collapsible compilation log viewer to the job details drawer. When a job is completed, users can now view the compilation logs directly in the drawer and navigate to the full compilation history.

The implementation includes:
- A new `ProjectCompileLog` component that fetches and displays logs for a specific job
- A reusable `CollapsablePaper` component for expandable/collapsible sections


![image.png](https://app.graphite.dev/user-attachments/assets/c1b136d2-0d88-49cb-9297-c096af74b411.png)

