### PR TITLE
feat: add project selection option to login command

### DIFF
--- a/packages/cli/src/handlers/login.ts
+++ b/packages/cli/src/handlers/login.ts
@@ -17,6 +17,8 @@ type LoginOptions = {
     token?: string;
     /** Use OAuth2 flow instead of password/token */
     oauth?: boolean;
+    /** Project UUID to select after login */
+    project?: string;
     interactive?: boolean;
     verbose: boolean;
 };
@@ -175,7 +177,9 @@ export const login = async (url: string, options: LoginOptions) => {
     console.error(`\n  ✅️ Login successful\n`);
 
     try {
-        if (process.env.CI === 'true') {
+        if (options.project) {
+            await setProjectCommand(undefined, options.project);
+        } else if (process.env.CI === 'true') {
             await setFirstProject();
         } else {
             const project = await setProjectCommand();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -186,6 +186,12 @@ ${styles.bold('Examples:')}
         'Login using OAuth2 flow (opens browser for authentication)',
         false,
     )
+    .option(
+        '--project <project uuid>',
+        'Select a project by UUID after login',
+        parseProjectArgument,
+        undefined,
+    )
     .option('--verbose', undefined, false)
     .action(login);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXX

Before
<img width="814" height="450" alt="Screenshot from 2025-10-27 08-36-23" src="https://github.com/user-attachments/assets/25bdc40b-e107-4f38-8bdf-f97d0259755e" />


After


<img width="1046" height="446" alt="image" src="https://github.com/user-attachments/assets/c70f607b-7c4d-4283-99b5-6c944178562c" />


### Description:
Added a new `--project` option to the login command that allows users to select a specific project by UUID after login. This enhances the login flow by enabling direct project selection without requiring additional interaction.

The implementation:
- Adds a new `project` parameter to the `LoginOptions` type
- Updates the login handler to use the provided project UUID when specified
- Adds the `--project` option to the CLI command with appropriate help text