### PR TITLE
fix: project admins to view organization roles

### DIFF
--- a/packages/backend/src/services/RolesService/RolesService.mock.ts
+++ b/packages/backend/src/services/RolesService/RolesService.mock.ts
@@ -155,6 +155,10 @@ export const mockProjectModel = {
         projectUuid: 'test-project-uuid',
         organizationUuid: 'test-org-uuid',
     }),
+    getAllByOrganizationUuid: jest.fn().mockResolvedValue([
+        { projectUuid: 'proj-1', organizationUuid: 'test-org-uuid' },
+        { projectUuid: 'proj-2', organizationUuid: 'test-org-uuid' },
+    ]),
 };
 
 export const mockGroupsModel = {

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -2,10 +2,8 @@ import { subject } from '@casl/ability';
 import {
     Account,
     AddScopesToRole,
-    CreateProjectMember,
     CreateRole,
     ForbiddenError,
-    getSystemRoles,
     isSystemRole,
     NotFoundError,
     OrganizationMemberRole,
@@ -106,9 +104,8 @@ export class RolesService extends BaseService {
         );
 
         const canManageSomeProjects = projects.some((project) =>
-            // Note that we don't check for 'manage' here because developers can update project access
             account.user.ability.can(
-                'update',
+                'manage',
                 subject('Project', {
                     organizationUuid,
                     projectUuid: project.projectUuid,
@@ -173,9 +170,8 @@ export class RolesService extends BaseService {
         if (projectUuid) {
             const project = await this.projectModel.getSummary(projectUuid);
             if (
-                // Note that we don't check for 'manage' here because developers can update project access
                 account.user.ability.cannot(
-                    'update',
+                    'manage',
                     subject('Project', {
                         organizationUuid: project.organizationUuid,
                         projectUuid,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -759,12 +759,23 @@ const Settings: FC = () => {
                                         }
                                     />
 
-                                    <RouterNavLink
-                                        label="Project access"
-                                        exact
-                                        to={`/generalSettings/projectManagement/${project.projectUuid}/projectAccess`}
-                                        icon={<MantineIcon icon={IconUsers} />}
-                                    />
+                                    <Can
+                                        I="manage"
+                                        this={subject('Project', {
+                                            organizationUuid:
+                                                organization.organizationUuid,
+                                            projectUuid: project.projectUuid,
+                                        })}
+                                    >
+                                        <RouterNavLink
+                                            label="Project access"
+                                            exact
+                                            to={`/generalSettings/projectManagement/${project.projectUuid}/projectAccess`}
+                                            icon={
+                                                <MantineIcon icon={IconUsers} />
+                                            }
+                                        />
+                                    </Can>
 
                                     {user.ability.can(
                                         'view',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
This PR enhances the roles and permissions system by allowing project admins to view organization roles. Previously, only organization admins could view roles, but now project admins can also access this information.

#### before

<img width="1401" height="1288" alt="Screenshot 2025-11-10 at 13 52 17" src="https://github.com/user-attachments/assets/ef1e03c5-11a9-417a-9538-1b2f01db0ca1" />


#### after 
<img width="2804" height="2524" alt="CleanShot 2025-11-11 at 10 09 57@2x" src="https://github.com/user-attachments/assets/e8a5f054-8a72-496a-8755-135768b64473" />

