### PR TITLE
fix: improve big number font size in smaller tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/gridUtils.ts
+++ b/packages/frontend/src/components/DashboardTabs/gridUtils.ts
@@ -14,7 +14,7 @@ const DEFAULT_COLS = 36;
 /**
  * Row height: fontSize * lineHeight + padding + borders
  */
-const DEFAULT_ROW_HEIGHT = 14 * 1.5 + 16 * 2 + 2;
+export const DEFAULT_ROW_HEIGHT = 14 * 1.5 + 16 * 2 + 2;
 
 export const getReactGridLayoutConfig = (
     tile: DashboardTile,

--- a/packages/frontend/src/components/DashboardTiles/TileBase/constants.ts
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/constants.ts
@@ -1,1 +1,0 @@
-export const TILE_HEADER_HEIGHT = 24;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17897

### Description:
Improves the responsive design of the SimpleStatistic component by:

- Exporting `DEFAULT_ROW_HEIGHT` from gridUtils.ts for consistent sizing
- Removing the separate TILE_HEADER_HEIGHT constant file
- Adjusting font size minimums for better readability (22px for values, 12px for labels)
- Optimizing line height and spacing calculations for better visual appearance
- Adding logic to remove margins when components are at minimum size to prevent overflow
- Improving text scaling behavior with more appropriate min/max values
- Fixing line height for comparison pill text

This change ensures statistics display properly at various sizes, especially in small dashboard tiles.


_after_
![image.png](https://app.graphite.com/user-attachments/assets/ae6726c0-cb55-4b2a-83d1-aa15994eceb0.png)

_before_
![image.png](https://app.graphite.com/user-attachments/assets/40e50915-e563-47c4-8340-4396c6569379.png)

