### PR TITLE
feat: add AI artifact verification and prompt reference tracking

### DIFF
--- a/packages/backend/src/ee/database/entities/aiArtifacts.ts
+++ b/packages/backend/src/ee/database/entities/aiArtifacts.ts
@@ -28,6 +28,8 @@ export type DbAiArtifactVersion = {
     saved_dashboard_uuid: string | null;
     chart_config: Record<string, unknown> | null;
     dashboard_config: Record<string, unknown> | null;
+    verified_by_user_uuid: string | null;
+    verified_at: Date | null;
 };
 
 export type AiArtifactVersionsTable = Knex.CompositeTableType<
@@ -44,6 +46,28 @@ export type AiArtifactVersionsTable = Knex.CompositeTableType<
             | 'saved_dashboard_uuid'
             | 'chart_config'
             | 'dashboard_config'
+            | 'verified_by_user_uuid'
+            | 'verified_at'
         >
     >
+>;
+
+export const AiPromptArtifactReferencesTableName =
+    'ai_prompt_artifact_references';
+
+export type DbAiPromptArtifactReference = {
+    ai_prompt_uuid: string;
+    ai_artifact_version_uuid: string;
+    project_uuid: string;
+    similarity_score: number | null;
+    created_at: Date;
+};
+
+export type AiPromptArtifactReferencesTable = Knex.CompositeTableType<
+    DbAiPromptArtifactReference,
+    Pick<
+        DbAiPromptArtifactReference,
+        'ai_prompt_uuid' | 'ai_artifact_version_uuid' | 'project_uuid'
+    > &
+        Partial<Pick<DbAiPromptArtifactReference, 'similarity_score'>>
 >;

--- a/packages/backend/src/ee/database/migrations/20251103061409_add_artifact_version_search_and_verification.ts
+++ b/packages/backend/src/ee/database/migrations/20251103061409_add_artifact_version_search_and_verification.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+const AI_ARTIFACT_VERSIONS_TABLE = 'ai_artifact_versions';
+
+export async function up(knex: Knex): Promise<void> {
+    // Add verified_by_user_uuid and verified_at columns
+    await knex.schema.alterTable(AI_ARTIFACT_VERSIONS_TABLE, (table) => {
+        table.uuid('verified_by_user_uuid').nullable();
+        table.timestamp('verified_at').nullable();
+        table
+            .foreign('verified_by_user_uuid')
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AI_ARTIFACT_VERSIONS_TABLE, (table) => {
+        table.dropColumn('verified_at');
+        table.dropColumn('verified_by_user_uuid');
+    });
+}

--- a/packages/backend/src/ee/database/migrations/20251103081354_add_ai_prompt_artifact_references.ts
+++ b/packages/backend/src/ee/database/migrations/20251103081354_add_ai_prompt_artifact_references.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+const AI_PROMPT_ARTIFACT_REFERENCES_TABLE = 'ai_prompt_artifact_references';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(
+        AI_PROMPT_ARTIFACT_REFERENCES_TABLE,
+        (table) => {
+            table.uuid('ai_prompt_uuid').notNullable();
+            table.uuid('ai_artifact_version_uuid').notNullable();
+            table.uuid('project_uuid').notNullable();
+            table.float('similarity_score').nullable();
+            table
+                .timestamp('created_at')
+                .notNullable()
+                .defaultTo(knex.fn.now());
+
+            table
+                .foreign('ai_prompt_uuid')
+                .references('ai_prompt_uuid')
+                .inTable('ai_prompt')
+                .onDelete('CASCADE');
+
+            table
+                .foreign('ai_artifact_version_uuid')
+                .references('ai_artifact_version_uuid')
+                .inTable('ai_artifact_versions')
+                .onDelete('CASCADE');
+
+            table
+                .foreign('project_uuid')
+                .references('project_uuid')
+                .inTable('projects')
+                .onDelete('CASCADE');
+
+            table.primary(['ai_prompt_uuid', 'ai_artifact_version_uuid']);
+
+            table.index('ai_prompt_uuid');
+            table.index('ai_artifact_version_uuid');
+            table.index('project_uuid');
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AI_PROMPT_ARTIFACT_REFERENCES_TABLE);
+}

--- a/packages/backend/src/ee/database/migrations/20251103091500_add_artifact_embedding_vector.ts
+++ b/packages/backend/src/ee/database/migrations/20251103091500_add_artifact_embedding_vector.ts
@@ -1,0 +1,34 @@
+import { Knex } from 'knex';
+
+const AI_ARTIFACT_VERSIONS_TABLE = 'ai_artifact_versions';
+
+export async function up(knex: Knex): Promise<void> {
+    // Enable pgvector extension (safe to re-run)
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS vector');
+
+    // Add embedding_vector column (1536 dimensions for text-embedding-3-small)
+    await knex.raw(`
+        ALTER TABLE ${AI_ARTIFACT_VERSIONS_TABLE}
+        ADD COLUMN embedding_vector vector(1536)
+    `);
+
+    // Create HNSW index for cosine similarity search
+    await knex.raw(`
+        CREATE INDEX ai_artifact_versions_embedding_vector_idx
+        ON ${AI_ARTIFACT_VERSIONS_TABLE}
+        USING hnsw (embedding_vector vector_cosine_ops)
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AI_ARTIFACT_VERSIONS_TABLE, (table) => {
+        table.dropIndex(
+            'embedding_vector',
+            'ai_artifact_versions_embedding_vector_idx',
+        );
+    });
+
+    await knex.schema.alterTable(AI_ARTIFACT_VERSIONS_TABLE, (table) => {
+        table.dropColumn('embedding_vector');
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR adds artifact verification and semantic search capabilities to AI artifacts:

1. Adds verification tracking to AI artifact versions with `verified_by_user_uuid` and `verified_at` fields
2. Creates a new `ai_prompt_artifact_references` table to track relationships between prompts and artifacts
3. Adds vector embedding support using pgvector for semantic search of artifacts
4. Implements HNSW indexing for efficient cosine similarity searches
