### PR TITLE
fix: clarify that pagination starts at 1 in tool schema

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
@@ -33,7 +33,9 @@ const toolSchemaBuilder = <$Schema extends z.ZodRawShape>(
                     .number()
                     .positive()
                     .nullable()
-                    .describe('Use this to paginate through the results'),
+                    .describe(
+                        'Use this to paginate through the results. Starts at 1.',
+                    ),
             }),
         ) as ToolSchemaBuilder<$Schema & { page: z.ZodNullable<z.ZodNumber> }>,
 


### PR DESCRIPTION
### Description:
Clarifies the pagination description in the tool schema builder by specifying that page numbering starts at 1. This helps developers and AI agents understand how to properly use the pagination parameter.