### PR TITLE
fix: support dbt 1.10+ column meta location in model YML

### DIFF
--- a/packages/common/src/types/yamlSchema.ts
+++ b/packages/common/src/types/yamlSchema.ts
@@ -4,6 +4,9 @@ export type YamlColumn = {
     name: string;
     description?: string;
     meta?: DbtColumnMetadata;
+    config?: {
+        meta?: DbtColumnMetadata;
+    };
 };
 
 export type YamlModel = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #[issue number]

### Description:
Add support for dbt 1.10+ column metadata structure

This PR adds compatibility for dbt 1.10+ which changed the location of column metadata from the root `meta` field to `config.meta`. The changes include:

1. Added a new helper function `getColumnMeta()` that reads metadata from the correct location based on the dbt version
2. Updated the `findAndUpdateModelYaml` function to use this helper when accessing dimension type metadata
3. Extended the `YamlColumn` type to include the new `config.meta` structure

This ensures proper handling of column metadata regardless of whether using dbt 1.10+ or earlier versions.