### PR TITLE
feat: add missing row indicator when previewing a thread 

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
@@ -37,9 +37,15 @@ type PromptRowProps = {
     result: AiAgentEvaluationRunResult;
     index: number;
     onViewThread: (result: AiAgentEvaluationRunResult) => void;
+    selected?: boolean;
 };
 
-const PromptRow: FC<PromptRowProps> = ({ result, index, onViewThread }) => {
+const PromptRow: FC<PromptRowProps> = ({
+    result,
+    index,
+    onViewThread,
+    selected,
+}) => {
     const statusStyle = statusConfig[result.status];
     const promptText = result.prompt || `Prompt ${index + 1}`;
     const isEvalRunning = isRunning(result.status);
@@ -58,6 +64,7 @@ const PromptRow: FC<PromptRowProps> = ({ result, index, onViewThread }) => {
                 cursor: isClickable ? 'pointer' : 'default',
             }}
             onClick={handleRowClick}
+            {...(selected ? { bg: 'gray.2' } : {})}
         >
             <Table.Td>
                 <Text size="sm" fw={500} c="dimmed">
@@ -108,7 +115,8 @@ export const EvalRunDetails: FC<Props> = ({
     runUuid,
 }) => {
     const navigate = useNavigate();
-    const { setSelectedThreadUuid } = useEvalSectionContext();
+    const { setSelectedThreadUuid, selectedThreadUuid } =
+        useEvalSectionContext();
 
     const { data: runData, isLoading } = useAiAgentEvaluationRunResults(
         projectUuid,
@@ -272,6 +280,9 @@ export const EvalRunDetails: FC<Props> = ({
                                     result={result}
                                     index={index}
                                     onViewThread={handleViewThread}
+                                    selected={
+                                        result.threadUuid === selectedThreadUuid
+                                    }
                                 />
                             ))}
                         </Table.Tbody>


### PR DESCRIPTION


### Description:
Added visual indication for selected prompts in the AI Copilot evaluation run details view. When a prompt is selected, it now has a gray background to help users identify which prompt they are currently viewing. This improves the user experience by providing clear visual feedback about the current selection state.

The implementation passes the selected state to the PromptRow component and applies a background color when the prompt's thread UUID matches the selected thread UUID from the context.

![image.png](https://app.graphite.dev/user-attachments/assets/7c8a2b64-dc92-4185-a885-b5e38aa80800.png)

