### PR TITLE
feat: add chart embedding support in embed settings

### DIFF
--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -167,7 +167,7 @@ type EmbedJwtContentDashboardSlug = CommonEmbedJwtContent & {
     dashboardSlug: string;
 };
 
-type EmbedJwtContentChart = CommonChartEmbedJwtContent & {
+export type EmbedJwtContentChart = CommonChartEmbedJwtContent & {
     contentId: string;
 };
 

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
@@ -8,7 +8,7 @@ import { Button, Flex, MultiSelect, Stack, Switch } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import React, { type FC } from 'react';
 
-const EmbedDashboardsAndChartsForm: FC<{
+const EmbedAllowListForm: FC<{
     disabled: boolean;
     embedConfig: DecodedEmbed;
     dashboards: DashboardBasicDetails[];
@@ -90,7 +90,7 @@ const EmbedDashboardsAndChartsForm: FC<{
                         }
                         defaultValue={[]}
                         placeholder={
-                            dashboards.length === 0
+                            charts.length === 0
                                 ? 'No charts available to embed'
                                 : 'Select a chart...'
                         }
@@ -117,4 +117,4 @@ const EmbedDashboardsAndChartsForm: FC<{
     );
 };
 
-export default EmbedDashboardsAndChartsForm;
+export default EmbedAllowListForm;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.test.ts
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+// Test the language helper functions by simulating different scenarios
+// Since these are internal to the component, we'll test them indirectly through string patterns
+
+// Simple enum to match the one in the component
+enum SnippetLanguage {
+    NODE = 'node',
+    PYTHON = 'python',
+    GO = 'go',
+}
+
+// Re-implement helpers to test them independently
+const languageUndefined = (language: SnippetLanguage): string => {
+    switch (language) {
+        case SnippetLanguage.NODE:
+            return 'undefined';
+        case SnippetLanguage.PYTHON:
+        case SnippetLanguage.GO:
+            return 'None';
+        default:
+            throw new Error(`Unknown language ${language}`);
+    }
+};
+
+const languageBoolean = (
+    language: SnippetLanguage,
+    value?: boolean,
+): string => {
+    if (value === undefined) {
+        return languageUndefined(language);
+    }
+    switch (language) {
+        case SnippetLanguage.NODE:
+        case SnippetLanguage.GO:
+            return value ? 'true' : 'false';
+        case SnippetLanguage.PYTHON:
+            return value ? 'True' : 'False';
+        default:
+            throw new Error(`Unknown language ${language}`);
+    }
+};
+
+const languageString = (language: SnippetLanguage, value?: string): string => {
+    if (value === undefined || value === null) {
+        return languageUndefined(language);
+    }
+    return `"${value}"`;
+};
+
+const languageStringArray = (
+    language: SnippetLanguage,
+    values?: string[] | null,
+): string => {
+    if (!values || values.length === 0) {
+        switch (language) {
+            case SnippetLanguage.NODE:
+            case SnippetLanguage.PYTHON:
+                return '[]';
+            case SnippetLanguage.GO:
+                return '';
+            default:
+                throw new Error(`Unknown language ${language}`);
+        }
+    }
+    switch (language) {
+        case SnippetLanguage.NODE:
+        case SnippetLanguage.PYTHON:
+            return JSON.stringify(values);
+        case SnippetLanguage.GO:
+            return `"${values.join('","')}"`;
+        default:
+            throw new Error(`Unknown language ${language}`);
+    }
+};
+
+describe('EmbedCodeSnippet Language Helpers', () => {
+    describe('languageBoolean', () => {
+        it('should format true/false for Node.js', () => {
+            expect(languageBoolean(SnippetLanguage.NODE, true)).toBe('true');
+            expect(languageBoolean(SnippetLanguage.NODE, false)).toBe('false');
+        });
+
+        it('should format True/False for Python', () => {
+            expect(languageBoolean(SnippetLanguage.PYTHON, true)).toBe('True');
+            expect(languageBoolean(SnippetLanguage.PYTHON, false)).toBe(
+                'False',
+            );
+        });
+
+        it('should format true/false for Go', () => {
+            expect(languageBoolean(SnippetLanguage.GO, true)).toBe('true');
+            expect(languageBoolean(SnippetLanguage.GO, false)).toBe('false');
+        });
+
+        it('should handle undefined booleans', () => {
+            expect(languageBoolean(SnippetLanguage.NODE, undefined)).toBe(
+                'undefined',
+            );
+            expect(languageBoolean(SnippetLanguage.PYTHON, undefined)).toBe(
+                'None',
+            );
+            expect(languageBoolean(SnippetLanguage.GO, undefined)).toBe('None');
+        });
+    });
+
+    describe('languageString', () => {
+        it('should format strings for all languages', () => {
+            const testString = 'test-value';
+            expect(languageString(SnippetLanguage.NODE, testString)).toBe(
+                '"test-value"',
+            );
+            expect(languageString(SnippetLanguage.PYTHON, testString)).toBe(
+                '"test-value"',
+            );
+            expect(languageString(SnippetLanguage.GO, testString)).toBe(
+                '"test-value"',
+            );
+        });
+
+        it('should handle undefined strings', () => {
+            expect(languageString(SnippetLanguage.NODE, undefined)).toBe(
+                'undefined',
+            );
+            expect(languageString(SnippetLanguage.PYTHON, undefined)).toBe(
+                'None',
+            );
+            expect(languageString(SnippetLanguage.GO, undefined)).toBe('None');
+        });
+    });
+
+    describe('languageStringArray', () => {
+        const testArray = ['scope1', 'scope2', 'scope3'];
+
+        it('should format arrays for Node.js as JSON', () => {
+            expect(languageStringArray(SnippetLanguage.NODE, testArray)).toBe(
+                '["scope1","scope2","scope3"]',
+            );
+        });
+
+        it('should format arrays for Python as JSON', () => {
+            expect(languageStringArray(SnippetLanguage.PYTHON, testArray)).toBe(
+                '["scope1","scope2","scope3"]',
+            );
+        });
+
+        it('should format arrays for Go as comma-separated strings', () => {
+            expect(languageStringArray(SnippetLanguage.GO, testArray)).toBe(
+                '"scope1","scope2","scope3"',
+            );
+        });
+
+        it('should handle empty arrays', () => {
+            expect(languageStringArray(SnippetLanguage.NODE, [])).toBe('[]');
+            expect(languageStringArray(SnippetLanguage.PYTHON, [])).toBe('[]');
+            expect(languageStringArray(SnippetLanguage.GO, [])).toBe('');
+        });
+
+        it('should handle null/undefined arrays', () => {
+            expect(languageStringArray(SnippetLanguage.NODE, null)).toBe('[]');
+            expect(languageStringArray(SnippetLanguage.PYTHON, undefined)).toBe(
+                '[]',
+            );
+            expect(languageStringArray(SnippetLanguage.GO, null)).toBe('');
+        });
+    });
+
+    describe('languageUndefined', () => {
+        it('should return language-specific undefined values', () => {
+            expect(languageUndefined(SnippetLanguage.NODE)).toBe('undefined');
+            expect(languageUndefined(SnippetLanguage.PYTHON)).toBe('None');
+            expect(languageUndefined(SnippetLanguage.GO)).toBe('None');
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
@@ -1,0 +1,281 @@
+import {
+    type ApiError,
+    type CreateEmbedJwt,
+    type EmbedJwtContentChart,
+    type EmbedUrl,
+    type IntrinsicUserAttributes,
+    type SavedChart,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    Flex,
+    Group,
+    Input,
+    Select,
+    Stack,
+    Switch,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback, type FC } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { lightdashApi } from '../../../../api';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import useToaster from '../../../../hooks/toaster/useToaster';
+import { useAsyncClipboard } from '../../../../hooks/useAsyncClipboard';
+import useUser from '../../../../hooks/user/useUser';
+import EmbedCodeSnippet from './EmbedCodeSnippet';
+
+const useEmbedUrlCreateMutation = (projectUuid: string) => {
+    const { showToastError } = useToaster();
+    return useMutation<EmbedUrl, ApiError, CreateEmbedJwt>(
+        (data: CreateEmbedJwt) =>
+            lightdashApi<EmbedUrl>({
+                url: `/embed/${projectUuid}/get-embed-url`,
+                method: 'POST',
+                body: JSON.stringify(data),
+            }),
+        {
+            mutationKey: ['create-embed-url'],
+            onError: (error) => {
+                showToastError({
+                    title: `We couldn't create your embed url.`,
+                    subtitle: error.error.message,
+                });
+            },
+        },
+    );
+};
+
+type FormValues = {
+    chartUuid: string | undefined;
+    expiresIn: string;
+    userAttributes: Array<{
+        uuid: string;
+        key: string;
+        value: string;
+    }>;
+    canExportCsv?: boolean;
+    canExportImages?: boolean;
+    externalId?: string;
+    canExplore?: boolean;
+    canViewUnderlyingData?: boolean;
+} & IntrinsicUserAttributes;
+
+const EmbedPreviewChartForm: FC<{
+    projectUuid: string;
+    siteUrl: string;
+    charts: Pick<SavedChart, 'uuid' | 'name'>[];
+}> = ({ projectUuid, siteUrl, charts }) => {
+    const { mutateAsync: createEmbedUrl } =
+        useEmbedUrlCreateMutation(projectUuid);
+    const { data: user } = useUser(true);
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            chartUuid: undefined,
+            expiresIn: '1 hour',
+            userAttributes: [{ uuid: uuidv4(), key: '', value: '' }] as Array<{
+                uuid: string;
+                key: string;
+                value: string;
+            }>,
+            email: user?.email,
+            canExportCsv: false,
+            canExportImages: false,
+            canExplore: false,
+            canViewUnderlyingData: false,
+        },
+        validate: {
+            chartUuid: (value: undefined | string) => {
+                return value && value.length > 0 ? null : 'Chart is required';
+            },
+        },
+    });
+    const { onSubmit, values: formValues } = form;
+
+    const convertFormValuesToCreateEmbedJwt = useCallback(
+        (
+            values: FormValues,
+            isPreview: boolean = false,
+        ): Omit<CreateEmbedJwt, 'content'> & {
+            content: EmbedJwtContentChart;
+        } => {
+            return {
+                expiresIn: values.expiresIn,
+                content: {
+                    type: 'chart',
+                    projectUuid,
+                    contentId: values.chartUuid!,
+                    canExportCsv: values.canExportCsv,
+                    canExportImages: values.canExportImages,
+                    isPreview,
+                    canViewUnderlyingData: values.canViewUnderlyingData,
+                    scopes: undefined,
+                    dashboardFiltersInteractivity: undefined,
+                    parameterInteractivity: undefined,
+                },
+                userAttributes: values.userAttributes.reduce(
+                    (acc, item) => ({
+                        ...acc,
+                        [item.key]: item.value,
+                    }),
+                    {},
+                ),
+                user: {
+                    externalId: values.externalId,
+                    email: values.email,
+                },
+            };
+        },
+        [projectUuid],
+    );
+
+    const generateUrl = useCallback(async () => {
+        const data = await createEmbedUrl(
+            convertFormValuesToCreateEmbedJwt(form.values),
+        );
+        return data.url;
+    }, [convertFormValuesToCreateEmbedJwt, createEmbedUrl, form.values]);
+
+    const { handleCopy } = useAsyncClipboard(generateUrl);
+    const handleCopySubmit = onSubmit(handleCopy);
+
+    return (
+        <form id="generate-embed-url" onSubmit={handleCopySubmit}>
+            <Stack mb={'md'}>
+                <Stack spacing="xs">
+                    <Title order={5}>Preview</Title>
+                    <Text color="dimmed">
+                        Preview your embed URL and copy it to your clipboard.
+                    </Text>
+                </Stack>
+                <Select
+                    required
+                    label={'Chart'}
+                    data={charts.map((chart) => ({
+                        value: chart.uuid,
+                        label: chart.name,
+                    }))}
+                    placeholder="Select a chart..."
+                    searchable
+                    withinPortal
+                    {...form.getInputProps('chartUuid')}
+                />
+                <Select
+                    required
+                    label={'Expires in'}
+                    data={['1 hour', '1 day', '1 week', '30 days', '1 year']}
+                    withinPortal
+                    {...form.getInputProps('expiresIn')}
+                />
+                <Input.Wrapper label="User identifier">
+                    <TextInput
+                        size={'xs'}
+                        placeholder="1234"
+                        {...form.getInputProps(`externalId`)}
+                    />
+                </Input.Wrapper>
+                <Input.Wrapper label="User email">
+                    <TextInput
+                        size={'xs'}
+                        placeholder="Type an email to add as intrinsic user attribute"
+                        {...form.getInputProps('email')}
+                    />
+                </Input.Wrapper>
+                <Input.Wrapper label="User attributes">
+                    {form.values.userAttributes.map((item, index) => (
+                        <Group key={item.uuid} mt="xs">
+                            <TextInput
+                                size={'xs'}
+                                placeholder="E.g. user_country"
+                                {...form.getInputProps(
+                                    `userAttributes.${index}.key`,
+                                )}
+                            />
+                            <TextInput
+                                size={'xs'}
+                                placeholder="E.g. US"
+                                {...form.getInputProps(
+                                    `userAttributes.${index}.value`,
+                                )}
+                            />
+                            <ActionIcon
+                                variant="light"
+                                onClick={() =>
+                                    form.removeListItem('userAttributes', index)
+                                }
+                            >
+                                <MantineIcon color="red" icon={IconTrash} />
+                            </ActionIcon>
+                        </Group>
+                    ))}
+                    <Group>
+                        <Button
+                            size="xs"
+                            mr="xxs"
+                            variant="default"
+                            mt="xs"
+                            leftIcon={<MantineIcon icon={IconPlus} />}
+                            onClick={() =>
+                                form.insertListItem('userAttributes', {
+                                    key: '',
+                                    value: '',
+                                    uuid: uuidv4(),
+                                })
+                            }
+                        >
+                            Add attribute
+                        </Button>
+                    </Group>
+                </Input.Wrapper>
+
+                <Switch
+                    {...form.getInputProps(`canExportCsv`)}
+                    labelPosition="left"
+                    label={`Can export CSV`}
+                />
+                <Switch
+                    {...form.getInputProps(`canExportImages`)}
+                    labelPosition="left"
+                    label={`Can export Images`}
+                />
+                <Switch
+                    {...form.getInputProps(`canViewUnderlyingData`)}
+                    labelPosition="left"
+                    label={`Can view underlying data`}
+                />
+                <Flex justify="flex-end" gap="sm">
+                    <Button
+                        variant={'outline'}
+                        type="submit"
+                        leftIcon={<MantineIcon icon={IconLink} />}
+                    >
+                        Generate & copy URL
+                    </Button>
+                </Flex>
+            </Stack>
+            <Stack mb="md">
+                <Stack spacing="xs">
+                    <Title order={5}>Code snippet</Title>
+                    <Text color="dimmed">
+                        Copy and paste this code snippet into your application
+                        to generate embed urls.
+                    </Text>
+                </Stack>
+                <EmbedCodeSnippet
+                    projectUuid={projectUuid}
+                    siteUrl={siteUrl}
+                    data={convertFormValuesToCreateEmbedJwt(formValues)}
+                />
+            </Stack>
+        </form>
+    );
+};
+
+export default EmbedPreviewChartForm;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -74,7 +74,7 @@ type FormValues = {
     canViewUnderlyingData?: boolean;
 } & IntrinsicUserAttributes;
 
-const EmbedUrlForm: FC<{
+const EmbedPreviewDashboardForm: FC<{
     projectUuid: string;
     siteUrl: string;
     dashboards: DashboardBasicDetails[];
@@ -372,4 +372,4 @@ const EmbedUrlForm: FC<{
     );
 };
 
-export default EmbedUrlForm;
+export default EmbedPreviewDashboardForm;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -10,6 +10,7 @@ import {
     Paper,
     PasswordInput,
     Stack,
+    Tabs,
     Text,
     Title,
 } from '@mantine/core';
@@ -25,8 +26,9 @@ import { useDashboards } from '../../../../hooks/dashboard/useDashboards';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useCharts } from '../../../../hooks/useCharts';
 import useApp from '../../../../providers/App/useApp';
-import EmbedDashboardsAndChartsForm from './EmbedDashboardsAndChartsForm';
-import EmbedUrlForm from './EmbedUrlForm';
+import EmbedAllowListForm from './EmbedAllowListForm';
+import EmbedPreviewChartForm from './EmbedPreviewChartForm';
+import EmbedPreviewDashboardForm from './EmbedPreviewDashboardForm';
 
 const useEmbedConfig = (projectUuid: string) => {
     return useQuery<DecodedEmbed, ApiError>({
@@ -226,7 +228,7 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 <Stack spacing="sm" mb="md">
                     <Title order={4}>Allowed dashboards and charts</Title>
                 </Stack>
-                <EmbedDashboardsAndChartsForm
+                <EmbedAllowListForm
                     disabled={isSaving}
                     embedConfig={embedConfig}
                     dashboards={dashboards || []}
@@ -238,11 +240,30 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                 <Stack spacing="sm" mb="md">
                     <Title order={4}>Preview & code snippet</Title>
                 </Stack>
-                <EmbedUrlForm
-                    projectUuid={projectUuid}
-                    siteUrl={health.data.siteUrl}
-                    dashboards={allowedDashboards}
-                />
+                <Tabs defaultValue="dashboards" keepMounted>
+                    <Tabs.List>
+                        <Tabs.Tab value="dashboards">Dashboards</Tabs.Tab>
+                        <Tabs.Tab value="charts">Charts</Tabs.Tab>
+                    </Tabs.List>
+                    <Tabs.Panel value="dashboards">
+                        <Stack mt="md">
+                            <EmbedPreviewDashboardForm
+                                projectUuid={projectUuid}
+                                siteUrl={health.data.siteUrl}
+                                dashboards={allowedDashboards}
+                            />
+                        </Stack>
+                    </Tabs.Panel>
+                    <Tabs.Panel value="charts">
+                        <Stack mt="md">
+                            <EmbedPreviewChartForm
+                                projectUuid={projectUuid}
+                                siteUrl={health.data.siteUrl}
+                                charts={charts || []}
+                            />
+                        </Stack>
+                    </Tabs.Panel>
+                </Tabs>
             </Paper>
         </Stack>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-109/create-embed-url-with-charts
Closes: https://linear.app/lightdash/issue/CENG-106/configure-an-embedded-chart-in-settings



![image.png](https://app.graphite.com/user-attachments/assets/dc271d14-b7ff-4e85-85a9-1ee17fb225e5.png)

<img width="933" height="631" alt="image" src="https://github.com/user-attachments/assets/543941db-7caf-4058-a660-c43f0c018910" />


<img width="547" height="190" alt="image" src="https://github.com/user-attachments/assets/c6f045ca-0ff4-43e5-a22d-d8a5b73782a6" />


Note: 

This `get-embed-url` generates a valid token and url, [like this](http://localhost:3000/embed/3675b69e-8324-4110-bdca-059031aa8da3#eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250ZW50Ijp7InR5cGUiOiJjaGFydCIsInByb2plY3RVdWlkIjoiMzY3NWI2OWUtODMyNC00MTEwLWJkY2EtMDU5MDMxYWE4ZGEzIiwiY29udGVudElkIjoiNmU5MTMyYjctYmNhMS00NmJjLWEyYWEtNGVmOTIwYzRhYzBmIiwiY2FuRXhwb3J0Q3N2Ijp0cnVlLCJjYW5FeHBvcnRJbWFnZXMiOnRydWUsImlzUHJldmlldyI6ZmFsc2UsImNhblZpZXdVbmRlcmx5aW5nRGF0YSI6dHJ1ZX0sInVzZXJBdHRyaWJ1dGVzIjp7IiI6IiJ9LCJ1c2VyIjp7ImVtYWlsIjoiZGVtb0BsaWdodGRhc2guY29tIn0sImlhdCI6MTc2Mjg0NzcyOSwiZXhwIjoxNzYyODUxMzI5fQ.7HfSliddiVRA3xzNrjgTaNKvBC4OAZWzKGY9whqeu9M)

However, this throws an `Error loading dashboard` , I don't think this is  in the scope of this PR. The `getEmbedUrl` method in service is not specific to dashboards. 

### Description:

Added chart embedding functionality to the embed settings page. Users can now generate embed URLs for individual charts in addition to dashboards. The implementation includes:

- A new `EmbedPreviewChartForm` component that allows users to select charts and configure embedding options
- A tabbed interface in the settings page to switch between dashboard and chart embedding
- Export of the `EmbedJwtContentChart` type to support chart embedding
- Renamed the previous `EmbedUrlForm` to `EmbedPreviewDashboardForm` for clarity

This enhancement gives users more flexibility by allowing them to embed specific charts rather than entire dashboards.