### PR TITLE
feat: add reasoning display to AI agent responses

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5920,7 +5920,6 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['generateTableVizConfig'] },
                 { dataType: 'enum', enums: ['generateTimeSeriesVizConfig'] },
                 { dataType: 'enum', enums: ['generateDashboard'] },
-                { dataType: 'enum', enums: ['generateDashboardV2'] },
                 { dataType: 'enum', enums: ['findContent'] },
                 { dataType: 'enum', enums: ['findExplores'] },
                 { dataType: 'enum', enums: ['findFields'] },
@@ -6083,11 +6082,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6102,11 +6101,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6121,11 +6120,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6140,11 +6139,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6159,11 +6158,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6300,6 +6299,21 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReasoning: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                createdAt: { dataType: 'datetime', required: true },
+                text: { dataType: 'string', required: true },
+                reasoningId: { dataType: 'string', required: true },
+                promptUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_':
         {
             dataType: 'refAlias',
@@ -6371,6 +6385,11 @@ const models: TsoaRoute.Models = {
                         { dataType: 'string' },
                         { dataType: 'enum', enums: [null] },
                     ],
+                    required: true,
+                },
+                reasoning: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiAgentReasoning' },
                     required: true,
                 },
                 toolResults: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6583,7 +6583,6 @@
                     "generateTableVizConfig",
                     "generateTimeSeriesVizConfig",
                     "generateDashboard",
-                    "generateDashboardV2",
                     "findContent",
                     "findExplores",
                     "findFields",
@@ -6728,6 +6727,19 @@
                                                 },
                                                 "required": ["status"],
                                                 "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "error",
+                                                            "success"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
                                             }
                                         ]
                                     },
@@ -6741,6 +6753,34 @@
                         ]
                     }
                 ]
