### PR TITLE
fix: cancelling edit chart should keep header

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -282,6 +282,7 @@ const SavedChartsHeader: FC = () => {
         // Reset to saved chart state
         if (savedChart) {
             const resetState = {
+                savedChart,
                 isEditMode,
                 parameterReferences: Object.keys(savedChart.parameters ?? {}),
                 parameterDefinitions: {},
@@ -389,14 +390,12 @@ const SavedChartsHeader: FC = () => {
                                     </ActionIcon>
                                 )}
                             </Group>
-
                             <ChartUpdateModal
                                 opened={isRenamingChart}
                                 uuid={savedChart.uuid}
                                 onClose={() => setIsRenamingChart(false)}
                                 onConfirm={() => setIsRenamingChart(false)}
                             />
-
                             <Group spacing="xs">
                                 <UpdatedInfo
                                     updatedAt={savedChart.updatedAt}
@@ -417,7 +416,6 @@ const SavedChartsHeader: FC = () => {
                         </>
                     )}
                 </div>
-
                 {userTimeZonesEnabled &&
                     savedChart?.metricQuery.timezone &&
                     !isEditMode && (
@@ -425,7 +423,6 @@ const SavedChartsHeader: FC = () => {
                             {savedChart?.metricQuery.timezone}
                         </Text>
                     )}
-
                 {(userCanManageChart ||
                     userCanCreateDeliveriesAndAlerts ||
                     userCanManageExplore) && (


### PR DESCRIPTION
### Description:

Fixes an issue where editing charts from a dashboard and cancelling the edit cause the header to disappear. We weren't resetting state correctly and the savedChart was getting removed from the store. 

**The bug**
- Saved chart header disappears when cancelling edits

Repro:
- From a dashboard: edit chart
- Make and edit to the chart
- Click cancel changes
- The header disappears

![Kapture 2025-11-05 at 12 29 58](https://github.com/user-attachments/assets/1c91967e-019e-491d-abc6-5a0b72b0833c)
