### PR TITLE
feat: add reasoning feature toggle in AI agent settings

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -32,7 +32,7 @@ export const aiCopilotConfigSchema = z
                         .default({
                             enabled: false,
                             reasoningSummary: 'auto',
-                            reasoningEffort: 'medium',
+                            reasoningEffort: 'low',
                         }),
                 })
                 .optional(),

--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -12,6 +12,7 @@ export type DbAiAgent = {
     tags: string[] | null;
     enable_data_access: boolean;
     enable_self_improvement: boolean;
+    enable_reasoning: boolean;
     version: number;
     created_at: Date;
     updated_at: Date;

--- a/packages/backend/src/ee/database/migrations/20251024094448_add_enable_reasoning_to_ai_agent.ts
+++ b/packages/backend/src/ee/database/migrations/20251024094448_add_enable_reasoning_to_ai_agent.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const AI_AGENT_TABLE = 'ai_agent';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AI_AGENT_TABLE, (table) => {
+        table.boolean('enable_reasoning').notNullable().defaultTo(false);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AI_AGENT_TABLE, (table) => {
+        table.dropColumn('enable_reasoning');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -201,6 +201,7 @@ export class AiAgentModel {
                 imageUrl: `${AiAgentTableName}.image_url`,
                 enableDataAccess: `${AiAgentTableName}.enable_data_access`,
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
+                enableReasoning: `${AiAgentTableName}.enable_reasoning`,
                 version: `${AiAgentTableName}.version`,
                 groupAccess: this.database.raw(`
                     COALESCE(
@@ -310,6 +311,7 @@ export class AiAgentModel {
                 imageUrl: `${AiAgentTableName}.image_url`,
                 enableDataAccess: `${AiAgentTableName}.enable_data_access`,
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
+                enableReasoning: `${AiAgentTableName}.enable_reasoning`,
                 version: `${AiAgentTableName}.version`,
                 groupAccess: this.database.raw(`
                     COALESCE(
@@ -392,6 +394,7 @@ export class AiAgentModel {
             | 'userAccess'
             | 'enableDataAccess'
             | 'enableSelfImprovement'
+            | 'enableReasoning'
             | 'version'
         > & {
             organizationUuid: string;
@@ -408,6 +411,7 @@ export class AiAgentModel {
                     image_url: null,
                     enable_data_access: args.enableDataAccess,
                     enable_self_improvement: args.enableSelfImprovement,
+                    enable_reasoning: args.enableReasoning,
                     version: args.version,
                 })
                 .returning('*');
@@ -480,6 +484,7 @@ export class AiAgentModel {
                 userAccess,
                 enableDataAccess: agent.enable_data_access,
                 enableSelfImprovement: agent.enable_self_improvement,
+                enableReasoning: agent.enable_reasoning,
                 version: agent.version,
             };
         });
@@ -515,6 +520,9 @@ export class AiAgentModel {
                               enable_self_improvement:
                                   args.enableSelfImprovement,
                           }
+                        : {}),
+                    ...(args.enableReasoning !== undefined
+                        ? { enable_reasoning: args.enableReasoning }
                         : {}),
                     ...(args.version !== undefined
                         ? { version: args.version }
@@ -605,6 +613,7 @@ export class AiAgentModel {
                 userAccess,
                 enableDataAccess: agent.enable_data_access,
                 enableSelfImprovement: agent.enable_self_improvement,
+                enableReasoning: agent.enable_reasoning,
                 version: agent.version,
             };
         });

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -927,6 +927,7 @@ export class AiAgentService {
             userAccess: body.userAccess,
             enableDataAccess: body.enableDataAccess,
             enableSelfImprovement: body.enableSelfImprovement,
+            enableReasoning: body.enableReasoning,
             version: body.version,
         });
 
@@ -985,6 +986,7 @@ export class AiAgentService {
             userAccess: body.userAccess,
             enableDataAccess: body.enableDataAccess,
             enableSelfImprovement: body.enableSelfImprovement,
+            enableReasoning: body.enableReasoning,
             version: body.version,
         });
 
@@ -1239,8 +1241,16 @@ export class AiAgentService {
                     threadUuid,
                 });
 