+            },
+            "AiAgentReasoning": {
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "text": {
+                        "type": "string"
+                    },
+                    "reasoningId": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "createdAt",
+                    "text",
+                    "reasoningId",
+                    "promptUuid",
+                    "uuid"
+                ],
+                "type": "object"
             },
             "Pick_AiArtifact.artifactUuid-or-versionNumber-or-versionUuid-or-title-or-description-or-artifactType_": {
                 "properties": {
@@ -6794,6 +6834,12 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "reasoning": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReasoning"
+                        },
+                        "type": "array"
+                    },
                     "toolResults": {
                         "items": {
                             "$ref": "#/components/schemas/AiAgentToolResult"
@@ -6833,6 +6879,7 @@
                 "required": [
                     "artifacts",
                     "savedQueryUuid",
+                    "reasoning",
                     "toolResults",
                     "toolCalls",
                     "humanScore",
@@ -20999,7 +21046,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2104.5",
+        "version": "0.2114.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -150,6 +150,7 @@ export type AiAgentMessageAssistant = {
 
     toolCalls: AiAgentToolCall[];
     toolResults: AiAgentToolResult[];
+    reasoning: AiAgentReasoning[];
     savedQueryUuid: string | null;
 
     artifacts: AiAgentMessageAssistantArtifact[] | null;
@@ -343,6 +344,14 @@ export type AiAgentToolResult = {
           metadata: AgentToolOutput['metadata'];
       }
 );
+
+export type AiAgentReasoning = {
+    uuid: string;
+    promptUuid: string;
+    reasoningId: string;
+    text: string;
+    createdAt: Date;
+};
 
 export type AiAgentExploreAccessSummary = {
     exploreName: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -58,6 +58,7 @@ import { AiArtifactButton } from './ArtifactButton/AiArtifactButton';
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { AiChartToolCalls } from './ToolCalls/AiChartToolCalls';
 import { AiProposeChangeToolCall } from './ToolCalls/AiProposeChangeToolCall';
+import { AiReasoning } from './ToolCalls/AiReasoning';
 
 const AssistantBubbleContent: FC<{
     message: AiAgentMessageAssistant;
@@ -161,6 +162,9 @@ const AssistantBubbleContent: FC<{
                 </Paper>
             )}
 
+            {!isStreaming && message.reasoning.length > 0 && (
+                <AiReasoning reasoning={message.reasoning} />
+            )}
             {isStreaming && (
                 <AiChartToolCalls
                     toolCalls={streamingState?.toolCalls}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiReasoning.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiReasoning.tsx
@@ -1,0 +1,83 @@
+import { type AiAgentReasoning } from '@lightdash/common';
+import { Accordion } from '@mantine-8/core';
+import { IconBrain } from '@tabler/icons-react';
+import MDEditor from '@uiw/react-md-editor';
+import { type FC } from 'react';
+import {
+    mdEditorComponents,
+    rehypeRemoveHeaderLinks,
+    useMdEditorStyle,
+} from '../../../../../../utils/markdownUtils';
+import { ToolCallPaper } from './ToolCallPaper';
+
+type AiReasoningProps = {
+    reasoning: AiAgentReasoning[] | undefined;
+};
+
+export const AiReasoning: FC<AiReasoningProps> = ({ reasoning }) => {
+    const mdStyle = useMdEditorStyle();
+
+    if (!reasoning || reasoning.length === 0) return null;
+
+    return (
+        <ToolCallPaper
+            defaultOpened={false}
+            variant="dashed"
+            icon={IconBrain}
+            title="Reasoning"
+        >
+            <Accordion
+                pt="xs"
+                variant="contained"
+                chevronPosition="left"
+                styles={{
+                    label: {
+                        paddingTop: '0.5rem',
+                        paddingBottom: '0.5rem',
+                    },
+                    chevron: {
+                        marginLeft: '0.5rem',
+                        marginRight: '0.5rem',
+                    },
+                }}
+            >
+                {reasoning.map((r) => {
+                    const lines = r.text.split('\n');
+                    const firstLine = lines[0];
+                    const restOfContent = lines.slice(1).join('\n').trim();
+
+                    return (
+                        <Accordion.Item key={r.uuid} value={r.uuid}>
+                            <Accordion.Control>
+                                <MDEditor.Markdown
+                                    rehypeRewrite={rehypeRemoveHeaderLinks}
+                                    source={firstLine}
+                                    style={{
+                                        ...mdStyle,
+                                        fontSize: '0.75rem',
+                                        color: 'var(--mantine-color-gray-7)',
+                                    }}
+                                    components={mdEditorComponents}
+                                />
+                            </Accordion.Control>
+                            {restOfContent && (
+                                <Accordion.Panel>
+                                    <MDEditor.Markdown
+                                        rehypeRewrite={rehypeRemoveHeaderLinks}
+                                        source={restOfContent}
+                                        style={{
+                                            ...mdStyle,
+                                            fontSize: '0.75rem',
+                                            color: 'var(--mantine-color-gray-7)',
+                                        }}
+                                        components={mdEditorComponents}
+                                    />
+                                </Accordion.Panel>
+                            )}
+                        </Accordion.Item>
+                    );
+                })}
+            </Accordion>
+        </ToolCallPaper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -396,6 +396,7 @@ const createOptimisticMessages = (
             humanScore: null,
             toolCalls: [],
             toolResults: [],
+            reasoning: [],
             savedQueryUuid: null,
             artifacts: null,
         },


### PR DESCRIPTION
### Description:
This PR adds support for displaying AI agent reasoning in the chat interface. The implementation includes:

1. Added a new `AiAgentReasoning` type to represent reasoning data
2. Enhanced the `AiAgentModel` to retrieve reasoning for prompts
3. Added a new `AiReasoning` component to display reasoning in an accordion format
4. Updated the assistant message interface to include reasoning data

The reasoning is displayed in a collapsible section with a brain icon, allowing users to see the AI's thought process behind its responses.