### PR TITLE
feat: add virtualized side bar

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -264,6 +264,7 @@ export const lightdashConfigMock: LightdashConfig = {
         enabled: false,
     },
     experimentalExplorerImprovements: false,
+    experimentalVirtualizedSideBar: false,
     dashboardComments: {
         enabled: true,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -849,6 +849,7 @@ export type LightdashConfig = {
     };
     analyticsEmbedSecret?: string;
     experimentalExplorerImprovements: boolean;
+    experimentalVirtualizedSideBar: boolean;
     dashboardComments: {
         enabled: boolean;
     };
@@ -1633,6 +1634,8 @@ export const parseConfig = (): LightdashConfig => {
         analyticsEmbedSecret: process.env.ANALYTICS_EMBED_SECRET,
         experimentalExplorerImprovements:
             process.env.EXPERIMENTAL_EXPLORER_IMPROVEMENTS === 'true',
+        experimentalVirtualizedSideBar:
+            process.env.EXPERIMENTAL_VIRTUALIZED_SIDE_BAR === 'true',
         dashboardComments: {
             enabled: process.env.DISABLE_DASHBOARD_COMMENTS !== 'true',
         },

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -40,6 +40,8 @@ export class FeatureFlagModel {
                 this.getExperimentalExplorerImprovements.bind(this),
             [FeatureFlags.DashboardComments]:
                 this.getDashboardComments.bind(this),
+            [FeatureFlags.ExperimentalVirtualizedSideBar]:
+                this.getExperimentalVirtualizedSideBar.bind(this),
         };
     }
 
@@ -133,6 +135,32 @@ export class FeatureFlagModel {
             (user
                 ? await isFeatureFlagEnabled(
                       FeatureFlags.ExperimentalExplorerImprovements,
+                      {
+                          userUuid: user.userUuid,
+                          organizationUuid: user.organizationUuid,
+                      },
+                      {
+                          throwOnTimeout: false,
+                          timeoutMilliseconds: 500,
+                      },
+                  )
+                : false);
+
+        return {
+            id: featureFlagId,
+            enabled,
+        };
+    }
+
+    private async getExperimentalVirtualizedSideBar({
+        user,
+        featureFlagId,
+    }: FeatureFlagLogicArgs) {
+        const enabled =
+            this.lightdashConfig.experimentalVirtualizedSideBar ||
+            (user
+                ? await isFeatureFlagEnabled(
+                      FeatureFlags.ExperimentalVirtualizedSideBar,
                       {
                           userUuid: user.userUuid,
                           organizationUuid: user.organizationUuid,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -67,6 +67,11 @@ export enum FeatureFlags {
      * Enable experimental explorer improvements
      */
     ExperimentalExplorerImprovements = 'experimental-explorer-improvements',
+
+    /**
+     * Enable experimental virtualized side bar
+     */
+    ExperimentalVirtualizedSideBar = 'experimental-virtualized-side-bar',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -45,6 +45,8 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
     const treeSectionType = useTableTree((ctx) => ctx.treeSectionType);
     const expandedGroups = useTableTree((ctx) => ctx.expandedGroups);
     const onToggleGroup = useTableTree((ctx) => ctx.onToggleGroup);
+    const isVirtualized = useTableTree((ctx) => ctx.isVirtualized);
+    const depth = useTableTree((ctx) => ctx.depth);
     const [isHover, toggleHover] = useToggle(false);
 
     // Build unique group key
@@ -128,6 +130,15 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
         [isNavLinkOpen],
     );
 
+    // Apply indentation for virtualized mode only
+    // Non-virtualized mode uses NavLink's built-in nesting with childrenOffset
+    const pl = useMemo(() => {
+        if (isVirtualized) {
+            return depth ? `${(depth + 1) * 24}px` : '24px';
+        }
+        return undefined;
+    }, [depth, isVirtualized]);
+
     if (!hasVisibleChildren) return null;
 
     return (
@@ -142,6 +153,7 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
             // --end moves chevron to the left
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
+            pl={pl}
             label={
                 <Group>
                     {!isOpen && hasSelectedChildren && (
@@ -188,7 +200,10 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
                 </Group>
             }
         >
-            {isNavLinkOpen && <TreeNodes nodeMap={node.children} isNested />}
+            {/* In virtualized mode, children are rendered as separate items in the flat list */}
+            {isNavLinkOpen && !isVirtualized && (
+                <TreeNodes nodeMap={node.children} isNested />
+            )}
         </NavLink>
     );
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -84,6 +84,8 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
         (context) => context.missingCustomDimensions,
     );
     const onItemClick = useTableTree((context) => context.onItemClick);
+    const isVirtualized = useTableTree((context) => context.isVirtualized);
+    const depth = useTableTree((context) => context.depth);
     const { track } = useTracking();
 
     const addFilter = useAddFilter();
@@ -265,6 +267,15 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
         });
     }, [alerts]);
 
+    // Apply indentation for virtualized mode only
+    // Non-virtualized mode uses NavLink's built-in nesting with childrenOffset
+    const pl = useMemo(() => {
+        if (isVirtualized) {
+            return depth ? `${(depth + 1) * 24}px` : '24px';
+        }
+        return undefined;
+    }, [depth, isVirtualized]);
+
     if (!item || !isVisible) return null;
 
     return (
@@ -276,6 +287,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
             onClick={handleClick}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
+            pl={pl}
             label={
                 <Group noWrap spacing="xs">
                     <HoverCard

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/types.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/types.ts
@@ -54,4 +54,6 @@ export type TableTreeContext = TreeProviderProps & {
     nodeMap: NodeMap;
     isSearching: boolean;
     searchResults: string[];
+    isVirtualized?: boolean; // Flag to prevent group nodes from rendering children inline
+    depth?: number; // Nesting depth for indentation in virtualized mode
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualEmptyState.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualEmptyState.tsx
@@ -19,9 +19,7 @@ const VirtualEmptyStateComponent: FC<VirtualEmptyStateProps> = ({ item }) => {
     );
 };
 
-// ts-unused-exports:disable-next-line
-export const VirtualEmptyState = memo(VirtualEmptyStateComponent);
+const VirtualEmptyState = memo(VirtualEmptyStateComponent);
 VirtualEmptyState.displayName = 'VirtualEmptyState';
 
-// ts-unused-exports:disable-next-line
 export default VirtualEmptyState;

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
@@ -36,9 +36,7 @@ const VirtualMissingFieldComponent: FC<VirtualMissingFieldProps> = ({
     );
 };
 
-// ts-unused-exports:disable-next-line
-export const VirtualMissingField = memo(VirtualMissingFieldComponent);
+const VirtualMissingField = memo(VirtualMissingFieldComponent);
 VirtualMissingField.displayName = 'VirtualMissingField';
 
-// ts-unused-exports:disable-next-line
 export default VirtualMissingField;

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -23,9 +23,7 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     );
 };
 
-// ts-unused-exports:disable-next-line
-export const VirtualSectionHeader = memo(VirtualSectionHeaderComponent);
+const VirtualSectionHeader = memo(VirtualSectionHeaderComponent);
 VirtualSectionHeader.displayName = 'VirtualSectionHeader';
 
-// ts-unused-exports:disable-next-line
 export default VirtualSectionHeader;

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTableHeader.tsx
@@ -60,9 +60,7 @@ const VirtualTableHeaderComponent: FC<VirtualTableHeaderProps> = ({ item }) => {
     );
 };
 
-// ts-unused-exports:disable-next-line
-export const VirtualTableHeader = memo(VirtualTableHeaderComponent);
+const VirtualTableHeader = memo(VirtualTableHeaderComponent);
 VirtualTableHeader.displayName = 'VirtualTableHeader';
 
-// ts-unused-exports:disable-next-line
 export default VirtualTableHeader;

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeItem.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeItem.tsx
@@ -40,9 +40,7 @@ const VirtualTreeItemComponent: FC<VirtualTreeItemProps> = ({
     }
 };
 
-// ts-unused-exports:disable-next-line
-export const VirtualTreeItem = memo(VirtualTreeItemComponent);
+const VirtualTreeItem = memo(VirtualTreeItemComponent);
 VirtualTreeItem.displayName = 'VirtualTreeItem';
 
-// ts-unused-exports:disable-next-line
 export default VirtualTreeItem;

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeNode.tsx
@@ -19,7 +19,7 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
     item,
     sectionContexts,
 }) => {
-    const { node, isGroup, sectionKey } = item.data;
+    const { node, isGroup, sectionKey, depth } = item.data;
 
     // Look up the shared section context
     const sectionContext = sectionContexts.get(sectionKey);
@@ -80,8 +80,10 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
             treeSectionType: sectionContext.sectionType,
             expandedGroups: new Set<string>(), // Will be provided by parent
             onToggleGroup: () => {}, // Will be provided by parent
+            isVirtualized: true, // Flag to prevent inline children rendering
+            depth, // Nesting depth for indentation
         };
