### PR TITLE
fix: make the CSV export respect Show Table Names option

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1346,14 +1346,17 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                     }}
                 />
             )}
-
             <ExportDataModal
                 isOpen={isDataExportModalOpen}
                 onClose={closeDataExportModal}
                 projectUuid={projectUuid!}
                 totalResults={totalResults}
                 getDownloadQueryUuid={getDownloadQueryUuid}
-                showTableNames
+                showTableNames={
+                    isTableChartConfig(chart.chartConfig.config)
+                        ? chart.chartConfig.config.showTableNames ?? false
+                        : true
+                }
                 chartName={title || chart.name}
                 columnOrder={chart.tableConfig.columnOrder}
                 customLabels={getCustomLabelsFromTableConfig(
@@ -1621,7 +1624,11 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     projectUuid={projectUuid!}
                     totalResults={resultsData.totalResults}
                     getDownloadQueryUuid={getDownloadQueryUuid}
-                    showTableNames
+                    showTableNames={
+                        isTableChartConfig(chart.chartConfig.config)
+                            ? chart.chartConfig.config.showTableNames ?? false
+                            : true
+                    }
                     chartName={title || chart.name}
                     columnOrder={chart.tableConfig.columnOrder}
                     customLabels={getCustomLabelsFromTableConfig(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17570 

### Description:
The `showTableNames` flag that was getting passed to `ExportDataModel` component, was going always `true`. Changed to take the boolean value from chart configuration. 

<!-- Even better add a screenshot / gif / loom -->

https://github.com/user-attachments/assets/cd4ea197-6922-4300-853e-1a14b8dedb86
