### PR TITLE
fix: use correct table reference and add search operators in MCP service

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -889,7 +889,7 @@ export class McpService extends BaseService {
                     catalogSearch: {
                         type: CatalogType.Field,
                         yamlTags: tagsFromContext || undefined,
-                        tables: [args.exploreName],
+                        tables: [explore.baseTable],
                     },
                     userAttributes,
                     context: CatalogSearchContext.MCP,
@@ -910,6 +910,8 @@ export class McpService extends BaseService {
                             ...sharedArgs.catalogSearch,
                             filter: CatalogFilter.Dimensions,
                         },
+                        fullTextSearchOperator: 'OR',
+                        filteredExplore: explore,
                     });
 
                 const { data: metrics } =
@@ -919,6 +921,8 @@ export class McpService extends BaseService {
                             ...sharedArgs.catalogSearch,
                             filter: CatalogFilter.Metrics,
                         },
+                        fullTextSearchOperator: 'OR',
+                        filteredExplore: explore,
                     });
 
                 return {
@@ -999,6 +1003,7 @@ export class McpService extends BaseService {
                             pageSize: args.pageSize,
                         },
                         userAttributes,
+                        fullTextSearchOperator: 'OR',
                         filteredExplore: explore,
                     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR fixes the catalog search in the MCP service by:

1. Using the explore's base table instead of the explore name for catalog search
2. Adding 'OR' as the full text search operator for dimensions and metrics
3. Including the filtered explore in the search parameters for both dimensions and metrics