-    }, [sectionContext, nodeMap]);
+    }, [sectionContext, nodeMap, depth]);
 
     if (!sectionContext) {
         console.error(`Section context not found for key: ${sectionKey}`);
@@ -99,9 +101,7 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
     );
 };
 
-// ts-unused-exports:disable-next-line
-export const VirtualTreeNode = memo(VirtualTreeNodeComponent);
+const VirtualTreeNode = memo(VirtualTreeNodeComponent);
 VirtualTreeNode.displayName = 'VirtualTreeNode';
 
-// ts-unused-exports:disable-next-line
 export default VirtualTreeNode;

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.tsx
@@ -1,0 +1,95 @@
+import { MantineProvider } from '@mantine/core';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { memo, useRef, type FC } from 'react';
+import { getMantineThemeOverride } from '../../../../../mantineTheme';
+import type { FlattenedTreeData } from './types';
+import VirtualTreeItem from './VirtualTreeItem';
+
+interface VirtualizedTreeListProps {
+    data: FlattenedTreeData;
+}
+
+const themeOverride = getMantineThemeOverride({
+    components: {
+        NavLink: {
+            styles: (theme, _params) => ({
+                root: {
+                    height: theme.spacing.xxl,
+                    padding: `0 ${theme.spacing.sm}`,
+                    flexGrow: 0,
+                },
+                rightSection: {
+                    marginLeft: theme.spacing.xxs,
+                },
+            }),
+        },
+    },
+});
+
+/**
+ * Virtualized tree list using @tanstack/react-virtual
+ * Renders only visible items for optimal performance
+ */
+const VirtualizedTreeListComponent: FC<VirtualizedTreeListProps> = ({
+    data,
+}) => {
+    const { items, sectionContexts } = data;
+    const parentRef = useRef<HTMLDivElement>(null);
+
+    // Setup virtualizer
+    const virtualizer = useVirtualizer({
+        count: items.length,
+        getScrollElement: () => parentRef.current,
+        estimateSize: (index) => items[index].estimatedHeight,
+        overscan: 5, // Render 5 extra items above and below viewport
+    });
+
+    const virtualItems = virtualizer.getVirtualItems();
+
+    return (
+        <MantineProvider inherit theme={themeOverride}>
+            <div
+                ref={parentRef}
+                style={{
+                    height: '100%',
+                    overflow: 'auto',
+                }}
+            >
+                <div
+                    style={{
+                        height: `${virtualizer.getTotalSize()}px`,
+                        width: '100%',
+                        position: 'relative',
+                    }}
+                >
+                    {virtualItems.map((virtualItem) => {
+                        const item = items[virtualItem.index];
+                        return (
+                            <div
+                                key={virtualItem.key}
+                                data-index={virtualItem.index}
+                                style={{
+                                    position: 'absolute',
+                                    top: 0,
+                                    left: 0,
+                                    width: '100%',
+                                    transform: `translateY(${virtualItem.start}px)`,
+                                }}
+                            >
+                                <VirtualTreeItem
+                                    item={item}
+                                    sectionContexts={sectionContexts}
+                                />
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </MantineProvider>
+    );
+};
+
+const VirtualizedTreeList = memo(VirtualizedTreeListComponent);
+VirtualizedTreeList.displayName = 'VirtualizedTreeList';
+
+export default VirtualizedTreeList;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Adds a new experimental feature flag `experimentalVirtualizedSideBar` that enables virtualization for the Explorer sidebar tree. This implementation uses @tanstack/react-virtual to render only the visible items in the sidebar, significantly improving performance for projects with large numbers of fields.

The implementation:
- Adds a new feature flag in both backend and frontend
- Creates a virtualized tree list component that renders only visible items
- Modifies tree nodes to support proper indentation in virtualized mode
- Ensures proper nesting and hierarchy visualization while maintaining performance

This feature can be enabled via the `EXPERIMENTAL_VIRTUALIZED_SIDE_BAR` environment variable.