### PR TITLE
fix: get tooltip format field when pivotValuesColumnMap does not exist

### DIFF
--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -673,6 +673,8 @@ export const buildCartesianTooltipFormatter =
                     (pivotDim &&
                         pivotValuesColumnsMap?.[pivotDim]?.referenceField) ??
                     yRefField ??
+                    // Fallback to pivotReference.field when pivotValuesColumnsMap is unavailable
+                    seriesOption?.pivotReference?.field ??
                     dim ??
                     pivotDim ??
                     '';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->



### Description:

When we have pivoted data, each series has a `pivotReference` that specifies which field it represents (e.g., `orders_average_order_size`) and what pivot values it has (e.g., `orders_order_priority: "high"`).

The tooltip formatter was relying on `pivotValuesColumnsMap` to look up the original field name for formatting. When this map was `undefined`, the formatter would fall back to using the pivoted column name (like `orders_average_order_size.orders_order_priority.high`) to look up formatting info in `itemsMap`. But that pivoted column name doesn't exist in `itemsMap`—only the base field `orders_average_order_size` does.

**fix**
Added a fallback that uses `seriesOption?.pivotReference?.field` when `pivotValuesColumnsMap` is unavailable. This ensures that even when the pivot values map isn't provided, we can still extract the correct base field name from the series' pivot reference and apply proper formatting.

