### PR TITLE
feat: validate explore names in AI agent findExplores tool

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -265,6 +265,18 @@ export class McpService extends BaseService {
                     findExplores,
                     updateProgress: async () => {}, // No-op for MCP context
                     fieldSearchSize: 200,
+                    listExplores: async () => {
+                        const { user } = (context as McpProtocolContext)
+                            .authInfo!.extra;
+                        const tagsFromContext = await this.getTagsFromContext(
+                            context as McpProtocolContext,
+                        );
+                        return this.getAvailableExplores(
+                            user,
+                            argsWithProject.projectUuid,
+                            tagsFromContext,
+                        );
+                    },
                 });
                 const result = await findExploresTool.execute!(
                     argsWithProject,

--- a/packages/backend/src/ee/services/ai/agents/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/agent.ts
@@ -148,6 +148,7 @@ const getAgentTools = (
         fieldSearchSize: args.findExploresFieldSearchSize,
         findExplores: dependencies.findExplores,
         updateProgress: dependencies.updateProgress,
+        listExplores: dependencies.listExplores,
     });
 
     const findFields = getFindFields({

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -145,6 +145,7 @@ const getAgentTools = (
         fieldSearchSize: args.findExploresFieldSearchSize,
         findExplores: dependencies.findExplores,
         updateProgress: dependencies.updateProgress,
+        listExplores: dependencies.listExplores,
     });
 
     const findFields = getFindFields({

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -10,16 +10,19 @@ import {
 import { tool } from 'ai';
 import type {
     FindExploresFn,
+    ListExploresFn,
     UpdateProgressFn,
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
+import { validateExploreNameExists } from '../utils/validators';
 import { xmlBuilder } from '../xmlBuilder';
 
 type Dependencies = {
     fieldSearchSize: number;
     findExplores: FindExploresFn;
     updateProgress: UpdateProgressFn;
+    listExplores: ListExploresFn;
 };
 
 function getCatalogChartUsage(
@@ -177,6 +180,7 @@ export const getFindExplores = ({
     findExplores,
     updateProgress,
     fieldSearchSize,
+    listExplores,
 }: Dependencies) =>
     tool({
         description: toolFindExploresArgsSchemaV2.description,
@@ -187,6 +191,9 @@ export const getFindExplores = ({
                 await updateProgress(
                     `🔍 Searching explore: \`${args.exploreName}\`...`,
                 );
+
+                const availableExplores = await listExplores();
+                validateExploreNameExists(availableExplores, args.exploreName);
 
                 const { explore, catalogFields } = await findExplores({
                     exploreName: args.exploreName,

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -684,6 +684,27 @@ ${availableTableNames.map((t) => `- ${t}`).join('\n')}`;
     }
 }
 
+/**
+ * Validate that an explore name exists in the list of available explores
+ * @param availableExploreNames - Array of available explore names
+ * @param exploreName - The explore name to validate
+ */
+export function validateExploreNameExists(
+    availableExplores: Explore[],
+    exploreName: string,
+) {
+    if (availableExplores.some((e) => e.name === exploreName)) return;
+
+    const errorMessage = `Invalid explore name: "${exploreName}"
+
+Available explores:
+${availableExplores.map((e) => `- ${e.name}`).join('\n')}`;
+
+    Logger.error(`[AiAgent][Validate Explore Name Exists] ${errorMessage}`);
+
+    throw new Error(errorMessage);
+}
+
 // Numeric metric types that support most table calculations
 const NUMERIC_METRIC_TYPES: MetricType[] = [
     MetricType.NUMBER,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Added validation for explore names in AI agent tools to prevent errors when using non-existent explores. This implementation:

1. Added a `listExplores` function to the agent tools dependencies
2. Implemented the function in McpService to retrieve available explores for the current user
3. Created a new validator function `validateExploreNameExists` that checks if the requested explore exists
4. Added validation before executing explore searches in the findExplores tool

This change improves error handling by providing clear feedback when users attempt to query non-existent explores, showing a list of available explores in the error message.