### PR TITLE
fix: allow setting targetPath on cli commands

### DIFF
--- a/packages/cli/src/dbt/context.test.ts
+++ b/packages/cli/src/dbt/context.test.ts
@@ -96,4 +96,142 @@ models-path: "models"
             expect(context.modelsDir).toBe(path.join(tempDir, 'models'));
         });
     });
+
+    describe('target-path precedence', () => {
+        test('should use DBT_TARGET_PATH env var when set', async () => {
+            process.env.DBT_TARGET_PATH = 'env-target';
+
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+target-path: "yml-target"
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({ projectDir: tempDir });
+
+            expect(context.targetDir).toBe(path.join(tempDir, 'env-target'));
+        });
+
+        test('should use CLI option over DBT_TARGET_PATH env var', async () => {
+            process.env.DBT_TARGET_PATH = 'env-target';
+
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+target-path: "yml-target"
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({
+                projectDir: tempDir,
+                targetPath: 'cli-target',
+            });
+
+            expect(context.targetDir).toBe(path.join(tempDir, 'cli-target'));
+        });
+
+        test('should use CLI option over dbt_project.yml', async () => {
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+target-path: "yml-target"
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({
+                projectDir: tempDir,
+                targetPath: 'cli-target',
+            });
+
+            expect(context.targetDir).toBe(path.join(tempDir, 'cli-target'));
+        });
+
+        test('should use dbt_project.yml when no env var or CLI option', async () => {
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+target-path: "yml-target"
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({ projectDir: tempDir });
+
+            expect(context.targetDir).toBe(path.join(tempDir, 'yml-target'));
+        });
+
+        test('should use default target when nothing is set', async () => {
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({ projectDir: tempDir });
+
+            expect(context.targetDir).toBe(path.join(tempDir, './target'));
+        });
+
+        test('should use absolute path from DBT_TARGET_PATH without joining', async () => {
+            const absoluteTargetPath =
+                '/usr/app/examples/full-jaffle-shop/dbt/test_target';
+            process.env.DBT_TARGET_PATH = absoluteTargetPath;
+
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({ projectDir: tempDir });
+
+            expect(context.targetDir).toBe(absoluteTargetPath);
+        });
+
+        test('should use absolute path from CLI option without joining', async () => {
+            const absoluteTargetPath =
+                '/usr/app/examples/full-jaffle-shop/dbt/test_target';
+
+            const dbtProjectContent = `name: test_project
+profile: test_profile
+models-path: "models"
+`;
+
+            await fs.writeFile(
+                path.join(tempDir, 'dbt_project.yml'),
+                dbtProjectContent,
+            );
+
+            const context = await getDbtContext({
+                projectDir: tempDir,
+                targetPath: absoluteTargetPath,
+            });
+
+            expect(context.targetDir).toBe(absoluteTargetPath);
+        });
+    });
 });

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -55,7 +55,10 @@ export const compile = async (options: CompileHandlerOptions) => {
 
     GlobalState.debug(`> Compiling with project dir ${absoluteProjectPath}`);
 
-    const context = await getDbtContext({ projectDir: absoluteProjectPath });
+    const context = await getDbtContext({
+        projectDir: absoluteProjectPath,
+        targetPath: options.targetPath,
+    });
 
     const compiledModelIds: string[] | undefined =
         await maybeCompileModelsAndJoins(

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -124,6 +124,7 @@ type CreateProjectOptions = {
     copyContent?: boolean;
     warehouseCredentials?: boolean;
     organizationCredentials?: string;
+    targetPath?: string;
 };
 
 export const createProject = async (
@@ -146,7 +147,10 @@ export const createProject = async (
     const dbtVersion = await getDbtVersion();
 
     const absoluteProjectPath = path.resolve(options.projectDir);
-    const context = await getDbtContext({ projectDir: absoluteProjectPath });
+    const context = await getDbtContext({
+        projectDir: absoluteProjectPath,
+        targetPath: options.targetPath,
+    });
 
     let targetName: string | undefined;
     let credentials: CreateWarehouseCredentials | undefined;

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -30,6 +30,7 @@ export type DbtCompileOptions = {
     skipWarehouseCatalog: boolean | undefined;
     useDbtList: boolean | undefined;
     defer: boolean | undefined;
+    targetPath: string | undefined;
 };
 
 const dbtCompileArgs = [
@@ -47,6 +48,7 @@ const dbtCompileArgs = [
     'state',
     'fullRefresh',
     'defer',
+    'targetPath',
 ];
 
 const camelToSnakeCase = (str: string) =>

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -133,6 +133,7 @@ const createNewProject = async (
     const absoluteProjectPath = path.resolve(options.projectDir);
     const context = await getDbtContext({
         projectDir: absoluteProjectPath,
+        targetPath: options.targetPath,
     });
     const dbtName = friendlyName(context.projectName);
 

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -70,6 +70,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
 
     const context = await getDbtContext({
         projectDir: absoluteProjectPath,
+        targetPath: options.targetPath,
     });
     const profileName = options.profile || context.profileName;
 

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -288,6 +288,7 @@ export const previewHandler = async (
         const absoluteProjectPath = path.resolve(options.projectDir);
         const context = await getDbtContext({
             projectDir: absoluteProjectPath,
+            targetPath: options.targetPath,
         });
         const manifestFilePath = path.join(context.targetDir, 'manifest.json');
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -315,6 +315,11 @@ program
         undefined,
     )
     .option('--target <name>', 'target to use in profiles.yml file', undefined)
+    .option(
+        '--target-path <path>',
+        'The target directory for dbt (overrides DBT_TARGET_PATH and dbt_project.yml)',
+        undefined,
+    )
     .option('--vars <vars>')
     .option('--threads <number>')
     .option('--no-version-check')
@@ -380,6 +385,11 @@ program
         undefined,
     )
     .option('--target <name>', 'target to use in profiles.yml file', undefined)
+    .option(
+        '--target-path <path>',
+        'The target directory for dbt (overrides DBT_TARGET_PATH and dbt_project.yml)',
+        undefined,
+    )
     .option('--vars <vars>')
     .option(
         '--defer',
@@ -467,6 +477,11 @@ program
         undefined,
     )
     .option('--target <name>', 'target to use in profiles.yml file', undefined)
+    .option(
+        '--target-path <path>',
+        'The target directory for dbt (overrides DBT_TARGET_PATH and dbt_project.yml)',
+        undefined,
+    )
     .option('--vars <vars>')
     .option(
         '--defer',
@@ -630,6 +645,11 @@ program
         undefined,
     )
     .option('--target <name>', 'target to use in profiles.yml file', undefined)
+    .option(
+        '--target-path <path>',
+        'The target directory for dbt (overrides DBT_TARGET_PATH and dbt_project.yml)',
+        undefined,
+    )
     .option('--vars <vars>')
     .option('--threads <number>')
     .option('--no-version-check')
@@ -822,6 +842,11 @@ ${styles.bold('Examples:')}
         undefined,
     )
     .option('--target <name>', 'target to use in profiles.yml file', undefined)
+    .option(
+        '--target-path <path>',
+        'The target directory for dbt (overrides DBT_TARGET_PATH and dbt_project.yml)',
+        undefined,
+    )
     .option('--vars <vars>')
     .option('-y, --assume-yes', 'assume yes to prompts', false)
     .option('--skip-existing', 'skip files that already exist', false)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17833

### Description:

Added support for customizing the dbt target directory through a new `--target-path` CLI option. This implements a clear precedence order for target path resolution:

1. CLI option (`--target-path`)
2. Environment variable (`DBT_TARGET_PATH`)
3. Configuration in `dbt_project.yml`
4. Default value (`./target`)

The option is available in all relevant commands: `compile`, `preview`, `generate`, `deploy`, and `create-project`. Added comprehensive tests to verify the precedence logic works correctly.


Here's how to test the BROKEN behavior:

Setup Test Environment

  ### Navigate to the CLI package
  `cd packages/cli`

  ###  Build the CLI
 ` pnpm cli-build`

  ###  Go to a test dbt project
 ` cd ../../examples/full-jaffle-shop-demo/dbt`

  ## Test 1: Reproduce the Bug

  #### Set a custom target path via environment variable (like the customer did)
  `export DBT_TARGET_PATH='target_test'`

  ### Clean and compile with dbt (this will use DBT_TARGET_PATH)
  dbt clean
  dbt compile

  ### Verify the manifest was created in the custom location
  `ls -la target_test/manifest.json`
  > Should show: target_test/manifest.json exists

  ### Check that default target/ doesn't exist
 ` ls target/`
  > Should show: No such file or directory

  ### Now try to use Lightdash (THIS SHOULD FAIL)
 ` node ../../../packages/cli/dist/index.js compile --project-dir . --profiles-dir ../profiles --verbose`

  Expected BROKEN behavior:
 ``` 
Could not load manifest from /path/to/project/target/manifest.json:
    ENOENT: no such file or directory, open '/path/to/project/target/manifest.json'
```

  Notice it's looking for target/manifest.json even though DBT_TARGET_PATH is set to target_test!