### PR TITLE
fix: random black line appears on top of some charts

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1528,6 +1528,13 @@ const getEchartAxes = ({
               maybeGetAxisDefaultMinValue(allowFirstAxisDefaultRange)
             : undefined;
 
+    const showSecondaryXAxis = validCartesianConfig.layout.flipAxes
+        ? topAxisXFieldIds && topAxisXFieldIds.length > 0
+        : false;
+    const showSecondaryYAxis = !validCartesianConfig.layout.flipAxes
+        ? rightAxisYFieldIds && rightAxisYFieldIds.length > 0
+        : false;
+
     return {
         xAxis: [
             {
@@ -1581,6 +1588,7 @@ const getEchartAxes = ({
             },
             {
                 type: topAxisType,
+                show: showSecondaryXAxis,
                 ...(showXAxis
                     ? {
                           name: validCartesianConfig.layout.flipAxes
@@ -1621,6 +1629,7 @@ const getEchartAxes = ({
                 axisTick: getAxisTickStyle(
                     validCartesianConfig?.eChartsConfig?.showAxisTicks,
                 ),
+                inverse: !!xAxisConfiguration?.[1]?.inverse,
                 ...topAxisExtraConfig,
             },
         ],
@@ -1679,6 +1688,7 @@ const getEchartAxes = ({
             },
             {
                 type: rightAxisType,
+                show: showSecondaryYAxis,
                 ...(showYAxis
                     ? {
                           name: validCartesianConfig.layout.flipAxes
@@ -1725,6 +1735,7 @@ const getEchartAxes = ({
                 axisTick: getAxisTickStyle(
                     validCartesianConfig?.eChartsConfig?.showAxisTicks,
                 ),
+                inverse: !!yAxisConfiguration?.[1]?.inverse,
                 ...rightAxisExtraConfig,
             },
         ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17666

### Description:
Fixed an issue where a random line appears in charts (secondary axis). This occurs when configuring a chart with min/max axis values. When the library detects a min/max configuration, it renders the secondary axis using default colors. This PR improves secondary axis rendering to prevent this behavior while accounting for cases where the axis should be flipped.

_after_
![image.png](https://app.graphite.com/user-attachments/assets/d37c4881-2f29-46d3-b20c-e4258ba93a4f.png)

_before_

![image.png](https://app.graphite.com/user-attachments/assets/04a96efc-8538-4696-92fe-8d9600cd8639.png)

