### PR TITLE
fix: keep correct pivot dimension when switching charts

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -44,7 +44,6 @@ const VisualizationCardOptions: FC = memo(() => {
         setStacking,
         isLoading,
         resultsData,
-        setPivotDimensions,
         pivotDimensions,
     } = useVisualizationContext();
     const disabled = isLoading || !resultsData || resultsData.rows.length <= 0;
@@ -336,7 +335,6 @@ const VisualizationCardOptions: FC = memo(() => {
                     }
                     icon={<MantineIcon icon={IconChartPie} />}
                     onClick={() => {
-                        setPivotDimensions(undefined);
                         setStacking(undefined);
                         setCartesianType(undefined);
                         setChartType(ChartType.PIE);
@@ -354,7 +352,6 @@ const VisualizationCardOptions: FC = memo(() => {
                     }
                     icon={<MantineIcon icon={IconFilter} />}
                     onClick={() => {
-                        setPivotDimensions(undefined);
                         setStacking(undefined);
                         setCartesianType(undefined);
                         setChartType(ChartType.FUNNEL);
@@ -372,7 +369,6 @@ const VisualizationCardOptions: FC = memo(() => {
                     }
                     icon={<MantineIcon icon={IconChartTreemap} />}
                     onClick={() => {
-                        setPivotDimensions(undefined);
                         setStacking(undefined);
                         setCartesianType(undefined);
                         setChartType(ChartType.TREEMAP);
@@ -406,7 +402,6 @@ const VisualizationCardOptions: FC = memo(() => {
                     }
                     icon={<MantineIcon icon={IconSquareNumber1} />}
                     onClick={() => {
-                        setPivotDimensions(undefined);
                         setStacking(undefined);
                         setCartesianType(undefined);
                         setChartType(ChartType.BIG_NUMBER);
@@ -424,7 +419,6 @@ const VisualizationCardOptions: FC = memo(() => {
                     }
                     icon={<MantineIcon icon={IconCode} />}
                     onClick={() => {
-                        setPivotDimensions(undefined);
                         setStacking(undefined);
                         setCartesianType(undefined);
                         setChartType(ChartType.CUSTOM);

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -839,8 +839,14 @@ const useCartesianChartConfig = ({
                 }
 
                 // don't fallback pivot dimensions if we are using sql pivot results
-                if (itemsMap !== undefined && !useSqlPivotResults?.enabled)
+                // also don't override existing pivot dimensions if they're already set
+                if (
+                    itemsMap !== undefined &&
+                    !useSqlPivotResults?.enabled &&
+                    !pivotKeys
+                ) {
                     setPivotDimensions(newPivotFields);
+                }
                 return {
                     ...prev,
                     xField: newXField,
@@ -852,6 +858,7 @@ const useCartesianChartConfig = ({
         availableDimensions,
         availableFields,
         availableMetrics,
+        pivotKeys,
         getXField,
         getYFields,
         isFieldValidTableCalculation,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

[redux branch] When switching between charts, we were resetting the pivot dimension to the default. This makes it so we keep the pivot config when switching between chart types. 

To test:
- create a bar chart with 2 pivot dimension options
- choose the non-default option
- switch to big number
- switch back to bar chart
- the pivot dimension should now be maintained

Note that one upshot from this change is that switching to and from a table will maintain the pivot across types. This is actually kind of nice, but we can change the behavior back to what we had before when we cache each chart type separately. 