### PR TITLE
feat: add image dimension support with URL-based rendering

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.sql
@@ -1,1 +1,1 @@
-SELECT * FROM {{ ref('raw_events') }}
+SELECT *, 'https://placehold.co/300x100?text=id%20' || event as image_url  FROM {{ ref('raw_events') }}

--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -79,6 +79,14 @@ models:
           metrics:
             count:
               type: count
+      - name: image_url
+        description: "Image URL for the event from events.sql"
+        meta:
+          dimension:
+            type: string
+            groups: [ 'image' ]
+            image: 
+                url: "${value.raw}" 
       - name: event_id
         description: ""
         meta:
@@ -86,6 +94,28 @@ models:
             type: number
             groups: [ 'events', 'nested_group', 'another_nested_group' ]
           additional_dimensions:
+            image_event_id:
+              groups: [ 'image' ]
+              description: "Additional dimension of image URL for event_id. Uses event_id from SQL, but image URL template combines with event name from row"
+              type: string
+              # creates url in sql
+              # intentionally introduce some missing images to test the image cell
+              sql: |
+                case
+                  when ${event_id} > 100 then 'lightdash.com/missing-image.jpg'
+                  else 'placehold.co/300x100?text=id%20' || ${event_id}
+                  end
+              image:
+                # Template combines value (the URL from SQL) with other row fields
+                # Use liquidjs to combine the URL with the event name and upcase
+                url: "https://${value.raw}-${row.events.event.raw | upcase}" 
+            image_invalid_protocol:
+              groups: [ 'image' ]
+              description: "Invalid URL protocol"
+              type: string
+              sql: ${event_id}
+              image:
+                url: "file://${value.raw}" 
             event_tier:
               type: string
               description: Ratio of event_id to event

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -189,6 +189,7 @@ const convertDimension = (
         requiredAttributes: meta.dimension?.required_attributes,
         colors: meta.dimension?.colors,
         ...(meta.dimension?.urls ? { urls: meta.dimension.urls } : {}),
+        ...(meta.dimension?.image ? { image: meta.dimension.image } : {}),
         ...(isAdditionalDimension ? { isAdditionalDimension } : {}),
         groups,
         isIntervalBase,

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -73,13 +73,25 @@
                 "type": "object",
                 "properties": {
                     "url": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Liquidjs template for the URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}"
                     },
                     "label": {
                         "type": "string"
                     }
                 }
             }
+        },
+        "Image": {
+            "type": "object",
+            "description": "Displays the dimension value as an image",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Liquidjs template for the image URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}. Only fields selected in the query are available in row context."
+                }
+            },
+            "required": ["url"]
         },
         "Tags": {
             "oneOf": [
@@ -152,6 +164,9 @@
                 "urls": {
                     "$ref": "#/definitions/Urls"
                 },
+                "image": {
+                    "$ref": "#/definitions/Image"
+                },
                 "tags": {
                     "$ref": "#/definitions/Tags"
                 },
@@ -194,6 +209,9 @@
                 },
                 "urls": {
                     "$ref": "#/definitions/Urls"
+                },
+                "image": {
+                    "$ref": "#/definitions/Image"
                 },
                 "tags": {
                     "$ref": "#/definitions/Tags"

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -233,13 +233,25 @@
                                                     "type": "object",
                                                     "properties": {
                                                         "url": {
-                                                            "type": "string"
+                                                            "type": "string",
+                                                            "description": "Liquidjs template for the URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}"
                                                         },
                                                         "label": {
                                                             "type": "string"
                                                         }
                                                     }
                                                 }
+                                            },
+                                            "image": {
+                                                "type": "object",
+                                                "description": "Displays the dimension value as an image",
+                                                "properties": {
+                                                    "url": {
+                                                        "type": "string",
+                                                        "description": "Liquidjs template for the image URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}. Only fields selected in the query are available in row context."
+                                                    }
+                                                },
+                                                "required": ["url"]
                                             },
                                             "tags": {
                                                 "oneOf": [
@@ -717,13 +729,25 @@
                                                                 "type": "object",
                                                                 "properties": {
                                                                     "url": {
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "description": "Liquidjs template for the URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}"
                                                                     },
                                                                     "label": {
                                                                         "type": "string"
                                                                     }
                                                                 }
                                                             }
+                                                        },
+                                                        "image": {
+                                                            "type": "object",
+                                                            "description": "Displays the dimension value as an image",
+                                                            "properties": {
+                                                                "url": {
+                                                                    "type": "string",
+                                                                    "description": "Liquidjs template for the image URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}. Only fields selected in the query are available in row context."
+                                                                }
+                                                            },
+                                                            "required": ["url"]
                                                         },
                                                         "tags": {
                                                             "oneOf": [
@@ -952,13 +976,25 @@
                                                         "type": "object",
                                                         "properties": {
                                                             "url": {
-                                                                "type": "string"
+                                                                "type": "string",
+                                                                "description": "Liquidjs template for the URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}"
                                                             },
                                                             "label": {
                                                                 "type": "string"
                                                             }
                                                         }
                                                     }
+                                                },
+                                                "image": {
+                                                    "type": "object",
+                                                    "description": "Displays the dimension value as an image",
+                                                    "properties": {
+                                                        "url": {
+                                                            "type": "string",
+                                                            "description": "Liquidjs template for the image URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}. Only fields selected in the query are available in row context."
+                                                        }
+                                                    },
+                                                    "required": ["url"]
                                                 },
                                                 "tags": {
                                                     "oneOf": [
@@ -1127,13 +1163,25 @@
                                                                 "type": "object",
                                                                 "properties": {
                                                                     "url": {
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "description": "Liquidjs template for the URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}"
                                                                     },
                                                                     "label": {
                                                                         "type": "string"
                                                                     }
                                                                 }
                                                             }
+                                                        },
+                                                        "image": {
+                                                            "type": "object",
+                                                            "description": "Displays the dimension value as an image",
+                                                            "properties": {
+                                                                "url": {
+                                                                    "type": "string",
+                                                                    "description": "Liquidjs template for the image URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}. Only fields selected in the query are available in row context."
+                                                                }
+                                                            },
+                                                            "required": ["url"]
                                                         },
                                                         "tags": {
                                                             "oneOf": [
@@ -1288,13 +1336,25 @@
                                     "type": "object",
                                     "properties": {
                                         "url": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "description": "Liquidjs template for the URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}"
                                         },
                                         "label": {
                                             "type": "string"
                                         }
                                     }
                                 }
