### PR TITLE
chore: return empty columns when no active fields are selected

### DIFF
--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -159,7 +159,6 @@ export const getValueCell = (info: CellContext<RawResultRow, string>) => {
 };
 
 export const useColumns = (): TableColumn[] => {
-    // Use Redux for state that's available
     const tableName = useExplorerSelector(selectTableName);
     const tableCalculations = useExplorerSelector(selectTableCalculations);
     const customDimensions = useExplorerSelector(selectCustomDimensions);
@@ -167,12 +166,10 @@ export const useColumns = (): TableColumn[] => {
     const sorts = useExplorerSelector(selectSorts);
     const metricOverrides = useExplorerSelector(selectMetricOverrides);
 
-    // Get state from new query hook
     const { activeFields, query } = useExplorerQuery();
     const resultsMetricQuery = query.data?.metricQuery;
     const resultsFields = query.data?.fields;
 
-    // Get parameters from Redux
     const parameters = useExplorerSelector(selectParameters);
 
     const { data: exploreData } = useExplore(tableName, {
@@ -181,8 +178,10 @@ export const useColumns = (): TableColumn[] => {
 
     const { embedToken } = useEmbed();
 
+    const hasNoActiveFields = activeFields.size === 0;
+
     const itemsMap = useMemo<ItemsMap | undefined>(() => {
-        if (!exploreData) return;
+        if (!exploreData || hasNoActiveFields) return;
 
         const baseItemsMap = getItemMap(
             exploreData,
@@ -218,6 +217,7 @@ export const useColumns = (): TableColumn[] => {
             }),
         );
     }, [
+        hasNoActiveFields,
         resultsFields,
         exploreData,
         additionalMetrics,
@@ -271,6 +271,10 @@ export const useColumns = (): TableColumn[] => {
     });
 
     return useMemo(() => {
+        if (hasNoActiveFields) {
+            return [];
+        }
+
         const validColumns = Object.entries(activeItemsMap).reduce<
             TableColumn[]
         >((acc, [fieldId, item]) => {
@@ -395,5 +399,12 @@ export const useColumns = (): TableColumn[] => {
             [],
         );
         return [...validColumns, ...invalidColumns];
-    }, [activeItemsMap, invalidActiveItems, sorts, totals, exploreData]);
+    }, [
+        hasNoActiveFields,
+        activeItemsMap,
+        invalidActiveItems,
+        sorts,
+        totals,
+        exploreData,
+    ]);
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR fixes an issue where the table would attempt to render columns even when no fields are selected. Now, when there are no active fields, the `useColumns` hook returns an empty array and prevents unnecessary processing of the `itemsMap`.

The changes:
1. Added a `hasNoActiveFields` flag to track when no fields are selected
2. Added an early return in the columns generation when no fields are active
3. Added a condition to skip itemsMap creation when there are no active fields
4. Removed unnecessary comments in the code