### PR TITLE
chore: decrease ai and mcp sentry sample rate

### DIFF
--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -72,17 +72,6 @@ Sentry.init({
             return 0.0;
         }
 
-        if (
-            request?.url?.includes('aiAgents') &&
-            request?.url?.endsWith('stream')
-        ) {
-            return 1.0;
-        }
-
-        if (request?.url?.includes('mcp')) {
-            return 1.0;
-        }
-
         if (context.parentSampled) {
             return context.parentSampled;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Removes specific sampling rules for 'aiAgents/stream' and 'mcp' endpoints in Sentry configuration. These endpoints were previously set to 100% sampling rate (1.0), but will now follow the default sampling logic.