### PR TITLE
feat: show refresh dbt button on tables list

### DIFF
--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -13,6 +13,7 @@ import {
     selectMetrics,
     selectParameterReferences,
     selectParameters,
+    selectSavedChart,
     selectSorts,
     selectTableName,
     useExplorerDispatch,
@@ -29,6 +30,7 @@ import { Can } from '../../providers/Ability';
 import { DrillDownModal } from '../MetricQueryData/DrillDownModal';
 import MetricQueryDataProvider from '../MetricQueryData/MetricQueryDataProvider';
 import UnderlyingDataModal from '../MetricQueryData/UnderlyingDataModal';
+import RefreshDbtButton from '../RefreshDbtButton';
 import { CustomDimensionModal } from './CustomDimensionModal';
 import { CustomMetricModal } from './CustomMetricModal';
 import ExplorerHeader from './ExplorerHeader';
@@ -53,6 +55,8 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
             selectParameterReferences,
         );
         const parameters = useExplorerSelector(selectParameters);
+
+        const savedChart = useExplorerSelector(selectSavedChart);
 
         const { isOpen: isAdditionalMetricModalOpen } = useExplorerSelector(
             selectAdditionalMetricModal,
@@ -149,7 +153,12 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                 parameters={parameters}
             >
                 <Stack sx={{ flexGrow: 1 }}>
-                    {!hideHeader && isEditMode && <ExplorerHeader />}
+                    {!hideHeader &&
+                        (isEditMode ? (
+                            <ExplorerHeader />
+                        ) : (
+                            !savedChart && <RefreshDbtButton />
+                        ))}
 
                     {!!tableName &&
                         parameterReferencesFromRedux &&


### PR DESCRIPTION
### Description:

Shows the refresh dbt button on the page with the tables list. It used to only show when you selected a table, but it also makes sense here. If you have changed your models, you might want to refresh the list. 
