### PR TITLE
fix: use pre-computed group keys for virtualized tree nodes

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -47,10 +47,13 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
     const onToggleGroup = useTableTree((ctx) => ctx.onToggleGroup);
     const isVirtualized = useTableTree((ctx) => ctx.isVirtualized);
     const depth = useTableTree((ctx) => ctx.depth);
+    const contextGroupKey = useTableTree((ctx) => ctx.groupKey);
     const [isHover, toggleHover] = useToggle(false);
 
-    // Build unique group key
-    const groupKey = buildGroupKey(tableName, treeSectionType, node.key);
+    // Use pre-computed group key from context (virtualized with parent paths)
+    // or build it (non-virtualized)
+    const groupKey =
+        contextGroupKey ?? buildGroupKey(tableName, treeSectionType, node.key);
     const isOpen = expandedGroups.has(groupKey);
 
     const allChildrenKeys = useMemo(() => getAllChildrenKeys([node]), [node]);

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/types.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/types.ts
@@ -56,4 +56,5 @@ export type TableTreeContext = TreeProviderProps & {
     searchResults: string[];
     isVirtualized?: boolean; // Flag to prevent group nodes from rendering children inline
     depth?: number; // Nesting depth for indentation in virtualized mode
+    groupKey?: string; // Pre-computed group key (for virtualized tree with parent paths)
 };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeNode.tsx
@@ -3,12 +3,7 @@ import TreeContext from '../Tree/TreeContext';
 import TreeGroupNode from '../Tree/TreeGroupNode';
 import TreeSingleNode from '../Tree/TreeSingleNode';
 import { isGroupNode } from '../Tree/types';
-import {
-    buildGroupKey,
-    TreeSection,
-    type SectionContext,
-    type TreeNodeItem,
-} from './types';
+import { TreeSection, type SectionContext, type TreeNodeItem } from './types';
 
 interface VirtualTreeNodeProps {
     item: TreeNodeItem;
@@ -59,12 +54,8 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
         // This is used by TreeGroupNode to determine chevron rotation
         const expandedGroups = new Set<string>();
         if (isGroup && isExpanded) {
-            const groupKey = buildGroupKey(
-                sectionContext.tableName,
-                sectionContext.sectionType,
-                node.key,
-            );
-            expandedGroups.add(groupKey);
+            // Use item.id which already contains the unique key with parent path
+            expandedGroups.add(item.id);
         }
 
         return {
@@ -99,6 +90,7 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
             onToggleGroup,
             isVirtualized: true, // Flag to prevent inline children rendering
             depth, // Nesting depth for indentation
+            groupKey: isGroup ? item.id : undefined, // Pre-computed unique group key with parent path
         };
     }, [
         sectionContext,
@@ -107,7 +99,7 @@ const VirtualTreeNodeComponent: FC<VirtualTreeNodeProps> = ({
         onToggleGroup,
         isGroup,
         isExpanded,
-        node.key,
+        item.id,
     ]);
 
     if (!sectionContext) {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
@@ -44,6 +44,7 @@ function flattenNodeRecursive(
     searchResults: string[],
     isSearching: boolean,
     depth: number = 0,
+    parentPath: string = '',
 ): TreeNodeItem[] {
     const items: TreeNodeItem[] = [];
 
@@ -73,7 +74,12 @@ function flattenNodeRecursive(
         }
 
         // Add the group node itself
-        const groupKey = buildGroupKey(tableName, sectionType, node.key);
+        const groupKey = buildGroupKey(
+            tableName,
+            sectionType,
+            node.key,
+            parentPath,
+        );
         const isExpanded = expandedGroups.has(groupKey) || isSearching;
 
         items.push({
@@ -91,6 +97,11 @@ function flattenNodeRecursive(
 
         // Add children if expanded
         if (isExpanded) {
+            // Build the parent path for children: append current node's key
+            const childParentPath = parentPath
+                ? `${parentPath}-${node.key}`
+                : node.key;
+
             Object.values(groupNode.children).forEach((child) => {
                 items.push(
                     ...flattenNodeRecursive(
@@ -102,6 +113,7 @@ function flattenNodeRecursive(
                         searchResults,
                         isSearching,
                         depth + 1,
+                        childParentPath,
                     ),
                 );
             });

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/types.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/types.ts
@@ -24,8 +24,10 @@ export function buildGroupKey(
     tableName: string,
     sectionType: TreeSection,
     nodeKey: string,
+    parentPath: string = '',
 ): string {
-    return `${tableName}-${sectionType}-group-${nodeKey}`;
+    const pathPrefix = parentPath ? `${parentPath}-` : '';
+    return `${tableName}-${sectionType}-group-${pathPrefix}${nodeKey}`;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes the duplicate React key bug that caused nested metrics to overlap in the virtualized sidebar.

### Description:
Improved tree virtualization by implementing parent path tracking for group keys. This ensures unique identification of nested groups with the same key at different levels of the hierarchy. The implementation:

1. Modified `buildGroupKey` to include an optional parent path parameter
2. Updated `flattenNodeRecursive` to track and pass parent paths when processing nested groups
3. Added a `groupKey` property to the `TableTreeContext` to pass pre-computed keys to group nodes
4. Updated `VirtualTreeNode` to use the item's ID (which includes the parent path) as the group key
5. Modified `TreeGroupNode` to use the context-provided group key when available

This change fixes issues with tree expansion state not being properly maintained for nested groups with identical keys.