### PR TITLE
feat: remove compilation history empty footer space

### DIFF
--- a/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationHistoryTable.tsx
@@ -292,7 +292,7 @@ const CompilationHistoryTable: FC<CompilationHistoryTableProps> = ({
         manualSorting: true,
         enableRowVirtualization: true,
         enableTopToolbar: true,
-        enableBottomToolbar: true,
+        enableBottomToolbar: false,
         enableRowActions: false,
         renderTopToolbar: () => (
             <CompilationHistoryTopToolbar

--- a/packages/frontend/src/components/CompilationHistory/index.tsx
+++ b/packages/frontend/src/components/CompilationHistory/index.tsx
@@ -39,7 +39,7 @@ const CompilationHistory: FC<CompilationHistoryProps> = ({ projectUuid }) => {
         <>
             <LoadingOverlay visible={isLoadingProject} />
 
-            <Card>
+            <Card pb="xxl">
                 <Stack gap="md">
                     <Group justify="space-between">
                         <Stack gap={2}>


### PR DESCRIPTION

### Description:
Improves the UI of the Compilation History table by:
- Disabling the bottom toolbar to reduce visual clutter
- Adding padding to the bottom of the Card component to improve spacing

This change provides a cleaner interface for viewing compilation history data.

_before_
![image.png](https://app.graphite.dev/user-attachments/assets/67e99c28-83d8-4a47-a641-47c4b5f1f006.png)


_after_
![image.png](https://app.graphite.dev/user-attachments/assets/99d2b035-d6e9-4faf-a25c-d5def4429a20.png)


