### PR TITLE
feat: automatically assess eval results

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -140,6 +140,7 @@ import {
     getFollowUpToolBlocks,
     getProposeChangeBlocks,
 } from './ai/utils/getSlackBlocks';
+import { llmAsAJudge } from './ai/utils/llmAsAJudge';
 import { populateCustomMetricsSQL } from './ai/utils/populateCustomMetricsSQL';
 import { validateSelectedFieldsExistence } from './ai/utils/validators';
 import { AiOrganizationSettingsService } from './AiOrganizationSettingsService';
@@ -3914,9 +3915,14 @@ export class AiAgentService {
                 threadUuid,
             });
 
-            // Mark as completed
             await this.aiAgentModel.updateEvalRunResult(result.resultUuid, {
-                status: 'completed',
+                status: `assessing`,
+            });
+            await this.assessResult(result.resultUuid);
+
+            // Mark as completed with assessment status
+            await this.aiAgentModel.updateEvalRunResult(result.resultUuid, {
+                status: `completed`,
                 completedAt: new Date(),
             });
 
@@ -3925,7 +3931,6 @@ export class AiAgentService {
                 evalRunUuid,
             );
         } catch (error) {
-            // Update result as failed
             await this.aiAgentModel.updateEvalRunResult(result.resultUuid, {
                 status: 'failed',
                 errorMessage:
@@ -3940,6 +3945,97 @@ export class AiAgentService {
 
             throw error;
         }
+    }
+
+    /**
+     * Assess the correctness of an evaluation result based on factuality and context relevancy scores.
+     * TODO: Consider adding explores information for extra context relevancy assessment
+     * @param resultUuid
+     * @returns boolean - Indicates whether the result is correct or not.
+     */
+    async assessResult(resultUuid: string): Promise<boolean> {
+        Logger.info(`Assessing result ${resultUuid}`);
+        const { query, response, expectedAnswer, artifact } =
+            await this.aiAgentModel.getEvalResultDataForAssessment(resultUuid);
+
+        // TODO: Implement judge configuration in the future!
+        // reusing existing configuration for now
+        const { model: judge, callOptions } = getModel(
+            this.lightdashConfig.ai.copilot,
+        );
+
+        const artifactContext: string[] = artifact
+            ? [
+                  `Artifact type: ${artifact.artifactType}`,
+                  artifact.chartConfig
+                      ? `Chart config: ${JSON.stringify(artifact.chartConfig)}`
+                      : '',
+                  artifact.dashboardConfig
+                      ? `Dashboard config: ${JSON.stringify(
+                            artifact.dashboardConfig,
+                        )}`
+                      : '',
+              ].filter(Boolean)
+            : [];
+
+        const factualityScore = expectedAnswer
+            ? await llmAsAJudge({
+                  query,
+                  response,
+                  expectedAnswer,
+                  judge,
+                  callOptions,
+                  scorerType: 'factuality',
+              })
+            : null;
+
+        const contextRelevancyScore = artifact
+            ? await llmAsAJudge({
+                  query,
+                  response,
+                  context: artifactContext,
+                  judge,
+                  callOptions,
+                  scorerType: 'contextRelevancy',
+              })
+            : null;
+
+        const reasoning = [];
+        let passed = true;
+        if (factualityScore) {
+            reasoning.push(
+                ...[
+                    `Factuality score passed: ${factualityScore.meta.passed}`,
+                    `Factuality rationale: ${factualityScore.result.rationale}`,
+                ],
+            );
+            passed = passed && factualityScore.meta.passed;
+        }
+
+        if (contextRelevancyScore) {
+            reasoning.push(
+                ...[
+                    `Context relevancy score passed: ${contextRelevancyScore.meta.passed}`,
+                    `Context relevancy reason: ${contextRelevancyScore.result.reason}`,
+                ],
+            );
+            passed = passed && contextRelevancyScore.meta.passed;
+        }
+
+        if (reasoning.length === 0) {
+            reasoning.push('Not enough information to assess this result');
+            passed = false;
+        }
+
+        await this.aiAgentModel.createLlmAssessment({
+            runResultUuid: resultUuid,
+            passed,
+            reason: reasoning.join('\n'),
+            llmJudgeProvider: judge.provider,
+            llmJudgeModel: judge.modelId,
+        });
+
+        return passed;
     }
 
     async getArtifact(

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -9,9 +9,9 @@ import {
 } from '../../../../../vitest.setup.integration';
 import { getModel } from '../../models';
 import { getOpenaiGptmodel } from '../../models/openai-gpt';
+import { llmAsAJudge } from '../../utils/llmAsAJudge';
+import { llmAsJudgeForTools } from '../../utils/llmAsJudgeForTools';
 import { testCases } from './testCases';
-import { llmAsAJudge } from './utils/llmAsAJudge';
-import { llmAsJudgeForTools } from './utils/llmAsJudgeForTools';
 import { promptAndGetToolCalls } from './utils/testHelpers';
 import { createTestReport } from './utils/testReportWrapper';
 

--- a/packages/backend/src/ee/services/ai/agents/tests/eval-reporter.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/eval-reporter.ts
@@ -7,8 +7,8 @@ import {
     ContextRelevancyResponse,
     FactualityResponse,
     LlmJudgeResult,
-} from './utils/llmAsAJudge';
-import { ToolJudgeResult } from './utils/llmAsJudgeForTools';
+} from '../../utils/llmAsAJudge';
+import { ToolJudgeResult } from '../../utils/llmAsJudgeForTools';
 
 interface EvalResult {
     testCase: string;
@@ -272,15 +272,15 @@ export default class EvalHtmlReporter implements Reporter {
             font-size: 18px;
             margin-right: 6px;
         }
-        .pass { 
+        .pass {
             color: #28a745;
             font-weight: 600;
         }
-        .fail { 
+        .fail {
             color: #dc3545;
             font-weight: 600;
         }
-        .skip { 
+        .skip {
             color: #ffc107;
             font-weight: 600;
         }
@@ -336,7 +336,7 @@ export default class EvalHtmlReporter implements Reporter {
         function toggleExpand(testId) {
             const expandRow = document.getElementById('expand-' + testId);
             const toggleBtn = document.getElementById('toggle-' + testId);
-            
+
             if (expandRow.style.display === 'none' || expandRow.style.display === '') {
                 expandRow.style.display = 'table-row';
                 toggleBtn.textContent = '▼';
@@ -353,7 +353,7 @@ export default class EvalHtmlReporter implements Reporter {
         <div class="date">${formattedDate}</div>
         <div class="model-info">Agent: ${agentProvider} / ${agentModel}</div>
     </div>
-    
+
     <div class="summary">
         <div class="summary-item pass">
             <h3>Passed</h3>
@@ -687,7 +687,7 @@ export default class EvalHtmlReporter implements Reporter {
                         <div><strong>Score:</strong> ${(
                             (jsonResult.score ?? 0) * 100
                         ).toFixed(1)}%</div>
-                        
+
                     `;
                         break;
                     case 'contextRelevancy':

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/testReportWrapper.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/testReportWrapper.ts
@@ -1,7 +1,7 @@
 import { TestContext } from 'vitest';
 import { DbAiAgentToolCall } from '../../../../../database/entities/ai';
-import { LlmJudgeResult } from './llmAsAJudge';
-import { ToolJudgeResult } from './llmAsJudgeForTools';
+import { LlmJudgeResult } from '../../../utils/llmAsAJudge';
+import { ToolJudgeResult } from '../../../utils/llmAsJudgeForTools';
 import { setTaskMeta } from './taskMeta';
 
 interface TestReportData {

--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -2,8 +2,8 @@ import { assertUnreachable } from '@lightdash/common';
 import { generateObject, LanguageModel } from 'ai';
 import { JSONDiff, Score } from 'autoevals';
 import { z } from 'zod';
-import { getOpenaiGptmodel } from '../../../models/openai-gpt';
-import { defaultAgentOptions } from '../../agent';
+import { defaultAgentOptions } from '../agents/agent';
+import { getOpenaiGptmodel } from '../models/openai-gpt';
 
 export const factualityScores = {
     A: 0.4,

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -20,9 +20,9 @@ import { generateObject } from 'ai';
 import { JSONDiff } from 'autoevals';
 import { compact, differenceWith } from 'lodash';
 import { z } from 'zod';
-import { DbAiAgentToolCall } from '../../../../../database/entities/ai';
-import { getOpenaiGptmodel } from '../../../models/openai-gpt';
-import { defaultAgentOptions } from '../../agent';
+import { DbAiAgentToolCall } from '../../../database/entities/ai';
+import { defaultAgentOptions } from '../agents/agent';
+import { getOpenaiGptmodel } from '../models/openai-gpt';
 
 const TOOL_NAME_TO_DB_TOOL_NAME = {
     findExplores: 'find_explores',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7355,11 +7355,79 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AssessmentType: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['human'] },
+                { dataType: 'enum', enums: ['llm'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiEvalRunResultAssessment: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                createdAt: { dataType: 'datetime', required: true },
+                assessedAt: { dataType: 'datetime', required: true },
+                llmJudgeModel: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                llmJudgeProvider: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                assessedByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                reason: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                passed: { dataType: 'boolean', required: true },
+                assessmentType: { ref: 'AssessmentType', required: true },
+                runResultUuid: { dataType: 'string', required: true },
+                assessmentUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentEvaluationRunResult: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                assessment: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiEvalRunResultAssessment' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 createdAt: { dataType: 'datetime', required: true },
                 completedAt: {
                     dataType: 'union',
@@ -7383,6 +7451,7 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: ['pending'] },
                         { dataType: 'enum', enums: ['running'] },
                         { dataType: 'enum', enums: ['completed'] },
+                        { dataType: 'enum', enums: ['assessing'] },
                         { dataType: 'enum', enums: ['failed'] },
                     ],
                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7823,8 +7823,73 @@
             "ApiAiAgentEvaluationRunSummaryListResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData__runs-AiAgentEvaluationRunSummary-Array___"
             },
+            "AssessmentType": {
+                "type": "string",
+                "enum": ["human", "llm"]
+            },
+            "AiEvalRunResultAssessment": {
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "assessedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "llmJudgeModel": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "llmJudgeProvider": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "assessedByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "reason": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "passed": {
+                        "type": "boolean"
+                    },
+                    "assessmentType": {
+                        "$ref": "#/components/schemas/AssessmentType"
+                    },
+                    "runResultUuid": {
+                        "type": "string"
+                    },
+                    "assessmentUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "createdAt",
+                    "assessedAt",
+                    "llmJudgeModel",
+                    "llmJudgeProvider",
+                    "assessedByUserUuid",
+                    "reason",
+                    "passed",
+                    "assessmentType",
+                    "runResultUuid",
+                    "assessmentUuid"
+                ],
+                "type": "object"
+            },
             "AiAgentEvaluationRunResult": {
                 "properties": {
+                    "assessment": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiEvalRunResultAssessment"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -7840,7 +7905,13 @@
                     },
                     "status": {
                         "type": "string",
-                        "enum": ["pending", "running", "completed", "failed"]
+                        "enum": [
+                            "pending",
+                            "running",
+                            "completed",
+                            "assessing",
+                            "failed"
+                        ]
                     },
                     "threadUuid": {
                         "type": "string",
@@ -7855,6 +7926,7 @@
                     }
                 },
                 "required": [
+                    "assessment",
                     "createdAt",
                     "completedAt",
                     "errorMessage",

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -15,6 +15,7 @@ import type {
     ToolTimeSeriesArgs,
     ToolVerticalBarArgs,
 } from '../..';
+import { type AiEvalRunResultAssessment } from './aiEvalAssessment';
 import { type AgentToolOutput } from './schemas';
 import { type AiMetricQuery, type AiResultType } from './types';
 
@@ -461,6 +462,7 @@ export type AiAgentEvaluationRunResult = {
     errorMessage: string | null;
     completedAt: Date | null;
     createdAt: Date;
+    assessment: AiEvalRunResultAssessment | null;
 };
 
 /**


### PR DESCRIPTION
### Description:
Added automatic LLM assessment for AI agent evaluation results. The system now:

1. Automatically assesses evaluation results using an LLM judge
2. Evaluates both factuality and context relevancy of responses
3. Stores assessment data including pass/fail status, reasoning, and model information
4. Joins assessment data when retrieving evaluation results

The implementation includes:
- New `assessResult` method in `AiAgentService`
- Moved LLM judge utilities from test files to shared utils
- Added `getEvalResultDataForAssessment` to retrieve necessary data for assessment
- Enhanced result retrieval queries to include assessment information
- Added utility to extract model names from different provider configurations

This enables automated quality evaluation of AI agent responses without requiring manual review.

![image.png](https://app.graphite.dev/user-attachments/assets/033ded3a-d1be-450a-9d44-6eaefb4264c7.png)

