### PR TITLE
fix: excel formatting with formatting expressions

### DIFF
--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -217,7 +217,7 @@ describe('ExcelService', () => {
             expect(result[0]).toBe(1234.56);
             // Number with percentage format should be converted to actual number
             expect(result[1]).toBe(0.1234);
-            // Number without explicit format should still be converted to number with no formatting
+            // Number without explicit format should still be converted to number
             expect(result[2]).toBe(999.99);
             expect(typeof result[2]).toBe('number');
             // String should remain as string
@@ -687,12 +687,21 @@ describe('ExcelService', () => {
             expect(formatExpression).toBe('0.00%');
         });
 
-        it('should NOT return default format for fields without explicit format', () => {
+        it('should return default format for number fields without explicit format', () => {
             // Test that getFormatExpression returns default format for number fields without explicit format
             const noFormatField = mockItemMapWithFormats.number_without_format;
             const formatExpression = getFormatExpression(noFormatField);
 
             // Should return a default number format for fields without explicit format
+            expect(formatExpression).toBe('#,##0');
+        });
+
+        it('should NOT return default format for date fields without explicit format', () => {
+            // Test that getFormatExpression returns default format for date fields without explicit format
+            const dateField = mockItemMapWithFormats.date_column;
+            const formatExpression = getFormatExpression(dateField);
+
+            // Should return a default date format for fields without explicit format
             expect(formatExpression).toBeUndefined();
         });
 

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -336,7 +336,7 @@ export class ExcelService {
             };
 
             // Apply number formatting at column level if available
-            if (formatExpression) {
+            if (formatExpression && !onlyRaw) {
                 column.style = { numFmt: formatExpression };
             }
 

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
@@ -98,6 +98,7 @@ models:
               label: New metric
               description: description
               type: average
+              format: '#,##0'
   - name: table_b
     description: >-
       # Description This table has basic information

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -171,6 +171,7 @@ models:
               label: New metric
               description: description
               type: average
+              format: "#,##0"
           additional_dimensions:
             id:
               label: Sql dimension

--- a/packages/common/src/pivot/pivotQueryResults.mock.ts
+++ b/packages/common/src/pivot/pivotQueryResults.mock.ts
@@ -1165,7 +1165,7 @@ export const EXPECTED_PIVOT_DATA_WITH_TOTALS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 1746.77,
-                        formatted: '1,746.77',
+                        formatted: '1,747',
                     },
                 },
             },
@@ -1203,7 +1203,7 @@ export const EXPECTED_PIVOT_DATA_WITH_TOTALS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 1189.6,
-                        formatted: '1,189.6',
+                        formatted: '1,190',
                     },
                 },
             },
@@ -1241,7 +1241,7 @@ export const EXPECTED_PIVOT_DATA_WITH_TOTALS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 117.5,
-                        formatted: '117.5',
+                        formatted: '118',
                     },
                 },
             },
@@ -1527,7 +1527,7 @@ export const EXPECTED_PIVOT_DATA_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 1746.77,
-                        formatted: '1,746.77',
+                        formatted: '1,747',
                     },
                 },
             },
@@ -1571,7 +1571,7 @@ export const EXPECTED_PIVOT_DATA_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 1189.6,
-                        formatted: '1,189.6',
+                        formatted: '1,190',
                     },
                 },
             },
@@ -1615,7 +1615,7 @@ export const EXPECTED_PIVOT_DATA_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 117.5,
-                        formatted: '117.5',
+                        formatted: '118',
                     },
                 },
             },
@@ -2067,13 +2067,13 @@ export const EXPECTED_COMPLEX_PIVOT_DATA: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 52.5,
-                        formatted: '52.5',
+                        formatted: '53',
                     },
                 },
                 'row-total-1': {
                     value: {
                         raw: 52.5,
-                        formatted: '52.5',
+                        formatted: '53',
                     },
                 },
             },
@@ -2364,7 +2364,7 @@ export const EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 52.5,
-                        formatted: '52.5',
+                        formatted: '53',
                     },
                 },
             },
