### PR TITLE
fix: filter out orphaned chart and dashboard validations

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -43,6 +43,7 @@ const projectModel = {
 const validationModel = {
     delete: jest.fn(async () => {}),
     create: jest.fn(async () => {}),
+    get: jest.fn(async () => []),
 };
 const dashboardModel = {
     findDashboardsForValidation: jest.fn(async () => [dashboardForValidation]),
@@ -401,6 +402,84 @@ describe('validation', () => {
             fieldName: 'table_dimension',
             name: 'Dashboard with dangling filters',
             source: 'dashboard',
+        });
+    });
+
+    it('Should filter out orphaned chart validations when retrieving', async () => {
+        const mockUser = {
+            userUuid: 'user-uuid',
+            organizationUuid: 'org-uuid',
+            role: 'admin', // Admin role to skip space access checks
+            ability: {
+                cannot: jest.fn(() => false),
+            },
+        } as unknown as Parameters<typeof validationService.get>[0];
+
+        // Mock validations with some orphaned (null UUIDs)
+        (validationModel.get as jest.Mock).mockResolvedValueOnce([
+            {
+                validationId: 1,
+                projectUuid: 'projectUuid',
+                error: 'Chart error',
+                errorType: 'chart',
+                chartUuid: 'chart-1', // Valid
+                source: 'chart',
+            },
+            {
+                validationId: 2,
+                projectUuid: 'projectUuid',
+                error: 'Chart error for deleted',
+                errorType: 'chart',
+                chartUuid: null, // Orphaned - should be filtered out
+                source: 'chart',
+            },
+        ]);
+
+        const results = await validationService.get(mockUser, 'projectUuid');
+
+        // Should only return non-orphaned validations
+        expect(results.length).toEqual(1);
+        expect(results[0]).toMatchObject({
+            chartUuid: 'chart-1',
+        });
+    });
+
+    it('Should filter out orphaned dashboard validations when retrieving', async () => {
+        const mockUser = {
+            userUuid: 'user-uuid',
+            organizationUuid: 'org-uuid',
+            role: 'admin', // Admin role to skip space access checks
+            ability: {
+                cannot: jest.fn(() => false),
+            },
+        } as unknown as Parameters<typeof validationService.get>[0];
+
+        // Mock validations with some orphaned (null UUIDs)
+        (validationModel.get as jest.Mock).mockResolvedValueOnce([
+            {
+                validationId: 1,
+                projectUuid: 'projectUuid',
+                error: 'Dashboard error',
+                errorType: 'dashboard',
+                dashboardUuid: 'dashboard-1', // Valid
+                source: 'dashboard',
+            },
+            {
+                validationId: 2,
+                projectUuid: 'projectUuid',
+                error: 'Dashboard error for deleted',
+                errorType: 'dashboard',
+                dashboardUuid: null, // Orphaned - should be filtered out
+                source: 'dashboard',
+            },
+        ]);
+
+        const results = await validationService.get(mockUser, 'projectUuid');
+
+        // Should only return non-orphaned validations
+        expect(results.length).toEqual(1);
+        expect(results[0]).toMatchObject({
+            dashboardUuid: 'dashboard-1',
         });
     });
 });


### PR DESCRIPTION


### Description:
Filter out orphaned validations when retrieving validation errors. This prevents showing validation errors for charts and dashboards that have been deleted, which could confuse users.

The PR adds logic to the `get` method in ValidationService to filter out validation records where the referenced chart or dashboard UUID is null, indicating the content no longer exists.
