### PR TITLE
chore(pref): pre-load feature flag so it doesn't try to render the non virtualized side bar

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -1,4 +1,4 @@
-import { ChartType, type SavedChart } from '@lightdash/common';
+import { ChartType, FeatureFlags, type SavedChart } from '@lightdash/common';
 import { MantineProvider, type MantineThemeOverride } from '@mantine/core';
 import { IconUnlink } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -9,6 +9,7 @@ import Explorer from '../../../../../components/Explorer';
 import ExploreSideBar from '../../../../../components/Explorer/ExploreSideBar';
 import { explorerStore } from '../../../../../features/explorer/store';
 import { useExplore } from '../../../../../hooks/useExplore';
+import { useFeatureFlag } from '../../../../../hooks/useFeatureFlagEnabled';
 import { defaultQueryExecution } from '../../../../../providers/Explorer/defaultState';
 import ExplorerProvider from '../../../../../providers/Explorer/ExplorerProvider';
 import { ExplorerSection } from '../../../../../providers/Explorer/types';
@@ -97,6 +98,9 @@ const EmbedExplore: FC<Props> = ({
 }) => {
     const { projectUuid } = useEmbed();
     const { data, error: exploreError } = useExplore(exploreId);
+
+    // Pre-load the feature flag to avoid trying to render old side bar while it is fetching it in ExploreTree
+    useFeatureFlag(FeatureFlags.ExperimentalVirtualizedSideBar);
 
     if (!projectUuid) {
         return (

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
 
+import { FeatureFlags } from '@lightdash/common';
 import { useHotkeys } from '@mantine/hooks';
 import Page from '../components/common/Page/Page';
 import Explorer from '../components/Explorer';
@@ -19,6 +20,7 @@ import {
     useExplorerRoute,
     useExplorerUrlState,
 } from '../hooks/useExplorerRoute';
+import { useFeatureFlag } from '../hooks/useFeatureFlagEnabled';
 import { ProfilerWrapper } from '../perf/ProfilerWrapper';
 import useApp from '../providers/App/useApp';
 import { defaultState } from '../providers/Explorer/defaultState';
@@ -29,6 +31,9 @@ const ExplorerWithUrlParams = memo(() => {
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();
     useExplorerRoute();
+
+    // Pre-load the feature flag to avoid trying to render old side bar while it is fetching it in ExploreTree
+    useFeatureFlag(FeatureFlags.ExperimentalVirtualizedSideBar);
 
     // Get table name from Redux
     const tableId = useExplorerSelector(selectTableName);

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import { lazy, memo, Suspense, useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
@@ -10,6 +11,7 @@ import SavedChartsHeader from '../components/Explorer/SavedChartsHeader';
 import { explorerStore } from '../features/explorer/store';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
+import { useFeatureFlag } from '../hooks/useFeatureFlagEnabled';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
 import { defaultQueryExecution } from '../providers/Explorer/defaultState';
@@ -23,6 +25,9 @@ const LazyExplorePanel = lazy(
 const SavedExplorerContent = memo<{ isEditMode: boolean }>(({ isEditMode }) => {
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();
+
+    // Pre-load the feature flag to avoid trying to render old side bar while it is fetching it in ExploreTree
+    useFeatureFlag(FeatureFlags.ExperimentalVirtualizedSideBar);
 
     return (
         <Page


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-57/navigating-from-tables-listdashboard-to-explorer-takes-a-couple

### Description:
Pre-loads the `ExperimentalVirtualizedSideBar` feature flag in Explorer pages to prevent UI flicker when the sidebar renders. This change ensures the feature flag is fetched before the sidebar component attempts to render, avoiding a situation where the old sidebar might briefly appear while the flag is being fetched.

The fix has been applied to the main Explorer page, SavedExplorer page, and the EmbedExplore component to ensure consistent behavior across all explorer views.