### PR TITLE
fix: update parameter placeholder detection in chart formatting

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -98,10 +98,10 @@ models:
            
             with_currency_parameter: 
               type: sum 
-              format: '${ld.parameters.currency=="usd"?"$":""}${ld.parameters.currency=="eur"?"€":""}${ld.parameters.currency=="gbp"?"£":""}0,0.00'
+              format: '${lightdash.parameters.currency=="usd"?"$":""}${lightdash.parameters.currency=="eur"?"€":""}${lightdash.parameters.currency=="gbp"?"£":""}0,0.00'
               sql: |
                 CASE 
-                  WHEN ${ld.parameters.currency} = 'usd' THEN ${event_id} * 1
+                  WHEN ${lightdash.parameters.currency} = 'usd' THEN ${event_id} * 1
                   ELSE ${event_id} * 0.86
                 END
             with_multiple_parameters: 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -45,6 +45,7 @@ import {
     isMetric,
     isPivotReferenceWithValues,
     isTableCalculation,
+    LightdashParameters,
     MetricType,
     StackType,
     TableCalculationType,
@@ -601,7 +602,8 @@ const seriesValueFormatter = (
     if (hasValidFormatExpression(item)) {
         // Check if format uses parameter placeholders
         const hasParameterPlaceholders =
-            item.format.includes('${ld.parameters');
+            item.format.includes(`\${${LightdashParameters.PREFIX_SHORT}`) ||
+            item.format.includes(`\${${LightdashParameters.PREFIX}`);
 
         // Evaluate conditional expressions if parameters are provided
         const formatExpression =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

See thread: https://lightdash.slack.com/archives/C08LVBCMMSQ/p1762422385598529?thread_ts=1759414406.927949&cid=C08LVBCMMSQ

```
              format:               '${lightdash.parameters.currency=="usd"?"$":""}${lightdash.parameters.currency=="eur"?"€":""}${lightdash.parameters.currency=="gbp"?"£":""}0,0.00'

```


Before
<img width="1274" height="724" alt="image" src="https://github.com/user-attachments/assets/5c2577d9-e888-4525-ab7e-a8fe7085945b" />


After
<img width="1227" height="756" alt="image" src="https://github.com/user-attachments/assets/2b56d4dd-a977-4853-8a82-7b67cc119b3f" />



### Description:
Fix parameter reference in format expressions by updating the parameter placeholder detection logic to support both `ld.parameters` and `lightdash.parameters` prefixes. This ensures consistent parameter handling in chart formatting.

The PR:
1. Updates an example in events.yml to use `lightdash.parameters.currency` instead of `ld.parameters.currency` in one place
2. Enhances the parameter placeholder detection in useEchartsCartesianConfig.ts to check for both short and full parameter prefix formats