### PR TITLE
feat: remove AgentV2 feature flag and make v2 the default

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -22,8 +22,6 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             [CommercialFeatureFlags.Scim]: this.getScimFlag.bind(this),
             [CommercialFeatureFlags.AiCopilot]:
                 this.getAiCopilotFlag.bind(this),
-            [CommercialFeatureFlags.AgentV2]:
-                CommercialFeatureFlagModel.getAgentV2Flag.bind(this),
             [CommercialFeatureFlags.AgentReasoning]:
                 CommercialFeatureFlagModel.getAgentReasoningFlag.bind(this),
         };
@@ -103,29 +101,6 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             enabled = this.lightdashConfig.ai.copilot.enabled;
         }
 
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private static async getAgentV2Flag({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled = user
-            ? await isFeatureFlagEnabled(
-                  CommercialFeatureFlags.AgentV2 as AnyType as FeatureFlags,
-                  {
-                      userUuid: user.userUuid,
-                      organizationUuid: user.organizationUuid,
-                      organizationName: user.organizationName,
-                  },
-                  {
-                      throwOnTimeout: false,
-                  },
-              )
-            : false;
         return {
             id: featureFlagId,
             enabled,

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -107,10 +107,7 @@ import { wrapSentryTransaction } from '../../utils';
 import { AiAgentModel } from '../models/AiAgentModel';
 import { CommercialSlackAuthenticationModel } from '../models/CommercialSlackAuthenticationModel';
 import { CommercialSchedulerClient } from '../scheduler/SchedulerClient';
-import {
-    generateAgentResponse as generateAgentResponseV1,
-    streamAgentResponse as streamAgentResponseV1,
-} from './ai/agents/agent';
+import { streamAgentResponse as streamAgentResponseV1 } from './ai/agents/agent';
 import {
     generateAgentResponse as generateAgentResponseV2,
     streamAgentResponse as streamAgentResponseV2,
@@ -2510,23 +2507,21 @@ export class AiAgentService {
         };
 
         // Route to correct agent version based on agentSettings.version
-        const agentVersion = agentSettings.version;
+        // const agentVersion = agentSettings.version;
 
-        if (agentVersion === 1) {
-            return stream
-                ? streamAgentResponseV1({ args, dependencies })
-                : generateAgentResponseV1({ args, dependencies });
-        }
+        // if (agentVersion === 1) {
+        //     return stream
+        //         ? streamAgentResponseV1({ args, dependencies })
+        //         : generateAgentResponseV1({ args, dependencies });
+        // }
 
-        if (agentVersion === 2) {
-            return stream
-                ? streamAgentResponseV2({ args, dependencies })
-                : generateAgentResponseV2({ args, dependencies });
-        }
+        return stream
+            ? streamAgentResponseV2({ args, dependencies })
+            : generateAgentResponseV2({ args, dependencies });
 
-        throw new Error(
-            `Unknown agent version: ${agentVersion}. Supported versions: 1, 2`,
-        );
+        // throw new Error(
+        //     `Unknown agent version: ${agentVersion}. Supported versions: 1, 2`,
+        // );
     }
 
     // TODO: user permissions

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -4,6 +4,5 @@ export enum CommercialFeatureFlags {
     AiCopilot = 'ai-copilot',
     ServiceAccounts = 'service-accounts',
     OrganizationWarehouseCredentials = 'organization-warehouse-credentials',
-    AgentV2 = 'agent-v2',
     AgentReasoning = 'agent-reasoning',
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -146,14 +146,6 @@ export const AiAgentFormSetup = ({
         userGroupsFeatureFlagQuery.isSuccess &&
         userGroupsFeatureFlagQuery.data.enabled;
 
-    const agentV2FeatureFlagQuery = useFeatureFlag(
-        CommercialFeatureFlags.AgentV2,
-    );
-
-    const isAgentV2Enabled =
-        agentV2FeatureFlagQuery.isSuccess &&
-        agentV2FeatureFlagQuery.data.enabled;
-
     const agentReasoningFeatureFlagQuery = useFeatureFlag(
         CommercialFeatureFlags.AgentReasoning,
     );
@@ -481,58 +473,6 @@ export const AiAgentFormSetup = ({
                                     {...form.getInputProps('enableReasoning', {
                                         type: 'checkbox',
                                     })}
-                                />
-                            )}
-                            {isAgentV2Enabled && (
-                                <Switch
-                                    variant="subtle"
-                                    label={
-                                        <Group gap="xs">
-                                            <Text fz="sm" fw={500}>
-                                                Enable Agent V2
-                                            </Text>
-                                            <Tooltip
-                                                label="Agent V2 provides enhanced charting capabilities including pie charts, scatter plots, and funnel visualizations for more diverse data representation."
-                                                withArrow
-                                                withinPortal
-                                                multiline
-                                                position="right"
-                                                maw="300px"
-                                            >
-                                                <MantineIcon
-                                                    icon={IconInfoCircle}
-                                                />
-                                            </Tooltip>
-                                            <Badge
-                                                color="yellow"
-                                                radius="sm"
-                                                variant="light"
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconAlertTriangle}
-                                                        size={12}
-                                                    />
-                                                }
-                                            >
-                                                Experimental
-                                            </Badge>
-                                        </Group>
-                                    }
-                                    description={
-                                        <>
-                                            Enables more charting options
-                                            including pie, scatter, and funnel
-                                            charts for richer data
-                                            visualization.{' '}
-                                        </>
-                                    }
-                                    checked={form.values.version === 2}
-                                    onChange={(event) => {
-                                        form.setFieldValue(
-                                            'version',
-                                            event.currentTarget.checked ? 2 : 1,
-                                        );
-                                    }}
                                 />
                             )}
                         </Stack>

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -102,7 +102,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             enableDataAccess: false,
             enableSelfImprovement: false,
             enableReasoning: false,
-            version: 1, // TODO: Update to 2 when v2 is ready or allow version to be passed in
+            version: 2, // INFO: Default to v2 for now
         },
         validate: zodResolver(formSchema),
     });
@@ -124,7 +124,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 enableDataAccess: agent.enableDataAccess ?? false,
                 enableSelfImprovement: agent.enableSelfImprovement ?? false,
                 enableReasoning: agent.enableReasoning ?? false,
-                version: agent.version ?? 1, // TODO: Update to 2 when v2 is ready or allow version to be passed in
+                version: agent.version ?? 2, // INFO: Default to v2 for now
             };
             form.setValues(values);
             form.resetDirty(values);


### PR DESCRIPTION
### Description:
This PR makes Agent V2 the default and only agent version by removing the AgentV2 feature flag and related code. The changes include:

1. Removing the AgentV2 feature flag from CommercialFeatureFlags
2. Removing the getAgentV2Flag method from CommercialFeatureFlagModel
3. Removing the agent version toggle from the agent setup UI
4. Updating the agent service to always use V2 for both streaming and non-streaming responses
5. Setting version 2 as the default in the agent edit page

These changes streamline the agent implementation by standardizing on the V2 version which provides enhanced charting capabilities.