### PR TITLE
feat: add RunQuery efficiency scoring to agent evaluations

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -30,6 +30,20 @@ export type ContextRelevancyResponse = {
     reason: string;
 };
 
+export type RunQueryEfficiencyResponse = {
+    score: number;
+    runQueryCount: number;
+};
+
+export const calculateRunQueryEfficiencyScore = (
+    runQueryCount: number,
+): number => {
+    if (runQueryCount === 0) {
+        return 1;
+    }
+    return 1 / 2 ** (runQueryCount - 1);
+};
+
 type LlmJudgeResultBase = {
     query: string;
     response: string;
@@ -51,6 +65,10 @@ export type LlmJudgeResult =
           scorerType: 'contextRelevancy';
           context: string[];
           result: ContextRelevancyResponse;
+      })
+    | (LlmJudgeResultBase & {
+          scorerType: 'runQueryEfficiency';
+          result: RunQueryEfficiencyResponse;
       });
 
 type BaseLlmAsJudgeParams = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

![CleanShot 2025-11-05 at 17.43.54@2x.png](https://app.graphite.com/user-attachments/assets/cc2ba9f2-c7f2-4faa-9d65-f7a43466c85e.png)



### Description:

Added a new RunQuery efficiency evaluation to agent integration tests. This feature tracks the number of query_result tool calls made by the agent and calculates an efficiency score based on how many database queries were executed.

The implementation includes:

- New `calculateRunQueryEfficiencyScore` function that scores efficiency on a scale where 1 query = 100%, 2 queries = 50%, etc.
- Added RunQueryEfficiency type and scoring logic to the evaluation system
- Updated the HTML reporter to display query efficiency metrics in test reports
- Enabled data access in the agent test configuration