### PR TITLE
fix: get correct axis for stacked bar charts series

### DIFF
--- a/packages/frontend/src/hooks/echarts/styles/barChartStyles.ts
+++ b/packages/frontend/src/hooks/echarts/styles/barChartStyles.ts
@@ -188,13 +188,19 @@ export const applyStackedBarCategoryData = (
     const categoryData = rows.map((row) => row[categoryFieldHash]?.value?.raw);
 
     // Add category data to the appropriate axis
+    // For stacked bars with data arrays, must use 'category' axis type
+    // This ensures bars are positioned at discrete points, not spread across continuous time
     if (isFlipAxes) {
         // Horizontal: categories on y-axis
         return {
             xAxis: axes.xAxis,
             yAxis: axes.yAxis.map((axis, idx) =>
                 idx === 0
-                    ? ({ ...axis, data: categoryData } as typeof axis)
+                    ? ({
+                          ...axis,
+                          type: 'category',
+                          data: categoryData,
+                      } as typeof axis)
                     : axis,
             ),
         };
@@ -203,7 +209,11 @@ export const applyStackedBarCategoryData = (
         return {
             xAxis: axes.xAxis.map((axis, idx) =>
                 idx === 0
-                    ? ({ ...axis, data: categoryData } as typeof axis)
+                    ? ({
+                          ...axis,
+                          type: 'category',
+                          data: categoryData,
+                      } as typeof axis)
                     : axis,
             ),
             yAxis: axes.yAxis,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -772,9 +772,14 @@ const getPivotSeries = ({
                     )),
                 ...(itemsMap &&
                     itemsMap[series.encode.yRef.field] && {
-                        formatter: (value: any) => {
+                        formatter: (param: any) => {
                             const field = itemsMap[series.encode.yRef.field];
-                            const rawValue = value?.value?.[yFieldHash];
+                            // Handle both dataset encoding and data array modes
+                            // Dataset mode: param.value is the row, access via field hash
+                            // Data array mode: param.value is the actual number value
+                            const rawValue = param?.value?.[yFieldHash] !== undefined
+                                ? param.value[yFieldHash]
+                                : param?.value;
                             return seriesValueFormatter(field, rawValue);
                         },
                     }),
@@ -870,9 +875,14 @@ const getSimpleSeries = ({
                 getValueLabelStyle(theme, series.color, series.label.position)),
             ...(itemsMap &&
                 itemsMap[yFieldHash] && {
-                    formatter: (value: any) => {
+                    formatter: (param: any) => {
                         const field = itemsMap[yFieldHash];
-                        const rawValue = value?.value?.[yFieldHash];
+                        // Handle both dataset encoding and data array modes
+                        // Dataset mode: param.value is the row, access via field hash
+                        // Data array mode: param.value is the actual number value
+                        const rawValue = param?.value?.[yFieldHash] !== undefined
+                            ? param.value[yFieldHash]
+                            : param?.value;
                         return seriesValueFormatter(field, rawValue);
                     },
                 }),
@@ -1998,6 +2008,13 @@ const useEchartsCartesianConfig = (
             (s) => s.type === CartesianSeriesType.BAR && s.stack && !isStack100,
         );
 
+        console.log('[useEchartsCartesianConfig] Before applyStackedBarBorderRadius:', {
+            isStack100,
+            stackedBarSeriesCount: stackedBarSeries.length,
+            allSeriesCount: seriesWithValidStack.length,
+            rowsCount: rows.length,
+        });
+
         const seriesWithBorderRadius = applyStackedBarBorderRadius(
             seriesWithValidStack,
             stackedBarSeries,
@@ -2594,6 +2611,15 @@ const useEchartsCartesianConfig = (
         const categoryFieldHash = validCartesianConfig?.layout.flipAxes
             ? validCartesianConfig?.layout?.yField?.[0]
             : validCartesianConfig?.layout?.xField;
+
+        console.log('[useEchartsCartesianConfig] Before applyStackedBarCategoryData:', {
+            categoryFieldHash,
+            flipAxes: validCartesianConfig?.layout.flipAxes,
+            xAxisType: axes.xAxis[0]?.type,
+            yAxisType: axes.yAxis[0]?.type,
+            xAxisData: axes.xAxis[0]?.data?.length || 'no data',
+            yAxisData: axes.yAxis[0]?.data?.length || 'no data',
+        });
 
         const modifiedAxes = applyStackedBarCategoryData(
             axes,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Fixed stacked bar chart rendering by ensuring proper axis type configuration. This PR:

1. Explicitly sets the axis type to 'category' for stacked bar charts to ensure bars are positioned at discrete points rather than spread across a continuous time axis
2. Improves the value formatter to handle both dataset encoding and data array modes, making it more robust across different chart configurations
3. Added debug logging to help diagnose stacked bar chart rendering issues

These changes ensure stacked bar charts display correctly regardless of data structure or axis orientation.
[
http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/campaigns?create_saved_chart_version=%7B%22uuid%22%3A%220a8f373a-042f-44c2-b574-32d092fb89b3%22%2C%22projectUuid%22%3A%223675b69e-8324-4110-bdca-059031aa8da3%22%2C%22name%22%3A%22asdasd%22%2C%22description%22%3A%22%22%2C%22tableName%22%3A%22campaigns%22%2C%22updatedAt%22%3A%222025-10-30T16%3A04%3A16.396Z%22%2C%22updatedByUser%22%3A%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%7D%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22campaigns%22%2C%22dimensions%22%3A%5B%22campaigns_campaign_type%22%2C%22campaigns_start_date_month%22%2C%22campaigns_target_audience%22%5D%2C%22metrics%22%3A%5B%22campaigns_total_budget%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22campaigns_campaign_type%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A500%2C%22metricOverrides%22%3A%7B%7D%2C%22tableCalculations%22%3A%5B%7B%22name%22%3A%22test%22%2C%22displayName%22%3A%22test%22%2C%22sql%22%3A%22ROUND%28%28%28%24%7Bcampaigns.total_budget%7D+%2F%5Cnsum%28%24%7Bcampaigns.total_budget%7D%29+over+%28%5Cn++++partition+by+%24%7Bcampaigns.start_date_month%7D%5Cn%29%29+*+100%29%2C+1%29%22%2C%22format%22%3A%7B%22type%22%3A%22default%22%2C%22separator%22%3A%22default%22%7D%2C%22type%22%3A%22number%22%7D%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22stack%22%3A%22stack%22%2C%22xField%22%3A%22campaigns_campaign_type%22%2C%22yField%22%3A%5B%22campaigns_total_budget%22%5D%7D%2C%22eChartsConfig%22%3A%7B%7D%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22campaigns_campaign_type%22%2C%22campaigns_start_date_month%22%2C%22campaigns_target_audience%22%2C%22campaigns_total_budget%22%2C%22test%22%5D%7D%2C%22organizationUuid%22%3A%22172a2270-000f-42be-9c68-c4752c23ae51%22%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22campaigns_target_audience%22%5D%7D%2C%22spaceUuid%22%3A%22f14fe9d7-77f1-450b-9f27-31242b93a262%22%2C%22spaceName%22%3A%22Parent+Space+5%22%2C%22pinnedListUuid%22%3Anull%2C%22pinnedListOrder%22%3Anull%2C%22dashboardUuid%22%3Anull%2C%22dashboardName%22%3Anull%2C%22colorPalette%22%3A%5B%22%2333ffb1%22%2C%22%23ff33e1%22%2C%22%2333e6ff%22%2C%22%23ffdd8a%22%2C%22%23ffdefa%22%2C%22%2373c0de%22%2C%22%23ff8178%22%2C%22%239a60b4%22%2C%22%23ea7ccc%22%2C%22%2333ff7d%22%2C%22%2333ffb1%22%2C%22%2333ffe6%22%2C%22%2333e6ff%22%2C%22%2333b1ff%22%2C%22%23337dff%22%2C%22%233349ff%22%2C%22%235e33ff%22%2C%22%239233ff%22%2C%22%23c633ff%22%2C%22%23ff33e1%22%5D%2C%22slug%22%3A%22asdasd-2%22%2C%22isPrivate%22%3Atrue%2C%22access%22%3A%5B%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%2C%22email%22%3A%22demo%40lightdash.com%22%2C%22role%22%3A%22admin%22%2C%22hasDirectAccess%22%3Atrue%2C%22inheritedRole%22%3A%22admin%22%2C%22inheritedFrom%22%3A%22organization%22%2C%22projectRole%22%3A%22admin%22%7D%5D%7D](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/campaigns?create_saved_chart_version=%7B%22uuid%22%3A%22ca3fed5c-16ec-4982-8bb9-16ef03450053%22%2C%22projectUuid%22%3A%223675b69e-8324-4110-bdca-059031aa8da3%22%2C%22name%22%3A%22asdasd%22%2C%22description%22%3A%22%22%2C%22tableName%22%3A%22campaigns%22%2C%22updatedAt%22%3A%222025-10-30T16%3A05%3A45.035Z%22%2C%22updatedByUser%22%3A%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%7D%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22campaigns%22%2C%22dimensions%22%3A%5B%22campaigns_campaign_type%22%2C%22campaigns_start_date_month%22%2C%22campaigns_target_audience%22%5D%2C%22metrics%22%3A%5B%22campaigns_total_budget%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22campaigns_campaign_type%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A500%2C%22metricOverrides%22%3A%7B%7D%2C%22tableCalculations%22%3A%5B%7B%22name%22%3A%22test%22%2C%22displayName%22%3A%22test%22%2C%22sql%22%3A%22ROUND%28%28%28%24%7Bcampaigns.total_budget%7D+%2F%5Cnsum%28%24%7Bcampaigns.total_budget%7D%29+over+%28%5Cn++++partition+by+%24%7Bcampaigns.start_date_month%7D%5Cn%29%29+*+100%29%2C+1%29%22%2C%22format%22%3A%7B%22type%22%3A%22default%22%2C%22separator%22%3A%22default%22%7D%2C%22type%22%3A%22number%22%7D%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22stack%22%3A%22stack%22%2C%22xField%22%3A%22campaigns_start_date_month%22%2C%22yField%22%3A%5B%22campaigns_total_budget%22%5D%7D%2C%22eChartsConfig%22%3A%7B%7D%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22campaigns_campaign_type%22%2C%22campaigns_start_date_month%22%2C%22campaigns_target_audience%22%2C%22campaigns_total_budget%22%2C%22test%22%5D%7D%2C%22organizationUuid%22%3A%22172a2270-000f-42be-9c68-c4752c23ae51%22%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22campaigns_target_audience%22%5D%7D%2C%22spaceUuid%22%3A%22f14fe9d7-77f1-450b-9f27-31242b93a262%22%2C%22spaceName%22%3A%22Parent+Space+5%22%2C%22pinnedListUuid%22%3Anull%2C%22pinnedListOrder%22%3Anull%2C%22dashboardUuid%22%3Anull%2C%22dashboardName%22%3Anull%2C%22colorPalette%22%3A%5B%22%2333ffb1%22%2C%22%23ff33e1%22%2C%22%2333e6ff%22%2C%22%23ffdd8a%22%2C%22%23ffdefa%22%2C%22%2373c0de%22%2C%22%23ff8178%22%2C%22%239a60b4%22%2C%22%23ea7ccc%22%2C%22%2333ff7d%22%2C%22%2333ffb1%22%2C%22%2333ffe6%22%2C%22%2333e6ff%22%2C%22%2333b1ff%22%2C%22%23337dff%22%2C%22%233349ff%22%2C%22%235e33ff%22%2C%22%239233ff%22%2C%22%23c633ff%22%2C%22%23ff33e1%22%5D%2C%22slug%22%3A%22asdasd-3%22%2C%22isPrivate%22%3Atrue%2C%22access%22%3A%5B%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%2C%22email%22%3A%22demo%40lightdash.com%22%2C%22role%22%3A%22admin%22%2C%22hasDirectAccess%22%3Atrue%2C%22inheritedRole%22%3A%22admin%22%2C%22inheritedFrom%22%3A%22organization%22%2C%22projectRole%22%3A%22admin%22%7D%5D%7D)

before

![image.png](https://app.graphite.dev/user-attachments/assets/1443acbd-6ca1-4a11-9e00-7745e13d042f.png)

after

![image.png](https://app.graphite.dev/user-attachments/assets/0633072b-aa6e-49ec-af74-653de6c92b6f.png)

