### PR TITLE
chore: improve logging for unsupported native pagination

### DIFF
--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -59,7 +59,7 @@ export default abstract class WarehouseBaseClient<
         _rowFormatter?: (row: Record<string, unknown>) => TFormattedRow,
     ): Promise<WarehouseGetAsyncQueryResults<TFormattedRow>> {
         throw new NotImplementedError(
-            `Paginated query results are not supported for warehouse type: ${this.getAdapterType()}`,
+            `Native pagination not supported. Please configure S3 Storage to use ${this.getAdapterType()} - https://docs.lightdash.com/self-host/customize-deployment/environment-variables#s3`,
         );
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Updated the error message for unsupported paginated query results in WarehouseBaseClient to provide clearer guidance. The new message specifically directs users to configure S3 for the warehouse adapter type and includes a link to the relevant documentation.