### PR TITLE
fix: don't wrap sql in parentheses for attribute replacement in sql runner queries

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2773,6 +2773,7 @@ export class AsyncQueryService extends ProjectService {
             intrinsicUserAttributes,
             userAttributes,
             warehouseConnection.warehouseClient,
+            { noWrap: true },
         );
 
         // Then replace parameters in SQL before running column discovery query

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -272,29 +272,24 @@ export const replaceUserAttributes = (
 export const replaceUserAttributesAsStrings = (
     sql: string,
     intrinsicUserAttributes: IntrinsicUserAttributes,
-    userAtttributes: UserAttributeValueMap,
+    userAttributes: UserAttributeValueMap,
     warehouseSqlBuilder: WarehouseSqlBuilder,
+    opts?: { noWrap?: boolean },
 ) =>
     replaceUserAttributes(
         sql,
         intrinsicUserAttributes,
-        userAtttributes,
+        userAttributes,
         warehouseSqlBuilder.getStringQuoteChar(),
-        '(',
+        opts?.noWrap ? '' : '(',
     );
 
 export const replaceUserAttributesRaw = (
     sql: string,
     intrinsicUserAttributes: IntrinsicUserAttributes,
-    userAtttributes: UserAttributeValueMap,
+    userAttributes: UserAttributeValueMap,
 ) =>
-    replaceUserAttributes(
-        sql,
-        intrinsicUserAttributes,
-        userAtttributes,
-        '',
-        '',
-    );
+    replaceUserAttributes(sql, intrinsicUserAttributes, userAttributes, '', '');
 
 export const assertValidDimensionRequiredAttribute = (
     dimension: CompiledDimension,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17362
Relates to: #16903

### Description:
Added a `noWrap` option to `replaceUserAttributesAsStrings` to prevent wrapping the sql in parentheses when replacing user attributes. This option is now used in the `AsyncQueryService` when replacing parameters in SQL for sql runner queries.

**Note:** Keeps backwards compatibility by defaulting to wrapping sql

**Steps to test**
1. Use trino warehouse
2. Go to the sql runner and use the following sql
```sql
with table_1 as (
SELECT
  ${ld.user.email} as email_value
)
select * from table_1
```

**Before**

```sql
(with table_1 as ('SELECT 'demo@lightdash.com' as email_value"') select * from table_1)
```

![image.png](https://app.graphite.dev/user-attachments/assets/00fdfbf5-ee54-462e-a76c-2e3eacb418bf.png)

**After**

```sql
with table_1 as ('SELECT 'demo@lightdash.com' as email_value"') select * from table_1
```

![image.png](https://app.graphite.dev/user-attachments/assets/a6dc6c8f-0cff-4a31-a39c-5b33656a1eaf.png)

