### PR TITLE
feat: add findContent tool to AI agent tools list

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -37,6 +37,7 @@ export const ToolDisplayMessagesSchema = z.record(ToolNameSchema, z.string());
 export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     findExplores: 'Finding relevant explores',
     findDashboards: 'Finding relevant dashboards',
+    findContent: 'Finding relevant content',
     findFields: 'Finding relevant fields',
     searchFieldValues: 'Searching field values',
     generateBarVizConfig: 'Generating a bar chart',
@@ -55,6 +56,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         findExplores: 'Found relevant explores',
         findDashboards: 'Found relevant dashboards',
         findFields: 'Found relevant fields',
+        findContent: 'Found relevant content',
         searchFieldValues: 'Found field values',
         generateBarVizConfig: 'Generated a bar chart',
         generateTableVizConfig: 'Generated a table',

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -118,6 +118,7 @@ export function useAiAgentThreadStreamMutation() {
                                 case 'tool-findExplores':
                                 case 'tool-findFields':
                                 case 'tool-findDashboards':
+                                case 'tool-findContent':
                                 case 'tool-findCharts':
                                 case 'tool-improveContext':
                                 case 'tool-searchFieldValues':


### PR DESCRIPTION

### Description:
Added support for the `findContent` tool in the AI Agent. This includes adding display messages for when the tool is running and after completion, as well as handling the tool in the streaming mutation.