### PR TITLE
feat: add Chart to embed SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ data/
 .local/*
 
 CLAUDE.local.md
+http-client.private.env.json

--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -1,0 +1,10 @@
+# HTTP Client API Examples
+
+Use these files with your IDEs HTTP client to exercise API calls. 
+
+## Environment Variables
+
+Copy http-client.env.json to http-client.private.env.json and fill in the required values. You can override
+any values in the public env file by adding them to your private env file.
+
+Using this env file will allow you to leverage the variables defined within it in your HTTP client requests.

--- a/examples/api/embedding.http
+++ b/examples/api/embedding.http
@@ -10,6 +10,7 @@ Content-Type: application/json
 }
 
 ### Logout
+
 GET http://localhost:8080/api/v1/logout
 
 ### Get project config
@@ -49,11 +50,10 @@ Content-Type: application/json
     "chartUuid": "e6efe2fa-f884-47ea-ac9b-1e3ebe303b30"
 }
 
-### Generate embed url - use the dashboardUuid you want to embed
+### Generate dashboard embed url
+#### use the dashboardUuid you want to embed
 
-@dashboardUuid = e45dcfb9-d5fe-4c0e-9d8c-70871e904aea
-
-POST http://localhost:8080/api/v1/embed/3675b69e-8324-4110-bdca-059031aa8da3/get-embed-url
+POST http://localhost:8080/api/v1/embed/{{projectUuid}}/get-embed-url
 Content-Type: application/json
 
 {
@@ -68,16 +68,13 @@ Content-Type: application/json
         "canExportImages": true,
         "canDateZoom": true,
         "canExportPagePdf": true,
-        "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3"
+        "projectUuid": "{{projectUuid}}"
     }
 }
 
 ### Generate embed url for chart - use the chartUuid you want to embed
 
-@chartUuid = 0854611a-9842-4937-9cab-37fb3557e852
-@projectUuid = 3675b69e-8324-4110-bdca-059031aa8da3
-
-POST http://localhost:8080/api/v1/embed/3675b69e-8324-4110-bdca-059031aa8da3/get-embed-url
+POST http://localhost:8080/api/v1/embed/{{projectUuid}}/get-embed-url
 Content-Type: application/json
 
 {
@@ -92,13 +89,13 @@ Content-Type: application/json
         "canExportCsv": true,
         "canExportImages": false,
         "canViewUnderlyingData": true,
-        "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3"
+        "projectUuid": "{{projectUuid}}"
     },
     "expiresIn": "24h"
 }
 
 
-# We can use JWT token to call some endpoints that support `account` parameters. 
+### We can use JWT token to call some endpoints that support `account` parameters.
 
 ### Get chart results using JWT token
 GET http://localhost:8080/api/v1/saved/{{chartUuid}}
@@ -120,7 +117,7 @@ Content-Type: application/json
 }
    
 
-# This calculate total endpoint does not support chart JWT token, only dashboard
+### This calculate total endpoint does not support chart JWT token, only dashboard
 @chartJwtToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImV4dGVybmFsSWQiOiJjaGFydC11c2VyQGV4YW1wbGUuY29tIiwiZW1haWwiOiJjaGFydC11c2VyQGV4YW1wbGUuY29tIn0sImNvbnRlbnQiOnsidHlwZSI6ImNoYXJ0IiwiY29udGVudElkIjoiMDg1NDYxMWEtOTg0Mi00OTM3LTljYWItMzdmYjM1NTdlODUyIiwic2NvcGVzIjpbInZpZXc6Q2hhcnQiXSwiY2FuRXhwb3J0Q3N2Ijp0cnVlLCJjYW5FeHBvcnRJbWFnZXMiOmZhbHNlLCJjYW5WaWV3VW5kZXJseWluZ0RhdGEiOnRydWUsInByb2plY3RVdWlkIjoiMzY3NWI2OWUtODMyNC00MTEwLWJkY2EtMDU5MDMxYWE4ZGEzIn0sImlhdCI6MTc2MTIxNDgxNCwiZXhwIjoxNzYxMzAxMjE0fQ.h1bv99NPtjIICpsmQ0QqZPDJOJYtJ7iJ4-urQqNDXP8
 POST http://localhost:8080/api/v1/embed/{{projectUuid}}/chart/{{chartUuid}}/calculate-total
 Lightdash-Embed-Token: {{chartJwtToken}}

--- a/examples/api/http-client.env.json
+++ b/examples/api/http-client.env.json
@@ -1,0 +1,10 @@
+// Override environment variables for HTTP Client API examples.
+// Create a http-client.private.env.json file.
+{
+  "development": {
+    "dashboardUuid": "<YOUR_DASHBOARD_UUID>",
+    "chartUuid": "<YOUR_CHART_UUID>",
+    "projectUuid": "3675b69e-8324-4110-bdca-059031aa8da3"
+
+  }
+}

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -12,6 +12,7 @@ import {
     ForbiddenError,
     isExecuteAsyncDashboardSqlChartByUuidParams,
     isExecuteAsyncSqlChartByUuidParams,
+    isJwtUser,
     QueryExecutionContext,
     type ApiDownloadAsyncQueryResults,
     type ApiDownloadAsyncQueryResultsAsCsv,
@@ -191,9 +192,11 @@ export class QueryController extends BaseController {
 
         const context = body.context ?? getContextFromHeader(req);
 
-        if (req.account!.isJwtUser()) {
-            // we need more granular CASTL abilities before enabling this
-            throw new ForbiddenError('Feature not available for JWT users');
+        if (
+            isJwtUser(req.account!) &&
+            req.account!.access.contentType !== 'chart'
+        ) {
+            throw new ForbiddenError('Feature not available for this JWT');
         }
 
         const results = await this.services

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4369,7 +4369,6 @@ export class ProjectService extends BaseService {
                     : await this.projectModel.getSummary(projectUuid);
 
                 if (
-                    ProjectService.isChartEmbed(account) ||
                     account.user.ability.cannot(
                         'view',
                         subject('Project', {

--- a/packages/e2e/cypress/e2e/api/embedChart.cy.ts
+++ b/packages/e2e/cypress/e2e/api/embedChart.cy.ts
@@ -468,7 +468,7 @@ describe('Embed Chart JWT API', () => {
                 });
             });
 
-            it('should block chart JWT from accessing getExplore for any explore', () => {
+            it('allows chart JWT to access getExplore for any explore', () => {
                 cy.get<string>('@chartJwtToken').then((token) => {
                     // Try to access an explore (doesn't matter which one)
                     const exploreName = 'orders';
@@ -480,9 +480,9 @@ describe('Embed Chart JWT API', () => {
                         method: 'GET',
                         failOnStatusCode: false,
                     }).then((resp) => {
-                        // Should fail with 403 Forbidden to prevent schema disclosure
-                        expect(resp.status).to.eq(403);
-                        expect(resp.body).to.have.property('error');
+                        // TODO: This should fail if token chartUuid doesn't match the requested explore
+                        expect(resp.status).to.eq(200);
+                        expect(resp.body).not.to.have.property('error');
                     });
                 });
             });

--- a/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
@@ -1,0 +1,121 @@
+import { Box, MantineProvider, type MantineThemeOverride } from '@mantine/core';
+import { IconUnlink } from '@tabler/icons-react';
+import { memo, useMemo, type FC } from 'react';
+import LightdashVisualization from '../../../../../components/LightdashVisualization';
+import VisualizationProvider from '../../../../../components/LightdashVisualization/VisualizationProvider';
+import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
+import {
+    selectSavedChart,
+    useExplorerSelector,
+} from '../../../../../features/explorer/store';
+import { useExplorerQuery } from '../../../../../hooks/useExplorerQuery';
+import { useSavedQuery } from '../../../../../hooks/useSavedQuery';
+import MinimalSavedExplorer from '../../../../../pages/MinimalSavedExplorer';
+import useApp from '../../../../../providers/App/useApp';
+
+const themeOverride: MantineThemeOverride = {
+    globalStyles: () => ({
+        'html, body': {
+            backgroundColor: 'white',
+        },
+    }),
+};
+
+const MinimalChartContent = memo(() => {
+    const { health } = useApp();
+
+    // Get query state from hook
+    const { query, queryResults } = useExplorerQuery();
+
+    const resultsData = useMemo(
+        () => ({
+            ...queryResults,
+            metricQuery: query.data?.metricQuery,
+            fields: query.data?.fields,
+        }),
+        [queryResults, query.data],
+    );
+
+    // Get savedChart from Redux
+    const savedChart = useExplorerSelector(selectSavedChart);
+
+    const isLoadingQueryResults =
+        query.isFetching || queryResults.isFetchingRows;
+
+    if (!savedChart || health.isInitialLoading || !health.data) {
+        return null;
+    }
+
+    return (
+        <VisualizationProvider
+            minimal
+            chartConfig={savedChart.chartConfig}
+            initialPivotDimensions={savedChart.pivotConfig?.columns}
+            resultsData={resultsData}
+            isLoading={isLoadingQueryResults}
+            columnOrder={savedChart.tableConfig.columnOrder}
+            pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
+            savedChartUuid={savedChart.uuid}
+            colorPalette={savedChart.colorPalette}
+            parameters={query.data?.usedParametersValues}
+        >
+            <MantineProvider inherit theme={themeOverride}>
+                <Box mih="inherit" h="100%">
+                    <LightdashVisualization
+                        className="sentry-block ph-no-capture"
+                        data-testid="visualization"
+                    />
+                </Box>
+            </MantineProvider>
+        </VisualizationProvider>
+    );
+});
+
+MinimalChartContent.displayName = 'MinimalChartContent';
+
+type Props = {
+    containerStyles?: React.CSSProperties;
+    savedQueryUuid: string;
+};
+
+const EmbedChart: FC<Props> = ({ containerStyles, savedQueryUuid }) => {
+    const { data, isInitialLoading, isError, error } = useSavedQuery({
+        id: savedQueryUuid,
+    });
+
+    if (isInitialLoading) {
+        return null;
+    }
+
+    if (isError) {
+        return (
+            <Box mt={20}>
+                <SuboptimalState
+                    title="Error loading chart"
+                    icon={IconUnlink}
+                    description={
+                        error.error.message.includes('jwt expired')
+                            ? 'This embed link has expired'
+                            : error.error.message
+                    }
+                />
+            </Box>
+        );
+    }
+
+    if (!data) {
+        return (
+            <Box mt={20}>
+                <SuboptimalState title="Chart not found" icon={IconUnlink} />
+            </Box>
+        );
+    }
+
+    return (
+        <div style={containerStyles}>
+            <MinimalSavedExplorer savedQueryUuid={savedQueryUuid} />
+        </div>
+    );
+};
+
+export default EmbedChart;

--- a/packages/frontend/src/ee/pages/EmbedChart.tsx
+++ b/packages/frontend/src/ee/pages/EmbedChart.tsx
@@ -1,0 +1,39 @@
+import { IconUnlink } from '@tabler/icons-react';
+import { type FC } from 'react';
+import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
+import EmbedChart from '../features/embed/EmbedChart/components/EmbedChart';
+import useEmbed from '../providers/Embed/useEmbed';
+
+const EmbedChartPage: FC<{
+    containerStyles?: React.CSSProperties;
+}> = ({ containerStyles }) => {
+    const { embedToken, savedQueryUuid } = useEmbed();
+
+    if (!embedToken) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <SuboptimalState
+                    icon={IconUnlink}
+                    title="This embed link is not valid"
+                />
+            </div>
+        );
+    }
+
+    if (!savedQueryUuid) {
+        return (
+            <div style={{ marginTop: '20px' }}>
+                <SuboptimalState title="Missing chart ID" icon={IconUnlink} />
+            </div>
+        );
+    }
+
+    return (
+        <EmbedChart
+            containerStyles={containerStyles}
+            savedQueryUuid={savedQueryUuid}
+        />
+    );
+};
+
+export default EmbedChartPage;

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -23,6 +23,7 @@ type Props = {
     onExplore?: (options: { chart: SavedChart }) => void;
     onBackToDashboard?: () => void;
     savedChart?: SavedChart;
+    savedQueryUuid?: string;
 };
 
 const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
@@ -34,6 +35,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     onExplore,
     onBackToDashboard,
     savedChart,
+    savedQueryUuid,
 }) => {
     const embedToken = encodedToken || window.location.hash.replace('#', '');
     const [isInitialized, setIsInitialized] = useState(false);
@@ -98,6 +100,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             languageMap: contentOverrides,
             onExplore,
             savedChart,
+            savedQueryUuid,
             onBackToDashboard,
             mode,
         };
@@ -110,6 +113,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         contentOverrides,
         onExplore,
         savedChart,
+        savedQueryUuid,
         onBackToDashboard,
         mode,
     ]);

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -27,6 +27,8 @@ export interface EmbedContext {
     onBackToDashboard?: () => void;
     // The chart that the user is exploring
     savedChart?: SavedChart;
+    // The UUID of the saved query being viewed in an embedded Chart
+    savedQueryUuid?: string;
     // The mode of the embed: 'sdk' when embedded via SDK (no URL sync), 'direct' when navigating directly to /embed (sync URL)
     mode: EmbedMode;
 }

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -1,6 +1,7 @@
 import { FeatureFlags, type FieldId } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
+import useEmbed from '../ee/providers/Embed/useEmbed';
 import {
     explorerActions,
     selectIsEditMode,
@@ -58,10 +59,13 @@ export const useExplorerQueryManager = () => {
         selectUnpivotedQueryUuidHistory,
     );
 
-    const { savedQueryUuid, projectUuid } = useParams<{
+    const embed = useEmbed();
+    const params = useParams<{
         savedQueryUuid: string;
         projectUuid: string;
     }>();
+    const savedQueryUuid = embed?.savedQueryUuid || params.savedQueryUuid;
+    const projectUuid = embed?.projectUuid || params.projectUuid!;
     const viewModeQueryArgs = useMemo(() => {
         return savedQueryUuid ? { chartUuid: savedQueryUuid } : undefined;
     }, [savedQueryUuid]);

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -26,6 +26,10 @@ const themeOverride: MantineThemeOverride = {
     }),
 };
 
+type Props = {
+    savedQueryUuid?: string;
+};
+
 const MinimalExplorerContent = memo(() => {
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects({ minimal: true });
@@ -89,10 +93,13 @@ const MinimalExplorerContent = memo(() => {
     );
 });
 
-const MinimalSavedExplorer: FC = () => {
-    const { savedQueryUuid } = useParams<{
+const MinimalSavedExplorer: FC<Props> = ({
+    savedQueryUuid: queryUuidProps,
+}) => {
+    const params = useParams<{
         savedQueryUuid: string;
     }>();
+    const savedQueryUuid = queryUuidProps || params.savedQueryUuid!;
 
     const { data, isInitialLoading, isError, error } = useSavedQuery({
         id: savedQueryUuid,

--- a/packages/sdk-test-app/src/App.tsx
+++ b/packages/sdk-test-app/src/App.tsx
@@ -1,6 +1,6 @@
 import Lightdash from '@lightdash/sdk';
 import '@lightdash/sdk/sdk.css';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FilterOperator, SavedChart } from '../../common/src';
 
@@ -78,7 +78,7 @@ const contentStyle = {
     width: '100%',
 };
 
-// Chart container style
+// Dashboard Chart container style
 const chartContainerStyle = {
     width: '100%',
     height: '500px',
@@ -87,6 +87,12 @@ const chartContainerStyle = {
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'aliceblue',
+};
+
+const singleChartContainerStyle = {
+    width: '50%',
+    height: '500px',
+    border: '2px dashed #ccc',
 };
 
 // Info box style with bluish text and a light blue background
@@ -117,6 +123,11 @@ function App() {
     const handleExploreClick = (options: { chart: SavedChart }) => {
         setSavedChart(options.chart);
     };
+
+    const chartIdRef = useRef<HTMLInputElement>(null);
+    const [chartUuidOrSlug, setChartUuidOrSlug] = useState<string>(
+        localStorage.getItem('chartUuidOrSlug') || '',
+    );
 
     useEffect(() => {
         const [lightdashUrl, rest] = embedUrl.split('embed');
@@ -260,6 +271,79 @@ function App() {
                         <div style={infoBoxStyle}>
                             {t(
                                 'Additional Information: This chart is powered by Lightdash SDK.',
+                            )}
+                        </div>
+
+                        <h2
+                            style={{
+                                color: '#555',
+                                margin: '30px 0 10px 0',
+                            }}
+                        >
+                            {t('Chart component')}
+                        </h2>
+                        <p
+                            style={{
+                                fontSize: '1.1em',
+                                lineHeight: '1.6',
+                                color: '#666',
+                            }}
+                        >
+                            {t(
+                                'This section demonstrates the Chart component. Enter a chart UUID or slug to display just the visualization.',
+                            )}
+                        </p>
+
+                        <div style={{ marginBottom: '10px' }}>
+                            <h4>Chart UUID or Slug:</h4>
+                            <div style={{ display: 'flex', gap: '8px' }}>
+                                <input
+                                    type="text"
+                                    defaultValue={chartUuidOrSlug}
+                                    ref={chartIdRef}
+                                    placeholder="Enter chart UUID or slug"
+                                    style={{ flexGrow: 1 }}
+                                />
+                                <button
+                                    onClick={() => {
+                                        const { value } = chartIdRef.current;
+                                        setChartUuidOrSlug(value);
+                                        localStorage.setItem(
+                                            'chartUuidOrSlug',
+                                            value,
+                                        );
+                                    }}
+                                >
+                                    {t('Load Chart')}
+                                </button>
+                                <button
+                                    onClick={() => {
+                                        setChartUuidOrSlug('');
+                                        localStorage.removeItem(
+                                            'chartUuidOrSlug',
+                                        );
+                                    }}
+                                >
+                                    {t('Clear')}
+                                </button>
+                            </div>
+                        </div>
+
+                        <div style={singleChartContainerStyle}>
+                            {chartUuidOrSlug ? (
+                                <Lightdash.Chart
+                                    instanceUrl={lightdashUrl}
+                                    token={lightdashToken}
+                                    styles={{
+                                        backgroundColor: 'transparent',
+                                        fontFamily: 'Arial, sans-serif',
+                                    }}
+                                    id={chartUuidOrSlug}
+                                />
+                            ) : (
+                                <p style={{ color: '#999' }}>
+                                    {t('Enter a chart UUID or slug to display')}
+                                </p>
                             )}
                         </div>
                     </main>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: CENG-104

### Description:

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

Adds a Chart component to the Lightdash Embed SDK. This is a two part PR with stricter permissions coming in a [follow up](https://linear.app/lightdash/issue/CENG-148/add-stricter-permissions-for-chart-embeds).

### Testing

I added an http-client env file. This works for both VSCode and WebStorm HTTP clients. You can create an http-client.env.private.json file to override values in the public file. 

Create an embed URL for the charts you need and use that in the SDK test app.

### Examples

#### Render Embedded Chart

JWTs for charts work only for charts. Dashboards will not load. 

![Screen Cast 2025-11-11 at 12.36.24 PM.gif](https://app.graphite.com/user-attachments/assets/c021e055-f280-45d5-9170-c86833955e5c.gif)

#### Allow chart slugs in addition to UUIDs

Allow both UUIDs and slugs. Debugging breakpoints are optional. 

![Screen Cast 2025-11-11 at 12.37.11 PM.gif](https://app.graphite.com/user-attachments/assets/118c40a1-2772-4c4c-a3e1-d0d9c2b22856.gif)

#### Only allow chart UUID in JWT

Only load embedded charts for a chart UUID or slug that matches what's bound to the JWT

![Screen Cast 2025-11-11 at 12.37.58 PM.gif](https://app.graphite.com/user-attachments/assets/150323c4-01f4-4254-b509-8447b9cafca1.gif)

