### PR TITLE
feat: add suggested questions from verified artifacts

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -19,6 +19,7 @@ import {
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadSummaryListResponse,
     ApiAiAgentVerifiedArtifactsResponse,
+    ApiAiAgentVerifiedQuestionsResponse,
     ApiAppendEvaluationRequest,
     ApiAppendInstructionRequest,
     ApiAppendInstructionResponse,
@@ -202,6 +203,25 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentUuid}/verified-questions')
+    @OperationId('getVerifiedQuestions')
+    async getVerifiedQuestions(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+    ): Promise<ApiAiAgentVerifiedQuestionsResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getVerifiedQuestions(
+                req.user!,
+                agentUuid,
+            ),
         };
     }
 

--- a/packages/backend/src/ee/database/entities/aiArtifacts.ts
+++ b/packages/backend/src/ee/database/entities/aiArtifacts.ts
@@ -30,6 +30,7 @@ export type DbAiArtifactVersion = {
     dashboard_config: Record<string, unknown> | null;
     verified_by_user_uuid: string | null;
     verified_at: Date | null;
+    verified_question: string | null;
 };
 
 export type AiArtifactVersionsTable = Knex.CompositeTableType<
@@ -48,6 +49,7 @@ export type AiArtifactVersionsTable = Knex.CompositeTableType<
             | 'dashboard_config'
             | 'verified_by_user_uuid'
             | 'verified_at'
+            | 'verified_question'
         >
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20251107141324_add_verified_question_to_artifact_versions.ts
+++ b/packages/backend/src/ee/database/migrations/20251107141324_add_verified_question_to_artifact_versions.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const AI_ARTIFACT_VERSIONS_TABLE = 'ai_artifact_versions';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AI_ARTIFACT_VERSIONS_TABLE, (table) => {
+        table.text('verified_question').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AI_ARTIFACT_VERSIONS_TABLE, (table) => {
+        table.dropColumn('verified_question');
+    });
+}

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -2,6 +2,7 @@ import {
     AiAgentEvalRunJobPayload,
     EE_SCHEDULER_TASKS,
     EmbedArtifactVersionJobPayload,
+    GenerateArtifactQuestionJobPayload,
     SlackPromptJobPayload,
 } from '@lightdash/common';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
