### PR TITLE
fix: Restore funnel chart color overrides by using field IDs as keys

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -229,18 +229,15 @@ export const ConfigTabs: FC = memo(() => {
                                     .map((step) => {
                                         return (
                                             <StepConfig
-                                                key={step.name}
+                                                key={step.id}
+                                                id={step.id}
                                                 defaultColor={
-                                                    colorDefaults[step.name]
+                                                    colorDefaults[step.id]
                                                 }
                                                 defaultLabel={step.name}
                                                 swatches={[]}
-                                                color={
-                                                    colorOverrides[step.name]
-                                                }
-                                                label={
-                                                    labelOverrides[step.name]
-                                                }
+                                                color={colorOverrides[step.id]}
+                                                label={labelOverrides[step.id]}
                                                 onColorChange={
                                                     onColorOverridesChange
                                                 }

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/StepConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/StepConfig.tsx
@@ -9,19 +9,21 @@ import { EditableText } from '../common/EditableText';
 type StepConfigProps = {
     defaultColor: string;
     defaultLabel: string;
+    id?: string;
 
     swatches: string[];
 
     color: string | undefined;
     label: string | undefined;
 
-    onColorChange: (label: string, newColor: string) => void;
-    onLabelChange: (label: string, newLabel: string) => void;
+    onColorChange: (id: string, newColor: string) => void;
+    onLabelChange: (id: string, newLabel: string) => void;
 };
 
 export const StepConfig: FC<StepConfigProps> = ({
     defaultColor,
     defaultLabel,
+    id,
     swatches,
     color,
     label,
@@ -29,6 +31,7 @@ export const StepConfig: FC<StepConfigProps> = ({
     onLabelChange,
     ...rest
 }) => {
+    const stepId = id ?? defaultLabel;
     return (
         <Stack spacing="xs" {...rest}>
             <Group spacing="xs">
@@ -37,7 +40,7 @@ export const StepConfig: FC<StepConfigProps> = ({
                     defaultColor={defaultColor}
                     swatches={swatches}
                     onColorChange={(newColor: string) =>
-                        onColorChange(defaultLabel, newColor)
+                        onColorChange(stepId, newColor)
                     }
                 />
                 <Box style={{ flexGrow: 1 }}>
@@ -45,10 +48,7 @@ export const StepConfig: FC<StepConfigProps> = ({
                         placeholder={defaultLabel}
                         value={label}
                         onChange={(event) => {
-                            onLabelChange(
-                                defaultLabel,
-                                event.currentTarget.value,
-                            );
+                            onLabelChange(stepId, event.currentTarget.value);
                         }}
                     />
                 </Box>

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -23,6 +23,7 @@ import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 export type FunnelSeriesDataPoint = NonNullable<
     FunnelSeriesOption['data']
 >[number] & {
+    id: string;
     name: string;
     value: number;
     meta: {
@@ -91,13 +92,13 @@ const useEchartsFunnelConfig = (
         return {
             type: 'funnel',
             gap: 3,
-            data: seriesData.map(({ name, value, meta }) => {
+            data: seriesData.map(({ id, name, value, meta }) => {
                 return {
-                    name: labelOverrides?.[name] ?? name,
+                    name: labelOverrides?.[id] ?? name,
                     value,
                     meta,
                     itemStyle: {
-                        color: colorOverrides?.[name] ?? colorDefaults[name],
+                        color: colorOverrides?.[id] ?? colorDefaults[id],
                     },
                 };
             }),

--- a/packages/frontend/src/hooks/useFunnelChartConfig.ts
+++ b/packages/frontend/src/hooks/useFunnelChartConfig.ts
@@ -177,7 +177,9 @@ const useFunnelChartConfig: FunnelChartConfigFn = (
                     if (dataValue > dataMaxValue) {
                         dataMaxValue = dataValue;
                     }
+                    const rowId = rowValues[0].formatted;
                     return {
+                        id: rowId,
                         name: rowValues[0].formatted,
                         value: dataValue,
                         meta: {
@@ -204,6 +206,7 @@ const useFunnelChartConfig: FunnelChartConfigFn = (
                                 ? getItemLabelWithoutTableName(item)
                                 : id;
                             acc.push({
+                                id,
                                 name: fieldName,
                                 value: dataValue,
                                 meta: {
@@ -231,7 +234,7 @@ const useFunnelChartConfig: FunnelChartConfigFn = (
     const colorDefaults = useMemo(() => {
         return Object.fromEntries(
             data.map((item, index) => {
-                return [item.name, colorPalette[index % colorPalette.length]];
+                return [item.id, colorPalette[index % colorPalette.length]];
             }),
         );
     }, [data, colorPalette]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixes a regression introduced in #17368 where funnel  chart color overrides stopped working when using column configuration. After the changes, funnel charts displayed human-readable field labels  instead of IDs (e.g., "Total Amount" instead of "payments_total_amount") but this caused color and label  overrides to break because:

  1. Color/label overrides were stored with field IDs as keys
  2. The data points now used labels as their `name` property
  3. When looking up `colorOverrides[name]`, the label didn't match the stored ID keys
  4. Result: All funnel steps used default colors instead of custom colors

This pr includes **both** an `id` and a `name` property, using ID for stable key for color/label overrides and name for labels in the chart


**Caveat**: Funnels created with custom colors between #17368 and this will not retain the colors, which I think is a valid tradeoff without needing to introduce a migration function to cover this short timeframe.