### PR TITLE
chore: refactor eval report creation

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/tests/utils/testReportWrapper.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/testReportWrapper.ts
@@ -1,0 +1,148 @@
+import { TestContext } from 'vitest';
+import { DbAiAgentToolCall } from '../../../../../database/entities/ai';
+import { LlmJudgeResult } from './llmAsAJudge';
+import { ToolJudgeResult } from './llmAsJudgeForTools';
+import { setTaskMeta } from './taskMeta';
+
+interface TestReportData {
+    prompts?: string[];
+    responses?: string[];
+    toolCalls?: string[];
+    llmJudgeResults?: Array<LlmJudgeResult & { passed: boolean }>;
+    llmToolJudgeResults?: ToolJudgeResult[];
+}
+
+/**
+ * Wrapper that automatically tracks test metadata for report generation.
+ * Use this to wrap test assertions and automatically collect metadata.
+ *
+ * @example
+ * await withTestReport(task, {
+ *   prompts: [promptQueryText],
+ *   responses: [response],
+ *   toolCalls: toolCalls.map(tc => tc.tool_name),
+ *   llmJudgeResults: [{ ...factualityMeta, passed: isFactualityPassing }],
+ * }, async () => {
+ *   // Your test assertions here
+ *   expect(isFactualityPassing).toBe(true);
+ * });
+ */
+export async function withTestReport<T>(
+    { task }: TestContext,
+    reportData: TestReportData,
+    testFn: () => T | Promise<T>,
+): Promise<T> {
+    try {
+        return await testFn();
+    } finally {
+        // Always set metadata, even if test fails
+        if (reportData.prompts) {
+            setTaskMeta(task.meta, 'prompts', reportData.prompts);
+        }
+        if (reportData.responses) {
+            setTaskMeta(task.meta, 'responses', reportData.responses);
+        }
+        if (reportData.toolCalls) {
+            setTaskMeta(task.meta, 'toolCalls', reportData.toolCalls);
+        }
+        if (reportData.llmJudgeResults) {
+            setTaskMeta(
+                task.meta,
+                'llmJudgeResults',
+                reportData.llmJudgeResults,
+            );
+        }
+        if (reportData.llmToolJudgeResults) {
+            setTaskMeta(
+                task.meta,
+                'llmToolJudgeResults',
+                reportData.llmToolJudgeResults,
+            );
+        }
+    }
+}
+
+/**
+ * Helper to build report data incrementally during a test.
+ *
+ * @example
+ * const report = createTestReport({
+ *   prompt: promptQueryText,
+ *   response,
+ *   toolCalls,
+ * });
+ * report.addLlmJudgeResult({ ...factualityMeta, passed: isFactualityPassing });
+ *
+ * await report.finalize(test, () => {
+ *   expect(isFactualityPassing).toBe(true);
+ * });
+ */
+export class TestReportBuilder {
+    private data: TestReportData = {};
+
+    constructor(config?: {
+        prompt?: string;
+        prompts?: string[];
+        response?: string;
+        responses?: string[];
+        toolCalls?: string[] | DbAiAgentToolCall[];
+    }) {
+        if (config?.prompt) {
+            this.data.prompts = [config.prompt];
+        } else if (config?.prompts) {
+            this.data.prompts = config.prompts;
+        }
+
+        if (config?.response) {
+            this.data.responses = [config.response];
+        } else if (config?.responses) {
+            this.data.responses = config.responses;
+        }
+
+        if (config?.toolCalls) {
+            const toolNames = Array.isArray(config.toolCalls)
+                ? config.toolCalls.map((tc) =>
+                      typeof tc === 'string' ? tc : tc.tool_name,
+                  )
+                : [];
+            this.data.toolCalls = toolNames;
+        }
+    }
+
+    addLlmJudgeResult(result: LlmJudgeResult & { passed: boolean }): this {
+        if (!this.data.llmJudgeResults) {
+            this.data.llmJudgeResults = [];
+        }
+        this.data.llmJudgeResults.push(result);
+        return this;
+    }
+
+    addLlmToolJudgeResult(result: ToolJudgeResult): this {
+        if (!this.data.llmToolJudgeResults) {
+            this.data.llmToolJudgeResults = [];
+        }
+        this.data.llmToolJudgeResults.push(result);
+        return this;
+    }
+
+    async finalize<T>(
+        test: TestContext,
+        testFn: () => T | Promise<T>,
+    ): Promise<T> {
+        return withTestReport(test, this.data, testFn);
+    }
+
+    getData(): TestReportData {
+        return { ...this.data };
+    }
+}
+
+export function createTestReport(config?: {
+    prompt?: string;
+    prompts?: string[];
+    response?: string;
+    responses?: string[];
+    toolCalls?: string[] | DbAiAgentToolCall[];
+}): TestReportBuilder {
+    return new TestReportBuilder(config);
+}


### PR DESCRIPTION
### Description:
Refactored agent integration tests to use a new TestReportBuilder pattern for collecting and reporting test metadata. This replaces the direct use of `setTaskMeta` with a more structured approach that:

1. Introduces a `TestReportBuilder` class that collects test data incrementally
2. Provides a fluent API for adding prompts, responses, tool calls, and LLM judge results
3. Simplifies test code by encapsulating metadata collection logic
4. Standardizes how test reports are generated across all agent tests

The new pattern makes tests more readable by separating test logic from reporting concerns and ensures consistent metadata collection even when tests fail.