### PR TITLE
fix: border radius for pie charts based on segment size

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/pieChartStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/pieChartStyles.ts
@@ -1,13 +1,32 @@
 import { GRAY_3, GRAY_6, GRAY_7, WHITE } from './themeColors';
 
 /**
- * Get pie slice styling
+ * Calculate border radius based on slice percentage
+ * Uses a smooth scaling formula to prevent over-rounding on small slices
+ */
+export const calculateBorderRadiusForSlice = (percent: number): number => {
+    const MAX_RADIUS = 4;
+    const MIN_RADIUS = 2;
+    const THRESHOLD_PERCENT = 2;
+
+    if (percent >= THRESHOLD_PERCENT) {
+        return MAX_RADIUS;
+    }
+
+    // For smaller slices, scale proportionally to create a smooth curve from MIN_RADIUS to MAX_RADIUS
+    const scale = percent / THRESHOLD_PERCENT;
+    return MIN_RADIUS + (MAX_RADIUS - MIN_RADIUS) * scale;
+};
+
+/**
+ * Get pie slice styling for series-level configuration
+ * Note: borderRadius is applied per data point in the frontend
+ * to enable dynamic sizing based on slice percentage
  */
 export const getPieSliceStyle = (isDonut: boolean) =>
     isDonut
         ? {
               itemStyle: {
-                  borderRadius: 4,
                   borderColor: WHITE,
                   borderWidth: 2,
               },

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -1,4 +1,5 @@
 import {
+    calculateBorderRadiusForSlice,
     formatColorIndicator,
     formatItemValue,
     formatTooltipLabel,
@@ -53,6 +54,7 @@ const useEchartsPieConfig = (
             sortedGroupLabels,
             groupFieldIds,
             validConfig: {
+                isDonut,
                 valueLabel: valueLabelDefault,
                 showValue: showValueDefault,
                 showPercentage: showPercentageDefault,
@@ -63,6 +65,9 @@ const useEchartsPieConfig = (
         } = chartConfig;
 
         if (!selectedMetric) return;
+
+        // Calculate total for percentage calculation
+        const total = data.reduce((sum, { value }) => sum + value, 0);
 
         return data
             .sort(
@@ -87,6 +92,12 @@ const useEchartsPieConfig = (
                     groupColorOverrides?.[name] ??
                     getGroupColor(groupPrefix, name);
 
+                // Calculate percentage for this slice
+                const percent = (value / total) * 100;
+
+                const borderRadius = isDonut
+                    ? calculateBorderRadiusForSlice(percent)
+                    : 0;
                 const config: PieSeriesDataPoint = {
                     id: name,
                     groupId: name,
@@ -94,6 +105,7 @@ const useEchartsPieConfig = (
                     value: value,
                     itemStyle: {
                         color: itemColor,
+                        borderRadius,
                     },
                     label: {
                         show: valueLabel !== 'hidden',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17754

### Description:

Implemented dynamic border radius for pie chart slices based on their percentage of the total. Small slices now have proportionally smaller border radius to prevent over-rounding, using a smooth scaling formula between 2px and 4px with a 2% threshold.

The border radius calculation has been moved from series-level configuration to per-data-point styling, allowing each slice to have its own appropriate border radius based on its size.

_after_
![image.png](https://app.graphite.dev/user-attachments/assets/292f0fe0-3dd4-49d8-b6ad-cbb44a6b10d5.png)

_before_
![image.png](https://app.graphite.dev/user-attachments/assets/e60d9a01-7039-49e5-8dd5-9832785a977b.png)