### PR TITLE
feat: add table name toggle and default hidden titles for BigNumber charts

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -53,6 +53,7 @@ export type BigNumber = {
     style?: CompactOrAlias;
     selectedField?: string;
     showBigNumberLabel?: boolean;
+    showTableNamesInLabel?: boolean;
     showComparison?: boolean;
     comparisonFormat?: ComparisonFormatTypes;
     flipColors?: boolean;

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -212,6 +212,11 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                             properties: {
                                 savedChartUuid: uuid,
                                 chartName: chart?.name ?? '',
+                                // BigNumber charts default to hidden title for cleaner appearance
+                                hideTitle:
+                                    chart?.chartKind === ChartKind.BIG_NUMBER
+                                        ? true
+                                        : undefined,
                             },
                             tabUuid: undefined,
                             ...defaultTileSize,

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberComparison.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberComparison.tsx
@@ -1,6 +1,5 @@
 import { ComparisonFormatTypes, type CompactOrAlias } from '@lightdash/common';
 import {
-    Grid,
     Group,
     SegmentedControl,
     Select,
@@ -14,7 +13,7 @@ import { useVisualizationContext } from '../../LightdashVisualization/useVisuali
 import { Config } from '../common/Config';
 import { StyleOptions } from './common';
 
-export const Comparison = () => {
+export const Comparison: React.FC = () => {
     const { visualizationConfig } = useVisualizationContext();
 
     if (!isBigNumberVisualizationConfig(visualizationConfig)) return null;
@@ -91,53 +90,35 @@ export const Comparison = () => {
                                 }}
                             />
 
-                            <Grid gutter="xs">
-                                <Grid.Col
-                                    span={
-                                        showStyle &&
-                                        comparisonFormat ===
-                                            ComparisonFormatTypes.RAW
-                                            ? 7
-                                            : 12 // Mantine's default Grid system is 12 columns
-                                    }
-                                >
-                                    <TextInput
-                                        label="Comparison label"
-                                        value={comparisonLabel ?? ''}
-                                        placeholder={'Add an optional label'}
-                                        onChange={(e) =>
-                                            setComparisonLabel(
-                                                e.currentTarget.value,
-                                            )
-                                        }
+                            {showStyle &&
+                                comparisonFormat ===
+                                    ComparisonFormatTypes.RAW && (
+                                    <Select
+                                        label="Format"
+                                        data={StyleOptions}
+                                        value={bigNumberComparisonStyle ?? ''}
+                                        onChange={(newValue) => {
+                                            if (!newValue) {
+                                                setBigNumberComparisonStyle(
+                                                    undefined,
+                                                );
+                                            } else {
+                                                setBigNumberComparisonStyle(
+                                                    newValue as CompactOrAlias,
+                                                );
+                                            }
+                                        }}
                                     />
-                                </Grid.Col>
-                                <Grid.Col span="auto">
-                                    {showStyle &&
-                                        comparisonFormat ===
-                                            ComparisonFormatTypes.RAW && (
-                                            <Select
-                                                label="Format"
-                                                data={StyleOptions}
-                                                value={
-                                                    bigNumberComparisonStyle ??
-                                                    ''
-                                                }
-                                                onChange={(newValue) => {
-                                                    if (!newValue) {
-                                                        setBigNumberComparisonStyle(
-                                                            undefined,
-                                                        );
-                                                    } else {
-                                                        setBigNumberComparisonStyle(
-                                                            newValue as CompactOrAlias,
-                                                        );
-                                                    }
-                                                }}
-                                            />
-                                        )}
-                                </Grid.Col>
-                            </Grid>
+                                )}
+
+                            <TextInput
+                                label="Comparison label"
+                                value={comparisonLabel ?? ''}
+                                placeholder={'Add an optional label'}
+                                onChange={(e) =>
+                                    setComparisonLabel(e.currentTarget.value)
+                                }
+                            />
                         </>
                     ) : null}
                 </Config.Section>

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberLayout.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberLayout.tsx
@@ -1,6 +1,11 @@
 import { getItemId, type CompactOrAlias } from '@lightdash/common';
-import { ActionIcon, Grid, Select, TextInput } from '@mantine/core';
-import { IconEye, IconEyeOff } from '@tabler/icons-react';
+import { ActionIcon, Group, Select, TextInput, Tooltip } from '@mantine/core';
+import {
+    IconEye,
+    IconEyeOff,
+    IconTable,
+    IconTableOff,
+} from '@tabler/icons-react';
 import { type FC } from 'react';
 import { isBigNumberVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -27,6 +32,8 @@ export const Layout: FC = () => {
         getField,
         showBigNumberLabel,
         setShowBigNumberLabel,
+        showTableNamesInLabel,
+        setShowTableNamesInLabel,
     } = visualizationConfig.chartConfig;
 
     const selectedField = getField(selectedFieldId);
@@ -47,63 +54,89 @@ export const Layout: FC = () => {
                     hasGrouping
                 />
 
-                <Grid gutter="xs">
-                    <Grid.Col
-                        span={
-                            showStyle ? 7 : 12 // Mantine's default Grid system is 12 columns
-                        }
-                    >
-                        <TextInput
-                            variant={showBigNumberLabel ? 'default' : 'filled'}
-                            label="Label"
-                            value={bigNumberLabel}
-                            placeholder={defaultLabel}
-                            onChange={(e) =>
-                                setBigNumberLabel(e.currentTarget.value)
+                {showStyle && (
+                    <Select
+                        label="Format"
+                        data={StyleOptions}
+                        value={bigNumberStyle ?? ''}
+                        onChange={(newValue) => {
+                            if (!newValue) {
+                                setBigNumberStyle(undefined);
+                                setBigNumberComparisonStyle(undefined);
+                            } else {
+                                setBigNumberStyle(newValue as CompactOrAlias);
+                                setBigNumberComparisonStyle(
+                                    newValue as CompactOrAlias,
+                                );
                             }
-                            readOnly={!showBigNumberLabel}
-                            rightSection={
+                        }}
+                    />
+                )}
+
+                <TextInput
+                    variant={showBigNumberLabel ? 'default' : 'filled'}
+                    label="Label"
+                    value={bigNumberLabel}
+                    placeholder={defaultLabel}
+                    onChange={(e) => setBigNumberLabel(e.currentTarget.value)}
+                    readOnly={!showBigNumberLabel}
+                    styles={{
+                        rightSection: {
+                            width: '60px',
+                        },
+                    }}
+                    rightSection={
+                        <Group spacing={4} noWrap>
+                            <Tooltip
+                                withinPortal
+                                label={
+                                    bigNumberLabel
+                                        ? 'Clear custom label to toggle table names'
+                                        : showTableNamesInLabel
+                                        ? 'Hide table names in label'
+                                        : 'Show table names in label'
+                                }
+                            >
                                 <ActionIcon
                                     onClick={() => {
-                                        setShowBigNumberLabel(
-                                            !showBigNumberLabel,
-                                        );
+                                        if (!bigNumberLabel) {
+                                            setShowTableNamesInLabel(
+                                                !showTableNamesInLabel,
+                                            );
+                                        }
+                                    }}
+                                    disabled={!!bigNumberLabel}
+                                    style={{
+                                        cursor: bigNumberLabel
+                                            ? 'not-allowed'
+                                            : 'pointer',
                                     }}
                                 >
                                     <MantineIcon
                                         icon={
-                                            showBigNumberLabel
-                                                ? IconEye
-                                                : IconEyeOff
+                                            showTableNamesInLabel
+                                                ? IconTable
+                                                : IconTableOff
                                         }
                                     />
                                 </ActionIcon>
-                            }
-                        />
-                    </Grid.Col>
-                    <Grid.Col span="auto">
-                        {showStyle && (
-                            <Select
-                                label="Format"
-                                data={StyleOptions}
-                                value={bigNumberStyle ?? ''}
-                                onChange={(newValue) => {
-                                    if (!newValue) {
-                                        setBigNumberStyle(undefined);
-                                        setBigNumberComparisonStyle(undefined);
-                                    } else {
-                                        setBigNumberStyle(
-                                            newValue as CompactOrAlias,
-                                        );
-                                        setBigNumberComparisonStyle(
-                                            newValue as CompactOrAlias,
-                                        );
-                                    }
+                            </Tooltip>
+                            <ActionIcon
+                                onClick={() => {
+                                    setShowBigNumberLabel(!showBigNumberLabel);
                                 }}
-                            />
-                        )}
-                    </Grid.Col>
-                </Grid>
+                            >
+                                <MantineIcon
+                                    icon={
+                                        showBigNumberLabel
+                                            ? IconEye
+                                            : IconEyeOff
+                                    }
+                                />
+                            </ActionIcon>
+                        </Group>
+                    }
+                />
             </Config.Section>
         </Config>
     );

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    ChartType,
     DashboardTileTypes,
     assertUnreachable,
     getDefaultChartTileSize,
@@ -254,6 +255,11 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                         belongsToDashboard: true,
                         savedChartUuid: savedQuery.uuid,
                         chartName: values.name,
+                        // BigNumber charts default to hidden title for cleaner appearance
+                        hideTitle:
+                            savedData.chartConfig?.type === ChartType.BIG_NUMBER
+                                ? true
+                                : undefined,
                     },
                     ...getDefaultChartTileSize(savedData.chartConfig?.type),
                 };

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -8,6 +8,7 @@ import {
     getCustomFormatFromLegacy,
     getItemId,
     getItemLabel,
+    getItemLabelWithoutTableName,
     hasFormatOptions,
     hasValidFormatExpression,
     isField,
@@ -189,11 +190,21 @@ const useBigNumberConfig = (
         return itemsMap[selectedField];
     }, [itemsMap, selectedField]);
 
+    const [showTableNamesInLabel, setShowTableNamesInLabel] = useState<
+        BigNumber['showTableNamesInLabel'] | undefined
+    >(bigNumberConfigData?.showTableNamesInLabel);
+
     const label = useMemo(() => {
+        // For backwards compatibility: undefined means show table names (existing charts)
+        // false means hide table names (new charts default to hidden)
+        const shouldShowTableName = showTableNamesInLabel ?? true;
+
         return item
-            ? getItemLabel(item)
+            ? shouldShowTableName
+                ? getItemLabel(item)
+                : getItemLabelWithoutTableName(item)
             : selectedField && friendlyName(selectedField);
-    }, [item, selectedField]);
+    }, [item, selectedField, showTableNamesInLabel]);
 
     const [bigNumberLabel, setBigNumberLabel] = useState<
         BigNumber['label'] | undefined
@@ -227,6 +238,9 @@ const useBigNumberConfig = (
 
         setBigNumberLabel(bigNumberConfigData?.label);
         setShowBigNumberLabel(bigNumberConfigData?.showBigNumberLabel ?? true);
+        setShowTableNamesInLabel(
+            bigNumberConfigData?.showTableNamesInLabel ?? true,
+        );
 
         setBigNumberStyle(bigNumberConfigData?.style);
         setBigNumberComparisonStyle(bigNumberConfigData?.style);
@@ -383,6 +397,7 @@ const useBigNumberConfig = (
             style: bigNumberStyle,
             selectedField: selectedField,
             showBigNumberLabel,
+            showTableNamesInLabel,
             showComparison,
             comparisonFormat,
             flipColors,
@@ -393,6 +408,7 @@ const useBigNumberConfig = (
         bigNumberStyle,
         selectedField,
         showBigNumberLabel,
+        showTableNamesInLabel,
         showComparison,
         comparisonFormat,
         flipColors,
@@ -426,6 +442,8 @@ const useBigNumberConfig = (
         comparisonTooltip,
         comparisonLabel,
         setComparisonLabel,
+        showTableNamesInLabel,
+        setShowTableNamesInLabel,
     };
 };
 

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -5,7 +5,7 @@ import { type ConfigCacheMap } from './types';
 
 const DEFAULTS: Record<ChartType, () => unknown> = {
     [ChartType.CARTESIAN]: () => ({ ...EMPTY_CARTESIAN_CHART_CONFIG }), // factory to avoid shared refs
-    [ChartType.BIG_NUMBER]: () => ({}),
+    [ChartType.BIG_NUMBER]: () => ({ showTableNamesInLabel: false }),
     [ChartType.TABLE]: () => ({ showTableNames: false }),
     [ChartType.PIE]: () => ({}),
     [ChartType.FUNNEL]: () => ({}),


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17664

### Description:
Improved BigNumber chart UX with several enhancements:

1. Added option to show/hide table names in BigNumber labels
2. Set BigNumber charts to hide titles by default when added to dashboards
3. Improved layout of BigNumber configuration panels:
   - Reorganized format controls for better spacing
   - Added tooltip for table name toggle
   - Improved right section styling in the label input

These changes make BigNumber charts cleaner and more customizable, with sensible defaults for new charts while maintaining backward compatibility for existing ones.