### PR TITLE
chore: display agent info in evals report

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -624,6 +624,77 @@ const parseAndSanitizeSchedulerTasks = (): Array<SchedulerTaskName> => {
     return ALL_TASK_NAMES;
 };
 
+export const getAiConfig = () => ({
+    enabled: process.env.AI_COPILOT_ENABLED === 'true',
+    debugLoggingEnabled:
+        process.env.AI_COPILOT_DEBUG_LOGGING_ENABLED === 'true',
+    telemetryEnabled: process.env.AI_COPILOT_TELEMETRY_ENABLED === 'true',
+    requiresFeatureFlag:
+        process.env.AI_COPILOT_REQUIRES_FEATURE_FLAG === 'true',
+    askAiButtonEnabled: process.env.ASK_AI_BUTTON_ENABLED === 'true',
+    defaultProvider:
+        process.env.AI_DEFAULT_PROVIDER || DEFAULT_DEFAULT_AI_PROVIDER,
+    providers: {
+        azure: process.env.AZURE_AI_API_KEY
+            ? {
+                  endpoint: process.env.AZURE_AI_ENDPOINT,
+                  apiKey: process.env.AZURE_AI_API_KEY,
+                  apiVersion: process.env.AZURE_AI_API_VERSION,
+                  deploymentName: process.env.AZURE_AI_DEPLOYMENT_NAME,
+                  temperature: getFloatFromEnvironmentVariable(
+                      'AZURE_AI_TEMPERATURE',
+                  ),
+              }
+            : undefined,
+        openai: process.env.OPENAI_API_KEY
+            ? {
+                  apiKey: process.env.OPENAI_API_KEY,
+                  modelName:
+                      process.env.OPENAI_MODEL_NAME ||
+                      DEFAULT_OPENAI_MODEL_NAME,
+                  baseUrl: process.env.OPENAI_BASE_URL,
+                  temperature:
+                      getFloatFromEnvironmentVariable('OPENAI_TEMPERATURE'),
+                  responsesApi: process.env.OPENAI_RESPONSES_API === 'true',
+                  reasoning: {
+                      enabled: process.env.OPENAI_REASONING_ENABLED === 'true',
+                      reasoningSummary: process.env.OPENAI_REASONING_SUMMARY,
+                      reasoningEffort: process.env.OPENAI_REASONING_EFFORT,
+                  },
+              }
+            : undefined,
+        anthropic: process.env.ANTHROPIC_API_KEY
+            ? {
+                  apiKey: process.env.ANTHROPIC_API_KEY,
+                  modelName:
+                      process.env.ANTHROPIC_MODEL_NAME ||
+                      DEFAULT_ANTHROPIC_MODEL_NAME,
+                  temperature: getFloatFromEnvironmentVariable(
+                      'ANTHROPIC_TEMPERATURE',
+                  ),
+              }
+            : undefined,
+        openrouter: process.env.OPENROUTER_API_KEY
+            ? {
+                  apiKey: process.env.OPENROUTER_API_KEY,
+                  modelName:
+                      process.env.OPENROUTER_MODEL_NAME ||
+                      DEFAULT_OPENROUTER_MODEL_NAME,
+                  sortOrder: process.env.OPENROUTER_SORT_ORDER,
+                  allowedProviders: getArrayFromCommaSeparatedList(
+                      'OPENROUTER_ALLOWED_PROVIDERS',
+                  ),
+                  temperature: getFloatFromEnvironmentVariable(
+                      'OPENROUTER_TEMPERATURE',
+                  ),
+              }
+            : undefined,
+    },
+    maxQueryLimit:
+        getIntegerFromEnvironmentVariable('AI_COPILOT_MAX_QUERY_LIMIT') ||
+        AI_DEFAULT_MAX_QUERY_LIMIT,
+});
+
 export type LoggingConfig = {
     level: LoggingLevel;
     format: LoggingFormat;
@@ -1078,79 +1149,7 @@ export const parseConfig = (): LightdashConfig => {
         );
     }
 
