### PR TITLE
fix: dashboard validation error message types and frontend rendering

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1185,6 +1185,7 @@ const models: TsoaRoute.Models = {
                 canDateZoom: { dataType: 'boolean' },
                 canExportImages: { dataType: 'boolean' },
                 canExportCsv: { dataType: 'boolean' },
+                canChangeParameters: { dataType: 'boolean' },
                 dashboardFiltersInteractivity: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -5116,7 +5117,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ExecuteAsyncDashboardChartRequestParams.dashboardFilters-or-dashboardSorts-or-pivotResults-or-invalidateCache-or-dateZoom_':
+    'Pick_ExecuteAsyncDashboardChartRequestParams.dashboardFilters-or-dashboardSorts-or-pivotResults-or-invalidateCache-or-dateZoom-or-parameters_':
         {
             dataType: 'refAlias',
             type: {
@@ -5149,6 +5150,13 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { ref: 'DateZoom' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    parameters: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'ParametersValuesMap' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -6091,11 +6099,106 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6205,106 +6308,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9234,6 +9242,15 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardFilterValidationErrorType: {
+        dataType: 'refEnum',
+        enums: [
+            'field_does_not_exist',
+            'table_not_used_by_any_chart',
+            'table_does_not_exist',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ValidationErrorDashboardResponse: {
         dataType: 'refAlias',
         type: {
@@ -9246,6 +9263,10 @@ const models: TsoaRoute.Models = {
                         dashboardViews: { dataType: 'double', required: true },
                         lastUpdatedAt: { dataType: 'datetime' },
                         lastUpdatedBy: { dataType: 'string' },
+                        dashboardFilterErrorType: {
+                            ref: 'DashboardFilterValidationErrorType',
+                        },
+                        tableName: { dataType: 'string' },
                         fieldName: { dataType: 'string' },
                         chartName: { dataType: 'string' },
                         dashboardUuid: {
@@ -13310,6 +13331,13 @@ const models: TsoaRoute.Models = {
                 projectUuid: { dataType: 'string', required: true },
                 organizationUuid: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
+                parameters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ParametersValuesMap' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 updatedAt: { dataType: 'datetime', required: true },
                 chartConfig: { ref: 'ChartConfig', required: true },
                 spaceUuid: { dataType: 'string', required: true },
@@ -13383,13 +13411,6 @@ const models: TsoaRoute.Models = {
                     },
                     required: true,
                 },
-                parameters: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'ParametersValuesMap' },
-                        { dataType: 'undefined' },
-                    ],
-                },
                 colorPalette: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -13451,6 +13472,13 @@ const models: TsoaRoute.Models = {
                 projectUuid: { dataType: 'string', required: true },
                 organizationUuid: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
+                parameters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DashboardParameters' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 updatedAt: { dataType: 'datetime', required: true },
                 spaceUuid: { dataType: 'string', required: true },
                 pinnedListUuid: {
@@ -13487,13 +13515,6 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: [null] },
                     ],
                     required: true,
-                },
-                parameters: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'DashboardParameters' },
-                        { dataType: 'undefined' },
-                    ],
                 },
                 dashboardVersionId: { dataType: 'double', required: true },
                 tiles: {
@@ -14609,6 +14630,13 @@ const models: TsoaRoute.Models = {
                         ],
                     },
                     name: { dataType: 'string', required: true },
+                    parameters: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'ParametersValuesMap' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     chartConfig: { ref: 'ChartConfig', required: true },
                     tableName: { dataType: 'string', required: true },
                     metricQuery: { ref: 'MetricQuery', required: true },
@@ -14638,13 +14666,6 @@ const models: TsoaRoute.Models = {
                             },
                         },
                         required: true,
-                    },
-                    parameters: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'ParametersValuesMap' },
-                            { dataType: 'undefined' },
-                        ],
                     },
                 },
                 validators: {},
@@ -15421,7 +15442,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15431,7 +15452,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15441,7 +15462,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -15454,7 +15475,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -18102,6 +18123,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                parameters: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'Record_string.LightdashProjectParameter_' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 tags: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -18111,13 +18139,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                parameters: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'Record_string.LightdashProjectParameter_' },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -22983,6 +23004,7 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                parameters: { ref: 'ParametersValuesMap' },
                 dashboardSorts: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'SortField' },
