### PR TITLE
fix: reloading the explore when results is opened

### DIFF
--- a/packages/frontend/src/hooks/useDefaultSortField.ts
+++ b/packages/frontend/src/hooks/useDefaultSortField.ts
@@ -17,7 +17,10 @@ const useDefaultSortField = (
         metricQuery: { dimensions, metrics },
         tableConfig: { columnOrder },
     } = savedChart;
-    const { data } = useExplore(tableName);
+    const { data } = useExplore(tableName, {
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+    });
 
     return useMemo(() => {
         if (data) {

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -88,7 +88,10 @@ export const useExplorerQueryManager = () => {
     );
 
     // Get explore data and pivot configuration
-    const { data: explore } = useExplore(tableName);
+    const { data: explore } = useExplore(tableName, {
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+    });
     const { data: useSqlPivotResults } = useFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );


### PR DESCRIPTION
### Description:

The explore was reloading when the results card was opened. This caused some odd behavior in the side bar. This adds 
` refetchOnMount: false` to calls to useExplore. It's possible that should be the default for this hook? But this fixes a specific issue for now. 

Note that this doesn't fix the fact that the query is re-running as well. We'll need to fix that separately. 

**The bug (in main)**

![Kapture 2025-10-30 at 14 21 39](https://github.com/user-attachments/assets/cf9ec175-b86e-472a-b78d-2f87ad0ddf19)
