### PR TITLE
chore: use constant empty objects for default metric overrides and parameters

### DIFF
--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -9,13 +9,15 @@ import {
     type AdditionalMetric,
     type CustomDimension,
     type Explore,
+    type MetricOverrides,
+    type ParametersValuesMap,
 } from '@lightdash/common';
 import { createSelector } from '@reduxjs/toolkit';
 import type { ExplorerStoreState } from '.';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 
-const EMPTY_METRIC_OVERRIDES = {};
-const EMPTY_PARAMETERS = {};
+const EMPTY_METRIC_OVERRIDES: MetricOverrides = {};
+const EMPTY_PARAMETERS: ParametersValuesMap = {};
 
 // Base selectors
 const selectExplorerState = (state: ExplorerStoreState) => state.explorer;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Introduced constant values `EMPTY_METRIC_OVERRIDES` and `EMPTY_PARAMETERS` to replace inline empty objects in the explorer selectors. This prevents unnecessary object creation and improves performance by reusing the same empty object references.