@@ -23065,7 +23087,7 @@ export function RegisterRoutes(app: Router) {
                     },
                 },
                 {
-                    ref: 'Pick_ExecuteAsyncDashboardChartRequestParams.dashboardFilters-or-dashboardSorts-or-pivotResults-or-invalidateCache-or-dateZoom_',
+                    ref: 'Pick_ExecuteAsyncDashboardChartRequestParams.dashboardFilters-or-dashboardSorts-or-pivotResults-or-invalidateCache-or-dateZoom-or-parameters_',
                 },
             ],
         },
@@ -23142,6 +23164,7 @@ export function RegisterRoutes(app: Router) {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 invalidateCache: { dataType: 'boolean' },
+                parameters: { ref: 'ParametersValuesMap' },
                 dashboardFilters: { ref: 'AnyType' },
             },
         },
@@ -23227,6 +23250,7 @@ export function RegisterRoutes(app: Router) {
                     array: { dataType: 'string' },
                     required: true,
                 },
+                parameters: { ref: 'ParametersValuesMap' },
                 dashboardFilters: { ref: 'DashboardFilters' },
             },
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1220,6 +1220,9 @@
                     "canExportCsv": {
                         "type": "boolean"
                     },
+                    "canChangeParameters": {
+                        "type": "boolean"
+                    },
                     "dashboardFiltersInteractivity": {
                         "properties": {
                             "hidden": {
@@ -5735,7 +5738,7 @@
                 },
                 "type": "object"
             },
-            "Pick_ExecuteAsyncDashboardChartRequestParams.dashboardFilters-or-dashboardSorts-or-pivotResults-or-invalidateCache-or-dateZoom_": {
+            "Pick_ExecuteAsyncDashboardChartRequestParams.dashboardFilters-or-dashboardSorts-or-pivotResults-or-invalidateCache-or-dateZoom-or-parameters_": {
                 "properties": {
                     "dashboardFilters": {
                         "$ref": "#/components/schemas/DashboardFilters"
@@ -5754,6 +5757,9 @@
                     },
                     "dateZoom": {
                         "$ref": "#/components/schemas/DateZoom"
+                    },
+                    "parameters": {
+                        "$ref": "#/components/schemas/ParametersValuesMap"
                     }
                 },
                 "required": ["dashboardFilters", "dashboardSorts"],
@@ -6731,19 +6737,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -9551,6 +9544,14 @@
                     }
                 ]
             },
+            "DashboardFilterValidationErrorType": {
+                "enum": [
+                    "field_does_not_exist",
+                    "table_not_used_by_any_chart",
+                    "table_does_not_exist"
+                ],
+                "type": "string"
+            },
             "ValidationErrorDashboardResponse": {
                 "allOf": [
                     {
@@ -9567,6 +9568,12 @@
                                 "format": "date-time"
                             },
                             "lastUpdatedBy": {
+                                "type": "string"
+                            },
+                            "dashboardFilterErrorType": {
+                                "$ref": "#/components/schemas/DashboardFilterValidationErrorType"
+                            },
+                            "tableName": {
                                 "type": "string"
                             },
                             "fieldName": {
@@ -13873,6 +13880,9 @@
                     "uuid": {
                         "type": "string"
                     },
+                    "parameters": {
+                        "$ref": "#/components/schemas/ParametersValuesMap"
+                    },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time"
@@ -13938,9 +13948,6 @@
                         },
                         "required": ["columnOrder"],
                         "type": "object"
-                    },
-                    "parameters": {
-                        "$ref": "#/components/schemas/ParametersValuesMap"
                     },
                     "colorPalette": {
                         "items": {
@@ -14016,6 +14023,9 @@
                     "uuid": {
                         "type": "string"
                     },
+                    "parameters": {
+                        "$ref": "#/components/schemas/DashboardParameters"
+                    },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time"
@@ -14056,9 +14066,6 @@
                             }
                         ],
                         "nullable": true
-                    },
-                    "parameters": {
-                        "$ref": "#/components/schemas/DashboardParameters"
                     },
                     "dashboardVersionId": {
                         "type": "number",
@@ -15397,6 +15404,9 @@
                     "name": {
                         "type": "string"
                     },
+                    "parameters": {
+                        "$ref": "#/components/schemas/ParametersValuesMap"
+                    },
                     "chartConfig": {
                         "$ref": "#/components/schemas/ChartConfig"
                     },
@@ -15429,9 +15439,6 @@
                         },
                         "required": ["columnOrder"],
                         "type": "object"
