### PR TITLE
fix: update table header display behavior in visualization tests

### DIFF
--- a/packages/e2e/cypress/e2e/app/explore.cy.ts
+++ b/packages/e2e/cypress/e2e/app/explore.cy.ts
@@ -360,24 +360,24 @@ describe('Explore', () => {
                     cy.get('[data-testid="VisualizationCardOptions"]').click();
                     cy.get('[role="menuitem"]').contains('Table').click();
 
-                    // check that chart table headers are correct
+                    // check that chart table headers are correct (table names hidden by default)
+                    cy.findByTestId('visualization')
+                        .find('th')
+                        .contains('First name')
+                        .should('exist');
                     cy.findByTestId('visualization')
                         .find('th')
                         .contains('Order Customer First name')
-                        .should('exist');
+                        .should('not.exist');
 
                     cy.findByLabelText('Show table names').click({
                         force: true,
                     });
 
-                    // check that chart table headers are correct
+                    // check that chart table headers show table names after toggle
                     cy.findByTestId('visualization')
                         .find('th')
                         .contains('Order Customer First name')
-                        .should('not.exist');
-                    cy.findByTestId('visualization')
-                        .find('th')
-                        .contains('First name')
                         .should('exist');
                 });
 
@@ -405,15 +405,15 @@ describe('Explore', () => {
                     cy.get('[data-testid="VisualizationCardOptions"]').click();
                     cy.get('[role="menuitem"]').contains('Table').click();
 
-                    // check that chart table headers are correct
+                    // check that chart table headers are correct (table names hidden by default)
                     cy.findByTestId('visualization')
                         .find('th')
                         .eq(1)
-                        .contains('Order Customer First name')
+                        .contains('First name')
                         .should('exist');
 
-                    // open configuration and flip Show table names in the config
-                    cy.findByPlaceholderText('Order Customer First name')
+                    // open configuration and add custom header
+                    cy.findByPlaceholderText('First name')
                         .focus()
                         .type('Overridden header')
                         .blur();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes: failing explore.cy.ts 

### Description:
Fixed the table visualization tests to reflect that table names are now hidden by default. Updated assertions to check that only field names are shown initially, and table names appear only after toggling the "Show table names" option.

The test for custom headers was also updated to use the correct placeholder text that appears when table names are hidden.