### PR TITLE
fix: Save chart/Save dashboard button uses stale message data after refetch

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -432,7 +432,9 @@ export const AssistantBubble: FC<Props> = memo(
                                                       messageArtifact.artifactUuid,
                                                   versionUuid:
                                                       messageArtifact.versionUuid,
-                                                  message: message,
+                                                  messageUuid: message.uuid,
+                                                  threadUuid:
+                                                      message.threadUuid,
                                                   projectUuid: projectUuid,
                                                   agentUuid: agentUuid,
                                               }),

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactInline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactInline.tsx
@@ -23,7 +23,8 @@ export const AiArtifactInline: FC<AiArtifactInlineProps> = ({
                 artifact={{
                     artifactUuid: artifact.artifactUuid,
                     versionUuid: artifact.versionUuid,
-                    message: message,
+                    messageUuid: message.uuid,
+                    threadUuid: message.threadUuid,
                     projectUuid: projectUuid,
                     agentUuid: agentUuid,
                 }}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -1,9 +1,10 @@
 import type { AiAgentMessageAssistant } from '@lightdash/common';
 import { Box, Center, Loader, Stack, Text } from '@mantine-8/core';
 import { IconExclamationCircle } from '@tabler/icons-react';
-import { memo, type FC } from 'react';
+import { memo, useMemo, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiAgentArtifact } from '../../hooks/useAiAgentArtifacts';
+import { useAiAgentThread } from '../../hooks/useProjectAiAgents';
 import { AiChartVisualization } from './AiChartVisualization';
 import { AiDashboardVisualization } from './AiDashboardVisualization';
 import { ChatElementsUtils } from './utils';
@@ -14,7 +15,8 @@ type AiArtifactPanelProps = {
         agentUuid: string;
         artifactUuid: string;
         versionUuid: string;
-        message: AiAgentMessageAssistant;
+        messageUuid: string;
+        threadUuid: string;
     };
     showCloseButton?: boolean;
 };
@@ -32,7 +34,21 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
             versionUuid: artifact.versionUuid,
         });
 
-        if (isArtifactLoading) {
+        const { data: thread } = useAiAgentThread(
+            artifact.projectUuid,
+            artifact.agentUuid,
+            artifact.threadUuid,
+        );
+
+        const message = useMemo(() => {
+            return thread?.messages.find(
+                (msg) =>
+                    msg.role === 'assistant' &&
+                    msg.uuid === artifact.messageUuid,
+            ) as AiAgentMessageAssistant | undefined;
+        }, [thread?.messages, artifact.messageUuid]);
+
+        if (isArtifactLoading || !message) {
             return (
                 <Box {...ChatElementsUtils.centeredElementProps} p="md">
                     <Center>
@@ -77,7 +93,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                             projectUuid={artifact.projectUuid}
                             agentUuid={artifact.agentUuid}
                             dashboardConfig={artifactData.dashboardConfig!}
-                            message={artifact.message}
+                            message={message}
                             showCloseButton={showCloseButton}
                         />
                     </Stack>
@@ -95,7 +111,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                         agentUuid={artifact.agentUuid}
                         artifactUuid={artifact.artifactUuid}
                         versionUuid={artifact.versionUuid}
-                        message={artifact.message}
+                        message={message}
                         showCloseButton={showCloseButton}
                     />
                 </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
@@ -51,7 +51,7 @@ export const useAiAgentThreadArtifact = ({
     useEffect(() => {
         if (!artifact && prevArtifactRef.current && latestAssistantMessage) {
             const wasLatestArtifactOpen =
-                prevArtifactRef.current.message.uuid ===
+                prevArtifactRef.current.messageUuid ===
                 latestAssistantMessage.uuid;
             if (wasLatestArtifactOpen) {
                 lastHandledMessageUuidRef.current = latestAssistantMessage.uuid;
@@ -62,10 +62,16 @@ export const useAiAgentThreadArtifact = ({
 
     // Auto-select latest artifact if not already handled
     useEffect(() => {
-        if (!projectUuid || !agentUuid || !latestAssistantMessage) return;
+        if (
+            !projectUuid ||
+            !agentUuid ||
+            !threadUuid ||
+            !latestAssistantMessage
+        )
+            return;
         if (lastHandledMessageUuidRef.current === latestAssistantMessage.uuid)
             return;
-        if (artifact?.message.uuid === latestAssistantMessage.uuid) return;
+        if (artifact?.messageUuid === latestAssistantMessage.uuid) return;
 
         const latestArtifact = latestAssistantMessage.artifacts?.at(-1);
         if (!latestArtifact) return;
@@ -73,12 +79,20 @@ export const useAiAgentThreadArtifact = ({
             setArtifact({
                 artifactUuid: latestArtifact.artifactUuid,
                 versionUuid: latestArtifact.versionUuid,
-                message: latestAssistantMessage,
+                messageUuid: latestAssistantMessage.uuid,
+                threadUuid,
                 projectUuid,
                 agentUuid,
             }),
         );
 
         lastHandledMessageUuidRef.current = latestAssistantMessage.uuid;
-    }, [artifact, latestAssistantMessage, projectUuid, agentUuid, dispatch]);
+    }, [
+        artifact,
+        latestAssistantMessage,
+        projectUuid,
+        agentUuid,
+        threadUuid,
+        dispatch,
+    ]);
 };

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
@@ -1,10 +1,10 @@
-import { type AiAgentMessageAssistant } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 export interface ArtifactData {
     artifactUuid: string;
     versionUuid: string;
-    message: AiAgentMessageAssistant;
+    messageUuid: string;
+    threadUuid: string;
     projectUuid: string;
     agentUuid: string;
 }
@@ -26,7 +26,8 @@ export const aiArtifactSlice = createSlice({
             action: PayloadAction<{
                 artifactUuid: string;
                 versionUuid: string;
-                message: AiAgentMessageAssistant;
+                messageUuid: string;
+                threadUuid: string;
                 projectUuid: string;
                 agentUuid: string;
             }>,
@@ -34,14 +35,16 @@ export const aiArtifactSlice = createSlice({
             const {
                 artifactUuid,
                 versionUuid,
-                message,
+                messageUuid,
+                threadUuid,
                 projectUuid,
                 agentUuid,
             } = action.payload;
             state.artifact = {
                 artifactUuid,
                 versionUuid,
-                message,
+                messageUuid,
+                threadUuid,
                 projectUuid,
                 agentUuid,
             };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixed: Save chart/Save dashboard button uses stale message data after refetch

Refactored AI artifact handling to use message UUID and thread UUID instead of passing the entire message object. This change improves data flow by:

- Replacing the full message object with specific identifiers (messageUuid and threadUuid)
