### PR TITLE
fix: set dashboard tabs in embeds

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -129,6 +129,8 @@ const EmbedDashboard: FC<{
     const activeTab = useDashboardContext((c) => c.activeTab);
     const setActiveTab = useDashboardContext((c) => c.setActiveTab);
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
+    const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
+    const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
 
     const { embedToken, mode } = useEmbed();
     const navigate = useNavigate();
@@ -176,16 +178,12 @@ const EmbedDashboard: FC<{
         return dashboard.tabs.sort((a, b) => a.order - b.order);
     }, [dashboard?.tabs]);
 
-    // Set active tab to first tab if no active tab is set and no tab in URL
+    // Ensure dashboard tabs are set in context
     useEffect(() => {
-        if (
-            sortedTabs.length > 0 &&
-            !activeTab &&
-            !pathname.includes('/tabs/')
-        ) {
-            setActiveTab(sortedTabs[0]);
+        if (!dashboardTabs.length && sortedTabs.length) {
+            setDashboardTabs(sortedTabs);
         }
-    }, [sortedTabs, activeTab, pathname, setActiveTab]);
+    }, [sortedTabs, dashboardTabs, setDashboardTabs]);
 
     // Filter tiles by active tab
     const filteredTiles = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

At some point dashboard tabs were not being set in DashboardProvider. This created a bug where we no longer loaded an embedded tab in the iframe if provided—we just defer to the first tab. 

This explicitly sets dashboard tabs if they're empty and have sorted tabs in the EmbedDashboard. 
