### PR TITLE
refactor: rename canChangeParameters to parameterInteractivity

### DIFF
--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -108,7 +108,7 @@ export const fromJwt = ({
         access: {
             dashboardId: dashboardUuid,
             filtering: decodedToken.content.dashboardFiltersInteractivity,
-            canChangeParameters: decodedToken.content.canChangeParameters,
+            parameters: decodedToken.content.parameterInteractivity,
             controls: userAttributes,
         },
         // Create the fields we're able to set from the JWT

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -36,6 +36,7 @@ import {
     isExploreError,
     isFilterableDimension,
     isFilterInteractivityEnabled,
+    isParameterInteractivityEnabled,
     LightdashSessionUser,
     MetricQuery,
     NotFoundError,
@@ -473,7 +474,7 @@ export class EmbedService extends BaseService {
             isPrivate: false,
             access: [],
             dashboardFiltersInteractivity: account.access.filtering,
-            canChangeParameters: account.access.canChangeParameters,
+            parameterInteractivity: account.access.parameters,
             canExportCsv,
             canExportImages,
             canExportPagePdf: canExportPagePdf ?? true, // enabled by default for backwards compatibility
@@ -923,7 +924,10 @@ export class EmbedService extends BaseService {
 
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
         const acceptedUserParameters =
-            account.access.canChangeParameters && parameters ? parameters : {};
+            isParameterInteractivityEnabled(account.access.parameters) &&
+            parameters
+                ? parameters
+                : {};
         const combinedParameters = await this.projectService.combineParameters(
             projectUuid,
             explore,
@@ -1034,7 +1038,8 @@ export class EmbedService extends BaseService {
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         const acceptedUserParameters =
-            account.access.canChangeParameters && userParameters
+            isParameterInteractivityEnabled(account.access.parameters) &&
+            userParameters
                 ? userParameters
                 : {};
         const combinedParameters = await this.projectService.combineParameters(
@@ -1179,7 +1184,8 @@ export class EmbedService extends BaseService {
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         const acceptedUserParameters =
-            account.access.canChangeParameters && userParameters
+            isParameterInteractivityEnabled(account.access.parameters) &&
+            userParameters
                 ? userParameters
                 : {};
         const combinedParameters = await this.projectService.combineParameters(
@@ -1271,7 +1277,8 @@ export class EmbedService extends BaseService {
         const dashboardParameters = getDashboardParametersValuesMap(dashboard);
 
         const acceptedUserParameters =
-            account.access.canChangeParameters && userParameters
+            isParameterInteractivityEnabled(account.access.parameters) &&
+            userParameters
                 ? userParameters
                 : {};
         const combinedParameters = await this.projectService.combineParameters(

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -48,10 +48,18 @@ export type DashboardFilterInteractivityOptions = z.infer<
     typeof DashboardFilterInteractivityOptionsSchema
 >;
 
+export const ParameterInteractivityOptionsSchema = z.object({
+    enabled: z.boolean(),
+});
+
+export type ParameterInteractivityOptions = z.infer<
+    typeof ParameterInteractivityOptionsSchema
+>;
+
 export const InteractivityOptionsSchema = z.object({
     dashboardFiltersInteractivity:
         DashboardFilterInteractivityOptionsSchema.optional(),
-    canChangeParameters: z.boolean().optional(),
+    parameterInteractivity: ParameterInteractivityOptionsSchema.optional(),
     canExportCsv: z.boolean().optional(),
     canExportImages: z.boolean().optional(),
     canExportPagePdf: z.boolean().optional(),
@@ -109,7 +117,9 @@ type CommonEmbedJwtContent = {
         // Should the filters be rendered hidden or visible in the UI
         hidden?: boolean;
     };
-    canChangeParameters?: boolean;
+    parameterInteractivity?: {
+        enabled: boolean;
+    };
     canExportCsv?: boolean;
     canExportImages?: boolean;
     canDateZoom?: boolean;
@@ -192,4 +202,10 @@ export function isFilterInteractivityEnabled(
                 `Unknown FilterInteractivityValue ${filterInteractivityValue}`,
             );
     }
+}
+
+export function isParameterInteractivityEnabled(
+    parameterInteractivityOptions?: ParameterInteractivityOptions,
+): boolean {
+    return parameterInteractivityOptions?.enabled ?? false;
 }

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -1,6 +1,7 @@
 import {
     type CreateEmbedJwt,
     type DashboardFilterInteractivityOptions,
+    type ParameterInteractivityOptions,
 } from '../ee';
 import { ForbiddenError } from './errors';
 import { type Organization } from './organization';
@@ -88,8 +89,8 @@ export type DashboardAccess = {
     filtering?: DashboardFilterInteractivityOptions;
     /** User-specific access controls */
     controls?: UserAccessControls;
-    /** Whether users can change dashboard parameters in embedded dashboards */
-    canChangeParameters?: boolean;
+    /** Dashboard parameter interactivity options */
+    parameters?: ParameterInteractivityOptions;
 };
 
 export type AccountHelpers = {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
@@ -1,5 +1,6 @@
 import {
     isFilterInteractivityEnabled,
+    isParameterInteractivityEnabled,
     type Dashboard,
     type InteractivityOptions,
 } from '@lightdash/common';
@@ -18,7 +19,7 @@ type Props = {
 const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid }) => {
     const hasHeader =
         dashboard.canDateZoom ||
-        dashboard.canChangeParameters ||
+        isParameterInteractivityEnabled(dashboard.parameterInteractivity) ||
         isFilterInteractivityEnabled(dashboard.dashboardFiltersInteractivity);
 
     // If no header, and exportPagePdf is enabled, show the Export button on the top right corner
@@ -47,7 +48,9 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid }) => {
             style={{ flexGrow: 1 }}
         >
             {shouldShowFilters && <EmbedDashboardFilters />}
-            {dashboard.canChangeParameters && <EmbedDashboardParameters />}
+            {isParameterInteractivityEnabled(
+                dashboard.parameterInteractivity,
+            ) && <EmbedDashboardParameters />}
             {dashboard.canDateZoom && <DateZoom isEditMode={false} />}
 
             {dashboard.canExportPagePdf && (

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -31,7 +31,9 @@ const data = {
             enabled: "{{dashboardFiltersInteractivityEnabled}}",
             allowedFilters: {{dashboardFiltersInteractivityAllowedFilters}},
         },
-        canChangeParameters: {{canChangeParameters}},
+        parameterInteractivity: {
+            enabled: {{canChangeParameters}},
+        },
         canExportCsv: {{canExportCsvEnabled}},
         canExportImages: {{canExportImagesEnabled}},
         canExportPagePdf: {{canExportPagePdf}},
@@ -65,7 +67,9 @@ data = {
             "enabled": "{{dashboardFiltersInteractivityEnabledPython}}",
             "allowedFilters": {{dashboardFiltersInteractivityAllowedFiltersPython}},
         },
-        "canChangeParameters": {{canChangeParametersPython}},
+        "parameterInteractivity": {
+            "enabled": {{canChangeParametersPython}},
+        },
         "canExportCsv": {{canExportCsvEnabledPython}},
         "canExportImages": {{canExportImagesEnabledPython}},
         "canExportPagePdf": {{canExportPagePdfPython}},
@@ -109,7 +113,9 @@ func main() {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
             } \`json:"dashboardFiltersInteractivity"\`
-            CanChangeParameters bool \`json:"canChangeParameters"\`
+            ParameterInteractivity struct {
+                Enabled bool \`json:"enabled"\`
+            } \`json:"parameterInteractivity"\`
             CanExportCsv bool \`json:"canExportCsv"\`
             CanExportImages bool \`json:"canExportImages"\`
             CanExportPagePdf bool \`json:"canExportPagePdf"\`
@@ -135,7 +141,9 @@ func main() {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
             } \`json:"dashboardFiltersInteractivity"\`
-            CanChangeParameters bool \`json:"canChangeParameters"\`
+            ParameterInteractivity struct {
+                Enabled bool \`json:"enabled"\`
+            } \`json:"parameterInteractivity"\`
             CanExportCsv bool \`json:"canExportCsv"\`
             CanExportImages bool \`json:"canExportImages"\`
             CanExportPagePdf bool \`json:"canExportPagePdf"\`
@@ -153,7 +161,11 @@ func main() {
                 Enabled: "{{dashboardFiltersInteractivityEnabled}}",
                 AllowedFilters: []string{{{dashboardFiltersInteractivityAllowedFiltersGo}}},
             },
-            CanChangeParameters: {{canChangeParameters}},
+            ParameterInteractivity: struct {
+                Enabled bool \`json:"enabled"\`
+            }{
+                Enabled: {{canChangeParameters}},
+            },
             CanExportCsv: {{canExportCsvEnabled}},
             CanExportImages: {{canExportImagesEnabled}},
             CanExportPagePdf: {{canExportPagePdf}},
@@ -255,11 +267,11 @@ const getCodeSnippet = (
         )
         .replace(
             '{{canChangeParameters}}',
-            data.content.canChangeParameters ? 'true' : 'false',
+            data.content.parameterInteractivity?.enabled ? 'true' : 'false',
         )
         .replace(
             '{{canChangeParametersPython}}',
-            data.content.canChangeParameters ? 'True' : 'False',
+            data.content.parameterInteractivity?.enabled ? 'True' : 'False',
         )
         .replace('{{canDateZoom}}', data.content.canDateZoom ? 'true' : 'false')
         .replace(

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedUrlForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedUrlForm.tsx
@@ -6,6 +6,7 @@ import {
     type DashboardFilterInteractivityOptions,
     type EmbedUrl,
     type IntrinsicUserAttributes,
+    type ParameterInteractivityOptions,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -63,7 +64,7 @@ type FormValues = {
         value: string;
     }>;
     dashboardFiltersInteractivity: DashboardFilterInteractivityOptions;
-    canChangeParameters?: boolean;
+    parameterInteractivity: ParameterInteractivityOptions;
     canExportCsv?: boolean;
     canExportImages?: boolean;
     externalId?: string;
@@ -95,7 +96,9 @@ const EmbedUrlForm: FC<{
             dashboardFiltersInteractivity: {
                 enabled: FilterInteractivityValues.none,
             },
-            canChangeParameters: false,
+            parameterInteractivity: {
+                enabled: false,
+            },
             canExportCsv: false,
             canExportImages: false,
             canDateZoom: false,
@@ -132,7 +135,7 @@ const EmbedUrlForm: FC<{
                               }
                             : {}),
                     },
-                    canChangeParameters: values.canChangeParameters,
+                    parameterInteractivity: values.parameterInteractivity,
                     canExportCsv: values.canExportCsv,
                     canExportImages: values.canExportImages,
                     isPreview,
@@ -294,7 +297,12 @@ const EmbedUrlForm: FC<{
                 </Input.Wrapper>
 
                 <Switch
-                    {...form.getInputProps(`canChangeParameters`)}
+                    checked={form.values.parameterInteractivity.enabled}
+                    onChange={(event) =>
+                        form.setFieldValue('parameterInteractivity', {
+                            enabled: event.currentTarget.checked,
+                        })
+                    }
                     labelPosition="left"
                     label={`Allow users to change parameters`}
                 />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Refactored parameter interactivity in embedded dashboards to use a structured approach similar to filter interactivity. Changed `canChangeParameters` boolean to a more flexible `parameterInteractivity` object with an `enabled` property. This provides a consistent pattern for handling interactivity settings and allows for future expansion of parameter control options.

The changes include:
- Updated JWT content structure to use `parameterInteractivity` object
- Added `isParameterInteractivityEnabled()` helper function
- Updated embed code snippets to reflect the new structure
- Modified UI components to use the new parameter interactivity check