### PR TITLE
fix: pivot table wrapping values when not expanded

### DIFF
--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -323,7 +323,7 @@ export const useTableCellStyles = createStyles<
                 height: CELL_HEIGHT,
 
                 textAlign: 'left',
-                whiteSpace: 'pre-wrap',
+                whiteSpace: 'pre',
 
                 fontFamily: theme.other.tableFont ?? "'Inter', sans-serif",
                 fontFeatureSettings: '"tnum"',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17860
Relates to: https://github.com/lightdash/lightdash/pull/17727

### Description:
Changed the `whiteSpace` property in pivot table cells from `pre-wrap` to `pre` to prevent text wrapping within cells. This ensures table content displays on a single line, improving readability and maintaining consistent table layout.

**Before**
![image.png](https://app.graphite.com/user-attachments/assets/01ceb000-a2e3-4b36-85e2-bd63a183c767.png)

**After**
![image.png](https://app.graphite.com/user-attachments/assets/a7a0ea1f-088c-4b83-a155-1a0b5ca24e22.png)

