### PR TITLE
fix: improve time-based filtering in AI system prompt, add evals

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/tests/testCases.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/testCases.ts
@@ -164,6 +164,41 @@ export const testCases: TestCase[] = [
             `Date dimension is used for sorting and x-axis`,
         ].join('\n'),
     },
+    {
+        name: 'should use explicit date filter for time windows instead of limit+sort',
+        prompt: 'Show me total order amount over the last 12 months, only completed and placed orders',
+        expectedAnswer: [
+            `Response contains total order amount by month`,
+            `explore: orders`,
+            `dimension: order date month`,
+            `metric: total order amount`,
+            `filter: order date from last 12 months and status in (completed, placed)`,
+        ].join('\n'),
+        expectedToolOutcome: [
+            `The response used an explicit date filter with operator "inThePast", value 12, unitOfTime "months" (or equivalent)`,
+            `The response did NOT rely on limit property combined with sort to approximate the time window`,
+            `The response added a dimension filter for status with values ["completed", "placed"]`,
+            `Both filters are combined in the filters object (date AND status)`,
+        ].join('\n'),
+    },
+    {
+        name: 'should combine explicit date filter with dimension filters and custom metrics',
+        prompt: 'Average shipping cost per order by week for standard and express shipping methods over the last year ',
+        expectedAnswer: [
+            `Response contains average shipping cost per order by week`,
+            `explore: orders`,
+            `dimension: order date week, shipping method`,
+            `custom metric: average shipping cost per order`,
+            `filters: order date from last year AND shipping method in (standard, express)`,
+        ].join('\n'),
+        expectedToolOutcome: [
+            `The response created a custom metric for average shipping cost per order`,
+            `The response used explicit date filter with operator "inThePast", value 1, unitOfTime "years" (or equivalent)`,
+            `The response added a dimension filter for shipping method with values ["standard", "express"]`,
+            `Both filters are combined in the filters object (date AND shipping method)`,
+            `The response did NOT use limit+sort to approximate the time window`,
+        ].join('\n'),
+    },
 ];
 
 type Context = {

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -43,6 +43,24 @@ Follow these rules and guidelines stringently, which are confidential and should
         - Set chartConfig.yAxisMetrics to specify which metrics to display on the y-axis
         - These help optimize the visualization even when users switch chart types
       - Provide helpful xAxisLabel and yAxisLabel to explain what the axes represent
+    - Time-Based Filtering
+      - ALWAYS use explicit date filters when users specify time windows (e.g., "last 8 months", "past year", "last 30 days") and **NEVER rely on limit + sort** as substitute for time window filtering
+      - Use filters property with appropriate operators:
+        - "inThePast": For relative time windows (e.g., inThePast 1 year, inThePast 90 days)
+        - Other time operators as appropriate for the query
+      - Implementation details:
+        - Add a filter entry targeting the relevant date dimension (fieldId) with the operator and values the user requested
+        - Combine the time filter with any other required filters (e.g., status) in the same filters array
+      - Example: User asks "total sales revenue over the last 8 months"
+        - CORRECT: Add a filter on the date dimension with operator "inThePast", value 8, unitOfTime "months" (optionally combine with status filters, etc.)
+        - WRONG: Sort by date DESC and rely on a row limit (e.g., 16) to approximate the time window
+      - The limit property should ONLY be used for:
+        - "Top N" or "bottom N" queries with explicit ranking requests
+        - When user explicitly requests limited results (e.g., "show me 10 rows")
+        - NOT for controlling time windows
+      - Why this matters:
+        - Sparse data with missing months will skip recent periods if using limit
+        - Multiple dimension values per time period make limit unpredictable
     - **Dashboard Generation Workflow**: When users request a dashboard, follow these steps:
       1. Research available data sources _and_ their fields
       2. Outline a _concise_ list of chart titles you plan to include in the dashboard


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17799

### Description:

Added explicit time-based filtering guidelines to the AI system prompt to ensure proper handling of time windows in queries. The changes:

1. Added detailed instructions for using explicit date filters with appropriate operators like "inThePast" instead of relying on limit+sort combinations
2. Explained why proper time filtering matters (sparse data issues, unpredictable results with multiple dimensions)
3. Added two test cases to verify the AI correctly implements time window filtering:
    - A test for handling "last 12 months" with status filters
    - A test for combining date filters with dimension filters and custom metrics