### PR TITLE
fix: legend shape changes when disabling item

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/legendStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/legendStyles.ts
@@ -16,7 +16,7 @@ export const getLegendStyle = (iconType: LegendIconType = 'square') => ({
           }
         : {
               icon: 'roundRect',
-              itemStyle: { borderRadius: 3 },
+              itemStyle: { borderRadius: 3, borderWidth: 0 },
           }),
     textStyle: {
         color: GRAY_7,
@@ -24,6 +24,7 @@ export const getLegendStyle = (iconType: LegendIconType = 'square') => ({
         fontWeight: 500,
         padding: [0, 0, 0, 2],
     },
+    inactiveBorderWidth: 0, // Remove border on inactive items to prevent visual size increase
     // Navigation controls (for scrollable legends)
     pageButtonItemGap: 16, // Space between left arrow, page text, and right arrow
     pageButtonGap: 8, // Space between legend items and navigation controls


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17732

### Description:
Legend shapes were changing between inactive/active states because of the border color. When elements are active, in charts with defined border colors (pies, funnels), it adds a color to it. Because the chart border color is white, the legend border disappears, making the element look smaller:

_after_
[Screen Recording 2025-11-06 at 15.51.47.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d9952725-d219-4d2b-9363-069b0dded58d.mov" />](https://app.graphite.com/user-attachments/video/d9952725-d219-4d2b-9363-069b0dded58d.mov)

_before_
[Screen Recording 2025-11-06 at 15.52.20.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a39fa29e-2539-46cd-bbfd-44bdf990552d.mov" />](https://app.graphite.com/user-attachments/video/a39fa29e-2539-46cd-bbfd-44bdf990552d.mov)
