### PR TITLE
fix: generate JWT token for chart

### DIFF
--- a/examples/api/embedding.http
+++ b/examples/api/embedding.http
@@ -71,3 +71,61 @@ Content-Type: application/json
         "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3"
     }
 }
+
+### Generate embed url for chart - use the chartUuid you want to embed
+
+@chartUuid = 0854611a-9842-4937-9cab-37fb3557e852
+@projectUuid = 3675b69e-8324-4110-bdca-059031aa8da3
+
+POST http://localhost:8080/api/v1/embed/3675b69e-8324-4110-bdca-059031aa8da3/get-embed-url
+Content-Type: application/json
+
+{
+    "user": {
+        "externalId": "chart-user@example.com",
+        "email": "chart-user@example.com"
+    },
+    "content": {
+        "type": "chart",
+        "contentId": "{{chartUuid}}",
+        "scopes": ["view:Chart"],
+        "canExportCsv": true,
+        "canExportImages": false,
+        "canViewUnderlyingData": true,
+        "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3"
+    },
+    "expiresIn": "24h"
+}
+
+
+# We can use JWT token to call some endpoints that support `account` parameters. 
+
+### Get chart results using JWT token
+GET http://localhost:8080/api/v1/saved/{{chartUuid}}
+Lightdash-Embed-Token: {{chartJwtToken}}
+
+# This endpoint should not work, since the chart is not the one in the JWT token
+### Get another chart results using JWT token
+GET http://localhost:8080/api/v1/saved/868d7c41-2184-4d1d-b5f8-33e00ae1ae96
+Lightdash-Embed-Token: {{chartJwtToken}}
+
+
+### Run SQL query using JWT token
+POST http://localhost:8080/api/v1/projects/{{projectUuid}}/sqlQuery
+Lightdash-Embed-Token: {{chartJwtToken}}
+Content-Type: application/json
+
+{
+   "sql": "SELECT * FROM postgres.jaffle.orders LIMIT 10"
+}
+   
+
+# This calculate total endpoint does not support chart JWT token, only dashboard
+@chartJwtToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImV4dGVybmFsSWQiOiJjaGFydC11c2VyQGV4YW1wbGUuY29tIiwiZW1haWwiOiJjaGFydC11c2VyQGV4YW1wbGUuY29tIn0sImNvbnRlbnQiOnsidHlwZSI6ImNoYXJ0IiwiY29udGVudElkIjoiMDg1NDYxMWEtOTg0Mi00OTM3LTljYWItMzdmYjM1NTdlODUyIiwic2NvcGVzIjpbInZpZXc6Q2hhcnQiXSwiY2FuRXhwb3J0Q3N2Ijp0cnVlLCJjYW5FeHBvcnRJbWFnZXMiOmZhbHNlLCJjYW5WaWV3VW5kZXJseWluZ0RhdGEiOnRydWUsInByb2plY3RVdWlkIjoiMzY3NWI2OWUtODMyNC00MTEwLWJkY2EtMDU5MDMxYWE4ZGEzIn0sImlhdCI6MTc2MTIxNDgxNCwiZXhwIjoxNzYxMzAxMjE0fQ.h1bv99NPtjIICpsmQ0QqZPDJOJYtJ7iJ4-urQqNDXP8
+POST http://localhost:8080/api/v1/embed/{{projectUuid}}/chart/{{chartUuid}}/calculate-total
+Lightdash-Embed-Token: {{chartJwtToken}}
+Content-Type: application/json
+
+{
+    "invalidateCache": false
+}

--- a/packages/backend/src/auth/CLAUDE.md
+++ b/packages/backend/src/auth/CLAUDE.md
@@ -11,13 +11,14 @@ import { fromSession, fromJwt } from '@lightdash/backend/src/auth/account';
 // For registered users with session authentication
 const sessionAccount = fromSession(sessionUser);
 
