### PR TITLE
feat: display evaluation reason in thread preview sidebar

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../store/hooks';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { AiArtifactPanel } from '../ChatElements/AiArtifactPanel';
+import { EvalAssessmentDisplay } from '../Evals/EvalAssessmentDisplay';
 
 type ThreadPreviewSidebarProps = {
     projectUuid: string;
@@ -30,6 +31,8 @@ type ThreadPreviewSidebarProps = {
     onClose: () => void;
     renderArtifactsInline?: boolean;
     showAddToEvalsButton?: boolean;
+    evalUuid?: string;
+    runUuid?: string;
 };
 
 export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
@@ -40,6 +43,8 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
     onClose,
     renderArtifactsInline = false,
     showAddToEvalsButton = false,
+    evalUuid,
+    runUuid,
 }) => {
     const dispatch = useAiAgentStoreDispatch();
     const aiArtifact = useAiAgentStoreSelector(
@@ -109,6 +114,16 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
             </Group>
 
             <Divider />
+
+            {evalUuid && runUuid && (
+                <EvalAssessmentDisplay
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    evalUuid={evalUuid}
+                    runUuid={runUuid}
+                    threadUuid={threadUuid}
+                />
+            )}
 
             {threadData && (
                 <>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalAssessmentDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalAssessmentDisplay.tsx
@@ -1,0 +1,96 @@
+import { Badge, Box, Divider, Group, Loader, Text } from '@mantine-8/core';
+import { IconCheck, IconClipboardList, IconX } from '@tabler/icons-react';
+import { type FC, useMemo } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiAgentEvaluationRunResults } from '../../hooks/useAiAgentEvaluations';
+import { ToolCallPaper } from '../ChatElements/ToolCalls/ToolCallPaper';
+import { getAssessmentConfig } from './utils';
+
+type EvalAssessmentDisplayProps = {
+    projectUuid: string;
+    agentUuid: string;
+    evalUuid: string;
+    runUuid: string;
+    threadUuid: string;
+};
+
+export const EvalAssessmentDisplay: FC<EvalAssessmentDisplayProps> = ({
+    projectUuid,
+    agentUuid,
+    evalUuid,
+    runUuid,
+    threadUuid,
+}) => {
+    const { data, isLoading } = useAiAgentEvaluationRunResults(
+        projectUuid,
+        agentUuid,
+        evalUuid,
+        runUuid,
+    );
+    const assessment = useMemo(() => {
+        if (!data?.results || !threadUuid) return null;
+        const result = data.results.find((r) => r.threadUuid === threadUuid);
+        return result?.assessment ?? null;
+    }, [data?.results, threadUuid]);
+
+    if (isLoading)
+        return (
+            <>
+                <Box m="sm">
+                    <ToolCallPaper
+                        title="Evaluation Assessment"
+                        icon={IconClipboardList}
+                        defaultOpened={false}
+                    >
+                        <Group align="center" justify="center" w="100%">
+                            <Loader color="gray" size="sm" />
+                        </Group>
+                    </ToolCallPaper>
+                </Box>
+                <Divider />
+            </>
+        );
+
+    if (!assessment) {
+        return null;
+    }
+
+    const assessmentConfig = getAssessmentConfig(assessment.passed);
+
+    return (
+        <>
+            <Box m="sm">
+                <ToolCallPaper
+                    title="Evaluation Assessment"
+                    icon={IconClipboardList}
+                    defaultOpened
+                    rightAction={
+                        <Badge
+                            color={assessmentConfig.color}
+                            variant="white"
+                            leftSection={
+                                <MantineIcon
+                                    size={14}
+                                    icon={assessment.passed ? IconCheck : IconX}
+                                />
+                            }
+                        >
+                            {assessmentConfig.label}
+                        </Badge>
+                    }
+                >
+                    {assessment.reason && (
+                        <Text
+                            size="xs"
+                            style={{ whiteSpace: 'pre-wrap' }}
+                            mt="xs"
+                        >
+                            {assessment.reason}
+                        </Text>
+                    )}
+                </ToolCallPaper>
+            </Box>
+            <Divider />
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
@@ -42,7 +42,6 @@ export const EvalSectionLayout: FC<EvalSectionLayoutProps> = ({ children }) => {
     }>();
     const { selectedThreadUuid, isSidebarOpen, clearThread } =
         useEvalSectionContext();
-
     // Fetch evaluation data if we're on an eval detail page
     const { data: evaluation } = useAiAgentEvaluation(
         projectUuid!,
@@ -265,6 +264,8 @@ export const EvalSectionLayout: FC<EvalSectionLayoutProps> = ({ children }) => {
                                     isOpen={isSidebarOpen}
                                     onClose={handleCloseSidebar}
                                     renderArtifactsInline
+                                    evalUuid={evalUuid}
+                                    runUuid={runUuid}
                                 />
                             )}
                     </Panel>


### PR DESCRIPTION
### Description:
Added evaluation assessment display to thread preview sidebar in AI Copilot. This enhancement shows assessment results (pass/fail status and reasoning) when viewing threads that are part of an evaluation run.

The implementation:
- Created a new `EvalAssessmentDisplay` component that shows evaluation results for a specific thread
- Updated `ThreadPreviewSidebar` to accept and pass evaluation context (evalUuid and runUuid)
- Added conditional rendering of the assessment display when evaluation context is available
- Included appropriate loading states and styling consistent with the existing UI

_passed_
![image.png](https://app.graphite.dev/user-attachments/assets/5d2e73a9-5c95-46e4-af28-597740b99ec4.png)

_failed_
![image.png](https://app.graphite.dev/user-attachments/assets/79443a09-f6d0-4184-81dd-257ee853da39.png)

_error during evaluation, no assessment_
![image.png](https://app.graphite.dev/user-attachments/assets/61fa8500-e524-4808-9d44-ef329f47db10.png)

