### PR TITLE
feat(perf): only call getNodeMapFromItemsMap once per section at the root level and memoize it

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeNode.tsx
@@ -3,7 +3,6 @@ import TreeContext from '../Tree/TreeContext';
 import TreeGroupNode from '../Tree/TreeGroupNode';
 import TreeSingleNode from '../Tree/TreeSingleNode';
 import { isGroupNode } from '../Tree/types';
-import { getNodeMapFromItemsMap } from '../Tree/utils';
 import { TreeSection, type SectionContext, type TreeNodeItem } from './types';
 
 interface VirtualTreeNodeProps {
@@ -27,12 +26,6 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
 
     // Look up the shared section context
     const sectionContext = sectionContexts.get(sectionKey);
-
-    // Create a temporary nodeMap for this specific node and its context
-    const nodeMap = useMemo(() => {
-        if (!sectionContext) return {};
-        return getNodeMapFromItemsMap(sectionContext.itemsMap, undefined);
-    }, [sectionContext]);
 
     // Build the context value from the section context
     const contextValue = useMemo(() => {
@@ -59,7 +52,7 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
 
         return {
             itemsMap: sectionContext.itemsMap,
-            nodeMap,
+            nodeMap: sectionContext.nodeMap,
             isSearching:
                 !!sectionContext.searchQuery &&
                 sectionContext.searchQuery !== '',
@@ -90,7 +83,7 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
             isVirtualized: true, // Flag to prevent inline children rendering
             depth, // Nesting depth for indentation
         };
-    }, [sectionContext, nodeMap, depth, onSelectedFieldChange, onToggleGroup]);
+    }, [sectionContext, depth, onSelectedFieldChange, onToggleGroup]);
 
     if (!sectionContext) {
         console.error(`Section context not found for key: ${sectionKey}`);

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/types.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/types.ts
@@ -7,7 +7,7 @@ import type {
     Metric,
     OrderFieldsByStrategy,
 } from '@lightdash/common';
-import type { Node, NodeItem } from '../Tree/types';
+import type { Node, NodeItem, NodeMap } from '../Tree/types';
 
 export enum TreeSection {
     Dimensions = 'dimensions',
@@ -92,6 +92,7 @@ export interface SectionContext {
     tableName: string;
     sectionType: TreeSection;
     itemsMap: Record<string, NodeItem>;
+    nodeMap: NodeMap; // Pre-computed node hierarchy
     missingCustomMetrics?: AdditionalMetric[];
     missingCustomDimensions?: CustomDimension[];
     itemsAlerts?: {
@@ -173,6 +174,9 @@ export interface FlattenTreeOptions {
     // Git integration
     isGithubIntegrationEnabled?: boolean;
     gitIntegration?: GitIntegrationConfiguration;
+
+    // Pre-computed node maps (key: `${tableName}-${sectionType}`)
+    sectionNodeMaps: Map<string, NodeMap>;
 }
 
 // Section info for organizing nodes


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Optimized the virtualized tree rendering by pre-computing node maps instead of recalculating them for each node. This change:

- Added a new `getNodeMapsForVirtualization` function to compute node maps once for all sections
- Modified `flattenTreeForVirtualization` to use pre-computed node maps
- Updated the `SectionContext` to include the pre-computed node map
- Removed redundant node map calculation in `VirtualTreeNode`
- Added tests to verify the node map pre-computation works correctly

This optimization reduces redundant calculations during tree rendering, improving performance especially for large data sets.