### PR TITLE
feat: add option to show/hide axis tick lines in charts

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -286,6 +286,7 @@ export type CompleteEChartsConfig = {
     xAxis: XAxis[];
     yAxis: Axis[];
     tooltip?: string;
+    showAxisTicks?: boolean;
 };
 
 export type EChartsConfig = Partial<CompleteEChartsConfig>;

--- a/packages/common/src/visualizations/helpers/styles/axisStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/axisStyles.ts
@@ -31,9 +31,12 @@ export const getAxisLineStyle = () => ({
 
 /**
  * Get tick line styling (small marks on axis)
+ * @param show - Whether to show tick lines. Defaults to true when undefined for backwards compatibility with existing charts, false for new charts
  */
-export const getAxisTickStyle = () => ({
-    show: true,
+export const getAxisTickStyle = (show?: boolean) => ({
+    // For backwards compatibility: undefined means show ticks (existing charts)
+    // false means hide ticks (new charts default to hidden)
+    show: show ?? true,
     lineStyle: {
         color: GRAY_4,
         type: 'solid' as const,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -71,6 +71,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setShowGridY,
         setShowXAxis,
         setShowYAxis,
+        setShowAxisTicks,
         setXAxisSort,
         setXAxisLabelRotation,
         dirtyChartType,
@@ -369,6 +370,18 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             }}
                         />
                     </Stack>
+                </Config.Section>
+            </Config>
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Show tick lines</Config.Heading>
+                    <Checkbox
+                        label="Show tick lines on axes"
+                        checked={!!dirtyEchartsConfig?.showAxisTicks}
+                        onChange={(e) => {
+                            setShowAxisTicks(e.currentTarget.checked);
+                        }}
+                    />
                 </Config.Section>
             </Config>
         </Stack>

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -157,7 +157,9 @@ function getXAxisSortConfig(
 
 export const EMPTY_CARTESIAN_CHART_CONFIG: CartesianChart = {
     layout: {},
-    eChartsConfig: {},
+    eChartsConfig: {
+        showAxisTicks: false, // New charts default to hiding tick lines
+    },
 };
 
 const useCartesianChartConfig = ({
@@ -180,7 +182,14 @@ const useCartesianChartConfig = ({
 
     const [dirtyEchartsConfig, setDirtyEchartsConfig] = useState<
         Partial<CartesianChart['eChartsConfig']> | undefined
-    >(initialChartConfig?.eChartsConfig);
+    >(
+        initialChartConfig?.eChartsConfig
+            ? {
+                  ...EMPTY_CARTESIAN_CHART_CONFIG.eChartsConfig,
+                  ...initialChartConfig.eChartsConfig,
+              }
+            : initialChartConfig?.eChartsConfig,
+    );
     const isInitiallyStacked = (dirtyEchartsConfig?.series || []).some(
         (series: Series) => series.stack !== undefined,
     );
@@ -370,6 +379,12 @@ const useCartesianChartConfig = ({
         setDirtyLayout((prev) => ({
             ...prev,
             showYAxis: hide,
+        }));
+    }, []);
+    const setShowAxisTicks = useCallback((show: boolean) => {
+        setDirtyEchartsConfig((prev) => ({
+            ...prev,
+            showAxisTicks: show,
         }));
     }, []);
     const setXAxisSort = useCallback((sort: XAxisSort) => {
@@ -1047,6 +1062,7 @@ const useCartesianChartConfig = ({
         setShowGridY,
         setShowXAxis,
         setShowYAxis,
+        setShowAxisTicks,
         setXAxisSort,
         setXAxisLabelRotation,
         updateSeries,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1563,7 +1563,9 @@ const getEchartAxes = ({
                     ? gridStyle
                     : { show: false },
                 axisLine: getAxisLineStyle(),
-                axisTick: getAxisTickStyle(),
+                axisTick: getAxisTickStyle(
+                    validCartesianConfig?.eChartsConfig?.showAxisTicks,
+                ),
                 // Override formatter for 100% stacking with flipped axes
                 ...(shouldStack100 &&
                     validCartesianConfig.layout.flipAxes &&
@@ -1616,7 +1618,9 @@ const getEchartAxes = ({
                     ? gridStyle
                     : { show: false },
                 axisLine: getAxisLineStyle(),
-                axisTick: getAxisTickStyle(),
+                axisTick: getAxisTickStyle(
+                    validCartesianConfig?.eChartsConfig?.showAxisTicks,
+                ),
                 ...topAxisExtraConfig,
             },
         ],
@@ -1667,7 +1671,9 @@ const getEchartAxes = ({
                     ? gridStyle
                     : { show: false },
                 axisLine: getAxisLineStyle(),
-                axisTick: getAxisTickStyle(),
+                axisTick: getAxisTickStyle(
+                    validCartesianConfig?.eChartsConfig?.showAxisTicks,
+                ),
                 inverse: !!yAxisConfiguration?.[0].inverse,
                 ...leftAxisExtraConfig,
             },
@@ -1716,7 +1722,9 @@ const getEchartAxes = ({
                     ? gridStyle
                     : { show: false },
                 axisLine: getAxisLineStyle(),
-                axisTick: getAxisTickStyle(),
+                axisTick: getAxisTickStyle(
+                    validCartesianConfig?.eChartsConfig?.showAxisTicks,
+                ),
                 ...rightAxisExtraConfig,
             },
         ],


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17663

### Description:
Added an option to show/hide tick lines on chart axes. By default, new charts will hide tick lines for a cleaner look, while existing charts will maintain their current appearance for backward compatibility.

The PR adds:
- A new `showAxisTicks` property to the ECharts configuration
- A checkbox in the Axes configuration panel to toggle tick lines visibility
- Updated axis styling logic to respect this new configuration

![image](https://github.com/user/repo/assets/12345/example-image-id)