-                    },
-                    "parameters": {
-                        "$ref": "#/components/schemas/ParametersValuesMap"
                     }
                 },
                 "required": [
@@ -16128,22 +16135,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -18706,6 +18713,9 @@
                         "required": ["visibility"],
                         "type": "object"
                     },
+                    "parameters": {
+                        "$ref": "#/components/schemas/Record_string.LightdashProjectParameter_"
+                    },
                     "tags": {
                         "items": {
                             "type": "string"
@@ -18714,9 +18724,6 @@
                     },
                     "warehouse": {
                         "type": "string"
-                    },
-                    "parameters": {
-                        "$ref": "#/components/schemas/Record_string.LightdashProjectParameter_"
                     },
                     "groupLabel": {
                         "type": "string"
@@ -21428,7 +21435,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2118.0",
+        "version": "0.2121.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
@@ -1,0 +1,100 @@
+import { DashboardFilterValidationErrorType } from '@lightdash/common';
+import { ValidationModel } from './ValidationModel';
+
+describe('ValidationModel', () => {
+    describe('parseDashboardFilterError', () => {
+        it('Should parse "table not used by any chart" error', () => {
+            const error =
+                "Filter error: the field 'orders_status' references table 'orders' which is not used by any chart on this dashboard";
+
+            const result = ValidationModel.parseDashboardFilterError(error);
+
+            expect(result).toEqual({
+                tableName: 'orders',
+                dashboardFilterErrorType:
+                    DashboardFilterValidationErrorType.TableNotUsedByAnyChart,
+            });
+        });
+
+        it('Should parse "field no longer exists" error', () => {
+            const error =
+                "Filter error: the field 'orders_status' no longer exists";
+
+            const result = ValidationModel.parseDashboardFilterError(error);
+
+            expect(result).toEqual({
+                dashboardFilterErrorType:
+                    DashboardFilterValidationErrorType.FieldDoesNotExist,
+            });
+        });
+
+        it('Should parse "table no longer exists" error', () => {
+            const error = "Table 'orders' no longer exists";
+
+            const result = ValidationModel.parseDashboardFilterError(error);
+
+            expect(result).toEqual({
+                tableName: 'orders',
+                dashboardFilterErrorType:
+                    DashboardFilterValidationErrorType.TableDoesNotExist,
+            });
+        });
+
+        it('Should distinguish between "table no longer exists" and "field no longer exists"', () => {
+            const tableError = "Table 'orders' no longer exists";
+            const fieldError =
+                "Filter error: the field 'orders_status' no longer exists";
+
+            const tableResult =
+                ValidationModel.parseDashboardFilterError(tableError);
+            const fieldResult =
+                ValidationModel.parseDashboardFilterError(fieldError);
+
+            // Table error should be categorized as TableDoesNotExist
+            expect(tableResult).toEqual({
+                tableName: 'orders',
+                dashboardFilterErrorType:
+                    DashboardFilterValidationErrorType.TableDoesNotExist,
+            });
+
+            // Field error should be categorized as FieldDoesNotExist
+            expect(fieldResult).toEqual({
+                dashboardFilterErrorType:
+                    DashboardFilterValidationErrorType.FieldDoesNotExist,
+            });
+        });
+
+        it('Should return empty object for unrecognized error patterns', () => {
+            const error = 'Some other error message';
+
+            const result = ValidationModel.parseDashboardFilterError(error);
+
+            expect(result).toEqual({});
+        });
+
+        it('Should handle errors with special characters in field names', () => {
+            const error =
+                "Filter error: the field 'orders_is_completed' references table 'orders' which is not used by any chart on this dashboard";
+
+            const result = ValidationModel.parseDashboardFilterError(error);
+
+            expect(result).toEqual({
+                tableName: 'orders',
+                dashboardFilterErrorType:
+                    DashboardFilterValidationErrorType.TableNotUsedByAnyChart,
+            });
+        });
+
+        it('Should handle errors with underscores in table names', () => {
+            const error = "Table 'order_items' no longer exists";
+
+            const result = ValidationModel.parseDashboardFilterError(error);
+
+            expect(result).toEqual({
+                tableName: 'order_items',
+                dashboardFilterErrorType:
+                    DashboardFilterValidationErrorType.TableDoesNotExist,
+            });
+        });
+    });
+});

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -25,6 +25,8 @@ export type ValidationErrorDashboardResponse = ValidationResponseBase & {
     dashboardUuid: string | undefined; // NOTE: can be undefined if private content
     chartName?: string;
     fieldName?: string;
+    tableName?: string; // For dashboard filter errors referencing specific tables
+    dashboardFilterErrorType?: DashboardFilterValidationErrorType;
     lastUpdatedBy?: string;
     lastUpdatedAt?: Date;
     dashboardViews: number;
@@ -100,6 +102,12 @@ export enum ValidationErrorType {
     Model = 'model',
     Dimension = 'dimension',
     CustomMetric = 'custom metric',
+}
+
+export enum DashboardFilterValidationErrorType {
+    FieldDoesNotExist = 'field_does_not_exist',
+    TableNotUsedByAnyChart = 'table_not_used_by_any_chart',
+    TableDoesNotExist = 'table_does_not_exist',
 }
 
 export enum ValidationSourceType {

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
@@ -1,4 +1,5 @@
 import {
+    DashboardFilterValidationErrorType,
     friendlyName,
     isChartValidationError,
     isDashboardValidationError,
@@ -36,21 +37,50 @@ const ErrorMessageByType: FC<{
     }
 
     if (isDashboardValidationError(validationError)) {
-        return (
-            <Text>
-                {validationError.fieldName ? (
-                    <>
-                        <CustomMark>{validationError.fieldName}</CustomMark> no
-                        longer exists
-                    </>
-                ) : (
-                    <>
-                        <CustomMark>{validationError.chartName}</CustomMark> is
-                        broken
-                    </>
-                )}
-            </Text>
-        );
+        // Handle dashboard filter errors with typed error types
+        if (validationError.dashboardFilterErrorType) {
+            switch (validationError.dashboardFilterErrorType) {
+                case DashboardFilterValidationErrorType.TableNotUsedByAnyChart:
+                    return (
+                        <Text>
+                            <CustomMark>{validationError.fieldName}</CustomMark>{' '}
+                            references table{' '}
+                            <CustomMark>{validationError.tableName}</CustomMark>{' '}
+                            which is not used by any chart on this dashboard
+                        </Text>
+                    );
+                case DashboardFilterValidationErrorType.FieldDoesNotExist:
+                    return (
+                        <Text>
+                            <CustomMark>{validationError.fieldName}</CustomMark>{' '}
+                            no longer exists
+                        </Text>
+                    );
+                case DashboardFilterValidationErrorType.TableDoesNotExist:
+                    return (
+                        <Text>
+                            Table{' '}
+                            <CustomMark>{validationError.tableName}</CustomMark>{' '}
+                            no longer exists
+                        </Text>
+                    );
+                default:
+                    return <Text>{validationError.error}</Text>;
+            }
+        }
+
+        // Handle broken chart errors
+        if (validationError.chartName) {
+            return (
+                <Text>
+                    <CustomMark>{validationError.chartName}</CustomMark> is
+                    broken
+                </Text>
+            );
+        }
+
+        // Fallback for unexpected cases
+        return <Text>{validationError.error}</Text>;
     }
 
     if (isTableValidationError(validationError) && validationError) {


### PR DESCRIPTION
### Description:
This PR adds support for dashboard filter validation error types to improve error handling and user experience. It introduces a new `DashboardFilterValidationErrorType` enum with three error types: `field_does_not_exist`, `table_not_used_by_any_chart`, and `table_does_not_exist`.

The PR also enhances the validation model to parse dashboard filter errors and extract relevant information like table names. The frontend now displays more specific and user-friendly error messages based on the error type.

Additionally, this PR adds the `canChangeParameters` property to control parameter editing permissions and reorganizes the parameters field in several data structures to maintain consistency.