### PR TITLE
feat: allow toggling feedback ratings in AI chat assistant

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -358,20 +358,18 @@ export const AssistantBubble: FC<Props> = memo(
         const hasRating = upVoted || downVoted;
 
         const handleUpvote = useCallback(() => {
-            if (hasRating) return;
             updateFeedbackMutation.mutate({
                 messageUuid: message.uuid,
-                humanScore: 1,
+                humanScore: upVoted ? 0 : 1,
             });
-        }, [hasRating, updateFeedbackMutation, message.uuid]);
+        }, [updateFeedbackMutation, message.uuid, upVoted]);
 
         const handleDownvote = useCallback(() => {
-            if (hasRating) return;
             updateFeedbackMutation.mutate({
                 messageUuid: message.uuid,
-                humanScore: -1,
+                humanScore: downVoted ? 0 : -1,
             });
-        }, [hasRating, updateFeedbackMutation, message.uuid]);
+        }, [updateFeedbackMutation, message.uuid, downVoted]);
 
         const isPending = message.status === 'pending';
         const isLoading =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Allow users to toggle their feedback on AI assistant messages by clicking the same button again. Previously, once a user upvoted or downvoted a message, they couldn't change their rating. Now, clicking the same button again will remove their feedback.
