### PR TITLE
style: reasoning component

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiReasoning.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiReasoning.tsx
@@ -7,7 +7,7 @@ import {
     rehypeRemoveHeaderLinks,
     useMdEditorStyle,
 } from '../../../../../../utils/markdownUtils';
-import { ToolCallPaper } from './ToolCallPaper';
+import { ToolCallContainer } from './ToolCallContainer';
 
 type StreamingReasoning = {
     reasoningId: string;
@@ -47,11 +47,12 @@ export const AiReasoning: FC<AiReasoningProps> = ({
         .join('\n\n---\n\n');
 
     return (
-        <ToolCallPaper
-            defaultOpened={false}
-            variant="dashed"
-            icon={IconBrain}
+        <ToolCallContainer
+            defaultOpened={type !== 'persisted'}
             title="Reasoning"
+            isStreaming={type === 'streaming'}
+            enableIconAnimation={false}
+            icon={IconBrain}
         >
             <MDEditor.Markdown
                 rehypeRewrite={rehypeRemoveHeaderLinks}
@@ -59,11 +60,11 @@ export const AiReasoning: FC<AiReasoningProps> = ({
                 style={{
                     ...mdStyle,
                     padding: '0.5rem 0',
-                    fontSize: '0.875rem',
+                    fontSize: 'var(--mantine-font-size-xs)',
                     color: 'var(--mantine-color-gray-7)',
                 }}
                 components={mdEditorComponents}
             />
-        </ToolCallPaper>
+        </ToolCallContainer>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallContainer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallContainer.tsx
@@ -9,6 +9,7 @@ type ToolCallContainerProps = {
     defaultOpened?: boolean;
     title: string;
     isStreaming?: boolean;
+    enableIconAnimation?: boolean;
     icon?: (props: TablerIconsProps) => JSX.Element;
 };
 
@@ -17,6 +18,7 @@ export const ToolCallContainer: FC<ToolCallContainerProps> = ({
     defaultOpened = true,
     title,
     isStreaming = false,
+    enableIconAnimation = true,
     icon = IconSparkles,
 }) => {
     return (
@@ -24,7 +26,11 @@ export const ToolCallContainer: FC<ToolCallContainerProps> = ({
             defaultOpened={defaultOpened}
             variant="dashed"
             icon={icon}
-            iconClassName={isStreaming ? classes.streamingIcon : undefined}
+            iconClassName={
+                isStreaming && enableIconAnimation
+                    ? classes.streamingIcon
+                    : undefined
+            }
             title={
                 isStreaming ? (
                     <Box component="span" className={classes.streamingTitle}>


### PR DESCRIPTION
Updated the AI reasoning component to use the more flexible `ToolCallContainer` instead of `ToolCallPaper`.