### PR TITLE
feat: add configurable similarity threshold for verified answers

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -76,6 +76,11 @@ export const aiCopilotConfigSchema = z
         debugLoggingEnabled: z.boolean(),
         askAiButtonEnabled: z.boolean(),
         maxQueryLimit: z.number().positive(),
+        verifiedAnswerSimilarityThreshold: z
+            .number()
+            .min(0)
+            .max(1)
+            .default(0.6),
     })
     .refine(
         ({ providers, defaultProvider, enabled }) =>

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -221,6 +221,7 @@ export const lightdashConfigMock: LightdashConfig = {
                     },
                 },
             },
+            verifiedAnswerSimilarityThreshold: 0.5,
         },
     },
     embedding: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -693,6 +693,10 @@ export const getAiConfig = () => ({
     maxQueryLimit:
         getIntegerFromEnvironmentVariable('AI_COPILOT_MAX_QUERY_LIMIT') ||
         AI_DEFAULT_MAX_QUERY_LIMIT,
+    verifiedAnswerSimilarityThreshold:
+        getFloatFromEnvironmentVariable(
+            'AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD',
+        ) ?? 0.6,
 });
 
 export type LoggingConfig = {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -322,7 +322,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
         },
         modelProviders: {
-            aiAgentModel: ({ database }) => new AiAgentModel({ database }),
+            aiAgentModel: ({ database }) =>
+                new AiAgentModel({ database, lightdashConfig }),
             aiOrganizationSettingsModel: ({ database }) =>
                 new AiOrganizationSettingsModel({ database }),
             embedModel: ({ database }) => new EmbedModel({ database }),

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -55,6 +55,7 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import moment from 'moment';
+import { LightdashConfig } from '../../config/parseConfig';
 import { AiAgentReasoningTableName } from '../../database/entities/aiAgentReasoning';
 import { DbEmail, EmailTableName } from '../../database/entities/emails';
 import { DbProject, ProjectTableName } from '../../database/entities/projects';
@@ -115,13 +116,17 @@ import {
 
 type Dependencies = {
     database: Knex;
+    lightdashConfig: LightdashConfig;
 };
 
 export class AiAgentModel {
     private database: Knex;
 
+    private lightdashConfig: LightdashConfig;
+
     constructor(dependencies: Dependencies) {
         this.database = dependencies.database;
+        this.lightdashConfig = dependencies.lightdashConfig;
     }
 
     static async withTrx<T>(
@@ -1503,7 +1508,9 @@ export class AiAgentModel {
                 }
 
                 const embeddingJson = JSON.stringify(queryEmbedding);
-                const similarityThreshold = 0.3;
+                const similarityThreshold =
+                    this.lightdashConfig.ai.copilot
+                        .verifiedAnswerSimilarityThreshold;
 
                 const results = await this.database(AiArtifactVersionsTableName)
                     .select(


### PR DESCRIPTION
### TL;DR

Added a configurable similarity threshold for verified AI answers.

### What changed?

- Added a new configuration parameter `verifiedAnswerSimilarityThreshold` to the AI copilot config schema
- Set a default value of 0.6 with constraints that it must be between 0 and 1
- Made the threshold configurable via the `AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD` environment variable
- Updated the `AiAgentModel` to use this configurable threshold instead of the previously hardcoded value of 0.3

### How to test?

1. Set the `AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD` environment variable to different values between 0 and 1
2. Verify that the system uses this threshold when determining similarity for verified answers
3. Confirm that the default value of 0.6 is used when no environment variable is set

### Why make this change?

This change allows for fine-tuning the similarity threshold used when matching AI queries to verified answers. By making this configurable, administrators can adjust how strictly the system matches new queries to existing verified answers, improving the accuracy and relevance of AI responses.