### PR TITLE
fix: new props causing 'save' in existing charts

### DIFF
--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -3,7 +3,7 @@ import omit from 'lodash/omit';
 import { EMPTY_CARTESIAN_CHART_CONFIG } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import { type ConfigCacheMap } from './types';
 
-const DEFAULTS: Record<ChartType, () => unknown> = {
+const DEFAULTS = {
     [ChartType.CARTESIAN]: () => ({ ...EMPTY_CARTESIAN_CHART_CONFIG }), // factory to avoid shared refs
     [ChartType.BIG_NUMBER]: () => ({ showTableNamesInLabel: false }),
     [ChartType.TABLE]: () => ({ showTableNames: false }),
@@ -41,23 +41,38 @@ export const getCachedPivotConfig = (
 };
 
 // Clean the config to remove runtime-only properties like isFilteredOut
+// and merge with defaults to handle backwards compatibility when new properties are added
 export const cleanConfig = (config: ChartConfig): ChartConfig => {
     if (
         config.type === ChartType.CARTESIAN &&
         config.config?.eChartsConfig?.series
     ) {
+        // Merge with defaults to ensure old saved charts have new default properties
+        const defaults = DEFAULTS[ChartType.CARTESIAN]();
+
         return {
-            ...config,
+            type: config.type,
             config: {
+                ...defaults,
                 ...config.config,
                 eChartsConfig: {
+                    ...defaults.eChartsConfig,
                     ...config.config.eChartsConfig,
                     series: config.config.eChartsConfig.series.map(
                         (s: Series) => omit(s, ['isFilteredOut']),
                     ),
                 },
             },
-        };
+        } as ChartConfig;
     }
-    return config;
+
+    // For non-Cartesian charts, still merge with defaults
+    const defaults = DEFAULTS[config.type]();
+    return {
+        type: config.type,
+        config: {
+            ...defaults,
+            ...config.config,
+        },
+    } as ChartConfig;
 };


### PR DESCRIPTION
### Description:

**The problem:** 
New properties (showAxisTicks) were causing old charts to show the 'save changes' button, even when nothing was changed. This was because we diff the savedChart with the unsavedChartVersion and the diff was including new properties in the unsaved version. 

**The fix:**
Include the defaults for any new properties in the diff with the saved chart. 

**Repro:**
- Open a chart created before Nov 6
- Edit
- It will show the save button, even if nothing has changed (there is a `showAxisTicks: false in the unsaved version)`
