### PR TITLE
style: reduce value label text border width from 2px to 1.5px

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts
@@ -28,7 +28,7 @@ export const getValueLabelStyle = (
         return {
             ...base,
             textBorderColor: WHITE,
-            textBorderWidth: 2,
+            textBorderWidth: 1.5,
             textBorderType: 'solid',
         };
     }


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17821

### Description:
Reduced the text border width for value labels from 2 to 1.5 pixels to improve readability and visual appearance of labels with white borders.