### PR TITLE
fix: set default showTableNames to false

### DIFF
--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -64,9 +64,7 @@ const useTableConfig = (
     >(tableChartConfig?.conditionalFormattings ?? []);
 
     const [showTableNames, setShowTableNames] = useState<boolean>(
-        tableChartConfig?.showTableNames === undefined
-            ? true
-            : tableChartConfig.showTableNames,
+        tableChartConfig?.showTableNames ?? false,
     );
     const [showResultsTotal, setShowResultsTotal] = useState<boolean>(
         tableChartConfig?.showResultsTotal ?? false,

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -6,7 +6,7 @@ import { type ConfigCacheMap } from './types';
 const DEFAULTS: Record<ChartType, () => unknown> = {
     [ChartType.CARTESIAN]: () => ({ ...EMPTY_CARTESIAN_CHART_CONFIG }), // factory to avoid shared refs
     [ChartType.BIG_NUMBER]: () => ({}),
-    [ChartType.TABLE]: () => ({}),
+    [ChartType.TABLE]: () => ({ showTableNames: false }),
     [ChartType.PIE]: () => ({}),
     [ChartType.FUNNEL]: () => ({}),
     [ChartType.TREEMAP]: () => ({}),


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/9841

### Description:

Changed the default behavior for showing table names in table visualizations. Previously, table names were shown by default (true), but now they are hidden by default (false). This change ensures consistent behavior between the initial state in `useTableConfig` and the default configuration in the Explorer provider.