### PR TITLE
feat: add human feedback text field to AI agent responses

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -484,13 +484,14 @@ export class AiAgentController extends BaseController {
         @Path() agentUuid: string,
         @Path() threadUuid: string,
         @Path() messageUuid: string,
-        @Body() body: { humanScore: number },
+        @Body() body: { humanScore: number; humanFeedback?: string | null },
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
         await this.getAiAgentService().updateHumanScoreForMessage(
             req.user!,
             messageUuid,
             body.humanScore,
+            body.humanFeedback,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -76,6 +76,7 @@ export type DbAiPrompt = {
     viz_config_output: object | null;
     filters_output: object | null;
     human_score: number | null;
+    human_feedback: string | null;
     metric_query: object | null;
     saved_query_uuid: string | null;
 };
@@ -93,6 +94,7 @@ export type AiPromptTable = Knex.CompositeTableType<
             | 'viz_config_output'
             | 'filters_output'
             | 'human_score'
+            | 'human_feedback'
             | 'metric_query'
             | 'saved_query_uuid'
         > & {

--- a/packages/backend/src/ee/database/migrations/20251105154122_add_human_feedback_to_ai_prompt.ts
+++ b/packages/backend/src/ee/database/migrations/20251105154122_add_human_feedback_to_ai_prompt.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const tableName = 'ai_prompt';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.text('human_feedback').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.dropColumn('human_feedback');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -1220,6 +1220,7 @@ export class AiAgentModel {
                     | 'viz_config_output'
                     | 'metric_query'
                     | 'human_score'
+                    | 'human_feedback'
                     | 'saved_query_uuid'
                 > &
                     Pick<DbUser, 'user_uuid'> &
@@ -1238,6 +1239,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.viz_config_output`,
                 `${AiPromptTableName}.metric_query`,
                 `${AiPromptTableName}.human_score`,
+                `${AiPromptTableName}.human_feedback`,
                 `${AiPromptTableName}.saved_query_uuid`,
                 `${UserTableName}.user_uuid`,
                 `${AiThreadTableName}.ai_thread_uuid`,
@@ -1322,6 +1324,7 @@ export class AiAgentModel {
                     row.responded_at?.toISOString() ??
                     row.created_at.toISOString(),
                 humanScore: row.human_score,
+                humanFeedback: row.human_feedback,
                 artifacts: artifacts ?? null,
                 referencedArtifacts: referencedArtifacts ?? null,
                 toolCalls: toolCalls
@@ -1699,6 +1702,7 @@ export class AiAgentModel {
                     | 'viz_config_output'
                     | 'metric_query'
                     | 'human_score'
+                    | 'human_feedback'
                     | 'saved_query_uuid'
                 > &
                     Pick<DbUser, 'user_uuid'> &
@@ -1717,6 +1721,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.viz_config_output`,
                 `${AiPromptTableName}.metric_query`,
                 `${AiPromptTableName}.human_score`,
+                `${AiPromptTableName}.human_feedback`,
                 `${AiPromptTableName}.saved_query_uuid`,
                 `${UserTableName}.user_uuid`,
                 `${AiThreadTableName}.ai_thread_uuid`,
@@ -1834,6 +1839,7 @@ export class AiAgentModel {
                     message: row.response ?? '',
                     createdAt: row.responded_at?.toString() ?? '',
                     humanScore: row.human_score,
+                    humanFeedback: row.human_feedback,
                     artifacts: artifacts.length > 0 ? artifacts : null,
                     referencedArtifacts,
                     toolCalls: toolCalls
@@ -1990,6 +1996,7 @@ export class AiAgentModel {
                 'viz_config_output',
                 'metric_query',
                 'human_score',
+                'human_feedback',
                 'user_uuid',
             )
             .select({
@@ -2125,10 +2132,13 @@ export class AiAgentModel {
     async updateHumanScore(data: {
         promptUuid: string;
         humanScore: number | null;
+        humanFeedback?: string | null;
     }) {
         await this.database(AiPromptTableName)
             .update({
                 human_score: data.humanScore,
+                human_feedback:
+                    data.humanScore === -1 ? data.humanFeedback ?? null : null,
             })
             .where({
                 ai_prompt_uuid: data.promptUuid,

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1519,6 +1519,7 @@ export class AiAgentService {
         user: SessionUser,
         messageUuid: string,
         humanScore: number,
+        humanFeedback?: string | null,
     ) {
         this.analytics.track<AiAgentPromptFeedbackEvent>({
             event: 'ai_agent_prompt.feedback',
@@ -1534,6 +1535,7 @@ export class AiAgentService {
         await this.aiAgentModel.updateHumanScore({
             promptUuid: messageUuid,
             humanScore,
+            humanFeedback,
         });
     }
 
@@ -2132,13 +2134,19 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 }
 
                 if (message.human_score) {
+                    let feedbackContent =
+                        // TODO: we don't have a neutral option, we are storing -1 and 1 at the moment
+                        message.human_score > 0
+                            ? 'I liked this response'
+                            : 'I did not like this response';
+
+                    if (message.human_feedback) {
+                        feedbackContent += `\nReasoning: ${message.human_feedback}`;
+                    }
+
                     messages.push({
                         role: 'user',
-                        content:
-                            // TODO: we don't have a neutral option, we are storing -1 and 1 at the moment
-                            message.human_score > 0
-                                ? 'I liked this response'
-                                : 'I did not like this response',
+                        content: feedbackContent,
                     } satisfies UserModelMessage);
                 }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6601,6 +6601,13 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'AiAgentToolCall' },
                     required: true,
                 },
+                humanFeedback: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 humanScore: {
                     dataType: 'union',
                     subSchemas: [
@@ -25416,6 +25423,13 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                humanFeedback: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 humanScore: { dataType: 'double', required: true },
             },
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7108,6 +7108,10 @@
                         },
                         "type": "array"
                     },
+                    "humanFeedback": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "humanScore": {
                         "type": "number",
                         "format": "double",

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -153,6 +153,7 @@ export type AiAgentMessageAssistant = {
     createdAt: string;
 
     humanScore: number | null;
+    humanFeedback?: string | null;
 
     toolCalls: AiAgentToolCall[];
     toolResults: AiAgentToolResult[];

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
@@ -1,17 +1,8 @@
-.contentLink {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--mantine-spacing-xxs);
-    padding: var(--mantine-spacing-two) var(--mantine-spacing-xs);
-    border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-gray-3);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    position: relative;
-    vertical-align: middle;
-    margin-right: var(--mantine-spacing-two);
-    &:hover {
-        background-color: var(--mantine-color-gray-1) !important;
+.feedbackInput {
+    background-color: rgba(255, 255, 255, 0.3) !important;
+
+    --input-bd-focus: var(--mantine-color-gray-7);
+    &:focus {
+        outline: 4px solid var(--mantine-color-gray-2);
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -10,8 +10,10 @@ import {
     Group,
     Loader,
     Paper,
+    Popover,
     Stack,
     Text,
+    Textarea,
     Tooltip,
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
@@ -20,6 +22,7 @@ import {
     IconCheck,
     IconCopy,
     IconExclamationCircle,
+    IconMessageX,
     IconRefresh,
     IconTestPipe,
     IconThumbDown,
@@ -28,7 +31,7 @@ import {
     IconThumbUpFilled,
 } from '@tabler/icons-react';
 import MDEditor from '@uiw/react-md-editor';
-import { memo, useCallback, type FC } from 'react';
+import { memo, useCallback, useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
     mdEditorComponents,
@@ -46,6 +49,7 @@ import {
     useAiAgentThreadMessageStreaming,
     useAiAgentThreadStreamQuery,
 } from '../../streaming/useAiAgentThreadStreamQuery';
+import styles from './AgentChatAssistantBubble.module.css';
 import AgentChatDebugDrawer from './AgentChatDebugDrawer';
 import { AiArtifactInline } from './AiArtifactInline';
 import { AiArtifactButton } from './ArtifactButton/AiArtifactButton';
@@ -287,6 +291,10 @@ export const AssistantBubble: FC<Props> = memo(
         const downVoted = message.humanScore === -1;
         const hasRating = upVoted || downVoted;
 
+        const [popoverOpened, { open: openPopover, close: closePopover }] =
+            useDisclosure(false);
+        const [feedbackText, setFeedbackText] = useState('');
+
         const handleUpvote = useCallback(() => {
             updateFeedbackMutation.mutate({
                 messageUuid: message.uuid,
@@ -295,11 +303,36 @@ export const AssistantBubble: FC<Props> = memo(
         }, [updateFeedbackMutation, message.uuid, upVoted]);
 
         const handleDownvote = useCallback(() => {
-            updateFeedbackMutation.mutate({
-                messageUuid: message.uuid,
-                humanScore: downVoted ? 0 : -1,
-            });
-        }, [updateFeedbackMutation, message.uuid, downVoted]);
+            if (downVoted) {
+                updateFeedbackMutation.mutate({
+                    messageUuid: message.uuid,
+                    humanScore: 0,
+                });
+            } else {
+                updateFeedbackMutation.mutate({
+                    messageUuid: message.uuid,
+                    humanScore: -1,
+                });
+                openPopover();
+            }
+        }, [updateFeedbackMutation, message.uuid, downVoted, openPopover]);
+
+        const handleSubmitFeedback = useCallback(() => {
+            if (feedbackText.trim().length !== 0) {
+                updateFeedbackMutation.mutate({
+                    messageUuid: message.uuid,
+                    humanScore: -1,
+                    humanFeedback: feedbackText.trim(),
+                });
+            }
+            closePopover();
+            setFeedbackText('');
+        }, [updateFeedbackMutation, message.uuid, feedbackText, closePopover]);
+
+        const handleCancelFeedback = useCallback(() => {
+            closePopover();
+            setFeedbackText('');
+        }, [closePopover]);
 
         const isPending = message.status === 'pending';
         const isLoading =
@@ -379,6 +412,25 @@ export const AssistantBubble: FC<Props> = memo(
                               ))}
                     </Stack>
                 )}
+                {!popoverOpened && downVoted && message.humanFeedback && (
+                    <Paper p="xs" mt="xs" radius="md" withBorder>
+                        <Stack gap="xs">
+                            <Group gap="xs">
+                                <MantineIcon
+                                    icon={IconMessageX}
+                                    size={16}
+                                    color="gray.7"
+                                />
+                                <Text size="xs" c="dimmed" fw={600}>
+                                    User feedback
+                                </Text>
+                            </Group>
+                            <Text size="sm" c="dimmed" fw={500}>
+                                {message.humanFeedback}
+                            </Text>
+                        </Stack>
+                    </Paper>
+                )}
                 {isLoading ? null : (
                     <Group gap={0}>
                         <CopyButton value={message.message ?? ''}>
@@ -423,20 +475,81 @@ export const AssistantBubble: FC<Props> = memo(
                         )}
 
                         {(!hasRating || downVoted) && (
-                            <ActionIcon
-                                variant="subtle"
-                                color="gray"
-                                aria-label="downvote"
-                                onClick={handleDownvote}
+                            <Popover
+                                width={500}
+                                position="top-start"
+                                trapFocus
+                                opened={popoverOpened}
+                                onChange={() => {
+                                    closePopover();
+                                    setFeedbackText('');
+                                }}
+                                withArrow
                             >
-                                <MantineIcon
-                                    icon={
-                                        downVoted
-                                            ? IconThumbDownFilled
-                                            : IconThumbDown
-                                    }
-                                />
-                            </ActionIcon>
+                                <Popover.Target>
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="gray"
+                                        aria-label="downvote"
+                                        onClick={handleDownvote}
+                                    >
+                                        <MantineIcon
+                                            icon={
+                                                downVoted
+                                                    ? IconThumbDownFilled
+                                                    : IconThumbDown
+                                            }
+                                        />
+                                    </ActionIcon>
+                                </Popover.Target>
+                                <Popover.Dropdown>
+                                    <form
+                                        onSubmit={(e) => {
+                                            e.preventDefault();
+                                            handleSubmitFeedback();
+                                        }}
+                                    >
+                                        <Stack gap="xs">
+                                            <Textarea
+                                                autoFocus
+                                                classNames={{
+                                                    input: styles.feedbackInput,
+                                                }}
+                                                placeholder="Tell us what went wrong, feedback will be added to agent context (optional)"
+                                                value={feedbackText}
+                                                onChange={(e) =>
+                                                    setFeedbackText(
+                                                        e.currentTarget.value,
+                                                    )
+                                                }
+                                                minRows={3}
+                                                maxRows={5}
+                                                radius="md"
+                                                resize="vertical"
+                                            />
+                                            <Group gap="xs">
+                                                <Button
+                                                    type="submit"
+                                                    size="xs"
+                                                    color="dark.5"
+                                                >
+                                                    Submit
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    size="xs"
+                                                    variant="subtle"
+                                                    onClick={
+                                                        handleCancelFeedback
+                                                    }
+                                                >
+                                                    Cancel
+                                                </Button>
+                                            </Group>
+                                        </Stack>
+                                    </form>
+                                </Popover.Dropdown>
+                            </Popover>
                         )}
 
                         {showAddToEvalsButton && onAddToEvals && (

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -394,6 +394,7 @@ const createOptimisticMessages = (
             filtersOutput: null,
             metricQuery: null,
             humanScore: null,
+            humanFeedback: null,
             toolCalls: [],
             toolResults: [],
             reasoning: [],
@@ -716,11 +717,12 @@ const updatePromptFeedback = async (
     threadUuid: string,
     messageUuid: string,
     humanScore: number,
+    humanFeedback?: string | null,
 ) =>
     lightdashApi<ApiSuccessEmpty>({
         url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/messages/${messageUuid}/feedback`,
         method: 'PATCH',
-        body: JSON.stringify({ humanScore }),
+        body: JSON.stringify({ humanScore, humanFeedback }),
     });
 
 export const useUpdatePromptFeedbackMutation = (
@@ -735,17 +737,22 @@ export const useUpdatePromptFeedbackMutation = (
     return useMutation<
         ApiSuccessEmpty,
         ApiError,
-        { messageUuid: string; humanScore: number }
+        {
+            messageUuid: string;
+            humanScore: number;
+            humanFeedback?: string | null;
+        }
     >({
-        mutationFn: ({ messageUuid, humanScore }) =>
+        mutationFn: ({ messageUuid, humanScore, humanFeedback }) =>
             updatePromptFeedback(
                 projectUuid,
                 agentUuid,
                 threadUuid,
                 messageUuid,
                 humanScore,
+                humanFeedback,
             ),
-        onMutate: ({ messageUuid, humanScore }) => {
+        onMutate: ({ messageUuid, humanScore, humanFeedback }) => {
             queryClient.setQueryData(
                 [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', threadUuid],
                 (
@@ -757,14 +764,24 @@ export const useUpdatePromptFeedbackMutation = (
 
                     return {
                         ...currentData,
-                        messages: currentData.messages.map((message) =>
-                            message.uuid === messageUuid
-                                ? {
-                                      ...message,
-                                      humanScore,
-                                  }
-                                : message,
-                        ),
+                        messages: currentData.messages.map((message) => {
+                            if (message.uuid !== messageUuid) {
+                                return message;
+                            }
+
+                            if (message.role !== 'assistant') {
+                                return message;
+                            }
+
+                            return {
+                                ...message,
+                                humanScore,
+                                humanFeedback:
+                                    humanScore === -1
+                                        ? humanFeedback ?? null
+                                        : null,
+                            };
+                        }),
                     };
                 },
             );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added human feedback functionality to AI agent responses. Users can now provide detailed feedback when downvoting an AI response, which is stored in the database and displayed in the chat interface. The feedback is also included in the agent context for future interactions.

This PR:

- Adds a `human_feedback` column to the `ai_prompt` table
- Implements a feedback input form that appears when users downvote a response
- Displays submitted feedback in the chat interface
- Includes feedback in the agent context with the format "I did not like this response\nReasoning: [feedback]"
- Updates API endpoints and types to support the new feedback field
