### PR TITLE
fix: large text not expanding

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -196,6 +196,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                         <PivotTable
                             className={className}
                             data={pivotTableData.data}
+                            isMinimal={minimal}
                             conditionalFormattings={conditionalFormattings}
                             minMaxMap={minMaxMap}
                             getFieldLabel={getFieldLabel}

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -49,6 +49,7 @@ type TableRowProps = PolymorphicComponentProps<'tr', BoxProps> & {
     index: number;
 };
 type TableCellProps = PolymorphicComponentProps<'th' | 'td', BoxProps> & {
+    isMinimal: boolean;
     withMinimalWidth?: boolean;
     withAlignRight?: boolean;
     withBoldFont?: boolean;
@@ -344,6 +345,7 @@ const BaseCell = (
         (
             {
                 children,
+                isMinimal = false,
                 withMinimalWidth = false,
                 withAlignRight = false,
                 withTooltip = false,
@@ -393,12 +395,13 @@ const BaseCell = (
             });
 
             const cellHasLargeContent = useMemo(() => {
-                return (
+                return !!(
                     sectionType === SectionType.Body &&
-                    typeof children === 'string' &&
-                    children.length > SMALL_TEXT_LENGTH
+                    withValue &&
+                    typeof withValue === 'string' &&
+                    withValue.length > SMALL_TEXT_LENGTH
                 );
-            }, [sectionType, children]);
+            }, [sectionType, withValue]);
 
             const component = useMemo(() => {
                 switch (cellType) {
@@ -423,7 +426,8 @@ const BaseCell = (
                         data-is-selected={isSelected}
                         className={cx(classes.root, rest.className, {
                             [classes.withSticky]: withSticky,
-                            [classes.withLargeContent]: cellHasLargeContent,
+                            [classes.withLargeContent]:
+                                cellHasLargeContent && !isMinimal,
                             [classes.withMinimalWidth]: withMinimalWidth,
                             [classes.withAlignRight]: withAlignRight,
                             [classes.withBoldFont]: withBoldFont,
@@ -460,6 +464,7 @@ const BaseCell = (
                     component,
                     ref,
                     rest,
+                    isSelected,
                     cx,
                     classes.root,
                     classes.withSticky,
@@ -473,6 +478,7 @@ const BaseCell = (
                     classes.withCopying,
                     withSticky,
                     cellHasLargeContent,
+                    isMinimal,
                     withMinimalWidth,
                     withAlignRight,
                     withBoldFont,
@@ -480,11 +486,10 @@ const BaseCell = (
                     withInteractions,
                     withBackground,
                     clipboard.copied,
+                    children,
                     withTooltip,
-                    isSelected,
                     toggleCell,
                     cellId,
-                    children,
                 ],
             );
 

--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -251,7 +251,7 @@ export const useTableCellStyles = createStyles<
                 height: CELL_HEIGHT,
 
                 textAlign: 'left',
-                whiteSpace: 'nowrap',
+                whiteSpace: 'pre-wrap',
 
                 fontFamily: theme.other.tableFont ?? "'Inter', sans-serif",
                 fontFeatureSettings: '"tnum"',
@@ -272,10 +272,11 @@ export const useTableCellStyles = createStyles<
                 textOverflow: 'ellipsis',
                 overflow: 'hidden',
                 maxWidth: '300px',
+                whiteSpace: 'pre',
 
                 '&:hover, &[data-is-selected="true"]': {
                     overflow: 'visible',
-                    whiteSpace: 'normal',
+                    whiteSpace: 'pre-wrap',
                     wordWrap: 'break-word',
                     minWidth: '300px',
                 },

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -95,6 +95,7 @@ type PivotTableProps = BoxProps & // TODO: remove this
         getField: (fieldId: string) => ItemsMap[string] | undefined;
         showSubtotals?: boolean;
         columnProperties?: ColumnProperties;
+        isMinimal: boolean;
     };
 
 const PivotTable: FC<PivotTableProps> = ({
@@ -107,6 +108,7 @@ const PivotTable: FC<PivotTableProps> = ({
     className,
     showSubtotals = false,
     columnProperties = {},
+    isMinimal = false,
     ...tableProps
 }) => {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -419,9 +421,16 @@ const PivotTable: FC<PivotTableProps> = ({
                         {/* shows empty cell if row numbers are visible */}
                         {hideRowNumbers ? null : headerRowIndex <
                           data.headerValues.length - 1 ? (
-                            <Table.Cell withMinimalWidth />
+                            <Table.Cell
+                                isMinimal={isMinimal}
+                                withMinimalWidth
+                            />
                         ) : (
-                            <Table.CellHead withMinimalWidth withBoldFont>
+                            <Table.CellHead
+                                isMinimal={isMinimal}
+                                withMinimalWidth
+                                withBoldFont
+                            >
                                 #
                             </Table.CellHead>
                         )}
@@ -440,12 +449,14 @@ const PivotTable: FC<PivotTableProps> = ({
                                 return isEmpty ? (
                                     <Table.Cell
                                         key={`title-${headerRowIndex}-${titleFieldIndex}`}
+                                        isMinimal={isMinimal}
                                         withMinimalWidth
                                     />
                                 ) : (
                                     <Table.CellHead
                                         key={`title-${headerRowIndex}-${titleFieldIndex}`}
                                         withAlignRight={isHeaderTitle}
+                                        isMinimal={isMinimal}
                                         withMinimalWidth
                                         withBoldFont
                                         withTooltip={
@@ -474,6 +485,7 @@ const PivotTable: FC<PivotTableProps> = ({
                             return isLabel || headerValue.colSpan > 0 ? (
                                 <Table.CellHead
                                     key={`header-${headerRowIndex}-${headerColIndex}`}
+                                    isMinimal={isMinimal}
                                     withBoldFont={isLabel}
                                     withTooltip={description}
                                     colSpan={
@@ -495,6 +507,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                       totalLabel ? (
                                           <Table.CellHead
                                               key={`header-total-${headerRowIndex}-${headerColIndex}`}
+                                              isMinimal={isMinimal}
                                               withBoldFont
                                               withMinimalWidth
                                           >
@@ -507,6 +520,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                       ) : (
                                           <Table.Cell
                                               key={`header-total-${headerRowIndex}-${headerColIndex}`}
+                                              isMinimal={isMinimal}
                                               withMinimalWidth
                                           />
                                       ),
@@ -640,6 +654,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 return (
                                     <TableCellComponent
                                         key={`value-${rowIndex}-${colIndex}`}
+                                        isMinimal={isMinimal}
                                         withAlignRight={isNumericItem(item)}
                                         withColor={conditionalFormatting?.color}
                                         withBoldFont={meta?.type === 'label'}
@@ -775,6 +790,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                     totalLabel ? (
                                         <Table.CellHead
                                             key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                            isMinimal={isMinimal}
                                             withAlignRight
                                             withBoldFont
                                         >
@@ -787,6 +803,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                     ) : (
                                         <Table.Cell
                                             key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                            isMinimal={isMinimal}
                                         />
                                     ),
                             )}
@@ -805,6 +822,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                     <Table.CellHead
                                         key={`column-total-${totalRowIndex}-${totalColIndex}`}
                                         withAlignRight
+                                        isMinimal={isMinimal}
                                         withBoldFont
                                         withInteractions
                                         withValue={value.formatted}
@@ -830,6 +848,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 ) : (
                                     <Table.Cell
                                         key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                        isMinimal={isMinimal}
                                     />
                                 );
                             })}
@@ -838,6 +857,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 ? data.rowTotalFields?.[0].map((_, index) => (
                                       <Table.Cell
                                           key={`footer-empty-${totalRowIndex}-${index}`}
+                                          isMinimal={isMinimal}
                                       />
                                   ))
                                 : null}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -149,7 +149,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                 onMouseEnter={canHaveTooltip ? openTooltip : undefined}
                 onMouseLeave={canHaveTooltip ? closeTooltip : undefined}
             >
-                <span style={{ whiteSpace: 'pre' }}>{children}</span>
+                <span>{children}</span>
             </Td>
 
             {shouldRenderMenu ? (

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -212,29 +212,22 @@ export const Td = styled.td<{
     $hasUrls: boolean;
 }>`
     max-width: 300px;
-    white-space: nowrap;
+    white-space: pre;
     overflow: hidden;
     text-overflow: ellipsis;
     box-sizing: border-box;
     height: ${ROW_HEIGHT_PX}px;
 
-    ${({ $isLargeText, $isSelected, $isMinimal, $hasNewlines }) =>
+    ${({ $isLargeText, $isSelected, $isMinimal }) =>
         $isLargeText
             ? `
                 min-width: 300px;
-                white-space: ${
-                    $isSelected || $isMinimal
-                        ? $hasNewlines
-                            ? 'pre-line'
-                            : 'normal'
-                        : 'nowrap'
-                };
+                white-space: ${$isSelected || $isMinimal ? 'pre-wrap' : 'pre'};
                 :hover {
-                    white-space: ${$hasNewlines ? 'pre-line' : 'normal'};
+                    white-space: pre-wrap;
                 }
             `
             : ''}
-
     ${CellStyles}
 
     ${({ $hasUrls }) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17698
Relates to: #17610

### Description:
Fix large content detection in LightTable BaseCell component by checking `withValue` instead of `children`. This ensures that the cell correctly identifies large content based on the actual value being displayed rather than the React children.

**Pivoted table**

https://github.com/user-attachments/assets/643a3e4c-5d85-4971-ad8d-45a7bda1cbc5

**Pivoted minimal table**

<img width="1745" height="1244" alt="image" src="https://github.com/user-attachments/assets/ee5b11fb-737b-4f4a-bd3d-58b2c955fabe" />

**Normal table**

https://github.com/user-attachments/assets/c0c9ade0-e877-490c-ae6c-9d4a726f2784

**Normal minimal table**

<img width="962" height="1211" alt="image" src="https://github.com/user-attachments/assets/ee41982d-d483-41bb-ae82-80341b4faae5" />

**Sql Runner preserve white spaces**
<img width="1036" height="726" alt="white-spaces-still-preserved" src="https://github.com/user-attachments/assets/57a46c5e-6c6e-474b-af6b-16b0d5bfc151" />

