### PR TITLE
fix: table calc modal clears viz config

### DIFF
--- a/packages/frontend/src/hooks/useExplorerAceEditorCompleter.ts
+++ b/packages/frontend/src/hooks/useExplorerAceEditorCompleter.ts
@@ -89,15 +89,18 @@ export const useTableCalculationAceEditorCompleter = (): {
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
     const customDimensions = useExplorerSelector(selectCustomDimensions);
     const tableCalculations = useExplorerSelector(selectTableCalculations);
-    const explore = useExplore(tableName);
+    const { data: exploreData } = useExplore(tableName, {
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+    });
     const [aceEditor, setAceEditor] = useState<Ace.Editor>();
 
     useEffect(() => {
-        if (aceEditor && explore.data) {
-            const activeExplore = explore.data;
+        if (aceEditor && exploreData) {
+            const activeExplore = exploreData;
             const customMetrics = (additionalMetrics || []).reduce<Metric[]>(
                 (acc, additionalMetric) => {
-                    const table = explore.data.tables[additionalMetric.table];
+                    const table = exploreData.tables[additionalMetric.table];
                     if (table) {
                         const metric = convertAdditionalMetric({
                             additionalMetric,
@@ -159,7 +162,7 @@ export const useTableCalculationAceEditorCompleter = (): {
         };
     }, [
         aceEditor,
-        explore,
+        exploreData,
         activeFields,
         additionalMetrics,
         customDimensions,
@@ -175,12 +178,15 @@ export const useCustomDimensionsAceEditorCompleter = (): {
     setAceEditor: Dispatch<SetStateAction<Ace.Editor | undefined>>;
 } => {
     const tableName = useExplorerSelector(selectTableName);
-    const explore = useExplore(tableName);
+    const { data: exploreData } = useExplore(tableName, {
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+    });
     const [aceEditor, setAceEditor] = useState<Ace.Editor>();
 
     useEffect(() => {
-        if (aceEditor && explore.data) {
-            const activeExplore = explore.data;
+        if (aceEditor && exploreData) {
+            const activeExplore = exploreData;
             const fields = mapFieldsToCompletions(
                 getDimensions(activeExplore),
                 'Dimension',
@@ -190,7 +196,7 @@ export const useCustomDimensionsAceEditorCompleter = (): {
         return () => {
             langTools.setCompleters([]);
         };
-    }, [aceEditor, explore]);
+    }, [aceEditor, exploreData]);
 
     return {
         setAceEditor,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Opening the table calculation dialog was causing the chart config panel to unmount. The table calculation dialog was re-fetching the explore. This is a pretty low-risk fix for this specific issue -- it just makes it so that the table calc dialog doesn't refetch the explore, which it doesn't really need to anyway. 

It's not clear why re-fetching the explore was unmounting the sidebar. We'll probably have to fix that too, but this fixes the issue and unblocks some tests.

**The bug (in main)**
![Kapture 2025-10-29 at 13 59 04](https://github.com/user-attachments/assets/2a2a6962-53a4-4a10-ae51-ee80c8e0cff3)

Can be reproed by 
- Opening the viz config
- Wait a little while (for the react query cache)
- Open table calc menu