### PR TITLE
feat: add ai eval run assessment table

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -294,6 +294,8 @@ import {
 import {
     AiEvalPromptTable,
     AiEvalPromptTableName,
+    AiEvalRunResultAssessmentTable,
+    AiEvalRunResultAssessmentTableName,
     AiEvalRunResultTable,
     AiEvalRunResultTableName,
     AiEvalRunTable,
@@ -423,6 +425,7 @@ declare module 'knex/types/tables' {
         [AiEvalPromptTableName]: AiEvalPromptTable;
         [AiEvalRunTableName]: AiEvalRunTable;
         [AiEvalRunResultTableName]: AiEvalRunResultTable;
+        [AiEvalRunResultAssessmentTableName]: AiEvalRunResultAssessmentTable;
         [ChangesetsTableName]: ChangesetsTable;
         [ChangesTableName]: ChangesTable;
     }

--- a/packages/backend/src/ee/database/entities/aiEvals.ts
+++ b/packages/backend/src/ee/database/entities/aiEvals.ts
@@ -28,6 +28,7 @@ export type DbAiEvalPrompt = {
     prompt: string | null;
     ai_prompt_uuid: string | null;
     ai_thread_uuid: string | null;
+    expected_response: string | null;
     created_at: Date;
 };
 
@@ -63,7 +64,7 @@ export type DbAiEvalRunResult = {
     ai_eval_run_uuid: string;
     ai_eval_prompt_uuid: string | null;
     ai_thread_uuid: string | null;
-    status: 'pending' | 'running' | 'completed' | 'failed';
+    status: 'pending' | 'running' | 'completed' | 'assessing' | 'failed';
     error_message: string | null;
     completed_at: Date | null;
     created_at: Date;
@@ -81,4 +82,29 @@ export type AiEvalRunResultTable = Knex.CompositeTableType<
             'ai_thread_uuid' | 'status' | 'error_message' | 'completed_at'
         >
     >
+>;
+
+export const AiEvalRunResultAssessmentTableName =
+    'ai_eval_run_result_assessment';
+
+export type DbAiEvalRunResultAssessment = {
+    ai_eval_run_result_assessment_uuid: string;
+    ai_eval_run_result_uuid: string;
+    assessment_type: 'human' | 'llm';
+    passed: boolean;
+    reason: string | null;
+    assessed_by_user_uuid: string | null;
+    llm_judge_provider: string | null;
+    llm_judge_model: string | null;
+    assessed_at: Date;
+    created_at: Date;
+};
+
+export type AiEvalRunResultAssessmentTable = Knex.CompositeTableType<
+    DbAiEvalRunResultAssessment,
+    Omit<
+        DbAiEvalRunResultAssessment,
+        'ai_eval_run_result_assessment_uuid' | 'created_at' | 'assessed_at'
+    >,
+    never
 >;

--- a/packages/backend/src/ee/database/migrations/20251031122046_add_ai_eval_run_result_assessment.ts
+++ b/packages/backend/src/ee/database/migrations/20251031122046_add_ai_eval_run_result_assessment.ts
@@ -1,0 +1,92 @@
+import { Knex } from 'knex';
+
+const aiEvalRunResultAssessmentTable = 'ai_eval_run_result_assessment';
+const aiEvalRunResultTable = 'ai_eval_run_result';
+const aiEvalPromptTable = 'ai_eval_prompt';
+const usersTable = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiEvalPromptTable, (table) => {
+        table.text('expected_response').nullable();
+    });
+
+    // Add 'assessing' status to ai_eval_run_result
+    await knex.raw(`
+        ALTER TABLE ${aiEvalRunResultTable}
+        DROP CONSTRAINT IF EXISTS ai_eval_run_result_status_check;
+    `);
+
+    await knex.raw(`
+        ALTER TABLE ${aiEvalRunResultTable}
+        ADD CONSTRAINT ai_eval_run_result_status_check
+        CHECK (status IN ('pending', 'running', 'completed', 'assessing', 'failed'));
+    `);
+
+    await knex.schema.createTable(aiEvalRunResultAssessmentTable, (table) => {
+        table
+            .uuid('ai_eval_run_result_assessment_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_eval_run_result_uuid')
+            .notNullable()
+            .references('ai_eval_run_result_uuid')
+            .inTable(aiEvalRunResultTable)
+            .onDelete('CASCADE');
+        table
+            .enum('assessment_type', ['human', 'llm'])
+            .notNullable()
+            .defaultTo('llm');
+        table.boolean('passed').notNullable();
+        table.text('reason');
+        table
+            .uuid('assessed_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL');
+        table.string('llm_judge_provider', 50);
+        table.string('llm_judge_model', 100);
+        table
+            .timestamp('assessed_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        // Unique constraint: one assessment per result per type (max one human + one llm)
+        table.unique(['ai_eval_run_result_uuid', 'assessment_type']);
+
+        table.index(['ai_eval_run_result_uuid']);
+        table.index(['assessment_type']);
+        table.index(['assessed_by_user_uuid']);
+        table.index(['llm_judge_model']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(aiEvalRunResultAssessmentTable);
+
+    // Revert any 'assessing' statuses back to 'completed' before dropping constraint
+    await knex(aiEvalRunResultTable)
+        .where('status', 'assessing')
+        .update({ status: 'completed' });
+
+    // Restore original constraint without 'assessing'
+    await knex.raw(`
+        ALTER TABLE ${aiEvalRunResultTable}
+        DROP CONSTRAINT IF EXISTS ai_eval_run_result_status_check;
+    `);
+
+    await knex.raw(`
+        ALTER TABLE ${aiEvalRunResultTable}
+        ADD CONSTRAINT ai_eval_run_result_status_check
+        CHECK (status IN ('pending', 'running', 'completed', 'failed'));
+    `);
+
+    await knex.schema.alterTable(aiEvalPromptTable, (table) => {
+        table.dropColumn('expected_response');
+    });
+}

--- a/packages/common/src/ee/AiAgent/aiEvalAssessment.ts
+++ b/packages/common/src/ee/AiAgent/aiEvalAssessment.ts
@@ -1,0 +1,22 @@
+export type AssessmentType = 'human' | 'llm';
+
+export type AiEvalRunResultAssessment = {
+    assessmentUuid: string;
+    runResultUuid: string;
+    assessmentType: AssessmentType;
+    passed: boolean;
+    reason: string | null;
+    assessedByUserUuid: string | null;
+    llmJudgeProvider: string | null;
+    llmJudgeModel: string | null;
+    assessedAt: Date;
+    createdAt: Date;
+};
+
+export type CreateLlmAssessment = {
+    runResultUuid: string;
+    passed: boolean;
+    reason: string | null;
+    llmJudgeProvider: string;
+    llmJudgeModel: string;
+};

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -19,6 +19,7 @@ import { type AgentToolOutput } from './schemas';
 import { type AiMetricQuery, type AiResultType } from './types';
 
 export * from './adminTypes';
+export * from './aiEvalAssessment';
 export * from './chartConfig/slack';
 export * from './chartConfig/web';
 export * from './constants';
@@ -456,7 +457,7 @@ export type AiAgentEvaluationRunResult = {
     resultUuid: string;
     evalPromptUuid: string | null;
     threadUuid: string | null;
-    status: 'pending' | 'running' | 'completed' | 'failed';
+    status: 'pending' | 'running' | 'completed' | 'assessing' | 'failed';
     errorMessage: string | null;
     completedAt: Date | null;
     createdAt: Date;


### PR DESCRIPTION


### Description:
Adds AI evaluation assessment capabilities to track the quality of AI responses. This PR:

- Creates a new `ai_eval_run_result_assessment` table to store assessment results
- Adds an `expected_response` field to the AI eval prompts table


```
ai_eval 
  └── ai_eval_prompt[]
        ├── prompt: text 
        └── expected_response: text (🆕 - optional)

ai_eval_run 
  └── ai_eval_run_result[] 
        └── ai_eval_run_result_assessment[] 🆕
              ├── assessment_uuid: uuid
              ├── run_result_uuid: uuid 
              ├── assessment_type: "llm" | "human" (human work comes later)
              ├── passed: true/false
              ├── reason: "LLM explanation..."
              ├── llm_judge_provider: "anthropic"
              ├── llm_judge_model: "claude-3-5-sonnet"
              ├── assessed_at: timestamp
              ├── created_at: timestamp
              └── assessed_by_user_uuid: uuid (later)
```