### PR TITLE
fix: fallback to embed dashboard abilities rather than chart

### DIFF
--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -190,9 +190,7 @@ export function applyEmbeddedAbility(
     }
 
     const abilities =
-        contentType === 'dashboard'
-            ? dashboardTypeAbilities
-            : chartTypeAbilities;
+        contentType === 'chart' ? chartTypeAbilities : dashboardTypeAbilities;
     const applyAbilities = flow(abilities);
 
     applyAbilities({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
With our new charts, we were checking for 'dashboard' type and falling back to chart abilities. This won't work for existing JWTs if they fail this check for some reason. Either way, we should fallback to the legacy behavior. 