### PR TITLE
fix: trigger render on load of compilation table

### DIFF
--- a/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
@@ -1,11 +1,4 @@
-import {
-    Box,
-    Group,
-    Loader,
-    Text,
-    Tooltip,
-    useMantineTheme,
-} from '@mantine-8/core';
+import { Group, Text, Tooltip, useMantineTheme } from '@mantine-8/core';
 import {
     IconAlertTriangleFilled,
     IconArrowDown,
@@ -118,6 +111,14 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
 
     const totalDBRowCount = data?.pages?.[0]?.pagination?.totalResults ?? 0;
     const totalFetched = compileLogs.length;
+
+    // Temporary workaround to resolve a memoization issue with react-mantine-table.
+    // In certain scenarios, the content fails to render properly even when the data is updated.
+    // This issue may be addressed in a future library update.
+    const [tableData, setTableData] = useState<ProjectCompileLog[]>([]);
+    useEffect(() => {
+        setTableData(compileLogs);
+    }, [compileLogs]);
 
     // Callback to fetch more data when scrolling
     const fetchMoreOnBottomReached = useCallback(
@@ -275,7 +276,7 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
 
     const table = useMantineReactTable({
         columns,
-        data: compileLogs,
+        data: tableData,
         enableColumnResizing: false,
         enableRowNumbers: false,
         enablePagination: false,
@@ -384,25 +385,6 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
             sorting,
         },
         onSortingChange: setSorting,
-        renderBottomToolbar: () => (
-            <Box>
-                <Group gap="xs" px="md" py="xs">
-                    {isFetching ? (
-                        <>
-                            <Loader size={14} c="gray" />{' '}
-                            <Text size="xs" c="dimmed">
-                                Loading...
-                            </Text>
-                        </>
-                    ) : (
-                        <Text size="xs" c="dimmed">
-                            Showing {totalFetched} of {totalDBRowCount} log
-                            {totalDBRowCount === 1 ? '' : 's'}
-                        </Text>
-                    )}
-                </Group>
-            </Box>
-        ),
     });
 
     if (!project) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Fixed a memoization issue in the CompilationHistoryTable component by implementing a temporary workaround. The table was failing to render properly when data was updated in certain scenarios.

Changes include:
- Added a local state variable `tableData` to properly handle updates to compilation logs
- Removed unused imports (Box, Loader)
- Removed the bottom toolbar that displayed loading status and record count

This fix ensures the table content renders correctly when compilation data changes.

> [!TIP]
> Test with no react StrictMode + navigate between settings. 