### PR TITLE
feat: add AI agent reasoning configuration

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -123,6 +123,10 @@ import {
 } from '../database/entities/warehouseCredentials';
 
 import {
+    AiAgentReasoningTable,
+    AiAgentReasoningTableName,
+} from '../database/entities/aiAgentReasoning';
+import {
     AnalyticsChartViews,
     AnalyticsChartViewsTableName,
     AnalyticsDashboardViews,
@@ -395,6 +399,7 @@ declare module 'knex/types/tables' {
         [AiAgentSlackIntegrationTableName]: AiAgentSlackIntegrationTable;
         [AiAgentInstructionVersionsTableName]: AiAgentInstructionVersionsTable;
         [AiAgentUserPreferencesTableName]: AiAgentUserPreferencesTable;
+        [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;
         [AiAgentToolResultTableName]: AiAgentToolResultTable;
         [DashboardTabsTableName]: DashboardTabsTable;

--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -18,6 +18,22 @@ export const aiCopilotConfigSchema = z
                     baseUrl: z.string().optional(),
                     temperature: z.number().min(0).max(2).default(0.2),
                     responsesApi: z.boolean().default(false),
+                    reasoning: z
+                        .object({
+                            enabled: z.boolean().default(false),
+                            reasoningSummary: z
+                                .enum(['auto', 'detailed'])
+                                .default('auto'),
+                            reasoningEffort: z
+                                .enum(['minimal', 'low', 'medium', 'high'])
+                                .default('medium'),
+                        })
+                        .optional()
+                        .default({
+                            enabled: false,
+                            reasoningSummary: 'auto',
+                            reasoningEffort: 'medium',
+                        }),
                 })
                 .optional(),
             azure: z

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -206,6 +206,11 @@ export const lightdashConfigMock: LightdashConfig = {
                     modelName: 'mock_model_name',
                     temperature: 0.2,
                     responsesApi: false,
+                    reasoning: {
+                        enabled: false,
+                        reasoningSummary: 'auto',
+                        reasoningEffort: 'medium',
+                    },
                 },
             },
         },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1110,6 +1110,13 @@ export const parseConfig = (): LightdashConfig => {
                       temperature:
                           getFloatFromEnvironmentVariable('OPENAI_TEMPERATURE'),
                       responsesApi: process.env.OPENAI_RESPONSES_API === 'true',
+                      reasoning: {
+                          enabled:
+                              process.env.OPENAI_REASONING_ENABLED === 'true',
+                          reasoningSummary:
+                              process.env.OPENAI_REASONING_SUMMARY,
+                          reasoningEffort: process.env.OPENAI_REASONING_EFFORT,
+                      },
                   }
                 : undefined,
             anthropic: process.env.ANTHROPIC_API_KEY

--- a/packages/backend/src/database/entities/aiAgentReasoning.ts
+++ b/packages/backend/src/database/entities/aiAgentReasoning.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+export const AiAgentReasoningTableName = 'ai_agent_reasoning';
+
+export type DbAiAgentReasoning = {
+    ai_agent_reasoning_uuid: string;
+    ai_prompt_uuid: string;
+    reasoning_id: string;
+    text: string;
+    created_at: Date;
+};
+
+type DbAiAgentReasoningInsert = Pick<
+    DbAiAgentReasoning,
+    'ai_prompt_uuid' | 'reasoning_id' | 'text'
+>;
+
+export type AiAgentReasoningTable = Knex.CompositeTableType<
+    DbAiAgentReasoning,
+    DbAiAgentReasoningInsert
+>;

