### PR TITLE
fix: border radius rules are not applying to horizontal bars

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -598,11 +598,13 @@ export class CartesianChartDataModel {
                     display?.series?.[col.referenceField]?.type ??
                     defaultSeriesType) === 'bar',
         ).length;
+        const isHorizontal = false; // CartesianChartDataModel doesn't support flipAxes
         const nonStackedBorderRadius = !shouldStack
             ? calculateDynamicBorderRadius(
                   dataToRender.length,
                   barSeriesCount,
                   false, // isStacked
+                  isHorizontal,
               )
             : undefined;
 
@@ -660,7 +662,7 @@ export class CartesianChartDataModel {
                     seriesType === 'bar' && !shouldStack
                         ? {
                               borderRadius: getBarBorderRadius(
-                                  false, // isHorizontal - CartesianChartDataModel doesn't support flipAxes
+                                  isHorizontal,
                                   true, // isStackEnd - always true for non-stacked bars
                                   nonStackedBorderRadius,
                               ),
@@ -749,6 +751,7 @@ export class CartesianChartDataModel {
                 dataPointCount,
                 stackedBarSeriesCount,
                 isStacked,
+                isHorizontal,
             );
 
             // Apply rounded corners to stack data
@@ -758,7 +761,7 @@ export class CartesianChartDataModel {
                 dataToRender,
                 {
                     radius,
-                    isHorizontal: false, // CartesianChartDataModel doesn't support flipAxes
+                    isHorizontal,
                     legendSelected: undefined,
                 },
             );

--- a/packages/common/src/visualizations/helpers/styles/barChartStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/barChartStyles.ts
@@ -11,29 +11,30 @@ import { GRAY_9 } from './themeColors';
  * @param dataPointCount - Number of data points (categories) in the chart
  * @param seriesCount - Number of bar series (non-stacked bars in same category)
  * @param isStacked - Whether bars are stacked
+ * @param isHorizontal - Whether the bar chart is horizontal (flipAxes)
  * @returns Appropriate border radius (max 4px, scales down for thin bars)
  */
 export const calculateDynamicBorderRadius = (
     dataPointCount: number,
     seriesCount: number,
     isStacked: boolean,
+    isHorizontal: boolean = false,
 ): number => {
-    // Estimate relative bar width based on number of categories and series
-    // Assumptions: typical chart is ~600px wide, barCategoryGap is 25%
-    const estimatedChartWidth = 600;
+    // Estimate relative bar width/height based on number of categories and series
+    // Assumptions: typical chart is ~600px wide, horizontal charts use ~200px height (1/3), barCategoryGap 25%
+    const estimatedChartSize = isHorizontal ? 200 : 600;
     const barCategoryGap = 0.25;
 
-    // Width available per category
-    const categoryWidth = estimatedChartWidth / dataPointCount;
+    const categorySize = estimatedChartSize / dataPointCount;
 
-    // Width for bars (after gap)
-    const barGroupWidth = categoryWidth * (1 - barCategoryGap);
+    // Size for bars (after gap)
+    const barGroupSize = categorySize * (1 - barCategoryGap);
 
-    // Individual bar width (stacked bars share width, non-stacked split it)
-    const barWidth = isStacked ? barGroupWidth : barGroupWidth / seriesCount;
+    // Individual bar size (stacked bars share size, non-stacked split it)
+    const barSize = isStacked ? barGroupSize : barGroupSize / seriesCount;
 
-    // Calculate radius as percentage of bar width (15%), capped at 4px minimum 2px
-    const dynamicRadius = Math.max(1, Math.min(4, barWidth * 0.15));
+    // Calculate radius as percentage of bar size (15%), capped at 4px minimum 2px
+    const dynamicRadius = Math.max(2, Math.min(4, barSize * 0.15));
 
     return Math.round(dynamicRadius);
 };

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1938,7 +1938,7 @@ const useEchartsCartesianConfig = (
     const stackedSeriesWithColorAssignments = useMemo(() => {
         if (!itemsMap) return;
 
-        const isHorizontal = validCartesianConfig?.layout.flipAxes;
+        const isHorizontal = Boolean(validCartesianConfig?.layout.flipAxes);
 
         // Calculate dynamic border radius based on chart characteristics
         const barSeries = series.filter(
@@ -1953,6 +1953,7 @@ const useEchartsCartesianConfig = (
             rows.length,
             Math.max(1, nonStackedBarCount),
             isStacked,
+            isHorizontal,
         );
 
         const seriesWithValidStack = series.map<EChartsSeries>((serie) => {
@@ -1987,7 +1988,7 @@ const useEchartsCartesianConfig = (
                         getValidStack(serie) === undefined) && {
                         itemStyle: {
                             borderRadius: getBarBorderRadius(
-                                !!isHorizontal,
+                                isHorizontal,
                                 true,
                                 dynamicRadius,
                             ),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17765

### Description:
Improved bar chart border radius calculation by adding `isHorizontal` parameter to properly handle horizontal bar charts. This ensures that border radius is calculated correctly based on the chart orientation, using appropriate size estimations for both vertical and horizontal layouts.

The changes:
- Added `isHorizontal` parameter to `calculateDynamicBorderRadius` function
- Updated the calculation to use different size estimations for horizontal charts (~200px) vs vertical charts (~600px)
- Ensured consistent use of the `isHorizontal` parameter across all border radius calculations
- Set minimum border radius to 2px for better visual appearance


_after_
![image.png](https://app.graphite.com/user-attachments/assets/4a6b1f36-8ea5-4e82-8b05-820bda9a64c1.png)


_before_
![image.png](https://app.graphite.com/user-attachments/assets/89319c01-b339-4a82-a229-1d91a6e290f4.png)


> [!IMPORTANT]  
> I think the best approach would be to pass the actual container's width/height. It was not straightforward, so I'm gonna defer that work for later!