### PR TITLE
style: have ai charts in dashboard height 100%

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
@@ -103,6 +103,8 @@ export const AiDashboardVisualization: FC<Props> = memo(
                                     p="md"
                                     radius="md"
                                     h={400}
+                                    display="flex"
+                                    dir="column"
                                 >
                                     <ErrorBoundary>
                                         <AiDashboardVisualizationItem

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualizationItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualizationItem.tsx
@@ -8,8 +8,8 @@ import {
     type ToolVerticalBarArgs,
 } from '@lightdash/common';
 import {
-    Box,
     Center,
+    Flex,
     Group,
     HoverCard,
     Loader,
@@ -261,23 +261,18 @@ export const AiDashboardVisualizationItem: FC<Props> = memo(
         }
 
         return (
-            <Stack gap="sm">
-                {/* Actual Visualization */}
-                <Box mih={300}>
-                    <AiVisualizationRenderer
-                        results={queryResults}
-                        queryExecutionHandle={queryExecutionHandle}
-                        chartConfig={visualization}
-                        headerContent={<VisualizationHeaderWithButton />}
-                        onDashboardChartTypeChange={
-                            handleDashboardChartTypeChange
-                        }
-                        onDashboardChartConfigChange={
-                            handleDashboardChartConfigChange
-                        }
-                    />
-                </Box>
-            </Stack>
+            <Flex direction="column" h="100%">
+                <AiVisualizationRenderer
+                    results={queryResults}
+                    queryExecutionHandle={queryExecutionHandle}
+                    chartConfig={visualization}
+                    headerContent={<VisualizationHeaderWithButton />}
+                    onDashboardChartTypeChange={handleDashboardChartTypeChange}
+                    onDashboardChartConfigChange={
+                        handleDashboardChartConfigChange
+                    }
+                />
+            </Flex>
         );
     },
 );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -214,7 +214,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
                         </Group>
                     )}
                     <Box
-                        flex="1 0 0"
+                        flex="1"
                         style={{
                             // Scrolling for tables
                             overflow: 'auto',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Improved the layout of AI dashboard visualizations by:
- Adding `display="flex"` and `dir="column"` to the visualization container for better structure
- Replacing `Box` with `Flex` component in the visualization item for more consistent layout control
- Removing unnecessary `Stack` and `Box` wrappers to simplify the component hierarchy
- Setting the visualization to take full height with `h="100%"` 
- Adjusting the flex property from `flex="1 0 0"` to `flex="1"` for better scaling behavior

These changes ensure visualizations properly fill their containers and maintain consistent layout across different screen sizes.

before

[CleanShot 2025-11-10 at 16.26.32.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/793065ad-6564-4657-af7d-9476cea57b0b.mp4" />](https://app.graphite.com/user-attachments/video/793065ad-6564-4657-af7d-9476cea57b0b.mp4)

[CleanShot 2025-11-10 at 16.26.02.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8f62c4f7-0205-4223-88b8-cb6ebd51f513.mp4" />](https://app.graphite.com/user-attachments/video/8f62c4f7-0205-4223-88b8-cb6ebd51f513.mp4)

after

