### PR TITLE
feat: add SCIM role controller and service for role-based access management

### DIFF
--- a/packages/backend/src/ee/controllers/scimRoleController.ts
+++ b/packages/backend/src/ee/controllers/scimRoleController.ts
@@ -1,0 +1,69 @@
+import {
+    ScimErrorPayload,
+    ScimListResponse,
+    ScimRole,
+} from '@lightdash/common';
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Path,
+    Query,
+    Request,
+    Response,
+    Route,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { BaseController } from '../../controllers/baseController';
+import { isScimAuthenticated } from '../authentication';
+import { ScimService } from '../services/ScimService/ScimService';
+
+@Route('/api/v1/scim/v2/Roles')
+@Hidden()
+@Tags('SCIM')
+export class ScimRoleController extends BaseController {
+    /**
+     * Get a list of roles within an organization
+     * @param req express request
+     * @param filter Filter to apply to the role list (optional)
+     */
+    @Middlewares([isScimAuthenticated])
+    @Get('/')
+    @OperationId('GetScimRoles')
+    @Response<ScimListResponse<ScimRole>>('200', 'Success')
+    async getScimRoles(
+        @Request() req: express.Request,
+        @Query() filter?: string,
+    ): Promise<ScimListResponse<ScimRole>> {
+        const organizationUuid = req.serviceAccount?.organizationUuid as string;
+        return this.getScimService().listRoles({
+            organizationUuid,
+            filter,
+        });
+    }
+
+    /**
+     * Get a SCIM role by ID
+     * @param req express request
+     * @param roleId Role ID - this is used as a unique identifier for SCIM
+     */
+    @Middlewares([isScimAuthenticated])
+    @Get('/{roleId}')
+    @OperationId('GetScimRole')
+    @Response<ScimRole>('200', 'Success')
+    @Response<ScimErrorPayload>('404', 'Not found')
+    async getScimRole(
+        @Request() req: express.Request,
+        @Path() roleId: string,
+    ): Promise<ScimRole> {
+        const organizationUuid = req.serviceAccount?.organizationUuid as string;
+        return this.getScimService().getRole(organizationUuid, roleId);
+    }
+
+    // Convenience method to access the SCIM service
+    protected getScimService() {
+        return this.services.getScimService<ScimService>();
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14,6 +14,8 @@ import { ScimUserController } from './../ee/controllers/scimUserController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ScimRootController } from './../ee/controllers/scimRootController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ScimRoleController } from './../ee/controllers/scimRoleController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ScimOrganizationAccessTokenController } from './../ee/controllers/scimOrganizationAccessTokenController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ScimGroupController } from './../ee/controllers/scimGroupController';
@@ -856,6 +858,85 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ScimSchemaType.ROLE': {
+        dataType: 'refEnum',
+        enums: ['urn:ietf:params:scim:schemas:extension:2.0:Role'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimRoleType: {
+        dataType: 'refEnum',
+        enums: ['ORG_SYSTEM', 'PROJECT_SYSTEM', 'PROJECT_CUSTOM'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimRole: {
+        dataType: 'refObject',
+        properties: {
+            schemas: {
+                dataType: 'array',
+                array: { dataType: 'refEnum', ref: 'ScimSchemaType.ROLE' },
+                required: true,
+            },
+            id: { dataType: 'string', required: true },
+            meta: {
+                dataType: 'intersection',
+                subSchemas: [
+                    {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            version: { dataType: 'string' },
+                            location: { dataType: 'string' },
+                            lastModified: { dataType: 'datetime' },
+                            created: { dataType: 'datetime' },
+                            resourceType: { dataType: 'string' },
+                        },
+                    },
+                    {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            location: { dataType: 'string', required: true },
+                            lastModified: { dataType: 'datetime' },
+                            created: { dataType: 'datetime' },
+                            resourceType: {
+                                dataType: 'enum',
+                                enums: ['Role'],
+                                required: true,
+                            },
+                        },
+                    },
+                ],
+                required: true,
+            },
+            value: { dataType: 'string', required: true },
+            display: { dataType: 'string' },
+            type: { ref: 'ScimRoleType' },
+            supported: { dataType: 'boolean', required: true },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ScimListResponse_ScimRole_: {
+        dataType: 'refObject',
+        properties: {
+            schemas: {
+                dataType: 'array',
+                array: {
+                    dataType: 'refEnum',
+                    ref: 'ScimSchemaType.LIST_RESPONSE',
+                },
+                required: true,
+            },
+            totalResults: { dataType: 'double', required: true },
+            itemsPerPage: { dataType: 'double', required: true },
+            startIndex: { dataType: 'double', required: true },
+            Resources: {
+                dataType: 'array',
+                array: { dataType: 'refObject', ref: 'ScimRole' },
+                required: true,
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_ServiceAccount.expiresAt-or-description_': {
         dataType: 'refAlias',
         type: {
@@ -1185,7 +1266,12 @@ const models: TsoaRoute.Models = {
                 canDateZoom: { dataType: 'boolean' },
                 canExportImages: { dataType: 'boolean' },
                 canExportCsv: { dataType: 'boolean' },
-                canChangeParameters: { dataType: 'boolean' },
+                parameterInteractivity: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        enabled: { dataType: 'boolean', required: true },
+                    },
+                },
                 dashboardFiltersInteractivity: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -6099,11 +6185,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6118,11 +6204,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6137,11 +6223,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6156,11 +6242,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6175,11 +6261,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6194,11 +6280,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6213,11 +6299,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6232,11 +6318,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6251,11 +6337,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6270,11 +6356,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6289,11 +6375,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6308,11 +6394,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6457,6 +6543,15 @@ const models: TsoaRoute.Models = {
                 },
                 threadUuid: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
+                status: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['idle'] },
+                        { dataType: 'enum', enums: ['pending'] },
+                        { dataType: 'enum', enums: ['error'] },
+                    ],
+                    required: true,
+                },
                 role: {
                     dataType: 'enum',
                     enums: ['assistant'],
@@ -15442,7 +15537,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15452,7 +15547,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -15462,7 +15557,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -15475,7 +15570,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21862,6 +21957,121 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getResourceType',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsScimRoleController_getScimRoles: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        filter: { in: 'query', name: 'filter', dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/scim/v2/Roles',
+        ...fetchMiddlewares<RequestHandler>(ScimRoleController),
+        ...fetchMiddlewares<RequestHandler>(
+            ScimRoleController.prototype.getScimRoles,
+        ),
+
+        async function ScimRoleController_getScimRoles(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsScimRoleController_getScimRoles,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ScimRoleController>(
+                    ScimRoleController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getScimRoles',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsScimRoleController_getScimRole: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        roleId: {
+            in: 'path',
+            name: 'roleId',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/scim/v2/Roles/:roleId',
+        ...fetchMiddlewares<RequestHandler>(ScimRoleController),
+        ...fetchMiddlewares<RequestHandler>(
+            ScimRoleController.prototype.getScimRole,
+        ),
+
+        async function ScimRoleController_getScimRole(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsScimRoleController_getScimRole,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<ScimRoleController>(
+                    ScimRoleController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getScimRole',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -852,6 +852,127 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "ScimSchemaType.ROLE": {
+                "enum": ["urn:ietf:params:scim:schemas:extension:2.0:Role"],
+                "type": "string"
+            },
+            "ScimRoleType": {
+                "enum": ["ORG_SYSTEM", "PROJECT_SYSTEM", "PROJECT_CUSTOM"],
+                "type": "string"
+            },
+            "ScimRole": {
+                "properties": {
+                    "schemas": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaType.ROLE"
+                        },
+                        "type": "array"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "meta": {
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "version": {
+                                        "type": "string"
+                                    },
+                                    "location": {
+                                        "type": "string"
+                                    },
+                                    "lastModified": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "created": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "resourceType": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "location": {
+                                        "type": "string"
+                                    },
+                                    "lastModified": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "created": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "resourceType": {
+                                        "type": "string",
+                                        "enum": ["Role"],
+                                        "nullable": false
+                                    }
+                                },
+                                "required": ["location", "resourceType"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "value": {
+                        "type": "string"
+                    },
+                    "display": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ScimRoleType"
+                    },
+                    "supported": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["schemas", "id", "value", "supported", "meta"],
+                "type": "object",
+                "additionalProperties": true
+            },
+            "ScimListResponse_ScimRole_": {
+                "properties": {
+                    "schemas": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimSchemaType.LIST_RESPONSE"
+                        },
+                        "type": "array"
+                    },
+                    "totalResults": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "itemsPerPage": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "startIndex": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "Resources": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScimRole"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "schemas",
+                    "totalResults",
+                    "itemsPerPage",
+                    "startIndex",
+                    "Resources"
+                ],
+                "type": "object",
+                "additionalProperties": true
+            },
             "Pick_ServiceAccount.expiresAt-or-description_": {
                 "properties": {
                     "expiresAt": {
@@ -1093,6 +1214,15 @@
                     "allowAllDashboards": {
                         "type": "boolean"
                     },
+                    "chartUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "allowAllCharts": {
+                        "type": "boolean"
+                    },
                     "createdAt": {
                         "type": "string"
                     },
@@ -1105,6 +1235,8 @@
                     "organization",
                     "dashboardUuids",
                     "allowAllDashboards",
+                    "chartUuids",
+                    "allowAllCharts",
                     "createdAt",
                     "user"
                 ],
@@ -1148,6 +1280,12 @@
             },
             "CreateEmbedRequestBody": {
                 "properties": {
+                    "chartUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "dashboardUuids": {
                         "items": {
                             "type": "string"
@@ -1155,11 +1293,19 @@
                         "type": "array"
                     }
                 },
-                "required": ["dashboardUuids"],
                 "type": "object"
             },
             "UpdateEmbed": {
                 "properties": {
+                    "allowAllCharts": {
+                        "type": "boolean"
+                    },
+                    "chartUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "allowAllDashboards": {
                         "type": "boolean"
                     },
@@ -1220,8 +1366,14 @@
                     "canExportCsv": {
                         "type": "boolean"
                     },
-                    "canChangeParameters": {
-                        "type": "boolean"
+                    "parameterInteractivity": {
+                        "properties": {
+                            "enabled": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": ["enabled"],
+                        "type": "object"
                     },
                     "dashboardFiltersInteractivity": {
                         "properties": {
@@ -6747,8 +6899,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -6884,6 +7036,10 @@
                     "uuid": {
                         "type": "string"
                     },
+                    "status": {
+                        "type": "string",
+                        "enum": ["idle", "pending", "error"]
+                    },
                     "role": {
                         "type": "string",
                         "enum": ["assistant"],
@@ -6901,6 +7057,7 @@
                     "message",
                     "threadUuid",
                     "uuid",
+                    "status",
                     "role"
                 ],
                 "type": "object"
@@ -16135,22 +16292,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -21435,7 +21592,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2121.0",
+        "version": "0.2126.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -9,6 +9,7 @@ export enum ScimSchemaType {
     ERROR = 'urn:ietf:params:scim:api:messages:2.0:Error',
     USER = 'urn:ietf:params:scim:schemas:core:2.0:User',
     GROUP = 'urn:ietf:params:scim:schemas:core:2.0:Group',
+    ROLE = 'urn:ietf:params:scim:schemas:extension:2.0:Role',
     LIST_RESPONSE = 'urn:ietf:params:scim:api:messages:2.0:ListResponse',
     SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Schema',
     PATCH = 'urn:ietf:params:scim:api:messages:2.0:PatchOp',

--- a/packages/common/src/ee/scim/types.ts
+++ b/packages/common/src/ee/scim/types.ts
@@ -53,6 +53,26 @@ export interface ScimGroupMember {
     display?: string;
 }
 
+export enum ScimRoleType {
+    ORG = 'ORG_SYSTEM',
+    PROJECT = 'PROJECT_SYSTEM',
+    PROJECT_CUSTOM = 'PROJECT_CUSTOM',
+}
+
+export interface ScimRole extends ScimResource {
+    schemas: ScimSchemaType.ROLE[];
+    value: string;
+    display?: string;
+    type?: ScimRoleType;
+    supported: boolean;
+    meta: ScimResource['meta'] & {
+        resourceType: 'Role';
+        created?: Date;
+        lastModified?: Date;
+        location: string;
+    };
+}
+
 export type ScimErrorPayload = {
     /**
      * NOTE: this is taken from the SCIM spec here: https://datatracker.ietf.org/doc/html/rfc7644#section-3.7.3


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #SCIM-roles-support

### Description:
This PR adds SCIM role support to enable identity providers to discover and retrieve Lightdash roles through the SCIM API. The implementation includes:

- New `ScimRoleController` with endpoints to list roles and get a specific role
- Support for system roles (viewer, interactive_viewer, editor, developer, admin) in the SCIM API
- Added role schema definition to the SCIM schema registry
- Updated SCIM service with methods to convert Lightdash roles to SCIM format
- Added appropriate tests for the new functionality

This enhancement allows identity providers to map their roles to Lightdash roles during user provisioning, improving the SCIM integration experience.

**Next PR** will also return project roles.

List roles
<img width="1149" height="1276" alt="Screenshot 2025-11-03 at 14 35 02" src="https://github.com/user-attachments/assets/9a17447a-6bb8-4a39-be4d-d21c20646fd1" />

Get role
<img width="1150" height="1274" alt="Screenshot 2025-11-03 at 14 36 00" src="https://github.com/user-attachments/assets/a8f9088d-1327-4799-942d-7631c21f87ff" />

List resource types
<img width="1150" height="1274" alt="Screenshot 2025-11-03 at 14 30 11" src="https://github.com/user-attachments/assets/249c5751-4d3d-413c-a149-9c8714f4af77" />

Get resource type
<img width="1150" height="1272" alt="Screenshot 2025-11-03 at 14 30 52" src="https://github.com/user-attachments/assets/15fcf7cc-1a9b-4ad3-ad54-00f9d46423a6" />

List schemas
<img width="1148" height="1277" alt="Screenshot 2025-11-03 at 14 25 49" src="https://github.com/user-attachments/assets/d8ebae6d-9323-4931-a101-17610c174a37" />

Get schema
<img width="1148" height="1277" alt="Screenshot 2025-11-03 at 14 27 50" src="https://github.com/user-attachments/assets/c126563f-7084-4932-b0b9-476800b11e4e" />
