### PR TITLE
fix: clicking on metrics becomes slow because of expensive useColumns recalculation

### DIFF
--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -180,29 +180,50 @@ export const useColumns = (): TableColumn[] => {
 
     const hasNoActiveFields = activeFields.size === 0;
 
-    const itemsMap = useMemo<ItemsMap | undefined>(() => {
+    // Split itemsMap into base map (rarely changes) and override layer (frequently changes)
+    // This prevents full recalculation when only metricOverrides change
+    const baseItemsMap = useMemo<ItemsMap | undefined>(() => {
         if (!exploreData || hasNoActiveFields) return;
 
-        const baseItemsMap = getItemMap(
+        const baseFields = getItemMap(
             exploreData,
             additionalMetrics,
             tableCalculations,
             customDimensions,
         );
 
-        const mergedMap = {
-            ...baseItemsMap,
+        return {
+            ...baseFields,
             ...(resultsFields || {}),
         };
+    }, [
+        hasNoActiveFields,
+        resultsFields,
+        exploreData,
+        additionalMetrics,
+        tableCalculations,
+        customDimensions,
+    ]);
 
+    // Apply metric overrides as a separate layer
+    const itemsMap = useMemo<ItemsMap | undefined>(() => {
+        if (!baseItemsMap) return;
+
+        // If no overrides, return base map directly
+        if (!metricOverrides || Object.keys(metricOverrides).length === 0) {
+            return baseItemsMap;
+        }
+
+        // Only apply overrides to items that have them
         return Object.fromEntries(
-            Object.entries(mergedMap).map(([key, value]) => {
+            Object.entries(baseItemsMap).map(([key, value]) => {
                 const isFromResults = resultsFields && key in resultsFields;
                 if (isFromResults) {
                     return [key, value];
                 }
 
-                if (!metricOverrides?.[key]) return [key, value];
+                if (!metricOverrides[key]) return [key, value];
+
                 const itemWithoutLegacyFormat = omit(value, [
                     'format',
                     'round',
@@ -216,47 +237,36 @@ export const useColumns = (): TableColumn[] => {
                 ];
             }),
         );
-    }, [
-        hasNoActiveFields,
-        resultsFields,
-        exploreData,
-        additionalMetrics,
-        tableCalculations,
-        customDimensions,
-        metricOverrides,
-    ]);
+    }, [baseItemsMap, metricOverrides, resultsFields]);
 
     const { activeItemsMap, invalidActiveItems } = useMemo<{
         activeItemsMap: ItemsMap;
         invalidActiveItems: string[];
     }>(() => {
-        if (itemsMap) {
-            return Array.from(activeFields).reduce<{
-                activeItemsMap: ItemsMap;
-                invalidActiveItems: string[];
-            }>(
-                (acc, key) => {
-                    const item = itemsMap?.[key];
-                    return item
-                        ? {
-                              ...acc,
-                              activeItemsMap: {
-                                  ...acc.activeItemsMap,
-                                  [key]: item,
-                              },
-                          }
-                        : {
-                              ...acc,
-                              invalidActiveItems: [
-                                  ...acc.invalidActiveItems,
-                                  key,
-                              ],
-                          };
-                },
-                { activeItemsMap: {}, invalidActiveItems: [] },
-            );
+        if (!itemsMap) {
+            return { activeItemsMap: {}, invalidActiveItems: [] };
         }
-        return { activeItemsMap: {}, invalidActiveItems: [] };
+
+        const result: {
+            activeItemsMap: ItemsMap;
+            invalidActiveItems: string[];
+        } = {
+            activeItemsMap: {},
+            invalidActiveItems: [],
+        };
+
+        // Filter itemsMap to only include active fields
+        // This is more efficient than spreading objects in a reduce
+        for (const key of activeFields) {
+            const item = itemsMap[key];
+            if (item) {
+                result.activeItemsMap[key] = item;
+            } else {
+                result.invalidActiveItems.push(key);
+            }
+        }
+
+        return result;
     }, [itemsMap, activeFields]);
 
     const { data: totals } = useCalculateTotal({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Optimized the `useColumns` hook by splitting the item map calculation into two layers:

1. A base layer that contains fields that rarely change
2. An override layer for metric overrides that change frequently

This prevents full recalculation when only metric overrides change. Additionally:

- Improved the filtering of active fields by using a direct loop instead of Array.reduce
- Added early return when there are no metric overrides
- Simplified the logic for applying overrides to only items that have them

These changes should reduce unnecessary re-renders and improve performance when working with tables that have many columns or frequent metric override changes.

**Before**

[Screen Recording 2025-10-31 at 12.16.01.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/0e33adbb-72aa-4816-976e-44a5b0da31bf.mov" />](https://app.graphite.dev/user-attachments/video/0e33adbb-72aa-4816-976e-44a5b0da31bf.mov)

**After**

[Screen Recording 2025-10-31 at 12.14.52.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/7590c521-60d2-4042-916f-2f6c470516a3.mov" />](https://app.graphite.dev/user-attachments/video/7590c521-60d2-4042-916f-2f6c470516a3.mov)

