### PR TITLE
feat: keep markdown and loom tiles when dashboard is locked

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/components/DashboardTabs/GridTile.tsx
@@ -28,6 +28,14 @@ const GridTile: FC<
     useProfiler(`Dashboard-${tile.type}`);
 
     if (props.locked) {
+        // Allow markdown and loom tiles to show even when locked since they are not filterable
+        if (tile.type === DashboardTileTypes.MARKDOWN) {
+            return <MarkdownTile {...props} tile={tile} />;
+        }
+        if (tile.type === DashboardTileTypes.LOOM) {
+            return <LoomTile {...props} tile={tile} />;
+        }
+
         return (
             <Box h="100%">
                 <TileBase isLoading={false} title={''} {...props} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17930

### Description:

Allow markdown and loom tiles to display even when the dashboard is locked, since these tile types are not filterable. This ensures that important static content remains visible to users regardless of the dashboard's locked state.

![Screenshot 2025-11-06 at 17.46.27.png](https://app.graphite.com/user-attachments/assets/8396e9f5-66f7-42f6-b6b7-e10d6eb5568e.png)