### PR TITLE
fix: improve tooltip positioning and z-index

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/tooltipStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/tooltipStyles.ts
@@ -22,6 +22,7 @@ export const getTooltipStyle = () => ({
     borderWidth: 1,
     borderRadius: 8,
     backgroundColor: WHITE,
+    appendToBody: true,
     textStyle: {
         color: GRAY_7,
         fontSize: 12,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17771

### Description:
Enhances tooltip functionality by appending tooltips to the document body and removing confinement restrictions. This allows tooltips to be displayed outside their parent container boundaries. Also increases the z-index to ensure tooltips appear above other elements on the page.