### PR TITLE
feat: store tool calls in the evaluation reports

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/tests/utils/testHelpers.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/testHelpers.ts
@@ -6,10 +6,11 @@ import {
 } from '../../../../../../vitest.setup.integration';
 import { DbAiAgentToolCall } from '../../../../../database/entities/ai';
 
+export type ToolCallWithResult = DbAiAgentToolCall & { result?: unknown };
 export interface PromptAndGetToolCallsResult {
     response: string;
     threadUuid: string;
-    toolCalls: Array<DbAiAgentToolCall & { result?: unknown }>;
+    toolCalls: ToolCallWithResult[];
 }
 
 export const promptAndGetToolCalls = async (
@@ -61,7 +62,8 @@ export const promptAndGetToolCalls = async (
             'ai_agent_tool_result.tool_call_id',
         )
         .where('ai_agent_tool_call.ai_prompt_uuid', messageUuid)
-        .select<Array<DbAiAgentToolCall & { result?: unknown }>>('*');
+        .select<ToolCallWithResult[]>('*')
+        .orderBy('ai_agent_tool_call.created_at', 'asc');
 
     return {
         response,

--- a/packages/backend/src/ee/services/ai/agents/tests/utils/testReportWrapper.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/utils/testReportWrapper.ts
@@ -3,11 +3,12 @@ import { DbAiAgentToolCall } from '../../../../../database/entities/ai';
 import { LlmJudgeResult } from '../../../utils/llmAsAJudge';
 import { ToolJudgeResult } from '../../../utils/llmAsJudgeForTools';
 import { setTaskMeta } from './taskMeta';
+import { ToolCallWithResult } from './testHelpers';
 
 interface TestReportData {
     prompts?: string[];
     responses?: string[];
-    toolCalls?: string[];
+    toolCalls?: ToolCallWithResult[];
     llmJudgeResults?: LlmJudgeResult[];
     llmToolJudgeResults?: ToolJudgeResult[];
     agentInfo?: { provider: string; model: string };
@@ -94,7 +95,7 @@ export class TestReportBuilder {
         prompts?: string[];
         response?: string;
         responses?: string[];
-        toolCalls?: string[] | DbAiAgentToolCall[];
+        toolCalls?: ToolCallWithResult[];
         agentInfo?: { provider: string; model: string };
     }) {
         if (config?.prompt) {
@@ -110,12 +111,7 @@ export class TestReportBuilder {
         }
 
         if (config?.toolCalls) {
-            const toolNames = Array.isArray(config.toolCalls)
-                ? config.toolCalls.map((tc) =>
-                      typeof tc === 'string' ? tc : tc.tool_name,
-                  )
-                : [];
-            this.data.toolCalls = toolNames;
+            this.data.toolCalls = config.toolCalls;
         }
 
         if (config?.agentInfo) {
@@ -156,7 +152,7 @@ export function createTestReport(config?: {
     prompts?: string[];
     response?: string;
     responses?: string[];
-    toolCalls?: string[] | DbAiAgentToolCall[];
+    toolCalls?: ToolCallWithResult[];
     agentInfo?: { provider: string; model: string };
 }): TestReportBuilder {
     return new TestReportBuilder(config);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Full tool calls and responses





### Description:

Enhanced tool call reporting in evaluation results by adding detailed tool call information to the HTML report. The changes include:

1. Created a structured `ToolCallData` type to store tool name, arguments, and results
2. Updated the HTML reporter to display detailed tool call information including:
    - Tool name
    - Arguments (formatted JSON)
    - Results (when available)
3. Improved the visual presentation of tool calls in the report with collapsible sections
4. Modified the `TestReportBuilder` to properly capture and store complete tool call data