### PR TITLE
feat: pass availableExplores via experimental_context

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -261,28 +261,28 @@ export class McpService extends BaseService {
                         context as McpProtocolContext,
                     );
 
+                const { user } = (context as McpProtocolContext).authInfo!
+                    .extra;
+                const tagsFromContext = await this.getTagsFromContext(
+                    context as McpProtocolContext,
+                );
+                const availableExplores = await this.getAvailableExplores(
+                    user,
+                    argsWithProject.projectUuid,
+                    tagsFromContext,
+                );
+
                 const findExploresTool = getFindExplores({
                     findExplores,
                     updateProgress: async () => {}, // No-op for MCP context
                     fieldSearchSize: 200,
-                    listExplores: async () => {
-                        const { user } = (context as McpProtocolContext)
-                            .authInfo!.extra;
-                        const tagsFromContext = await this.getTagsFromContext(
-                            context as McpProtocolContext,
-                        );
-                        return this.getAvailableExplores(
-                            user,
-                            argsWithProject.projectUuid,
-                            tagsFromContext,
-                        );
-                    },
                 });
                 const result = await findExploresTool.execute!(
                     argsWithProject,
                     {
                         toolCallId: '',
                         messages: [],
+                        experimental_context: { availableExplores },
                     },
                 );
 

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -3,6 +3,7 @@ import {
     CompiledDimension,
     CompiledMetric,
     convertToAiHints,
+    Explore,
     getItemId,
     toolFindExploresArgsSchemaV2,
     toolFindExploresOutputSchema,
@@ -10,7 +11,6 @@ import {
 import { tool } from 'ai';
 import type {
     FindExploresFn,
-    ListExploresFn,
     UpdateProgressFn,
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
@@ -22,7 +22,10 @@ type Dependencies = {
     fieldSearchSize: number;
     findExplores: FindExploresFn;
     updateProgress: UpdateProgressFn;
-    listExplores: ListExploresFn;
+};
+
+type AgentContext = {
+    availableExplores: Explore[];
 };
 
 function getCatalogChartUsage(
@@ -180,19 +183,18 @@ export const getFindExplores = ({
     findExplores,
     updateProgress,
     fieldSearchSize,
-    listExplores,
 }: Dependencies) =>
     tool({
         description: toolFindExploresArgsSchemaV2.description,
         inputSchema: toolFindExploresArgsSchemaV2,
         outputSchema: toolFindExploresOutputSchema,
-        execute: async (args) => {
+        execute: async (args, { experimental_context: context }) => {
             try {
                 await updateProgress(
                     `🔍 Searching explore: \`${args.exploreName}\`...`,
                 );
 
-                const availableExplores = await listExplores();
+                const { availableExplores } = context as AgentContext;
                 validateExploreNameExists(availableExplores, args.exploreName);
 
                 const { explore, catalogFields } = await findExplores({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
This PR optimizes the AI agent's explore handling by passing available explores through experimental context instead of fetching them multiple times. The changes:

1. Refactored `getAgentMessages` to accept explores directly rather than fetching them
2. Moved the `listExplores` call outside of the message generation
3. Added `experimental_context` with available explores to OpenAI API calls
4. Removed the `listExplores` dependency from the `findExplores` tool
5. Added error logging in the agent's stream error handler

These changes improve performance by avoiding redundant explore fetching and make the code more maintainable by simplifying the data flow.