### PR TITLE
feat: add chart embedding support to embed configuration

### DIFF
--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -139,7 +139,7 @@ export class EmbedController extends BaseController {
     @SuccessResponse('200', 'Success')
     @Patch('/config/dashboards')
     @OperationId('updateEmbeddedDashboards')
-    @Deprecated()
+    @Deprecated() // Use /config endpoint below instead
     async updateEmbeddedDashboards(
         @Request() req: express.Request,
         @Path() projectUuid: string,
@@ -158,6 +158,13 @@ export class EmbedController extends BaseController {
         };
     }
 
+    /**
+     * This endpoint is used for updating the embed config for dashboards and charts.
+     * @param req
+     * @param projectUuid
+     * @param body Contains dashboardUuids, allowAllDashboards, chartUuids, allowAllCharts
+     * @returns
+     */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Patch('/config')

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedDashboardsAndChartsForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedDashboardsAndChartsForm.tsx
@@ -1,22 +1,26 @@
 import {
     type DashboardBasicDetails,
     type DecodedEmbed,
+    type SavedChart,
     type UpdateEmbed,
 } from '@lightdash/common';
 import { Button, Flex, MultiSelect, Stack, Switch } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import React, { type FC } from 'react';
 
-const EmbedDashboardsForm: FC<{
+const EmbedDashboardsAndChartsForm: FC<{
     disabled: boolean;
     embedConfig: DecodedEmbed;
     dashboards: DashboardBasicDetails[];
+    charts: Pick<SavedChart, 'uuid' | 'name'>[];
     onSave: (values: UpdateEmbed) => void;
-}> = ({ disabled, embedConfig, dashboards, onSave }) => {
+}> = ({ disabled, embedConfig, dashboards, charts, onSave }) => {
     const form = useForm({
         initialValues: {
             allowAllDashboards: embedConfig.allowAllDashboards,
             dashboardUuids: embedConfig.dashboardUuids,
+            allowAllCharts: embedConfig.allowAllCharts,
+            chartUuids: embedConfig.chartUuids,
         },
     });
 
@@ -24,8 +28,8 @@ const EmbedDashboardsForm: FC<{
         onSave({
             dashboardUuids: values.dashboardUuids,
             allowAllDashboards: values.allowAllDashboards,
-            chartUuids: [],
-            allowAllCharts: false,
+            chartUuids: values.chartUuids,
+            allowAllCharts: values.allowAllCharts,
         });
     });
 
@@ -64,10 +68,46 @@ const EmbedDashboardsForm: FC<{
                         {...form.getInputProps('dashboardUuids')}
                     />
                 )}
+                <Switch
+                    name="allowAllCharts"
+                    label="Allow all charts"
+                    {...form.getInputProps('allowAllCharts', {
+                        type: 'checkbox',
+                    })}
+                />
+                {!form.values.allowAllCharts && (
+                    <MultiSelect
+                        required={!form.values.allowAllCharts}
+                        label={'Charts'}
+                        data={charts.map((chart) => ({
+                            value: chart.uuid,
+                            label: chart.name,
+                        }))}
+                        disabled={
+                            disabled ||
+                            charts.length === 0 ||
+                            form.values.allowAllCharts
+                        }
+                        defaultValue={[]}
+                        placeholder={
+                            dashboards.length === 0
+                                ? 'No charts available to embed'
+                                : 'Select a chart...'
+                        }
+                        searchable
+                        withinPortal
+                        description="Only these charts will be allowed to be embedded."
+                        {...form.getInputProps('chartUuids')}
+                    />
+                )}
                 <Flex justify="flex-end" gap="sm">
                     <Button
                         type="submit"
-                        disabled={disabled || dashboards.length === 0}
+                        disabled={
+                            disabled ||
+                            dashboards.length === 0 ||
+                            charts.length === 0
+                        }
                     >
                         Save changes
                     </Button>
@@ -77,4 +117,4 @@ const EmbedDashboardsForm: FC<{
     );
 };
 
-export default EmbedDashboardsForm;
+export default EmbedDashboardsAndChartsForm;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -23,8 +23,9 @@ import { SettingsGridCard } from '../../../../components/common/Settings/Setting
 import SuboptimalState from '../../../../components/common/SuboptimalState/SuboptimalState';
 import { useDashboards } from '../../../../hooks/dashboard/useDashboards';
 import useToaster from '../../../../hooks/toaster/useToaster';
+import { useCharts } from '../../../../hooks/useCharts';
 import useApp from '../../../../providers/App/useApp';
-import EmbedDashboardsForm from './EmbedDashboardsForm';
+import EmbedDashboardsAndChartsForm from './EmbedDashboardsAndChartsForm';
 import EmbedUrlForm from './EmbedUrlForm';
 
 const useEmbedConfig = (projectUuid: string) => {
@@ -75,13 +76,20 @@ const useEmbedConfigUpdateMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastError } = useToaster();
     return useMutation<null, ApiError, UpdateEmbed>(
-        ({ dashboardUuids, allowAllDashboards }: UpdateEmbed) =>
+        ({
+            dashboardUuids,
+            allowAllDashboards,
+            chartUuids,
+            allowAllCharts,
+        }: UpdateEmbed) =>
             lightdashApi<null>({
-                url: `/embed/${projectUuid}/config/dashboards`,
+                url: `/embed/${projectUuid}/config`,
                 method: 'PATCH',
                 body: JSON.stringify({
                     dashboardUuids,
                     allowAllDashboards,
+                    chartUuids,
+                    allowAllCharts,
                 }),
             }),
         {
@@ -110,6 +118,8 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         undefined,
         true,
     );
+
+    const { isLoading: isLoadingCharts, data: charts } = useCharts(projectUuid);
     const { mutate: createEmbedConfig, isLoading: isCreating } =
         useEmbedConfigCreateMutation(projectUuid);
     const { mutate: updateEmbedConfig, isLoading: isUpdating } =
@@ -128,7 +138,7 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         );
     }, [dashboards, embedConfig]);
 
-    if (isLoading || isLoadingDashboards || !health.data) {
+    if (isLoading || isLoadingDashboards || isLoadingCharts || !health.data) {
         return (
             <div style={{ marginTop: '20px' }}>
                 <SuboptimalState title="Loading embed config" loading />
@@ -214,12 +224,13 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
             </SettingsGridCard>
             <Paper shadow="sm" withBorder p="md">
                 <Stack spacing="sm" mb="md">
-                    <Title order={4}>Allowed dashboards</Title>
+                    <Title order={4}>Allowed dashboards and charts</Title>
                 </Stack>
-                <EmbedDashboardsForm
+                <EmbedDashboardsAndChartsForm
                     disabled={isSaving}
                     embedConfig={embedConfig}
                     dashboards={dashboards || []}
+                    charts={charts || []}
                     onSave={updateEmbedConfig}
                 />
             </Paper>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

100% AI free 

<img width="930" height="387" alt="Screenshot from 2025-11-07 10-01-55" src="https://github.com/user-attachments/assets/11143732-4f86-4dbf-8602-4b3bac427cb8" />

### Description:
Extends the embed configuration to support both dashboards and charts in a unified interface. This PR:

- Renames `EmbedDashboardsForm` to `EmbedDashboardsAndChartsForm` to reflect its expanded functionality
- Adds chart selection controls alongside dashboard selection in the embed settings
- Updates the backend API to use the consolidated `/config` endpoint instead of the deprecated `/config/dashboards`
- Adds JSDoc comments to clarify the purpose of the `/config` endpoint
- Updates the frontend to fetch and display available charts for embedding

This change allows users to configure which charts can be embedded alongside dashboards in a single interface.