### PR TITLE
chore: lift expanded state

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/TableTreeSections.tsx
@@ -38,6 +38,7 @@ import DocumentationHelpButton from '../../../DocumentationHelpButton';
 import MantineIcon from '../../../common/MantineIcon';
 import { TreeProvider } from './Tree/TreeProvider';
 import TreeRoot from './Tree/TreeRoot';
+import { TreeSection } from './Virtualization/types';
 
 type Props = {
     searchQuery?: string;
@@ -50,6 +51,8 @@ type Props = {
     missingFieldIds: string[];
     searchResults: string[];
     isSearching: boolean;
+    expandedGroups: Set<string>;
+    onToggleGroup: (groupKey: string) => void;
 };
 const TableTreeSections: FC<Props> = ({
     searchQuery,
@@ -62,6 +65,8 @@ const TableTreeSections: FC<Props> = ({
     onSelectedNodeChange,
     searchResults,
     isSearching,
+    expandedGroups,
+    onToggleGroup,
 }) => {
     const selectedDimensions = useExplorerSelector(selectDimensions);
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -309,6 +314,10 @@ const TableTreeSections: FC<Props> = ({
                     groupDetails={table.groupDetails}
                     onItemClick={handleItemClickDimension}
                     searchResults={searchResults}
+                    tableName={table.name}
+                    treeSectionType={TreeSection.Dimensions}
+                    expandedGroups={expandedGroups}
+                    onToggleGroup={onToggleGroup}
                 >
                     <TreeRoot />
                 </TreeProvider>
@@ -357,6 +366,10 @@ const TableTreeSections: FC<Props> = ({
                     groupDetails={table.groupDetails}
                     onItemClick={handleItemClickMetric}
                     searchResults={searchResults}
+                    tableName={table.name}
+                    treeSectionType={TreeSection.Metrics}
+                    expandedGroups={expandedGroups}
+                    onToggleGroup={onToggleGroup}
                 >
                     <TreeRoot />
                 </TreeProvider>
@@ -408,6 +421,10 @@ const TableTreeSections: FC<Props> = ({
                     isGithubIntegrationEnabled={isGithubProject}
                     gitIntegration={gitIntegration}
                     searchResults={searchResults}
+                    tableName={table.name}
+                    treeSectionType={TreeSection.CustomMetrics}
+                    expandedGroups={expandedGroups}
+                    onToggleGroup={onToggleGroup}
                 >
                     <TreeRoot />
                 </TreeProvider>
@@ -460,6 +477,10 @@ const TableTreeSections: FC<Props> = ({
                     groupDetails={table.groupDetails}
                     onItemClick={handleItemClickDimension}
                     searchResults={searchResults}
+                    tableName={table.name}
+                    treeSectionType={TreeSection.CustomDimensions}
+                    expandedGroups={expandedGroups}
+                    onToggleGroup={onToggleGroup}
                 >
                     <TreeRoot />
                 </TreeProvider>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../../../features/explorer/store';
 import MantineIcon from '../../../../common/MantineIcon';
 import { ItemDetailPreview } from '../ItemDetailPreview';
+import { buildGroupKey } from '../Virtualization/types';
 import TreeNodes from './TreeNodes';
 import { type GroupNode, type Node } from './types';
 import useTableTree from './useTableTree';
@@ -40,8 +41,15 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
     const isSearching = useTableTree((ctx) => ctx.isSearching);
     const searchQuery = useTableTree((ctx) => ctx.searchQuery);
     const searchResults = useTableTree((ctx) => ctx.searchResults);
-    const [isOpen, toggleOpen] = useToggle(false);
+    const tableName = useTableTree((ctx) => ctx.tableName);
+    const treeSectionType = useTableTree((ctx) => ctx.treeSectionType);
+    const expandedGroups = useTableTree((ctx) => ctx.expandedGroups);
+    const onToggleGroup = useTableTree((ctx) => ctx.onToggleGroup);
     const [isHover, toggleHover] = useToggle(false);
+
+    // Build unique group key
+    const groupKey = buildGroupKey(tableName, treeSectionType, node.key);
+    const isOpen = expandedGroups.has(groupKey);
 
     const allChildrenKeys = useMemo(() => getAllChildrenKeys([node]), [node]);
 
@@ -83,7 +91,10 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
         );
     }, [toggleHover, dispatch, label, description]);
 
-    const handleToggleOpen = useCallback(() => toggleOpen(), [toggleOpen]);
+    const handleToggleOpen = useCallback(
+        () => onToggleGroup(groupKey),
+        [onToggleGroup, groupKey],
+    );
     const handleMouseEnter = useCallback(
         () => toggleHover(true),
         [toggleHover],

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeProvider.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeProvider.tsx
@@ -16,6 +16,10 @@ const TreeProviderComponent: FC<React.PropsWithChildren<TreeProviderProps>> = ({
     gitIntegration,
     onItemClick,
     searchResults,
+    tableName,
+    treeSectionType,
+    expandedGroups,
+    onToggleGroup,
 }) => {
     const nodeMap = useMemo(
         () => getNodeMapFromItemsMap(itemsMap, groupDetails),
@@ -39,6 +43,10 @@ const TreeProviderComponent: FC<React.PropsWithChildren<TreeProviderProps>> = ({
             gitIntegration,
             onItemClick,
             searchResults,
+            tableName,
+            treeSectionType,
+            expandedGroups,
+            onToggleGroup,
         }),
         [
             itemsMap,
@@ -53,6 +61,10 @@ const TreeProviderComponent: FC<React.PropsWithChildren<TreeProviderProps>> = ({
             gitIntegration,
             onItemClick,
             searchResults,
+            tableName,
+            treeSectionType,
+            expandedGroups,
+            onToggleGroup,
         ],
     );
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/types.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/types.ts
@@ -7,6 +7,7 @@ import {
     type Metric,
     type OrderFieldsByStrategy,
 } from '@lightdash/common';
+import type { TreeSection } from '../Virtualization/types';
 
 export type Node = {
     key: string;
@@ -43,6 +44,10 @@ export type TreeProviderProps = {
     gitIntegration?: GitIntegrationConfiguration;
     onItemClick: (key: string, item: NodeItem) => void;
     searchResults: string[];
+    tableName: string; // Table name for building group keys
+    treeSectionType: TreeSection; // Section type for building group keys
+    expandedGroups: Set<string>;
+    onToggleGroup: (groupKey: string) => void;
 };
 
 export type TableTreeContext = TreeProviderProps & {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/index.tsx
@@ -86,7 +86,8 @@ const TableTreeWrapper: FC<React.PropsWithChildren<TableTreeWrapperProps>> = ({
 };
 
 type Props = {
-    isOpenByDefault: boolean;
+    isExpanded: boolean;
+    onToggle: () => void;
     searchQuery?: string;
     showTableLabel: boolean;
     table: CompiledTable;
@@ -98,6 +99,8 @@ type Props = {
     missingFieldIds: string[];
     searchResults: string[];
     isSearching: boolean;
+    expandedGroups: Set<string>;
+    onToggleGroup: (groupKey: string) => void;
 };
 
 const EmptyWrapper: FC<React.PropsWithChildren<{}>> = ({ children }) => (
@@ -122,7 +125,8 @@ const themeOverride = getMantineThemeOverride({
 });
 
 const TableTreeComponent: FC<Props> = ({
-    isOpenByDefault,
+    isExpanded,
+    onToggle,
     showTableLabel,
     table,
     additionalMetrics,
@@ -132,17 +136,18 @@ const TableTreeComponent: FC<Props> = ({
     missingFieldIds,
     searchQuery,
     isSearching,
+    expandedGroups,
+    onToggleGroup,
     ...rest
 }) => {
     const Wrapper = showTableLabel ? TableTreeWrapper : EmptyWrapper;
-    const [isOpen, toggle] = useToggle(isOpenByDefault);
 
     return (
         <TrackSection name={SectionName.SIDEBAR}>
             <MantineProvider inherit theme={themeOverride}>
                 <Wrapper
-                    isOpen={isSearching || isOpen}
-                    toggle={toggle}
+                    isOpen={isSearching || isExpanded}
+                    toggle={onToggle}
                     table={table}
                 >
                     <TableTreeSections
@@ -154,6 +159,8 @@ const TableTreeComponent: FC<Props> = ({
                         missingCustomDimensions={missingCustomDimensions}
                         missingFieldIds={missingFieldIds}
                         isSearching={isSearching}
+                        expandedGroups={expandedGroups}
+                        onToggleGroup={onToggleGroup}
                         {...rest}
                     />
                 </Wrapper>

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -143,6 +143,42 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
             );
     }, [explore, isSearching, searchResultsMap]);
 
+    // Manage table expansion state
+    const [expandedTables, setExpandedTables] = useState<Set<string>>(() => {
+        // Initialize with first table expanded
+        const firstTable = tableTrees[0];
+        return firstTable ? new Set([firstTable.name]) : new Set();
+    });
+
+    // Manage group expansion state
+    const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+        new Set(),
+    );
+
+    const toggleTable = useCallback((tableName: string) => {
+        setExpandedTables((prev) => {
+            const next = new Set(prev);
+            if (next.has(tableName)) {
+                next.delete(tableName);
+            } else {
+                next.add(tableName);
+            }
+            return next;
+        });
+    }, []);
+
+    const toggleGroup = useCallback((groupKey: string) => {
+        setExpandedGroups((prev) => {
+            const next = new Set(prev);
+            if (next.has(groupKey)) {
+                next.delete(groupKey);
+            } else {
+                next.add(groupKey);
+            }
+            return next;
+        });
+    }, []);
+
     /**
      * Preserve scroll position when fields are selected/deselected
      *
@@ -175,12 +211,13 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
     const tableTreeComponents = useMemo(
         () =>
             tableTrees.length > 0 ? (
-                tableTrees.map((table, index) => (
+                tableTrees.map((table) => (
                     <TableTree
                         key={table.name}
-                        isOpenByDefault={index === 0}
+                        isExpanded={expandedTables.has(table.name)}
+                        onToggle={() => toggleTable(table.name)}
                         searchQuery={debouncedSearch}
-                        showTableLabel={tableTrees.length > 1}
+                        showTableLabel={Object.keys(explore.tables).length > 1}
                         table={table}
                         additionalMetrics={additionalMetrics}
                         onSelectedNodeChange={onSelectedFieldChange}
@@ -190,6 +227,8 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
                         missingFieldIds={missingFieldIds}
                         searchResults={searchResultsMap[table.name]}
                         isSearching={isSearching}
+                        expandedGroups={expandedGroups}
+                        onToggleGroup={toggleGroup}
                     />
                 ))
             ) : (
@@ -201,6 +240,9 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
             additionalMetrics,
             customDimensions,
             debouncedSearch,
+            expandedGroups,
+            expandedTables,
+            explore.tables,
             isSearching,
             missingCustomDimensions,
             missingCustomMetrics,
@@ -208,6 +250,8 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
             onSelectedFieldChange,
             searchResultsMap,
             tableTrees,
+            toggleGroup,
+            toggleTable,
         ],
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Implemented persistent expansion state for tables and groups in the Explorer tree. This enhancement:

- Added state management for expanded tables and groups using React's useState
- Created a unique key system for identifying groups across different tree sections
- Modified TreeGroupNode to use the centralized expansion state instead of local toggle
- Added new props to pass expansion state and toggle handlers down the component tree
- Initialized the first table as expanded by default for better UX

This change improves the explorer experience by maintaining the expanded/collapsed state of tables and groups, preventing them from collapsing when users interact with other parts of the UI.