--- a/packages/backend/src/ee/database/migrations/20251023121941_ai_agent_reasoning_table.ts
+++ b/packages/backend/src/ee/database/migrations/20251023121941_ai_agent_reasoning_table.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+const AI_AGENT_REASONING_TABLE = 'ai_agent_reasoning';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AI_AGENT_REASONING_TABLE, (table) => {
+        table
+            .uuid('ai_agent_reasoning_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table.uuid('ai_prompt_uuid').notNullable();
+        table.string('reasoning_id').notNullable().unique();
+        table.text('text').notNullable();
+        table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+
+        table
+            .foreign('ai_prompt_uuid')
+            .references('ai_prompt_uuid')
+            .inTable('ai_prompt')
+            .onDelete('CASCADE');
+
+        table.index('ai_prompt_uuid');
+        table.index(['ai_prompt_uuid', 'created_at']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AI_AGENT_REASONING_TABLE);
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -50,6 +50,7 @@ import {
     type AiAgent,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { AiAgentReasoningTableName } from '../../database/entities/aiAgentReasoning';
 import { DbEmail, EmailTableName } from '../../database/entities/emails';
 import { DbProject, ProjectTableName } from '../../database/entities/projects';
 import { DbUser, UserTableName } from '../../database/entities/users';
@@ -2234,6 +2235,22 @@ export class AiAgentModel {
 
             return toolResults.map((tr) => tr.ai_agent_tool_result_uuid);
         });
+    }
+
+    async createReasoning(data: {
+        promptUuid: string;
+        reasoningId: string;
+        text: string;
+    }): Promise<string> {
+        const [reasoning] = await this.database(AiAgentReasoningTableName)
+            .insert({
+                ai_prompt_uuid: data.promptUuid,
+                reasoning_id: data.reasoningId,
+                text: data.text,
+            })
+            .returning('ai_agent_reasoning_uuid');
+
+        return reasoning.ai_agent_reasoning_uuid;
     }
 
     async updateToolResultMetadata(

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -131,6 +131,7 @@ import {
     RunMiniMetricQueryFn,
     SearchFieldValuesFn,
     SendFileFn,
+    StoreReasoningFn,
     StoreToolCallFn,
     StoreToolResultsFn,
     UpdateProgressFn,
@@ -2135,6 +2136,17 @@ export class AiAgentService {
             );
         };
 
+        const storeReasoning: StoreReasoningFn = async (args) => {
+            void wrapSentryTransaction(
+                'AiAgent.storeReasoning',
+                {
+                    promptUuid: args.promptUuid,
+                    reasoningId: args.reasoningId,
+                },
+                () => this.aiAgentModel.createReasoning(args),
+            );
+        };
+
         const findDashboards: FindDashboardsFn = async (args) =>
             wrapSentryTransaction('AiAgent.findDashboards', args, async () => {
                 const searchResults = await this.searchModel.searchDashboards(
@@ -2308,6 +2320,7 @@ export class AiAgentService {
             sendFile,
             storeToolCall,
             storeToolResults,
+            storeReasoning,
             searchFieldValues,
             createChange,
             getExploreCompiler,
@@ -2392,6 +2405,7 @@ export class AiAgentService {
             sendFile,
             storeToolCall,
             storeToolResults,
+            storeReasoning,
             searchFieldValues,
             getExploreCompiler,
             createChange,
@@ -2440,6 +2454,7 @@ export class AiAgentService {
             sendFile,
             storeToolCall,
             storeToolResults,
+            storeReasoning,
             searchFieldValues,
             getExploreCompiler,
             createChange,

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -35,6 +35,11 @@ describeOrSkip.concurrent('agent integration tests', () => {
             ? parseFloat(process.env.OPENAI_TEMPERATURE)
             : 0.2,
         responsesApi: false,
+        reasoning: {
+            enabled: false,
+            reasoningEffort: 'medium',
+            reasoningSummary: 'auto',
+        },
     });
 
     beforeAll(async () => {

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -1,4 +1,4 @@
-import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAI, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import { AiModel } from './types';
 
@@ -31,8 +31,10 @@ export const getOpenaiGptmodel = (
             [PROVIDER]: {
                 strictJsonSchema: true,
                 parallelToolCalls: false,
-                reasoningEffort: 'high',
-                textVerbosity: 'medium',
+                ...(config.reasoning.enabled && {
+                    reasoningSummary: config.reasoning.reasoningSummary,
+                    reasoningEffort: config.reasoning.reasoningEffort,
+                }),
             },
         },
     };

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -16,6 +16,7 @@ import {
     RunMiniMetricQueryFn,
     SearchFieldValuesFn,
     SendFileFn,
+    StoreReasoningFn,
     StoreToolCallFn,
     StoreToolResultsFn,
     TrackEventFn,
@@ -73,6 +74,7 @@ export type AiAgentDependencies = {
     updateProgress: UpdateProgressFn;
     storeToolCall: StoreToolCallFn;
     storeToolResults: StoreToolResultsFn;
+    storeReasoning: StoreReasoningFn;
     searchFieldValues: SearchFieldValuesFn;
     trackEvent: TrackEventFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -123,6 +123,12 @@ export type StoreToolResultsFn = (
     }>,
 ) => Promise<void>;
 
+export type StoreReasoningFn = (data: {
+    promptUuid: string;
+    reasoningId: string;
+    text: string;
+}) => Promise<void>;
+
 export type TrackEventFn = (
     event: AiAgentResponseStreamed | AiAgentToolCallEvent,
 ) => void;


### PR DESCRIPTION
### Description:
Add AI agent reasoning capabilities to track and store the reasoning process behind AI responses. This PR introduces:

1. A new database table `ai_agent_reasoning` to store reasoning data
2. Configuration options for reasoning in the OpenAI integration:
   - Enable/disable reasoning
   - Control reasoning summary level (auto/detailed)
   - Adjust reasoning effort (minimal/low/medium/high)
3. Environment variables to control reasoning behavior:
   - `OPENAI_REASONING_ENABLED`
   - `OPENAI_REASONING_SUMMARY`
   - `OPENAI_REASONING_EFFORT`
4. Logic to capture and store reasoning chunks from the AI stream

This enhancement allows for better transparency and debugging of AI agent decision-making processes.