### PR TITLE
fix: avoid duplicate artifact embedding jobs

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2317,6 +2317,23 @@ export class AiAgentModel {
         );
     }
 
+    async getArtifactEmbedding(
+        artifactVersionUuid: string,
+    ): Promise<number[] | null> {
+        const result = await this.database(AiArtifactVersionsTableName)
+            .select('embedding_vector')
+            .where({ ai_artifact_version_uuid: artifactVersionUuid })
+            .first();
+
+        if (!result) {
+            throw new NotFoundError(
+                `Artifact version ${artifactVersionUuid} not found`,
+            );
+        }
+
+        return result.embedding_vector;
+    }
+
     async updateSlackResponseTs(data: UpdateSlackResponseTs) {
         await this.database(AiSlackPromptTableName)
             .update({

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1748,22 +1748,28 @@ export class AiAgentService {
             return;
         }
 
-        void this.schedulerClient
-            .embedArtifactVersion({
-                organizationUuid,
-                projectUuid: agent.projectUuid,
-                userUuid: user.userUuid,
-                artifactVersionUuid: versionUuid,
-                title: artifact.title,
-                description: artifact.description,
-            })
-            .catch((error) => {
-                Logger.error(
-                    'Failed to enqueue embedding job:',
-                    error instanceof Error ? error.message : error,
-                );
-                Sentry.captureException(error);
-            });
+        // Only embed if not already embedded
+        const embedding = await this.aiAgentModel.getArtifactEmbedding(
+            versionUuid,
+        );
+        if (embedding === null) {
+            void this.schedulerClient
+                .embedArtifactVersion({
+                    organizationUuid,
+                    projectUuid: agent.projectUuid,
+                    userUuid: user.userUuid,
+                    artifactVersionUuid: versionUuid,
+                    title: artifact.title,
+                    description: artifact.description,
+                })
+                .catch((error) => {
+                    Logger.error(
+                        'Failed to enqueue embedding job:',
+                        error instanceof Error ? error.message : error,
+                    );
+                    Sentry.captureException(error);
+                });
+        }
     }
 
     async embedArtifactVersion(payload: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a check to prevent duplicate embedding of artifact versions. The PR introduces a new `getArtifactEmbedding` method in the `AiAgentModel` class to retrieve existing embeddings, and modifies the embedding process to only schedule new embedding jobs when an embedding doesn't already exist for a given artifact version.
