### PR TITLE
fix: disable refetching of query results

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -224,6 +224,9 @@ export const useGetReadyQueryResults = (
             useSqlPivotResults,
         ],
         keepPreviousData: true, // needed to keep the last metric query which could break cartesian chart config
+        staleTime: Infinity,
+        refetchOnWindowFocus: false,
+        refetchOnMount: false,
         queryFn: ({ signal }) => {
             return executeAsyncQuery(
                 data


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Optimizes query results caching by setting `staleTime` to `Infinity` and disabling refetching on window focus and component mount. This prevents unnecessary API calls and ensures that the last metric query is preserved for cartesian chart configurations.