### PR TITLE
fix: explore from here should run query on load regardless of auto fetch settings

### DIFF
--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -236,6 +236,11 @@ export const selectTableCalculationsMetadata = createSelector(
     (explorer) => explorer.metadata?.tableCalculations,
 );
 
+export const selectIsExploreFromHere = createSelector(
+    [selectExplorerState],
+    (explorer) => explorer.isExploreFromHere,
+);
+
 // Stable empty Set to prevent unnecessary re-renders
 const EMPTY_ACTIVE_FIELDS_SET: Set<string> = new Set();
 

--- a/packages/frontend/src/hooks/useExplorerQueryEffects.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryEffects.ts
@@ -13,6 +13,7 @@ import {
     explorerActions,
     selectFromDashboard,
     selectIsEditMode,
+    selectIsExploreFromHere,
     selectIsResultsExpanded,
     selectSavedChart,
     selectUnsavedChartVersion,
@@ -51,6 +52,7 @@ export const useExplorerQueryEffects = ({
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const isResultsOpen = useExplorerSelector(selectIsResultsExpanded);
     const fromDashboard = useExplorerSelector(selectFromDashboard);
+    const isExploreFromHere = useExplorerSelector(selectIsExploreFromHere);
 
     const { data: useSqlPivotResults } = useFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
@@ -89,10 +91,8 @@ export const useExplorerQueryEffects = ({
     useEffect(() => {
         if (
             autoFetchEnabled ||
-            ((isSavedChart || fromDashboard) &&
-                !isEditMode &&
-                !query.isFetched) ||
-            (isEditMode && !query.isFetched && (isSavedChart || fromDashboard))
+            ((isSavedChart || fromDashboard || isExploreFromHere) &&
+                !query.isFetched)
         ) {
             runQuery();
         }
@@ -103,6 +103,7 @@ export const useExplorerQueryEffects = ({
         runQuery,
         query.isFetched,
         isEditMode,
+        isExploreFromHere,
     ]);
 
     // Effect 2: Setup unpivoted query args when needed

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -101,6 +101,9 @@ export const getExplorerUrlFromCreateSavedChartVersion = (
     }
     newParams.set('create_saved_chart_version', stringifiedChart);
 
+    // Always set isExploreFromHere to true when creating the url for shareable links this ensures the query is executed when the url is loaded
+    newParams.set('isExploreFromHere', 'true');
+
     return {
         pathname: `/projects/${projectUuid}/tables/${createSavedChart.tableName}`,
         search: newParams.toString(),
@@ -216,6 +219,9 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
 
     const [searchParams] = useSearchParams();
     const fromDashboard = searchParams.get('fromDashboard');
+    const isExploreFromHere = useMemo(() => {
+        return searchParams.get('isExploreFromHere') === 'true';
+    }, [searchParams]);
 
     return useMemo(() => {
         if (pathParams.tableId) {
@@ -273,6 +279,7 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                     },
                     parameters: {},
                     fromDashboard: fromDashboard ?? undefined,
+                    isExploreFromHere: isExploreFromHere,
                     queryExecution: defaultQueryExecution,
                 };
             } catch (e: any) {
@@ -283,7 +290,7 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                 });
             }
         }
-    }, [pathParams, search, showToastError, fromDashboard]);
+    }, [pathParams, search, showToastError, fromDashboard, isExploreFromHere]);
 };
 
 export const createMetricPreviewUnsavedChartVersion = (

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -250,6 +250,7 @@ export interface ExplorerReduceState {
         unpivotedQueryUuidHistory: string[];
     };
     fromDashboard?: string;
+    isExploreFromHere?: boolean;
     savedChart?: SavedChart;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added support for "Explore from here" functionality by introducing a new state flag `isExploreFromHere` that ensures queries are automatically executed when navigating to the explorer from external links or dashboards.

The implementation:
1. Added a new selector `selectIsExploreFromHere` to access this state
2. Updated URL generation to include the `isExploreFromHere=true` parameter for shareable links
3. Modified the query execution logic to automatically run queries when this flag is set
4. Simplified the conditional logic for when to auto-fetch data

This change improves the user experience by ensuring that data is loaded automatically when users follow "explore from here" links.