### PR TITLE
feat: update tooltips for cartesian & pie

### DIFF
--- a/packages/frontend/src/hooks/echarts/echartsStyleUtils.ts
+++ b/packages/frontend/src/hooks/echarts/echartsStyleUtils.ts
@@ -203,3 +203,57 @@ export const getAxisTickStyle = (theme: MantineTheme) => ({
         type: 'solid' as const,
     },
 });
+
+/**
+ * Get base tooltip styling
+ * Padding: 8px, Border: gray.3, Border radius: 8px
+ */
+export const getTooltipStyle = (theme: MantineTheme) => ({
+    padding: 8,
+    borderColor: theme.colors.gray[3],
+    borderWidth: 1,
+    borderRadius: 8,
+    backgroundColor: '#FFFFFF',
+    textStyle: {
+        color: theme.colors.gray[7],
+    },
+});
+
+/**
+ * Format a tooltip value with pill styling
+ * Background: gray.0, Border: gray.1, Text: gray.7
+ * Padding: 2px 6px, Border radius: 6px
+ */
+export const formatTooltipValue = (
+    value: string,
+    theme: MantineTheme,
+): string => {
+    return `<span style="display: inline-block; background-color: ${theme.colors.gray[0]}; border: 1px solid ${theme.colors.gray[1]}; color: ${theme.colors.gray[7]}; padding: 2px 6px; border-radius: 6px; font-weight: 500;">${value}</span>`;
+};
+
+/**
+ * Format tooltip header with proper styling and margin
+ * Color: gray.7, margin-bottom: 4px
+ */
+export const formatTooltipHeader = (
+    header: string,
+    theme: MantineTheme,
+): string => {
+    return `<div style="color: ${theme.colors.gray[7]}; font-weight: 500; margin-bottom: 4px;">${header}</div>`;
+};
+
+/**
+ * Get tooltip divider
+ * Color: gray.1, margin-bottom: 4px
+ */
+export const getTooltipDivider = (theme: MantineTheme): string => {
+    return `<div style="height: 1px; background-color: ${theme.colors.gray[1]}; margin-bottom: 4px;"></div>`;
+};
+
+/**
+ * Format a color indicator (square) for tooltip
+ * Size: 10px × 10px, Border radius: 2px
+ */
+export const formatColorIndicator = (color: string): string => {
+    return `<span style="display: inline-block; width: 10px; height: 10px; background-color: ${color}; border-radius: 2px; margin-right: 6px; vertical-align: middle;"></span>`;
+};

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -11,11 +11,14 @@ import { useMemo } from 'react';
 import { isPieVisualizationConfig } from '../../components/LightdashVisualization/types';
 import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
 import {
+    formatColorIndicator,
+    formatTooltipValue,
     getLegendStyle,
     getPieExternalLabelStyle,
     getPieInternalLabelStyle,
     getPieLabelLineStyle,
     getPieSliceStyle,
+    getTooltipStyle,
     isColorDark,
 } from './echartsStyleUtils';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
@@ -170,7 +173,8 @@ const useEchartsPieConfig = (
             ...getPieSliceStyle(!!isDonut),
             tooltip: {
                 trigger: 'item',
-                formatter: ({ marker, name, value, percent }) => {
+                formatter: (params) => {
+                    const { color, name, value, percent } = params;
                     const formattedValue = formatItemValue(
                         selectedMetric,
                         value,
@@ -184,11 +188,22 @@ const useEchartsPieConfig = (
                               )}...`
                             : name;
 
-                    return `${marker} <b>${truncatedName}</b><br />${percent}% - ${formattedValue}`;
+                    // Build tooltip with proper spacing
+                    const colorIndicator = formatColorIndicator(
+                        color as string,
+                    );
+                    const label = `<span style="color: ${theme.colors.gray[7]};">${truncatedName}</span>`;
+                    const valueWithPercent = `${percent}% - ${formattedValue}`;
+                    const valuePill = formatTooltipValue(
+                        valueWithPercent,
+                        theme,
+                    );
+
+                    return `<div style="display: flex; align-items: center; gap: 2px;">${colorIndicator}${label}</div><div style="margin-top: 2px; margin-left: 16px;">${valuePill}</div>`;
                 },
             },
         };
-    }, [chartConfig, seriesData]);
+    }, [chartConfig, seriesData, theme]);
 
     const { tooltip: legendDoubleClickTooltip } = useLegendDoubleClickTooltip();
 
@@ -235,6 +250,7 @@ const useEchartsPieConfig = (
             },
             tooltip: {
                 trigger: 'item',
+                ...getTooltipStyle(theme),
             },
             series: [pieSeriesOption],
             animation: !(isInDashboard || minimal),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #17643

### Description:
Enhances chart tooltips with improved styling and formatting for better readability. This PR:

- Adds new tooltip styling utilities in `echartsStyleUtils.ts` including:
  - Base tooltip styling with consistent padding and borders
  - Pill-style value formatting
  - Header formatting with proper margins
  - Divider styling
  - Color indicator squares for series

- Implements the new tooltip styles in both cartesian charts and pie charts
  - Cartesian charts now display values in pill containers with better alignment
  - Pie charts show cleaner tooltips with color indicators and properly formatted values
  - Adds proper spacing and visual hierarchy to all tooltips

[CleanShot 2025-10-28 at 10.49.22.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/5905fb75-3932-4b25-b7ca-1954588b9737.mp4" />](https://app.graphite.dev/user-attachments/video/5905fb75-3932-4b25-b7ca-1954588b9737.mp4)

