### PR TITLE
chore: use prompt from eval result instead new api call

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7422,6 +7422,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                prompt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 assessment: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7892,6 +7892,10 @@
             },
             "AiAgentEvaluationRunResult": {
                 "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "assessment": {
                         "allOf": [
                             {
@@ -7936,6 +7940,7 @@
                     }
                 },
                 "required": [
+                    "prompt",
                     "assessment",
                     "createdAt",
                     "completedAt",

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -465,6 +465,7 @@ export type AiAgentEvaluationRunResult = {
     completedAt: Date | null;
     createdAt: Date;
     assessment: AiEvalRunResultAssessment | null;
+    prompt: string | null;
 };
 
 /**


### PR DESCRIPTION
### Description:
Added prompt text to evaluation run results. Before the UI had to fetch each thread separately to display the prompt text

The implementation includes:
- A subquery to fetch the first prompt from each thread
- Modified the database query to include prompt text in the results
- Updated types and interfaces to include the new prompt field
- Simplified the PromptRow component by removing the need to fetch thread data

This change improves performance by eliminating unnecessary API calls and provides a better user experience by immediately displaying prompt text in the evaluation results table.