### PR TITLE
fix: support fieldId format in custom metrics with backward compatibility

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/proposeChange.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.ts
@@ -3,7 +3,9 @@ import {
     ChangeBase,
     convertAdditionalMetric,
     Explore,
+    getFields,
     getItemId,
+    resolveFieldIdFromBaseDimension,
     ToolProposeChangeArgs,
     toolProposeChangeArgsSchema,
     toolProposeChangeOutputSchema,
@@ -139,15 +141,19 @@ export const getProposeChange = ({
                         switch (change.value.type) {
                             case 'create':
                                 validateTableNames(explore, [entityTableName]);
+
+                                const exploreFields = getFields(explore);
+                                const fieldIdToValidate =
+                                    resolveFieldIdFromBaseDimension(
+                                        change.value.value.metric
+                                            .baseDimensionName,
+                                        entityTableName,
+                                        exploreFields,
+                                    );
+
                                 validateFieldEntityType(
                                     explore,
-                                    [
-                                        getItemId({
-                                            table: entityTableName,
-                                            name: change.value.value.metric
-                                                .baseDimensionName,
-                                        }),
-                                    ],
+                                    [fieldIdToValidate],
                                     'dimension',
                                 );
                                 break;

--- a/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.test.ts
@@ -1,0 +1,412 @@
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    SupportedDbtAdapter,
+    type AdditionalMetric,
+    type CustomMetricBase,
+    type Explore,
+} from '@lightdash/common';
+
+import {
+    populateCustomMetricSQL,
+    populateCustomMetricsSQL,
+} from './populateCustomMetricsSQL';
+
+const mockExplore: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'test_explore',
+    label: 'Test Explore',
+    tags: [],
+    spotlight: {
+        visibility: 'show',
+        categories: [],
+    },
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'test_db',
+            schema: 'public',
+            sqlTable: 'orders',
+            sqlWhere: undefined,
+            uncompiledSqlWhere: undefined,
+            dimensions: {
+                order_date: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    name: 'order_date',
+                    label: 'Order Date',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.order_date',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.order_date',
+                    tablesReferences: ['orders'],
+                },
+                amount: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    name: 'amount',
+                    label: 'Amount',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.amount',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.amount',
+                    tablesReferences: ['orders'],
+                },
+                customer_name: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'customer_name',
+                    label: 'Customer Name',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.customer_name',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.customer_name',
+                    tablesReferences: ['orders'],
+                },
+            },
+            metrics: {
+                total_revenue: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.SUM,
+                    name: 'total_revenue',
+                    label: 'Total Revenue',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: 'SUM(${TABLE}.amount)',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'SUM(orders.amount)',
+                    tablesReferences: ['orders'],
+                },
+            },
+            lineageGraph: {},
+            source: undefined,
+            groupLabel: undefined,
+        },
+    },
+    groupLabel: undefined,
+    warehouse: undefined,
+    sqlPath: undefined,
+    ymlPath: undefined,
+    databricksCompute: undefined,
+};
+
+describe('populateCustomMetricSQL', () => {
+    describe('Edge Cases', () => {
+        it('should return null when baseDimensionName is missing', () => {
+            const metric: CustomMetricBase = {
+                name: 'avg_amount',
+                label: 'Average Amount',
+                description: 'Average order amount',
+                type: MetricType.AVERAGE,
+                baseDimensionName: undefined as unknown as string,
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+            expect(result).toBeNull();
+        });
+
+        it('should return null when baseDimensionName is empty string', () => {
+            const metric: CustomMetricBase = {
+                name: 'avg_amount',
+                label: 'Average Amount',
+                description: 'Average order amount',
+                type: MetricType.AVERAGE,
+                baseDimensionName: '',
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+            expect(result).toBeNull();
+        });
+
+        it('should return null when field does not exist', () => {
+            const metric: CustomMetricBase = {
+                name: 'avg_nonexistent',
+                label: 'Average Nonexistent',
+                description: 'Average nonexistent field',
+                type: MetricType.AVERAGE,
+                baseDimensionName: 'orders_nonexistent',
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('Happy Paths - fieldId format', () => {
+        it('should populate SQL for valid custom metric with fieldId format', () => {
+            const metric: CustomMetricBase = {
+                name: 'avg_amount',
+                label: 'Average Amount',
+                description: 'Average order amount',
+                type: MetricType.AVERAGE,
+                baseDimensionName: 'orders_amount',
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+
+            expect(result).not.toBeNull();
+            expect(result?.sql).toBe('${TABLE}.amount');
+            expect(result?.baseDimensionName).toBe('amount'); // Converted from fieldId to field name
+            expect(result?.name).toBe('avg_amount');
+            expect(result?.type).toBe(MetricType.AVERAGE);
+            expect(result?.table).toBe('orders');
+        });
+
+        it('should populate SQL for valid custom metric with fieldId format for DATE dimension', () => {
+            const metric: CustomMetricBase = {
+                name: 'min_date',
+                label: 'Min Date',
+                description: 'Minimum order date',
+                type: MetricType.MIN,
+                baseDimensionName: 'orders_order_date',
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+
+            expect(result).not.toBeNull();
+            expect(result?.sql).toBe('${TABLE}.order_date');
+            expect(result?.baseDimensionName).toBe('order_date');
+            expect(result?.name).toBe('min_date');
+            expect(result?.type).toBe(MetricType.MIN);
+        });
+
+        it('should populate SQL for valid custom metric with fieldId format for STRING dimension', () => {
+            const metric: CustomMetricBase = {
+                name: 'unique_customers',
+                label: 'Unique Customers',
+                description: 'Count distinct customer names',
+                type: MetricType.COUNT_DISTINCT,
+                baseDimensionName: 'orders_customer_name',
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+
+            expect(result).not.toBeNull();
+            expect(result?.sql).toBe('${TABLE}.customer_name');
+            expect(result?.baseDimensionName).toBe('customer_name');
+            expect(result?.name).toBe('unique_customers');
+            expect(result?.type).toBe(MetricType.COUNT_DISTINCT);
+        });
+    });
+
+    describe('Happy Paths - field name format (backward compatibility)', () => {
+        it('should populate SQL for valid custom metric with field name format', () => {
+            const metric: CustomMetricBase = {
+                name: 'avg_amount',
+                label: 'Average Amount',
+                description: 'Average order amount',
+                type: MetricType.AVERAGE,
+                baseDimensionName: 'amount',
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+
+            expect(result).not.toBeNull();
+            expect(result?.sql).toBe('${TABLE}.amount');
+            expect(result?.baseDimensionName).toBe('amount'); // Already a field name, unchanged
+            expect(result?.name).toBe('avg_amount');
+            expect(result?.type).toBe(MetricType.AVERAGE);
+        });
+
+        it('should populate SQL for valid custom metric with field name format for DATE dimension', () => {
+            const metric: CustomMetricBase = {
+                name: 'min_date',
+                label: 'Min Date',
+                description: 'Minimum order date',
+                type: MetricType.MIN,
+                baseDimensionName: 'order_date',
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+
+            expect(result).not.toBeNull();
+            expect(result?.sql).toBe('${TABLE}.order_date');
+            expect(result?.baseDimensionName).toBe('order_date');
+            expect(result?.name).toBe('min_date');
+        });
+    });
+
+    describe('Happy Paths - AdditionalMetric input', () => {
+        it('should populate SQL for AdditionalMetric without sql field', () => {
+            const metric: Omit<AdditionalMetric, 'sql'> = {
+                name: 'avg_amount',
+                label: 'Average Amount',
+                description: 'Average order amount',
+                type: MetricType.AVERAGE,
+                baseDimensionName: 'orders_amount',
+                table: 'orders',
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+
+            expect(result).not.toBeNull();
+            expect(result?.sql).toBe('${TABLE}.amount');
+            expect(result?.baseDimensionName).toBe('amount');
+        });
+
+        it('should preserve other AdditionalMetric fields', () => {
+            const metric: Omit<AdditionalMetric, 'sql'> = {
+                name: 'avg_amount',
+                label: 'Average Amount',
+                description: 'Average order amount',
+                type: MetricType.AVERAGE,
+                baseDimensionName: 'orders_amount',
+                table: 'orders',
+                hidden: true,
+                round: 2,
+            };
+
+            const result = populateCustomMetricSQL(metric, mockExplore);
+
+            expect(result).not.toBeNull();
+            expect(result?.hidden).toBe(true);
+            expect(result?.round).toBe(2);
+            expect(result?.sql).toBe('${TABLE}.amount');
+        });
+    });
+});
+
+describe('populateCustomMetricsSQL', () => {
+    describe('Edge Cases', () => {
+        it('should return empty array when customMetrics is null', () => {
+            const result = populateCustomMetricsSQL(null, mockExplore);
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array when customMetrics is undefined', () => {
+            const result = populateCustomMetricsSQL(undefined, mockExplore);
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array when customMetrics is empty array', () => {
+            const result = populateCustomMetricsSQL([], mockExplore);
+            expect(result).toEqual([]);
+        });
+
+        it('should filter out metrics that cannot be populated', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_amount',
+                    table: 'orders',
+                },
+                {
+                    name: 'avg_nonexistent',
+                    label: 'Average Nonexistent',
+                    description: 'Average nonexistent field',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_nonexistent',
+                    table: 'orders',
+                },
+            ];
+
+            const result = populateCustomMetricsSQL(customMetrics, mockExplore);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]?.name).toBe('avg_amount');
+            expect(result[0]?.sql).toBe('${TABLE}.amount');
+        });
+    });
+
+    describe('Happy Paths', () => {
+        it('should populate SQL for multiple valid custom metrics', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_amount',
+                    table: 'orders',
+                },
+                {
+                    name: 'min_date',
+                    label: 'Min Date',
+                    description: 'Minimum order date',
+                    type: MetricType.MIN,
+                    baseDimensionName: 'orders_order_date',
+                    table: 'orders',
+                },
+            ];
+
+            const result = populateCustomMetricsSQL(customMetrics, mockExplore);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]?.name).toBe('avg_amount');
+            expect(result[0]?.sql).toBe('${TABLE}.amount');
+            expect(result[0]?.baseDimensionName).toBe('amount');
+            expect(result[1]?.name).toBe('min_date');
+            expect(result[1]?.sql).toBe('${TABLE}.order_date');
+            expect(result[1]?.baseDimensionName).toBe('order_date');
+        });
+
+        it('should handle mix of fieldId and field name formats', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_amount', // fieldId format
+                    table: 'orders',
+                },
+                {
+                    name: 'min_date',
+                    label: 'Min Date',
+                    description: 'Minimum order date',
+                    type: MetricType.MIN,
+                    baseDimensionName: 'order_date', // field name format
+                    table: 'orders',
+                },
+            ];
+
+            const result = populateCustomMetricsSQL(customMetrics, mockExplore);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]?.baseDimensionName).toBe('amount');
+            expect(result[1]?.baseDimensionName).toBe('order_date');
+        });
+
+        it('should handle AdditionalMetric inputs', () => {
+            const customMetrics: Omit<AdditionalMetric, 'sql'>[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_amount',
+                    table: 'orders',
+                    hidden: true,
+                },
+            ];
+
+            const result = populateCustomMetricsSQL(customMetrics, mockExplore);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]?.sql).toBe('${TABLE}.amount');
+            expect(result[0]?.hidden).toBe(true);
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/validateCustomMetricsDefinition.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateCustomMetricsDefinition.test.ts
@@ -1,0 +1,470 @@
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    SupportedDbtAdapter,
+    type CustomMetricBase,
+    type Explore,
+} from '@lightdash/common';
+
+import { validateCustomMetricsDefinition } from './validators';
+
+const mockExplore: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'test_explore',
+    label: 'Test Explore',
+    tags: [],
+    spotlight: {
+        visibility: 'show',
+        categories: [],
+    },
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'test_db',
+            schema: 'public',
+            sqlTable: 'orders',
+            sqlWhere: undefined,
+            uncompiledSqlWhere: undefined,
+            dimensions: {
+                order_date: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    name: 'order_date',
+                    label: 'Order Date',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.order_date',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.order_date',
+                    tablesReferences: ['orders'],
+                },
+                customer_name: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'customer_name',
+                    label: 'Customer Name',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.customer_name',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.customer_name',
+                    tablesReferences: ['orders'],
+                },
+                amount: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    name: 'amount',
+                    label: 'Amount',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.amount',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.amount',
+                    tablesReferences: ['orders'],
+                },
+                is_active: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.BOOLEAN,
+                    name: 'is_active',
+                    label: 'Is Active',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.is_active',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.is_active',
+                    tablesReferences: ['orders'],
+                },
+            },
+            metrics: {
+                total_revenue: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.SUM,
+                    name: 'total_revenue',
+                    label: 'Total Revenue',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: 'SUM(${TABLE}.amount)',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'SUM(orders.amount)',
+                    tablesReferences: ['orders'],
+                },
+                order_count: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.COUNT,
+                    name: 'order_count',
+                    label: 'Order Count',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: 'COUNT(*)',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'COUNT(*)',
+                    tablesReferences: ['orders'],
+                },
+            },
+            lineageGraph: {},
+            source: undefined,
+            groupLabel: undefined,
+        },
+    },
+    groupLabel: undefined,
+    warehouse: undefined,
+    sqlPath: undefined,
+    ymlPath: undefined,
+    databricksCompute: undefined,
+};
+
+describe('validateCustomMetricsDefinition', () => {
+    describe('Edge Cases', () => {
+        it('should not throw when customMetrics is null', () => {
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, null),
+            ).not.toThrow();
+        });
+
+        it('should not throw when customMetrics is an empty array', () => {
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, []),
+            ).not.toThrow();
+        });
+    });
+
+    describe('Happy Paths', () => {
+        it('should not throw for valid custom metric with fieldId format', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_amount',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).not.toThrow();
+        });
+
+        it('should not throw for valid custom metric with field name format (backward compatibility)', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'amount',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).not.toThrow();
+        });
+
+        it('should not throw for valid custom metric with COUNT on STRING dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'unique_customers',
+                    label: 'Unique Customers',
+                    description: 'Count distinct customer names',
+                    type: MetricType.COUNT_DISTINCT,
+                    baseDimensionName: 'orders_customer_name',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).not.toThrow();
+        });
+
+        it('should not throw for valid custom metric with COUNT on BOOLEAN dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'active_count',
+                    label: 'Active Count',
+                    description: 'Count active orders',
+                    type: MetricType.COUNT,
+                    baseDimensionName: 'orders_is_active',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).not.toThrow();
+        });
+
+        it('should not throw for valid custom metric with MIN/MAX on DATE dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'earliest_order',
+                    label: 'Earliest Order',
+                    description: 'Minimum order date',
+                    type: MetricType.MIN,
+                    baseDimensionName: 'orders_order_date',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).not.toThrow();
+        });
+
+        it('should not throw for multiple valid custom metrics', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_amount',
+                    table: 'orders',
+                },
+                {
+                    name: 'unique_customers',
+                    label: 'Unique Customers',
+                    description: 'Count distinct customer names',
+                    type: MetricType.COUNT_DISTINCT,
+                    baseDimensionName: 'orders_customer_name',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).not.toThrow();
+        });
+    });
+
+    describe('Error Cases', () => {
+        it('should throw when baseDimensionName is missing', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: '',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/base dimension name is required/);
+        });
+
+        it('should throw when baseDimensionName (fieldId) does not exist in explore', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_nonexistent',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/does not exist in the explore/);
+        });
+
+        it('should throw when baseDimensionName (field name) does not exist in explore', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'nonexistent',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/does not exist in the explore/);
+        });
+
+        it('should throw when baseDimensionName is from wrong table', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_amount',
+                    label: 'Average Amount',
+                    description: 'Average order amount',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'payments_amount',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/does not exist in the explore/);
+        });
+
+        it('should throw when baseDimensionName points to a metric instead of dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'double_revenue',
+                    label: 'Double Revenue',
+                    description: 'Double the total revenue',
+                    type: MetricType.SUM,
+                    baseDimensionName: 'orders_total_revenue',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/is not a dimension/);
+        });
+
+        it('should throw when applying AVERAGE to STRING dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_customer',
+                    label: 'Average Customer',
+                    description: 'Invalid: average on string',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_customer_name',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/cannot apply average aggregation to string dimension/i);
+        });
+
+        it('should throw when applying SUM to STRING dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'sum_customer',
+                    label: 'Sum Customer',
+                    description: 'Invalid: sum on string',
+                    type: MetricType.SUM,
+                    baseDimensionName: 'orders_customer_name',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/cannot apply sum aggregation to string dimension/i);
+        });
+
+        it('should throw when applying PERCENTILE to STRING dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'percentile_customer',
+                    label: 'Percentile Customer',
+                    description: 'Invalid: percentile on string',
+                    type: MetricType.PERCENTILE,
+                    baseDimensionName: 'orders_customer_name',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(
+                /cannot apply percentile aggregation to string dimension/i,
+            );
+        });
+
+        it('should throw when applying AVERAGE to BOOLEAN dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_active',
+                    label: 'Average Active',
+                    description: 'Invalid: average on boolean',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_is_active',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/cannot apply average aggregation to boolean dimension/i);
+        });
+
+        it('should throw when applying SUM to BOOLEAN dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'sum_active',
+                    label: 'Sum Active',
+                    description: 'Invalid: sum on boolean',
+                    type: MetricType.SUM,
+                    baseDimensionName: 'orders_is_active',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/cannot apply sum aggregation to boolean dimension/i);
+        });
+
+        it('should throw when applying AVERAGE to DATE dimension', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_date',
+                    label: 'Average Date',
+                    description: 'Invalid: average on date',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_order_date',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(/cannot apply average aggregation to date dimension/i);
+        });
+
+        it('should throw with multiple error messages when multiple custom metrics are invalid', () => {
+            const customMetrics: CustomMetricBase[] = [
+                {
+                    name: 'avg_customer',
+                    label: 'Average Customer',
+                    description: 'Invalid: average on string',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_customer_name',
+                    table: 'orders',
+                },
+                {
+                    name: 'nonexistent_metric',
+                    label: 'Nonexistent Metric',
+                    description: 'Invalid: field does not exist',
+                    type: MetricType.AVERAGE,
+                    baseDimensionName: 'orders_nonexistent',
+                    table: 'orders',
+                },
+            ];
+
+            expect(() =>
+                validateCustomMetricsDefinition(mockExplore, customMetrics),
+            ).toThrow(
+                /average aggregation to string[\s\S]*does not exist in the explore|does not exist in the explore[\s\S]*average aggregation to string/i,
+            );
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -29,6 +29,7 @@ import {
     renderFilterRuleSql,
     renderFilterRuleSqlFromField,
     renderTableCalculationFilterRuleSql,
+    resolveFieldIdFromBaseDimension,
     stringFilterSchema,
     SupportedDbtAdapter,
     TableCalcSchema,
@@ -106,15 +107,13 @@ export function validateCustomMetricsDefinition(
             return;
         }
 
-        const field = exploreFields.find(
-            (f) =>
-                metric.baseDimensionName &&
-                getItemId(f) ===
-                    getItemId({
-                        name: metric.baseDimensionName,
-                        table: metric.table,
-                    }),
+        const fieldId = resolveFieldIdFromBaseDimension(
+            metric.baseDimensionName,
+            metric.table,
+            exploreFields,
         );
+
+        const field = exploreFields.find((f) => getItemId(f) === fieldId);
 
         if (!field) {
             errors.push(

--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { MetricType } from '../../../types/field';
+import { getFieldIdSchema } from './fieldId';
 
 export const customMetricBaseSchema = z.object({
     name: z
@@ -17,11 +18,10 @@ export const customMetricBaseSchema = z.object({
         .describe(
             'Brief explanation of what the metric represents, how it is calculated, and why it matters. Example: "Calculates the total revenue by summing all transaction amounts in the sales table."',
         ),
-    baseDimensionName: z
-        .string()
-        .describe(
-            'Name of the base dimension/column this metric calculates from',
-        ),
+    baseDimensionName: getFieldIdSchema({
+        additionalDescription:
+            'Field ID of the base dimension/column this metric calculates from (e.g., "payments_amount"). Must be from the table specified in the table field.',
+    }),
     table: z
         .string()
         .describe(
@@ -54,14 +54,15 @@ export const customMetricsSchema = z
 IMPORTANT: If the user requests metrics that don't exist (like "average customer age"), create them using the customMetrics field. Analyze available dimensions from findFields results and create appropriate SQL aggregations.
 
 When using custom metrics:
-1. Create the metric in customMetrics array with just the metric name (e.g., "avg_customer_age")
+1. Create the metric object in customMetrics array with name, label, type, baseDimensionName (fieldId format like "table_fieldname"), and table
 2. Reference it in metrics array using the format "table_metricname" (e.g., "customers_avg_customer_age")
 3. Reference it in sorts array using the format "table_metricname" (e.g., "customers_avg_customer_age")
 4. DO NOT use the raw metric name in metrics or sorts arrays
+5. baseDimensionName must be in fieldId format (e.g., "customers_age") - use the fieldId from findFields results, not just the field name
 
 For example:
 - "Show me average customer age sorted descending" →
-customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
+customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "customers_age", table: "customers"}]
 metrics: ["customers_avg_customer_age"]
 sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17757

### Description:

Improved custom metrics handling to support field IDs in the `baseDimensionName` property while maintaining backward compatibility with field names. This change:

1. Updated `populateCustomMetricSQL` to first try treating `baseDimensionName` as a field ID before falling back to field name format
2. Added `extractFieldNameFromFieldId` utility function to convert field IDs back to field names for the query engine
3. Updated validation logic in `validateCustomMetricsDefinition` to support both field ID and field name formats
4. Added comprehensive test suite for custom metrics validation covering various edge cases and error scenarios
5. Updated schema documentation to clarify that `baseDimensionName` should use field ID format

This enhancement makes custom metrics more consistent with how fields are referenced elsewhere in the application while ensuring existing implementations continue to work.