@@ -2422,7 +2422,7 @@ export const EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 52.5,
-                        formatted: '52.5',
+                        formatted: '53',
                     },
                 },
             },

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -151,12 +151,24 @@ describe('Formatting', () => {
         });
 
         describe('when applying round', () => {
-            test('if round is undefined it should keep up to 3 decimal places', () => {
+            test('if round is undefined and custom format is not number format it should keep up to 3 decimal places', () => {
                 expect(applyCustomFormat(5.9)).toEqual('5.9');
                 expect(applyCustomFormat(5.99)).toEqual('5.99');
                 expect(applyCustomFormat(5.999)).toEqual('5.999');
                 expect(applyCustomFormat(5.9999)).toEqual('6');
                 expect(applyCustomFormat(5.99999)).toEqual('6');
+                expect(
+                    applyCustomFormat(5.9, {
+                        type: CustomFormatType.CURRENCY,
+                        currency: Format.USD,
+                    }),
+                ).toEqual('$5.90');
+            });
+
+            test('if round is undefined and format is number it should keep 0 decimal places', () => {
+                expect(
+                    applyCustomFormat(5.9, { type: CustomFormatType.NUMBER }),
+                ).toEqual('6');
             });
 
             test('when round zero it should return the right round', () => {
@@ -444,14 +456,12 @@ describe('Formatting', () => {
             };
 
             test('it should return the right style', () => {
-                expect(applyCustomFormat(5, thousandsConfig)).toEqual('0.005K');
+                expect(applyCustomFormat(5, thousandsConfig)).toEqual('0K');
                 expect(applyCustomFormat(5, millionsConfig)).toEqual('0M');
-                expect(applyCustomFormat(500000, billionsConfig)).toEqual(
-                    '0.001B',
-                );
+                expect(applyCustomFormat(500000, billionsConfig)).toEqual('0B');
                 expect(applyCustomFormat(5, billionsConfig)).toEqual('0B');
                 expect(applyCustomFormat(5000000000, trillionsConfig)).toEqual(
-                    '0.005T',
+                    '0T',
                 );
             });
 
@@ -1234,7 +1244,7 @@ describe('Formatting', () => {
                 applyCustomFormat(12345.56789, {
                     type: CustomFormatType.NUMBER,
                 }),
-            ).toEqual('12,345.568');
+            ).toEqual('12,346');
             expect(
                 applyCustomFormat(12345.1235, {
                     type: CustomFormatType.NUMBER,
@@ -1252,7 +1262,7 @@ describe('Formatting', () => {
                     prefix: 'foo ',
                     suffix: ' bar',
                 }),
-            ).toEqual('foo 12,345.124 bar');
+            ).toEqual('foo 12,345 bar');
         });
 
         test('convert table calculation formats with invalid numbers', () => {

--- a/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
+++ b/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
@@ -113,7 +113,7 @@ describe('Custom dimensions', () => {
 
         // Check results
         cy.contains('payment_credit_card');
-        cy.contains('1,452.16');
+        cy.contains('1,452');
         // Show SQL
         cy.findByTestId('Chart-card-expand').click(); // Close chart
         cy.findByTestId('Results-card-expand').click(); // Close results


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17763

### Description:
Improves Excel export number formatting by removing default formats for fields without explicit formatting. This ensures that numbers without specific formats are exported as plain numbers without any automatic formatting applied. The PR also enhances the value conversion logic to properly handle different data types and edge cases.

Key changes:
- Improved type conversion logic for Excel exports
- Fixed handling of non-numeric values when applying format expressions (e.g. dates)
- Optimized the custom format detection to only apply legacy formats when explicitly defined

<img width="1130" height="342" alt="image" src="https://github.com/user-attachments/assets/c04208e5-2aec-4a8b-af87-1f9134717772" />


**Before**

<img width="365" height="243" alt="image" src="https://github.com/user-attachments/assets/400e88b8-a909-4471-9f08-2e858906a0f0" />


**After**

<img width="341" height="248" alt="image" src="https://github.com/user-attachments/assets/1868cb58-bd40-494d-868c-92fcd11503f2" />


