### PR TITLE
fix: use formatItemValue instead of formatValueWithExpression

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -4,7 +4,6 @@ import {
     CustomFormatType,
     applyCustomFormat,
     formatItemValue,
-    formatValueWithExpression,
     friendlyName,
     getCustomFormatFromLegacy,
     getItemId,
@@ -266,7 +265,7 @@ const useBigNumberConfig = (
             hasValidFormatExpression(item) &&
             !bigNumberStyle // If the big number has a comparison style, don't use the format expression returned by the backend
         ) {
-            return formatValueWithExpression(item.format, firstRowValueRaw);
+            return formatItemValue(item, firstRowValueRaw, false, parameters);
         } else if (item !== undefined && hasFormatOptions(item)) {
             // Custom metrics case
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/17906



Before
<img width="1260" height="799" alt="Screenshot from 2025-11-06 09-47-50" src="https://github.com/user-attachments/assets/14fbeffc-0077-413f-a568-0f5d874c93db" />


After

[Screencast from 2025-11-06 10-19-28.webm](https://github.com/user-attachments/assets/aa50612f-1d17-4303-8770-ef96ac3c0091)


### Description:
Replace `formatValueWithExpression` with `formatItemValue` in `useBigNumberConfig.ts` to ensure consistent formatting behavior. This change allows the function to properly handle format expressions while also passing the parameters needed for correct value formatting.