### PR TITLE
feat: databricks oauth on CLI

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/macros/quarter_end_date.sql
+++ b/examples/full-jaffle-shop-demo/dbt/macros/quarter_end_date.sql
@@ -9,7 +9,9 @@
     ({{ quarter_start_column }} + interval '3' month - interval '1' day)
   {% elif target.type == 'clickhouse' %}
     addDays(addMonths({{ quarter_start_column }}, 3), -1)
+  {% elif target.type == 'databricks' %}
+    DATE_ADD(ADD_MONTHS({{ quarter_start_column }}, 3), -1)
   {% else %}
-    {{ exceptions.raise_compiler_error("Unsupported database type: " ~ target.type) }}
+    {{ exceptions.raise_compiler_error("Unsupported database type \"" ~ target.type ~ "\". Update quarter_end_date.sql macro to handle this warehouse") }}
   {% endif %}
 {% endmacro %}

--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -211,7 +211,10 @@ const credentialsTarget = (
                     http_path: credentials.httpPath,
                 },
                 environment: {
-                    [envVar('token')]: tokenValue,
+                    [envVar('token')]:
+                        credentials.personalAccessToken ||
+                        credentials.token ||
+                        '',
                 },
             };
         }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8231,7 +8231,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DatabricksAuthenticationType: {
         dataType: 'refEnum',
-        enums: ['personal_access_token', 'oauth'],
+        enums: ['personal_access_token', 'oauth_m2m'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__':
@@ -8832,6 +8832,8 @@ const models: TsoaRoute.Models = {
                     ],
                 },
                 requireUserCredentials: { dataType: 'boolean' },
+                oauthClientSecret: { dataType: 'string' },
+                oauthClientId: { dataType: 'string' },
                 token: { dataType: 'string' },
                 refreshToken: { dataType: 'string' },
                 personalAccessToken: { dataType: 'string' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8472,7 +8472,7 @@
                 "type": "string"
             },
             "DatabricksAuthenticationType": {
-                "enum": ["personal_access_token", "oauth"],
+                "enum": ["personal_access_token", "oauth_m2m"],
                 "type": "string"
             },
             "Pick_CreateDatabricksCredentials.Exclude_keyofCreateDatabricksCredentials.SensitiveCredentialsFieldNames__": {
@@ -9151,6 +9151,12 @@
                     },
                     "requireUserCredentials": {
                         "type": "boolean"
+                    },
+                    "oauthClientSecret": {
+                        "type": "string"
+                    },
+                    "oauthClientId": {
+                        "type": "string"
                     },
                     "token": {
                         "type": "string"

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -43,6 +43,7 @@ import {
     DashboardBasicDetails,
     type DashboardDAO,
     DashboardFilters,
+    DatabricksAuthenticationType,
     DateZoom,
     DbtExposure,
     DbtExposureType,
@@ -167,7 +168,11 @@ import {
     WarehouseTableSchema,
     WarehouseTypes,
 } from '@lightdash/common';
-import { BigqueryWarehouseClient, SshTunnel } from '@lightdash/warehouses';
+import {
+    BigqueryWarehouseClient,
+    exchangeDatabricksOAuthCredentials,
+    SshTunnel,
+} from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
@@ -734,6 +739,79 @@ export class ProjectService extends BaseService {
                 throw new SnowflakeTokenError(errorMessage);
             }
         }
+
+        if (
+            args.type === WarehouseTypes.DATABRICKS &&
+            args.authenticationType === DatabricksAuthenticationType.OAUTH_M2M
+        ) {
+            try {
+                // Try to use stored OAuth credentials first, then fall back to refresh token
+                if (
+                    args.oauthClientId &&
+                    args.oauthClientSecret &&
+                    !args.refreshToken
+                ) {
+                    this.logger.debug(
+                        `Exchanging Databricks OAuth credentials for access token for user ${userUuid}`,
+                    );
+                    const { accessToken, refreshToken } =
+                        await exchangeDatabricksOAuthCredentials(
+                            args.serverHostName,
+                            args.oauthClientId,
+                            args.oauthClientSecret,
+                        );
+                    return {
+                        ...args,
+                        authenticationType:
+                            DatabricksAuthenticationType.OAUTH_M2M,
+                        token: accessToken,
+                        refreshToken,
+                    };
+                }
+
+                let { refreshToken } = args;
+
+                // If no refresh token provided, try to get it from user's OpenID table
+                if (refreshToken === undefined) {
+                    refreshToken = await this.userModel.getRefreshToken(
+                        userUuid,
+                        OpenIdIdentityIssuerType.DATABRICKS,
+                    );
+                }
+
+                // If we still don't have a refresh token, we can't refresh
+                if (!refreshToken) {
+                    throw new Error(
+                        'No refresh token or OAuth credentials available for Databricks OAuth authentication',
+                    );
+                }
+
+                this.logger.debug(
+                    `Refreshing databricks token for user ${userUuid}`,
+                );
+
+                const accessToken =
+                    await UserService.generateDatabricksAccessToken(
+                        refreshToken,
+                    );
+                return {
+                    ...args,
+                    authenticationType: DatabricksAuthenticationType.OAUTH_M2M,
+                    token: accessToken,
+                };
+            } catch (e: unknown) {
+                if (e instanceof LightdashError) {
+                    throw e;
+                }
+                this.logger.error(
+                    `Error refreshing databricks token: ${JSON.stringify(e)}`,
+                );
+                throw new UnexpectedServerError(
+                    'Error refreshing databricks token',
+                );
+            }
+        }
+
         return args;
     }
 
@@ -886,7 +964,8 @@ export class ProjectService extends BaseService {
 
         if (
             args.warehouseConnection.type === WarehouseTypes.DATABRICKS &&
-            args.warehouseConnection.authenticationType === 'oauth' &&
+            args.warehouseConnection.authenticationType ===
+                DatabricksAuthenticationType.OAUTH_M2M &&
             !organizationWarehouseCredentialsUuid
         ) {
             const refreshToken = await this.userModel.getRefreshToken(
@@ -1926,16 +2005,40 @@ export class ProjectService extends BaseService {
 
         if (
             project.warehouseConnection.type === WarehouseTypes.DATABRICKS &&
-            project.warehouseConnection.authenticationType === 'oauth' &&
-            project.warehouseConnection.refreshToken
+            project.warehouseConnection.authenticationType ===
+                DatabricksAuthenticationType.OAUTH_M2M
         ) {
-            this.logger.debug(
-                `Refreshing databricks warehouse credentials from refresh token on buildAdapter`,
-            );
-            const accessToken = await UserService.generateDatabricksAccessToken(
-                project.warehouseConnection.refreshToken,
-            );
-            project.warehouseConnection.token = accessToken;
+            // If we have OAuth credentials but no refresh token, exchange them for tokens
+            if (
+                project.warehouseConnection.oauthClientId &&
+                project.warehouseConnection.oauthClientSecret &&
+                !project.warehouseConnection.refreshToken
+            ) {
+                this.logger.debug(
+                    `Exchanging Databricks OAuth credentials for access token on buildAdapter`,
+                );
+                const { accessToken, refreshToken } =
+                    await exchangeDatabricksOAuthCredentials(
+                        project.warehouseConnection.serverHostName,
+                        project.warehouseConnection.oauthClientId,
+                        project.warehouseConnection.oauthClientSecret,
+                    );
+                project.warehouseConnection.token = accessToken;
+                if (refreshToken) {
+                    project.warehouseConnection.refreshToken = refreshToken;
+                    // Note: refresh token will be persisted when project credentials are next saved
+                }
+            } else if (project.warehouseConnection.refreshToken) {
+                // If we have a refresh token, use it to get a fresh access token
+                this.logger.debug(
+                    `Refreshing databricks warehouse credentials from refresh token on buildAdapter`,
+                );
+                const accessToken =
+                    await UserService.generateDatabricksAccessToken(
+                        project.warehouseConnection.refreshToken,
+                    );
+                project.warehouseConnection.token = accessToken;
+            }
         }
 
         const sshTunnel = new SshTunnel(project.warehouseConnection);

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1783,7 +1783,7 @@ export class UserService extends BaseService {
             name: 'Default',
             credentials: {
                 type: WarehouseTypes.DATABRICKS,
-                authenticationType: DatabricksAuthenticationType.OAUTH,
+                authenticationType: DatabricksAuthenticationType.OAUTH_M2M,
                 refreshToken,
                 database: '', // Will be set when connecting to a project
                 serverHostName: '', // Will be set when connecting to a project

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -70,6 +70,8 @@ export const sensitiveCredentialsFieldNames = [
     'sslrootcert',
     'token',
     'refreshToken',
+    'oauthClientId',
+    'oauthClientSecret',
 ] as const;
 export type SensitiveCredentialsFieldNames =
     typeof sensitiveCredentialsFieldNames[number];
@@ -80,7 +82,7 @@ export type BigqueryCredentials = Omit<
 
 export enum DatabricksAuthenticationType {
     PERSONAL_ACCESS_TOKEN = 'personal_access_token',
-    OAUTH = 'oauth',
+    OAUTH_M2M = 'oauth_m2m',
 }
 
 export type CreateDatabricksCredentials = {
@@ -94,6 +96,8 @@ export type CreateDatabricksCredentials = {
     personalAccessToken?: string; // Optional when using OAuth
     refreshToken?: string; // Refresh token for OAuth, used to generate a new access token
     token?: string; // Access token for OAuth, has a low expiry time (1 hour)
+    oauthClientId?: string; // OAuth M2M client ID (Service Principal)
+    oauthClientSecret?: string; // OAuth M2M client secret (Service Principal)
     requireUserCredentials?: boolean;
     startOfWeek?: WeekDay | null;
     compute?: Array<{

--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -15,6 +15,7 @@
         "lodash": "^4.17.21",
         "pg": "^8.13.1",
         "pg-cursor": "^2.10.0",
+        "node-fetch": "^2.7.0",
         "snowflake-sdk": "~2.3.1",
         "ssh2": "^1.14.0",
         "trino-client": "0.2.6"
@@ -23,6 +24,7 @@
         "@types/pg": "^8.11.10",
         "@types/pg-cursor": "^2.7.0",
         "@types/ssh2": "^1.11.15",
+        "@types/node-fetch": "^2.6.13",
         "copyfiles": "^2.4.1"
     },
     "description": "Warehouse connectors for Lightdash",

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -5,6 +5,8 @@ import IDBSQLClient, {
 import IDBSQLSession from '@databricks/sql/dist/contracts/IDBSQLSession';
 import IOperation from '@databricks/sql/dist/contracts/IOperation';
 import { TTypeId as DatabricksDataTypes } from '@databricks/sql/thrift/TCLIService_types';
+import fetch from 'node-fetch';
+
 import {
     AnyType,
     CreateDatabricksCredentials,
@@ -229,7 +231,7 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
         // Build connection options based on authentication type
         if (
             credentials.authenticationType ===
-            DatabricksAuthenticationType.OAUTH
+            DatabricksAuthenticationType.OAUTH_M2M
         ) {
             if (!credentials.token) {
                 throw new UnexpectedServerError(
@@ -496,3 +498,43 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
         return this.parseWarehouseCatalog(rows, mapFieldType);
     }
 }
+
+/**
+ * Exchange Databricks OAuth M2M credentials for access and refresh tokens
+ */
+export const exchangeDatabricksOAuthCredentials = async (
+    host: string,
+    clientId: string,
+    clientSecret: string,
+): Promise<{ accessToken: string; refreshToken?: string }> => {
+    const tokenUrl = `https://${host}/oidc/v1/token`;
+
+    const response = await fetch(tokenUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+            grant_type: 'client_credentials',
+            client_id: clientId,
+            client_secret: clientSecret,
+            scope: 'sql',
+        }).toString(),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+            `Failed to obtain Databricks OAuth token: ${response.status} ${errorText}`,
+        );
+    }
+
+    const data = (await response.json()) as {
+        access_token: string;
+        refresh_token?: string;
+    };
+    return {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+    };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1369,6 +1369,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      node-fetch:
+        specifier: ^2.7.0
+        version: 2.7.0(encoding@0.1.13)
       pg:
         specifier: ^8.13.1
         version: 8.13.1
@@ -1385,6 +1388,9 @@ importers:
         specifier: 0.2.6
         version: 0.2.6
     devDependencies:
+      '@types/node-fetch':
+        specifier: ^2.6.13
+        version: 2.6.13
       '@types/pg':
         specifier: ^8.11.10
         version: 8.11.10
@@ -20967,7 +20973,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -26232,7 +26238,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.2.0
@@ -26266,7 +26272,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.5.4
@@ -33319,7 +33325,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -35715,7 +35721,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.7(supports-color@9.1.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -37821,7 +37827,7 @@ snapshots:
 
   zod-from-json-schema@0.0.5:
     dependencies:
-      zod: 3.25.55
+      zod: 3.25.76
 
   zod-from-json-schema@0.5.0:
     dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/15901

This allows `auth_type: oauth `  on databricks for the CLI 

Most of the databricks oauth logic and types are in here https://github.com/lightdash/lightdash/pull/17745

Databricks SDK is not available for js (only python/go/java) , so we need to handle tokens manually.

To test this, check `Databricks oauth credentials` on 1password 

Before:
<img width="972" height="409" alt="Screenshot from 2025-10-30 16-52-40" src="https://github.com/user-attachments/assets/0b990fd6-f950-4fd5-aa06-f2f65ef7038b" />


After

tested with `compile` and `preview`

<img width="978" height="496" alt="Screenshot from 2025-10-30 16-57-08" src="https://github.com/user-attachments/assets/5d5033e3-8469-4cb7-bf39-449f397cb0a3" />

You can also run queries using the M2M credentials on explore

<img width="1672" height="819" alt="image" src="https://github.com/user-attachments/assets/6821605b-7de5-4d74-a9d4-83994ae36d0d" />



Note: this is still not adding the Oauth on the UI 

<img width="965" height="547" alt="Screenshot from 2025-10-30 16-57-31" src="https://github.com/user-attachments/assets/1845a068-c315-4b65-bcb5-3f620129fd53" />

### Not in scope


- [ ] Add UI for oauth M2M. Also available for new projects
- [ ] Store and reuse refresh token to generate new app tokens

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
