### PR TITLE
fix: allow embedding private space content

### DIFF
--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -46,7 +46,6 @@ const dashboardAbilities: EmbeddedAbilityBuilder = ({
     can('view', 'SavedChart', {
         organizationUuid: organization.organizationUuid,
         projectUuid: embed.projectUuid,
-        isPrivate: false,
     });
 
     can('view', 'Project', {
@@ -74,7 +73,6 @@ const chartAbilities: EmbeddedAbilityBuilder = ({
                 chartUuid: contentUuid,
             },
         },
-        isPrivate: false,
         organizationUuid: organization.organizationUuid,
         projectUuid: embed.projectUuid,
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Removing checks for private content. Embedded content can be sourced from private spaces once again. 

https://lightdash.slack.com/archives/C08JQ04MT4L/p1762532736451249