### PR TITLE
fix: running totals should always accumulate in ascending order regardless of table sort

### DIFF
--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -249,9 +249,16 @@ export function compilePostCalculationMetric({
     const finalOrderByClause = orderByClause ?? `ORDER BY (SELECT NULL)`;
 
     if (type === MetricType.RUNNING_TOTAL) {
+        // For RUNNING_TOTAL, convert all DESC to ASC to ensure running totals
+        // always accumulate in ascending order regardless of table sort direction
+        const runningTotalOrderByClause = finalOrderByClause.replaceAll(
+            'DESC',
+            'ASC',
+        );
+
         return `SUM(${sql}) OVER (${
             partitionByClause ?? ' '
-        }${finalOrderByClause} ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`;
+        }${runningTotalOrderByClause} ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`;
     }
 
     if (type === MetricType.PERCENT_OF_PREVIOUS) {

--- a/packages/backend/src/tableCalculationTemplateQueryCompiler.test.ts
+++ b/packages/backend/src/tableCalculationTemplateQueryCompiler.test.ts
@@ -510,7 +510,7 @@ describe('compileTableCalculationFromTemplate - Frame Clauses', () => {
             );
 
             expect(result).toBe(
-                'SUM("table_revenue") OVER (ORDER BY "table_date" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
+                'SUM("table_revenue") OVER (ORDER BY "table_date" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
             );
         });
 
@@ -531,7 +531,7 @@ describe('compileTableCalculationFromTemplate - Frame Clauses', () => {
             );
 
             expect(result).toBe(
-                'SUM("table_revenue") OVER (ORDER BY "table_year" ASC, "table_month" ASC, "table_day" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
+                'SUM("table_revenue") OVER (ORDER BY "table_year" ASC, "table_month" ASC, "table_day" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
             );
         });
 
@@ -568,7 +568,7 @@ describe('compileTableCalculationFromTemplate - Frame Clauses', () => {
             );
 
             expect(result).toBe(
-                'SUM("table_sales") OVER (ORDER BY "table_region" ASC, "table_date" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
+                'SUM("table_sales") OVER (ORDER BY "table_region" ASC, "table_date" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
             );
         });
     });

--- a/packages/backend/src/tableCalculationTemplateQueryCompiler.ts
+++ b/packages/backend/src/tableCalculationTemplateQueryCompiler.ts
@@ -214,13 +214,10 @@ export const compileTableCalculationFromTemplate = (
             return `RANK() OVER (ORDER BY ${quotedFieldId} ASC)`;
 
         case TableCalculationTemplateType.RUNNING_TOTAL: {
+            // Running totals should always accumulate in ascending order for consistent
+            // cumulative behavior, regardless of how the table is sorted for display
             const orderByArgumentsSql = (sortFields || [])
-                .map(
-                    (sort) =>
-                        `${quoteChar}${sort.fieldId}${quoteChar} ${
-                            sort.descending ? 'DESC' : 'ASC'
-                        }`,
-                )
+                .map((sort) => `${quoteChar}${sort.fieldId}${quoteChar} ASC`)
                 .join(', ');
             const orderByClauseSql =
                 orderByArgumentsSql && `ORDER BY ${orderByArgumentsSql} `; // trailing space intentional

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -1090,7 +1090,7 @@ GROUP BY 1,2
 postcalculation_metrics AS (
 SELECT
   *,
-  SUM(metrics."table1_metric1") OVER (PARTITION BY "table1_category"ORDER BY "table1_metric1" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS "table1_running_total_metric"
+  SUM(metrics."table1_metric1") OVER (PARTITION BY "table1_category"ORDER BY "table1_metric1" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS "table1_running_total_metric"
 FROM metrics
 )
 SELECT


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17807

### Description:
Fixes running total calculations to always accumulate in ascending order, regardless of table sort direction. This ensures consistent cumulative behavior for running totals by:

1. Modifying `compilePostCalculationMetric` to convert all `DESC` to `ASC` in the ORDER BY clause for RUNNING_TOTAL metrics
2. Updating `tableCalculationTemplateQueryCompiler` to always use `ASC` ordering for running totals
3. Updating tests to reflect the new behavior

This change ensures running totals always accumulate properly from top to bottom, providing more intuitive and predictable results for users.

**Before**
<img width="2131" height="928" alt="image" src="https://github.com/user-attachments/assets/ea81f871-2a1d-4275-9d0f-29c781e909a0" />

**After**
<img width="2137" height="967" alt="image" src="https://github.com/user-attachments/assets/91acbd04-a9fb-489a-bb44-2e5a9051a7dd" />
