### PR TITLE
feat: add SQL view and chart options to AI dashboard visualizations

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -77,6 +77,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                             projectUuid={artifact.projectUuid}
                             agentUuid={artifact.agentUuid}
                             dashboardConfig={artifactData.dashboardConfig!}
+                            message={artifact.message}
                             showCloseButton={showCloseButton}
                         />
                     </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -29,6 +29,7 @@ type Props = {
     saveChartOptions?: {
         name: string | null;
         description: string | null;
+        linkToMessage: boolean;
     };
     message: AiAgentMessageAssistant;
     compiledSql?: string;
@@ -36,7 +37,7 @@ type Props = {
 
 export const AiChartQuickOptions = ({
     projectUuid,
-    saveChartOptions = { name: '', description: '' },
+    saveChartOptions = { name: '', description: '', linkToMessage: true },
     message,
     compiledSql,
 }: Props) => {
@@ -63,6 +64,10 @@ export const AiChartQuickOptions = ({
 
     const isDisabled = !metricQuery || !type || !visualizationConfig;
     const onSaveChart = (savedData: SavedChart) => {
+        if (!saveChartOptions.linkToMessage) {
+            close();
+            return;
+        }
         void savePromptQuery({ savedQueryUuid: savedData.uuid });
         if (
             user?.data?.userUuid &&

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -149,6 +149,7 @@ export const AiChartVisualization: FC<Props> = ({
                                     description:
                                         queryExecutionHandle.data.metadata
                                             .description,
+                                    linkToMessage: true,
                                 }}
                                 compiledSql={compiledSql?.query}
                             />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
@@ -1,4 +1,8 @@
-import { type AiArtifact, type ToolDashboardArgs } from '@lightdash/common';
+import {
+    type AiAgentMessageAssistant,
+    type AiArtifact,
+    type ToolDashboardArgs,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -23,6 +27,7 @@ type Props = {
     projectUuid: string;
     agentUuid: string;
     dashboardConfig: ToolDashboardArgs;
+    message: AiAgentMessageAssistant;
     showCloseButton?: boolean;
 };
 
@@ -32,6 +37,7 @@ export const AiDashboardVisualization: FC<Props> = memo(
         projectUuid,
         agentUuid,
         dashboardConfig,
+        message,
         showCloseButton = true,
     }) => {
         const dispatch = useAiAgentStoreDispatch();
@@ -110,6 +116,7 @@ export const AiDashboardVisualization: FC<Props> = memo(
                                             versionUuid={
                                                 artifactData.versionUuid
                                             }
+                                            message={message}
                                             index={index}
                                         />
                                     </ErrorBoundary>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added message passing to AI dashboard visualization components to enable SQL viewing and chart quick options. The PR adds:

1. A new `message` prop to `AiDashboardVisualization` and `AiDashboardVisualizationItem` components
2. Enhanced visualization headers with SQL viewing capability
3. Added chart quick options in the dashboard visualization items
4. Implemented compiled SQL query retrieval for dashboard visualizations
