### PR TITLE
fix: display tiles respecting tab order

### DIFF
--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -152,17 +152,27 @@ const MinimalDashboard: FC = () => {
         };
     }, [dashboard?.tiles, schedulerTabsSelected, activeTab, gridProps.cols]);
 
-    const filteredDashboardTiles = useMemo(() => {
-        return (
+    const filteredAndSortedDashboardTiles = useMemo(() => {
+        const filteredTiles =
             dashboard?.tiles.filter((tile) =>
                 // If there are selected tabs when sending now/scheduling, aggregate ALL tiles into one view.
                 schedulerTabsSelected
                     ? schedulerTabsSelected.includes(tile.tabUuid)
                     : // This is when viewed a dashboard with tabs in mobile mode - you can navigate between tabs.
                       !activeTab || activeTab.uuid === tile.tabUuid,
-            ) ?? []
-        );
-    }, [dashboard?.tiles, schedulerTabsSelected, activeTab]);
+            ) ?? [];
+
+        // Sort tiles by their tab order
+        return filteredTiles.sort((a, b) => {
+            const tabAIndex = sortedTabs.findIndex(
+                (tab) => tab.uuid === a.tabUuid,
+            );
+            const tabBIndex = sortedTabs.findIndex(
+                (tab) => tab.uuid === b.tabUuid,
+            );
+            return tabAIndex - tabBIndex;
+        });
+    }, [dashboard?.tiles, schedulerTabsSelected, activeTab, sortedTabs]);
 
     if (isDashboardError || isSchedulerError) {
         if (dashboardError) return <>{dashboardError.error.message}</>;
@@ -211,7 +221,7 @@ const MinimalDashboard: FC = () => {
                 />
             ) : (
                 <ResponsiveGridLayout {...gridProps} layouts={layouts}>
-                    {filteredDashboardTiles.map((tile) => (
+                    {filteredAndSortedDashboardTiles.map((tile) => (
                         <div key={tile.uuid}>
                             {tile.type === DashboardTileTypes.SAVED_CHART ? (
                                 <ChartTile


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17824

### Description:
Sort dashboard tiles by their tab order when displaying them in the MinimalDashboard component. Previously, tiles were only filtered based on tab selection but weren't sorted according to the tab order, which could lead to inconsistent display order. This change ensures tiles appear in the same order as their corresponding tabs.

The implementation renames `filteredDashboardTiles` to `filteredAndSortedDashboardTiles` to better reflect its functionality and adds a sorting step after filtering that uses the `sortedTabs` array to determine the correct order.

**Before**

![image.png](https://app.graphite.dev/user-attachments/assets/12aa7460-3150-4837-a778-ff3633037f4d.png)

**After**

![image.png](https://app.graphite.dev/user-attachments/assets/56fd5bcb-527c-4690-8c8b-a649e025481a.png)

Repro steps in issue

