### PR TITLE
chore: big number sizing poc

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/POC_FONT_SIZE_TESTING.md
+++ b/packages/frontend/src/components/SimpleStatistic/POC_FONT_SIZE_TESTING.md
@@ -1,0 +1,120 @@
+# Big Number Font Size POC
+
+## Problem Statement
+The big number value feels too small by default, with lots of whitespace around it. It doesn't feel impactful on some dashboards, especially in larger tiles.
+
+## Issues Fixed
+1. **Title Overlap**: The tile header was cutting into the big number content. Fixed by calculating available height properly (subtracting tile header height before font size calculation).
+2. **Removed Bottom Padding**: No longer need `pb={TILE_HEADER_HEIGHT}` since we account for header in size calculation.
+
+## Current Implementation
+- **Value Font Size**: 24px (min) → 64px (max)
+- **Label Font Size**: 14px (min) → 32px (max)
+- **Comparison Font Size**: 12px (min) → 22px (max)
+
+## Proposed Changes (POC)
+- **Value Font Size**: 24px (min) → **96px (max)** (+50% increase)
+- **Label Font Size**: 14px (min) → **40px (max)** (+25% increase)
+- **Comparison Font Size**: 12px (min) → 22px (max) (unchanged)
+
+## Testing Instructions
+
+### 1. Enable POC
+The POC is already enabled in the code. Check the console logs for debugging information.
+
+### 2. Test Different Tile Sizes
+Test the following tile configurations on a dashboard:
+
+#### Small Tiles (1x1 or 2x1)
+- **Expected behavior**: Font size should stay at minimum (24px for value)
+- **Goal**: Ensure small tiles don't get oversized text
+
+#### Medium Tiles (2x2 or 3x2)
+- **Expected behavior**: Font size should scale proportionally
+- **Goal**: Verify readability and "big number" impact
+
+#### Large Tiles (4x3 or larger)
+- **Expected behavior**: Font size should reach near maximum (96px for value)
+- **Goal**: Maximize visual impact without overwhelming the design
+
+### 3. Check Console Logs
+Open browser DevTools and check console for logs like:
+```
+[BigNumber POC] Tile size: {
+  width: 500,
+  height: 300,
+  boundWidth: 500,
+  boundHeight: 300,
+  valueFontSize: 64,
+  labelFontSize: 28
+}
+```
+
+### 4. Visual Checklist
+For each tile size, verify:
+- [ ] Value is prominent and impactful
+- [ ] Label is readable but secondary to value
+- [ ] Comparison value doesn't overpower the main value
+- [ ] Text doesn't overflow or clip
+- [ ] Whitespace feels balanced (not too cramped or too sparse)
+- [ ] Transition between sizes is smooth when resizing
+
+### 5. Edge Cases to Test
+- [ ] Very long numbers (e.g., "1,234,567,890")
+- [ ] Numbers with decimals (e.g., "12.34%")
+- [ ] Short numbers (e.g., "5")
+- [ ] With and without labels
+- [ ] With and without comparison values
+- [ ] Different comparison value types (positive/negative/neutral)
+
+## Sizing Formula
+The component uses linear scaling based on tile dimensions:
+
+```
+scalingFactor = min(widthScale, heightScale)
+fontSize = fontSizeMin + (fontSizeMax - fontSizeMin) × scalingFactor
+```
+
+Where:
+- `widthScale = (tileWidth - 150) / (1000 - 150)`
+- `heightScale = (tileHeight - 25) / (1000 - 25)`
+
+## Alternative Options to Test
+
+If 96px feels too large, try these alternatives:
+
+### Option 1: Moderate Increase (80px)
+```typescript
+const VALUE_SIZE_MAX = 80; // +25% from original 64px
+const LABEL_SIZE_MAX = 36;  // +12.5% from original 32px
+```
+
+### Option 2: Conservative Increase (72px)
+```typescript
+const VALUE_SIZE_MAX = 72; // +12.5% from original 64px
+const LABEL_SIZE_MAX = 34;  // +6.25% from original 32px
+```
+
+### Option 3: Aggressive Increase (112px)
+```typescript
+const VALUE_SIZE_MAX = 112; // +75% from original 64px
+const LABEL_SIZE_MAX = 44;   // +37.5% from original 32px
+```
+
+## Decision Criteria
+
+Choose the max font size that:
+1. ✅ Makes large tiles feel more impactful
+2. ✅ Maintains readability across all tile sizes
+3. ✅ Doesn't cause text overflow or clipping
+4. ✅ Preserves visual hierarchy (value > label > comparison)
+5. ✅ Feels balanced with the Mantine design system
+
+## Cleanup After Testing
+
+Once you've chosen the final values, remove:
+1. The POC comments in the constants section
+2. The console.log debugging statement
+3. This POC_FONT_SIZE_TESTING.md file
+
+Update the constants to the chosen values and commit.

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -40,11 +40,16 @@ const BOX_MAX_WIDTH = 1000;
 const BOX_MIN_HEIGHT = 25;
 const BOX_MAX_HEIGHT = 1000;
 
