### PR TITLE
fix: format values as percentages in 100% stacked charts

### DIFF
--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -83,3 +83,24 @@ describe('Pivot Tables', () => {
         cy.contains('$1.00');
     });
 });
+
+describe('100% stacked bar chart', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+    it('Can create a 100% stacked bar chart with correct percentage labels', () => {
+        // Load directly a chart with parameters to build a 100% bar chat with labels
+        const chartConfig = `?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_status%22%2C%22orders_order_date_month%22%5D%2C%22metrics%22%3A%5B%22orders_unique_order_count%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_status%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_status%22%2C%22orders_order_date_month%22%2C%22orders_unique_order_count%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_order_date_month%22%2C%22yField%22%3A%5B%22orders_unique_order_count%22%5D%2C%22stack%22%3A%22stack100%22%7D%2C%22eChartsConfig%22%3A%7B%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22label%22%3A%7B%22show%22%3Atrue%2C%22position%22%3A%22inside%22%7D%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_month%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_unique_order_count%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22orders_status%22%2C%22value%22%3A%22completed%22%7D%5D%7D%7D%2C%22stack%22%3A%22orders_unique_order_count%22%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22label%22%3A%7B%22show%22%3Atrue%2C%22position%22%3A%22inside%22%7D%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_month%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_unique_order_count%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22orders_status%22%2C%22value%22%3A%22placed%22%7D%5D%7D%7D%2C%22stack%22%3A%22orders_unique_order_count%22%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22label%22%3A%7B%22show%22%3Atrue%2C%22position%22%3A%22inside%22%7D%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_month%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_unique_order_count%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22orders_status%22%2C%22value%22%3A%22returned%22%7D%5D%7D%7D%2C%22stack%22%3A%22orders_unique_order_count%22%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22label%22%3A%7B%22show%22%3Atrue%2C%22position%22%3A%22inside%22%7D%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_month%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_unique_order_count%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22orders_status%22%2C%22value%22%3A%22return_pending%22%7D%5D%7D%7D%2C%22stack%22%3A%22orders_unique_order_count%22%2C%22isFilteredOut%22%3Afalse%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22label%22%3A%7B%22show%22%3Atrue%2C%22position%22%3A%22inside%22%7D%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_month%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_unique_order_count%22%2C%22pivotValues%22%3A%5B%7B%22field%22%3A%22orders_status%22%2C%22value%22%3A%22shipped%22%7D%5D%7D%7D%2C%22stack%22%3A%22orders_unique_order_count%22%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22orders_status%22%5D%7D%7D&isExploreFromHere=true`;
+        cy.visit(
+            `/projects/${SEED_PROJECT.project_uuid}/tables/orders${chartConfig}`,
+        );
+        cy.findByTestId('page-spinner').should('not.exist');
+
+        // These data should remain constant for the same data in orders table
+        // Check labels on the chart are showing % values
+        cy.get('svg').contains('100.0%').should('exist');
+        cy.get('svg').contains('88.9%').should('exist');
+        cy.get('svg').contains('22.2%').should('exist');
+        cy.get('svg').contains('0.0%').should('exist');
+    });
+});

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -5,9 +5,11 @@ import {
     buildCartesianTooltipFormatter,
     calculateDynamicBorderRadius,
     CartesianSeriesType,
+    CustomFormatType,
     DimensionType,
     evaluateConditionalFormatExpression,
     formatItemValue,
+    formatNumberValue,
     formatValueWithExpression,
     friendlyName,
     getCartesianAxisFormatterConfig as getAxisFormatterConfig,
@@ -588,6 +590,7 @@ type GetPivotSeriesArg = {
     pivotReference: Required<PivotReference>;
     pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null;
     parameters?: ParametersValuesMap;
+    isStack100?: boolean;
 };
 
 const seriesValueFormatter = (
@@ -623,6 +626,19 @@ const seriesValueFormatter = (
         const formatOptions = isMetric(item) ? item.formatOptions : undefined;
         return applyCustomFormat(value, formatOptions || defaultFormatOptions);
     }
+};
+
+/**
+ * Format value for 100% stacked charts
+ * For stack100, values are already percentages (0-100) so we just append %
+ */
+const formatStack100Value = (value: unknown): string => {
+    return typeof value === 'number'
+        ? `${formatNumberValue(value, {
+              type: CustomFormatType.NUMBER,
+              round: 1,
+          })}%`
+        : `${value}%`;
 };
 
 /**
@@ -675,6 +691,7 @@ const getPivotSeries = ({
     cartesianChart,
     pivotValuesColumnsMap,
     parameters,
+    isStack100,
 }: GetPivotSeriesArg): EChartsSeries => {
     const pivotLabel = pivotReference.pivotValues.reduce(
         (acc, { field, value }) => {
@@ -747,6 +764,12 @@ const getPivotSeries = ({
                                 yFieldHash,
                                 !!flipAxes,
                             );
+
+                            // For 100% stacked charts, values are already percentages (0-100)
+                            if (isStack100) {
+                                return formatStack100Value(raw);
+                            }
+
                             return seriesValueFormatter(field, raw, parameters);
                         },
                     }),
@@ -791,6 +814,7 @@ type GetSimpleSeriesArg = {
     xFieldHash: string;
     pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null;
     parameters?: ParametersValuesMap;
+    isStack100?: boolean;
 };
 
 const getSimpleSeries = ({
@@ -801,6 +825,7 @@ const getSimpleSeries = ({
     itemsMap,
     pivotValuesColumnsMap,
     parameters,
+    isStack100,
 }: GetSimpleSeriesArg) => ({
     ...series,
     xAxisIndex: flipAxes ? series.yAxisIndex : undefined,
@@ -862,6 +887,11 @@ const getSimpleSeries = ({
                             rawValue = v;
                         }
 
+                        // For 100% stacked charts, values are already percentages (0-100)
+                        if (isStack100) {
+                            return formatStack100Value(rawValue);
+                        }
+
                         return seriesValueFormatter(
                             field,
                             rawValue,
@@ -893,6 +923,9 @@ const getEchartsSeriesFromPivotedData = (
         | undefined,
     parameters?: ParametersValuesMap,
 ): EChartsSeries[] => {
+    // Check if 100% stacking is enabled
+    const isStack100 = cartesianChart.layout.stack === StackType.PERCENT;
+
     // Use pivotDetails to find the correct column name for each series
     const findMatchingColumnName = (series: Series): string | undefined => {
         if (isPivotReferenceWithValues(series.encode.yRef)) {
@@ -969,6 +1002,7 @@ const getEchartsSeriesFromPivotedData = (
                     yFieldHash,
                     pivotValuesColumnsMap,
                     parameters,
+                    isStack100,
                 });
             }
 
@@ -981,6 +1015,7 @@ const getEchartsSeriesFromPivotedData = (
                 xFieldHash,
                 pivotValuesColumnsMap,
                 parameters,
+                isStack100,
             });
         });
 
@@ -993,6 +1028,9 @@ const getEchartsSeries = (
     pivotKeys: string[] | undefined,
     parameters?: ParametersValuesMap,
 ): EChartsSeries[] => {
+    // Check if 100% stacking is enabled
+    const isStack100 = cartesianChart.layout.stack === StackType.PERCENT;
+
     return (cartesianChart.eChartsConfig.series || [])
         .filter((s) => !s.hidden)
         .map<EChartsSeries>((series) => {
@@ -1009,6 +1047,7 @@ const getEchartsSeries = (
                     xFieldHash,
                     yFieldHash,
                     parameters,
+                    isStack100,
                 });
             }
 
@@ -1019,6 +1058,7 @@ const getEchartsSeries = (
                 yFieldHash,
                 xFieldHash,
                 parameters,
+                isStack100,
             });
         });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-132/fix-stacked-bar-chart-value-labels
Closes: https://linear.app/lightdash/issue/CENG-131/fix-100percent-bar-chart-issues
Closes: https://github.com/lightdash/lightdash/issues/17739


Before

<img width="437" height="538" alt="Screenshot from 2025-11-05 12-44-44" src="https://github.com/user-attachments/assets/0cc92116-fd70-4c8d-8e14-bb9b7bfd6e18" />

Numbers were not formatted (https://github.com/lightdash/lightdash/issues/17739) : 

<img width="319" height="295" alt="image" src="https://github.com/user-attachments/assets/ae9a9283-b08c-4072-add0-f4f66a4bc4fe" />

SQL runner 

<img width="1275" height="395" alt="image" src="https://github.com/user-attachments/assets/bbbe593e-7a9f-444f-938d-e6dd024a196e" />

After
<img width="1273" height="552" alt="Screenshot from 2025-11-05 12-46-28" src="https://github.com/user-attachments/assets/0431cb94-ab56-47d4-b41f-4ec2aac21887" />

SQL runner

<img width="427" height="307" alt="image" src="https://github.com/user-attachments/assets/98682b71-7841-4864-af99-06f758f99dc3" />


### Added new e2e tests

<img width="1430" height="676" alt="image" src="https://github.com/user-attachments/assets/6c9be9ea-633b-4c7c-8f1c-94dc5053f220" />

### Description:
Improves formatting for 100% stacked charts by displaying values with a percentage sign and proper decimal rounding. This ensures that values in 100% stacked charts are consistently displayed as percentages, making the visualization more intuitive for users.

The implementation adds special formatting logic for stack100 charts in both the CartesianChartDataModel and the ECharts configuration hooks, ensuring that percentage values are properly formatted across all chart components.