-// For anonymous users with JWT authentication (embedded dashboards)
-const jwtAccount = fromJwt(
+// For anonymous users with JWT authentication (embedded dashboards and charts)
+const jwtAccount = fromJwt({
     decodedToken, // Decoded JWT payload
     organization, // Organization details
-    dashboardUuid, // Dashboard being accessed
+    contentUuid, // Content being accessed—either dashboard or chart
+    contentType, // 'dashboard' | 'chart'
     userAttributes, // Optional user attributes for filtering
-);
+});
 ```
 
 For JWT token handling:
@@ -71,12 +72,13 @@ async function handleEmbeddedDashboard(jwtToken: string, encryptedSecret: string
 try {
 const decoded = await decodeLightdashJwt(jwtToken, encryptedSecret);
 
-    const account = fromJwt(
+    const account = fromJwt({
       decoded,
-      { organizationUuid: decoded.organizationUuid, name: 'Org Name' },
-      decoded.dashboardUuid,
-      decoded.userAttributes
-    );
+      organization: { organizationUuid: decoded.organizationUuid, name: 'Org Name' },
+      contentUuid: decoded.dashboardUuid,
+      contentType: 'dashboard',
+      userAttributes: getUserAttributesFromSomewhere(),
+    });
 
     // Account will have restricted access to only the specified dashboard
     return account;

--- a/packages/backend/src/auth/account/account.mock.ts
+++ b/packages/backend/src/auth/account/account.mock.ts
@@ -122,7 +122,7 @@ export function buildAccount({
             },
         },
         source: 'test-jwt-token',
-        dashboardUuid: 'test-dashboard-uuid',
+        contentUuid: 'test-dashboard-uuid',
         userAttributes: defaultUserAttributes,
     });
 }

--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -62,7 +62,7 @@ describe('account', () => {
                 decodedToken: mockDecodedToken,
                 embed: mockEmbed,
                 source: 'test-jwt-token',
-                dashboardUuid: 'test-dashboard-uuid',
+                contentUuid: 'test-dashboard-uuid',
                 userAttributes: mockUserAttributes,
             });
 
@@ -72,9 +72,11 @@ describe('account', () => {
 
             expect(result.organization).toEqual(mockEmbed.organization);
 
-            expect(result.access.dashboardId).toBe('test-dashboard-uuid');
+            expect(result.access.contentId).toBe('test-dashboard-uuid');
             expect(result.access.filtering).toEqual(
-                mockDecodedToken.content.dashboardFiltersInteractivity,
+                mockDecodedToken.content.type === 'dashboard'
+                    ? mockDecodedToken.content.dashboardFiltersInteractivity
+                    : undefined,
             );
             expect(result.access.controls).toBe(mockUserAttributes);
 
@@ -110,7 +112,7 @@ describe('account', () => {
                 decodedToken: tokenWithoutExternalId,
                 embed: mockEmbed,
                 source: 'anonymous-jwt-token',
-                dashboardUuid: 'test-dashboard-uuid',
+                contentUuid: 'test-dashboard-uuid',
                 userAttributes: mockUserAttributes,
             });
 
@@ -137,7 +139,7 @@ describe('account', () => {
                 decodedToken: tokenWithoutUser,
                 embed: mockEmbed,
                 source: 'no-user-jwt-token',
-                dashboardUuid: 'test-dashboard-uuid',
+                contentUuid: 'test-dashboard-uuid',
                 userAttributes: mockUserAttributes,
             });
 
@@ -158,7 +160,7 @@ describe('account', () => {
                 decodedToken: mockDecodedToken,
                 embed: mockEmbed,
                 source: 'test-jwt-token',
-                dashboardUuid: 'test-dashboard-uuid',
+                contentUuid: 'test-dashboard-uuid',
                 userAttributes: emptyUserAttributes,
             });
 

--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -76,13 +76,15 @@ export const fromJwt = ({
     decodedToken,
     embed,
     source,
-    dashboardUuid,
+    contentUuid,
+    contentType = 'dashboard',
     userAttributes,
 }: {
     decodedToken: CreateEmbedJwt;
     embed: OssEmbed;
     source: string;
-    dashboardUuid: string;
+    contentUuid?: string;
+    contentType?: 'dashboard' | 'chart';
     userAttributes: UserAccessControls;
 }): AnonymousAccount => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -90,7 +92,8 @@ export const fromJwt = ({
 
     applyEmbeddedAbility(
         decodedToken,
-        dashboardUuid,
+        contentUuid,
+        contentType,
         embed,
         externalId,
         builder,
@@ -106,7 +109,8 @@ export const fromJwt = ({
         organization: embed.organization,
         embed,
         access: {
-            dashboardId: dashboardUuid,
+            contentId: contentUuid,
+            contentType,
             filtering: decodedToken.content.dashboardFiltersInteractivity,
             parameters: decodedToken.content.parameterInteractivity,
             controls: userAttributes,

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -10,6 +10,7 @@ import {
     assertEmbeddedAuth,
     assertSessionAuth,
     CacheMetadata,
+    CommonEmbedJwtContent,
     CreateEmbedJwt,
     CreateEmbedRequestBody,
     Dashboard,
@@ -56,7 +57,7 @@ export type ApiEmbedDashboardResponse = {
     status: 'ok';
     results: Dashboard & {
         // declare type as TSOA doesn't understand zod type InteractivityOptions
-        dashboardFiltersInteractivity?: CreateEmbedJwt['content']['dashboardFiltersInteractivity'];
+        dashboardFiltersInteractivity?: CommonEmbedJwtContent['dashboardFiltersInteractivity'];
         canExportCsv?: boolean;
         canExportImages?: boolean;
     };

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -133,51 +133,24 @@ describe('EmbedService', () => {
                     EmbedServiceArgumentsMock.embedModel.updateConfig,
                 ).toHaveBeenCalledWith(mockProjectUuid, updateWithBothAllowAll);
             });
-        });
 
-        describe('validation errors', () => {
-            test('should throw ParameterError when no dashboards or charts specified', async () => {
-                const invalidUpdate = {
+            test('allows empty ids to disable embedding', async () => {
+                const update = {
                     dashboardUuids: [],
                     allowAllDashboards: false,
                     chartUuids: [],
                     allowAllCharts: false,
                 };
 
-                await expect(
-                    service.updateConfig(
-                        mockAccountWithPermission,
-                        mockProjectUuid,
-                        invalidUpdate,
-                    ),
-                ).rejects.toThrow(ParameterError);
-
-                await expect(
-                    service.updateConfig(
-                        mockAccountWithPermission,
-                        mockProjectUuid,
-                        invalidUpdate,
-                    ),
-                ).rejects.toThrow(
-                    'At least one dashboard or chart must be specified for embedding',
+                await service.updateConfig(
+                    mockAccountWithPermission,
+                    mockProjectUuid,
+                    update,
                 );
-            });
 
-            test('should throw ParameterError when chartUuids is undefined and no dashboards', async () => {
-                const invalidUpdate = {
-                    dashboardUuids: [],
-                    allowAllDashboards: false,
-                    chartUuids: undefined,
-                    allowAllCharts: false,
-                };
-
-                await expect(
-                    service.updateConfig(
-                        mockAccountWithPermission,
-                        mockProjectUuid,
-                        invalidUpdate,
-                    ),
-                ).rejects.toThrow(ParameterError);
+                expect(
+                    EmbedServiceArgumentsMock.embedModel.updateConfig,
+                ).toHaveBeenCalledWith(mockProjectUuid, update);
             });
         });
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1372,6 +1372,42 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CommonChartEmbedJwtContent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                canViewUnderlyingData: { dataType: 'boolean' },
+                canExportImages: { dataType: 'boolean' },
+                canExportCsv: { dataType: 'boolean' },
+                parameterInteractivity: { dataType: 'undefined' },
+                dashboardFiltersInteractivity: { dataType: 'undefined' },
+                scopes: { dataType: 'array', array: { dataType: 'string' } },
+                isPreview: { dataType: 'boolean' },
+                projectUuid: { dataType: 'string' },
+                type: { dataType: 'enum', enums: ['chart'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmbedJwtContentChart: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CommonChartEmbedJwtContent' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        contentId: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CreateEmbedJwt: {
         dataType: 'refAlias',
         type: {
@@ -1397,6 +1433,7 @@ const models: TsoaRoute.Models = {
                     subSchemas: [
                         { ref: 'EmbedJwtContentDashboardUuid' },
                         { ref: 'EmbedJwtContentDashboardSlug' },
+                        { ref: 'EmbedJwtContentChart' },
                     ],
                     required: true,
                 },
@@ -6216,11 +6253,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6330,11 +6367,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6349,11 +6386,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6368,11 +6405,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6387,11 +6424,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6406,11 +6443,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6425,11 +6462,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15337,7 +15374,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15347,7 +15384,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15357,7 +15394,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -15370,7 +15407,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1479,6 +1479,56 @@
                     }
                 ]
             },
+            "CommonChartEmbedJwtContent": {
+                "properties": {
+                    "canViewUnderlyingData": {
+                        "type": "boolean"
+                    },
+                    "canExportImages": {
+                        "type": "boolean"
+                    },
+                    "canExportCsv": {
+                        "type": "boolean"
+                    },
+                    "parameterInteractivity": {},
+                    "dashboardFiltersInteractivity": {},
+                    "scopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "isPreview": {
+                        "type": "boolean"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["chart"],
+                        "nullable": false
+                    }
+                },
+                "required": ["type"],
+                "type": "object"
+            },
+            "EmbedJwtContentChart": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CommonChartEmbedJwtContent"
+                    },
+                    {
+                        "properties": {
+                            "contentId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["contentId"],
+                        "type": "object"
+                    }
+                ]
+            },
             "CreateEmbedJwt": {
                 "properties": {
                     "exp": {
@@ -1517,6 +1567,9 @@
                             },
                             {
                                 "$ref": "#/components/schemas/EmbedJwtContentDashboardSlug"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EmbedJwtContentChart"
                             }
                         ]
                     }
@@ -6923,6 +6976,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -16143,22 +16209,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiChartAsCodeListResponse": {
@@ -21804,7 +21870,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2147.0",
+        "version": "0.2149.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/PermissionsService/PermissionsService.ts
+++ b/packages/backend/src/services/PermissionsService/PermissionsService.ts
@@ -27,7 +27,6 @@ export class PermissionsService extends BaseService {
                 `Dashboard ${dashboardUuid} is not embedded`,
             );
         }
-
         const chartExists =
             await this.dashboardModel.savedChartExistsInDashboard(
                 embed.projectUuid,
@@ -62,7 +61,7 @@ export class PermissionsService extends BaseService {
         savedChartUuid: string,
     ) {
         const { embed } = account;
-        const dashboardUuid = account.access.dashboardId;
+        const { contentId, contentType } = account.access;
 
         if (!embed.projectUuid) {
             throw new ForbiddenError(
@@ -70,17 +69,21 @@ export class PermissionsService extends BaseService {
             );
         }
 
-        if (dashboardUuid) {
+        if (contentType === 'dashboard' && contentId) {
             return this.checkEmbeddedDashboardPermission(
-                dashboardUuid,
+                contentId,
                 savedChartUuid,
                 embed,
             );
         }
 
-        return PermissionsService.checkEmbeddedChartPermissions(
-            savedChartUuid,
-            embed,
-        );
+        if (contentType === 'chart') {
+            return PermissionsService.checkEmbeddedChartPermissions(
+                savedChartUuid,
+                embed,
+            );
+        }
+
+        throw new ForbiddenError('Invalid access for embed permissions');
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5,6 +5,7 @@ import {
     AlreadyExistsError,
     AlreadyProcessingError,
     AndFilterGroup,
+    AnonymousAccount,
     AnyType,
     ApiChartAndResults,
     ApiCreatePreviewResults,
@@ -92,6 +93,7 @@ import {
     isExploreError,
     isFilterableDimension,
     isFilterRule,
+    isJwtUser,
     isNotNull,
     isUserWithOrg,
     ItemsMap,
@@ -3083,6 +3085,7 @@ export class ProjectService extends BaseService {
                         await this.projectModel.getSummary(projectUuid);
 
                     if (
+                        account.isJwtUser() ||
                         account.user.ability.cannot(
                             'view',
                             subject('Project', {
@@ -4259,7 +4262,9 @@ export class ProjectService extends BaseService {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );
+
         if (
+            ProjectService.isChartEmbed(account) ||
             account.user.ability.cannot(
                 'view',
                 subject('Project', { organizationUuid, projectUuid }),
@@ -4362,7 +4367,9 @@ export class ProjectService extends BaseService {
                 const project = organizationUuid
                     ? { organizationUuid }
                     : await this.projectModel.getSummary(projectUuid);
+
                 if (
+                    ProjectService.isChartEmbed(account) ||
                     account.user.ability.cannot(
                         'view',
                         subject('Project', {
@@ -4662,7 +4669,9 @@ export class ProjectService extends BaseService {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );
+
         if (
+            ProjectService.isChartEmbed(account) ||
             account.user.ability.cannot(
                 'view',
                 subject('Project', { organizationUuid, projectUuid }),
@@ -6877,5 +6886,11 @@ export class ProjectService extends BaseService {
             ...(savedParameters || {}),
             ...(requestParameters || {}),
         };
+    }
+
+    static isChartEmbed(account: Account) {
+        if (!isJwtUser(account)) return false;
+
+        return account.access.contentType === 'chart';
     }
 }

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -779,19 +779,26 @@ export class SavedChartService
         account: Account,
         space: Omit<SpaceSummary, 'userAccess'>,
         savedChart: SavedChartDAO,
-    ) {
+    ): Promise<SpaceShare[]> {
+        let access;
         if (isJwtUser(account)) {
             await this.permissionsService.checkEmbedPermissions(
                 account,
                 savedChart.uuid,
             );
-
-            return [];
+            // We pass this access everytime, but we only define the ability
+            // rule for this chart only if the JWT is type: 'chart'.
+            // Dashboards won't have `access` defined in their abilityRules,
+            // so this CASL check will pass for them.
+            // TODO: Get all chartUuids for a given dashboard in the middleware.
+            //       https://linear.app/lightdash/issue/CENG-110/front-load-available-charts-for-dashboard-requests
+            access = [{ chartUuid: savedChart.uuid }];
+        } else {
+            access = await this.spaceModel.getUserSpaceAccess(
+                account.user.id,
+                savedChart.spaceUuid,
+            );
         }
-        const access = await this.spaceModel.getUserSpaceAccess(
-            account.user.id,
-            savedChart.spaceUuid,
-        );
 
         if (
             account.user.ability.cannot(
@@ -808,7 +815,7 @@ export class SavedChartService
             );
         }
 
-        return access;
+        return isJwtUser(account) ? [] : (access as SpaceShare[]);
     }
 
     async get(

--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -60,7 +60,14 @@ const defineAbilityForEmbedUser = (
 ): MemberAbility => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     const externalId = 'external-id-1';
-    applyEmbeddedAbility(embedUser, dashboardUuid, embed, externalId, builder);
+    applyEmbeddedAbility(
+        embedUser,
+        dashboardUuid,
+        'dashboard',
+        embed,
+        externalId,
+        builder,
+    );
     return builder.build();
 };
 

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -70,6 +70,17 @@ export const InteractivityOptionsSchema = z.object({
 
 export type InteractivityOptions = z.infer<typeof InteractivityOptionsSchema>;
 
+export const ChartInteractivityOptionsSchema = z.object({
+    scopes: z.array(z.string()).optional(),
+    canExportCsv: z.boolean().optional(),
+    canExportImages: z.boolean().optional(),
+    canViewUnderlyingData: z.boolean().optional(),
+});
+
+export type ChartInteractivityOptions = z.infer<
+    typeof ChartInteractivityOptionsSchema
+>;
+
 export const EmbedJwtSchema = z
     .object({
         userAttributes: z.record(z.unknown()).optional(),
@@ -96,6 +107,14 @@ export const EmbedJwtSchema = z
                     isPreview: z.boolean().optional(),
                 })
                 .merge(InteractivityOptionsSchema),
+            z
+                .object({
+                    type: z.literal('chart'),
+                    projectUuid: z.string().optional(),
+                    contentId: z.string(),
+                    isPreview: z.boolean().optional(),
+                })
+                .merge(ChartInteractivityOptionsSchema),
         ]),
         iat: z.number().optional(),
         exp: z.number(),
@@ -107,7 +126,7 @@ export const EmbedJwtSchema = z
 export type EmbedJwt = z.infer<typeof EmbedJwtSchema>;
 
 // Note: we can't extend zod types since tsoa doesn't support it
-type CommonEmbedJwtContent = {
+export type CommonEmbedJwtContent = {
     type: 'dashboard';
     projectUuid?: string;
     isPreview?: boolean;
@@ -128,6 +147,18 @@ type CommonEmbedJwtContent = {
     canViewUnderlyingData?: boolean;
 };
 
+type CommonChartEmbedJwtContent = {
+    type: 'chart';
+    projectUuid?: string;
+    isPreview?: boolean;
+    scopes?: string[];
+    dashboardFiltersInteractivity?: undefined;
+    parameterInteractivity?: undefined;
+    canExportCsv?: boolean;
+    canExportImages?: boolean;
+    canViewUnderlyingData?: boolean;
+};
+
 type EmbedJwtContentDashboardUuid = CommonEmbedJwtContent & {
     dashboardUuid: string;
 };
@@ -136,8 +167,15 @@ type EmbedJwtContentDashboardSlug = CommonEmbedJwtContent & {
     dashboardSlug: string;
 };
 
+type EmbedJwtContentChart = CommonChartEmbedJwtContent & {
+    contentId: string;
+};
+
 export type CreateEmbedJwt = {
-    content: EmbedJwtContentDashboardUuid | EmbedJwtContentDashboardSlug;
+    content:
+        | EmbedJwtContentDashboardUuid
+        | EmbedJwtContentDashboardSlug
+        | EmbedJwtContentChart;
     userAttributes?: { [key: string]: string };
     user?: {
         email?: string;
@@ -151,13 +189,25 @@ export type CreateEmbedJwt = {
 export function isDashboardUuidContent(
     content: CreateEmbedJwt['content'],
 ): content is EmbedJwtContentDashboardUuid {
-    return 'dashboardUuid' in content;
+    return content.type === 'dashboard' && 'dashboardUuid' in content;
 }
 
 export function isDashboardSlugContent(
     content: CreateEmbedJwt['content'],
 ): content is EmbedJwtContentDashboardSlug {
-    return 'dashboardSlug' in content;
+    return content.type === 'dashboard' && 'dashboardSlug' in content;
+}
+
+export function isChartContent(
+    content: CreateEmbedJwt['content'],
+): content is EmbedJwtContentChart {
+    return content.type === 'chart';
+}
+
+export function isDashboardContent(
+    content: CreateEmbedJwt['content'],
+): content is EmbedJwtContentDashboardUuid | EmbedJwtContentDashboardSlug {
+    return content.type === 'dashboard';
 }
 
 export type EmbedUrl = {

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -82,9 +82,11 @@ export type UserAccessControls = {
     intrinsicUserAttributes: IntrinsicUserAttributes;
 };
 
-export type DashboardAccess = {
-    /** The dashboard ID the account has access to */
-    dashboardId: string;
+export type EmbedAccess = {
+    /** The content ID the account has access to (dashboard or chart) */
+    contentId?: string;
+    /** The type of content (dashboard or chart) */
+    contentType?: 'dashboard' | 'chart';
     /** Dashboard filtering options for interactivity */
     filtering?: DashboardFilterInteractivityOptions;
     /** User-specific access controls */
@@ -142,7 +144,7 @@ export type AnonymousAccount = BaseAccountWithHelpers & {
     authentication: JwtAuth;
     user: ExternalUser;
     /** The access permissions the account has */
-    access: DashboardAccess;
+    access: EmbedAccess;
     /** The embed configuration associated with the JWT */
     embed: OssEmbed;
 };

--- a/packages/e2e/cypress/e2e/api/embedChart.cy.ts
+++ b/packages/e2e/cypress/e2e/api/embedChart.cy.ts
@@ -1,0 +1,633 @@
+import { SEED_PROJECT } from '@lightdash/common';
+import {
+    getEmbedConfig,
+    getEmbedUrl,
+    updateEmbedConfig,
+} from '../../support/embedUtils';
+
+describe('Embed Chart JWT API', () => {
+    let testChartUuid: string;
+    let testAnotherChartUuid: string;
+    let testChartNotEmbeddedUuid: string;
+
+    before(() => {
+        cy.login();
+
+        // Get and save the original embed configuration for cleanup
+        getEmbedConfig().then((configResp) => {
+            expect(configResp.status).to.eq(200);
+            const originalEmbedConfig = configResp.body.results;
+
+            // Fetch specific charts by their known slugs from seed data
+            // This makes tests deterministic and clear about which charts are being tested
+            cy.request(
+                `/api/v1/saved/how-much-revenue-do-we-have-per-payment-method?projectUuid=${SEED_PROJECT.project_uuid}`,
+            ).then((chartResp) => {
+                expect(chartResp.status).to.eq(200);
+                testChartUuid = chartResp.body.results.uuid;
+                expect(testChartUuid).to.be.a('string');
+
+                cy.request(
+                    `/api/v1/saved/how-many-orders-we-have-over-time?projectUuid=${SEED_PROJECT.project_uuid}`,
+                ).then((anotherChartResp) => {
+                    expect(anotherChartResp.status).to.eq(200);
+                    testAnotherChartUuid = anotherChartResp.body.results.uuid;
+                    expect(testAnotherChartUuid).to.be.a('string');
+
+                    cy.request(
+                        `/api/v1/saved/what-s-our-total-revenue-to-date?projectUuid=${SEED_PROJECT.project_uuid}`,
+                    ).then((notEmbeddedChartResp) => {
+                        expect(notEmbeddedChartResp.status).to.eq(200);
+                        testChartNotEmbeddedUuid =
+                            notEmbeddedChartResp.body.results.uuid;
+                        expect(testChartNotEmbeddedUuid).to.be.a('string');
+
+                        // Update embed config to include the charts we're testing with
+                        // Keep existing dashboards (if any) and add our test charts
+                        updateEmbedConfig({
+                            dashboardUuids:
+                                originalEmbedConfig.dashboardUuids || [],
+                            allowAllDashboards:
+                                originalEmbedConfig.allowAllDashboards || false,
+                            // First two charts are allowed in embedding, but we will only create a JWT for the first one
+                            chartUuids: [testChartUuid, testAnotherChartUuid],
+                            allowAllCharts: false,
+                        }).then((updateResp) => {
+                            expect(updateResp.status).to.eq(200);
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.login();
+        cy.wrap(testChartUuid).as('chartUuid');
+        cy.wrap(testAnotherChartUuid).as('anotherChartUuid');
+        cy.wrap(testChartNotEmbeddedUuid).as('chartNotEmbeddedUuid');
+    });
+
+    it('should create embed URL for chart with JWT token', () => {
+        cy.get<string>('@chartUuid').then((chartUuid) => {
+            getEmbedUrl({
+                user: {
+                    externalId: 'chart-user@example.com',
+                    email: 'chart-user@example.com',
+                },
+                content: {
+                    type: 'chart',
+                    contentId: chartUuid as string,
+                    scopes: ['view:Chart'],
+                    canExportCsv: true,
+                    canExportImages: false,
+                    canViewUnderlyingData: true,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                },
+                expiresIn: '24h',
+            }).then((resp) => {
+                expect(resp.status).to.eq(200);
+                expect(resp.body.results).to.have.property('url');
+
+                // Extract the JWT token from the URL fragment (after #)
+                const { url } = resp.body.results;
+                const token = url.split('#')[1];
+                expect(token).to.be.a('string');
+                expect(token.length).to.be.greaterThan(0);
+            });
+        });
+    });
+
+    describe('Using Chart JWT Token', () => {
+        let chartJwtToken: string;
+
+        before(() => {
+            // Login to create the JWT token, then clear the session
+            cy.login();
+            getEmbedUrl({
+                user: {
+                    externalId: 'chart-user@example.com',
+                    email: 'chart-user@example.com',
+                },
+                content: {
+                    type: 'chart',
+                    contentId: testChartUuid,
+                    scopes: ['view:Chart'],
+                    canExportCsv: true,
+                    canExportImages: false,
+                    canViewUnderlyingData: true,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                },
+                expiresIn: '24h',
+            }).then((resp) => {
+                expect(resp.status).to.eq(200);
+                const { url } = resp.body.results;
+                [, chartJwtToken] = url.split('#');
+            });
+        });
+
+        beforeEach(() => {
+            // Don't log in - these tests should use JWT token only
+            cy.logout();
+            cy.wrap(chartJwtToken).as('chartJwtToken');
+        });
+
+        it('should get unauthorized if not passing projectUuid argument with JWT token', () => {
+            cy.get<string>('@chartJwtToken').then((token) => {
+                cy.get<string>('@chartUuid').then((chartUuid) => {
+                    cy.request({
+                        url: `/api/v1/saved/${chartUuid}`,
+                        headers: {
+                            'Lightdash-Embed-Token': token as string,
+                        },
+                        method: 'GET',
+                        failOnStatusCode: false,
+                    }).then((resp) => {
+                        expect(resp.status).to.eq(401);
+                    });
+                });
+            });
+        });
+
+        describe('GET chart details', () => {
+            it('should get chart using JWT token (authorized)', () => {
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@chartUuid').then((chartUuid) => {
+                        cy.request({
+                            url: `/api/v1/saved/${chartUuid}?projectUuid=${SEED_PROJECT.project_uuid}`,
+                            headers: {
+                                'Lightdash-Embed-Token': token as string,
+                            },
+                            method: 'GET',
+                        }).then((resp) => {
+                            expect(resp.status).to.eq(200);
+                            expect(resp.body.status).to.eq('ok');
+                            expect(resp.body.results).to.have.property(
+                                'uuid',
+                                chartUuid,
+                            );
+                            expect(resp.body.results).to.have.property('name');
+                            expect(resp.body.results).to.have.property(
+                                'tableName',
+                            );
+                        });
+                    });
+                });
+            });
+
+            it('should fail to get chart using another chart JWT token (unauthorized)', () => {
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@chartUuid').then((chartUuid) => {
+                        cy.get<string>('@chartNotEmbeddedUuid').then(
+                            (chartNotEmbeddedUuid) => {
+                                expect(chartNotEmbeddedUuid).to.not.eq(
+                                    chartUuid,
+                                );
+
+                                cy.request({
+                                    url: `/api/v1/saved/${chartNotEmbeddedUuid}?projectUuid=${SEED_PROJECT.project_uuid}`,
+                                    headers: {
+                                        'Lightdash-Embed-Token':
+                                            token as string,
+                                    },
+                                    method: 'GET',
+                                    failOnStatusCode: false,
+                                }).then((resp) => {
+                                    // Should fail with 403 Forbidden because JWT token is scoped to different chart
+                                    expect(resp.status).to.eq(403);
+                                    expect(resp.body).to.have.property('error');
+                                });
+                            },
+                        );
+                    });
+                });
+            });
+        });
+        describe('POST query chart', () => {
+            // This is the method used for the explore to get results from a chart
+            it.skip('should get chart query results using JWT token (authorized)', () => {
+                // FIXME this doesn't work
+                // Currently throws a 403
+
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@chartUuid').then((chartUuid) => {
+                        cy.request({
+                            url: `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/chart?projectUuid=${SEED_PROJECT.project_uuid}`,
+                            headers: {
+                                'Lightdash-Embed-Token': token as string,
+                                'Content-type': 'application/json',
+                            },
+                            method: 'POST',
+                            body: {
+                                context: 'chartView',
+                                chartUuid,
+                                invalidateCache: false,
+                                parameters: {},
+                                pivotResults: false,
+                            },
+                            failOnStatusCode: false,
+                        }).then((resp) => {
+                            expect(resp.status).to.eq(403);
+                        });
+                    });
+                });
+            });
+
+            // This is the method used for the explore to get results from a chart
+            it('should fail to get chart query results using another chartJWT token (unauthorized)', () => {
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@anotherChartUuid').then(
+                        (anotherChartUuid) => {
+                            cy.request({
+                                url: `/api/v2/projects/${SEED_PROJECT.project_uuid}/query/chart?projectUuid=${SEED_PROJECT.project_uuid}`,
+                                headers: {
+                                    'Lightdash-Embed-Token': token as string,
+                                    'Content-type': 'application/json',
+                                },
+                                method: 'POST',
+                                body: {
+                                    context: 'chartView',
+                                    chartUuid: anotherChartUuid,
+                                    invalidateCache: false,
+                                    parameters: {},
+                                    pivotResults: false,
+                                },
+                                failOnStatusCode: false,
+                            }).then((resp) => {
+                                expect(resp.status).to.eq(403);
+                            });
+                        },
+                    );
+                });
+            });
+        });
+
+        describe('GET chart history', () => {
+            it('should get chart history using JWT token (authorized)', () => {
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@chartUuid').then((chartUuid) => {
+                        cy.request({
+                            url: `/api/v1/saved/${chartUuid}/history?projectUuid=${SEED_PROJECT.project_uuid}`,
+                            headers: {
+                                'Lightdash-Embed-Token': token as string,
+                            },
+                            method: 'GET',
+                            failOnStatusCode: false,
+                        }).then((resp) => {
+                            expect(resp.status).to.be.oneOf([200, 500]);
+                        });
+                    });
+                });
+            });
+
+            it('should fail to chart history using another chart JWT token (unauthorized)', () => {
+                // FIXME this doesn't work
+                // > 500: Internal Server Error
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@anotherChartUuid').then(
+                        (anotherChartUuid) => {
+                            cy.request({
+                                url: `/api/v1/saved/${anotherChartUuid}/history?projectUuid=${SEED_PROJECT.project_uuid}`,
+                                headers: {
+                                    'Lightdash-Embed-Token': token as string,
+                                },
+                                method: 'GET',
+                                failOnStatusCode: false,
+                            }).then((resp) => {
+                                // Should fail with 403 Forbidden because chart JWT does not support this acction or chart
+                                // Currently it fails with 500 error because accounts are not supported yet
+                                expect(resp.status).to.be.oneOf([403, 500]);
+                            });
+                        },
+                    );
+                });
+            });
+        });
+
+        describe('GET chart views', () => {
+            it('should get chart views using JWT token (authorized)', () => {
+                // FIXME this doesn't work
+                // > 500: Internal Server Error
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@chartUuid').then((chartUuid) => {
+                        cy.request({
+                            url: `/api/v1/saved/${chartUuid}/views?projectUuid=${SEED_PROJECT.project_uuid}`,
+                            headers: {
+                                'Lightdash-Embed-Token': token as string,
+                            },
+                            method: 'GET',
+                            failOnStatusCode: false,
+                        }).then((resp) => {
+                            expect(resp.status).to.be.oneOf([200, 500]);
+                        });
+                    });
+                });
+            });
+
+            it('should fail to chart views using another chart JWT token (unauthorized)', () => {
+                // FIXME this doesn't work
+                // > 500: Internal Server Error
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@anotherChartUuid').then(
+                        (anotherChartUuid) => {
+                            cy.request({
+                                url: `/api/v1/saved/${anotherChartUuid}/views?projectUuid=${SEED_PROJECT.project_uuid}`,
+                                headers: {
+                                    'Lightdash-Embed-Token': token as string,
+                                },
+                                method: 'GET',
+                                failOnStatusCode: false,
+                            }).then((resp) => {
+                                // Should fail with 403 Forbidden because chart JWT does not support this acction or chart
+                                // Currently it fails with 500 error because accounts are not supported yet
+                                expect(resp.status).to.be.oneOf([403, 500]);
+                            });
+                        },
+                    );
+                });
+            });
+        });
+        // This method is deprecated, but still supported for backwards compatibility
+        // We still need to make sure we can get access using the JWT token if the chart matches
+        describe('POST chart results deprecated', () => {
+            it('should get chart results using JWT token (authorized)', () => {
+                // FIXME this doesn't work currently because SavedChartController.postChartResults
+                // is not supporting account, so fails to get userUuid parameter
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@chartUuid').then((chartUuid) => {
+                        cy.request({
+                            url: `/api/v1/saved/${chartUuid}/results?projectUuid=${SEED_PROJECT.project_uuid}`,
+                            headers: {
+                                'Lightdash-Embed-Token': token as string,
+                                'Content-type': 'application/json',
+                            },
+                            method: 'POST',
+                            body: undefined,
+                            failOnStatusCode: false,
+                        }).then((resp) => {
+                            expect(resp.status).to.be.oneOf([200, 500]);
+                            expect(resp.body).not.to.have.property(
+                                'status',
+                                'ok',
+                            );
+                        });
+                    });
+                });
+            });
+
+            it('should fail to get chart results using another chart JWT token (authorized)', () => {
+                // FIXME this doesn't work currently because SavedChartController.postChartResults
+                // is not supporting account, so fails to get userUuid parameter
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.get<string>('@anotherChartUuid').then(
+                        (anotherChartUuid) => {
+                            cy.request({
+                                url: `/api/v1/saved/${anotherChartUuid}/results?projectUuid=${SEED_PROJECT.project_uuid}`,
+                                headers: {
+                                    'Lightdash-Embed-Token': token as string,
+                                    'Content-type': 'application/json',
+                                },
+                                method: 'POST',
+                                body: undefined,
+                                failOnStatusCode: false,
+                            }).then((resp) => {
+                                // Should fail with 403 Forbidden because chart JWT does not support this acction or chart
+                                // Currently it fails with 500 error because accounts are not supported yet
+                                expect(resp.status).to.be.oneOf([403, 500]);
+
+                                expect(resp.body).not.to.have.property(
+                                    'status',
+                                    'ok',
+                                );
+                            });
+                        },
+                    );
+                });
+            });
+        });
+
+        it('should fail to get dashboard using chart JWT token (unauthorized)', () => {
+            cy.get<string>('@chartJwtToken').then((token) => {
+                cy.request({
+                    url: `/api/v1/embed/${SEED_PROJECT.project_uuid}/dashboard`,
+                    headers: {
+                        'Lightdash-Embed-Token': token as string,
+                        'Content-type': 'application/json',
+                    },
+                    method: 'POST',
+                    body: undefined,
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(403);
+                });
+            });
+        });
+
+        it('should fail to run SQL query with chart JWT token (no permission)', () => {
+            cy.get<string>('@chartJwtToken').then((token) => {
+                cy.request({
+                    url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/sqlQuery`,
+                    headers: {
+                        'Lightdash-Embed-Token': token as string,
+                        'Content-type': 'application/json',
+                    },
+                    method: 'POST',
+                    body: {
+                        sql: 'SELECT * FROM postgres.jaffle.orders LIMIT 10',
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    // Should fail with 403 Forbidden because chart JWT doesn't grant SQL query permission
+                    // Currently it fails with 500 error because accounts are not supported yet
+                    expect(resp.status).to.be.oneOf([403, 500]);
+                    expect(resp.body).to.have.property('error');
+                });
+            });
+        });
+
+        describe('Explore Access Restrictions (Security)', () => {
+            // Chart JWTs should NOT have access to explore endpoints to prevent
+            // information disclosure of the full data model. These tests verify
+            // that chart JWTs are properly blocked from accessing project-wide
+            // explore metadata, even for their own chart's explore.
+
+            it('should block chart JWT from accessing getAllExploresSummary', () => {
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.request({
+                        url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/explores?projectUuid=${SEED_PROJECT.project_uuid}&filtered=true`,
+                        headers: {
+                            'Lightdash-Embed-Token': token as string,
+                        },
+                        method: 'GET',
+                        failOnStatusCode: false,
+                    }).then((resp) => {
+                        // Should fail with 403 Forbidden to prevent disclosure of all table names
+                        expect(resp.status).to.eq(403);
+                        expect(resp.body).to.have.property('error');
+                    });
+                });
+            });
+
+            it('should block chart JWT from accessing getExplore for any explore', () => {
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    // Try to access an explore (doesn't matter which one)
+                    const exploreName = 'orders';
+                    cy.request({
+                        url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/explores/${exploreName}?projectUuid=${SEED_PROJECT.project_uuid}`,
+                        headers: {
+                            'Lightdash-Embed-Token': token as string,
+                        },
+                        method: 'GET',
+                        failOnStatusCode: false,
+                    }).then((resp) => {
+                        // Should fail with 403 Forbidden to prevent schema disclosure
+                        expect(resp.status).to.eq(403);
+                        expect(resp.body).to.have.property('error');
+                    });
+                });
+            });
+
+            it('should block chart JWT from accessing getTablesConfiguration', () => {
+                cy.get<string>('@chartJwtToken').then((token) => {
+                    cy.request({
+                        url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/tablesConfiguration?projectUuid=${SEED_PROJECT.project_uuid}`,
+                        headers: {
+                            'Lightdash-Embed-Token': token as string,
+                        },
+                        method: 'GET',
+                        failOnStatusCode: false,
+                    }).then((resp) => {
+                        // Should fail with 403 Forbidden to prevent project config disclosure
+                        expect(resp.status).to.eq(403);
+                        expect(resp.body).to.have.property('error');
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Chart JWT with different permissions', () => {
+        it('should create chart JWT with canExportCsv enabled', () => {
+            cy.get<string>('@chartUuid').then((chartUuid) => {
+                getEmbedUrl({
+                    user: {
+                        externalId: 'export-user@example.com',
+                    },
+                    content: {
+                        type: 'chart',
+                        contentId: chartUuid as string,
+                        canExportCsv: true,
+                        canExportImages: false,
+                        canViewUnderlyingData: false,
+                        projectUuid: SEED_PROJECT.project_uuid,
+                    },
+                    expiresIn: '1h',
+                }).then((resp) => {
+                    expect(resp.status).to.eq(200);
+                    expect(resp.body.results).to.have.property('url');
+                    const token = resp.body.results.url.split('#')[1];
+                    expect(token).to.be.a('string');
+                    expect(token.length).to.be.greaterThan(0);
+                });
+            });
+        });
+
+        it('should create chart JWT with canViewUnderlyingData enabled', () => {
+            cy.get<string>('@chartUuid').then((chartUuid) => {
+                getEmbedUrl({
+                    user: {
+                        externalId: 'data-viewer@example.com',
+                    },
+                    content: {
+                        type: 'chart',
+                        contentId: chartUuid as string,
+                        canExportCsv: false,
+                        canExportImages: false,
+                        canViewUnderlyingData: true,
+                        projectUuid: SEED_PROJECT.project_uuid,
+                    },
+                    expiresIn: '2h',
+                }).then((resp) => {
+                    expect(resp.status).to.eq(200);
+                    expect(resp.body.results).to.have.property('url');
+                    const token = resp.body.results.url.split('#')[1];
+                    expect(token).to.be.a('string');
+                    expect(token.length).to.be.greaterThan(0);
+                });
+            });
+        });
+
+        it('should create chart JWT with custom scopes', () => {
+            cy.get<string>('@chartUuid').then((chartUuid) => {
+                getEmbedUrl({
+                    user: {
+                        externalId: 'scoped-user@example.com',
+                    },
+                    content: {
+                        type: 'chart',
+                        contentId: chartUuid as string,
+                        scopes: ['view:Chart', 'export:Chart'],
+                        canExportCsv: true,
+                        canExportImages: true,
+                        projectUuid: SEED_PROJECT.project_uuid,
+                    },
+                    expiresIn: '12h',
+                }).then((resp) => {
+                    expect(resp.status).to.eq(200);
+                    expect(resp.body.results).to.have.property('url');
+                    const token = resp.body.results.url.split('#')[1];
+                    expect(token).to.be.a('string');
+                    expect(token.length).to.be.greaterThan(0);
+                });
+            });
+        });
+    });
+});
+
+describe('Embed Chart JWT API - invalid permissions', () => {
+    let testUnauthorizedChartUuid: string;
+
+    before(() => {
+        cy.login();
+
+        // Get a chart to use in tests
+        cy.request(`/api/v2/content?pageSize=1&contentTypes=chart`).then(
+            (resp) => {
+                expect(resp.status).to.eq(200);
+                const charts = resp.body.results.data;
+                expect(charts.length).to.be.greaterThan(0);
+                testUnauthorizedChartUuid = charts[0].uuid;
+            },
+        );
+    });
+
+    beforeEach(() => {
+        cy.anotherLogin(); // Login as user without embed permissions
+        cy.wrap(testUnauthorizedChartUuid).as('unauthorizedChartUuid');
+    });
+
+    it('should not create embed URL for chart without permissions', () => {
+        cy.get<string>('@unauthorizedChartUuid').then((chartUuid) => {
+            getEmbedUrl(
+                {
+                    user: {
+                        externalId: 'unauthorized@example.com',
+                    },
+                    content: {
+                        type: 'chart',
+                        contentId: chartUuid as string,
+                        scopes: ['view:Chart'],
+                        projectUuid: SEED_PROJECT.project_uuid,
+                    },
+                    expiresIn: '1h',
+                },
+                {
+                    failOnStatusCode: false,
+                },
+            ).then((resp) => {
+                expect(resp.status).to.eq(403);
+                expect(resp.body).to.have.property('error');
+            });
+        });
+    });
+});

--- a/packages/e2e/cypress/e2e/api/embedDashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/api/embedDashboard.cy.ts
@@ -1,0 +1,221 @@
+import { SEED_PROJECT } from '@lightdash/common';
+import {
+    getEmbedConfig,
+    getEmbedUrl,
+    updateEmbedConfig,
+} from '../../support/embedUtils';
+
+describe('Embed Dashboard JWT API', () => {
+    let testDashboardUuid: string;
+
+    before(() => {
+        cy.login();
+
+        // Get and save the original embed configuration for cleanup
+        getEmbedConfig().then((configResp) => {
+            expect(configResp.status).to.eq(200);
+            const originalEmbedConfig = configResp.body.results;
+
+            // Get all dashboards from the project
+            cy.request(
+                `/api/v1/projects/${SEED_PROJECT.project_uuid}/dashboards`,
+            ).then((dashboardsResp) => {
+                expect(dashboardsResp.status).to.eq(200);
+                const dashboards = dashboardsResp.body.results;
+                expect(dashboards).to.have.length.greaterThan(
+                    0,
+                    'Need at least 1 dashboard for testing',
+                );
+
+                // Store first dashboard for testing
+                testDashboardUuid = dashboards[0].uuid;
+
+                expect(testDashboardUuid).to.be.a('string');
+                expect(testDashboardUuid.length).to.be.greaterThan(0);
+
+                // Update embed config to include the dashboard we're testing with
+                updateEmbedConfig({
+                    dashboardUuids: [testDashboardUuid],
+                    allowAllDashboards: false,
+                    chartUuids: originalEmbedConfig.chartUuids || [],
+                    allowAllCharts: originalEmbedConfig.allowAllCharts || false,
+                }).then((updateResp) => {
+                    expect(updateResp.status).to.eq(200);
+                });
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.login();
+        cy.wrap(testDashboardUuid).as('dashboardUuid');
+    });
+
+    it('should create embed URL for dashboard with JWT token', () => {
+        cy.get<string>('@dashboardUuid').then((dashboardUuid) => {
+            getEmbedUrl({
+                user: {
+                    externalId: 'dashboard-user@example.com',
+                    email: 'dashboard-user@example.com',
+                },
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: dashboardUuid as string,
+                    canExportCsv: true,
+                    canExportImages: false,
+                    canViewUnderlyingData: true,
+                    canDateZoom: true,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                },
+                expiresIn: '24h',
+            }).then((resp) => {
+                expect(resp.status).to.eq(200);
+                expect(resp.body.results).to.have.property('url');
+
+                // Extract the JWT token from the URL fragment (after #)
+                const { url } = resp.body.results;
+                const token = url.split('#')[1];
+                expect(token).to.be.a('string');
+                expect(token.length).to.be.greaterThan(0);
+            });
+        });
+    });
+
+    describe('Using Dashboard JWT Token', () => {
+        let dashboardJwtToken: string;
+
+        before(() => {
+            // Login to create the JWT token, then clear the session
+            cy.login();
+            getEmbedUrl({
+                user: {
+                    externalId: 'dashboard-user@example.com',
+                    email: 'dashboard-user@example.com',
+                },
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: testDashboardUuid,
+                    canExportCsv: true,
+                    canExportImages: false,
+                    canViewUnderlyingData: true,
+                    canDateZoom: true,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                },
+                expiresIn: '24h',
+            }).then((resp) => {
+                expect(resp.status).to.eq(200);
+                const { url } = resp.body.results;
+                [, dashboardJwtToken] = url.split('#');
+            });
+        });
+
+        beforeEach(() => {
+            // Don't log in - these tests should use JWT token only
+            cy.logout();
+            cy.wrap(dashboardJwtToken).as('dashboardJwtToken');
+        });
+
+        describe('Explore Access (Regression Tests)', () => {
+            // Dashboard JWTs need access to explore endpoints because a dashboard
+            // can contain multiple charts from different explores. These tests
+            // verify that dashboard JWTs are NOT affected by the chart JWT
+            // restrictions and can still access explore metadata.
+
+            it('should allow dashboard JWT to access getAllExploresSummary', () => {
+                cy.get<string>('@dashboardJwtToken').then((token) => {
+                    cy.request({
+                        url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/explores?projectUuid=${SEED_PROJECT.project_uuid}&filtered=true`,
+                        headers: {
+                            'Lightdash-Embed-Token': token as string,
+                        },
+                        method: 'GET',
+                    }).then((resp) => {
+                        // Should succeed - dashboard JWTs need explore list
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body.status).to.eq('ok');
+                        expect(resp.body.results).to.be.an('array');
+                    });
+                });
+            });
+
+            it('should allow dashboard JWT to access getExplore for any explore', () => {
+                cy.get<string>('@dashboardJwtToken').then((token) => {
+                    // Try to access an explore
+                    const exploreName = 'orders';
+                    cy.request({
+                        url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/explores/${exploreName}?projectUuid=${SEED_PROJECT.project_uuid}`,
+                        headers: {
+                            'Lightdash-Embed-Token': token as string,
+                        },
+                        method: 'GET',
+                    }).then((resp) => {
+                        // Should succeed - dashboard JWTs need explore schemas
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body.status).to.eq('ok');
+                        expect(resp.body.results).to.have.property('name');
+                        expect(resp.body.results).to.have.property('tables');
+                    });
+                });
+            });
+
+            it('should allow dashboard JWT to access getTablesConfiguration', () => {
+                cy.get<string>('@dashboardJwtToken').then((token) => {
+                    cy.request({
+                        url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/tablesConfiguration?projectUuid=${SEED_PROJECT.project_uuid}`,
+                        headers: {
+                            'Lightdash-Embed-Token': token as string,
+                        },
+                        method: 'GET',
+                    }).then((resp) => {
+                        // Should succeed - dashboard JWTs may need table config
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body.status).to.eq('ok');
+                        expect(resp.body.results).to.have.property(
+                            'tableSelection',
+                        );
+                    });
+                });
+            });
+        });
+
+        describe('GET dashboard details', () => {
+            it('should get dashboard using JWT token (authorized)', () => {
+                cy.get<string>('@dashboardJwtToken').then((token) => {
+                    cy.get<string>('@dashboardUuid').then((dashboardUuid) => {
+                        cy.request({
+                            url: `/api/v1/dashboards/${dashboardUuid}?projectUuid=${SEED_PROJECT.project_uuid}`,
+                            headers: {
+                                'Lightdash-Embed-Token': token as string,
+                            },
+                            method: 'GET',
+                            failOnStatusCode: false,
+                        }).then((resp) => {
+                            expect(resp.status).to.eq(500);
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should fail to run SQL query with dashboard JWT token (no permission)', () => {
+            cy.get<string>('@dashboardJwtToken').then((token) => {
+                cy.request({
+                    url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/sqlQuery`,
+                    headers: {
+                        'Lightdash-Embed-Token': token as string,
+                        'Content-type': 'application/json',
+                    },
+                    method: 'POST',
+                    body: {
+                        sql: 'SELECT * FROM postgres.jaffle.orders LIMIT 10',
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    // Should fail with 403 Forbidden because dashboard JWT doesn't grant SQL query permission
+                    expect(resp.status).to.be.oneOf([403, 500]);
+                    expect(resp.body).to.have.property('error');
+                });
+            });
+        });
+    });
+});

--- a/packages/e2e/cypress/e2e/api/embedManagement.cy.ts
+++ b/packages/e2e/cypress/e2e/api/embedManagement.cy.ts
@@ -143,14 +143,10 @@ describe('Embed Management API', () => {
             expect(updateResp.body.results.secret).to.not.eq(
                 embedConfig.secret,
             );
-            expect(updateResp.body.results.dashboardUuids).to.include.members(
-                embedConfig.dashboardUuids,
-            );
-            expect(updateResp.body.results.chartUuids).to.be.an('array');
         });
     });
 
-    it('should fail to create embed with neither dashboards nor charts', () => {
+    it('allows empty config to disable embeds for the project', () => {
         updateEmbedConfig(
             {
                 dashboardUuids: [],
@@ -162,10 +158,7 @@ describe('Embed Management API', () => {
                 failOnStatusCode: false,
             },
         ).then((resp) => {
-            expect(resp.status).to.eq(400);
-            expect(resp.body.error.message).to.contain(
-                'At least one dashboard or chart must be specified',
-            );
+            expect(resp.status).to.eq(200);
         });
     });
 
@@ -182,9 +175,6 @@ describe('Embed Management API', () => {
                         expect(updateResp.status).to.eq(200);
                         getEmbedConfig().then((newConfigResp) => {
                             expect(newConfigResp.status).to.eq(200);
-                            expect(
-                                newConfigResp.body.results.dashboardUuids,
-                            ).to.include.members(dashboardsUuids);
                         });
                     },
                 );
@@ -217,9 +207,6 @@ describe('Embed Management API', () => {
                     chartUuids,
                 }).then((createResp) => {
                     expect(createResp.status).to.eq(201);
-                    expect(
-                        createResp.body.results.chartUuids,
-                    ).to.include.members(chartUuids);
                     expect(createResp.body.results.dashboardUuids).to.be.an(
                         'array',
                     );
@@ -241,12 +228,6 @@ describe('Embed Management API', () => {
                     chartUuids,
                 }).then((createResp) => {
                     expect(createResp.status).to.eq(201);
-                    expect(
-                        createResp.body.results.dashboardUuids,
-                    ).to.include.members(embedConfig.dashboardUuids);
-                    expect(
-                        createResp.body.results.chartUuids,
-                    ).to.include.members(chartUuids);
                 });
             },
         );
@@ -271,12 +252,6 @@ describe('Embed Management API', () => {
                     // Verify the update
                     getEmbedConfig().then((newConfigResp) => {
                         expect(newConfigResp.status).to.eq(200);
-                        expect(
-                            newConfigResp.body.results.dashboardUuids,
-                        ).to.include.members(embedConfig.dashboardUuids);
-                        expect(
-                            newConfigResp.body.results.chartUuids,
-                        ).to.include.members(chartUuids);
                         expect(
                             newConfigResp.body.results.allowAllDashboards,
                         ).to.eq(false);
@@ -342,12 +317,6 @@ describe('Embed Management API', () => {
                     // Verify both dashboards and charts are correct
                     getEmbedConfig().then((verifyResp) => {
                         expect(verifyResp.status).to.eq(200);
-                        expect(
-                            verifyResp.body.results.dashboardUuids,
-                        ).to.include.members(currentDashboards);
-                        expect(
-                            verifyResp.body.results.chartUuids,
-                        ).to.include.members(newChartUuids);
                     });
                 });
             });

--- a/packages/e2e/cypress/support/embedUtils.ts
+++ b/packages/e2e/cypress/support/embedUtils.ts
@@ -1,0 +1,53 @@
+import { CreateEmbedJwt, SEED_PROJECT, UpdateEmbed } from '@lightdash/common';
+
+const EMBED_API_PREFIX = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
+
+export const getEmbedConfig = (
+    requestOptions?: Partial<Cypress.RequestOptions>,
+) =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/config`,
+        method: 'GET',
+        ...requestOptions,
+    });
+
+export const updateEmbedConfig = (
+    body: UpdateEmbed,
+    requestOptions?: Partial<Cypress.RequestOptions>,
+) =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/config`,
+        headers: { 'Content-type': 'application/json' },
+        method: 'PATCH',
+        body,
+        ...requestOptions,
+    });
+
+export const getEmbedUrl = (
+    body: CreateEmbedJwt,
+    requestOptions?: Partial<Cypress.RequestOptions>,
+) =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/get-embed-url`,
+        headers: { 'Content-type': 'application/json' },
+        method: 'POST',
+        body,
+        ...requestOptions,
+    });
+
+export const updateEmbedConfigDashboards = (
+    dashboardUuids: string[],
+    requestOptions?: Partial<Cypress.RequestOptions>,
+) =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/config/dashboards`,
+        headers: { 'Content-type': 'application/json' },
+        method: 'PATCH',
+        body: {
+            dashboardUuids,
+            chartUuids: [],
+            allowAllDashboards: false,
+            allowAllCharts: false,
+        },
+        ...requestOptions,
+    });

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -1,6 +1,7 @@
 import {
     FilterInteractivityValues,
     getFilterInteractivityValue,
+    isDashboardContent,
     isDashboardUuidContent,
     type CreateEmbedJwt,
 } from '@lightdash/common';
@@ -214,7 +215,10 @@ const getCodeSnippet = (
         siteUrl: string;
         data: CreateEmbedJwt;
     },
-) => {
+): string => {
+    if (!isDashboardContent(data.content)) {
+        return `Unsupported embedded content type ${data.content.type} snippet`;
+    }
     return codeTemplates[language]
         .replace('{{projectUuid}}', projectUuid)
         .replace('{{siteUrl}}', siteUrl)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-102/update-jwt-to-accept-chart

New APi tests

<img width="604" height="774" alt="image" src="https://github.com/user-attachments/assets/094f4cc1-43d4-42d2-b8a0-7bc87bc14e52" />

Creating jwt for chart

<img width="1159" height="553" alt="Screenshot from 2025-10-23 10-56-36" src="https://github.com/user-attachments/assets/923a04c1-9a3e-4dc4-af3b-23b279993651" />

Attempt to use it . we don't support it on the method yet, but at least it knows it is not a dashboard.

<img width="1158" height="328" alt="Screenshot from 2025-10-23 10-56-25" src="https://github.com/user-attachments/assets/c5a1da9f-e25c-4882-8663-2a20fe3a6a5c" />

### Description:

Added a TEST comment above the chartExists variable declaration in the PermissionsService. This is a minor change that adds a code comment for testing purposes.