### PR TITLE
feat: add runSavedChartQuery tool for AI agent

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -19,6 +19,7 @@ import { getGenerateDashboardV2 } from '../tools/generateDashboardV2';
 import { getImproveContext } from '../tools/improveContext';
 import { getProposeChange } from '../tools/proposeChange';
 import { getRunQuery } from '../tools/runQuery';
+import { getRunSavedChartQuery } from '../tools/runSavedChartQuery';
 import { getSearchFieldValues } from '../tools/searchFieldValues';
 import type {
     AiAgentArgs,
@@ -170,6 +171,12 @@ const getAgentTools = (
         enableSelfImprovement: args.enableSelfImprovement,
     });
 
+    const runSavedChartQuery = getRunSavedChartQuery({
+        runSavedChartQuery: dependencies.runSavedChartQuery,
+        updateProgress: dependencies.updateProgress,
+        getPrompt: dependencies.getPrompt,
+    });
+
     const generateDashboard = getGenerateDashboardV2({
         getExplore: dependencies.getExplore,
         getPrompt: dependencies.getPrompt,
@@ -198,7 +205,9 @@ const getAgentTools = (
         ...(args.enableSelfImprovement && args.canManageAgent
             ? { proposeChange }
             : {}),
-        ...(args.enableDataAccess ? { searchFieldValues } : {}),
+        ...(args.enableDataAccess
+            ? { runSavedChartQuery, searchFieldValues }
+            : {}),
     };
 
     logger(

--- a/packages/backend/src/ee/services/ai/tools/runSavedChartQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSavedChartQuery.ts
@@ -1,0 +1,82 @@
+import {
+    AnyType,
+    ItemsMap,
+    toolRunSavedChartQueryArgsSchema,
+    toolRunSavedChartQueryOutputSchema,
+    type ToolRunSavedChartQueryArgs,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import type {
+    GetPromptFn,
+    UpdateProgressFn,
+} from '../types/aiAgentDependencies';
+import { convertQueryResultsToCsv } from '../utils/convertQueryResultsToCsv';
+import { serializeData } from '../utils/serializeData';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+
+type Dependencies = {
+    runSavedChartQuery: (args: {
+        chartUuid: string;
+        versionUuid?: string;
+        limit?: number | null;
+    }) => Promise<{
+        rows: Record<string, AnyType>[];
+        fields: ItemsMap;
+    }>;
+    updateProgress: UpdateProgressFn;
+    getPrompt: GetPromptFn;
+};
+
+export const getRunSavedChartQuery = ({
+    runSavedChartQuery,
+    updateProgress,
+    getPrompt,
+}: Dependencies) =>
+    tool({
+        description: toolRunSavedChartQueryArgsSchema.description,
+        inputSchema: toolRunSavedChartQueryArgsSchema,
+        outputSchema: toolRunSavedChartQueryOutputSchema,
+        execute: async (toolArgs: ToolRunSavedChartQueryArgs) => {
+            try {
+                await updateProgress('📊 Running saved chart query...');
+
+                const prompt = await getPrompt();
+
+                // Execute query and wait for results (polling is handled in the dependency)
+                const { rows, fields } = await runSavedChartQuery({
+                    chartUuid: toolArgs.chartUuid,
+                    limit: toolArgs.limit,
+                });
+
+                // Check if we have results
+                if (!rows || rows.length === 0) {
+                    return {
+                        result: 'No results found for this saved chart query.',
+                        metadata: { status: 'success' },
+                    };
+                }
+
+                // Convert results to CSV for AI consumption
+                const csv = convertQueryResultsToCsv({
+                    rows,
+                    fields,
+                    cacheMetadata: { cacheHit: false },
+                });
+
+                return {
+                    result: serializeData(csv, 'csv'),
+                    metadata: { status: 'success' },
+                };
+            } catch (e) {
+                return {
+                    result: toolErrorHandler(
+                        e,
+                        'Error running saved chart query.',
+                    ),
+                    metadata: { status: 'error' },
+                };
+            }
+        },
+        toModelOutput: (output) => toModelOutput(output),
+    });

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -14,6 +14,7 @@ import {
     GetPromptFn,
     ListExploresFn,
     RunMiniMetricQueryFn,
+    RunSavedChartQueryFn,
     SearchFieldValuesFn,
     SendFileFn,
     StoreToolCallFn,
@@ -61,6 +62,7 @@ export type AiAgentDependencies = {
     getExplore: GetExploreFn;
     getExploreCompiler: GetExploreCompilerFn;
     runMiniMetricQuery: RunMiniMetricQueryFn;
+    runSavedChartQuery: RunSavedChartQueryFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
     updatePrompt: UpdatePromptFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -6,6 +6,7 @@ import {
     AiWebAppPrompt,
     AllChartsSearchResult,
     AnyType,
+    ApiGetAsyncQueryResults,
     CacheMetadata,
     CatalogField,
     CatalogTable,
@@ -157,3 +158,12 @@ export type CreateChangeFn = (
 ) => Promise<string>;
 
 export type GetExploreCompilerFn = () => Promise<ExploreCompiler>;
+
+export type RunSavedChartQueryFn = (args: {
+    chartUuid: string;
+    versionUuid?: string;
+    limit?: number | null;
+}) => Promise<{
+    rows: Record<string, unknown>[];
+    fields: ItemsMap;
+}>;

--- a/packages/backend/src/ee/services/ai/utils/pollAsyncQueryResults.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/pollAsyncQueryResults.test.ts
@@ -1,0 +1,296 @@
+import {
+    ApiGetAsyncQueryResults,
+    QueryHistoryStatus,
+    type ResultRow,
+} from '@lightdash/common';
+import { pollAsyncQueryResults } from './pollAsyncQueryResults';
+
+jest.useFakeTimers();
+
+describe('pollAsyncQueryResults', () => {
+    const mockQueryUuid = 'test-query-uuid';
+
+    const mockResultRow: ResultRow = {
+        id: { value: { raw: 1, formatted: '1' } },
+        name: { value: { raw: 'Test', formatted: 'Test' } },
+    };
+
+    const createReadyResults = (
+        rows: ResultRow[] = [mockResultRow],
+    ): ApiGetAsyncQueryResults => ({
+        status: QueryHistoryStatus.READY,
+        queryUuid: mockQueryUuid,
+        rows,
+        columns: {},
+        initialQueryExecutionMs: 100,
+        resultsPageExecutionMs: 50,
+        pageSize: 25,
+        page: 1,
+        totalPageCount: 1,
+        totalResults: rows.length,
+        nextPage: undefined,
+        previousPage: undefined,
+        pivotDetails: {
+            totalColumnCount: null,
+            indexColumn: undefined,
+            valuesColumns: [],
+            groupByColumns: undefined,
+            sortBy: undefined,
+            originalColumns: {},
+        },
+    });
+
+    const createPendingResults = (): ApiGetAsyncQueryResults => ({
+        status: QueryHistoryStatus.PENDING,
+        queryUuid: mockQueryUuid,
+    });
+
+    const createErrorResults = (error?: string): ApiGetAsyncQueryResults => ({
+        status: QueryHistoryStatus.ERROR,
+        queryUuid: mockQueryUuid,
+        error: error ?? null,
+    });
+
+    const createCancelledResults = (): ApiGetAsyncQueryResults => ({
+        status: QueryHistoryStatus.CANCELLED,
+        queryUuid: mockQueryUuid,
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+    });
+
+    describe('when query succeeds on first attempt', () => {
+        it('should return results immediately for READY status', async () => {
+            const mockResults = createReadyResults();
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValue(mockResults);
+
+            const promise = pollAsyncQueryResults(
+                getAsyncQueryResults,
+                mockQueryUuid,
+            );
+
+            const results = await promise;
+
+            expect(results).toEqual(mockResults);
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(1);
+            expect(getAsyncQueryResults).toHaveBeenCalledWith(mockQueryUuid);
+        });
+    });
+
+    describe('when query requires polling', () => {
+        it('should poll until READY with exponential backoff', async () => {
+            const pendingResults = createPendingResults();
+            const readyResults = createReadyResults();
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValueOnce(pendingResults)
+                .mockResolvedValueOnce(pendingResults)
+                .mockResolvedValueOnce(readyResults);
+
+            const promise = pollAsyncQueryResults(
+                getAsyncQueryResults,
+                mockQueryUuid,
+            );
+
+            // First call happens immediately
+            await jest.advanceTimersByTimeAsync(0);
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(1);
+
+            // Second call after 250ms backoff
+            await jest.advanceTimersByTimeAsync(250);
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(2);
+
+            // Third call after 500ms backoff (doubled)
+            await jest.advanceTimersByTimeAsync(500);
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(3);
+
+            const results = await promise;
+            expect(results).toEqual(readyResults);
+        });
+
+        it('should cap backoff at 1000ms', async () => {
+            const pendingResults = createPendingResults();
+            const readyResults = createReadyResults();
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValueOnce(pendingResults) // 250ms
+                .mockResolvedValueOnce(pendingResults) // 500ms
+                .mockResolvedValueOnce(pendingResults) // 1000ms (capped)
+                .mockResolvedValueOnce(pendingResults) // 1000ms (capped)
+                .mockResolvedValueOnce(readyResults);
+
+            const promise = pollAsyncQueryResults(
+                getAsyncQueryResults,
+                mockQueryUuid,
+            );
+
+            // Progress through backoffs
+            await jest.advanceTimersByTimeAsync(0);
+            await jest.advanceTimersByTimeAsync(250);
+            await jest.advanceTimersByTimeAsync(500);
+            await jest.advanceTimersByTimeAsync(1000);
+            await jest.advanceTimersByTimeAsync(1000);
+
+            const results = await promise;
+            expect(results).toEqual(readyResults);
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(5);
+        });
+    });
+
+    describe('when query fails', () => {
+        it('should throw error for ERROR status with error message', async () => {
+            const errorResults = createErrorResults('SQL syntax error');
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValue(errorResults);
+
+            await expect(
+                pollAsyncQueryResults(getAsyncQueryResults, mockQueryUuid),
+            ).rejects.toThrow('SQL syntax error');
+        });
+
+        it('should throw generic error for ERROR status without error message', async () => {
+            const errorResults = createErrorResults();
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValue(errorResults);
+
+            await expect(
+                pollAsyncQueryResults(getAsyncQueryResults, mockQueryUuid),
+            ).rejects.toThrow('Unknown error executing query.');
+        });
+
+        it('should throw error for CANCELLED status', async () => {
+            const cancelledResults = createCancelledResults();
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValue(cancelledResults);
+
+            await expect(
+                pollAsyncQueryResults(getAsyncQueryResults, mockQueryUuid),
+            ).rejects.toThrow('Query was cancelled.');
+        });
+
+        it('should throw timeout error after max attempts', async () => {
+            const pendingResults = createPendingResults();
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValue(pendingResults);
+
+            // Start polling
+            const promise = pollAsyncQueryResults(
+                getAsyncQueryResults,
+                mockQueryUuid,
+            );
+
+            // Advance through enough polling cycles to hit max attempts
+            // Each cycle: check, wait backoff, recurse
+            // Backoff pattern: 250ms, 500ms, 1000ms, 1000ms...
+            // We need to go through 120 attempts
+            let totalTime = 0;
+            for (let i = 0; i < 120; i += 1) {
+                let backoff = 1000;
+                if (i === 0) {
+                    backoff = 250;
+                } else if (i === 1) {
+                    backoff = 500;
+                }
+                totalTime += backoff;
+            }
+
+            // Advance by total time plus a bit more
+            const advancePromise = jest.advanceTimersByTimeAsync(totalTime);
+
+            // Now expect the promise to reject
+            await expect(promise).rejects.toThrow(
+                'Query timed out waiting for results.',
+            );
+
+            await advancePromise;
+
+            // Verify it hit the max attempts
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(120);
+        });
+    });
+
+    describe('with custom backoff', () => {
+        it('should use provided initial backoff value', async () => {
+            const pendingResults = createPendingResults();
+            const readyResults = createReadyResults();
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValueOnce(pendingResults)
+                .mockResolvedValueOnce(readyResults);
+
+            const customBackoff = 500;
+            const promise = pollAsyncQueryResults(
+                getAsyncQueryResults,
+                mockQueryUuid,
+                customBackoff,
+            );
+
+            // First call
+            await jest.advanceTimersByTimeAsync(0);
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(1);
+
+            // Second call after custom backoff
+            await jest.advanceTimersByTimeAsync(customBackoff);
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(2);
+
+            const results = await promise;
+            expect(results).toEqual(readyResults);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle network errors from getAsyncQueryResults', async () => {
+            const networkError = new Error('Network request failed');
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockRejectedValue(networkError);
+
+            await expect(
+                pollAsyncQueryResults(getAsyncQueryResults, mockQueryUuid),
+            ).rejects.toThrow('Network request failed');
+        });
+
+        it('should call getAsyncQueryResults with correct uuid on each poll', async () => {
+            const pendingResults = createPendingResults();
+            const readyResults = createReadyResults([]);
+
+            const getAsyncQueryResults = jest
+                .fn()
+                .mockResolvedValueOnce(pendingResults)
+                .mockResolvedValueOnce(pendingResults)
+                .mockResolvedValueOnce(readyResults);
+
+            const promise = pollAsyncQueryResults(
+                getAsyncQueryResults,
+                mockQueryUuid,
+            );
+
+            await jest.advanceTimersByTimeAsync(0);
+            await jest.advanceTimersByTimeAsync(250);
+            await jest.advanceTimersByTimeAsync(500);
+
+            await promise;
+
+            // Verify all calls used the same uuid
+            expect(getAsyncQueryResults).toHaveBeenCalledTimes(3);
+            getAsyncQueryResults.mock.calls.forEach((call) => {
+                expect(call[0]).toBe(mockQueryUuid);
+            });
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/pollAsyncQueryResults.ts
+++ b/packages/backend/src/ee/services/ai/utils/pollAsyncQueryResults.ts
@@ -1,0 +1,58 @@
+import { ApiGetAsyncQueryResults, QueryHistoryStatus } from '@lightdash/common';
+
+const MAX_POLL_ATTEMPTS = 120; // 2 minutes max
+
+/**
+ * Polls for async query results with exponential backoff
+ * Similar to frontend's pollForResults in executeQuery.ts
+ *
+ * @param getAsyncQueryResults - Function to fetch query results
+ * @param queryUuid - UUID of the query to poll
+ * @param backoffMs - Current backoff delay in milliseconds (default: 250ms)
+ * @returns Query results when ready
+ * @throws Error if query fails, is cancelled, or times out
+ */
+export const pollAsyncQueryResults = async (
+    getAsyncQueryResults: (
+        queryUuid: string,
+    ) => Promise<ApiGetAsyncQueryResults>,
+    queryUuid: string,
+    backoffMs: number = 250,
+    attempts: number = 0,
+): Promise<ApiGetAsyncQueryResults> => {
+    if (attempts >= MAX_POLL_ATTEMPTS) {
+        throw new Error('Query timed out waiting for results.');
+    }
+
+    const results = await getAsyncQueryResults(queryUuid);
+
+    if (results.status === QueryHistoryStatus.READY) {
+        return results;
+    }
+
+    if (results.status === QueryHistoryStatus.ERROR) {
+        throw new Error(
+            'error' in results && results.error
+                ? results.error
+                : 'Unknown error executing query.',
+        );
+    }
+
+    if (results.status === QueryHistoryStatus.CANCELLED) {
+        throw new Error('Query was cancelled.');
+    }
+
+    // Implement backoff: 250ms -> 500ms -> 1000ms (then stay at 1000ms)
+    const nextBackoff = Math.min(backoffMs * 2, 1000);
+
+    await new Promise((resolve) => {
+        setTimeout(resolve, backoffMs);
+    });
+
+    return pollAsyncQueryResults(
+        getAsyncQueryResults,
+        queryUuid,
+        nextBackoff,
+        attempts + 1,
+    );
+};

--- a/packages/common/src/ee/AiAgent/followUpTools.ts
+++ b/packages/common/src/ee/AiAgent/followUpTools.ts
@@ -14,6 +14,7 @@ export const followUpToolsText: FollowUpToolsText = {
     [AiResultType.DASHBOARD_V2_RESULT]: 'Generate a Dashboard (v2)',
     [AiResultType.IMPROVE_CONTEXT]: 'Improve Context',
     [AiResultType.PROPOSE_CHANGE]: 'Propose a Change',
+    [AiResultType.RUN_SAVED_CHART_QUERY]: 'Run Saved Chart Query',
 };
 
 export enum LegacyFollowUpTools {

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -8,6 +8,7 @@ import {
     type ToolImproveContextOutput,
     type ToolProposeChangeOutput,
     type ToolRunQueryOutput,
+    type ToolRunSavedChartQueryOutput,
     type ToolSearchFieldValuesOutput,
     type ToolTableVizOutput,
     type ToolTimeSeriesOutput,
@@ -33,6 +34,7 @@ export type AgentToolOutput =
     | ToolImproveContextOutput
     | ToolProposeChangeOutput
     | ToolRunQueryOutput
+    | ToolRunSavedChartQueryOutput
     | ToolSearchFieldValuesOutput
     | ToolTableVizOutput
     | ToolTimeSeriesOutput

--- a/packages/common/src/ee/AiAgent/schemas/parser.ts
+++ b/packages/common/src/ee/AiAgent/schemas/parser.ts
@@ -10,6 +10,7 @@ import {
     toolImproveContextArgsSchema,
     toolProposeChangeArgsSchema,
     toolRunQueryArgsSchemaTransformed,
+    toolRunSavedChartQueryArgsSchemaTransformed,
     toolSearchFieldValuesArgsSchemaTransformed,
     toolTableVizArgsSchemaTransformed,
     toolTimeSeriesArgsSchemaTransformed,
@@ -59,6 +60,10 @@ export const parseToolArgs = (toolName: ToolName, toolArgs: unknown) => {
             return toolProposeChangeArgsSchema.safeParse(toolArgs);
         case 'runQuery':
             return toolRunQueryArgsSchemaTransformed.safeParse(toolArgs);
+        case 'runSavedChartQuery':
+            return toolRunSavedChartQueryArgsSchemaTransformed.safeParse(
+                toolArgs,
+            );
         default:
             return assertUnreachable(
                 toolName,

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -9,6 +9,7 @@ export * from './toolImproveContextArgs';
 export * from './toolProposeChangeArgs';
 export * from './toolRunMetricQueryArgs';
 export * from './toolRunQueryArgs';
+export * from './toolRunSavedChartQueryArgs';
 export * from './toolSearchFieldValuesArgs';
 export * from './toolTableVizArgs';
 export * from './toolTimeSeriesArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunSavedChartQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunSavedChartQueryArgs.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { AiResultType } from '../../types';
+import { baseOutputMetadataSchema } from '../outputMetadata';
+import { createToolSchema } from '../toolSchemaBuilder';
+
+export const TOOL_RUN_SAVED_CHART_QUERY_DESCRIPTION = `Tool: runSavedChartQuery
+
+Purpose:
+Execute an existing saved chart by its UUID. Use this when the user asks about specific saved charts or wants to see results from charts that already exist in the project.
+
+When to use:
+- User asks about a specific saved chart (e.g., "show me the results of [chart name]")
+- Need to retrieve data from an existing chart rather than creating a new one
+- Want to use an existing chart's pre-configured query, filters, and visualization
+
+Parameters:
+- chartUuid: The UUID of the saved chart to execute (required)
+- versionUuid: Optional specific version of the chart to run
+- limit: Optional row limit to override the chart's default limit
+
+Important:
+- Use findCharts tool first to search for charts by name/description if you don't have the UUID
+- This tool requires enableDataAccess to be enabled to see the actual data
+- Results are returned as CSV format for analysis
+`;
+
+export const toolRunSavedChartQueryArgsSchema = createToolSchema({
+    type: AiResultType.RUN_SAVED_CHART_QUERY,
+    description: TOOL_RUN_SAVED_CHART_QUERY_DESCRIPTION,
+})
+    .extend({
+        chartUuid: z
+            .string()
+            .uuid()
+            .describe(
+                'The UUID of the saved chart to execute. Use findCharts tool to discover chart UUIDs.',
+            ),
+        limit: z
+            .number()
+            .positive()
+            .nullable()
+            .describe(
+                'Optional: maximum number of rows to return. Overrides the chart default limit if provided.',
+            ),
+    })
+    .build();
+
+export type ToolRunSavedChartQueryArgs = z.infer<
+    typeof toolRunSavedChartQueryArgsSchema
+>;
+
+export const toolRunSavedChartQueryArgsSchemaTransformed =
+    toolRunSavedChartQueryArgsSchema;
+
+export type ToolRunSavedChartQueryArgsTransformed = ToolRunSavedChartQueryArgs;
+
+export const toolRunSavedChartQueryOutputSchema = z.object({
+    result: z.string(),
+    metadata: baseOutputMetadataSchema,
+});
+
+export type ToolRunSavedChartQueryOutput = z.infer<
+    typeof toolRunSavedChartQueryOutputSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -20,6 +20,7 @@ export const ToolNameSchema = z.enum([
     'searchFieldValues',
     'findDashboards',
     'findCharts',
+    'runSavedChartQuery',
     'improveContext',
     'proposeChange',
     'runQuery',
@@ -43,6 +44,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     generateTimeSeriesVizConfig: 'Generating a line chart',
     generateDashboard: 'Generating a dashboard',
     findCharts: 'Finding relevant charts',
+    runSavedChartQuery: 'Running saved chart query',
     improveContext: 'Improving context',
     runQuery: 'Generating visualization',
 });
@@ -61,6 +63,7 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         findCharts: 'Found relevant charts',
         improveContext: 'Improved context',
         runQuery: 'Generated visualization',
+        runSavedChartQuery: 'Ran saved chart query',
     });
 
 export const AVAILABLE_VISUALIZATION_TYPES = VisualizationTools;

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -16,6 +16,7 @@ export enum AiResultType {
     DASHBOARD_V2_RESULT = 'dashboard_v2',
     IMPROVE_CONTEXT = 'improve_context',
     PROPOSE_CHANGE = 'propose_change',
+    RUN_SAVED_CHART_QUERY = 'run_saved_chart_query',
 }
 
 export type AiMetricQuery = Pick<

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -145,6 +145,7 @@ export const ToolCallDescription: FC<{
             );
         case AiResultType.IMPROVE_CONTEXT:
         case AiResultType.PROPOSE_CHANGE:
+        case AiResultType.RUN_SAVED_CHART_QUERY:
             return <> </>;
         default:
             return assertUnreachable(toolArgs, `Unknown tool name ${toolName}`);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -30,6 +30,7 @@ export const getToolIcon = (toolName: ToolName) => {
             improveContext: IconSchool,
             proposeChange: IconPencil,
             runQuery: IconTable,
+            runSavedChartQuery: IconChartLine,
         };
 
     return iconMap[toolName];

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -123,6 +123,7 @@ export function useAiAgentThreadStreamMutation() {
                                 case 'tool-searchFieldValues':
                                 case 'tool-runQuery':
                                 case 'tool-generateDashboard':
+                                case 'tool-runSavedChartQuery':
                                     if (part.state !== 'input-available') break;
 
                                     const toolNameUnsafe =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a new `runSavedChartQuery` tool that allows the AI agent to execute existing saved charts by their UUID. This enables users to ask about specific saved charts and get their results directly in the chat.

The implementation includes:

- A new tool schema and type definitions
- Backend service method to execute saved chart queries
- Polling mechanism with exponential backoff for async query results
- Integration with the AI agent system
- Frontend support for displaying the tool in the chat UI
