### PR TITLE
feat: add feedback modal for AI agent downvotes in slack

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -2716,6 +2716,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         organizationUuid: string | undefined,
         promptUuid: string,
         humanScore: number,
+        humanFeedback?: string,
     ) {
         this.analytics.track<AiAgentPromptFeedbackEvent>({
             event: 'ai_agent_prompt.feedback',
@@ -2730,6 +2731,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         await this.aiAgentModel.updateHumanScore({
             promptUuid,
             humanScore,
+            humanFeedback,
         });
     }
 
@@ -3264,7 +3266,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
     public handlePromptDownvote(app: App) {
         app.action(
             'prompt_human_score.downvote',
-            async ({ ack, body, respond, context }) => {
+            async ({ ack, body, respond, client, context }) => {
                 await ack();
                 const { user } = body;
                 const newBlock = {
@@ -3290,12 +3292,14 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                                   teamId,
                               )
                             : undefined;
+
                         await this.updateHumanScoreForSlackPrompt(
                             user.id,
                             organizationUuid,
                             promptUuid,
                             -1,
                         );
+
                         const { message } = body;
                         if (message) {
                             const { blocks } = message;
@@ -3309,10 +3313,79 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                                 ),
                             });
                         }
+
+                        await client.views.open({
+                            trigger_id: body.trigger_id,
+                            view: {
+                                type: 'modal',
+                                callback_id: 'downvote_feedback_modal',
+                                private_metadata: JSON.stringify({
+                                    promptUuid,
+                                }),
+                                title: {
+                                    type: 'plain_text',
+                                    text: 'Feedback',
+                                },
+                                submit: {
+                                    type: 'plain_text',
+                                    text: 'Submit',
+                                },
+                                close: {
+                                    type: 'plain_text',
+                                    text: 'Skip',
+                                },
+                                blocks: [
+                                    {
+                                        type: 'section',
+                                        text: {
+                                            type: 'mrkdwn',
+                                            text: 'Help us improve! What went wrong with this answer?',
+                                        },
+                                    },
+                                    {
+                                        type: 'input',
+                                        block_id: 'feedback_input',
+                                        optional: false,
+                                        element: {
+                                            type: 'plain_text_input',
+                                            action_id: 'feedback_text',
+                                            multiline: true,
+                                            placeholder: {
+                                                type: 'plain_text',
+                                                text: 'Your feedback will help improve the AI agent (optional)',
+                                            },
+                                        },
+                                        label: {
+                                            type: 'plain_text',
+                                            text: 'Feedback',
+                                        },
+                                    },
+                                ],
+                            },
+                        });
                     }
                 }
             },
         );
+
+        // Handle modal submission
+        app.view('downvote_feedback_modal', async ({ ack, view, body }) => {
+            await ack();
+
+            const metadata = JSON.parse(view.private_metadata);
+            const { promptUuid } = metadata;
+
+            const feedbackValue =
+                view.state.values.feedback_input?.feedback_text?.value;
+
+            if (feedbackValue) {
+                await this.aiAgentModel.updateHumanScore({
+                    promptUuid,
+                    humanScore: -1,
+                    humanFeedback: feedbackValue,
+                });
+            }
+        });
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/16420
Closes: https://github.com/lightdash/lightdash/issues/17870

### Description:

Added a feedback modal for downvoted AI agent prompts in Slack. When users downvote a prompt, they now see a modal asking for specific feedback on what went wrong with the answer. This feedback is stored alongside the negative score, providing valuable context for improving AI responses.

The implementation includes:

- Added `humanFeedback` parameter to the `updateHumanScore` method
- Created a modal dialog that appears after downvoting
- Added a view handler to process the submitted feedback

![CleanShot 2025-11-10 at 14.24.36@2x.png](https://app.graphite.com/user-attachments/assets/c10b8a5e-7263-4e76-bcc6-0d966a8da9ea.png)