### PR TITLE
fix: improve user deletion flow and add test IDs to search inputs

### DIFF
--- a/packages/e2e/cypress/e2e/app/settings/invites.cy.ts
+++ b/packages/e2e/cypress/e2e/app/settings/invites.cy.ts
@@ -51,12 +51,18 @@ describe('Settings - Invites', () => {
         cy.get('table')
             .contains('tr', 'demo+marygreen@lightdash.com')
             .scrollIntoView()
-            .find('.tabler-icon-trash')
+            .find('.tabler-icon-dots')
             .click({ force: true });
-        cy.findByText('Are you sure you want to delete this user?')
-            .parents('.mantine-Modal-root')
-            .findByText('Delete')
-            .click();
+        cy.findByRole('menuitem', { name: /delete/i }).click();
+
+        // Wait for modal to appear
+        cy.findByText('Are you sure you want to delete this user?').should(
+            'be.visible',
+        );
+
+        // Click the Delete button in the modal
+        cy.findByRole('button', { name: 'Delete' }).click();
+
         cy.findByText('Success! User was deleted.').should('be.visible');
         cy.findByText('demo+marygreen@lightdash.com').should('not.exist');
     });

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -124,6 +124,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({
             <SettingsCard shadow="none" p={0}>
                 <Paper p="sm">
                     <TextInput
+                        data-testid="org-users-search-input"
                         size="xs"
                         placeholder="Search users by name, email, or role"
                         onChange={(e) => setSearch(e.target.value)}

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTopToolbar.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTopToolbar.tsx
@@ -46,6 +46,7 @@ export const UsersTopToolbar: FC<UsersTopToolbarProps> = memo(
                         label="Search by name, email, or role"
                     >
                         <TextInput
+                            data-testid="org-users-search-input"
                             size="xs"
                             radius="md"
                             type="search"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes: settings/invites e2e test

### Description:
Updated the user deletion flow in the Settings - Invites test to use the new dots menu pattern instead of directly clicking the trash icon. Also improved test reliability by waiting for the modal to be visible before proceeding.

Added `data-testid="org-users-search-input"` to the search input fields in both ProjectAccess and UsersTopToolbar components to make them more easily targetable in tests.