+// POC: Testing increased font sizes for more impact
+// Original: VALUE_SIZE_MIN = 24, VALUE_SIZE_MAX = 64
+// Testing larger max to make big numbers more prominent
 const VALUE_SIZE_MIN = 24;
-const VALUE_SIZE_MAX = 64;
+const VALUE_SIZE_MAX = 96; // Increased from 64 to 96 for POC
 
+// Original: LABEL_SIZE_MIN = 14, LABEL_SIZE_MAX = 32
+// Proportionally increased to maintain hierarchy
 const LABEL_SIZE_MIN = 14;
-const LABEL_SIZE_MAX = 32;
+const LABEL_SIZE_MAX = 40; // Increased from 32 to 40 for POC
 
 const COMPARISON_VALUE_SIZE_MIN = 12;
 const COMPARISON_VALUE_SIZE_MAX = 22;
@@ -137,8 +142,14 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             BOX_MAX_WIDTH,
         );
 
+        // Smarter height calculation: subtract tile header height when not hidden
+        // This ensures font size calculation uses actual available content area
+        const availableHeight =
+            (observerElementSize?.height || 0) -
+            (isDashboard && !isTitleHidden ? TILE_HEADER_HEIGHT : 0);
+
         const boundHeight = clamp(
-            observerElementSize?.height || 0,
+            availableHeight,
             BOX_MIN_HEIGHT,
             BOX_MAX_HEIGHT,
         );
@@ -164,12 +175,24 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             boundHeight,
         );
 
+        // POC: Debug logging to test different tile sizes
+        // eslint-disable-next-line no-console
+        console.log('[BigNumber POC] Tile size:', {
+            width: observerElementSize?.width,
+            height: observerElementSize?.height,
+            availableHeight,
+            boundWidth,
+            boundHeight,
+            valueFontSize: valueSize,
+            labelFontSize: labelSize,
+        });
+
         return {
             valueFontSize: valueSize,
             labelFontSize: labelSize,
             comparisonFontSize: comparisonValueSize,
         };
-    }, [observerElementSize]);
+    }, [observerElementSize, isDashboard, isTitleHidden]);
 
     if (!isBigNumber) return null;
 
@@ -202,7 +225,6 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             justify="center"
             align="center"
             gap={0}
-            pb={isDashboard && isTitleHidden ? 0 : TILE_HEADER_HEIGHT}
             ref={(elem) => {
                 setRef(elem);
             }}
@@ -226,7 +248,12 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             </Flex>
 
             {showBigNumberLabel ? (
-                <Flex style={{ flexShrink: 1 }} justify="center" align="center">
+                <Flex
+                    style={{ flexShrink: 1 }}
+                    justify="center"
+                    align="center"
+                    mt={valueFontSize * 0.1}
+                >
                     <BigNumberText fz={labelFontSize} c="gray.6" fw={400}>
                         {bigNumberLabel || defaultLabel}
                     </BigNumberText>
@@ -240,7 +267,8 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                     display="inline-flex"
                     wrap="wrap"
                     style={{ flexShrink: 1 }}
-                    mt={labelFontSize / 2}
+                    mt={showBigNumberLabel ? labelFontSize * 0.5 : valueFontSize * 0.1}
+                    gap="xs"
                 >
                     <Tooltip withinPortal label={comparisonTooltip}>
                         <Group
@@ -277,7 +305,6 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                             fz={comparisonFontSize}
                             c="gray.6"
                             fw={400}
-                            ml="xs"
                         >
                             {comparisonLabel}
                         </BigNumberText>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #17644

### Description:
Increases the maximum font size for big number statistics to make them more impactful in dashboard tiles, especially in larger layouts.

- Increased value font size max from 64px to 96px (+50%)
- Increased label font size max from 32px to 40px (+25%)
- Fixed title overlap issue by properly accounting for tile header height
- Removed redundant bottom padding since header height is now calculated correctly
- Added small margin adjustments between elements for better spacing
- Improved gap handling in comparison section

This change makes large statistics more visually prominent while maintaining readability across all tile sizes.