### PR TITLE
fix: improve project access role inheritance and display logic

### DIFF
--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -409,10 +409,6 @@ export class RolesService extends BaseService {
         // Get existing project access data
         const projectAccess = await this.getProjectAccess(account, projectId);
 
-        console.log(
-            'projectAccess',
-            projectAccess.users.map((u) => `${u.userUuid}-${u.roleName}`),
-        );
         const assignments: RoleAssignment[] = [];
 
         // Convert user access to unified format

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -119,8 +119,6 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
         return <LoadingState title="Loading user access" />;
     }
 
-    console.log('usersWithProjectRole', usersWithProjectRole);
-
     return (
         <>
             <SettingsCard shadow="none" p={0}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17973

### Description:
Improves the role inheritance logic in the ProjectAccessRowV2 component by refactoring how the highest role is determined. The changes consolidate the role calculation into a single useMemo hook that properly considers project roles alongside organization and group roles. This ensures that the correct role is displayed and that the inheritance hierarchy (organization → project → group) is properly respected.


Before:
<img width="1589" height="1288" alt="Screenshot 2025-11-07 at 15 23 51" src="https://github.com/user-attachments/assets/16888906-a2d8-4574-a3de-e653581f4c33" />

After:

<img width="1345" height="744" alt="Screenshot 2025-11-10 at 10 43 53" src="https://github.com/user-attachments/assets/b8ce7387-879c-4702-86ee-ed5fdd2f1c56" />
