### PR TITLE
fix: add recepient to failed notification email log

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2162,6 +2162,7 @@ export default class SchedulerTask {
                     organizationUuid: notification.organizationUuid,
                     createdByUserUuid: notification.userUuid,
                 },
+                target: recipient,
             });
 
             throw e; // Cascade error to it can be retried by graphile


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added the `target` recipient information to the error context when sending notifications fails. This will help with debugging by providing more context about which recipient was being processed when the error occurred.