To test: [http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/orders?create_saved_chart_version={"uuid"%3A"0364bd48-e79f-4a45-8e69-afb1441ac8c3"%2C"projectUuid"%3A"3675b69e-8324-4110-bdca-059031aa8da3"%2C"name"%3A"test"%2C"description"%3A""%2C"tableName"%3A"orders"%2C"updatedAt"%3A"2025-10-20T12%3A58%3A29.588Z"%2C"updatedByUser"%3A{"userUuid"%3A"b264d83a-9000-426a-85ec-3f9c20f368ce"%2C"firstName"%3A"Davide"%2C"lastName"%3A"Attenborough"}%2C"metricQuery"%3A{"exploreName"%3A"orders"%2C"dimensions"%3A["orders_order_priority"%2C"orders_order_date_month"]%2C"metrics"%3A["orders_average_order_size"%2C"orders_total_order_amount"]%2C"filters"%3A{}%2C"sorts"%3A[{"fieldId"%3A"orders_order_priority"%2C"descending"%3Afalse}]%2C"limit"%3A500%2C"metricOverrides"%3A{}%2C"tableCalculations"%3A[]%2C"additionalMetrics"%3A[]%2C"customDimensions"%3A[]}%2C"chartConfig"%3A{"type"%3A"cartesian"%2C"config"%3A{"layout"%3A{"xField"%3A"orders_order_date_month"%2C"yField"%3A["orders_average_order_size"%2C"orders_total_order_amount"]}%2C"eChartsConfig"%3A{}}}%2C"tableConfig"%3A{"columnOrder"%3A["orders_order_priority"%2C"orders_order_date_month"%2C"orders_average_order_size"%2C"orders_total_order_amount"]}%2C"organizationUuid"%3A"172a2270-000f-42be-9c68-c4752c23ae51"%2C"pivotConfig"%3A{"columns"%3A["orders_order_priority"]}%2C"spaceUuid"%3A"c85c523e-0aa6-4fad-a577-9c80c75e3a16"%2C"spaceName"%3A"Jaffle+shop"%2C"pinnedListUuid"%3Anull%2C"pinnedListOrder"%3Anull%2C"dashboardUuid"%3A"d1fbbf14-3b73-4826-87a4-1b0f2583bc08"%2C"dashboardName"%3A"Jaffle+dashboard"%2C"colorPalette"%3A["%2333ffb1"%2C"%23ff33e1"%2C"%2333e6ff"%2C"%23ffdd8a"%2C"%23ffdefa"%2C"%2373c0de"%2C"%23ff8178"%2C"%239a60b4"%2C"%23ea7ccc"%2C"%2333ff7d"%2C"%2333ffb1"%2C"%2333ffe6"%2C"%2333e6ff"%2C"%2333b1ff"%2C"%23337dff"%2C"%233349ff"%2C"%235e33ff"%2C"%239233ff"%2C"%23c633ff"%2C"%23ff33e1"]%2C"slug"%3A"test"%2C"isPrivate"%3Afalse%2C"access"%3A[{"userUuid"%3A"b264d83a-9000-426a-85ec-3f9c20f368ce"%2C"firstName"%3A"Davide"%2C"lastName"%3A"Attenborough"%2C"email"%3A"demo%40lightdash.com"%2C"role"%3A"admin"%2C"hasDirectAccess"%3Atrue%2C"inheritedRole"%3A"admin"%2C"inheritedFrom"%3A"organization"%2C"projectRole"%3A"admin"}]}&isExploreFromHere=true](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/orders?create_saved_chart_version=%7B%22uuid%22%3A%220364bd48-e79f-4a45-8e69-afb1441ac8c3%22%2C%22projectUuid%22%3A%223675b69e-8324-4110-bdca-059031aa8da3%22%2C%22name%22%3A%22test%22%2C%22description%22%3A%22%22%2C%22tableName%22%3A%22orders%22%2C%22updatedAt%22%3A%222025-10-20T12%3A58%3A29.588Z%22%2C%22updatedByUser%22%3A%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22Davide%22%2C%22lastName%22%3A%22Attenborough%22%7D%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_order_priority%22%2C%22orders_order_date_month%22%5D%2C%22metrics%22%3A%5B%22orders_average_order_size%22%2C%22orders_total_order_amount%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_order_priority%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A500%2C%22metricOverrides%22%3A%7B%7D%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_order_date_month%22%2C%22yField%22%3A%5B%22orders_average_order_size%22%2C%22orders_total_order_amount%22%5D%7D%2C%22eChartsConfig%22%3A%7B%7D%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_order_priority%22%2C%22orders_order_date_month%22%2C%22orders_average_order_size%22%2C%22orders_total_order_amount%22%5D%7D%2C%22organizationUuid%22%3A%22172a2270-000f-42be-9c68-c4752c23ae51%22%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22orders_order_priority%22%5D%7D%2C%22spaceUuid%22%3A%22c85c523e-0aa6-4fad-a577-9c80c75e3a16%22%2C%22spaceName%22%3A%22Jaffle+shop%22%2C%22pinnedListUuid%22%3Anull%2C%22pinnedListOrder%22%3Anull%2C%22dashboardUuid%22%3A%22d1fbbf14-3b73-4826-87a4-1b0f2583bc08%22%2C%22dashboardName%22%3A%22Jaffle+dashboard%22%2C%22colorPalette%22%3A%5B%22%2333ffb1%22%2C%22%23ff33e1%22%2C%22%2333e6ff%22%2C%22%23ffdd8a%22%2C%22%23ffdefa%22%2C%22%2373c0de%22%2C%22%23ff8178%22%2C%22%239a60b4%22%2C%22%23ea7ccc%22%2C%22%2333ff7d%22%2C%22%2333ffb1%22%2C%22%2333ffe6%22%2C%22%2333e6ff%22%2C%22%2333b1ff%22%2C%22%23337dff%22%2C%22%233349ff%22%2C%22%235e33ff%22%2C%22%239233ff%22%2C%22%23c633ff%22%2C%22%23ff33e1%22%5D%2C%22slug%22%3A%22test%22%2C%22isPrivate%22%3Afalse%2C%22access%22%3A%5B%7B%22userUuid%22%3A%22b264d83a-9000-426a-85ec-3f9c20f368ce%22%2C%22firstName%22%3A%22Davide%22%2C%22lastName%22%3A%22Attenborough%22%2C%22email%22%3A%22demo%40lightdash.com%22%2C%22role%22%3A%22admin%22%2C%22hasDirectAccess%22%3Atrue%2C%22inheritedRole%22%3A%22admin%22%2C%22inheritedFrom%22%3A%22organization%22%2C%22projectRole%22%3A%22admin%22%7D%5D%7D&isExploreFromHere=true)

**before**

![image.png](https://app.graphite.com/user-attachments/assets/926930a9-3a45-4ae2-a5e1-b08a84bb600c.png)

**after**

![image.png](https://app.graphite.com/user-attachments/assets/00f48c7b-37c4-4dd1-89a8-933ec04f4da1.png)