### PR TITLE
fix: retry mechanism for sending emails

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -13,11 +13,21 @@ import { marked } from 'marked';
 import * as nodemailer from 'nodemailer';
 import hbs from 'nodemailer-express-handlebars';
 import Mail from 'nodemailer/lib/mailer';
-import { AuthenticationType } from 'nodemailer/lib/smtp-connection';
+import SMTPConnection, {
+    AuthenticationType,
+} from 'nodemailer/lib/smtp-connection';
 import SMTPPool from 'nodemailer/lib/smtp-pool';
 import path from 'path';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
+
+const RETRYABLE_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND'];
+
+function isNodemailerSmtpError(
+    error: unknown,
+): error is SMTPConnection.SMTPError {
+    return error instanceof Error;
+}
 
 // Timeout configurations based on Nodemailer defaults, adjusted for scheduler compatibility
 export const SMTP_CONNECTION_CONFIG = {
@@ -168,11 +178,11 @@ export default class EmailClient {
                 } catch (error) {
                     const isLastAttempt = attempt === maxRetries;
                     const isRetryableError =
-                        error instanceof Error &&
-                        (error.message.includes('ECONNRESET') ||
-                            error.message.includes('ETIMEDOUT') ||
-                            error.message.includes('ENOTFOUND') ||
-                            error.message.includes('Connection timeout'));
+                        isNodemailerSmtpError(error) &&
+                        ((error.code &&
+                            RETRYABLE_ERROR_CODES.includes(error.code)) ||
+                            // It can be either `Connection timeout` or `Timeout`
+                            error.message.toLowerCase().includes('timeout'));
 
                     if (isLastAttempt || !isRetryableError) {
                         const isFileError =
@@ -192,8 +202,8 @@ export default class EmailClient {
                     // On the last retry attempt, try recreating the transporter to handle stale connections
                     if (
                         attempt === maxRetries - 1 &&
-                        error instanceof Error &&
-                        error.message.includes('ECONNRESET')
+                        isNodemailerSmtpError(error) &&
+                        error.code === 'ECONNRESET'
                     ) {
                         Logger.warn(
                             'Recreating email transporter due to connection reset',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17746

### Description:
Improves email error handling by:
- Adding a constant `RETRYABLE_ERROR_CODES` to centralize error codes that should trigger retries
- Creating a type guard `isNodemailerSmtpError` to properly check for Nodemailer SMTP errors
- Enhancing error detection for timeout conditions by checking both "Connection timeout" and "Timeout" messages
- Refining the connection reset detection logic to use the error code property directly

These changes make the email client more robust when handling transient network issues.

**Steps to test**

1. Apply the following diff, this will make your emails always timeout
```diff
diff --git a/packages/backend/src/clients/EmailClient/EmailClient.ts b/packages/backend/src/clients/EmailClient/EmailClient.ts
index 529392d1ef..2b59708679 100644
--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -8,6 +8,7 @@ import {
     SchedulerFormat,
     SessionUser,
     SmptError,
+    type AnyType,
 } from '@lightdash/common';
 import { marked } from 'marked';
 import * as nodemailer from 'nodemailer';
@@ -127,26 +128,27 @@ export default class EmailClient {
             pool: true, // Enable pooled connections
             maxConnections: 5, // Maximum number of connections (default is 5)
             maxMessages: 100, // Maximum number of messages per connection (default is 100)
-            connectionTimeout: SMTP_CONNECTION_CONFIG.connectionTimeout,
-            greetingTimeout: SMTP_CONNECTION_CONFIG.greetingTimeout,
-            socketTimeout: SMTP_CONNECTION_CONFIG.socketTimeout,
+            // FORCE ETIMEDOUT ERROR FOR DEBUGGING - Set extremely short timeout
+            connectionTimeout: 1, // 1ms - will force timeout
+            greetingTimeout: 1, // 1ms - will force timeout
+            socketTimeout: 1, // 1ms - will force timeout
         };
 
         this.transporter = nodemailer.createTransport(options, {
             from: `"${this.lightdashConfig.smtp.sender.name}" <${this.lightdashConfig.smtp.sender.email}>`,
         });
-        this.transporter.verify((error) => {
-            if (error) {
-                throw new SmptError(
-                    `Failed to verify email transporter. ${error}`,
-                    {
-                        error,
-                    },
-                );
-            } else {
-                Logger.debug(`Email transporter verified with success`);
-            }
-        });
+        // this.transporter.verify((error) => {
+        //     if (error) {
+        //         throw new SmptError(
+        //             `Failed to verify email transporter. ${error}`,
+        //             {
+        //                 error,
+        //             },
+        //         );
+        //     } else {
+        //         Logger.debug(`Email transporter verified with success`);
+        //     }
+        // });
 
         this.transporter.use(
             'compile',

```

2. Try to send an email. With the current code it should always retry, with the previous version it would only try once for example when the error message contained just `Timeout` and not `Connection timeout`

e.g.
```
SmptError: Failed to send email after 1 attempts. Timeout
```

