### PR TITLE
fix: constraint dimension/size for custom charts

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -1,5 +1,4 @@
 import { Anchor, Text } from '@mantine/core';
-import { useResizeObserver } from '@mantine/hooks';
 import { IconChartBarOff } from '@tabler/icons-react';
 import { Suspense, lazy, useEffect, type FC } from 'react';
 import { type CustomVisualizationConfigAndData } from '../../hooks/useCustomVisualizationConfig';
@@ -18,10 +17,13 @@ type Props = {
 };
 
 const CustomVisualization: FC<Props> = (props) => {
-    const { isLoading, visualizationConfig, resultsData, isDashboard } =
-        useVisualizationContext();
-
-    const [ref, rect] = useResizeObserver();
+    const {
+        isLoading,
+        visualizationConfig,
+        resultsData,
+        containerWidth,
+        containerHeight,
+    } = useVisualizationContext();
 
     useEffect(() => {
         // Load all the rows
@@ -80,18 +82,18 @@ const CustomVisualization: FC<Props> = (props) => {
                 width: '100%',
                 overflow: 'hidden',
             }}
-            ref={ref}
         >
             <Suspense fallback={<LoadingChart />}>
                 <VegaLite
                     style={{
-                        width: rect.width,
-                        height: rect.height,
+                        width: containerWidth,
+                        height: containerHeight,
                     }}
                     config={{
+                        font: 'Inter, sans-serif',
                         autosize: {
                             type: 'fit',
-                            ...(isDashboard && { resize: true }),
+                            resize: true,
                         },
                     }}
                     // TODO: We are ignoring some typescript errors here because the type

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -45,7 +45,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard, useElementSize } from '@mantine/hooks';
 import {
     IconAlertCircle,
     IconAlertTriangle,
@@ -236,6 +236,12 @@ const ValidDashboardChartTile: FC<{
     const { health } = useApp();
 
     const {
+        ref: measureRef,
+        width: containerWidth,
+        height: containerHeight,
+    } = useElementSize();
+
+    const {
         executeQueryResponse: { cacheMetadata, metricQuery, fields },
         chart,
     } = dashboardChartReadyQuery;
@@ -278,7 +284,6 @@ const ValidDashboardChartTile: FC<{
 
     return (
         <VisualizationProvider
-            isDashboard
             chartConfig={chart.chartConfig}
             initialPivotDimensions={chart.pivotConfig?.columns}
             resultsData={resultsDataWithQueryData}
@@ -296,8 +301,12 @@ const ValidDashboardChartTile: FC<{
                 dashboardChartReadyQuery.executeQueryResponse
                     .usedParametersValues
             }
+            containerWidth={containerWidth}
+            containerHeight={containerHeight}
+            isDashboard
         >
             <LightdashVisualization
+                ref={measureRef}
                 isDashboard
                 tileUuid={tileUuid}
                 isTitleHidden={isTitleHidden}
@@ -330,6 +339,12 @@ const ValidDashboardChartTileMinimal: FC<{
     const { health } = useApp();
 
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
+
+    const {
+        ref: measureRef,
+        width: containerWidth,
+        height: containerHeight,
+    } = useElementSize();
 
     const { validPivotDimensions } = usePivotDimensions(
         chart.pivotConfig?.columns,
@@ -371,7 +386,6 @@ const ValidDashboardChartTileMinimal: FC<{
     return (
         <VisualizationProvider
             minimal
-            isDashboard
             chartConfig={chart.chartConfig}
             initialPivotDimensions={chart.pivotConfig?.columns}
             resultsData={resultsDataWithQueryData}
@@ -388,8 +402,12 @@ const ValidDashboardChartTileMinimal: FC<{
                 dashboardChartReadyQuery.executeQueryResponse
                     .usedParametersValues
             }
+            containerWidth={containerWidth}
+            containerHeight={containerHeight}
+            isDashboard
         >
             <LightdashVisualization
+                ref={measureRef}
                 isDashboard
                 tileUuid={tileUuid}
                 isTitleHidden={isTitleHidden}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -11,6 +11,7 @@ import {
     type FieldId,
 } from '@lightdash/common';
 import { Button } from '@mantine/core';
+import { useElementSize } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,
     IconLayoutSidebarLeftExpand,
@@ -152,6 +153,12 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
 
     const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
+    const {
+        ref: measureRef,
+        width: containerWidth,
+        height: containerHeight,
+    } = useElementSize();
+
     useLayoutEffect(() => {
         if (isVisualizationConfigOpen) {
             const target = document.getElementById(VisualizationConfigPortalId);
@@ -257,6 +264,9 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                 colorPalette={org?.chartColors ?? ECHARTS_DEFAULT_COLORS}
                 tableCalculationsMetadata={tableCalculationsMetadata}
                 parameters={query.data?.usedParametersValues}
+                containerWidth={containerWidth}
+                containerHeight={containerHeight}
+                isDashboard={false}
             >
                 <CollapsableCard
                     title="Chart"
@@ -341,6 +351,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                     }
                 >
                     <LightdashVisualization
+                        ref={measureRef}
                         className="sentry-block ph-no-capture"
                         data-testid="visualization"
                     />

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -52,7 +52,6 @@ import { type useVisualizationContext } from './useVisualizationContext';
 
 export type VisualizationProviderProps = {
     minimal?: boolean;
-    isDashboard?: boolean;
     chartConfig: ChartConfig;
     initialPivotDimensions: string[] | undefined;
     unsavedMetricQuery?: MetricQuery;
@@ -79,13 +78,15 @@ export type VisualizationProviderProps = {
     setEchartsRef?: (ref: RefObject<EChartsReact | null>) => void;
     computedSeries?: Series[];
     apiErrorDetail?: ApiErrorDetail | null;
+    containerWidth?: number;
+    containerHeight?: number;
+    isDashboard?: boolean;
 };
 
 const VisualizationProvider: FC<
     React.PropsWithChildren<VisualizationProviderProps>
 > = ({
     minimal = false,
-    isDashboard = false,
     initialPivotDimensions,
     resultsData,
     isLoading,
@@ -107,6 +108,9 @@ const VisualizationProvider: FC<
     apiErrorDetail,
     parameters,
     unsavedMetricQuery,
+    containerWidth,
+    containerHeight,
+    isDashboard,
 }) => {
     const itemsMap = useMemo(() => {
         return resultsData?.fields;
@@ -301,7 +305,6 @@ const VisualizationProvider: FC<
         'visualizationConfig'
     > = {
         minimal,
-        isDashboard,
         pivotDimensions: validPivotDimensions,
         chartRef,
         resultsData: lastValidResultsData,
@@ -319,6 +322,9 @@ const VisualizationProvider: FC<
         getSeriesColor,
         chartConfig,
         parameters,
+        containerWidth,
+        containerHeight,
+        isDashboard,
     };
 
     switch (chartConfig.type) {

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -18,7 +18,6 @@ import { type VisualizationConfig } from './types';
 
 type VisualizationContext = {
     minimal: boolean;
-    isDashboard: boolean;
     chartRef: RefObject<EChartsReact | null>;
     pivotDimensions: string[] | undefined;
     resultsData:
@@ -48,6 +47,10 @@ type VisualizationContext = {
     chartConfig: ChartConfig;
     apiErrorDetail?: ApiErrorDetail | null;
     parameters?: ParametersValuesMap;
+    // Container dimensions for responsive visualizations
+    containerWidth?: number;
+    containerHeight?: number;
+    isDashboard?: boolean;
 };
 
 const Context = createContext<VisualizationContext | undefined>(undefined);

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -1,7 +1,7 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
 import { Anchor, Text } from '@mantine/core';
 import { IconChartBarOff } from '@tabler/icons-react';
-import { Fragment, memo, type FC } from 'react';
+import { forwardRef, Fragment, memo } from 'react';
 import { EmptyState } from '../common/EmptyState';
 import MantineIcon from '../common/MantineIcon';
 import CustomVisualization from '../CustomVisualization';
@@ -21,141 +21,157 @@ interface LightdashVisualizationProps {
     'data-testid'?: string;
 }
 
-const LightdashVisualization: FC<LightdashVisualizationProps> = memo(
-    ({
-        isDashboard = false,
-        tileUuid,
-        isTitleHidden = false,
-        className,
-        ...props
-    }) => {
-        const { visualizationConfig, minimal, apiErrorDetail } =
-            useVisualizationContext();
+const LightdashVisualization = memo(
+    forwardRef<HTMLDivElement, LightdashVisualizationProps>(
+        (
+            {
+                isDashboard = false,
+                tileUuid,
+                isTitleHidden = false,
+                className,
+                ...props
+            },
+            ref,
+        ) => {
+            const { visualizationConfig, minimal, apiErrorDetail } =
+                useVisualizationContext();
 
-        if (!visualizationConfig) {
-            return null;
-        }
+            if (!visualizationConfig) {
+                return null;
+            }
 
-        if (apiErrorDetail) {
-            return (
-                <EmptyState
-                    icon={
-                        // Icon consistent with SuboptimalState in charts
-                        <MantineIcon
-                            color="gray.5"
-                            size="xxl"
-                            icon={IconChartBarOff}
+            if (apiErrorDetail) {
+                return (
+                    <EmptyState
+                        icon={
+                            // Icon consistent with SuboptimalState in charts
+                            <MantineIcon
+                                color="gray.5"
+                                size="xxl"
+                                icon={IconChartBarOff}
+                            />
+                        }
+                        h="100%"
+                        w="100%"
+                        justify="center"
+                        title="Unable to load visualization"
+                        description={
+                            <Fragment>
+                                <Text style={{ whiteSpace: 'pre-wrap' }}>
+                                    {apiErrorDetail.message || ''}
+                                </Text>
+                                {apiErrorDetail.data.documentationUrl && (
+                                    <Fragment>
+                                        <br />
+                                        <Anchor
+                                            href={
+                                                apiErrorDetail.data
+                                                    .documentationUrl
+                                            }
+                                            target="_blank"
+                                            rel="noreferrer"
+                                        >
+                                            Learn how to resolve this in our
+                                            documentation →
+                                        </Anchor>
+                                    </Fragment>
+                                )}
+                            </Fragment>
+                        }
+                    ></EmptyState>
+                );
+            }
+
+            switch (visualizationConfig.chartType) {
+                case ChartType.BIG_NUMBER:
+                    return (
+                        <SimpleStatistic
+                            minimal={minimal}
+                            isTitleHidden={isTitleHidden}
+                            isDashboard={isDashboard}
+                            className={className}
+                            data-testid={props['data-testid']}
+                            {...props}
                         />
-                    }
-                    h="100%"
-                    w="100%"
-                    justify="center"
-                    title="Unable to load visualization"
-                    description={
-                        <Fragment>
-                            <Text style={{ whiteSpace: 'pre-wrap' }}>
-                                {apiErrorDetail.message || ''}
-                            </Text>
-                            {apiErrorDetail.data.documentationUrl && (
-                                <Fragment>
-                                    <br />
-                                    <Anchor
-                                        href={
-                                            apiErrorDetail.data.documentationUrl
-                                        }
-                                        target="_blank"
-                                        rel="noreferrer"
-                                    >
-                                        Learn how to resolve this in our
-                                        documentation →
-                                    </Anchor>
-                                </Fragment>
-                            )}
-                        </Fragment>
-                    }
-                ></EmptyState>
-            );
-        }
+                    );
+                case ChartType.TABLE:
+                    return (
+                        <SimpleTable
+                            tileUuid={tileUuid}
+                            minimal={minimal}
+                            isDashboard={!!isDashboard}
+                            className={className}
+                            $shouldExpand
+                            data-testid={props['data-testid']}
+                            {...props}
+                        />
+                    );
+                case ChartType.CARTESIAN:
+                    return (
+                        <SimpleChart
+                            className={className}
+                            isInDashboard={!!isDashboard}
+                            $shouldExpand
+                            data-testid={props['data-testid']}
+                            {...props}
+                        />
+                    );
+                case ChartType.PIE:
+                    return (
+                        <SimplePieChart
+                            className={className}
+                            isInDashboard={!!isDashboard}
+                            $shouldExpand
+                            data-testid={props['data-testid']}
+                            {...props}
+                        />
+                    );
+                case ChartType.FUNNEL:
+                    return (
+                        <FunnelChart
+                            className={className}
+                            isInDashboard={!!isDashboard}
+                            $shouldExpand
+                            data-testid={props['data-testid']}
+                            {...props}
+                        />
+                    );
+                case ChartType.TREEMAP:
+                    return (
+                        <SimpleTreemap
+                            className={className}
+                            isInDashboard={!!isDashboard}
+                            $shouldExpand
+                            data-testid={props['data-testid']}
+                            {...props}
+                        />
+                    );
+                case ChartType.CUSTOM:
+                    return (
+                        <div
+                            ref={ref}
+                            style={{
+                                width: '100%',
+                                height: '100%',
+                                display: 'flex',
+                                flexDirection: 'column',
+                            }}
+                        >
+                            <CustomVisualization
+                                data-testid={props['data-testid']}
+                                className={className}
+                            />
+                        </div>
+                    );
 
-        switch (visualizationConfig.chartType) {
-            case ChartType.BIG_NUMBER:
-                return (
-                    <SimpleStatistic
-                        minimal={minimal}
-                        isTitleHidden={isTitleHidden}
-                        isDashboard={isDashboard}
-                        className={className}
-                        data-testid={props['data-testid']}
-                        {...props}
-                    />
-                );
-            case ChartType.TABLE:
-                return (
-                    <SimpleTable
-                        tileUuid={tileUuid}
-                        minimal={minimal}
-                        isDashboard={!!isDashboard}
-                        className={className}
-                        $shouldExpand
-                        data-testid={props['data-testid']}
-                        {...props}
-                    />
-                );
-            case ChartType.CARTESIAN:
-                return (
-                    <SimpleChart
-                        className={className}
-                        isInDashboard={!!isDashboard}
-                        $shouldExpand
-                        data-testid={props['data-testid']}
-                        {...props}
-                    />
-                );
-            case ChartType.PIE:
-                return (
-                    <SimplePieChart
-                        className={className}
-                        isInDashboard={!!isDashboard}
-                        $shouldExpand
-                        data-testid={props['data-testid']}
-                        {...props}
-                    />
-                );
-            case ChartType.FUNNEL:
-                return (
-                    <FunnelChart
-                        className={className}
-                        isInDashboard={!!isDashboard}
-                        $shouldExpand
-                        data-testid={props['data-testid']}
-                        {...props}
-                    />
-                );
-            case ChartType.TREEMAP:
-                return (
-                    <SimpleTreemap
-                        className={className}
-                        isInDashboard={!!isDashboard}
-                        $shouldExpand
-                        data-testid={props['data-testid']}
-                        {...props}
-                    />
-                );
-            case ChartType.CUSTOM:
-                return (
-                    <CustomVisualization
-                        data-testid={props['data-testid']}
-                        className={className}
-                    />
-                );
-
-            default:
-                return assertUnreachable(
-                    visualizationConfig,
-                    `Chart type is not implemented`,
-                );
-        }
-    },
+                default:
+                    return assertUnreachable(
+                        visualizationConfig,
+                        `Chart type is not implemented`,
+                    );
+            }
+        },
+    ),
 );
 
 export default LightdashVisualization;

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -1,4 +1,5 @@
 import { Box, MantineProvider, type MantineThemeOverride } from '@mantine/core';
+import { useElementSize } from '@mantine/hooks';
 import { memo, useMemo, type FC } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
@@ -40,6 +41,12 @@ const MinimalExplorerContent = memo(() => {
 
     const { health } = useApp();
 
+    const {
+        ref: measureRef,
+        width: containerWidth,
+        height: containerHeight,
+    } = useElementSize();
+
     // Get query state from hook
     const { query, queryResults } = useExplorerQuery();
 
@@ -74,10 +81,13 @@ const MinimalExplorerContent = memo(() => {
             savedChartUuid={savedChart.uuid}
             colorPalette={savedChart.colorPalette}
             parameters={query.data?.usedParametersValues}
+            containerWidth={containerWidth}
+            containerHeight={containerHeight}
         >
             <MantineProvider inherit theme={themeOverride}>
                 <Box mih="inherit" h="100%">
                     <LightdashVisualization
+                        ref={measureRef}
                         // get rid of the classNames once you remove analytics providers
                         className="sentry-block ph-no-capture"
                         data-testid="visualization"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXX

### Description:

Improved responsive visualization handling by replacing the `useResizeObserver` hook with container dimensions passed through the visualization context. This change allows custom visualizations to properly resize based on their container's dimensions.

Key changes:
- Removed `useResizeObserver` from CustomVisualization component
- Added `containerWidth` and `containerHeight` props to VisualizationProvider
- Used `useElementSize` hook in VisualizationCard to measure container dimensions
- Made LightdashVisualization a forwardRef component to allow size measurements
- Simplified resize handling in custom visualizations

This change ensures that visualizations, especially custom ones, properly adapt to their container size without relying on individual resize observers.

--- similar to error 

go here, bottom tile - copy similar structure https://analytics.lightdash.cloud/projects/8a223608-a1e4-426e-adcd-0598ea72b9f8/dashboards/bf5bc01a-88b4-4f74-b22e-15001dcb2b0f

and ask ai locally to do something similar with the dims& metrics you have



You can use this to play around

http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/campaigns?create_saved_chart_version=%7B%22uuid%22%3A%2264c8b7c7-568b-41d1-8326-1b2c808452bf%22%2C%22projectUuid%22%3A%223675b69e-8324-4110-bdca-059031aa8da3%22%2C%22name%22%3A%22asdasd%22%2C%22description%22%3A%22%22%2C%22tableName%22%3A%22campaigns%22%2C%22updatedAt%22%3A%222025-10-09T13%3A14%3A36.051Z%22%2C%22updatedByUser%22%3A%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%7D%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22campaigns%22%2C%22dimensions%22%3A%5B%22campaigns_audience_segment%22%2C%22campaigns_campaign_id%22%5D%2C%22metrics%22%3A%5B%22campaigns_max_budget%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22campaigns_max_budget%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22metricOverrides%22%3A%7B%7D%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22custom%22%2C%22config%22%3A%7B%22spec%22%3A%7B%22mark%22%3A%22bar%22%2C%22%24schema%22%3A%22https%3A%2F%2Fvega.github.io%2Fschema%2Fvega-lite%2Fv5.json%22%2C%22encoding%22%3A%7B%22x%22%3A%7B%22axis%22%3A%7B%22tickColor%22%3A%22%236e7079%22%2C%22labelColor%22%3A%22%236e7079%22%2C%22labelFontSize%22%3A80%7D%2C%22type%22%3A%22ordinal%22%2C%22field%22%3A%22campaigns_audience_segment%22%7D%2C%22y%22%3A%7B%22axis%22%3A%7B%22tickColor%22%3A%22%236e7079%22%2C%22labelColor%22%3A%22%236e7079%22%7D%2C%22type%22%3A%22quantitative%22%2C%22field%22%3A%22campaigns_max_budget%22%7D%2C%22tooltip%22%3A%5B%7B%22type%22%3A%22ordinal%22%2C%22field%22%3A%22campaigns_audience_segment%22%2C%22title%22%3A%22Audience+Segment%22%7D%2C%7B%22type%22%3A%22quantitative%22%2C%22field%22%3A%22campaigns_max_budget%22%2C%22title%22%3A%22Max+Budget%22%7D%5D%7D%7D%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22campaigns_audience_segment%22%2C%22campaigns_campaign_id%22%2C%22campaigns_max_budget%22%5D%7D%2C%22organizationUuid%22%3A%22172a2270-000f-42be-9c68-c4752c23ae51%22%2C%22spaceUuid%22%3A%22f14fe9d7-77f1-450b-9f27-31242b93a262%22%2C%22spaceName%22%3A%22Parent+Space+5%22%2C%22pinnedListUuid%22%3Anull%2C%22pinnedListOrder%22%3Anull%2C%22dashboardUuid%22%3Anull%2C%22dashboardName%22%3Anull%2C%22colorPalette%22%3A%5B%22%2333ffb1%22%2C%22%23ff33e1%22%2C%22%2333e6ff%22%2C%22%23ffdd8a%22%2C%22%23ffdefa%22%2C%22%2373c0de%22%2C%22%23ff8178%22%2C%22%239a60b4%22%2C%22%23ea7ccc%22%2C%22%2333ff7d%22%2C%22%2333ffb1%22%2C%22%2333ffe6%22%2C%22%2333e6ff%22%2C%22%2333b1ff%22%2C%22%23337dff%22%2C%22%233349ff%22%2C%22%235e33ff%22%2C%22%239233ff%22%2C%22%23c633ff%22%2C%22%23ff33e1%22%5D%2C%22slug%22%3A%22asdasd%22%2C%22isPrivate%22%3Atrue%2C%22access%22%3A%5B%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22David%22%2C%22lastName%22%3A%22Attenborough%22%2C%22email%22%3A%22demo%40lightdash.com%22%2C%22role%22%3A%22admin%22%2C%22hasDirectAccess%22%3Atrue%2C%22inheritedRole%22%3A%22admin%22%2C%22inheritedFrom%22%3A%22organization%22%2C%22projectRole%22%3A%22admin%22%7D%5D%7D&isExploreFromHere=true

------