### PR TITLE
feat: add support for Snowflake external browser authentication

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -30,7 +30,12 @@ import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { getWarehouseIcon } from '../ProjectConnectFlow/utils';
 import { useProjectFormContext } from '../useProjectFormContext';
 import { SnowflakeDefaultValues } from './defaultValues';
-import { getSsoLabel, PASSWORD_LABEL, PRIVATE_KEY_LABEL } from './util';
+import {
+    EXTERNAL_BROWSER_LABEL,
+    getSsoLabel,
+    PASSWORD_LABEL,
+    PRIVATE_KEY_LABEL,
+} from './util';
 
 export const SnowflakeSchemaInput: FC<{
     disabled: boolean;
@@ -138,7 +143,8 @@ const SnowflakeForm: FC<{
 
     const [temporaryFile, setTemporaryFile] = useState<File>();
 
-    const authOptions = isSsoEnabled
+    // Build base authentication options
+    const baseAuthOptions = isSsoEnabled
         ? [
               {
                   value: SnowflakeAuthenticationType.SSO,
@@ -163,6 +169,18 @@ const SnowflakeForm: FC<{
                   label: PASSWORD_LABEL,
               },
           ];
+
+    // Only show EXTERNAL_BROWSER if it's already selected (edit mode only)
+    const authOptions =
+        savedAuthType === SnowflakeAuthenticationType.EXTERNAL_BROWSER
+            ? [
+                  ...baseAuthOptions,
+                  {
+                      value: SnowflakeAuthenticationType.EXTERNAL_BROWSER,
+                      label: EXTERNAL_BROWSER_LABEL,
+                  },
+              ]
+            : baseAuthOptions;
 
     return (
         <>
@@ -285,30 +303,36 @@ const SnowflakeForm: FC<{
                         </Group>
 
                         {authenticationType !==
-                            SnowflakeAuthenticationType.SSO && (
-                            <>
-                                <TextInput
-                                    name="warehouse.user"
-                                    label="User"
-                                    description="This is the database user name."
-                                    required={requireSecrets}
-                                    {...form.getInputProps('warehouse.user')}
-                                    placeholder={
-                                        disabled || !requireSecrets
-                                            ? '**************'
-                                            : undefined
-                                    }
-                                    disabled={disabled}
-                                />
-                                <TextInput
-                                    name="warehouse.role"
-                                    label="Role"
-                                    description="This is the role to assume when running queries as the specified user."
-                                    {...form.getInputProps('warehouse.role')}
-                                    disabled={disabled}
-                                />
-                            </>
-                        )}
+                            SnowflakeAuthenticationType.SSO &&
+                            authenticationType !==
+                                SnowflakeAuthenticationType.EXTERNAL_BROWSER && (
+                                <>
+                                    <TextInput
+                                        name="warehouse.user"
+                                        label="User"
+                                        description="This is the database user name."
+                                        required={requireSecrets}
+                                        {...form.getInputProps(
+                                            'warehouse.user',
+                                        )}
+                                        placeholder={
+                                            disabled || !requireSecrets
+                                                ? '**************'
+                                                : undefined
+                                        }
+                                        disabled={disabled}
+                                    />
+                                    <TextInput
+                                        name="warehouse.role"
+                                        label="Role"
+                                        description="This is the role to assume when running queries as the specified user."
+                                        {...form.getInputProps(
+                                            'warehouse.role',
+                                        )}
+                                        disabled={disabled}
+                                    />
+                                </>
+                            )}
 
                         {authenticationType ===
                         SnowflakeAuthenticationType.PRIVATE_KEY ? (
@@ -399,6 +423,13 @@ const SnowflakeForm: FC<{
                                     openLoginPopup={openLoginPopup}
                                 />
                             )
+                        ) : authenticationType ===
+                          SnowflakeAuthenticationType.EXTERNAL_BROWSER ? (
+                            <Text size="sm" c="dimmed">
+                                External browser authentication is configured.
+                                Authentication will occur through your default
+                                browser when connecting to Snowflake.
+                            </Text>
                         ) : (
                             <>
                                 <PasswordInput

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
@@ -4,3 +4,4 @@ export const getSsoLabel = (warehouse: WarehouseTypes) =>
     `User Account (Sign in with ${capitalize(warehouse)})`;
 export const PRIVATE_KEY_LABEL = `Service Account (JSON key file)`;
 export const PASSWORD_LABEL = `Password`;
+export const EXTERNAL_BROWSER_LABEL = `External Browser`;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-113/display-externalbrowser-option-in-snowflake-project-settings-when

Fixes a missing UI selection when externalbrowser is selected

When project has externalbrowser

<img width="930" height="573" alt="Screenshot from 2025-10-27 14-27-17" src="https://github.com/user-attachments/assets/c2f7e188-10b0-43a0-9add-78d20528c4d7" />


On creating a  new project (no externalbrowser can be selected)
<img width="989" height="498" alt="Screenshot from 2025-10-27 14-27-33" src="https://github.com/user-attachments/assets/838157cd-b182-4e17-bcbe-0cfb624b2747" />

### Description:
Added support for External Browser authentication in the Snowflake connection form. This authentication method is now preserved when editing existing connections that use it, while not being offered as an option for new connections. The UI conditionally shows appropriate fields based on the authentication type and displays an informative message when External Browser authentication is selected.