### PR TITLE
feat: add list_explores tool for mcp

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/mcpListExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/mcpListExplores.tsx
@@ -1,0 +1,65 @@
+import {
+    Explore,
+    mcpToolListExploresArgsSchema,
+    mcpToolListExploresOutputSchema,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+import { xmlBuilder } from '../xmlBuilder';
+
+type Dependencies = {
+    listExplores: () => Promise<Explore[]>;
+};
+
+const renderExplore = (explore: Explore) => (
+    <explore
+        name={explore.name}
+        label={explore.label}
+        baseTable={explore.baseTable}
+    >
+        {explore.tags && explore.tags.length > 0 && (
+            <tags>
+                {explore.tags.map((tag) => (
+                    <tag>{tag}</tag>
+                ))}
+            </tags>
+        )}
+        <joinedTables count={explore.joinedTables.length}>
+            {explore.joinedTables.map((joinedTable) => (
+                <table>{joinedTable.table}</table>
+            ))}
+        </joinedTables>
+    </explore>
+);
+
+export const getMcpListExplores = ({ listExplores }: Dependencies) =>
+    tool({
+        description: mcpToolListExploresArgsSchema.description,
+        inputSchema: mcpToolListExploresArgsSchema,
+        outputSchema: mcpToolListExploresOutputSchema,
+        execute: async () => {
+            try {
+                const explores = await listExplores();
+
+                return {
+                    result: (
+                        <explores count={explores.length}>
+                            {explores.map((explore) => renderExplore(explore))}
+                        </explores>
+                    ).toString(),
+                    metadata: {
+                        status: 'success',
+                    },
+                };
+            } catch (error) {
+                return {
+                    result: toolErrorHandler(error, 'Error listing explores'),
+                    metadata: {
+                        status: 'error',
+                    },
+                };
+            }
+        },
+        toModelOutput: (output) => toModelOutput(output),
+    });

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -1,3 +1,4 @@
+export * from './mcpToolListExploresArgs';
 export * from './toolDashboardArgs';
 export * from './toolDashboardV2Args';
 export * from './toolFindChartsArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/mcpToolListExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/mcpToolListExploresArgs.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { baseOutputMetadataSchema } from '../outputMetadata';
+
+export const MCP_TOOL_LIST_EXPLORES_DESCRIPTION = `Tool: listExplores
+
+Purpose:
+Lists all Explores available to the user in the current project. Returns a summary of each explore including its name, label, base table, and tags.
+
+Usage Tips:
+- Use this to discover what data sources are available before using findExplores for detailed field information
+- No arguments needed - automatically uses the current project context
+- Results are filtered based on user permissions and selected tags
+- Returns explore metadata without field details for quick overview
+`;
+
+// MCP-only tool - no type field needed
+export const mcpToolListExploresArgsSchema = z
+    .object({})
+    .describe(MCP_TOOL_LIST_EXPLORES_DESCRIPTION);
+
+export type McpToolListExploresArgs = z.infer<
+    typeof mcpToolListExploresArgsSchema
+>;
+
+export const mcpToolListExploresOutputSchema = z.object({
+    result: z.string(),
+    metadata: baseOutputMetadataSchema,
+});
+
+export type McpToolListExploresOutput = z.infer<
+    typeof mcpToolListExploresOutputSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -25,10 +25,6 @@ export const toolFindExploresArgsSchemaV1 = createToolSchema({
     .withPagination()
     .build();
 
-export type ToolFindExploresArgsV1 = z.infer<
-    typeof toolFindExploresArgsSchemaV1
->;
-
 export const toolFindExploresArgsSchemaV2 = createToolSchema({
     type: 'find_explores',
     description: TOOL_FIND_EXPLORES_DESCRIPTION,
@@ -53,6 +49,9 @@ export const toolFindExploresOutputSchema = z.object({
     metadata: baseOutputMetadataSchema,
 });
 
+export type ToolFindExploresArgsV1 = z.infer<
+    typeof toolFindExploresArgsSchemaV1
+>;
 export type ToolFindExploresArgsV2 = z.infer<
     typeof toolFindExploresArgsSchemaV2
 >;


### PR DESCRIPTION
### Description:
Added a new `list_explores` tool to the MCP service that allows users to get a summary of all available explores in the current project. This tool provides basic metadata about each explore (name, label, base table, tags) without detailed field information, making it useful for discovery before using the more detailed `find_explores` tool.

The implementation includes:
- New schema definition in common package
- Tool registration in McpService
- Implementation of the tool functionality with XML output formatting
- Proper error handling and user permission validation

AI agents can now quickly discover what data sources are available before diving into detailed field exploration.