### PR TITLE
fix: getSchedulerLogs not returning all jobs for each job in a job group

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -1008,7 +1008,10 @@ export class SchedulerModel {
         const uniqueLogs = sortedLogs.reduce<SchedulerLog[]>((acc, log) => {
             if (
                 acc.some(
-                    (l) => l.jobGroup === log.jobGroup && l.task === log.task,
+                    (l) =>
+                        l.jobId === log.jobId &&
+                        l.task === log.task &&
+                        l.status === log.status,
                 )
             ) {
                 return acc;

--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -16,6 +16,7 @@ import {
     IconChevronUp,
     IconClock,
     IconDots,
+    IconInfoCircle,
     IconSend,
     IconTextCaption,
 } from '@tabler/icons-react';
@@ -399,9 +400,26 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                     } else {
                         // Child row: show task name
                         return (
-                            <Text fz="xs" fw={400} c="gray.7">
-                                {formatTaskName(rowData.log.task)}
-                            </Text>
+                            <Group gap="two">
+                                <Text fz="xs" fw={400} c="gray.7">
+                                    {formatTaskName(rowData.log.task)}
+                                </Text>
+                                {rowData.log.targetType === 'email' && (
+                                    <Tooltip
+                                        variant="xs"
+                                        disabled={
+                                            rowData.log.targetType !== 'email'
+                                        }
+                                        label={rowData.log.target}
+                                    >
+                                        <MantineIcon
+                                            icon={IconInfoCircle}
+                                            color="gray.6"
+                                            size="sm"
+                                        />
+                                    </Tooltip>
+                                )}
+                            </Group>
                         );
                     }
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17933

### Description:
Fix duplicate log filtering in SchedulerModel by updating the uniqueness criteria. Previously, logs were considered duplicates if they had the same `jobGroup` and `task`. Now, logs are considered duplicates only if they have the same `jobId`, `task`, and `status`, which provides more accurate log filtering.

**Before**
![image.png](https://app.graphite.com/user-attachments/assets/389c05df-743b-4faa-9cfc-08e9261bb745.png)

**After**

<img width="2107" height="895" alt="image" src="https://github.com/user-attachments/assets/97ae44e2-7c87-4184-9522-aae9d587b4d4" />


