### PR TITLE
fix: column order was duplicaing customSqlDimenions

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1020,7 +1020,6 @@ export class SavedChartModel {
                     ...fields,
                     ...tableCalculations,
                     ...customBinDimensionsRows,
-                    ...customSqlDimensionsRows,
                 ]
                     .sort((a, b) => a.order - b.order)
                     .map((x) => x.name);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17902

### Description:
Removed `customSqlDimensionsRows` from the array of fields being sorted and mapped in the `SavedChartModel` class. 

`customSqlDimensions` are returned in `fields` query