### PR TITLE
feat: display round bars in bar charts

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -163,6 +163,20 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
                                     // so we need to generate it here (and wrap it in an array) and then reuse the formatter used
                                     // on `useEchartsCartesianConfig` to generate the tooltip
                                     if (eChartsOptions.tooltip.formatter) {
+                                        // When using data array approach with primitives (regular stacked)
+                                        // param.value is a number/string and param.name contains category
+                                        if (
+                                            typeof param.value !== 'object' ||
+                                            param.value === null
+                                        ) {
+                                            return (
+                                                eChartsOptions.tooltip
+                                                    .formatter as any
+                                            )([param]);
+                                        }
+
+                                        // When using data array approach with full row objects (100% stacked)
+                                        // or dataset approach, param.value is an object with dimension keys
                                         const dim =
                                             param.encode?.x?.[0] !== undefined
                                                 ? param.dimensionNames[

--- a/packages/frontend/src/hooks/echarts/echartsStyleUtils.ts
+++ b/packages/frontend/src/hooks/echarts/echartsStyleUtils.ts
@@ -19,3 +19,32 @@ export const getLegendStyle = (
         padding: [0, 0, 0, 2],
     },
 });
+
+/**
+ * Get border radius array for a bar chart data point
+ * @param isHorizontal - Whether the bar chart is horizontal (flipAxes)
+ * @param isStackEnd - Whether this data point is at the end (top/right) of the stack
+ */
+export const getBarBorderRadius = (
+    isHorizontal: boolean,
+    isStackEnd: boolean,
+): number | number[] => {
+    if (!isStackEnd) {
+        return 0;
+    }
+
+    const radius = 4;
+
+    // Horizontal (flipAxes): round right side [top-right, bottom-right, bottom-left, top-left]
+    // Vertical: round top side [top-left, top-right, bottom-right, bottom-left]
+    return isHorizontal
+        ? [0, radius, radius, 0]
+        : [radius, radius, 0, 0];
+};
+
+/**
+ * Get base bar styling configuration for cartesian charts
+ */
+export const getBarStyle = () => ({
+    barCategoryGap: '25%', // Gap between bars: width is 3x the gap (75% / 25% = 3)
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #17643

### Description:

Adds rounded corners (border radius) and consistent spacing to bar charts in cartesian visualizations. This applies to both regular and stacked bar charts, with special handling
  for different chart types.

  Changes

  Visual Improvements

  - All bar charts: Applied bar CategoryGap: 25% for consistent spacing (bar width is 3x the gap size)
  - Non-stacked bars: Added 4px border radius to top corners (vertical) or right corners (horizontal)
  - Stacked bars (non-percentage): Added 4px border radius only to the topmost segment of each stack
  - 100% stacked bars: No border radius applied (preserved existing behavior to avoid breaking tooltip functionality)

  Technical Implementation

For Stacked bar charts, implemented per-data-point border radius using ECharts data arrays (https://github.com/apache/echarts/issues/12319)
ECharts only supports per-series itemStyle, but we need per-data-point styling to round only the top segment of each stack.

  Solution:
  1. Built stackInfo map tracking which series is the "stack end" for each data point
  2. Converted from dataset + encode pattern to data array pattern for stacked bars
  3. Used hybrid approach: primitive values for non-end points, objects with itemStyle for stack-end points
  4. Added category axis data explicitly when using data arrays (ECharts requirement)

  // Example data array structure:
```
  [
    871.43,                          // Non-stack-end: primitive value
    { value: 1234.56, itemStyle: {  // Stack-end: object with styling
      borderRadius: [4, 4, 0, 0]
    }}
  ]
```

  3. Tooltip Fixes

  In ` useEchartsCartesianConfig.ts`
  - Added fallback for tooltip header: params[0].axisValueLabel || params[0].name
  - Handle both dataset (object values) and data array (primitive values) approaches

  In `SimpleChart/index.tsx`:
  - Detect data array usage by checking typeof param.value
  - For primitives: pass param directly (category from param.name)
  - For objects: extract dimension value and format as before

Why 100% stacked charts are excluded: they go all the way to the top of the grid, so didn't make sense to add a border radius - happy to change though. 

before 

![before-bar-chart-changes.png](https://app.graphite.dev/user-attachments/assets/c451229f-2791-4bd8-8873-f72e24497c5f.png)


after

![screencapture-localhost-3000-projects-3675b69e-8324-4110-bdca-059031aa8da3-dashboards-d8b21988-efb4-4d0b-94a6-a5213c9f2efb-view-2025-10-27-18_39_08.png](https://app.graphite.dev/user-attachments/assets/21e6b5cf-a76b-488d-9b13-dbf0f08b1b27.png)

