### PR TITLE
feat: add GPT-5 model support with custom reasoning settings

### DIFF
--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -17,15 +17,22 @@ export const getOpenaiGptmodel = (
     // TODO: Use config.responsesApi to determine if we should use the responses API.
     const model = openai(config.modelName);
 
+    const isGpt5 = model.modelId.includes('gpt-5');
+
     return {
         model,
         callOptions: {
-            temperature: config.temperature,
+            ...(!isGpt5 && {
+                // gpt-5 models don't support temperature
+                temperature: config.temperature,
+            }),
         },
         providerOptions: {
             [PROVIDER]: {
                 strictJsonSchema: true,
                 parallelToolCalls: false,
+                reasoningEffort: 'high',
+                textVerbosity: 'medium',
             },
         },
     };

--- a/packages/backend/src/ee/services/ai/models/types.ts
+++ b/packages/backend/src/ee/services/ai/models/types.ts
@@ -1,6 +1,6 @@
 import { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
-import { JSONValue, LanguageModel } from 'ai';
+import { JSONValue, LanguageModel, type CallSettings } from 'ai';
 import { AiCopilotConfigSchemaType } from '../../../../config/aiConfigSchema';
 
 export type AiProvider = keyof AiCopilotConfigSchemaType['providers'];
@@ -14,7 +14,7 @@ export type ProviderOptionsMap = {
 
 export type AiModel<P extends AiProvider> = {
     model: Exclude<LanguageModel, string>;
-    callOptions: { temperature: number };
+    callOptions: CallSettings;
     providerOptions:
         | {
               [K in P]: ProviderOptionsMap[K];


### PR DESCRIPTION
### Description:
Add support for GPT-5 models by conditionally applying temperature settings, as GPT-5 doesn't support temperature configuration. Also enhance model behavior by adding `reasoningEffort: 'high'` and `textVerbosity: 'medium'` to the provider options, improving the quality of AI responses.

The PR also updates the type definition for `callOptions` to use the more accurate `CallSettings` type from the AI SDK instead of the previously hardcoded temperature-only type.