### PR TITLE
fix: table calculations when filtering non selected metric

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1794,10 +1794,9 @@ export class MetricQueryBuilder {
                               (tableCalc) =>
                                   `  ${fieldQuoteChar}${tableCalc.name}${fieldQuoteChar}`,
                           ),
-                          ...simpleTableCalcs.map(
-                              (tableCalc) =>
-                                  `${fieldQuoteChar}${tableCalc.name}${fieldQuoteChar}`,
-                          ),
+                          ...(shouldInlineSimpleCalcs
+                              ? simpleTableCalculationSelects
+                              : []),
                       ]
                     : [
                           '  *',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17661

### Description:

Refactored the MetricQueryBuilder to conditionally include simple table calculations based on the `shouldInlineSimpleCalcs` flag. When enabled, it uses the `simpleTableCalculationSelects` array instead of directly mapping over `simpleTableCalcs`.

This change improves the flexibility of the query builder by allowing more control over how simple table calculations are included in the query.

**Steps to test**

1. use `Repro 2` from https://github.com/lightdash/lightdash/pull/17427
2. add a table calculation (simple) - this will fail
3. add another table calculation, depending on the one created previously - this works