### PR TITLE
fix: on new question add proper initialiser

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalFormModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalFormModal.tsx
@@ -92,7 +92,7 @@ export const EvalFormModal: FC<Props> = ({
                             expectedResponse: p.expectedResponse,
                         };
                     },
-                ) || [''],
+                ) || [{ prompt: '', expectedResponse: '' }],
             };
         }
         return {
@@ -158,7 +158,7 @@ export const EvalFormModal: FC<Props> = ({
     };
 
     const addPrompt = () => {
-        form.insertListItem('prompts', '');
+        form.insertListItem('prompts', { prompt: '', expectedResponse: '' });
     };
 
     const removePrompt = (index: number) => {
@@ -277,14 +277,12 @@ export const EvalFormModal: FC<Props> = ({
                                         key={index}
                                         gap="sm"
                                         align="flex-start"
-                                        mb="md"
                                     >
                                         <Text
                                             size="sm"
                                             fw={500}
                                             c="dimmed"
                                             miw={20}
-                                            mt={8}
                                         >
                                             {index + 1}.
                                         </Text>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18012


### Description:
Fixed the EvalFormModal component by properly initializing empty prompt objects. Previously, when no prompts existed, the form would initialize with an array containing an empty string, which caused type errors. Now it correctly initializes with an object containing empty prompt and expectedResponse fields.

Also fixed the addPrompt function to insert a properly structured object instead of an empty string, and removed unnecessary margin styling from the prompt list items.



