### PR TITLE
fix: prevent refetch loop on email verification page

### DIFF
--- a/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
@@ -1,3 +1,4 @@
+import { type EmailStatusExpiring } from '@lightdash/common';
 import {
     Alert,
     Anchor,
@@ -12,7 +13,6 @@ import { IconAlertCircle } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import Countdown, { zeroPad } from 'react-countdown';
 import {
-    useEmailStatus,
     useOneTimePassword,
     useVerifyEmail,
 } from '../../hooks/useEmailVerification';
@@ -20,13 +20,15 @@ import useApp from '../../providers/App/useApp';
 import LoadingState from '../common/LoadingState';
 import MantineIcon from '../common/MantineIcon';
 
-const VerifyEmailForm: FC<{ isLoading?: boolean }> = ({ isLoading }) => {
+const VerifyEmailForm: FC<{
+    isLoading?: boolean;
+    emailStatusData?: EmailStatusExpiring;
+    statusLoading?: boolean;
+}> = ({ isLoading, emailStatusData, statusLoading }) => {
     const { health, user } = useApp();
     const { mutate: verifyCode, isLoading: verificationLoading } =
         useVerifyEmail();
-    const { data, isInitialLoading: statusLoading } = useEmailStatus(
-        !!health.data?.isAuthenticated,
-    );
+    const data = emailStatusData;
     const { mutate: sendVerificationEmail, isLoading: emailLoading } =
         useOneTimePassword();
     const form = useForm<{ code: string }>({

--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -1,4 +1,4 @@
-import { ProjectType } from '@lightdash/common';
+import { ProjectType, type AnyType } from '@lightdash/common';
 import { Box, createStyles } from '@mantine/core';
 import { useDisclosure, useElementSize } from '@mantine/hooks';
 import { type FC } from 'react';
@@ -229,15 +229,21 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
         isSidebarResizing,
         { open: startSidebarResizing, close: stopSidebarResizing },
     ] = useDisclosure(false);
+
     const { activeProjectUuid } = useActiveProjectUuid({
         refetchOnMount: true,
+        enabled: withNavbar,
+    } as AnyType);
+    const { data: projects } = useProjects({
+        enabled: withNavbar,
     });
-    const { data: projects } = useProjects();
-    const isCurrentProjectPreview = !!projects?.find(
-        (project) =>
-            project.projectUuid === activeProjectUuid &&
-            project.type === ProjectType.PREVIEW,
-    );
+    const isCurrentProjectPreview =
+        withNavbar &&
+        !!projects?.find(
+            (project) =>
+                project.projectUuid === activeProjectUuid &&
+                project.type === ProjectType.PREVIEW,
+        );
 
     const { classes } = usePageStyles(
         {

--- a/packages/frontend/src/hooks/useEmailVerification.ts
+++ b/packages/frontend/src/hooks/useEmailVerification.ts
@@ -32,6 +32,11 @@ export const useEmailStatus = (enabled: boolean) =>
         queryKey: ['email_status'],
         queryFn: () => getEmailStatusQuery(),
         enabled,
+        // Prevent infinite loop on /verify-email page when session has issues
+        // This query only needs to run once on mount - verification updates via
+        // manual invalidation (useVerifyEmail onSuccess)
+        refetchOnMount: false,
+        refetchOnReconnect: false,
     });
 
 export const useOneTimePassword = () => {

--- a/packages/frontend/src/pages/VerifyEmail.tsx
+++ b/packages/frontend/src/pages/VerifyEmail.tsx
@@ -74,7 +74,10 @@ const VerifyEmailPage: FC = () => {
                     my="lg"
                 />
                 <Card p="xl" radius="xs" withBorder shadow="xs">
-                    <VerifyEmailForm />
+                    <VerifyEmailForm
+                        emailStatusData={data}
+                        statusLoading={statusLoading}
+                    />
                 </Card>
                 <Text color="gray.6" ta="center" px="xs">
                     You need to verify your email to get access to Lightdash. If


### PR DESCRIPTION
## Summary
  Fixes infinite request loop on `/verify-email` page when session expires.

  ## The Issue
  When users are on the `/verify-email` page and their session expires, three endpoints were looping infinitely:
  1. `/api/v1/user/me/email/status`
  2. `/api/v1/org/projects`
  3. `/api/v1/org`

  **The loop mechanism:**
  1. Query gets 401 → global error handler invalidates `['health']`
  2. Health refetches → returns `isAuthenticated: true` (session cookie still present but expired)
  3. Component re-renders → queries become enabled again → refetch → 401 → repeat

  ## Changes Made

  ### 1. Page.tsx - Conditional project fetching
  Don't fetch `activeProjectUuid` and `projects` when `withNavbar={false}`.

  **Fixes:** The projects and organization endpoint loops.

  ### 2. useEmailVerification.ts - Prevent aggressive refetching
  Added `refetchOnMount: false` and `refetchOnReconnect: false` to `useEmailStatus` query.

  **Fixes:** The email/status endpoint loop.

  **Trade-off:** Loses automatic refetch-on-mount, but this is acceptable because:
  - Query only needs to run once on page load
  - Updates happen via manual `invalidateQueries` when user submits verification code
  - Defensive safeguard against loops on a critical auth page

  ### 3. VerifyEmailForm.tsx - Remove duplicate query call
  Pass email status data from parent instead of calling `useEmailStatus` twice.

  **Why:** Cleaner code, prevents multiple query observers.

  ## Important Note

  **This is a workaround, not a root cause fix.**

  The architectural issue is that the global 401 handler invalidates health for ALL 401 errors, but:
  - The `/health` endpoint doesn't require authentication and never returns 401
  - It relies on the presence of a session cookie, which may still exist even when expired
  - This creates a scenario where `isAuthenticated` stays `true` even though the session is invalid

  A proper fix would require:
  - Rethinking the global 401 handling strategy (query-specific error handling vs global)
  - OR making the `/health` endpoint actually return 401 when sessions are invalid
  - OR using a different mechanism to detect session expiry

  This workaround prevents the immediate production issue while we can architect a better solution.