### PR TITLE
fix: get correct series data when border-rounding stacked charts

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -261,7 +261,7 @@ const VisualizationProvider: FC<
             if ('pivotReference' in seriesLike && seriesLike.pivotReference) {
                 pivot = seriesLike.pivotReference.pivotValues?.[0];
             } else if (seriesLike.encode && 'yRef' in seriesLike.encode) {
-                pivot = seriesLike.encode.yRef.pivotValues?.[0];
+                pivot = seriesLike.encode.yRef?.pivotValues?.[0];
             }
             if (itemsMap && pivot) {
                 const { field, value } = pivot;

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -3,11 +3,10 @@ import { IconChartBarOff } from '@tabler/icons-react';
 import EChartsReact from 'echarts-for-react';
 import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
 import { memo, useCallback, useEffect, useMemo, type FC } from 'react';
-import useEchartsCartesianConfig, {
-    getFormattedValue,
-    isLineSeriesOption,
-} from '../../hooks/echarts/useEchartsCartesianConfig';
+import useEchartsCartesianConfig from '../../hooks/echarts/useEchartsCartesianConfig';
 import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
+import { isLineSeriesOption } from '../../hooks/echarts/utils/tooltipFormatter';
+import { getFormattedValue } from '../../hooks/echarts/utils/valueFormatter';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 

--- a/packages/frontend/src/hooks/echarts/styles/axisStyles.ts
+++ b/packages/frontend/src/hooks/echarts/styles/axisStyles.ts
@@ -24,7 +24,7 @@ export const getAxisTitleStyle = () => ({
 export const getAxisLineStyle = (theme: MantineTheme) => ({
     show: true,
     lineStyle: {
-        color: theme.colors.gray[3],
+        color: theme.colors.gray[4],
         type: 'solid' as const,
     },
 });
@@ -35,7 +35,7 @@ export const getAxisLineStyle = (theme: MantineTheme) => ({
 export const getAxisTickStyle = (theme: MantineTheme) => ({
     show: true,
     lineStyle: {
-        color: theme.colors.gray[3],
+        color: theme.colors.gray[4],
         type: 'solid' as const,
     },
 });

--- a/packages/frontend/src/hooks/echarts/styles/barChartStyles.ts
+++ b/packages/frontend/src/hooks/echarts/styles/barChartStyles.ts
@@ -1,6 +1,5 @@
-import { type ResultRow } from '@lightdash/common';
+import { CartesianSeriesType, type ResultRow } from '@lightdash/common';
 import { type MantineTheme } from '@mantine/core';
-import groupBy from 'lodash/groupBy';
 import { type EChartSeries } from '../useEchartsCartesianConfig';
 
 /**
@@ -73,140 +72,179 @@ export const getBarTotalLabelStyle = (theme: MantineTheme) => ({
 });
 
 /**
- * Apply border radius to the top of stacked bar series
- * Ref: https://github.com/apache/echarts/issues/12319#issuecomment-1341387601
- *
- * @param allSeries - All series (stacked and non-stacked)
- * @param stackedBarSeries - Filtered array of stacked bar series to process
- * @param rows - Result rows containing the data
- * @param isHorizontal - Whether the chart is horizontal (flipAxes)
- * @param dynamicRadius - The border radius value to apply
- * @returns New array of all series with border radius applied to stacked bars
+ * Resolve the tuple index for x/y given encode + dimensions
+ * @param enc - The encode object
+ * @param dimNames - The dimension names
+ * @param which - The axis to resolve the index for
+ * @returns The index of the axis
  */
-export const applyStackedBarBorderRadius = (
-    allSeries: EChartSeries[],
-    stackedBarSeries: EChartSeries[],
-    rows: ResultRow[],
-    isHorizontal: boolean,
-    dynamicRadius: number,
-): EChartSeries[] => {
-    if (stackedBarSeries.length === 0) return allSeries;
-
-    const seriesDataMap = new Map<EChartSeries, unknown[]>();
-
-    const seriesByStack = groupBy(stackedBarSeries, 'stack');
-
-    Object.values(seriesByStack).forEach((stackSeries) => {
-        for (let dataIndex = 0; dataIndex < rows.length; dataIndex++) {
-            // Find the topmost series with data at this index
-            const topSeries = stackSeries.findLast((serie) => {
-                const valueFieldHash = isHorizontal
-                    ? serie.encode?.x
-                    : serie.encode?.y;
-
-                if (!valueFieldHash) return false;
-
-                const rawValue = rows[dataIndex]?.[valueFieldHash]?.value?.raw;
-                return (
-                    rawValue !== null &&
-                    rawValue !== undefined &&
-                    rawValue !== '-'
-                );
-            });
-
-            // Apply border radius to the top series at this data point
-            if (topSeries) {
-                const valueFieldHash = isHorizontal
-                    ? topSeries.encode?.x
-                    : topSeries.encode?.y;
-
-                if (!valueFieldHash) continue;
-
-                // Lazy initialize data array for this series
-                if (!seriesDataMap.has(topSeries)) {
-                    seriesDataMap.set(
-                        topSeries,
-                        rows.map((row) => row[valueFieldHash]?.value?.raw),
-                    );
-                }
-
-                const dataArray = seriesDataMap.get(topSeries)!;
-                const value = rows[dataIndex][valueFieldHash]?.value?.raw;
-                dataArray[dataIndex] = {
-                    value,
-                    itemStyle: {
-                        borderRadius: getBarBorderRadius(
-                            isHorizontal,
-                            true,
-                            dynamicRadius,
-                        ),
-                    },
-                };
-            }
-        }
-    });
-
-    // Return all series, with border radius applied to modified ones
-    return allSeries.map((serie) => {
-        const dataArray = seriesDataMap.get(serie);
-        if (dataArray) {
-            return {
-                ...serie,
-                data: dataArray,
-            };
-        }
-        return serie;
-    });
+export const getIndexFromEncode = (
+    enc: EChartSeries['encode'],
+    dimNames: string[] | undefined,
+    which: 'x' | 'y',
+): number | undefined => {
+    const e = enc?.[which];
+    if (typeof e === 'number') return e;
+    if (Array.isArray(e)) return typeof e[0] === 'number' ? e[0] : undefined;
+    if (typeof e === 'string') {
+        const idx = dimNames ? dimNames.indexOf(e) : undefined;
+        return idx != null && idx >= 0 ? idx : undefined;
+    }
+    return undefined;
 };
 
+type LegendValues = { [name: string]: boolean } | undefined;
+
 /**
- * Apply category data to axes when using stacked bar data arrays
- * When stacked bars use data arrays (for border radius), ECharts requires explicit category data on the category axis
+ * Apply rounded corners to the visible end-segments of stacked bar series.
+ * Ref: https://github.com/apache/echarts/issues/12319#issuecomment-1341387601
  *
- * @param axes - Current axis configuration
- * @param series - All series (to check if any use data arrays)
- * @param rows - Result rows containing category values
- * @param isFlipAxes - Whether the chart is horizontal (flipAxes)
- * @param categoryFieldHash - The field hash for category values
- * @returns Modified axes with category data if needed, otherwise original axes
+ * Process:
+ * - For each stack and each category (row), finds which segment is visually at the end of the stack
+ *   (top-most for positive values, bottom-most for negative values).
+ * - Annotates only those segments with `itemStyle.borderRadius`, considering chart orientation
+ *   and legend visibility.
+ * - We scan from top to bottom of the stack using an index-based loop so the first visible segment
+ *   per category "wins" without extra allocations.
+ *
+ * @param series ECharts series produced for a cartesian chart
+ * @param rows Result rows aligned with the chart categories
+ * @param options.radius Corner radius in px (default: 4)
+ * @param options.isHorizontal Whether the chart is horizontal (flipAxes)
+ * @param options.legendSelected Map of legend selection states used to ignore hidden series
+ * @returns New series array with `itemStyle.borderRadius` applied to end segments only
+ *
  */
-export const applyStackedBarCategoryData = (
-    axes: { xAxis: any[]; yAxis: any[] },
+export const applyRoundedCornersToStackData = (
     series: EChartSeries[],
     rows: ResultRow[],
-    isFlipAxes: boolean,
-    categoryFieldHash: string | undefined,
-): { xAxis: any[]; yAxis: any[] } => {
-    // Check if any series are using data arrays (stacked bars with border radius)
-    const hasDataArraySeries = series.some((s) => s.data !== undefined);
+    {
+        radius = 4,
+        isHorizontal = false,
+        legendSelected,
+    }: {
+        radius?: number;
+        isHorizontal?: boolean;
+        legendSelected?: LegendValues;
+    } = {},
+): EChartSeries[] => {
+    const out = series.map((s) => ({ ...s }));
+    const indexMap = new Map<EChartSeries, number>();
+    series.forEach((s, i) => indexMap.set(s, i));
 
-    if (!hasDataArraySeries || !categoryFieldHash) {
-        return axes; // No modification needed
-    }
+    const isVisible = (s: EChartSeries) => {
+        if (!legendSelected) return true;
+        const name = s.name || s.dimensions?.[1]?.displayName || '';
+        if (!name) return true;
+        return legendSelected[name] ?? true;
+    };
 
-    // Extract category values from rows
-    const categoryData = rows.map((row) => row[categoryFieldHash]?.value?.raw);
+    const getDimNames = (s: EChartSeries) =>
+        (s.dimensions || [])
+            .map((d) => (typeof d === 'string' ? d : d?.name))
+            .filter(Boolean) as string[];
 
-    // Add category data to the appropriate axis
-    if (isFlipAxes) {
-        // Horizontal: categories on y-axis
-        return {
-            xAxis: axes.xAxis,
-            yAxis: axes.yAxis.map((axis, idx) =>
-                idx === 0
-                    ? ({ ...axis, data: categoryData } as typeof axis)
-                    : axis,
-            ),
-        };
-    } else {
-        // Vertical: categories on x-axis
-        return {
-            xAxis: axes.xAxis.map((axis, idx) =>
-                idx === 0
-                    ? ({ ...axis, data: categoryData } as typeof axis)
-                    : axis,
-            ),
-            yAxis: axes.yAxis,
-        };
-    }
+    const getHashFromEncode = (s: EChartSeries, which: 'x' | 'y') =>
+        (s.encode?.[which] as string | undefined) || undefined;
+
+    // Only stacked BAR series
+    const stacks: Record<string, EChartSeries[]> = {};
+    series.forEach((s) => {
+        if (s.type === CartesianSeriesType.BAR && s.stack) {
+            (stacks[s.stack] ||= []).push(s);
+        }
+    });
+
+    Object.values(stacks).forEach((group) => {
+        if (!group.length) return;
+
+        const topPosAt: number[] = rows.map(() => -1);
+        const topNegAt: number[] = rows.map(() => -1);
+
+        // Determine which series sits at the visible end for each category index
+        for (let i = group.length - 1; i >= 0; i--) {
+            const s = group[i];
+            if (!isVisible(s)) continue;
+
+            // Get the hash of the value field - if the chart is horizontal, it's the x field, otherwise it's the y field
+            const valHash = isHorizontal
+                ? getHashFromEncode(s, 'x')
+                : getHashFromEncode(s, 'y');
+            for (let r = 0; r < rows.length; r++) {
+                const raw = valHash
+                    ? rows[r]?.[valHash]?.value?.raw
+                    : undefined;
+                const v =
+                    typeof raw === 'number'
+                        ? raw
+                        : Number.isFinite(Number(raw))
+                        ? Number(raw)
+                        : null;
+                if (v == null || v === 0) continue;
+                // Track the index of the series that is at the top of the stack for each category
+                if (v > 0 && topPosAt[r] === -1) topPosAt[r] = i;
+                if (v < 0 && topNegAt[r] === -1) topNegAt[r] = i;
+            }
+        }
+
+        // Build data with tuple indices aligned to encode+dimensions
+        group.forEach((s, gi) => {
+            const outIdx = indexMap.get(s);
+            if (outIdx === undefined) return;
+
+            const dimNames = getDimNames(s);
+            const xIdx = getIndexFromEncode(s.encode, dimNames, 'x') ?? 0;
+            const yIdx = getIndexFromEncode(s.encode, dimNames, 'y') ?? 1;
+
+            const xHash = getHashFromEncode(s, 'x');
+            const yHash = getHashFromEncode(s, 'y');
+
+            const data = rows.map((row, r) => {
+                const catHash = isHorizontal ? yHash : xHash; // category field in data
+                const valHash = isHorizontal ? xHash : yHash; // numeric field in data
+
+                const cat = catHash ? row[catHash]?.value?.raw : undefined;
+                const raw = valHash ? row[valHash]?.value?.raw : undefined;
+                const v =
+                    typeof raw === 'number'
+                        ? raw
+                        : Number.isFinite(Number(raw))
+                        ? Number(raw)
+                        : null;
+
+                // Place values at the correct tuple indices
+                const value: any[] = [];
+                if (isHorizontal) {
+                    value[xIdx] = v;
+                    value[yIdx] = cat;
+                } else {
+                    value[xIdx] = cat;
+                    value[yIdx] = v;
+                }
+
+                if (v == null) return { value };
+
+                const isTopPos = v > 0 && topPosAt[r] === gi;
+                const isTopNeg = v < 0 && topNegAt[r] === gi;
+                if (!isTopPos && !isTopNeg) return { value };
+
+                const borderRadius = isHorizontal
+                    ? isTopPos
+                        ? [0, radius, radius, 0] // round right side for +X
+                        : [radius, 0, 0, radius] // round left side for -X
+                    : isTopPos
+                    ? [radius, radius, 0, 0] // round top for +Y
+                    : [0, 0, radius, radius]; // round bottom for -Y
+
+                return {
+                    value,
+                    itemStyle: { ...(s.itemStyle || {}), borderRadius },
+                };
+            });
+
+            out[outIdx] = { ...out[outIdx], data };
+        });
+    });
+
+    return out;
 };

--- a/packages/frontend/src/hooks/echarts/utils/tooltipFormatter.ts
+++ b/packages/frontend/src/hooks/echarts/utils/tooltipFormatter.ts
@@ -1,0 +1,492 @@
+import {
+    createStack100TooltipFormatter,
+    formatItemValue,
+    hashFieldReference,
+    isField,
+    isTableCalculation,
+    type ItemsMap,
+    type PivotValuesColumn,
+    StackType,
+    type TooltipParam,
+} from '@lightdash/common';
+import { type MantineTheme } from '@mantine/core';
+import DOMPurify from 'dompurify';
+import {
+    type DefaultLabelFormatterCallbackParams,
+    type LineSeriesOption,
+    type TooltipComponentFormatterCallback,
+} from 'echarts';
+import {
+    formatCartesianTooltipRow,
+    formatColorIndicator,
+    formatTooltipHeader,
+    formatTooltipValue,
+    getTooltipDivider,
+} from '../styles/tooltipStyles';
+import { type EChartSeries } from '../useEchartsCartesianConfig';
+import { getFormattedValue } from './valueFormatter';
+
+// NOTE: CallbackDataParams type doesn't have axisValue, axisValueLabel properties: https://github.com/apache/echarts/issues/17561
+type TooltipFormatterParams = DefaultLabelFormatterCallbackParams & {
+    axisId: string;
+    axisIndex: number;
+    axisType: string;
+    axisValue: string | number;
+    axisValueLabel: string;
+};
+
+type TooltipCtx = {
+    flipAxes: boolean;
+    mode: 'stack100' | 'stackRegular' | 'plain';
+    dataMode: 'dataset' | 'tuple';
+};
+
+/**
+ * Get the tooltip context
+ * When series are bar stacked, then it's tuple mode(@reference to applyRoundedCornersToStackData), otherwise it's dataset mode.
+ * @param params - The params
+ * @param stackValue - The stack value
+ * @param flipAxes - Whether the axes are flipped
+ * @returns The tooltip context
+ */
+const getTooltipCtx = (
+    params: (TooltipFormatterParams | TooltipFormatterParams)[],
+    stackValue: string | boolean | undefined,
+    flipAxes: boolean | undefined,
+): TooltipCtx => {
+    const v0 = params?.[0]?.value;
+    const dataMode: TooltipCtx['dataMode'] =
+        v0 && typeof v0 === 'object' && !Array.isArray(v0)
+            ? 'dataset'
+            : 'tuple';
+
+    const mode: TooltipCtx['mode'] =
+        stackValue === StackType.PERCENT
+            ? 'stack100'
+            : stackValue
+            ? 'stackRegular'
+            : 'plain';
+
+    return { flipAxes: !!flipAxes, mode, dataMode };
+};
+
+const getRawVal = (
+    param: TooltipFormatterParams,
+    dim: string | undefined,
+    yIdx: number | undefined,
+    ctx: TooltipCtx,
+) => {
+    const v = param.value;
+    if (Array.isArray(v)) {
+        if (typeof yIdx === 'number') return v[yIdx];
+        // ultimate fallback for tuple in regular stacks
+        if (ctx.dataMode === 'tuple' && ctx.mode === 'stackRegular') {
+            return ctx.flipAxes ? v[0] : v[1];
+        }
+        return undefined; // array but no valid index
+    }
+    if (v && typeof v === 'object' && dim) {
+        // Only return the value if the key exists, otherwise undefined
+        return v[dim as keyof typeof v];
+    }
+    // For non-object, non-array values (plain number/string), return as-is
+    // But if we have a dim and v is an object, we already handled it above
+    return typeof v === 'object' ? undefined : v;
+};
+
+/**
+ * Get the header from the params
+ * @param params - The params
+ * @returns The header
+ */
+const getHeader = (
+    params: (TooltipFormatterParams | TooltipFormatterParams)[],
+): string => params[0]?.axisValueLabel ?? params[0]?.name ?? '';
+
+const extractColor = (marker: unknown): string => {
+    const s = typeof marker === 'string' ? marker : '';
+    const m = s.match(/background-color:\s*([^;'"]+)/);
+    return m ? m[1].trim() : '#000';
+};
+
+const unwrapValue = (v: unknown): unknown => {
+    if (v && typeof v === 'object') {
+        if ('value' in v) return unwrapValue(v.value);
+        if ('raw' in v) return v.raw;
+        if ('formatted' in v) return v.formatted;
+    }
+    return v;
+};
+
+type AxisKey = 'x' | 'y';
+
+/**
+ * Helper function to get the dimension from the encode
+ */
+const getDimFromEncodeAxis = (
+    encode:
+        | TooltipFormatterParams['encode']
+        | EChartSeries['encode']
+        | undefined,
+    dimensionNames?: string[],
+    axis: AxisKey = 'y',
+): string | undefined => {
+    if (!encode) return undefined;
+    const e = encode[axis];
+
+    if (typeof e === 'string') return e; // dataset: field hash
+    if (Array.isArray(e) && typeof e[0] === 'number') {
+        const idx = e[0];
+        return dimensionNames && typeof idx === 'number'
+            ? dimensionNames[idx]
+            : undefined;
+    }
+    if (typeof e === 'number' && dimensionNames) {
+        return dimensionNames[e];
+    }
+    return undefined;
+};
+
+const getValueIdxFromEncode = (
+    encode:
+        | TooltipFormatterParams['encode']
+        | EChartSeries['encode']
+        | undefined,
+    ctx: TooltipCtx,
+    flipAxes?: boolean,
+): number | undefined => {
+    const axis: AxisKey = flipAxes ? 'x' : 'y';
+    if (!encode) {
+        // tuple fallback for regular stacks
+        return ctx.dataMode === 'tuple' && ctx.mode === 'stackRegular'
+            ? flipAxes
+                ? 0
+                : 1
+            : undefined;
+    }
+    const e = encode[axis];
+    if (typeof e === 'number') return e;
+    if (Array.isArray(e) && typeof e[0] === 'number') return e[0];
+    // tuple fallback for regular stacks
+    if (ctx.dataMode === 'tuple' && ctx.mode === 'stackRegular') {
+        return flipAxes ? 0 : 1;
+    }
+    return undefined;
+};
+
+export const isLineSeriesOption = (obj: unknown): obj is LineSeriesOption =>
+    typeof obj === 'object' && obj !== null && 'showSymbol' in obj;
+
+export const buildCartesianTooltipFormatter = ({
+    itemsMap,
+    stackValue,
+    flipAxes,
+    xFieldId,
+    originalValues,
+    series,
+    theme,
+    tooltipHtmlTemplate,
+    pivotValuesColumnsMap,
+}: {
+    itemsMap?: ItemsMap;
+    stackValue: string | boolean | undefined;
+    flipAxes: boolean | undefined;
+    xFieldId: string | undefined;
+    originalValues?: Map<string, Map<string, number>> | undefined;
+    series?: EChartSeries[];
+    theme: MantineTheme;
+    tooltipHtmlTemplate?: string;
+    pivotValuesColumnsMap?: Record<string, PivotValuesColumn>;
+}): TooltipComponentFormatterCallback<
+    TooltipFormatterParams | TooltipFormatterParams[]
+> => {
+    return (params) => {
+        if (!Array.isArray(params) || !itemsMap) return '';
+
+        const ctx = getTooltipCtx(params, stackValue, flipAxes);
+
+        // 100% stacks: use special formatter that shows percentage + original values
+        if (ctx.mode === 'stack100' && xFieldId && originalValues) {
+            return createStack100TooltipFormatter(
+                originalValues,
+                (param) => {
+                    const { encode, dimensionNames } = param;
+                    if (!dimensionNames || !encode) return undefined;
+                    if (flipAxes) return dimensionNames[1];
+                    const yIndex = Array.isArray(encode.y)
+                        ? encode.y[0]
+                        : encode.y;
+                    return typeof yIndex === 'number'
+                        ? dimensionNames[yIndex]
+                        : undefined;
+                },
+                xFieldId,
+            )(params as TooltipParam[]);
+        }
+
+        const header = getHeader(params);
+
+        // rows
+        const rowsHtml = params
+            .map((param) => {
+                const {
+                    marker,
+                    seriesName,
+                    dimensionNames,
+                    encode,
+                    seriesIndex,
+                } = param;
+
+                const seriesOption =
+                    typeof seriesIndex === 'number'
+                        ? series?.[seriesIndex]
+                        : undefined;
+                const effectiveEncode =
+                    encode ?? seriesOption?.encode ?? undefined;
+                const yRefField =
+                    seriesOption?.encode?.yRef?.field ?? undefined;
+
+                const yFieldHash =
+                    seriesOption?.encode?.yRef &&
+                    typeof seriesOption.encode.yRef === 'object'
+                        ? hashFieldReference(seriesOption.encode.yRef)
+                        : undefined;
+
+                const seriesDimensionNames = Array.isArray(
+                    seriesOption?.dimensions,
+                )
+                    ? seriesOption?.dimensions.map(
+                          (dimension: { name: string }) =>
+                              typeof dimension === 'string'
+                                  ? dimension
+                                  : dimension?.name,
+                      )
+                    : undefined;
+                const metricAxis: AxisKey = flipAxes ? 'x' : 'y';
+
+                const encodeDim =
+                    getDimFromEncodeAxis(
+                        effectiveEncode,
+                        dimensionNames,
+                        metricAxis,
+                    ) ??
+                    getDimFromEncodeAxis(
+                        effectiveEncode,
+                        seriesDimensionNames,
+                        metricAxis,
+                    );
+
+                const tooltipEncode = seriesOption?.encode?.tooltip;
+                const tooltipDim = Array.isArray(tooltipEncode)
+                    ? tooltipEncode[0]
+                    : typeof tooltipEncode === 'string'
+                    ? tooltipEncode
+                    : undefined;
+
+                const pivotDim =
+                    seriesOption?.pivotReference && pivotValuesColumnsMap
+                        ? Object.values(pivotValuesColumnsMap).find(
+                              (column) => {
+                                  const reference = seriesOption.pivotReference;
+                                  if (!reference) return false;
+                                  if (column.referenceField !== reference.field)
+                                      return false;
+                                  if (
+                                      column.pivotValues.length !==
+                                      reference.pivotValues?.length
+                                  )
+                                      return false;
+                                  return column.pivotValues.every(
+                                      (pivotValue, index) =>
+                                          pivotValue.value ===
+                                          reference.pivotValues?.[index]?.value,
+                                  );
+                              },
+                          )?.pivotColumnName
+                        : undefined;
+
+                // Prefer the real field hash from encode.y (works for pivot)
+                const dim =
+                    encodeDim ??
+                    tooltipDim ??
+                    pivotDim ??
+                    // final fallback: the second dimension name normally is the Y series
+                    (param?.dimensionNames?.[1] as string | undefined) ??
+                    undefined;
+
+                const valueIdx = getValueIdxFromEncode(
+                    effectiveEncode,
+                    ctx,
+                    !!flipAxes,
+                );
+                const rawValueKeys = [
+                    dim,
+                    pivotDim,
+                    tooltipDim,
+                    yFieldHash,
+                    yRefField,
+                ].filter((k): k is string => !!k && typeof k === 'string');
+
+                // Extract raw cell value in both dataset/tuple modes
+                let rawVal = getRawVal(param, dim, valueIdx, ctx);
+
+                const needsPivotFallback =
+                    pivotDim &&
+                    dim &&
+                    pivotDim !== dim &&
+                    typeof param?.value === 'object' &&
+                    !Array.isArray(param?.value) &&
+                    (param.value as Record<string, unknown>)[dim] === undefined;
+
+                if (
+                    needsPivotFallback ||
+                    (pivotDim && pivotDim !== dim && rawVal === param?.value)
+                ) {
+                    rawVal = getRawVal(param, pivotDim, valueIdx, ctx);
+                }
+
+                if (
+                    (rawVal === param?.value ||
+                        (rawVal &&
+                            typeof rawVal === 'object' &&
+                            !Array.isArray(rawVal))) &&
+                    rawValueKeys.length > 0
+                ) {
+                    for (const key of rawValueKeys) {
+                        const candidate = getRawVal(param, key, valueIdx, ctx);
+                        if (
+                            candidate !== undefined &&
+                            candidate !== null &&
+                            candidate !== param?.value &&
+                            !(
+                                candidate === rawVal &&
+                                typeof candidate === 'object'
+                            )
+                        ) {
+                            rawVal = candidate;
+                            break;
+                        }
+                        if (
+                            param?.value &&
+                            typeof param.value === 'object' &&
+                            !Array.isArray(param.value) &&
+                            param.value[key as keyof typeof param.value] !==
+                                undefined
+                        ) {
+                            rawVal =
+                                param.value[key as keyof typeof param.value];
+                            break;
+                        }
+                        if (
+                            param?.data &&
+                            typeof param.data === 'object' &&
+                            !Array.isArray(param.data) &&
+                            param.data[key as keyof typeof param.data] !==
+                                undefined
+                        ) {
+                            rawVal = param.data[key as keyof typeof param.data];
+                            break;
+                        }
+                    }
+                }
+
+                const valueForFormat = unwrapValue(rawVal);
+                if (valueForFormat === undefined || valueForFormat === null)
+                    return '';
+
+                const formatKey =
+                    (typeof dim === 'string' &&
+                        pivotValuesColumnsMap?.[dim]?.referenceField) ??
+                    (pivotDim &&
+                        pivotValuesColumnsMap?.[pivotDim]?.referenceField) ??
+                    yRefField ??
+                    dim ??
+                    pivotDim ??
+                    '';
+
+                const formattedValue = getFormattedValue(
+                    valueForFormat,
+                    formatKey as string,
+                    itemsMap,
+                    undefined,
+                    pivotValuesColumnsMap,
+                );
+
+                const colorIndicator = formatColorIndicator(
+                    extractColor(marker),
+                );
+                return formatCartesianTooltipRow(
+                    colorIndicator,
+                    seriesName || '',
+                    formatTooltipValue(formattedValue, theme),
+                    theme,
+                );
+            })
+            .join('');
+
+        // custom HTML template only in dataset mode
+        let tooltipHtml = tooltipHtmlTemplate ?? '';
+        if (tooltipHtml) {
+            tooltipHtml = DOMPurify.sanitize(tooltipHtml);
+            const firstValue = params[0]?.value;
+            const isDatasetMode =
+                firstValue &&
+                typeof firstValue === 'object' &&
+                !Array.isArray(firstValue);
+            if (isDatasetMode) {
+                const fields = tooltipHtml.match(/\${(.*?)}/g);
+                fields?.forEach((field) => {
+                    const ref = field.slice(2, -1);
+                    const val = unwrapValue(
+                        firstValue[ref as keyof typeof firstValue],
+                    );
+                    const formatted = getFormattedValue(
+                        val,
+                        ref,
+                        itemsMap,
+                        undefined,
+                        pivotValuesColumnsMap,
+                    );
+                    tooltipHtml = tooltipHtml.replace(field, formatted);
+                });
+            } else {
+                tooltipHtml = '';
+            }
+        }
+
+        const divider = getTooltipDivider(theme);
+        const dimensionId = params[0]?.dimensionNames?.[0];
+
+        if (dimensionId !== undefined) {
+            const field = itemsMap[dimensionId];
+            if (isTableCalculation(field)) {
+                const headerText = formatItemValue(field, header);
+                return `${formatTooltipHeader(
+                    headerText,
+                    theme,
+                )}${divider}${rowsHtml}`;
+            }
+            const hasFormat = isField(field)
+                ? field.format !== undefined
+                : false;
+            if (hasFormat) {
+                const headerText = getFormattedValue(
+                    header,
+                    dimensionId,
+                    itemsMap,
+                    undefined,
+                    pivotValuesColumnsMap,
+                );
+                return `${formatTooltipHeader(
+                    headerText,
+                    theme,
+                )}${divider}${tooltipHtml}${rowsHtml}`;
+            }
+        }
+
+        return `${formatTooltipHeader(
+            header,
+            theme,
+        )}${divider}${tooltipHtml}${rowsHtml}`;
+    };
+};

--- a/packages/frontend/src/hooks/echarts/utils/valueFormatter.ts
+++ b/packages/frontend/src/hooks/echarts/utils/valueFormatter.ts
@@ -1,0 +1,33 @@
+import {
+    formatItemValue,
+    type ItemsMap,
+    type PivotValuesColumn,
+} from '@lightdash/common';
+
+export const getFormattedValue = (
+    value: any,
+    key: string,
+    itemsMap: ItemsMap,
+    convertToUTC: boolean = true,
+    pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
+): string => {
+    const pivotValuesColumn = pivotValuesColumnsMap?.[key];
+    const item = itemsMap[pivotValuesColumn?.referenceField ?? key];
+    return formatItemValue(item, value, convertToUTC);
+};
+
+export const valueFormatter =
+    (
+        yFieldId: string,
+        itemsMap: ItemsMap,
+        pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
+    ) =>
+    (rawValue: any) => {
+        return getFormattedValue(
+            rawValue,
+            yFieldId,
+            itemsMap,
+            undefined,
+            pivotValuesColumnsMap,
+        );
+    };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Refactored chart tooltip formatting and stacked bar border radius handling to improve visualization quality and performance.

Key improvements:

- Extracted value formatting logic into a dedicated utility module
- Implemented a more robust tooltip formatter that handles complex data structures
- Rewrote the stacked bar border radius algorithm to properly handle rounded corners on visible end-segments only
- Fixed issues with tooltip value extraction in different chart modes (dataset vs tuple)
- Improved handling of pivot data in tooltips

### Main differences snapshot

###   
**Non-stacked (dataset mode: object-shaped values at runtime)** **\-** **this** **is** **the** **default** **behaviour**

**Series** (no per-point data array; values come from dataset):

```json
{
  "type": "bar",
  "encode": {
    "x": "campaigns_channel",
    "y": "campaigns_total_budget.campaigns_campaign_type.promotion",
    "tooltip": [
      "campaigns_total_budget.campaigns_campaign_type.promotion"
    ],
    "seriesName": "campaigns_total_budget.campaigns_campaign_type.promotion"
  },
  "dimensions": [
    { "name": "campaigns_channel", "displayName": "Channel" },
    { "name": "campaigns_total_budget.campaigns_campaign_type.promotion", "displayName": "promotion" }
  ]
}
```

**Tooltip** param snapshot (hover “email”) -> the tooltip formatter reads `value[encode.y]`​ 

```json
{
  "axisValueLabel": "email",
  "seriesName": "campaigns_total_budget.campaigns_campaign_type.promotion",
  "encode": {
    "x": "campaigns_channel",
    "y": "campaigns_total_budget.campaigns_campaign_type.promotion"
  },
  "dimensionNames": ["campaigns_channel", "campaigns_total_budget.campaigns_campaign_type.promotion"],
  "value": {
    "campaigns_channel": "email",
    "campaigns_total_budget.campaigns_campaign_type.promotion": 14000
  }
}
```

### **Stacked (regular) with rounded corners (tuple mode: per-point data array)** RECENT/**NEW**

**Series** (per-point tuples; end segments may include itemStyle.borderRadius): new behaviour/when redesign was worked on

```json
{
  "type": "bar",
  "stack": "campaigns_total_budget",
  "encode": {
    "x": "campaigns_channel",
    "y": "campaigns_total_budget.campaigns_campaign_type.promotion",
    "tooltip": [
      "campaigns_total_budget.campaigns_campaign_type.promotion"
    ],
    "seriesName": "campaigns_total_budget.campaigns_campaign_type.promotion"
  },
  "dimensions": [
    { "name": "campaigns_channel", "displayName": "Channel" },
    { "name": "campaigns_total_budget.campaigns_campaign_type.promotion", "displayName": "promotion" }
  ],
  "data": [
    { "value": ["multi_channel", 40000] },
    { "value": ["email", 14000] },
    { "value": ["push", null] },
    { "value": ["social", 3000] },
    {
      "value": ["online", 12000],
      "itemStyle": { "borderRadius": [4, 4, 0, 0] }
    }
  ]
}
```

**Tooltip** param snapshot (hover “email”) -> the tooltip formatter reads by index (**vertical: index 1**), enabling precise end‑segment rounding while keeping tooltip values correct.

```json
{
  "axisValueLabel": "email",
  "seriesName": "campaigns_total_budget.campaigns_campaign_type.promotion",
  "encode": {
    "x": "campaigns_channel",
    "y": "campaigns_total_budget.campaigns_campaign_type.promotion"
  },
  "dimensionNames": ["campaigns_channel", "campaigns_total_budget.campaigns_campaign_type.promotion"],
  "value": ["email", 14000]
}
```

[CleanShot 2025-10-30 at 23.37.09.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/4e727d4d-5b64-405d-9313-2b7ef8885623.mp4" />](https://app.graphite.dev/user-attachments/video/4e727d4d-5b64-405d-9313-2b7ef8885623.mp4)