### PR TITLE
fix: do not break early on trino query

### DIFF
--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -318,7 +318,10 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
                     );
                     // eslint-disable-next-line no-await-in-loop
                     queryResult = await query.next(); // Call .next() one more time to avoid warehouse timeouts
-                    break;
+                    // Don't break immediately - continue the loop to process any remaining data
+                    // The loop will exit naturally when queryResult.done becomes true
+                    // eslint-disable-next-line no-continue
+                    continue;
                 }
 
                 // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17721

### Description:

Fix a bug in the Trino warehouse client where the query loop would exit prematurely after encountering a warning. Instead of breaking out of the loop immediately, we now continue processing the remaining data until `queryResult.done` becomes true, ensuring all data is properly processed.