### PR TITLE
fix: csv and xsls files should be stored using the S3Client instead of S3ResultsStorageClient

### DIFF
--- a/packages/backend/src/clients/Aws/CLAUDE.md
+++ b/packages/backend/src/clients/Aws/CLAUDE.md
@@ -1,0 +1,120 @@
+<summary>
+AWS S3 storage clients for Lightdash backend. Provides two specialized S3 clients with distinct purposes: S3Client for user-facing file downloads (CSV/Excel exports, screenshots, scheduled deliveries) and S3ResultsFileStorageClient for query results in JSONL format.
+</summary>
+
+<howToUse>
+Access S3 clients through the ClientRepository singleton pattern. The general S3Client is used for final exports and user downloads, while S3ResultsFileStorageClient is specifically for caching query results. Use transformAndExportResults() utility for cross-bucket transformations when converting cached results to user downloads.
+
+```typescript
+import { ClientRepository } from '../../clients/ClientRepository';
+
+// Get S3 clients from repository
+const clientRepository = new ClientRepository({ lightdashConfig });
+const s3Client = clientRepository.getS3Client(); // General exports bucket
+const resultsStorage = clientRepository.getS3ResultsFileStorageClient(); // Query cache bucket
+
+// Upload user-facing files to general bucket
+const csvUrl = await s3Client.uploadCsv(csvBuffer, 'report.csv');
+const excelUrl = await s3Client.uploadExcel(fileStream, 'dashboard.xlsx');
+
+// Store query results in JSONL format
+const { write, close } = resultsStorage.createUploadStream(
+    'query-results-123.jsonl',
+    { contentType: 'application/jsonl' },
+);
+rows.forEach((row) => write([row]));
+await close();
+
+// Transform results from cache bucket to exports bucket
+import { transformAndExportResults } from './transformAndExportResults';
+const { fileUrl, truncated } = await transformAndExportResults(
+    'query-results-123', // source in results bucket
+    'export-report.csv', // destination in exports bucket
+    async (readStream, writeStream) => {
+        // Transform JSONL to CSV
+        return { truncated: false };
+    },
+    {
+        resultsStorageClient: resultsStorage,
+        exportsStorageClient: s3Client,
+    },
+    {
+        fileType: DownloadFileType.CSV,
+        attachmentDownloadName: 'My Report.csv',
+    },
+);
+```
+
+</howToUse>
+
+<codeExample>
+
+```typescript
+// Upload a CSV export for user download
+const s3Client = clientRepository.getS3Client();
+const csvUrl = await s3Client.uploadCsv(csvContent, 'sales-report-2025.csv');
+// Returns pre-signed URL valid for 3 days (default config)
+
+// Stream query results to cache bucket
+const resultsStorage = clientRepository.getS3ResultsFileStorageClient();
+const { write, close, writeStream } = resultsStorage.createUploadStream(
+    'async-query-abc123.jsonl',
+    { contentType: 'application/jsonl' },
+);
+
+// Write rows as JSONL
+queryResults.forEach((row) => write([row]));
+await close();
+
+// Later, retrieve and stream cached results
+const readStream = await resultsStorage.getDownloadStream('async-query-abc123');
+// Process stream...
+
+// Get pre-signed download URL for cached results
+const downloadUrl = await resultsStorage.getFileUrl(
+    'async-query-abc123',
+    'jsonl',
+);
+```
+
+Architecture diagram:
+
+```mermaid
+graph TD
+    A[User Request] --> B{Export Type}
+    B -->|Query Results| C[AsyncQueryService]
+    C --> D[Stream to Results Bucket<br/>JSONL Format]
+    D --> E[S3ResultsFileStorageClient]
+
+    C --> F[transformAndExportResults]
+    F --> G[Read from Results Bucket]
+    F --> H[Transform CSV/Excel]
+    F --> I[Write to Exports Bucket]
+    I --> J[S3Client]
+    J --> K[Pre-signed URL<br/>User Download]
+
+    B -->|Screenshots/PDFs| L[Direct Upload]
+    L --> J
+```
+
+</codeExample>
+
+<importantToKnow>
+- **Two Buckets, Two Purposes**: S3Client uses S3_BUCKET env var (general exports), S3ResultsFileStorageClient uses RESULTS_S3_BUCKET (falls back to S3_BUCKET if not set)
+- **Cross-Bucket Transforms**: Always use transformAndExportResults() utility to convert cached results to user downloads. Never write user-facing files to the results bucket
+- **Authentication**: Both clients support IAM role credentials (preferred) or access key/secret key via env vars
+- **Pre-signed URLs**: All uploads return pre-signed URLs with expiration times configured in lightdashConfig.s3.expirationTime
+- **Streaming Support**: S3ResultsFileStorageClient provides createUploadStream() and S3Client provides createResultsExportUploadStream() for memory-efficient uploading
+- **Content-Disposition**: File names in Content-Disposition headers are automatically set from filename parameter for proper browser downloads
+- **File Extensions**: S3ResultsFileStorageClient automatically adds .jsonl extension if not present in filename
+- **Base Class**: Both clients extend S3CacheClient which provides uploadResults(), getResults(), and getResultsMetadata() methods
+</importantToKnow>
+
+<links>
+@/packages/backend/src/clients/Aws/S3Client.ts - General exports S3 client
+@/packages/backend/src/clients/Aws/S3CacheClient.ts - Base S3 cache client
+@/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts - Query results storage
+@/packages/backend/src/clients/Aws/S3CrossBucketTransform.ts - Cross-bucket transformation utility
+@/packages/backend/src/clients/ClientRepository.ts - Client dependency injection
+@/packages/backend/src/config/parseConfig.ts - S3 configuration settings
+</links>

