### PR TITLE
feat: add --organization-credentials when creating project on the CLI

### DIFF
--- a/packages/backend/src/ee/controllers/OrganizationWarehouseCredentialsController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationWarehouseCredentialsController.ts
@@ -2,6 +2,7 @@ import {
     ApiErrorPayload,
     ApiOrganizationWarehouseCredentialsListResponse,
     ApiOrganizationWarehouseCredentialsResponse,
+    ApiOrganizationWarehouseCredentialsSummaryListResponse,
     ApiSuccessEmpty,
     CreateOrganizationWarehouseCredentials,
     UpdateOrganizationWarehouseCredentials,
@@ -15,6 +16,7 @@ import {
     Patch,
     Path,
     Post,
+    Query,
     Request,
     Response,
     Route,
@@ -37,14 +39,30 @@ export class OrganizationWarehouseCredentialsController extends BaseController {
      * Get all warehouse credentials for the current organization
      * @summary List warehouse credentials
      * @param req express request
+     * @param summary If true, returns only summaries (name, type) accessible to all members. If false/undefined, returns full credentials requiring manage permission.
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @Get()
     @OperationId('ListOrganizationWarehouseCredentials')
     async getAll(
         @Request() req: express.Request,
-    ): Promise<ApiOrganizationWarehouseCredentialsListResponse> {
+        @Query() summary?: boolean,
+    ): Promise<
+        | ApiOrganizationWarehouseCredentialsListResponse
+        | ApiOrganizationWarehouseCredentialsSummaryListResponse
+    > {
         this.setStatus(200);
+
+        if (summary) {
+            return {
+                status: 'ok',
+                results:
+                    await this.getOrganizationWarehouseCredentialsService().getAllSummaries(
+                        req.account!,
+                    ),
+            };
+        }
+
         return {
             status: 'ok',
             results:

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8222,6 +8222,58 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_OrganizationWarehouseCredentials.organizationWarehouseCredentialsUuid-or-name-or-description-or-warehouseType_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    description: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    name: { dataType: 'string', required: true },
+                    organizationWarehouseCredentialsUuid: {
+                        dataType: 'string',
+                        required: true,
+                    },
+                    warehouseType: { ref: 'WarehouseTypes', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    OrganizationWarehouseCredentialsSummary: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_OrganizationWarehouseCredentials.organizationWarehouseCredentialsUuid-or-name-or-description-or-warehouseType_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiOrganizationWarehouseCredentialsSummaryListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'OrganizationWarehouseCredentialsSummary',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiOrganizationWarehouseCredentialsResponse: {
         dataType: 'refAlias',
         type: {
@@ -26049,6 +26101,7 @@ export function RegisterRoutes(app: Router) {
         TsoaRoute.ParameterSchema
     > = {
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        summary: { in: 'query', name: 'summary', dataType: 'boolean' },
     };
     app.get(
         '/api/v1/org/warehouse-credentials',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8411,6 +8411,51 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "Pick_OrganizationWarehouseCredentials.organizationWarehouseCredentialsUuid-or-name-or-description-or-warehouseType_": {
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationWarehouseCredentialsUuid": {
+                        "type": "string"
+                    },
+                    "warehouseType": {
+                        "$ref": "#/components/schemas/WarehouseTypes"
+                    }
+                },
+                "required": [
+                    "description",
+                    "name",
+                    "organizationWarehouseCredentialsUuid",
+                    "warehouseType"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "OrganizationWarehouseCredentialsSummary": {
+                "$ref": "#/components/schemas/Pick_OrganizationWarehouseCredentials.organizationWarehouseCredentialsUuid-or-name-or-description-or-warehouseType_"
+            },
+            "ApiOrganizationWarehouseCredentialsSummaryListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/OrganizationWarehouseCredentialsSummary"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "ApiOrganizationWarehouseCredentialsResponse": {
                 "properties": {
                     "results": {
@@ -21383,7 +21428,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2117.0",
+        "version": "0.2118.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -21434,7 +21479,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ApiOrganizationWarehouseCredentialsListResponse"
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ApiOrganizationWarehouseCredentialsListResponse"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ApiOrganizationWarehouseCredentialsSummaryListResponse"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -21454,7 +21506,17 @@
                 "summary": "List warehouse credentials",
                 "tags": ["Organization Warehouse Credentials"],
                 "security": [],
-                "parameters": []
+                "parameters": [
+                    {
+                        "description": "If true, returns only summaries (name, type) accessible to all members. If false/undefined, returns full credentials requiring manage permission.",
+                        "in": "query",
+                        "name": "summary",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ]
             },
             "post": {
                 "operationId": "CreateOrganizationWarehouseCredentials",

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -32,6 +32,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     ignoreErrors: boolean;
     tableConfiguration: CreateProjectTableConfiguration;
     skipCopyContent?: boolean;
+    organizationCredentials?: string;
 };
 
 type StopPreviewHandlerOptions = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -438,6 +438,10 @@ program
         'Skip copying content from the source project',
         false,
     )
+    .option(
+        '--organization-credentials <name>',
+        'Use organization warehouse credentials with the specified name (Enterprise Edition feature)',
+    )
     .action(previewHandler);
 
 program
@@ -673,6 +677,10 @@ program
     .option(
         '--no-warehouse-credentials',
         'Create project without warehouse credentials. Skips dbt compile + warehouse catalog',
+    )
+    .option(
+        '--organization-credentials <name>',
+        'Use organization warehouse credentials with the specified name (Enterprise Edition feature)',
     )
     .action(deployHandler);
 

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -216,6 +216,9 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'MetricsTree', {
             organizationUuid: member.organizationUuid,
         });
+        can('view', 'OrganizationWarehouseCredentials', {
+            organizationUuid: member.organizationUuid,
+        });
     },
     developer(member, { can }) {
         applyOrganizationMemberStaticAbilities.editor(member, { can });

--- a/packages/common/src/types/organizationWarehouseCredentials.ts
+++ b/packages/common/src/types/organizationWarehouseCredentials.ts
@@ -39,3 +39,16 @@ export type ApiOrganizationWarehouseCredentialsListResponse = {
     status: 'ok';
     results: OrganizationWarehouseCredentials[];
 };
+
+export type OrganizationWarehouseCredentialsSummary = Pick<
+    OrganizationWarehouseCredentials,
+    | 'organizationWarehouseCredentialsUuid'
+    | 'name'
+    | 'description'
+    | 'warehouseType'
+>;
+
+export type ApiOrganizationWarehouseCredentialsSummaryListResponse = {
+    status: 'ok';
+    results: OrganizationWarehouseCredentialsSummary[];
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-112/add-organization-credentials-in-the-cli

Creating a project using org credential on the CLI 

<img width="982" height="373" alt="Screenshot from 2025-10-27 15-51-23" src="https://github.com/user-attachments/assets/afd0277c-f1fd-4c3c-87d3-c42a0d56c2b5" />
<img width="1029" height="508" alt="Screenshot from 2025-10-27 15-52-36" src="https://github.com/user-attachments/assets/d0341f77-b776-4f7f-9961-c26b1eaa226e" />


When trying to use a org credential that doesn't exist

<img width="1003" height="442" alt="Screenshot from 2025-10-27 15-51-09" src="https://github.com/user-attachments/assets/b6b52372-152c-4593-b7f2-fe14c251720b" />

### Description:
This PR adds a new endpoint to fetch organization warehouse credentials summaries that are accessible to all organization members, not just those with manage permissions. The summaries include only non-sensitive information (name, description, type, and UUID).

Key changes:
- Added a new `getAllSummaries` method to `OrganizationWarehouseCredentialsService`
- Updated the controller to accept a `summary` query parameter
- Added permission for all organization members to view credential summaries
- Enhanced the CLI to support using organization credentials by name with the new `--organization-credentials` flag
- Fixed error message to distinguish between view and manage permissions

This enables regular organization members to see available credential options without exposing sensitive connection details, and allows them to reference credentials by name in the CLI.