### PR TITLE
fix: adjust modal body height and improve space selector scrolling

### DIFF
--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -91,10 +91,10 @@ const MantineModal: React.FC<MantineModalProps> = ({
 
                 <Modal.Body
                     p={0}
-                    sx={() => ({
+                    sx={{
                         overflow: 'auto',
-                        maxHeight: 'calc(80vh - 130px)',
-                    })}
+                        maxHeight: 'calc(80vh - 80px)',
+                    }}
                     {...modalBodyProps}
                 >
                     <Stack

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -4,7 +4,7 @@ import {
     type ResourceViewItemType,
     type SpaceSummary,
 } from '@lightdash/common';
-import { Paper, ScrollArea, Stack, TextInput } from '@mantine/core';
+import { Paper, Stack, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { useMemo, useState } from 'react';
 import { hasDirectAccessToSpace } from '../../../hooks/useSpaces';
@@ -76,7 +76,7 @@ const SpaceSelector = ({
     );
 
     return (
-        <Stack h="600px">
+        <Stack>
             {userCanManageProject ? (
                 <AdminContentViewFilter
                     value={selectedAdminContentType}
@@ -96,12 +96,7 @@ const SpaceSelector = ({
                 placeholder="Search spaces"
             />
 
-            <Paper
-                component={ScrollArea}
-                w="100%"
-                sx={{ flexGrow: 1 }}
-                withBorder
-            >
+            <Paper w="100%" h={400} style={{ overflow: 'auto' }} withBorder>
                 <Tree
                     withRootSelectable={isRootSelectionEnabled}
                     data={fuzzyFilteredSpaces ?? filteredSpaces}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17688  
  
Description:

This PR improves the UI of modals and space selector components:

1. Fixed the modal body styling by:
    - Converting the dynamic style function to a static object
    - Adjusting the maxHeight from `calc(80vh - 130px)` to `calc(80vh - 80px)` for better content display
2. Enhanced the SpaceSelector component by:
    - Removing the ScrollArea component dependency
    - Replacing it with a Paper component that has a fixed height of 400px and overflow set to auto
    - Removing the fixed height (600px) from the parent Stack component for more flexible layout

These changes improve the user experience by providing better scrolling behavior and more appropriate spacing in the UI.