### PR TITLE
fix: key viz provider off of chart ID

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -238,6 +238,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
     return (
         <ErrorBoundary>
             <VisualizationProvider
+                key={savedChart?.uuid}
                 chartConfig={unsavedChartVersion.chartConfig}
                 initialPivotDimensions={
                     unsavedChartVersion.pivotConfig?.columns


### PR DESCRIPTION
### Description:

Re-mount the visualisation provider whenever the chart ID changes. This avoids caching any chart state in the viz provider.

