### PR TITLE
fix: scheduled deliveries with multiple targets are not delivering the email to everyone

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -38,6 +38,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { getSchedule, stringToArray } from 'cron-converter';
+import { createHash } from 'crypto';
 import { WorkerUtils, makeWorkerUtils } from 'graphile-worker';
 import moment from 'moment';
 import { nanoid } from 'nanoid';
@@ -209,9 +210,17 @@ export class SchedulerClient {
                 // Generate job key for scheduled delivery jobs to enable efficient lookup
                 // by the indexed 'key' column instead of scanning JSON payload
                 // We only define keys when there is a schedulerUuid, if it is undefined it means it was a manual run of the task (send now)
+                // Include a hash of the payload to differentiate jobs with different configurations (e.g. send email to different users)
                 const { schedulerUuid } = payload;
                 const jobKey = schedulerUuid
-                    ? `scheduler:${schedulerUuid}:${scheduledAt.getTime()}`
+                    ? (() => {
+                          // Hash the payload (excluding Sentry tracing headers) to create a stable key
+                          const payloadForHash = JSON.stringify(payload);
+                          const payloadHash = createHash('sha256')
+                              .update(payloadForHash)
+                              .digest('hex'); // Use full hash to prevent any collision risk
+                          return `scheduler:${schedulerUuid}:${scheduledAt.getTime()}:${payloadHash}`;
+                      })()
                     : undefined;
 
                 const { id } = await graphileClient.addJob(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17916

### Description:
Enhance scheduler job key generation by including a hash of the payload to differentiate jobs with different configurations. This ensures that scheduled jobs with the same UUID but different parameters (e.g., sending emails to different users) will have unique keys, preventing potential conflicts or overwrites.

The implementation uses SHA-256 to create a stable, collision-resistant hash from the job payload, which is then appended to the existing job key format.

**Steps to reproduce**
1. Create a scheduled delivery with multiple targets
2. Email is only delivered to one