### PR TITLE
feat: display llm eval assessments in ui

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -3768,11 +3768,6 @@ export class AiAgentService {
     ) {
         await this.getAgent(user, agentUuid, projectUuid);
 
-        const evalData = await this.aiAgentModel.getEval({
-            agentUuid,
-            evalUuid,
-        });
-
         return this.aiAgentModel.getEvalRuns(evalUuid, paginateArgs);
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7073,6 +7073,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                failedAssessments: { dataType: 'double', required: true },
+                passedAssessments: { dataType: 'double', required: true },
                 createdAt: { dataType: 'datetime', required: true },
                 completedAt: {
                     dataType: 'union',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7535,6 +7535,14 @@
             },
             "AiAgentEvaluationRunSummary": {
                 "properties": {
+                    "failedAssessments": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "passedAssessments": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -7556,6 +7564,8 @@
                     }
                 },
                 "required": [
+                    "failedAssessments",
+                    "passedAssessments",
                     "createdAt",
                     "completedAt",
                     "status",

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -448,6 +448,8 @@ export type AiAgentEvaluationRunSummary = {
     status: 'pending' | 'running' | 'completed' | 'failed';
     completedAt: Date | null;
     createdAt: Date;
+    passedAssessments: number;
+    failedAssessments: number;
 };
 
 export type AiAgentEvaluationRun = AiAgentEvaluationRunSummary & {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/utils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/utils.ts
@@ -1,0 +1,32 @@
+import type {
+    AiAgentEvaluationRunResult,
+    AiAgentEvaluationRunSummary,
+} from '@lightdash/common';
+import { type DefaultMantineColor } from '@mantine-8/core';
+
+type StatusUnion =
+    | AiAgentEvaluationRunResult['status']
+    | AiAgentEvaluationRunSummary['status'];
+
+export const isRunning = (status: StatusUnion) =>
+    status !== 'completed' && status !== 'failed';
+
+type Config = {
+    color: DefaultMantineColor;
+    label: string;
+};
+
+export const statusConfig = {
+    completed: { color: 'green', label: 'Completed' },
+    failed: { color: 'red', label: 'Errored' },
+    running: { color: 'yellow', label: 'Running' },
+    assessing: { color: 'indigo', label: 'Assessing' },
+    pending: { color: 'gray', label: 'Pending' },
+} satisfies Record<StatusUnion, Config>;
+
+export const getAssessmentConfig = (passed?: boolean): Config =>
+    passed === undefined
+        ? { label: 'N/A', color: 'gray' }
+        : passed
+        ? { label: 'Passed', color: 'green.8' }
+        : { label: 'Failed', color: 'red.8' };


### PR DESCRIPTION


### Description:
Added assessment counts to AI agent evaluation runs to provide better visibility into test results. The PR:

- Adds `passedAssessments` and `failedAssessments` fields to the `AiAgentEvaluationRunSummary` type
- Implements SQL queries to efficiently count passed and failed assessments for each run
- Updates the UI to display assessment counts with pass/fail indicators
- Improves the evaluation run details page with clearer status indicators and assessment results
- Enhances the run list view to show assessment counts with visual indicators

![image.png](https://app.graphite.dev/user-attachments/assets/a1e5ee53-4fa5-4315-9fa4-93bf51e08f96.png)

![image.png](https://app.graphite.dev/user-attachments/assets/4d21b098-a3e9-45ae-a327-8a124262ca92.png)

_in progress_
[Screen Recording 2025-11-03 at 10.11.44.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/495d2db7-979d-4e12-9735-a62eddf9892a.mov" />](https://app.graphite.dev/user-attachments/video/495d2db7-979d-4e12-9735-a62eddf9892a.mov)

