### PR TITLE
feat: add reasoning configuration for Anthropic Claude model

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -50,6 +50,16 @@ export const aiCopilotConfigSchema = z
                     apiKey: z.string(),
                     modelName: z.string().default(DEFAULT_ANTHROPIC_MODEL_NAME),
                     temperature: z.number().min(0).max(2).default(0.2),
+                    reasoning: z
+                        .object({
+                            enabled: z.boolean().default(false),
+                            budgetTokens: z.number().default(10000),
+                        })
+                        .optional()
+                        .default({
+                            enabled: false,
+                            budgetTokens: 10000,
+                        }),
                 })
                 .optional(),
             openrouter: z

--- a/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
+++ b/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
@@ -8,10 +8,19 @@ export const getAnthropicModel = (
     config: NonNullable<
         LightdashConfig['ai']['copilot']['providers']['anthropic']
     >,
+    options?: {
+        enableReasoning?: boolean;
+    },
 ): AiModel<typeof PROVIDER> => {
     const anthropic = createAnthropic({
         apiKey: config.apiKey,
     });
+
+    // Use agent-specific enableReasoning if provided, otherwise fall back to config
+    const reasoningEnabled =
+        options?.enableReasoning !== undefined
+            ? options.enableReasoning
+            : config.reasoning.enabled;
 
     const model = anthropic(config.modelName);
 
@@ -20,6 +29,15 @@ export const getAnthropicModel = (
         callOptions: {
             temperature: config.temperature,
         },
-        providerOptions: undefined,
+        providerOptions: {
+            [PROVIDER]: {
+                ...(reasoningEnabled && {
+                    thinking: {
+                        type: 'enabled',
+                        budgetTokens: config.reasoning.budgetTokens,
+                    },
+                }),
+            },
+        },
     };
 };

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -31,7 +31,7 @@ export const getModel = (
             if (!anthropicConfig) {
                 throw new ParameterError('Anthropic configuration is required');
             }
-            return getAnthropicModel(anthropicConfig);
+            return getAnthropicModel(anthropicConfig, options);
         }
         case 'openrouter': {
             const openrouterConfig = config.providers.openrouter;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Add reasoning capability to Anthropic Claude model. This enhancement allows the model to show its thinking process when generating responses by adding a new `reasoning` configuration option with `enabled` flag and `budgetTokens` parameter. When enabled, the model will include its reasoning steps in the response, providing more transparency into how it arrived at its conclusions.

The implementation passes reasoning configuration from the AI config to the Anthropic model and allows overriding the setting at the agent level through options.