### PR TITLE
fix: recreate store for each explore instance

### DIFF
--- a/packages/frontend/src/features/explorer/store/index.ts
+++ b/packages/frontend/src/features/explorer/store/index.ts
@@ -1,11 +1,17 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { explorerReducer } from './explorerSlice';
 
-export const explorerStore = configureStore({
-    reducer: {
-        explorer: explorerReducer,
-    },
-});
+// Factory function to create a new store instance
+// This prevents state leaking between different explorer instances
+export const createExplorerStore = () =>
+    configureStore({
+        reducer: {
+            explorer: explorerReducer,
+        },
+    });
+
+// Keep singleton for backward compatibility (Explorer.tsx uses it)
+export const explorerStore = createExplorerStore();
 
 export type ExplorerStoreState = ReturnType<typeof explorerStore.getState>;
 export type ExplorerStoreDispatch = typeof explorerStore.dispatch;

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router';
 import LightdashVisualization from '../components/LightdashVisualization';
 import VisualizationProvider from '../components/LightdashVisualization/VisualizationProvider';
 import {
-    explorerStore,
+    createExplorerStore,
     selectSavedChart,
     useExplorerInitialization,
     useExplorerSelector,
@@ -97,6 +97,10 @@ const MinimalSavedExplorer: FC = () => {
         id: savedQueryUuid,
     });
 
+    // Create a fresh store instance per chart to prevent state leaking between charts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const store = useMemo(() => createExplorerStore(), [savedQueryUuid]);
+
     if (isInitialLoading || !data) {
         return null;
     }
@@ -106,7 +110,7 @@ const MinimalSavedExplorer: FC = () => {
     }
 
     return (
-        <Provider store={explorerStore} key={`minimal-${savedQueryUuid}`}>
+        <Provider store={store} key={`minimal-${savedQueryUuid}`}>
             <MantineProvider inherit theme={themeOverride}>
                 <MinimalExplorerContent />
             </MantineProvider>

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { lazy, memo, Suspense, useEffect } from 'react';
+import { lazy, memo, Suspense, useEffect, useMemo } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
 import ErrorState from '../components/common/ErrorState';
@@ -9,7 +9,7 @@ import Explorer from '../components/Explorer';
 import LoadingSkeleton from '../components/Explorer/ExploreTree/LoadingSkeleton';
 import SavedChartsHeader from '../components/Explorer/SavedChartsHeader';
 import {
-    explorerStore,
+    createExplorerStore,
     useExplorerInitialization,
 } from '../features/explorer/store';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
@@ -78,6 +78,10 @@ const SavedExplorer = () => {
         id: savedQueryUuid,
     });
 
+    // Create a fresh store instance per chart to prevent state leaking between charts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const store = useMemo(() => createExplorerStore(), [savedQueryUuid]);
+
     useEffect(() => {
         // If the saved explore is part of a dashboard, set the dashboard chart info
         // so we can show the banner + the user can navigate back to the dashboard easily
@@ -101,7 +105,7 @@ const SavedExplorer = () => {
     }
 
     return (
-        <Provider store={explorerStore} key={`saved-${savedQueryUuid}-${mode}`}>
+        <Provider store={store} key={`saved-${savedQueryUuid}-${mode}`}>
             <SavedExplorerContent
                 isEditMode={isEditMode}
                 defaultLimit={health.data?.query.defaultLimit}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-63

### Description:

Recreates the explore store for each instance of the explore. This will prevent state from bleeding between explores as we have seen when editing multiple charts from a dashboard. 

It seems like this pattern is generally deemed safe IF you are only using the store on a single page in your app, which is currently the case for us. We don't need any of the explore page state outside of the explore page. And we do want to reset it per instance. 
