### PR TITLE
fix: prevent duplicate tool output handling in AI agent streaming

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -91,6 +91,8 @@ export function useAiAgentThreadStreamMutation() {
                     stream: chunkStream,
                 });
 
+                const handledToolOutputIds = new Set<string>();
+
                 for await (const uiMessage of stream) {
                     if (abortController.signal.aborted) return;
 
@@ -138,6 +140,14 @@ export function useAiAgentThreadStreamMutation() {
                                         break;
                                     }
 
+                                    if (
+                                        handledToolOutputIds.has(
+                                            part.toolCallId,
+                                        )
+                                    ) {
+                                        break;
+                                    }
+
                                     const output =
                                         toolRunQueryOutputSchema.safeParse(
                                             part.output,
@@ -148,6 +158,10 @@ export function useAiAgentThreadStreamMutation() {
                                         output.data.metadata.status ===
                                             'success'
                                     ) {
+                                        handledToolOutputIds.add(
+                                            part.toolCallId,
+                                        );
+
                                         void refetchThread?.();
                                     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Prevents duplicate tool output handling in AI agent thread streaming by tracking already processed tool call IDs in a Set. This fix ensures that each tool output is only processed once, avoiding potential duplicate actions when the same tool call ID appears multiple times in the stream.