-    const rawCopilotConfig = {
-        enabled: process.env.AI_COPILOT_ENABLED === 'true',
-        debugLoggingEnabled:
-            process.env.AI_COPILOT_DEBUG_LOGGING_ENABLED === 'true',
-        telemetryEnabled: process.env.AI_COPILOT_TELEMETRY_ENABLED === 'true',
-        requiresFeatureFlag:
-            process.env.AI_COPILOT_REQUIRES_FEATURE_FLAG === 'true',
-        askAiButtonEnabled: process.env.ASK_AI_BUTTON_ENABLED === 'true',
-        defaultProvider:
-            process.env.AI_DEFAULT_PROVIDER || DEFAULT_DEFAULT_AI_PROVIDER,
-        providers: {
-            azure: process.env.AZURE_AI_API_KEY
-                ? {
-                      endpoint: process.env.AZURE_AI_ENDPOINT,
-                      apiKey: process.env.AZURE_AI_API_KEY,
-                      apiVersion: process.env.AZURE_AI_API_VERSION,
-                      deploymentName: process.env.AZURE_AI_DEPLOYMENT_NAME,
-                      temperature: getFloatFromEnvironmentVariable(
-                          'AZURE_AI_TEMPERATURE',
-                      ),
-                  }
-                : undefined,
-            openai: process.env.OPENAI_API_KEY
-                ? {
-                      apiKey: process.env.OPENAI_API_KEY,
-                      modelName:
-                          process.env.OPENAI_MODEL_NAME ||
-                          DEFAULT_OPENAI_MODEL_NAME,
-                      baseUrl: process.env.OPENAI_BASE_URL,
-                      temperature:
-                          getFloatFromEnvironmentVariable('OPENAI_TEMPERATURE'),
-                      responsesApi: process.env.OPENAI_RESPONSES_API === 'true',
-                      reasoning: {
-                          enabled:
-                              process.env.OPENAI_REASONING_ENABLED === 'true',
-                          reasoningSummary:
-                              process.env.OPENAI_REASONING_SUMMARY,
-                          reasoningEffort: process.env.OPENAI_REASONING_EFFORT,
-                      },
-                  }
-                : undefined,
-            anthropic: process.env.ANTHROPIC_API_KEY
-                ? {
-                      apiKey: process.env.ANTHROPIC_API_KEY,
-                      modelName:
-                          process.env.ANTHROPIC_MODEL_NAME ||
-                          DEFAULT_ANTHROPIC_MODEL_NAME,
-                      temperature: getFloatFromEnvironmentVariable(
-                          'ANTHROPIC_TEMPERATURE',
-                      ),
-                  }
-                : undefined,
-            openrouter: process.env.OPENROUTER_API_KEY
-                ? {
-                      apiKey: process.env.OPENROUTER_API_KEY,
-                      modelName:
-                          process.env.OPENROUTER_MODEL_NAME ||
-                          DEFAULT_OPENROUTER_MODEL_NAME,
-                      sortOrder: process.env.OPENROUTER_SORT_ORDER,
-                      allowedProviders: getArrayFromCommaSeparatedList(
-                          'OPENROUTER_ALLOWED_PROVIDERS',
-                      ),
-                      temperature: getFloatFromEnvironmentVariable(
-                          'OPENROUTER_TEMPERATURE',
-                      ),
-                  }
-                : undefined,
-        },
-        maxQueryLimit:
-            getIntegerFromEnvironmentVariable('AI_COPILOT_MAX_QUERY_LIMIT') ||
-            AI_DEFAULT_MAX_QUERY_LIMIT,
-    };
-
+    const rawCopilotConfig = getAiConfig();
     const copilotConfigParse =
         aiCopilotConfigSchema.safeParse(rawCopilotConfig);
 

