### PR TITLE
fix: default number formatting to keep up to 3 decimal places

### DIFF
--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -687,13 +687,13 @@ describe('ExcelService', () => {
             expect(formatExpression).toBe('0.00%');
         });
 
-        it('should return default format for number fields without explicit format', () => {
+        it('should return default format for number fields without explicit format which keeps up to 3 decimal places', () => {
             // Test that getFormatExpression returns default format for number fields without explicit format
             const noFormatField = mockItemMapWithFormats.number_without_format;
             const formatExpression = getFormatExpression(noFormatField);
 
             // Should return a default number format for fields without explicit format
-            expect(formatExpression).toBe('#,##0');
+            expect(formatExpression).toBe('#,##0.###');
         });
 
         it('should NOT return default format for date fields without explicit format', () => {

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.mock.ts
@@ -98,7 +98,7 @@ models:
               label: New metric
               description: description
               type: average
-              format: '#,##0'
+              format: '#,##0.###'
   - name: table_b
     description: >-
       # Description This table has basic information

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -171,7 +171,7 @@ models:
               label: New metric
               description: description
               type: average
-              format: "#,##0"
+              format: "#,##0.###"
           additional_dimensions:
             id:
               label: Sql dimension

--- a/packages/common/src/pivot/pivotQueryResults.mock.ts
+++ b/packages/common/src/pivot/pivotQueryResults.mock.ts
@@ -1165,7 +1165,7 @@ export const EXPECTED_PIVOT_DATA_WITH_TOTALS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 1746.77,
-                        formatted: '1,747',
+                        formatted: '1,746.77',
                     },
                 },
             },
@@ -1203,7 +1203,7 @@ export const EXPECTED_PIVOT_DATA_WITH_TOTALS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 1189.6,
-                        formatted: '1,190',
+                        formatted: '1,189.6',
                     },
                 },
             },
@@ -1241,7 +1241,7 @@ export const EXPECTED_PIVOT_DATA_WITH_TOTALS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 117.5,
-                        formatted: '118',
+                        formatted: '117.5',
                     },
                 },
             },
@@ -1527,7 +1527,7 @@ export const EXPECTED_PIVOT_DATA_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 1746.77,
-                        formatted: '1,747',
+                        formatted: '1,746.77',
                     },
                 },
             },
@@ -1571,7 +1571,7 @@ export const EXPECTED_PIVOT_DATA_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 1189.6,
-                        formatted: '1,190',
+                        formatted: '1,189.6',
                     },
                 },
             },
@@ -1615,7 +1615,7 @@ export const EXPECTED_PIVOT_DATA_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 117.5,
-                        formatted: '118',
+                        formatted: '117.5',
                     },
                 },
             },
@@ -2067,13 +2067,13 @@ export const EXPECTED_COMPLEX_PIVOT_DATA: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 52.5,
-                        formatted: '53',
+                        formatted: '52.5',
                     },
                 },
                 'row-total-1': {
                     value: {
                         raw: 52.5,
-                        formatted: '53',
+                        formatted: '52.5',
                     },
                 },
             },
@@ -2364,7 +2364,7 @@ export const EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 52.5,
-                        formatted: '53',
+                        formatted: '52.5',
                     },
                 },
             },
@@ -2422,7 +2422,7 @@ export const EXPECTED_COMPLEX_PIVOT_DATA_WITH_METRICS_AS_ROWS: PivotData = {
                 'row-total-0': {
                     value: {
                         raw: 52.5,
-                        formatted: '53',
+                        formatted: '52.5',
                     },
                 },
             },

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -165,10 +165,10 @@ describe('Formatting', () => {
                 ).toEqual('$5.90');
             });
 
