### PR TITLE
feat: update axes label styles

### DIFF
--- a/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
+++ b/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
@@ -17,6 +17,7 @@ import { isTimeInterval, timeFrameConfigs } from '../../utils/timeFrames';
  * @param rotate - Rotate
  * @param defaultNameGap - Default name gap
  * @param show - Show
+ * @param axisLabelStyle - Optional styling for axis labels (color, fontSize, fontWeight, etc.)
  * @returns Axis config
  */
 export const getCartesianAxisFormatterConfig = ({
@@ -25,12 +26,14 @@ export const getCartesianAxisFormatterConfig = ({
     rotate,
     defaultNameGap,
     show,
+    axisLabelStyle,
 }: {
     axisItem: ItemsMap[string] | undefined;
     longestLabelWidth?: number;
     rotate?: number;
     defaultNameGap?: number;
     show?: boolean;
+    axisLabelStyle?: { color: string; fontWeight: string; fontSize: number };
 }) => {
     // Remove axis labels, lines, and ticks if the axis is not shown
     // This is done to prevent the grid from disappearing when the axis is not shown
@@ -161,6 +164,7 @@ export const getCartesianAxisFormatterConfig = ({
         const rotateRadians = (rotate * Math.PI) / 180;
         const oppositeSide = (longestLabelWidth || 0) * Math.sin(rotateRadians);
         axisConfig.axisLabel = {
+            ...(axisLabelStyle || {}),
             ...(axisConfig.axisLabel || {}),
             rotate,
             margin: 12,
@@ -168,6 +172,7 @@ export const getCartesianAxisFormatterConfig = ({
         axisConfig.nameGap = oppositeSide + 15;
     } else {
         axisConfig.axisLabel = {
+            ...(axisLabelStyle || {}),
             ...(axisConfig.axisLabel || {}),
             hideOverlap: true,
         };

--- a/packages/frontend/src/hooks/echarts/echartsStyleUtils.ts
+++ b/packages/frontend/src/hooks/echarts/echartsStyleUtils.ts
@@ -37,9 +37,7 @@ export const getBarBorderRadius = (
 
     // Horizontal (flipAxes): round right side [top-right, bottom-right, bottom-left, top-left]
     // Vertical: round top side [top-left, top-right, bottom-right, bottom-left]
-    return isHorizontal
-        ? [0, radius, radius, 0]
-        : [radius, radius, 0, 0];
+    return isHorizontal ? [0, radius, radius, 0] : [radius, radius, 0, 0];
 };
 
 /**
@@ -47,4 +45,34 @@ export const getBarBorderRadius = (
  */
 export const getBarStyle = () => ({
     barCategoryGap: '25%', // Gap between bars: width is 3x the gap (75% / 25% = 3)
+});
+
+/**
+ * Get axis label styling (for values like "Jan", "Feb", "Mar")
+ * Color: gray.6, Weight: 500, Size: 11px
+ */
+export const getAxisLabelStyle = (theme: MantineTheme) => ({
+    color: theme.colors.gray[6],
+    fontWeight: '500',
+    fontSize: 11,
+});
+
+/**
+ * Get axis title styling (for titles like "Month", "Amount")
+ * Color: gray.7, Weight: 500, Size: 12px
+ */
+export const getAxisTitleStyle = (theme: MantineTheme) => ({
+    color: theme.colors.gray[7],
+    fontWeight: '500',
+    fontSize: 12,
+});
+
+/**
+ * Get bar total label styling (values above/beside stacked bars)
+ * Color: gray.9, Weight: 500, Size: 11px
+ */
+export const getBarTotalLabelStyle = (theme: MantineTheme) => ({
+    color: theme.colors.gray[9],
+    fontWeight: '500',
+    fontSize: 11,
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -43,7 +43,7 @@ import {
     type TableCalculation,
     type TooltipParam,
 } from '@lightdash/common';
-import { useMantineTheme } from '@mantine/core';
+import { useMantineTheme, type MantineTheme } from '@mantine/core';
 import dayjs from 'dayjs';
 import DOMPurify from 'dompurify';
 import {
@@ -69,8 +69,11 @@ import {
 } from '../plottedData/getPlottedData';
 import { type InfiniteQueryResults } from '../useQueryResults';
 import {
+    getAxisLabelStyle,
+    getAxisTitleStyle,
     getBarBorderRadius,
     getBarStyle,
+    getBarTotalLabelStyle,
     getLegendStyle,
 } from './echartsStyleUtils';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
@@ -1048,12 +1051,14 @@ const getEchartAxes = ({
     series,
     resultsData,
     minsAndMaxes,
+    theme,
 }: {
     validCartesianConfig: CartesianChart;
     itemsMap: ItemsMap;
     series: EChartSeries[];
     resultsData: InfiniteQueryResults | undefined;
     minsAndMaxes: ReturnType<typeof getResultValueArray>['minsAndMaxes'];
+    theme: MantineTheme;
 }) => {
     const xAxisItemId = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.layout?.yField?.[0]
@@ -1375,9 +1380,7 @@ const getEchartAxes = ({
                                       getItemLabelWithoutTableName(xAxisItem)
                                     : undefined),
                           nameLocation: 'center',
-                          nameTextStyle: {
-                              fontWeight: 'bold',
-                          },
+                          nameTextStyle: getAxisTitleStyle(theme),
                       }
                     : {}),
                 ...getAxisFormatterConfig({
@@ -1388,6 +1391,7 @@ const getEchartAxes = ({
                     rotate: xAxisConfiguration?.[0]?.rotate,
                     defaultNameGap: 30,
                     show: showXAxis,
+                    axisLabelStyle: getAxisLabelStyle(theme),
                 }),
                 splitLine: {
                     show: validCartesianConfig.layout.flipAxes
@@ -1424,9 +1428,7 @@ const getEchartAxes = ({
                                 })
                               : undefined,
                           nameLocation: 'center',
-                          nameTextStyle: {
-                              fontWeight: 'bold',
-                          },
+                          nameTextStyle: getAxisTitleStyle(theme),
                       }
                     : {}),
                 min:
@@ -1448,6 +1450,7 @@ const getEchartAxes = ({
                     longestLabelWidth: calculateWidthText(longestValueXAxisTop),
                     defaultNameGap: 30,
                     show: showXAxis,
+                    axisLabelStyle: getAxisLabelStyle(theme),
                 }),
                 splitLine: {
                     show: isAxisTheSameForAllSeries,
@@ -1478,7 +1481,7 @@ const getEchartAxes = ({
                                 }),
                           nameLocation: 'center',
                           nameTextStyle: {
-                              fontWeight: 'bold',
+                              ...getAxisTitleStyle(theme),
                               align: 'center',
                           },
                       }
@@ -1489,6 +1492,7 @@ const getEchartAxes = ({
                     axisItem: leftAxisYField,
                     defaultNameGap: leftYaxisGap + defaultAxisLabelGap,
                     show: showYAxis,
+                    axisLabelStyle: getAxisLabelStyle(theme),
                 }),
                 // Override formatter for 100% stacking without flipped axes
                 ...(shouldStack100 &&
@@ -1525,7 +1529,7 @@ const getEchartAxes = ({
                           nameLocation: 'center',
                           nameRotate: -90,
                           nameTextStyle: {
-                              fontWeight: 'bold',
+                              ...getAxisTitleStyle(theme),
                               align: 'center',
                           },
                       }
@@ -1550,6 +1554,7 @@ const getEchartAxes = ({
                     axisItem: rightAxisYField,
                     defaultNameGap: rightYaxisGap + defaultAxisLabelGap,
                     show: showYAxis,
+                    axisLabelStyle: getAxisLabelStyle(theme),
                 }),
                 splitLine: {
                     show: isAxisTheSameForAllSeries,
@@ -1633,6 +1638,7 @@ const getStackTotalSeries = (
     itemsMap: ItemsMap,
     flipAxis: boolean | undefined,
     selectedLegendNames: LegendValues,
+    theme: MantineTheme,
 ) => {
     const seriesGroupedByStack = groupBy(seriesWithStack, 'stack');
     return Object.entries(seriesGroupedByStack).reduce<EChartSeries[]>(
@@ -1645,6 +1651,7 @@ const getStackTotalSeries = (
                 connectNulls: true,
                 stack: stack,
                 label: {
+                    ...getBarTotalLabelStyle(theme),
                     show: series[0].stackLabel?.show,
                     formatter: (param) => {
                         const stackTotal = param.data[2];
@@ -1658,7 +1665,6 @@ const getStackTotalSeries = (
                         }
                         return '';
                     },
-                    fontWeight: 'bold',
                     position: flipAxis ? 'right' : 'top',
                 },
                 labelLayout: {
@@ -1799,6 +1805,7 @@ const useEchartsCartesianConfig = (
             validCartesianConfig,
             resultsData,
             minsAndMaxes: resultsAndMinsAndMaxes.minsAndMaxes,
+            theme,
         });
     }, [
         itemsMap,
@@ -1806,6 +1813,7 @@ const useEchartsCartesianConfig = (
         series,
         resultsData,
         resultsAndMinsAndMaxes.minsAndMaxes,
+        theme,
     ]);
 
     const stackedSeriesWithColorAssignments = useMemo(() => {
@@ -1924,6 +1932,7 @@ const useEchartsCartesianConfig = (
                 itemsMap,
                 validCartesianConfig?.layout.flipAxes,
                 validCartesianConfigLegend,
+                theme,
             ),
         ];
     }, [
@@ -1934,6 +1943,7 @@ const useEchartsCartesianConfig = (
         rows,
         validCartesianConfigLegend,
         getSeriesColor,
+        theme,
     ]);
     const sortedResults = useMemo(() => {
         const results =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #17643

### Description:

Enhances chart visualization styling by adding consistent typography and color schemes for axis labels, titles, and bar value labels. This PR:

- Adds support for custom axis label styling in the `getCartesianAxisFormatterConfig` function
- Creates new utility functions for consistent styling:
  - `getAxisLabelStyle` - For axis tick labels (gray.6, 500 weight, 11px)
  - `getAxisTitleStyle` - For axis titles (gray.7, 500 weight, 12px)
  - `getBarTotalLabelStyle` - For stacked bar totals (gray.9, 500 weight, 11px)
  - `getBarValueLabelStyle` - For values inside bars (adaptive color based on background)
- Applies these styles consistently throughout the chart components
- Ensures proper theming integration with Mantine

before

![before-axes-changes.png](https://app.graphite.dev/user-attachments/assets/001cb582-4ac5-4bf0-9940-ecf0755ed184.png)

after

![screencapture-localhost-3000-projects-3675b69e-8324-4110-bdca-059031aa8da3-dashboards-d8b21988-efb4-4d0b-94a6-a5213c9f2efb-view-2025-10-28-09_55_05.png](https://app.graphite.dev/user-attachments/assets/6168d11b-79b7-470b-9e09-d0551247cf27.png)

