### PR TITLE
fix: set correct overflow on tables with footer

### DIFF
--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -187,7 +187,11 @@ const TableComponent = forwardRef<HTMLTableElement, TableProps>(
                 miw="inherit"
                 h="inherit"
                 pos="relative"
-                sx={{ overflow: 'auto' }}
+                sx={{
+                    overflow: 'auto',
+                    border: '1px solid #dcdcdd',
+                    borderRadius: '4px',
+                }}
             >
                 <Box
                     ref={ref}

--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -16,8 +16,6 @@ export const useTableStyles = createStyles((theme) => {
             borderSpacing: 0,
 
             borderRadius: '4px',
-            border: `1px solid ${borderColor}`,
-            overflow: 'hidden',
 
             margin: 0,
             padding: 0,

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -18,6 +18,7 @@ export const TableScrollableWrapper = styled.div`
     overflow: auto;
     min-width: 100%;
     border-radius: 4px;
+    border: 1px solid #dcdcdd;
 `;
 
 interface TableContainerProps {
@@ -55,10 +56,6 @@ export const Table = styled.table<{ $showFooter?: boolean }>`
     background-color: white;
     width: 100%;
     border-radius: 4px;
-    overflow: hidden;
-
-    /* Outer table border - solid gray border around entire table with border-radius */
-    border: 1px solid #dcdcdd;
 
     th,
     td {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17901

### Description:

Moved the border styling from the `Table` component to the `TableScrollableWrapper` to ensure proper border display when the table is scrollable. This fixes the issue where the border would be cut off or not properly displayed when the table content overflows.



[CleanShot 2025-11-05 at 18.54.51.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/687554e5-407d-44a2-9bcb-8ff63f8bb490.mp4" />](https://app.graphite.com/user-attachments/video/687554e5-407d-44a2-9bcb-8ff63f8bb490.mp4)



[CleanShot 2025-11-05 at 18.41.35.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8fbc27ed-f648-4b33-aac2-9cabe9be28a4.mp4" />](https://app.graphite.com/user-attachments/video/8fbc27ed-f648-4b33-aac2-9cabe9be28a4.mp4)