### PR TITLE
feat: add support for between operator in default_filters

### DIFF
--- a/packages/common/src/types/filterGrammar.ts
+++ b/packages/common/src/types/filterGrammar.ts
@@ -32,8 +32,23 @@ EMPTY_STRING = '' {
   }
 
 EXPRESSION
-= NUMERICAL / DATE_RESTRICTION / LIST / TERM
+= BETWEEN_DATE / BETWEEN_NUMERICAL / NUMERICAL / DATE_RESTRICTION / LIST / TERM
 
+BETWEEN_DATE = SPACE_SYMBOL* ("between"i / "BETWEEN") SPACE_SYMBOL+ min:DATE_STRING SPACE_SYMBOL+ ("and"i / "AND") SPACE_SYMBOL+ max:DATE_STRING {
+    return {
+        type: '${FilterOperator.IN_BETWEEN}',
+        values: [min, max],
+        is: true
+    }
+   }
+
+BETWEEN_NUMERICAL = SPACE_SYMBOL* ("between"i / "BETWEEN") SPACE_SYMBOL+ min:NUMBER SPACE_SYMBOL+ ("and"i / "AND") SPACE_SYMBOL+ max:NUMBER {
+    return {
+        type: '${FilterOperator.IN_BETWEEN}',
+        values: [min, max],
+        is: true
+    }
+   }
 
 NUMERICAL = SPACE_SYMBOL* operator:OPERATOR SPACE_SYMBOL* value:NUMBER {
     return {
@@ -43,6 +58,20 @@ NUMERICAL = SPACE_SYMBOL* operator:OPERATOR SPACE_SYMBOL* value:NUMBER {
    }
 
 OPERATOR = '>=' / '<=' / '>' / '<'
+
+DATE_STRING
+  = quotation_mark date:ISO_DATE quotation_mark { return date }
+  / ISO_DATE
+
+ISO_DATE
+  = year:YEAR "-" month:MONTH "-" day:DAY time:("T" TIME "Z"?)? {
+      return text();
+    }
+
+YEAR = [0-9][0-9][0-9][0-9]
+MONTH = ("0" [1-9]) / ("1" [0-2])
+DAY = ("0" [1-9]) / ([1-2] [0-9]) / ("3" [0-1])
+TIME = [0-9][0-9] ":" [0-9][0-9] ":" [0-9][0-9] ("." [0-9]+)?
 
 DATE_RESTRICTION = SPACE_SYMBOL* operator:DATE_OPERATOR SPACE_SYMBOL* value:NUMBER SPACE_SYMBOL* interval:DATE_INTERVAL {
     return {
@@ -216,6 +245,10 @@ export const parseOperator = (
             return FilterOperator.IN_THE_PAST;
         case FilterOperator.IN_THE_NEXT:
             return FilterOperator.IN_THE_NEXT;
+        case FilterOperator.IN_BETWEEN:
+            return isTrue
+                ? FilterOperator.IN_BETWEEN
+                : FilterOperator.NOT_IN_BETWEEN;
         case 'null':
         case 'NULL':
             return isTrue ? FilterOperator.NULL : FilterOperator.NOT_NULL;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

Adds support for the `between` operator in `default_filters` YAML configuration, allowing range filtering for both numeric and date fields with a single, intuitive filter definition.

![image.png](https://app.graphite.dev/user-attachments/assets/fb3ab813-7d02-4de4-8c22-4a6776503bf2.png)

### What's New

**Before**, you couldn't filter ranges without creating duplicate filter keys (which caused errors):
```yaml
default_filters:
  - estimated_delivery_days: '> 0'
  - estimated_delivery_days: '<= 7'  # ❌ Error: Duplicate filter key
```

**Now**, you can use the `between` operator:
```yaml
default_filters:
  - estimated_delivery_days: 'between 1 and 7'  # ✅ Works!
  - order_date_month: 'between 2024-01-01 and 2024-12-31'
```

### Supported Formats

**Numeric ranges:**
- Integers: `'between 1 and 100'`
- Decimals: `'between 0.5 and 99.9'`
- Negative numbers: `'between -10 and 10'`
- Case insensitive: `'BETWEEN 0 AND 100'`

**Date ranges:**
- ISO dates: `'between 2024-01-01 and 2024-12-31'`
- With quotes: `'between "2024-01-01" and "2024-12-31"'`
- Timestamps: `'between 2024-01-01T00:00:00Z and 2024-12-31T23:59:59Z'`

### Example from orders.yml

```yaml
models:
  - name: orders
    config:
      meta:
        default_filters:
          - order_date_month: "between 2024-01-01 and 2024-12-31"
          - estimated_delivery_days: "between 1 and 7"
          - status: "completed"
            required: false
```

This generates SQL like:
```sql
WHERE order_date_month >= '2024-01-01' 
  AND order_date_month <= '2024-12-31'
  AND estimated_delivery_days >= 1 
  AND estimated_delivery_days <= 7
  AND status = 'completed'
```

