### PR TITLE
fix: bar display/cell on tables should have accurate width

### DIFF
--- a/packages/frontend/src/hooks/TableCellBar.tsx
+++ b/packages/frontend/src/hooks/TableCellBar.tsx
@@ -1,9 +1,6 @@
-/**
- * Renders a bar chart display for positive numeric values in table cells.
- */
-import { type ReactElement } from 'react';
+import { Box, Text } from '@mantine-8/core';
 
-type BarChartDisplayProps = {
+type TableCellBarProps = {
     value: number;
     formatted: string;
     min: number;
@@ -11,13 +8,13 @@ type BarChartDisplayProps = {
     color?: string;
 };
 
-export const renderBarChartDisplay = ({
+export const TableCellBar = ({
     value,
     formatted,
     min,
     max,
     color = '#5470c6',
-}: BarChartDisplayProps): ReactElement => {
+}: TableCellBarProps) => {
     // Calculate bar width percentage
     const range = max - min;
     const percentage =
@@ -29,25 +26,30 @@ export const renderBarChartDisplay = ({
     const showBar = value > 0;
 
     return (
-        <div
+        <Box
             style={{
-                display: 'flex',
+                display: 'grid',
+                gridTemplateColumns: '1fr auto',
                 alignItems: 'center',
-                gap: '8px',
+                gap: '4px',
             }}
         >
             {showBar && (
-                <div
+                <Box
+                    h="20px"
+                    w={`${percentage}%`}
+                    bg={color}
+                    maw="100%"
+                    // Always show visible bar for positive values
+                    miw="2px"
                     style={{
-                        width: `${percentage}%`,
-                        minWidth: '2px', // Always show visible bar for positive values
-                        height: '20px',
-                        backgroundColor: color,
                         borderRadius: '2px',
                     }}
                 />
             )}
-            <span style={{ whiteSpace: 'nowrap' }}>{formatted}</span>
-        </div>
+            <Text span style={{ whiteSpace: 'nowrap' }} fz="xs">
+                {formatted}
+            </Text>
+        </Box>
     );
 };

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -47,7 +47,7 @@ import {
     selectTableName,
     useExplorerSelector,
 } from '../features/explorer/store';
-import { renderBarChartDisplay } from './barChartDisplay';
+import { TableCellBar } from './TableCellBar';
 import { useCalculateTotal } from './useCalculateTotal';
 import { useExplore } from './useExplore';
 import { useExplorerQuery } from './useExplorerQuery';
@@ -144,12 +144,9 @@ const formatBarDisplayCell = (
     const min = minMax?.min ?? 0;
     const max = minMax?.max ?? 100;
 
-    return renderBarChartDisplay({
-        value,
-        formatted,
-        min,
-        max,
-    });
+    return (
+        <TableCellBar value={value} formatted={formatted} min={min} max={max} />
+    );
 };
 
 export const getFormattedValueCell = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17802

### Description:

Refactored the bar chart display component to improve its implementation:

- Updated the layout from flexbox to grid for better alignment
- Made the text size smaller with `fz="xs"` for better visual hierarchy

To test: 


http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/campaigns?create_saved_chart_version=%7B%22tableName%22%3A%22campaigns%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22campaigns%22%2C%22dimensions%22%3A%5B%22campaigns_start_date_month%22%5D%2C%22metrics%22%3A%5B%22campaigns_total_budget%22%2C%22campaigns_total_campaign_days%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22campaigns_total_budget%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22campaigns_start_date_month%22%2C%22campaigns_total_budget%22%2C%22campaigns_total_campaign_days%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22table%22%2C%22config%22%3A%7B%22showColumnCalculation%22%3Afalse%2C%22showRowCalculation%22%3Afalse%2C%22showTableNames%22%3Atrue%2C%22showResultsTotal%22%3Afalse%2C%22showSubtotals%22%3Afalse%2C%22columns%22%3A%7B%22campaigns_total_budget%22%3A%7B%22displayStyle%22%3A%22text%22%7D%2C%22campaigns_total_campaign_days%22%3A%7B%22displayStyle%22%3A%22bar%22%7D%7D%2C%22hideRowNumbers%22%3Afalse%2C%22conditionalFormattings%22%3A%5B%5D%2C%22metricsAsRows%22%3Afalse%7D%7D%7D&isExploreFromHere=true


**Before**

![image.png](https://app.graphite.dev/user-attachments/assets/273d05a1-079f-424c-8e73-1d35c132ec8a.png)

**After**

![Screenshot 2025-11-04 at 13.53.48.png](https://app.graphite.dev/user-attachments/assets/687a1a83-bbce-41ce-a7c2-7dda2034c229.png)