### PR TITLE
fix: Agent evals runflow

### DIFF
--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -212,7 +212,10 @@ jobs:
                   PGPORT: 5432
                   PGUSER: postgres
                   PGPASSWORD: password
-                  PGDATABASE: lightdash
+                  # TODO :: improve database name management
+                  # PGCONNECTIONURI will be suffixed with _test and used for the application database
+                  # PGDATABASE will be used for seeding the test database and warehouse credentials (won't be suffixed)
+                  PGDATABASE: lightdash_test
                   AI_COPILOT_ENABLED: true
                   AI_DEFAULT_PROVIDER: ${{ matrix.ai_provider }}
                   OPENAI_MODEL_NAME: ${{ matrix.ai_provider == 'openai' && matrix.model_name || '' }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the database configuration in the AI agent integration tests workflow to use `lightdash_test` as the PGDATABASE value instead of `lightdash`. Added clarifying comments about database name management, explaining that PGCONNECTIONURI will be suffixed with `_test` for the application database, while PGDATABASE is used for seeding the test database and warehouse credentials without being suffixed.