@@ -40,6 +41,22 @@ export class CommercialSchedulerClient extends SchedulerClient {
         const now = new Date();
         const { id: jobId } = await graphileClient.addJob(
             EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION,
+            payload,
+            {
+                runAt: now,
+                maxAttempts: 3,
+            },
+        );
+        return { jobId };
+    }
+
+    async generateArtifactQuestion(
+        payload: GenerateArtifactQuestionJobPayload,
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION,
             payload,
             {
                 runAt: now,

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -57,6 +57,12 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             ) => {
                 await this.aiAgentService.embedArtifactVersion(payload);
             },
+            [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: async (
+                payload,
+                _helpers,
+            ) => {
+                await this.aiAgentService.generateArtifactQuestion(payload);
+            },
             [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: async (
                 payload,
                 helpers,

--- a/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/questionGenerator.ts
@@ -1,0 +1,60 @@
+import { generateObject, LanguageModel } from 'ai';
+import { z } from 'zod';
+
+const QUESTION_MAX_LENGTH_CHARS = 200;
+const QuestionSchema = z.object({
+    question: z
+        .string()
+        .min(1, 'Question must not be empty')
+        .max(
+            QUESTION_MAX_LENGTH_CHARS,
+            `Question must be ${QUESTION_MAX_LENGTH_CHARS} characters or less`,
+        )
+        .describe('A natural question a user might ask about this artifact'),
+});
+
+export type GeneratedQuestion = z.infer<typeof QuestionSchema>;
+
+export async function generateArtifactQuestion(
+    model: LanguageModel,
+    title: string | null,
+    description: string | null,
+    metadata: Record<string, string> = {},
+): Promise<string> {
+    const result = await generateObject({
+        model,
+        schema: QuestionSchema,
+        messages: [
+            {
+                role: 'system',
+                content: `You are a helpful assistant that creates natural questions users might ask to get the data shown in an artifact.
+
+Generate a concise question (maximum ${QUESTION_MAX_LENGTH_CHARS} characters) that a user might ask to obtain this data or insight.
+
+Good examples:
+- "What were the total orders in the last 30 days?"
+- "How has revenue changed over the last 12 months?"
+- "What is the average shipping cost by fulfillment center for express promo orders?"
+- "Which 5 shipping methods have the highest percentage of orders?"
+
+The question should be natural, specific, and actionable - something a user would type into a search or chat interface.`,
+            },
+            {
+                role: 'user',
+                content: `Please create a question based on this artifact:
+Title: ${title || 'N/A'}
+Description: ${description || 'N/A'}`,
+            },
+        ],
+        temperature: 0.3,
+        experimental_telemetry: {
+            functionId: 'generateArtifactQuestion',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
+    });
+
+    return result.object.question;
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5846,6 +5846,36 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess__question-string--uuid-string_-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            uuid: { dataType: 'string', required: true },
+                            question: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentVerifiedQuestionsResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess__question-string--uuid-string_-Array_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCreateAiAgentResponse: {
         dataType: 'refAlias',
         type: {
@@ -13307,6 +13337,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['slackAiPrompt'] },
                 { dataType: 'enum', enums: ['aiAgentEvalResult'] },
                 { dataType: 'enum', enums: ['embedArtifactVersion'] },
+                { dataType: 'enum', enums: ['generateArtifactQuestion'] },
                 { dataType: 'enum', enums: ['handleScheduledDelivery'] },
                 { dataType: 'enum', enums: ['sendSlackNotification'] },
                 { dataType: 'enum', enums: ['sendEmailNotification'] },
@@ -24670,6 +24701,72 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getVerifiedArtifacts',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getVerifiedQuestions: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/verified-questions',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getVerifiedQuestions,
+        ),
+
+        async function AiAgentController_getVerifiedQuestions(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getVerifiedQuestions,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getVerifiedQuestions',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6587,6 +6587,35 @@
             "ApiAiAgentVerifiedArtifactsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_AiAgentVerifiedArtifact-Array__"
             },
+            "ApiSuccess__question-string--uuid-string_-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "properties": {
+                                "uuid": {
+                                    "type": "string"
+                                },
+                                "question": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["uuid", "question"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentVerifiedQuestionsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess__question-string--uuid-string_-Array_"
+            },
             "ApiCreateAiAgentResponse": {
                 "properties": {
                     "results": {
@@ -13828,6 +13857,7 @@
                     "slackAiPrompt",
                     "aiAgentEvalResult",
                     "embedArtifactVersion",
+                    "generateArtifactQuestion",
                     "handleScheduledDelivery",
                     "sendSlackNotification",
                     "sendEmailNotification",

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -124,7 +124,17 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
 
-    [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: () => ({}),
+    [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
+
+    [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
 
     [SCHEDULER_TASKS.RENAME_RESOURCES]: (payload) => ({
         'organization.uuid': payload.organizationUuid,

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -432,6 +432,10 @@ export type ApiAiAgentVerifiedArtifactsResponse = ApiSuccess<
     KnexPaginatedData<AiAgentVerifiedArtifact[]>
 >;
 
+export type ApiAiAgentVerifiedQuestionsResponse = ApiSuccess<
+    { question: string; uuid: string }[]
+>;
+
 export type AiAgentEvaluationPrompt = {
     evalPromptUuid: string;
     createdAt: Date;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -104,6 +104,12 @@ export type EmbedArtifactVersionJobPayload = TraceTaskBase & {
     description: string | null;
 };
 
+export type GenerateArtifactQuestionJobPayload = TraceTaskBase & {
+    artifactVersionUuid: string;
+    title: string | null;
+    description: string | null;
+};
+
 export type CloneThread = {
     sourceThreadUuid: string;
     sourcePromptUuid: string;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -2,6 +2,7 @@ import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
     type EmbedArtifactVersionJobPayload,
+    type GenerateArtifactQuestionJobPayload,
     type SlackPromptJobPayload,
 } from '../ee';
 import { type SchedulerIndexCatalogJobPayload } from './catalog';
@@ -31,6 +32,7 @@ export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
+    GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -85,12 +87,14 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: DownloadAsyncQueryResultsPayload;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
+    [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
 }
 
 export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
+    [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
 }
 
 export type SchedulerTaskName =

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -80,6 +80,7 @@
         "echarts": "^5.6.0",
         "echarts-for-react": "^3.0.2",
         "emoji-picker-react": "^4.12.0",
+        "fastest-levenshtein": "^1.0.16",
         "fuse.js": "^6.5.3",
         "hast": "^1.0.0",
         "html2canvas": "^1.4.1",

--- a/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions.module.css
@@ -1,0 +1,24 @@
+.questionCard {
+    transition: all 0.15s ease;
+    overflow: hidden;
+}
+
+.questionCard:hover {
+    box-shadow: var(--mantine-shadow-sm);
+    border-color: var(--mantine-color-blue-4);
+}
+
+.questionCard:hover .questionButton:not(:disabled) {
+    background-color: var(--mantine-color-gray-0);
+}
+
+.questionButton {
+    width: 100%;
+    height: 100%;
+    padding: var(--mantine-spacing-xs);
+    text-align: left;
+    cursor: pointer;
+    border-radius: var(--mantine-radius-md);
+    transition: background-color 0.15s ease;
+    display: block;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions.tsx
@@ -1,0 +1,77 @@
+import {
+    Paper,
+    SimpleGrid,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
+import shuffle from 'lodash/shuffle';
+import { type FC, useMemo } from 'react';
+import classes from './SuggestedQuestions.module.css';
+import { getLeastSimilar } from './getLeastSimilar';
+
+type SuggestedQuestion = {
+    question: string;
+    uuid: string;
+};
+
+type SuggestedQuestionsProps = {
+    questions: SuggestedQuestion[];
+    onQuestionClick: (question: string) => void;
+    isLoading?: boolean;
+};
+
+const MIN_AVAILABLE_QUESTIONS = 6;
+const MIN_SUGGESTED_QUESTIONS = 2;
+
+export const SuggestedQuestions: FC<SuggestedQuestionsProps> = ({
+    questions,
+    onQuestionClick,
+    isLoading,
+}) => {
+    const selectedQuestions = useMemo(() => {
+        if (questions.length <= MIN_AVAILABLE_QUESTIONS) {
+            return [];
+        }
+
+        const shuffled = shuffle(questions);
+        return getLeastSimilar(
+            shuffled,
+            (q) => q.question,
+            MIN_SUGGESTED_QUESTIONS,
+        );
+    }, [questions]);
+
+    if (selectedQuestions.length < MIN_SUGGESTED_QUESTIONS) {
+        return null;
+    }
+
+    return (
+        <Stack gap="xs">
+            <Text size="sm" c="dimmed" fw={500}>
+                Suggested questions
+            </Text>
+            <SimpleGrid cols={2} spacing="xs">
+                {selectedQuestions.map((q) => (
+                    <Paper
+                        key={q.uuid}
+                        withBorder
+                        shadow="xs"
+                        radius="md"
+                        className={classes.questionCard}
+                    >
+                        <UnstyledButton
+                            onClick={() => onQuestionClick(q.question)}
+                            disabled={isLoading}
+                            className={classes.questionButton}
+                        >
+                            <Text size="sm" lh={1.4}>
+                                {q.question}
+                            </Text>
+                        </UnstyledButton>
+                    </Paper>
+                ))}
+            </SimpleGrid>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/getLeastSimilar.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/getLeastSimilar.test.ts
@@ -1,0 +1,40 @@
+import { getLeastSimilar } from './getLeastSimilar';
+
+const idfn = <T>(x: T) => x;
+
+describe('getLeastSimilar', () => {
+    it('should return the least similar items', () => {
+        const items = [
+            'zatto',
+            'catto',
+            'gatto',
+            'bird',
+            'dog',
+            'wolf',
+            'batto',
+        ];
+        const result = getLeastSimilar(items, idfn, 4);
+        expect(result).not.toContain(['catto', 'gatto']);
+    });
+
+    it('should diversify similar real questions', () => {
+        const questions = [
+            'How have unique order volumes by shipping method changed each month over time?',
+            'How have unique order counts and total order amounts changed each month over time?',
+            'What is the total revenue and unique payment count for each payment method?',
+            'What is the average payment amount for each payment method?',
+            'What is the average payment amount for each payment method?',
+            'How have unique order counts and total order amounts changed by month over time?',
+            'How have unique order counts and total order amounts changed each month over time?',
+            'How have unique order counts and total order amounts changed each month over time?',
+        ];
+
+        const result = getLeastSimilar(questions, idfn, 3);
+
+        expect(result).toEqual([
+            'How have unique order volumes by shipping method changed each month over time?',
+            'What is the total revenue and unique payment count for each payment method?',
+            'How have unique order counts and total order amounts changed by month over time?',
+        ]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/getLeastSimilar.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/getLeastSimilar.ts
@@ -1,0 +1,42 @@
+import { distance } from 'fastest-levenshtein';
+
+export function getLeastSimilar<T>(
+    xs: T[],
+    getValue: (x: T) => string,
+    m: number,
+): T[] {
+    if (m >= xs.length) return xs;
+
+    const selected: T[] = [];
+    const remaining = new Set(xs);
+
+    const first = xs[0];
+    selected.push(first);
+    remaining.delete(first);
+
+    while (selected.length < m) {
+        let maxMinDist = -Infinity;
+        let best: T | null = null;
+
+        for (const candidate of remaining) {
+            // Find minimum distance from candidate to any selected string
+            const minDist = Math.min(
+                ...selected.map((s) =>
+                    distance(getValue(candidate), getValue(s)),
+                ),
+            );
+
+            if (minDist > maxMinDist) {
+                maxMinDist = minDist;
+                best = candidate;
+            }
+        }
+
+        if (best) {
+            selected.push(best);
+            remaining.delete(best);
+        }
+    }
+
+    return selected;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -10,6 +10,7 @@ import type {
     ApiAiAgentThreadMessageVizQuery,
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadSummaryListResponse,
+    ApiAiAgentVerifiedQuestionsResponse,
     ApiAppendInstructionRequest,
     ApiAppendInstructionResponse,
     ApiCreateAiAgent,
@@ -1213,5 +1214,27 @@ export const useAppendInstructionMutation = (
                 apiError: error,
             });
         },
+    });
+};
+
+const getVerifiedQuestions = async (
+    projectUuid: string,
+    agentUuid: string,
+): Promise<ApiAiAgentVerifiedQuestionsResponse['results']> =>
+    lightdashApi<ApiAiAgentVerifiedQuestionsResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/verified-questions`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useVerifiedQuestions = (
+    projectUuid: string | undefined,
+    agentUuid: string | undefined,
+) => {
+    return useQuery<ApiAiAgentVerifiedQuestionsResponse['results'], ApiError>({
+        queryKey: [AI_AGENTS_KEY, projectUuid, agentUuid, 'verified-questions'],
+        queryFn: () => getVerifiedQuestions(projectUuid!, agentUuid!),
+        enabled: !!projectUuid && !!agentUuid,
     });
 };

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -10,20 +10,29 @@ import {
     Title,
 } from '@mantine-8/core';
 import { IconInfoCircle } from '@tabler/icons-react';
+import { type FC } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
 import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultAgentButton/DefaultAgentButton';
-import { useCreateAgentThreadMutation } from '../../features/aiCopilot/hooks/useProjectAiAgents';
+import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
+import {
+    useCreateAgentThreadMutation,
+    useVerifiedQuestions,
+} from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { type AgentContext } from './AgentPage';
 
-const AiAgentNewThreadPage = () => {
+const AiAgentNewThreadPage: FC = () => {
     const { agentUuid, projectUuid } = useParams();
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(agentUuid, projectUuid!);
     const { agent } = useOutletContext<AgentContext>();
+    const { data: verifiedQuestions } = useVerifiedQuestions(
+        projectUuid,
+        agentUuid,
+    );
 
     const onSubmit = (prompt: string) => {
         void createAgentThread({ prompt });
@@ -95,6 +104,14 @@ const AiAgentNewThreadPage = () => {
                             </Group>
                         )}
                     </Stack>
+
+                    {verifiedQuestions && verifiedQuestions.length > 1 && (
+                        <SuggestedQuestions
+                            questions={verifiedQuestions}
+                            onQuestionClick={onSubmit}
+                            isLoading={isCreatingThread}
+                        />
+                    )}
 
                     <AgentChatInput
                         onSubmit={onSubmit}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -951,6 +951,9 @@ importers:
       emoji-picker-react:
         specifier: ^4.12.0
         version: 4.12.0(react@19.2.0)
+      fastest-levenshtein:
+        specifier: ^1.0.16
+        version: 1.0.16
       fuse.js:
         specifier: ^6.5.3
         version: 6.5.3
@@ -19119,7 +19122,7 @@ snapshots:
       '@babel/traverse': 7.26.4
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19139,7 +19142,7 @@ snapshots:
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.0
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19239,6 +19242,13 @@ snapshots:
       semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.24.7':
+    dependencies:
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.28.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.24.7(supports-color@5.5.0)':
     dependencies:
@@ -19490,6 +19500,18 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
 
+  '@babel/traverse@7.25.6':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.28.0
+      '@babel/parser': 7.28.0
+      '@babel/template': 7.25.0
+      '@babel/types': 7.28.2
+      debug: 4.4.0(supports-color@8.1.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/traverse@7.25.6(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -19521,7 +19543,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.0
       '@babel/types': 7.28.2
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -19747,7 +19769,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.10.6':
     dependencies:
-      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.24.7
       '@babel/runtime': 7.27.0
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
@@ -20231,7 +20253,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.2.0
@@ -20608,7 +20630,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -26351,7 +26373,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.5.4)
     optionalDependencies:
@@ -26383,7 +26405,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -26397,7 +26419,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -26871,7 +26893,7 @@ snapshots:
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -28267,7 +28289,7 @@ snapshots:
       '@actions/core': 1.11.1
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.47.9(@babel/core@7.28.4)
       globby: 11.1.0
@@ -29474,7 +29496,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.5
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -29992,7 +30014,7 @@ snapshots:
       '@actions/core': 1.11.1
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       find-test-names: 1.29.5(@babel/core@7.28.4)
       globby: 11.1.0
       minimatch: 3.1.2
@@ -30884,7 +30906,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -30904,7 +30926,7 @@ snapshots:
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -35882,7 +35904,7 @@ snapshots:
   spec-change@1.11.11:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       deep-equal: 2.2.3
       dependency-tree: 11.0.1
       lazy-ass: 2.0.3


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15632

### Description:

This PR adds support for verified questions in AI agents. When an artifact is verified, the system now automatically generates a natural question that represents what a user might ask to get the data shown in the artifact. These questions are stored in a new `verified_question` column in the `ai_artifact_versions` table.

The PR also adds a new API endpoint to retrieve verified questions for an agent, and displays them as "Suggested questions" on the new thread page. Users can click on these suggestions to quickly start a new conversation with the agent.



![image.png](https://app.graphite.com/user-attachments/assets/3c63e1a7-a11a-425e-90cb-14fea6d0deda.png)