--- a/packages/backend/src/ee/services/ai/agents/tests/eval-reporter.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/eval-reporter.ts
@@ -29,6 +29,8 @@ interface EvalResult {
     llmToolJudgeResults?: TaskMeta['llmToolJudgeResults'];
     prompts?: TaskMeta['prompts'];
     responses?: TaskMeta['responses'];
+    agentProvider?: TaskMeta['agentProvider'];
+    agentModel?: TaskMeta['agentModel'];
 }
 
 export default class EvalHtmlReporter implements Reporter {
@@ -112,6 +114,8 @@ export default class EvalHtmlReporter implements Reporter {
                     llmToolJudgeResults: taskMeta.llmToolJudgeResults || [],
                     prompts: taskMeta.prompts || [],
                     responses: taskMeta.responses || [],
+                    agentProvider: taskMeta.agentProvider,
+                    agentModel: taskMeta.agentModel,
                 };
                 this.results.push(result);
             } else if (task.type === 'suite' && task.tasks) {
@@ -156,6 +160,13 @@ export default class EvalHtmlReporter implements Reporter {
             'en-GB',
         )} ${now.toLocaleTimeString('en-GB', { hour12: false })}`;
 
+        // Get agent provider/model from first test result that has it
+        const agentProvider =
+            this.results.find((r) => r.agentProvider)?.agentProvider ||
+            'unknown';
+        const agentModel =
+            this.results.find((r) => r.agentModel)?.agentModel || 'unknown';
+
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -186,6 +197,16 @@ export default class EvalHtmlReporter implements Reporter {
         .title .date {
             color: #6c757d;
             font-size: 14px;
+        }
+        .title .model-info {
+            color: #495057;
+            font-size: 12px;
+            margin-top: 8px;
+            font-family: monospace;
+            background: #e9ecef;
+            display: inline-block;
+            padding: 4px 8px;
+            border-radius: 4px;
         }
         .summary {
             display: flex;
@@ -330,6 +351,7 @@ export default class EvalHtmlReporter implements Reporter {
     <div class="title">
         <h1>AI Agent Evaluation Report</h1>
         <div class="date">${formattedDate}</div>
+        <div class="model-info">Agent: ${agentProvider} / ${agentModel}</div>
     </div>
     
     <div class="summary">
@@ -827,5 +849,7 @@ declare module 'vitest' {
         responses: string[];
         llmJudgeResults: LlmJudgeResult[];
         llmToolJudgeResults: ToolJudgeResult[];
+        agentProvider: string;
+        agentModel: string;
     }
 }

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsAJudge.ts
@@ -58,7 +58,7 @@ type BaseLlmAsJudgeParams = {
     response: string;
     expectedAnswer?: string;
     context?: string[];
-    model: Exclude<LanguageModel, string>;
+    judge: Exclude<LanguageModel, string>;
     callOptions: ReturnType<typeof getOpenaiGptmodel>['callOptions'];
     contextRelevancyThreshold?: number; // Threshold for context relevancy (default 0.7)
     factualityThreshold?: 'A' | 'B' | 'C' | 'D' | 'E'; // Minimum acceptable factuality score (default 'A' = subset or better)
@@ -92,7 +92,7 @@ export async function llmAsAJudge(
  * @param query The user's original query
  * @param response The agent's response
  * @param expectedAnswer The expected/reference answer
- * @param model Your configured AI model (e.g., openai('gpt-4'))
+ * @param judge Your configured AI model to be the judge (e.g., openai('gpt-4'))
  * @param scorerType The type of evaluation to perform
  * @param contextRelevancyThreshold Minimum score for context relevancy (0-1, default 0.7)
  * @param factualityThreshold Minimum acceptable factuality score (default 'A')
@@ -102,7 +102,7 @@ export async function llmAsAJudge({
     response,
     expectedAnswer,
     context,
-    model,
+    judge,
     callOptions,
     scorerType,
     contextRelevancyThreshold = 0.7,
@@ -150,7 +150,7 @@ export async function llmAsAJudge({
                 );
             }
             const { object } = await generateObject({
-                model,
+                model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
                 schema: z.object({
@@ -220,7 +220,7 @@ export async function llmAsAJudge({
             }
 
             const { object } = await generateObject({
-                model,
+                model: judge,
                 ...defaultAgentOptions,
                 ...callOptions,
                 schema: z.object({

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/llmAsJudgeForTools.ts
@@ -129,7 +129,7 @@ type Params = {
     prompt: string;
     toolCalls: DbAiAgentToolCall[];
     expectedOutcome: string;
-    model: ReturnType<typeof getOpenaiGptmodel>['model'];
+    judge: ReturnType<typeof getOpenaiGptmodel>['model'];
     callOptions: ReturnType<typeof getOpenaiGptmodel>['callOptions'];
     expectedArgsValidation?: {
         toolName: string;
@@ -271,7 +271,7 @@ export const evaluateToolCallSequence = async (
     prompt: string,
     expectedOutcome: string,
     toolCallsScores: ToolCallsScores,
-    model: ReturnType<typeof getOpenaiGptmodel>['model'],
+    judge: ReturnType<typeof getOpenaiGptmodel>['model'],
     callOptions: ReturnType<typeof getOpenaiGptmodel>['callOptions'],
 ): Promise<ToolEvaluationResponse> => {
     const toolCallsDescription = toolCallsScores.scores
@@ -279,7 +279,7 @@ export const evaluateToolCallSequence = async (
         .join('\n\n');
 
     const { object: evaluationResult } = await generateObject({
-        model,
+        model: judge,
         ...defaultAgentOptions,
         ...callOptions,
         schema: toolEvaluationSchema,
@@ -365,7 +365,7 @@ export const llmAsJudgeForTools = async ({
     prompt,
     toolCalls,
     expectedOutcome,
-    model,
+    judge,
     callOptions,
     expectedArgsValidation = [],
 }: Params): Promise<ToolJudgeResult> => {
@@ -378,7 +378,7 @@ export const llmAsJudgeForTools = async ({
         prompt,
         expectedOutcome,
         toolCallsScores,
-        model,
+        judge,
         callOptions,
     );
 

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/testReportWrapper.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/testReportWrapper.ts
@@ -10,6 +10,7 @@ interface TestReportData {
     toolCalls?: string[];
     llmJudgeResults?: LlmJudgeResult[];
     llmToolJudgeResults?: ToolJudgeResult[];
+    agentInfo?: { provider: string; model: string };
 }
 
 /**
@@ -59,6 +60,14 @@ export async function withTestReport<T>(
                 reportData.llmToolJudgeResults,
             );
         }
+        if (reportData.agentInfo) {
+            setTaskMeta(
+                task.meta,
+                'agentProvider',
+                reportData.agentInfo.provider,
+            );
+            setTaskMeta(task.meta, 'agentModel', reportData.agentInfo.model);
+        }
     }
 }
 
@@ -86,6 +95,7 @@ export class TestReportBuilder {
         response?: string;
         responses?: string[];
         toolCalls?: string[] | DbAiAgentToolCall[];
+        agentInfo?: { provider: string; model: string };
     }) {
         if (config?.prompt) {
             this.data.prompts = [config.prompt];
@@ -106,6 +116,10 @@ export class TestReportBuilder {
                   )
                 : [];
             this.data.toolCalls = toolNames;
+        }
+
+        if (config?.agentInfo) {
+            this.data.agentInfo = config.agentInfo;
         }
     }
 
@@ -143,6 +157,7 @@ export function createTestReport(config?: {
     response?: string;
     responses?: string[];
     toolCalls?: string[] | DbAiAgentToolCall[];
+    agentInfo?: { provider: string; model: string };
 }): TestReportBuilder {
     return new TestReportBuilder(config);
 }


### PR DESCRIPTION

### Description:
Refactored AI configuration handling by extracting the `getAiConfig()` function from `parseConfig()` to improve code organization and reusability. This allows the AI configuration to be accessed from other parts of the application without parsing the entire config.

Enhanced the agent integration tests to use the actual configured AI model for testing, while using a separate judge model for evaluation. Added agent model information to test reports, making it clearer which AI model was used during testing.

The test reporting system now displays the agent provider and model in the HTML report header, providing better visibility into which AI model was being evaluated.

![image.png](https://app.graphite.dev/user-attachments/assets/fc6d2372-9fa8-4358-8b22-6320f7328f61.png)

