### PR TITLE
feat: enhance chart delete modal with red color and clearer warning text

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
@@ -67,11 +67,13 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
                 {relatedDashboards.length > 0 && (
                     <>
                         <Alert
+                            color="red"
                             icon={<MantineIcon icon={IconAlertCircle} />}
                             title={
                                 <Text fw={600}>
-                                    This action will remove a chart tile from{' '}
-                                    {relatedDashboards.length} dashboard
+                                    This action will permanently remove a chart
+                                    tile from {relatedDashboards.length}{' '}
+                                    dashboard
                                     {relatedDashboards.length > 1 ? 's' : ''}:
                                 </Text>
                             }
@@ -80,6 +82,7 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
                                 {relatedDashboards.map((dashboard) => (
                                     <List.Item key={dashboard.uuid}>
                                         <Anchor
+                                            color="red"
                                             component={Link}
                                             target="_blank"
                                             to={`/projects/${projectUuid}/dashboards/${dashboard.uuid}`}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17959

### Description:
Enhanced the chart deletion warning in the ChartDeleteModal by:
- Adding a red color to the alert to emphasize the warning
- Clarifying that the action will "permanently" remove chart tiles
- Making dashboard links red to maintain the warning color scheme

This makes the destructive nature of the action more apparent to users before they confirm deletion.