### PR TITLE
fix: add organization name to user type in feature flag service

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -242,7 +242,10 @@ export class AiAgentService {
     }
 
     private async getIsCopilotEnabled(
-        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
+        user: Pick<
+            LightdashUser,
+            'userUuid' | 'organizationUuid' | 'organizationName'
+        >,
     ) {
         const aiCopilotFlag = await this.featureFlagService.get({
             user,

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -4,6 +4,7 @@ import {
     CommercialFeatureFlags,
     ComputedAiOrganizationSettings,
     ForbiddenError,
+    LightdashUser,
     UpdateAiOrganizationSettings,
     type SessionUser,
 } from '@lightdash/common';
@@ -51,11 +52,13 @@ export class AiOrganizationSettingsService {
     }
 
     private async getIsCopilotEnabled(
-        organizationUuid: string,
-        userUuid: string,
+        user: Pick<
+            LightdashUser,
+            'userUuid' | 'organizationUuid' | 'organizationName'
+        >,
     ): Promise<boolean> {
         const isCopilotEnabled = await this.commercialFeatureFlagModel.get({
-            user: { organizationUuid, userUuid },
+            user,
             featureFlagId: CommercialFeatureFlags.AiCopilot,
         });
         return isCopilotEnabled.enabled;
@@ -95,10 +98,7 @@ export class AiOrganizationSettingsService {
             throw new ForbiddenError('User must belong to an organization');
         }
 
-        const isCopilotEnabled = await this.getIsCopilotEnabled(
-            user.organizationUuid,
-            user.userUuid,
-        );
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
 
         // Check if organization qualifies for trial
         const isTrialEligible = await this.isEligibleForTrial(

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -61,7 +61,10 @@ export class FeatureFlagModel {
     }
 
     static async getPosthogFeatureFlag(
-        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
+        user: Pick<
+            LightdashUser,
+            'userUuid' | 'organizationUuid' | 'organizationName'
+        >,
         featureFlagId: FeatureFlags,
     ): Promise<FeatureFlag> {
         const enabled = await isFeatureFlagEnabled(featureFlagId, {

--- a/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
+++ b/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
@@ -23,7 +23,10 @@ export class FeatureFlagService extends BaseService {
         user,
         featureFlagId,
     }: {
-        user?: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>;
+        user?: Pick<
+            LightdashUser,
+            'userUuid' | 'organizationUuid' | 'organizationName'
+        >;
         featureFlagId: string;
     }) {
         return this.featureFlagModel.get({ user, featureFlagId });


### PR DESCRIPTION


### Description:
Updated the type signature for user objects across feature flag related services to include `organizationName`. This change ensures that the `organizationName` property is available when checking feature flags in the `AiAgentService`, `AiOrganizationSettingsService`, `FeatureFlagModel`, and `FeatureFlagService`.