-            // Get model configuration
-            const { model } = getModel(this.lightdashConfig.ai.copilot);
+            // Get agent settings to use reasoning preference
+            const agent = await this.aiAgentModel.getAgent({
+                organizationUuid: user.organizationUuid!,
+                agentUuid,
+            });
+
+            // Get model configuration with agent's reasoning setting
+            const { model } = getModel(this.lightdashConfig.ai.copilot, {
+                enableReasoning: agent.enableReasoning,
+            });
 
             // Generate title using the dedicated title generator
             const title = await generateTitleFromMessages(
@@ -2414,8 +2424,10 @@ export class AiAgentService {
             createChange,
         } = this.getAiAgentDependencies(user, prompt);
 
-        const modelProperties = getModel(this.lightdashConfig.ai.copilot);
         const agentSettings = await this.getAgentSettings(user, prompt);
+        const modelProperties = getModel(this.lightdashConfig.ai.copilot, {
+            enableReasoning: agentSettings.enableReasoning,
+        });
 
         const args: AiAgentArgs = {
             organizationId: user.organizationUuid,

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -5,14 +5,19 @@ import { getAzureGpt41Model } from './azure-openai-gpt-4.1';
 import { getOpenaiGptmodel } from './openai-gpt';
 import { getOpenRouterModel } from './openrouter';
 
-export const getModel = (config: LightdashConfig['ai']['copilot']) => {
+export const getModel = (
+    config: LightdashConfig['ai']['copilot'],
+    options?: {
+        enableReasoning?: boolean;
+    },
+) => {
     switch (config.defaultProvider) {
         case 'openai': {
             const openaiConfig = config.providers.openai;
             if (!openaiConfig) {
                 throw new ParameterError('OpenAI configuration is required');
             }
-            return getOpenaiGptmodel(openaiConfig);
+            return getOpenaiGptmodel(openaiConfig, options);
         }
         case 'azure': {
             const azureConfig = config.providers.azure;

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -1,4 +1,4 @@
-import { createOpenAI, OpenAIResponsesProviderOptions } from '@ai-sdk/openai';
+import { createOpenAI } from '@ai-sdk/openai';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import { AiModel } from './types';
 
@@ -8,6 +8,9 @@ export const getOpenaiGptmodel = (
     config: NonNullable<
         LightdashConfig['ai']['copilot']['providers']['openai']
     >,
+    options?: {
+        enableReasoning?: boolean;
+    },
 ): AiModel<typeof PROVIDER> => {
     const openai = createOpenAI({
         apiKey: config.apiKey,
@@ -18,6 +21,12 @@ export const getOpenaiGptmodel = (
     const model = openai(config.modelName);
 
     const isGpt5 = model.modelId.includes('gpt-5');
+
+    // Use agent-specific enableReasoning if provided, otherwise fall back to config
+    const reasoningEnabled =
+        options?.enableReasoning !== undefined
+            ? options.enableReasoning
+            : config.reasoning.enabled;
 
     return {
         model,
@@ -31,7 +40,7 @@ export const getOpenaiGptmodel = (
             [PROVIDER]: {
                 strictJsonSchema: true,
                 parallelToolCalls: false,
-                ...(config.reasoning.enabled && {
+                ...(reasoningEnabled && {
                     reasoningSummary: config.reasoning.reasoningSummary,
                     reasoningEffort: config.reasoning.reasoningEffort,
                 }),

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5296,7 +5296,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
+    'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -5368,6 +5368,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'boolean',
                         required: true,
                     },
+                    enableReasoning: { dataType: 'boolean', required: true },
                     version: { dataType: 'double', required: true },
                 },
                 validators: {},
@@ -5377,7 +5378,7 @@ const models: TsoaRoute.Models = {
     AiAgentSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_',
+            ref: 'Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_',
             validators: {},
         },
     },
@@ -5443,7 +5444,7 @@ const models: TsoaRoute.Models = {
         type: { ref: 'AiAgentUserPreferences', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -5515,6 +5516,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'boolean',
                         required: true,
                     },
+                    enableReasoning: { dataType: 'boolean', required: true },
                     version: { dataType: 'double', required: true },
                 },
                 validators: {},
@@ -5524,7 +5526,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_',
             validators: {},
         },
     },
@@ -5553,7 +5555,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_':
+    'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -5621,6 +5623,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'boolean',
                         required: true,
                     },
+                    enableReasoning: { dataType: 'boolean', required: true },
                     version: { dataType: 'double', required: true },
                 },
                 validators: {},
@@ -5630,12 +5633,12 @@ const models: TsoaRoute.Models = {
     ApiCreateAiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_',
+            ref: 'Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version__':
         {
             dataType: 'refAlias',
             type: {
@@ -5739,6 +5742,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    enableReasoning: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     version: {
                         dataType: 'union',
                         subSchemas: [
@@ -5757,7 +5767,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5933,7 +5933,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
+            "Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -6005,6 +6005,9 @@
                     "enableSelfImprovement": {
                         "type": "boolean"
                     },
+                    "enableReasoning": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -6025,13 +6028,14 @@
                     "userAccess",
                     "enableDataAccess",
                     "enableSelfImprovement",
+                    "enableReasoning",
                     "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgentSummary": {
-                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_"
+                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_"
             },
             "ApiAiAgentSummaryResponse": {
                 "properties": {
@@ -6089,7 +6093,7 @@
             "ApiUpdateUserAgentPreferences": {
                 "$ref": "#/components/schemas/AiAgentUserPreferences"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -6161,6 +6165,9 @@
                     "enableSelfImprovement": {
                         "type": "boolean"
                     },
+                    "enableReasoning": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -6181,13 +6188,14 @@
                     "userAccess",
                     "enableDataAccess",
                     "enableSelfImprovement",
+                    "enableReasoning",
                     "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -6217,7 +6225,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_": {
+            "Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -6273,6 +6281,9 @@
                         "type": "boolean"
                     },
                     "enableSelfImprovement": {
+                        "type": "boolean"
+                    },
+                    "enableReasoning": {
                         "type": "boolean"
                     },
                     "version": {
@@ -6291,15 +6302,16 @@
                     "userAccess",
                     "enableDataAccess",
                     "enableSelfImprovement",
+                    "enableReasoning",
                     "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ApiCreateAiAgent": {
-                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version_"
+                "$ref": "#/components/schemas/Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_"
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -6357,6 +6369,9 @@
                     "enableSelfImprovement": {
                         "type": "boolean"
                     },
+                    "enableReasoning": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -6368,7 +6383,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-version__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version__"
                     },
                     {
                         "properties": {

--- a/packages/backend/src/vitest.setup.integration.ts
+++ b/packages/backend/src/vitest.setup.integration.ts
@@ -194,6 +194,7 @@ export const setupIntegrationTest =
             imageUrl: null,
             enableDataAccess: false,
             enableSelfImprovement: false,
+            enableReasoning: false,
             version: 1,
         };
 

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -67,6 +67,7 @@ export const baseAgentSchema = z.object({
     userAccess: z.array(z.string()),
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
+    enableReasoning: z.boolean(),
     version: z.number(),
 });
 
@@ -88,6 +89,7 @@ export type AiAgent = Pick<
     | 'userAccess'
     | 'enableDataAccess'
     | 'enableSelfImprovement'
+    | 'enableReasoning'
     | 'version'
 >;
 
@@ -107,6 +109,7 @@ export type AiAgentSummary = Pick<
     | 'userAccess'
     | 'enableDataAccess'
     | 'enableSelfImprovement'
+    | 'enableReasoning'
     | 'version'
 >;
 
@@ -201,6 +204,7 @@ export type ApiCreateAiAgent = Pick<
     | 'userAccess'
     | 'enableDataAccess'
     | 'enableSelfImprovement'
+    | 'enableReasoning'
     | 'version'
 >;
 
@@ -217,6 +221,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'userAccess'
         | 'enableDataAccess'
         | 'enableSelfImprovement'
+        | 'enableReasoning'
         | 'version'
     >
 > & {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -76,6 +76,7 @@ const formSchema = z.object({
     userAccess: z.array(z.string()),
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
+    enableReasoning: z.boolean(),
     version: z.number(),
 });
 
@@ -424,6 +425,51 @@ export const AiAgentFormSetup = ({
                                         type: 'checkbox',
                                     },
                                 )}
+                            />
+                            <Switch
+                                variant="subtle"
+                                label={
+                                    <Group gap="xs">
+                                        <Text fz="sm" fw={500}>
+                                            Enable Reasoning
+                                        </Text>
+                                        <Tooltip
+                                            label="When enabled, the AI agent will show its reasoning process while generating responses, helping you understand how it arrives at conclusions."
+                                            withArrow
+                                            withinPortal
+                                            multiline
+                                            position="right"
+                                            maw="300px"
+                                        >
+                                            <MantineIcon
+                                                icon={IconInfoCircle}
+                                            />
+                                        </Tooltip>
+                                        <Badge
+                                            color="yellow"
+                                            radius="sm"
+                                            variant="light"
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconAlertTriangle}
+                                                    size={12}
+                                                />
+                                            }
+                                        >
+                                            Experimental
+                                        </Badge>
+                                    </Group>
+                                }
+                                description={
+                                    <>
+                                        Display the AI agent's reasoning process
+                                        while it works, showing how it thinks
+                                        through problems and arrives at answers.
+                                    </>
+                                }
+                                {...form.getInputProps('enableReasoning', {
+                                    type: 'checkbox',
+                                })}
                             />
                             {isAgentV2Enabled && (
                                 <Switch

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -55,6 +55,7 @@ const formSchema = z.object({
     userAccess: z.array(z.string()),
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
+    enableReasoning: z.boolean(),
     version: z.number(),
 });
 
@@ -100,6 +101,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             userAccess: [],
             enableDataAccess: false,
             enableSelfImprovement: false,
+            enableReasoning: false,
             version: 1, // TODO: Update to 2 when v2 is ready or allow version to be passed in
         },
         validate: zodResolver(formSchema),
@@ -121,6 +123,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 userAccess: agent.userAccess ?? [],
                 enableDataAccess: agent.enableDataAccess ?? false,
                 enableSelfImprovement: agent.enableSelfImprovement ?? false,
+                enableReasoning: agent.enableReasoning ?? false,
                 version: agent.version ?? 1, // TODO: Update to 2 when v2 is ready or allow version to be passed in
             };
             form.setValues(values);


### PR DESCRIPTION
### Description:
This PR adds a new "Enable Reasoning" feature for AI agents, allowing users to control whether an agent shows its reasoning process while generating responses. The feature helps users understand how the AI arrives at conclusions.

Key changes:
- Added `enable_reasoning` column to the `ai_agent` table with a database migration
- Updated AI agent models, services, and schemas to support the new reasoning flag
- Modified the model selection logic to respect agent-specific reasoning settings
- Added a new UI switch in the agent configuration form with an "Experimental" badge
- Changed the default reasoning effort from "medium" to "low" in the config schema

This gives users more control over AI agent behavior and transparency, allowing them to see the agent's thought process when needed.