+                            },
+                            "image": {
+                                "type": "object",
+                                "description": "Displays the dimension value as an image",
+                                "properties": {
+                                    "url": {
+                                        "type": "string",
+                                        "description": "Liquidjs template for the image URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}. Only fields selected in the query are available in row context."
+                                    }
+                                },
+                                "required": ["url"]
                             },
                             "tags": {
                                 "oneOf": [

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -168,6 +168,9 @@ export type DbtColumnLightdashDimension = {
     urls?: FieldUrl[];
     required_attributes?: Record<string, string | string[]>;
     ai_hint?: string | string[];
+    image?: {
+        url: string;
+    };
 } & DbtLightdashFieldTags;
 
 export type DbtColumnLightdashAdditionalDimension = Omit<

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -566,6 +566,9 @@ export interface Dimension extends Field {
     colors?: Record<string, string>;
     isIntervalBase?: boolean;
     aiHint?: string | string[];
+    image?: {
+        url: string;
+    };
 }
 
 type CompiledProperties = {

--- a/packages/frontend/src/components/common/Table/ImageCell.tsx
+++ b/packages/frontend/src/components/common/Table/ImageCell.tsx
@@ -1,0 +1,69 @@
+import { type Dimension } from '@lightdash/common';
+import { Tooltip } from '@mantine/core';
+import { IconPhotoOff } from '@tabler/icons-react';
+import { useState } from 'react';
+import MantineIcon from '../MantineIcon';
+
+export const BrokenImageCell = ({
+    imageUrl,
+    error,
+}: {
+    imageUrl: string;
+    error?: string;
+}) => {
+    return (
+        <Tooltip
+            withinPortal
+            w="400px"
+            multiline
+            label={`Could not load image "${imageUrl}" ${
+                error ? `: ${error}` : ''
+            }`}
+        >
+            <span style={{ display: 'inline-block', lineHeight: 0 }}>
+                <MantineIcon icon={IconPhotoOff} size="xxl" color="gray" />{' '}
+                {/* xxl =32px same size as image cell */}
+            </span>
+        </Tooltip>
+    );
+};
+
+export const ImageCell = ({
+    imageUrl,
+}: {
+    item: Dimension;
+    imageUrl: string;
+}) => {
+    const [isBroken, setIsBroken] = useState(false);
+
+    if (isBroken) {
+        return <BrokenImageCell imageUrl={imageUrl} />;
+    }
+
+    return (
+        <Tooltip
+            withinPortal
+            label={
+                // Full image in tooltip
+                <img
+                    src={imageUrl}
+                    alt=""
+                    style={{ maxWidth: '400px', maxHeight: '400px' }}
+                />
+            }
+        >
+            {/* Small thumbnail in table cell */}
+            <img
+                src={imageUrl}
+                alt=""
+                style={{
+                    height: '32px',
+                    width: 'auto',
+                    display: 'block',
+                    objectFit: 'contain',
+                }}
+                onError={() => setIsBroken(true)}
+            />
+        </Tooltip>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-130/investigate-images-on-table

Scrolling on virtual table rendering feels "ok". Having bigger images (eg: 48px) made it worse. 

<img width="827" height="640" alt="Screenshot from 2025-11-11 11-15-50" src="https://github.com/user-attachments/assets/4aa86298-37d9-4286-b3df-51a00e60d98a" />
<img width="624" height="758" alt="Screenshot from 2025-11-11 11-16-28" src="https://github.com/user-attachments/assets/9dce9d1a-03ca-415f-84ba-6e48d7b01f1a" />


## on image errors

<img width="866" height="470" alt="image" src="https://github.com/user-attachments/assets/3e133242-a153-4418-bba9-c7816e65ba9d" />


### Description:
Added support for image dimensions in Lightdash. This feature allows users to define image URLs in their dbt models and display them in the UI. Images are rendered with tooltips that show larger versions on hover.

The implementation includes:
- Added `image` property to dimension types in dbt.ts and field.ts
- Updated the translator to convert image metadata from dbt models
- Added image cell formatting in useColumns.tsx with tooltip functionality
- Added an example in the jaffle-shop demo showing how to create image URLs in SQL

