### PR TITLE
chore: measure ttft and first chunk when prompting

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -2465,6 +2465,17 @@ export class AiAgentService {
                         durationMs,
                     );
                 },
+                measureStreamFirstChunk: (durationMs) => {
+                    this.prometheusMetrics?.aiAgentStreamFirstChunkHistogram?.observe(
+                        durationMs,
+                    );
+                },
+                measureTTFT: (durationMs, model, mode) => {
+                    this.prometheusMetrics?.aiAgentTTFTHistogram?.observe(
+                        { model, mode },
+                        durationMs,
+                    );
+                },
             },
         };
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -399,7 +399,9 @@ export const generateAgentResponse = async ({
             `Generation complete. Result text length: ${result.text.length}`,
         );
 
-        dependencies.perf.measureGenerateResponseTime(Date.now() - startTime);
+        const totalTime = Date.now() - startTime;
+        dependencies.perf.measureGenerateResponseTime(totalTime);
+        dependencies.perf.measureTTFT(totalTime, modelName, 'generate');
 
         return result.text;
     } catch (error) {
@@ -433,6 +435,8 @@ export const streamAgentResponse = async ({
     const tools = getAgentTools(args, dependencies);
 
     const startTime = Date.now();
+    let firstChunkTime: number | null = null;
+    let firstTextTime: number | null = null;
     const modelName =
         typeof args.model === 'string' ? args.model : args.model.modelId;
 
@@ -450,6 +454,17 @@ export const streamAgentResponse = async ({
             messages,
             experimental_repairToolCall: getRepairToolCall(args, tools),
             onChunk: (event) => {
+                // Track time to first chunk (any type) - only once
+                if (firstChunkTime === null) {
+                    firstChunkTime = Date.now();
+                    const ttfc = firstChunkTime - startTime;
+                    logger(
+                        'First Chunk',
+                        `Time to first chunk (${event.chunk.type}): ${ttfc}ms`,
+                    );
+                    dependencies.perf.measureStreamFirstChunk(ttfc);
+                }
+
                 switch (event.chunk.type) {
                     case 'tool-call': {
                         logger(
@@ -525,6 +540,20 @@ export const streamAgentResponse = async ({
                         break;
                     }
                     case 'text-delta': {
+                        // Track time to first text token (TTFT) - only once
+                        if (firstTextTime === null) {
+                            firstTextTime = Date.now();
+                            const ttft = firstTextTime - startTime;
+                            logger(
+                                'Chunk Text Delta',
+                                `Time to first text token (TTFT): ${ttft}ms`,
+                            );
+                            dependencies.perf.measureTTFT(
+                                ttft,
+                                modelName,
+                                'stream',
+                            );
+                        }
                         logger(
                             'Chunk Text Delta',
                             `Received text chunk: ${event.chunk.text}`,

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -49,6 +49,12 @@ export type AiAgentArgs = AnyAiModel & {
 export type PerformanceMetrics = {
     measureGenerateResponseTime: (durationMs: number) => void;
     measureStreamResponseTime: (durationMs: number) => void;
+    measureStreamFirstChunk: (durationMs: number) => void;
+    measureTTFT: (
+        durationMs: number,
+        model: string,
+        mode: 'stream' | 'generate',
+    ) => void;
 };
 
 export type AiAgentDependencies = {

--- a/packages/backend/src/prometheus.ts
+++ b/packages/backend/src/prometheus.ts
@@ -23,6 +23,10 @@ export default class PrometheusMetrics {
     public aiAgentStreamResponseDurationHistogram: prometheus.Histogram | null =
         null;
 
+    public aiAgentStreamFirstChunkHistogram: prometheus.Histogram | null = null;
+
+    public aiAgentTTFTHistogram: prometheus.Histogram | null = null;
+
     constructor(config: LightdashConfig['prometheus']) {
         this.config = config;
     }
@@ -110,6 +114,54 @@ export default class PrometheusMetrics {
                         ],
                         ...rest,
                     });
+
+                this.aiAgentStreamFirstChunkHistogram =
+                    new prometheus.Histogram({
+                        name: 'ai_agent_stream_first_chunk_ms',
+                        help: 'Histogram of AI Agent time to first chunk (any type)',
+                        buckets: [
+                            50, // 50ms
+                            100, // 100ms
+                            250, // 250ms
+                            500, // 500ms
+                            1000, // 1 second
+                            2500, // 2.5 seconds
+                            5000, // 5 seconds
+                            10000, // 10 seconds
+                            15000, // 15 seconds
+                            20000, // 20 seconds
+                            30000, // 30 seconds
+                            45000, // 45 seconds
+                            60000, // 1 minute
+                            90000, // 1.5 minutes
+                            120000, // 2 minutes
+                        ],
+                        ...rest,
+                    });
+
+                this.aiAgentTTFTHistogram = new prometheus.Histogram({
+                    name: 'ai_agent_ttft_ms',
+                    help: 'Histogram of AI Agent TTFT (time to first token)',
+                    labelNames: ['model', 'mode'],
+                    buckets: [
+                        50, // 50ms
+                        100, // 100ms
+                        250, // 250ms
+                        500, // 500ms
+                        1000, // 1 second
+                        2500, // 2.5 seconds
+                        5000, // 5 seconds
+                        10000, // 10 seconds
+                        15000, // 15 seconds
+                        20000, // 20 seconds
+                        30000, // 30 seconds
+                        45000, // 45 seconds
+                        60000, // 1 minute
+                        90000, // 1.5 minutes
+                        120000, // 2 minutes
+                    ],
+                    ...rest,
+                });
 
                 const app = express();
                 this.server = http.createServer(app);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:

Added new performance metrics for AI Agent response generation:

1. Time to First Chunk - Measures how long it takes to receive the first chunk of any type during streaming
2. Time to First Token (TTFT) - Tracks how long it takes to receive the first text token, with labels for model and mode (stream/generate)

> How to run
>
> 1. **Ensure Prometheus metrics are enabled** in `.env.development.local`:
> 2. Start Prometheus server:
> `docker run -d ￼-p 9091:9090 ￼-v $(pwd)/docker/dev-configs/prometheus.dev.yml:/etc/prometheus/prometheus.yml ￼--name=prometheus ￼prom/prometheus`​



> 3\. Verify setup:
> \- Backend metrics: http://localhost:9090/metrics
> \- Prometheus graph UI: http://localhost:9091/graph



average ttft for stream mode

![image.png](https://app.graphite.dev/user-attachments/assets/c49997e0-b81c-474a-94c0-2c31f056958d.png)

ttft bucket

![image.png](https://app.graphite.dev/user-attachments/assets/77f20152-268c-4138-881f-63f855eb17df.png)

time-to-first-chunk average

(ai_agent_stream_first_chunk_ms_sum / ai_agent_stream_first_chunk_ms_count) / 1000

![image.png](https://app.graphite.dev/user-attachments/assets/1c87ca18-97bc-46f4-8a23-a357bf0022d1.png)