### PR TITLE
feat: detect dangling dashboard filters for tables not used by any chart

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -160,6 +160,34 @@ export const dashboardForValidation: {
     chartUuids: ['chartUuid'],
 };
 
+// Dashboard with filters but no charts (dangling filters scenario)
+export const dashboardWithDanglingFilters: {
+    dashboardUuid: string;
+    name: string;
+    filters: DashboardFilters;
+    chartUuids: string[];
+} = {
+    dashboardUuid: 'dashboardWithDanglingFilters',
+    name: 'Dashboard with dangling filters',
+    filters: {
+        dimensions: [
+            {
+                id: 'filter1',
+                target: {
+                    fieldId: 'table_dimension',
+                    tableName: 'table',
+                },
+                operator: FilterOperator.EQUALS,
+                values: ['value1'],
+                label: 'Dimension Filter',
+            },
+        ],
+        metrics: [],
+        tableCalculations: [],
+    },
+    chartUuids: [], // No charts - filters are dangling
+};
+
 export const explore: Explore = {
     targetDatabase: SupportedDbtAdapter.POSTGRES,
     name: 'valid_explore',

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -458,16 +458,40 @@ export class ValidationService extends BaseService {
 
     private async validateDashboards(
         projectUuid: string,
-        existingFields: CompiledField[],
+        exploreFields: Record<
+            string,
+            { dimensionIds: string[]; metricIds: string[] }
+        >,
         brokenCharts: Pick<CreateChartValidation, 'chartUuid' | 'name'>[],
+        allCharts: Array<{ uuid: string; tableName: string }>,
     ): Promise<CreateDashboardValidation[]> {
-        const existingFieldIds = existingFields.map(getItemId);
-
         const dashboardsToValidate =
             await this.dashboardModel.findDashboardsForValidation(projectUuid);
         const results: CreateDashboardValidation[] =
             dashboardsToValidate.flatMap(
                 ({ name, dashboardUuid, filters, chartUuids }) => {
+                    // Get unique explore names used by charts on this dashboard
+                    const dashboardExplores = new Set(
+                        chartUuids
+                            .map((chartUuid) => {
+                                const chart = allCharts.find(
+                                    (c) => c.uuid === chartUuid,
+                                );
+                                return chart?.tableName;
+                            })
+                            .filter((tableName): tableName is string =>
+                                Boolean(tableName),
+                            ),
+                    );
+
+                    // Build field list from only the explores used by this dashboard's charts
+                    const dashboardFieldIds = Array.from(
+                        dashboardExplores,
+                    ).flatMap((exploreName) => {
+                        const fields = exploreFields[exploreName];
+                        if (!fields) return [];
+                        return [...fields.dimensionIds, ...fields.metricIds];
+                    });
                     const commonValidation = {
                         name,
                         dashboardUuid,
@@ -519,9 +543,33 @@ export class ValidationService extends BaseService {
                                 // Skip SQL column targets
                                 return acc;
                             }
+
+                            // Check if the filter's table is used by any chart on this dashboard
+                            const filterTableName = isDashboardFieldTarget(
+                                filter.target,
+                            )
+                                ? filter.target.tableName
+                                : undefined;
+
+                            if (
+                                filterTableName &&
+                                !dashboardExplores.has(filterTableName)
+                            ) {
+                                // Filter references an explore not used by any chart on this dashboard
+                                return [
+                                    ...acc,
+                                    {
+                                        ...commonValidation,
+                                        errorType: ValidationErrorType.Filter,
+                                        error: `Filter error: the field '${filter.target.fieldId}' references table '${filterTableName}' which is not used by any chart on this dashboard`,
+                                        fieldName: filter.target.fieldId,
+                                    },
+                                ];
+                            }
+
                             return containsFieldId({
                                 acc,
-                                fieldIds: existingFieldIds,
+                                fieldIds: dashboardFieldIds,
                                 fieldId: filter.target.fieldId,
                                 error: `Filter error: the field '${filter.target.fieldId}' no longer exists`,
                                 errorType: ValidationErrorType.Filter,
@@ -555,9 +603,30 @@ export class ValidationService extends BaseService {
                                 isDashboardFieldTarget(tileTarget) &&
                                 !tileTarget.isSqlColumn // Skip SQL column targets
                             ) {
+                                // Check if the tile target's table is used by any chart on this dashboard
+                                const tileTargetTableName =
+                                    tileTarget.tableName;
+
+                                if (
+                                    tileTargetTableName &&
+                                    !dashboardExplores.has(tileTargetTableName)
+                                ) {
+                                    // Tile target references an explore not used by any chart on this dashboard
+                                    return [
+                                        ...acc,
+                                        {
+                                            ...commonValidation,
+                                            errorType:
+                                                ValidationErrorType.Filter,
+                                            error: `Filter error: the field '${tileTarget.fieldId}' references table '${tileTargetTableName}' which is not used by any chart on this dashboard`,
+                                            fieldName: tileTarget.fieldId,
+                                        },
+                                    ];
+                                }
+
                                 return containsFieldId({
                                     acc,
-                                    fieldIds: existingFieldIds,
+                                    fieldIds: dashboardFieldIds,
                                     fieldId: tileTarget.fieldId,
                                     error: `Filter error: the field '${tileTarget.fieldId}' no longer exists`,
                                     errorType: ValidationErrorType.Filter,
@@ -723,13 +792,26 @@ export class ValidationService extends BaseService {
                   )
                 : [];
 
+        // Get all charts for dashboard validation (need chart->explore mapping)
+        const allCharts =
+            !hasValidationTargets ||
+            validationTargets.has(ValidationTarget.DASHBOARDS)
+                ? await this.savedChartModel.findChartsForValidation(
+                      projectUuid,
+                  )
+                : [];
+
         const dashboardErrors =
             !hasValidationTargets ||
             validationTargets.has(ValidationTarget.DASHBOARDS)
                 ? await this.validateDashboards(
                       projectUuid,
-                      existingFields,
+                      exploreFields,
                       chartErrors,
+                      allCharts.map((c) => ({
+                          uuid: c.uuid,
+                          tableName: c.tableName,
+                      })),
                   )
                 : [];
 


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17778

### Description:
Adds validation for dashboard filters that reference tables not used by any charts on the dashboard (dangling filters). This prevents situations where filters reference fields from explores that aren't actually used in any of the dashboard's charts.

The validation now checks if a filter's referenced table is included in the set of tables used by the dashboard's charts, and raises an appropriate error if not. This helps users identify and fix filters that may have been left behind after removing charts.