### PR TITLE
feat: improve pie chart label formatting and default settings

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -122,23 +122,24 @@ const useEchartsPieConfig = (
                             // For outside labels, use rich text formatting
                             if (isOutside) {
                                 if (showValue && showPercentage) {
-                                    return `{name|${params.name}}\n{value|${params.percent}% - ${meta.value.formatted}}`;
+                                    return `{name|${params.name}: }{value|${params.percent}% - ${meta.value.formatted}}`;
                                 } else if (showValue) {
-                                    return `{name|${params.name}}\n{value|${meta.value.formatted}}`;
+                                    return `{name|${params.name}: }{value|${meta.value.formatted}}`;
                                 } else if (showPercentage) {
-                                    return `{name|${params.name}}\n{value|${params.percent}%}`;
+                                    return `{name|${params.name}: }{value|${params.percent}%}`;
                                 } else {
                                     return `{name|${params.name}}`;
                                 }
                             }
 
                             // For inside labels, use plain formatting (no rich text)
+                            // Always show name alongside value/percentage
                             return showValue && showPercentage
-                                ? `${params.percent}% - ${meta.value.formatted}`
+                                ? `${params.name}: ${params.percent}% - ${meta.value.formatted}`
                                 : showValue
-                                ? `${meta.value.formatted}`
+                                ? `${params.name}: ${meta.value.formatted}`
                                 : showPercentage
-                                ? `${params.percent}%`
+                                ? `${params.name}: ${params.percent}%`
                                 : `${params.name}`;
                         },
                     },

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -7,7 +7,7 @@ const DEFAULTS: Record<ChartType, () => unknown> = {
     [ChartType.CARTESIAN]: () => ({ ...EMPTY_CARTESIAN_CHART_CONFIG }), // factory to avoid shared refs
     [ChartType.BIG_NUMBER]: () => ({ showTableNamesInLabel: false }),
     [ChartType.TABLE]: () => ({ showTableNames: false }),
-    [ChartType.PIE]: () => ({}),
+    [ChartType.PIE]: () => ({ showLegend: false, valueLabel: 'outside' }),
     [ChartType.FUNNEL]: () => ({}),
     [ChartType.TREEMAP]: () => ({}),
     [ChartType.CUSTOM]: () => ({}),


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17665

### Description:
Improves pie chart label formatting by:
1. Changing outside labels to show name and value on the same line with a colon separator
2. Adding the data point name to inside labels for better context
3. Setting default pie chart configuration to hide legend and position value labels outside the chart

This makes pie chart labels more consistent and readable, especially when showing both percentages and values.