### PR TITLE
fix: cannot read properties of undefined (reading 'status')

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -208,14 +208,15 @@ export class UnfurlService extends BaseService {
                         `Received paginated response: ${response.url()}`,
                     );
                     const body = await response.body();
-                    const json = JSON.parse(body.toString()) as {
+                    const json = JSON.parse(body.toString()) as Partial<{
                         status: 'ok';
                         results: ApiGetAsyncQueryResults;
-                    };
+                    }>;
+
                     // Check if is last page (aka has no next page)
                     if (
-                        json.results.status === QueryHistoryStatus.READY &&
-                        !json.results.nextPage
+                        json.results?.status === QueryHistoryStatus.READY &&
+                        !json.results?.nextPage
                     ) {
                         responseCount += 1;
                         this.logger.info(
@@ -231,10 +232,10 @@ export class UnfurlService extends BaseService {
                     } else {
                         this.logger.debug(
                             `Paginated response is not complete. Status: ${
-                                json.results.status
+                                json.results?.status
                             }, hasNextPage: ${
-                                'nextPage' in json.results
-                                    ? !!json.results.nextPage
+                                json.results && 'nextPage' in json.results
+                                    ? !!json.results?.nextPage
                                     : 'N/A'
                             }`,
                         );
@@ -825,12 +826,12 @@ export class UnfurlService extends BaseService {
                                     ) {
                                         const json = JSON.parse(
                                             buffer.toString(),
-                                        ) as {
+                                        ) as Partial<{
                                             status: 'ok';
                                             results: ApiGetAsyncQueryResults;
-                                        };
+                                        }>;
                                         if (
-                                            json.results.status ===
+                                            json.results?.status ===
                                             QueryHistoryStatus.ERROR
                                         ) {
                                             this.logger.error(
@@ -1275,13 +1276,13 @@ export class UnfurlService extends BaseService {
         }
         const header = response.headers.get('set-cookie');
         if (header === null) {
-            const loginBody = (await response.json()) as {
+            const loginBody = (await response.json()) as Partial<{
                 status: string;
                 results: SessionUser;
-            };
+            }>;
             throw new AuthorizationError(
                 `Cannot sign in user before taking screenshot:\n${
-                    'results' in loginBody ? loginBody.results?.userUuid : ''
+                    loginBody.results?.userUuid ?? ''
                 }`,
             );
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17946

### Description:
Improved type safety in the UnfurlService by making JSON response objects partial types. This prevents potential runtime errors when accessing properties that might not exist in the response, particularly for `results` and its nested properties.

The changes include:
- Updated type definitions to use `Partial<{...}>` for JSON response objects
- Added null checks with optional chaining for accessing properties like `json.results?.status`
- Added conditional checks before accessing nested properties to prevent undefined errors