### PR TITLE
fix: display title and error message for deleted charts on dashboard tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -153,22 +153,30 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
 
     // No chart available or savedSqlUuid is undefined - which means that the chart was deleted
     if (chartData === undefined || !savedSqlUuid) {
+        const errorMessage = !savedSqlUuid
+            ? 'This SQL chart has been deleted.'
+            : chartError?.error?.message || 'Error fetching chart';
+
+        const tileTitle =
+            tile.properties.title ||
+            tile.properties.chartName ||
+            'Deleted SQL chart';
+
         return (
             <TileBase
                 isEditMode={isEditMode}
                 chartName={tile.properties.chartName ?? ''}
                 tile={tile}
                 isLoading={!!savedSqlUuid && isChartLoading}
-                title={tile.properties.title || tile.properties.chartName || ''}
+                title={tileTitle}
                 {...rest}
             >
-                {!isChartLoading && (
+                {(!savedSqlUuid || !isChartLoading) && (
                     <SuboptimalState
                         icon={IconAlertCircle}
                         title={formatChartErrorMessage(
                             tile.properties.chartName,
-                            chartError?.error?.message ||
-                                'Error fetching chart',
+                            errorMessage,
                         )}
                     />
                 )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17947

### Description:
Improved error handling for deleted charts on dashboards. Added proper error messages and titles for orphaned dashboard tiles where the underlying chart has been deleted. This includes:

- Created a new `ClientSideError` type to handle client-side error cases
- Added detection for orphaned chart tiles where `savedChartUuid` is null
- Ensured tile titles are displayed even when charts are in error states
- Improved error message display for deleted SQL charts
- Standardized fallback titles to show "Deleted chart" or "Deleted SQL chart" when appropriate

This change provides better user feedback when charts referenced by dashboard tiles no longer exist.

Quick demo of the new state, when the chart was deleted outside of the dashboard:
<img width="883" height="460" alt="Screenshot 2025-11-07 at 15 21 41" src="https://github.com/user-attachments/assets/de7f1037-eb19-4e83-9a33-bc593e096ba1" />
