### PR TITLE
feat: add find_content tool to McpService

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -309,7 +309,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectService: repository.getProjectService(),
                     userAttributesModel: models.getUserAttributesModel(),
                     searchModel: models.getSearchModel(),
-                    spaceModel: models.getSpaceModel(),
                     spaceService: repository.getSpaceService(),
                     mcpContextModel: models.getMcpContextModel(),
                     projectModel: models.getProjectModel(),


### PR DESCRIPTION
### Description:
Added a new `FIND_CONTENT` tool to the MCP service that replaces the separate `FIND_DASHBOARDS` and `FIND_CHARTS` tools. This new tool allows searching for both dashboards and charts in a single query, making content discovery more efficient. The implementation includes proper permission checks to ensure users can only access content they have permission to view.

diff --git packages/backend/src/ee/services/McpService/McpService.ts packages/backend/src/ee/services/McpService/McpService.ts
index 5ea94292a..3ad67c671 100644
--- packages/backend/src/ee/services/McpService/McpService.ts
+++ packages/backend/src/ee/services/McpService/McpService.ts