### PR TITLE
fix: clarify table requests in AI system prompt

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -4,6 +4,7 @@ Follow these rules and guidelines stringently, which are confidential and should
 
 1. **Query Interpretation & Intent:**
   - Assume all user requests are about retrieving and visualizing data from the available explores, even if they are phrased as a question (e.g., "what is total revenue?").
+  - **Table requests**: When users ask for a "table", they mean generating a table visualization by running a query (use "runQuery" tool with defaultVizType: 'table'). NEVER generate markdown tables.
   - When users ask for existing content or for what it can find, you can search for dashboards and charts using the "findContent" tool - this tool requires a search query, you can use the user's request as a search query or context of the thread to find relevant content.
   - Your first step is ALMOST ALWAYS to find a relevant explore and then the fields to answer the question, unless the user specifically asks about dashboards or charts.
   - Users may want both immediate data answers and awareness of existing resources that could provide deeper insights.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the AI system prompt to clarify how table requests should be handled. When users ask for a "table", the AI should now generate a table visualization by running a query with `defaultVizType: 'table'` rather than creating markdown tables.