--- a/packages/backend/src/clients/Aws/getContentTypeFromFileType.ts
+++ b/packages/backend/src/clients/Aws/getContentTypeFromFileType.ts
@@ -1,0 +1,23 @@
+import { assertUnreachable, DownloadFileType } from '@lightdash/common';
+
+export default function getContentTypeFromFileType(
+    fileType: DownloadFileType,
+): string {
+    switch (fileType) {
+        case DownloadFileType.CSV:
+            return 'text/csv';
+        case DownloadFileType.XLSX:
+            return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+        case DownloadFileType.IMAGE:
+            return 'image/png';
+        case DownloadFileType.JSONL:
+            return 'application/jsonl';
+        case DownloadFileType.S3_JSONL:
+            return 'application/jsonl';
+        default:
+            return assertUnreachable(
+                fileType,
+                `Unsupported file type: ${fileType}`,
+            );
+    }
+}

--- a/packages/backend/src/clients/Aws/transformAndExportResults.ts
+++ b/packages/backend/src/clients/Aws/transformAndExportResults.ts
@@ -1,0 +1,95 @@
+import { DownloadFileType, getErrorMessage } from '@lightdash/common';
+import { Readable, Writable } from 'stream';
+import Logger from '../../logging/logger';
+import { S3ResultsFileStorageClient } from '../ResultsFileStorageClients/S3ResultsFileStorageClient';
+import { S3Client } from './S3Client';
+import getContentTypeFromFileType from './getContentTypeFromFileType';
+
+/**
+ * Transforms query results from the results bucket to the exports bucket.
+ *
+ * This utility handles the cross-bucket operation of:
+ * 1. Reading JSONL query results from the results bucket (used for query caching)
+ * 2. Transforming the data via a stream processor (e.g., JSONL → CSV/Excel)
+ * 3. Writing the transformed file to the general exports bucket (for user downloads)
+ *
+ * @param sourceFileName - Name of the JSONL file in the results bucket (without extension)
+ * @param destFileName - Name for the output file in the exports bucket (with extension)
+ * @param streamProcessor - Function that transforms the read stream to write stream
+ * @param clients - S3 clients for source and destination buckets
+ * @param clients.resultsStorageClient - Client for results bucket (JSONL query cache)
+ * @param clients.exportsStorageClient - Client for exports bucket (user downloads)
+ * @param options - Optional configuration
+ * @param options.fileType - Type of file being exported (determines MIME type)
+ * @param options.attachmentDownloadName - Optional filename for Content-Disposition header
+ * @returns Promise with the signed URL to the exported file and truncation status
+ */
+export async function transformAndExportResults(
+    sourceFileName: string,
+    destFileName: string,
+    streamProcessor: (
+        readStream: Readable,
+        writeStream: Writable,
+    ) => Promise<{ truncated: boolean }>,
+    clients: {
+        resultsStorageClient: S3ResultsFileStorageClient;
+        exportsStorageClient: S3Client;
+    },
+    options?: {
+        fileType: DownloadFileType;
+        attachmentDownloadName?: string;
+    },
+): Promise<{ fileUrl: string; truncated: boolean }> {
+    const { resultsStorageClient, exportsStorageClient } = clients;
+
+    // Infer content type from file type
+    const contentType = options?.fileType
+        ? getContentTypeFromFileType(options.fileType)
+        : 'text/csv'; // Default to CSV if not specified
+
+    Logger.debug(
+        `Transforming results from ${sourceFileName} to ${destFileName} with content type: ${contentType}`,
+    );
+
+    try {
+        // Get the JSONL results stream from results bucket
+        const resultsStream = await resultsStorageClient.getDownloadStream(
+            sourceFileName,
+        );
+
+        // Create upload stream to exports bucket
+        const { writeStream, close } =
+            exportsStorageClient.createResultsExportUploadStream(
+                destFileName,
+                {
+                    contentType,
+                },
+                options?.attachmentDownloadName,
+            );
+
+        // Process the stream transformation
+        const { truncated } = await streamProcessor(resultsStream, writeStream);
+
+        // Close the upload stream and wait for completion
+        await close();
+
+        // Get the signed URL for the exported file
+        const fileUrl = await exportsStorageClient.getFileUrl(destFileName);
+
+        Logger.debug(
+            `Successfully transformed and exported ${sourceFileName} to ${destFileName}`,
+        );
+
+        return {
+            fileUrl,
+            truncated,
+        };
+    } catch (error) {
+        Logger.error(
+            `Failed to transform and export results from ${sourceFileName} to ${destFileName}: ${getErrorMessage(
+                error,
+            )}`,
+        );
+        throw error;
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -284,7 +284,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     downloadAuditModel: models.getDownloadAuditModel(),
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),
-                    storageClient: clients.getResultsFileStorageClient(),
+                    resultsStorageClient: clients.getResultsFileStorageClient(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -172,9 +172,9 @@ const getMockedAsyncQueryService = (
         } as unknown as QueryHistoryModel,
         userModel: {} as UserModel,
         savedSqlModel: {} as SavedSqlModel,
-        storageClient: {
+        resultsStorageClient: {
             isEnabled: true, // ! Hack for current tests that only check for results saved in S3
-            getDowloadStream: jest.fn(() => {
+            getDownloadStream: jest.fn(() => {
                 const readable = new Readable({
                     read() {
                         // Push some mock data and end the stream
@@ -1190,9 +1190,10 @@ describe('AsyncQueryService', () => {
             });
 
             // Mock storage client methods
-            const mockStorageClient = service.storageClient as unknown as {
-                createUploadStream: jest.Mock;
-            };
+            const mockStorageClient =
+                service.resultsStorageClient as unknown as {
+                    createUploadStream: jest.Mock;
+                };
             mockStorageClient.createUploadStream = jest.fn(() => ({
                 write: jest.fn(),
                 close: jest.fn(),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -89,6 +89,8 @@ import { createInterface } from 'readline';
 import { Readable, Writable } from 'stream';
 import { v4 as uuidv4 } from 'uuid';
 import { DownloadCsv } from '../../analytics/LightdashAnalytics';
+import { S3Client } from '../../clients/Aws/S3Client';
+import { transformAndExportResults } from '../../clients/Aws/transformAndExportResults';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { measureTime } from '../../logging/measureTime';
 import { DownloadAuditModel } from '../../models/DownloadAuditModel';
@@ -152,7 +154,7 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     cacheService?: ICacheService;
     savedSqlModel: SavedSqlModel;
     featureFlagModel: FeatureFlagModel;
-    storageClient: S3ResultsFileStorageClient;
+    resultsStorageClient: S3ResultsFileStorageClient;
     pivotTableService: PivotTableService;
     prometheusMetrics?: PrometheusMetrics;
     schedulerClient: SchedulerClient;
@@ -170,7 +172,9 @@ export class AsyncQueryService extends ProjectService {
 
     featureFlagModel: FeatureFlagModel;
 
-    storageClient: S3ResultsFileStorageClient;
+    resultsStorageClient: S3ResultsFileStorageClient;
+
+    exportsStorageClient: S3Client;
 
     pivotTableService: PivotTableService;
 
@@ -187,7 +191,8 @@ export class AsyncQueryService extends ProjectService {
         this.cacheService = args.cacheService;
         this.savedSqlModel = args.savedSqlModel;
         this.featureFlagModel = args.featureFlagModel;
-        this.storageClient = args.storageClient;
+        this.resultsStorageClient = args.resultsStorageClient;
+        this.exportsStorageClient = this.s3Client;
         this.pivotTableService = args.pivotTableService;
         this.prometheusMetrics = args.prometheusMetrics;
         this.schedulerClient = args.schedulerClient;
@@ -282,7 +287,7 @@ export class AsyncQueryService extends ProjectService {
         pageSize: number,
         formatter: (row: ResultRow) => ResultRow,
     ) {
-        if (!this.storageClient.isEnabled) {
+        if (!this.resultsStorageClient.isEnabled) {
             throw new S3Error('S3 is not enabled');
         }
 
@@ -292,7 +297,9 @@ export class AsyncQueryService extends ProjectService {
             );
         }
 
-        const cacheStream = await this.storageClient.getDowloadStream(fileName);
+        const cacheStream = await this.resultsStorageClient.getDownloadStream(
+            fileName,
+        );
 
         const rows: ResultRow[] = [];
         const rl = createInterface({
@@ -532,7 +539,8 @@ export class AsyncQueryService extends ProjectService {
             durationMs,
         } = await measureTime(
             () =>
-                this.storageClient.isEnabled || this.cacheService?.isEnabled
+                this.resultsStorageClient.isEnabled ||
+                this.cacheService?.isEnabled
                     ? this.getResultsPageFromS3(
                           queryUuid,
                           resultsFileName,
@@ -680,7 +688,7 @@ export class AsyncQueryService extends ProjectService {
                 throw new Error('Results file name not found for query');
             }
 
-            return this.storageClient.getDowloadStream(resultsFileName);
+            return this.resultsStorageClient.getDownloadStream(resultsFileName);
         }
 
         throw new Error('Invalid query status');
@@ -736,7 +744,7 @@ export class AsyncQueryService extends ProjectService {
                     ? SchedulerFormat.XLSX
                     : SchedulerFormat.CSV,
             values: onlyRaw ? 'raw' : 'formatted',
-            storage: this.s3Client.isEnabled() ? 's3' : 'local',
+            storage: this.exportsStorageClient.isEnabled() ? 's3' : 'local',
         };
         this.analytics.trackAccount(account, {
             event: 'download_results.started',
@@ -817,6 +825,7 @@ export class AsyncQueryService extends ProjectService {
         | ApiDownloadAsyncQueryResultsAsXlsx
     > {
         assertIsAccountWithOrg(account);
+
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
         );
@@ -912,7 +921,7 @@ export class AsyncQueryService extends ProjectService {
                         fields,
                         metricQuery: queryHistory.metricQuery,
                         projectUuid,
-                        storageClient: this.storageClient,
+                        storageClient: this.resultsStorageClient,
                         pivotDetails:
                             AsyncQueryService.getPivotDetailsFromQueryHistory(
                                 queryHistory,
@@ -952,7 +961,8 @@ export class AsyncQueryService extends ProjectService {
                         resultsFileName,
                         fields,
                         metricQuery: queryHistory.metricQuery,
-                        storageClient: this.storageClient,
+                        resultsStorageClient: this.resultsStorageClient,
+                        exportsStorageClient: this.exportsStorageClient,
                         lightdashConfig: this.lightdashConfig,
                         pivotDetails:
                             AsyncQueryService.getPivotDetailsFromQueryHistory(
@@ -973,7 +983,10 @@ export class AsyncQueryService extends ProjectService {
                 return ExcelService.downloadAsyncExcelDirectly(
                     resultsFileName,
                     resultFields,
-                    this.storageClient,
+                    {
+                        resultsStorageClient: this.resultsStorageClient,
+                        exportsStorageClient: this.exportsStorageClient,
+                    },
                     {
                         onlyRaw,
                         showTableNames,
@@ -1043,8 +1056,15 @@ export class AsyncQueryService extends ProjectService {
             hiddenFields,
         });
 
-        // Transform and upload the results
-        return this.storageClient.transformResultsIntoNewFile(
+        // Determine file type based on file extension
+        const fileExtension = formattedFileName.toLowerCase().split('.').pop();
+        const fileType =
+            fileExtension === 'xlsx'
+                ? DownloadFileType.XLSX
+                : DownloadFileType.CSV;
+
+        // Transform and export the results from results bucket to exports bucket
+        return transformAndExportResults(
             resultsFileName,
             formattedFileName,
             async (readStream, writeStream) => {
@@ -1064,7 +1084,16 @@ export class AsyncQueryService extends ProjectService {
                     truncated,
                 };
             },
-            attachmentDownloadName,
+            {
+                resultsStorageClient: this.resultsStorageClient,
+                exportsStorageClient: this.s3Client,
+            },
+            {
+                fileType,
+                attachmentDownloadName: attachmentDownloadName
+                    ? `${attachmentDownloadName}.${fileExtension}`
+                    : undefined,
+            },
         );
     }
 
@@ -1072,7 +1101,9 @@ export class AsyncQueryService extends ProjectService {
         resultsFileName: string,
     ): Promise<ApiDownloadAsyncQueryResults> {
         return {
-            fileUrl: await this.storageClient.getFileUrl(resultsFileName),
+            fileUrl: await this.resultsStorageClient.getFileUrl(
+                resultsFileName,
+            ),
         };
     }
 
@@ -1347,8 +1378,8 @@ export class AsyncQueryService extends ProjectService {
 
             // Create upload stream for storing results
             // If S3 is not configured, we don't write to S3
-            stream = this.storageClient.isEnabled
-                ? this.storageClient.createUploadStream(
+            stream = this.resultsStorageClient.isEnabled
+                ? this.resultsStorageClient.createUploadStream(
                       S3ResultsFileStorageClient.sanitizeFileExtension(
                           fileName,
                       ),

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -18,6 +18,8 @@ import moment from 'moment';
 import os from 'os';
 import path from 'path';
 import { Readable, Writable } from 'stream';
+import { S3Client } from '../../clients/Aws/S3Client';
+import { transformAndExportResults } from '../../clients/Aws/transformAndExportResults';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
@@ -198,7 +200,8 @@ export class ExcelService {
         resultsFileName,
         fields,
         metricQuery,
-        storageClient,
+        resultsStorageClient,
+        exportsStorageClient,
         lightdashConfig,
         options,
         pivotDetails,
@@ -206,7 +209,8 @@ export class ExcelService {
         resultsFileName: string;
         fields: ItemsMap;
         metricQuery: MetricQuery;
-        storageClient: S3ResultsFileStorageClient; // S3ResultsFileStorageClient type
+        resultsStorageClient: S3ResultsFileStorageClient;
+        exportsStorageClient: S3Client;
         lightdashConfig: LightdashConfig;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         options: {
@@ -219,11 +223,12 @@ export class ExcelService {
             attachmentDownloadName?: string;
         };
     }): Promise<{ fileUrl: string; truncated: boolean }> {
-        const { onlyRaw, customLabels, pivotConfig } = options;
+        const { onlyRaw, customLabels, pivotConfig, attachmentDownloadName } =
+            options;
 
         // Load rows from the results file using shared streaming utility
         // For pivot tables, we need to use csvCellsLimit to prevent memory issues
-        const readStream = await storageClient.getDowloadStream(
+        const readStream = await resultsStorageClient.getDownloadStream(
             resultsFileName,
         );
 
@@ -251,8 +256,7 @@ export class ExcelService {
             );
         }
 
-        const fileName =
-            options.attachmentDownloadName || `pivot-${resultsFileName}`;
+        const fileName = attachmentDownloadName || `pivot-${resultsFileName}`;
         const formattedFileName = ExcelService.generateFileId(
             fileName,
             truncated,
@@ -269,8 +273,8 @@ export class ExcelService {
             pivotDetails,
         });
 
-        // Upload the Excel buffer to storage using the storage client pattern
-        return storageClient.transformResultsIntoNewFile(
+        // Upload the Excel buffer to exports bucket using cross-bucket transform
+        return transformAndExportResults(
             resultsFileName,
             formattedFileName,
             async (_, writeStream: Writable) => {
@@ -278,6 +282,16 @@ export class ExcelService {
                 writeStream.write(Buffer.from(excelBuffer));
                 writeStream.end();
                 return { truncated };
+            },
+            {
+                resultsStorageClient,
+                exportsStorageClient,
+            },
+            {
+                fileType: DownloadFileType.XLSX,
+                attachmentDownloadName: attachmentDownloadName
+                    ? `${attachmentDownloadName}.xlsx`
+                    : undefined,
             },
         );
     }
@@ -395,7 +409,10 @@ export class ExcelService {
     static async downloadAsyncExcelDirectly(
         resultsFileName: string,
         fields: ItemsMap,
-        storageClient: S3ResultsFileStorageClient,
+        clients: {
+            resultsStorageClient: S3ResultsFileStorageClient;
+            exportsStorageClient: S3Client;
+        },
         options: {
             onlyRaw?: boolean;
             showTableNames?: boolean;
@@ -415,6 +432,8 @@ export class ExcelService {
             attachmentDownloadName,
         } = options;
 
+        const { resultsStorageClient, exportsStorageClient } = clients;
+
         // Process fields and generate headers using shared utility
         const { sortedFieldIds, headers } = processFieldsForExport(fields, {
             showTableNames,
@@ -428,7 +447,7 @@ export class ExcelService {
 
         try {
             // Step 1: Get source stream
-            const resultsStream = await storageClient.getDowloadStream(
+            const resultsStream = await resultsStorageClient.getDownloadStream(
                 resultsFileName,
             );
 
@@ -448,17 +467,14 @@ export class ExcelService {
                 truncated,
             );
 
-            // Step 3: Stream temp file directly to S3 (no memory spike!)
-            const fileUrl = await storageClient.uploadFile(
+            // Step 3: Upload temp file to exports bucket (not results bucket)
+            const fileStream = fs.createReadStream(tempFilePath);
+            const fileUrl = await exportsStorageClient.uploadExcel(
+                fileStream,
                 formattedFileName,
-                tempFilePath,
-                {
-                    contentType:
-                        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                    attachmentDownloadName: attachmentDownloadName
-                        ? `${attachmentDownloadName}.xlsx`
-                        : undefined,
-                },
+                attachmentDownloadName
+                    ? `${attachmentDownloadName}.xlsx`
+                    : undefined,
             );
 
             return {

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -109,11 +109,12 @@ export class PivotTableService extends BaseService {
             attachmentDownloadName?: string;
         };
     }): Promise<{ fileUrl: string; truncated: boolean }> {
-        const { onlyRaw, customLabels, pivotConfig } = options;
+        const { onlyRaw, customLabels, pivotConfig, attachmentDownloadName } =
+            options;
 
         // Load rows from the results file using shared streaming utility
         // Use the same logic as regular CSV exports - respect csvCellsLimit with field count
-        const readStream = await storageClient.getDowloadStream(
+        const readStream = await storageClient.getDownloadStream(
             resultsFileName,
         );
 
@@ -144,8 +145,7 @@ export class PivotTableService extends BaseService {
             );
         }
 
-        const fileName =
-            options.attachmentDownloadName || `pivot-${resultsFileName}`;
+        const fileName = attachmentDownloadName || `pivot-${resultsFileName}`;
 
         const attachmentUrl = await this.downloadPivotTableCsv({
             name: fileName,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -595,7 +595,8 @@ export class ServiceRepository
                     queryHistoryModel: this.models.getQueryHistoryModel(),
                     downloadAuditModel: this.models.getDownloadAuditModel(),
                     savedSqlModel: this.models.getSavedSqlModel(),
-                    storageClient: this.clients.getResultsFileStorageClient(),
+                    resultsStorageClient:
+                        this.clients.getResultsFileStorageClient(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     projectParametersModel:
                         this.models.getProjectParametersModel(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17725

### Description:
Adds a cross-bucket transformation utility for S3 storage to properly separate query results `jsonl` files from user-facing exports. This PR:

- Creates a new `transformAndExportResults` utility to handle the flow from results bucket to exports bucket
- Enhances `S3Client` with additional methods for Excel uploads and pre-signed URLs
- Adds a content type helper to standardize MIME types across file formats
- Updates `AsyncQueryService` and `ExcelService` to use the new cross-bucket pattern
- Renames `storageClient` to `resultsStorageClient` for clarity
- Adds comprehensive documentation in CLAUDE.md explaining the S3 storage architecture

This change improves the separation of concerns between query result caching (JSONL in results bucket) and user-facing downloads (CSV/Excel in exports bucket), making the system more maintainable and secure.

**After this PR you should see:**
- Results files get saved to the `RESULTS_S3_BUCKET` (defaults to `S3_BUCKET` if not present)
- Export files (csv/xsls) get saved to `S3_BUCKET`