### PR TITLE
feat: add reasoning support to Anthropic Claude model and optimize explore context

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -50,6 +50,16 @@ export const aiCopilotConfigSchema = z
                     apiKey: z.string(),
                     modelName: z.string().default(DEFAULT_ANTHROPIC_MODEL_NAME),
                     temperature: z.number().min(0).max(2).default(0.2),
+                    reasoning: z
+                        .object({
+                            enabled: z.boolean().default(false),
+                            budgetTokens: z.number().default(10000),
+                        })
+                        .optional()
+                        .default({
+                            enabled: false,
+                            budgetTokens: 10000,
+                        }),
                 })
                 .optional(),
             openrouter: z

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -261,28 +261,28 @@ export class McpService extends BaseService {
                         context as McpProtocolContext,
                     );
 
+                const { user } = (context as McpProtocolContext).authInfo!
+                    .extra;
+                const tagsFromContext = await this.getTagsFromContext(
+                    context as McpProtocolContext,
+                );
+                const availableExplores = await this.getAvailableExplores(
+                    user,
+                    argsWithProject.projectUuid,
+                    tagsFromContext,
+                );
+
                 const findExploresTool = getFindExplores({
                     findExplores,
                     updateProgress: async () => {}, // No-op for MCP context
                     fieldSearchSize: 200,
-                    listExplores: async () => {
-                        const { user } = (context as McpProtocolContext)
-                            .authInfo!.extra;
-                        const tagsFromContext = await this.getTagsFromContext(
-                            context as McpProtocolContext,
-                        );
-                        return this.getAvailableExplores(
-                            user,
-                            argsWithProject.projectUuid,
-                            tagsFromContext,
-                        );
-                    },
                 });
                 const result = await findExploresTool.execute!(
                     argsWithProject,
                     {
                         toolCallId: '',
                         messages: [],
+                        experimental_context: { availableExplores },
                     },
                 );
 

--- a/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
+++ b/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
@@ -8,10 +8,19 @@ export const getAnthropicModel = (
     config: NonNullable<
         LightdashConfig['ai']['copilot']['providers']['anthropic']
     >,
+    options?: {
+        enableReasoning?: boolean;
+    },
 ): AiModel<typeof PROVIDER> => {
     const anthropic = createAnthropic({
         apiKey: config.apiKey,
     });
+
+    // Use agent-specific enableReasoning if provided, otherwise fall back to config
+    const reasoningEnabled =
+        options?.enableReasoning !== undefined
+            ? options.enableReasoning
+            : config.reasoning.enabled;
 
     const model = anthropic(config.modelName);
 
@@ -20,6 +29,15 @@ export const getAnthropicModel = (
         callOptions: {
             temperature: config.temperature,
         },
-        providerOptions: undefined,
+        providerOptions: {
+            [PROVIDER]: {
+                ...(reasoningEnabled && {
+                    thinking: {
+                        type: 'enabled',
+                        budgetTokens: config.reasoning.budgetTokens,
+                    },
+                }),
+            },
+        },
     };
 };

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -31,7 +31,7 @@ export const getModel = (
             if (!anthropicConfig) {
                 throw new ParameterError('Anthropic configuration is required');
             }
-            return getAnthropicModel(anthropicConfig);
+            return getAnthropicModel(anthropicConfig, options);
         }
         case 'openrouter': {
             const openrouterConfig = config.providers.openrouter;

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -3,6 +3,7 @@ import {
     CompiledDimension,
     CompiledMetric,
     convertToAiHints,
+    Explore,
     getItemId,
     toolFindExploresArgsSchemaV2,
     toolFindExploresOutputSchema,
@@ -10,7 +11,6 @@ import {
 import { tool } from 'ai';
 import type {
     FindExploresFn,
-    ListExploresFn,
     UpdateProgressFn,
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
@@ -22,7 +22,10 @@ type Dependencies = {
     fieldSearchSize: number;
     findExplores: FindExploresFn;
     updateProgress: UpdateProgressFn;
-    listExplores: ListExploresFn;
+};
+
+type ExperimentalContext = {
+    availableExplores: Explore[];
 };
 
 function getCatalogChartUsage(
@@ -180,19 +183,18 @@ export const getFindExplores = ({
     findExplores,
     updateProgress,
     fieldSearchSize,
-    listExplores,
 }: Dependencies) =>
     tool({
         description: toolFindExploresArgsSchemaV2.description,
         inputSchema: toolFindExploresArgsSchemaV2,
         outputSchema: toolFindExploresOutputSchema,
-        execute: async (args) => {
+        execute: async (args, { experimental_context: context }) => {
             try {
                 await updateProgress(
                     `🔍 Searching explore: \`${args.exploreName}\`...`,
                 );
 
-                const availableExplores = await listExplores();
+                const { availableExplores } = context as ExperimentalContext;
                 validateExploreNameExists(availableExplores, args.exploreName);
 
                 const { explore, catalogFields } = await findExplores({


### PR DESCRIPTION
Added reasoning capabilities to Anthropic Claude models with a configurable token budget. This allows the AI to show its thinking process when generating responses.

The PR also optimizes explore data handling by passing available explores through experimental context instead of fetching them multiple times, improving performance and reducing redundant API calls.