-            test('if round is undefined and format is number it should keep 0 decimal places', () => {
+            test('if round is undefined and format is number it should keep up to 3 decimal places', () => {
                 expect(
                     applyCustomFormat(5.9, { type: CustomFormatType.NUMBER }),
-                ).toEqual('6');
+                ).toEqual('5.9');
             });
 
             test('when round zero it should return the right round', () => {
@@ -456,12 +456,14 @@ describe('Formatting', () => {
             };
 
             test('it should return the right style', () => {
-                expect(applyCustomFormat(5, thousandsConfig)).toEqual('0K');
+                expect(applyCustomFormat(5, thousandsConfig)).toEqual('0.005K');
                 expect(applyCustomFormat(5, millionsConfig)).toEqual('0M');
-                expect(applyCustomFormat(500000, billionsConfig)).toEqual('0B');
+                expect(applyCustomFormat(500000, billionsConfig)).toEqual(
+                    '0.001B',
+                );
                 expect(applyCustomFormat(5, billionsConfig)).toEqual('0B');
                 expect(applyCustomFormat(5000000000, trillionsConfig)).toEqual(
-                    '0T',
+                    '0.005T',
                 );
             });
 
@@ -1244,7 +1246,7 @@ describe('Formatting', () => {
                 applyCustomFormat(12345.56789, {
                     type: CustomFormatType.NUMBER,
                 }),
-            ).toEqual('12,346');
+            ).toEqual('12,345.568');
             expect(
                 applyCustomFormat(12345.1235, {
                     type: CustomFormatType.NUMBER,
@@ -1262,7 +1264,7 @@ describe('Formatting', () => {
                     prefix: 'foo ',
                     suffix: ' bar',
                 }),
-            ).toEqual('foo 12,345 bar');
+            ).toEqual('foo 12,345.124 bar');
         });
 
         test('convert table calculation formats with invalid numbers', () => {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -192,17 +192,8 @@ function getFormatNumberOptions(value: number, format?: CustomFormat) {
     const round = format?.round;
 
     if (round === undefined) {
-        // If the format is a currency format, set the currency options and keep default decimal places
-        if (hasCurrency) {
-            return currencyOptions;
-        }
-
-        // If the format is a number format, set the maximum fraction digits to 0
-        if (format?.type === CustomFormatType.NUMBER) {
-            return { maximumFractionDigits: 0 };
-        }
-
-        return {};
+        // When round is not defined, keep up to 3 decimal places
+        return hasCurrency ? currencyOptions : {};
     }
 
     if (round < 0) {
@@ -625,7 +616,7 @@ const customFormatConversionFnMap: Record<
         return formatExpression;
     },
     round: (formatExpression, format) => {
-        let round = 2;
+        let round: number | null = 2;
         if (format.round !== undefined) {
             round = format.round;
         } else if (
@@ -641,8 +632,14 @@ const customFormatConversionFnMap: Record<
                 ? mockCurrencyValue.split('.')[1].length
                 : 0;
         } else if (format.type === CustomFormatType.NUMBER) {
-            round = 0;
+            round = null;
         }
+
+        if (round === null) {
+            // Formatting with null round means we want to show up to 3 decimal places
+            return `${formatExpression}.###`;
+        }
+
         if (round > 0) {
             return `${formatExpression}.${'0'.repeat(round)}`;
         }

--- a/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
+++ b/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
@@ -113,7 +113,7 @@ describe('Custom dimensions', () => {
 
         // Check results
         cy.contains('payment_credit_card');
-        cy.contains('1,452');
+        cy.contains('1,452.16');
         // Show SQL
         cy.findByTestId('Chart-card-expand').click(); // Close chart
         cy.findByTestId('Results-card-expand').click(); // Close results


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17838

### Description:
Updated number formatting to preserve up to 3 decimal places for numeric values without explicit formatting. Changed the default number format from `#,##0` to `#,##0.###` to ensure decimal precision is maintained in Excel exports, pivot tables, and formatted outputs.

This change ensures that values like 1746.77 will now display as "1,746.77" instead of being rounded to "1,747", providing more accurate data representation across the application.

**Before**

![before.png](https://app.graphite.dev/user-attachments/assets/01ab0efa-a485-41fd-b13c-8ed9820c5b38.png)

**After**

![after.png](https://app.graphite.dev/user-attachments/assets/794b1eb9-392c-4551-9e27-2e8250c51e6c.png)

`xlsx`, `csv` and `ui` formatting should be consistent

Reverts all tests changes from: https://github.com/lightdash/lightdash/pull/17766/files 

