### PR TITLE
feat: add stricter embed chart permissions

### DIFF
--- a/packages/backend/src/auth/account/account.mock.ts
+++ b/packages/backend/src/auth/account/account.mock.ts
@@ -122,7 +122,12 @@ export function buildAccount({
             },
         },
         source: 'test-jwt-token',
-        contentUuid: 'test-dashboard-uuid',
+        content: {
+            type: 'dashboard',
+            dashboardUuid: 'test-dashboard-uuid',
+            chartUuids: [],
+            explores: [],
+        },
         userAttributes: defaultUserAttributes,
     });
 }

--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -62,7 +62,12 @@ describe('account', () => {
                 decodedToken: mockDecodedToken,
                 embed: mockEmbed,
                 source: 'test-jwt-token',
-                contentUuid: 'test-dashboard-uuid',
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: 'test-dashboard-uuid',
+                    chartUuids: [],
+                    explores: [],
+                },
                 userAttributes: mockUserAttributes,
             });
 
@@ -72,7 +77,9 @@ describe('account', () => {
 
             expect(result.organization).toEqual(mockEmbed.organization);
 
-            expect(result.access.contentId).toBe('test-dashboard-uuid');
+            expect(result.access.content.dashboardUuid).toBe(
+                'test-dashboard-uuid',
+            );
             expect(result.access.filtering).toEqual(
                 mockDecodedToken.content.type === 'dashboard'
                     ? mockDecodedToken.content.dashboardFiltersInteractivity
@@ -112,7 +119,12 @@ describe('account', () => {
                 decodedToken: tokenWithoutExternalId,
                 embed: mockEmbed,
                 source: 'anonymous-jwt-token',
-                contentUuid: 'test-dashboard-uuid',
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: 'test-dashboard-uuid',
+                    chartUuids: [],
+                    explores: [],
+                },
                 userAttributes: mockUserAttributes,
             });
 
@@ -139,7 +151,12 @@ describe('account', () => {
                 decodedToken: tokenWithoutUser,
                 embed: mockEmbed,
                 source: 'no-user-jwt-token',
-                contentUuid: 'test-dashboard-uuid',
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: 'test-dashboard-uuid',
+                    chartUuids: [],
+                    explores: [],
+                },
                 userAttributes: mockUserAttributes,
             });
 
@@ -160,7 +177,12 @@ describe('account', () => {
                 decodedToken: mockDecodedToken,
                 embed: mockEmbed,
                 source: 'test-jwt-token',
-                contentUuid: 'test-dashboard-uuid',
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: 'test-dashboard-uuid',
+                    chartUuids: [],
+                    explores: [],
+                },
                 userAttributes: emptyUserAttributes,
             });
 

--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -10,6 +10,7 @@ import {
     applyEmbeddedAbility,
     buildAccountHelpers,
     CreateEmbedJwt,
+    EmbedContent,
     ForbiddenError,
     MemberAbility,
     OauthAccount,
@@ -76,28 +77,19 @@ export const fromJwt = ({
     decodedToken,
     embed,
     source,
-    contentUuid,
-    contentType = 'dashboard',
     userAttributes,
+    content,
 }: {
     decodedToken: CreateEmbedJwt;
     embed: OssEmbed;
     source: string;
-    contentUuid?: string;
-    contentType?: 'dashboard' | 'chart';
     userAttributes: UserAccessControls;
+    content: EmbedContent;
 }): AnonymousAccount => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     const externalId = getExternalId(decodedToken, source, embed.organization);
 
-    applyEmbeddedAbility(
-        decodedToken,
-        contentUuid,
-        contentType,
-        embed,
-        externalId,
-        builder,
-    );
+    applyEmbeddedAbility(decodedToken, content, embed, externalId, builder);
     const abilities = builder.build();
 
     return createAccount({
@@ -109,8 +101,7 @@ export const fromJwt = ({
         organization: embed.organization,
         embed,
         access: {
-            contentId: contentUuid,
-            contentType,
+            content,
             filtering: decodedToken.content.dashboardFiltersInteractivity,
             parameters: decodedToken.content.parameterInteractivity,
             controls: userAttributes,

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -194,7 +194,7 @@ export class QueryController extends BaseController {
 
         if (
             isJwtUser(req.account!) &&
-            req.account!.access.contentType !== 'chart'
+            req.account!.access.content.type !== 'chart'
         ) {
             throw new ForbiddenError('Feature not available for this JWT');
         }

--- a/packages/backend/src/services/PermissionsService/PermissionsService.ts
+++ b/packages/backend/src/services/PermissionsService/PermissionsService.ts
@@ -61,7 +61,7 @@ export class PermissionsService extends BaseService {
         savedChartUuid: string,
     ) {
         const { embed } = account;
-        const { contentId, contentType } = account.access;
+        const { content } = account.access;
 
         if (!embed.projectUuid) {
             throw new ForbiddenError(
@@ -69,15 +69,15 @@ export class PermissionsService extends BaseService {
             );
         }
 
-        if (contentType === 'dashboard' && contentId) {
+        if (content.type === 'dashboard' && content.dashboardUuid) {
             return this.checkEmbeddedDashboardPermission(
-                contentId,
+                content.dashboardUuid,
                 savedChartUuid,
                 embed,
             );
         }
 
-        if (contentType === 'chart') {
+        if (content.type === 'chart') {
             return PermissionsService.checkEmbeddedChartPermissions(
                 savedChartUuid,
                 embed,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4368,15 +4368,24 @@ export class ProjectService extends BaseService {
                     ? { organizationUuid }
                     : await this.projectModel.getSummary(projectUuid);
 
-                if (
+                const isForbidden =
                     account.user.ability.cannot(
                         'view',
                         subject('Project', {
                             organizationUuid: project.organizationUuid,
                             projectUuid,
                         }),
-                    )
-                ) {
+                    ) &&
+                    account.user.ability.cannot(
+                        'view',
+                        subject('Explore', {
+                            organizationUuid: project.organizationUuid,
+                            projectUuid,
+                            exploreNames,
+                        }),
+                    );
+
+                if (isForbidden) {
                     throw new ForbiddenError();
                 }
                 const explores = await this.projectModel.findExploresFromCache(
@@ -6890,6 +6899,6 @@ export class ProjectService extends BaseService {
     static isChartEmbed(account: Account) {
         if (!isJwtUser(account)) return false;
 
-        return account.access.contentType === 'chart';
+        return account.access.content.type === 'chart';
     }
 }

--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -62,8 +62,7 @@ const defineAbilityForEmbedUser = (
     const externalId = 'external-id-1';
     applyEmbeddedAbility(
         embedUser,
-        dashboardUuid,
-        'dashboard',
+        { dashboardUuid, type: 'dashboard', chartUuids: [], explores: [] },
         embed,
         externalId,
         builder,
@@ -365,6 +364,8 @@ describe('Embedded dashboard abilities', () => {
             it('should allow only CSV and PDF when images is disabled', () => {
                 const embedUser = createEmbedJwt({
                     content: {
+                        type: 'dashboard',
+                        dashboardUuid,
                         canExportCsv: true,
                         canExportPagePdf: true,
                         canExportImages: false,

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { OssEmbed } from '../../types/auth';
+import type { EmbedContent, OssEmbed } from '../../types/auth';
 import assertUnreachable from '../../utils/assertUnreachable';
 
 /** @deprecated Use OssEmbed instead */
@@ -205,7 +205,7 @@ export function isChartContent(
 }
 
 export function isDashboardContent(
-    content: CreateEmbedJwt['content'],
+    content: CreateEmbedJwt['content'] | EmbedContent,
 ): content is EmbedJwtContentDashboardUuid | EmbedJwtContentDashboardSlug {
     return content.type === 'dashboard';
 }

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -82,11 +82,22 @@ export type UserAccessControls = {
     intrinsicUserAttributes: IntrinsicUserAttributes;
 };
 
+/**
+ * Details about the content bound to the given JWT
+ */
+export type EmbedContent = {
+    /** The dashboard UUID the JWT may have access to */
+    dashboardUuid?: string;
+    /** The chart IDs the JWT dashboard may have access to */
+    chartUuids: string[];
+    /** Explores available to the embedded dashboard */
+    explores: string[];
+    /** The type of content */
+    type: 'dashboard' | 'chart';
+};
+
 export type EmbedAccess = {
-    /** The content ID the account has access to (dashboard or chart) */
-    contentId?: string;
-    /** The type of content (dashboard or chart) */
-    contentType?: 'dashboard' | 'chart';
+    content: EmbedContent;
     /** Dashboard filtering options for interactivity */
     filtering?: DashboardFilterInteractivityOptions;
     /** User-specific access controls */

--- a/packages/e2e/cypress/e2e/api/embedChart.cy.ts
+++ b/packages/e2e/cypress/e2e/api/embedChart.cy.ts
@@ -468,10 +468,10 @@ describe('Embed Chart JWT API', () => {
                 });
             });
 
-            it('allows chart JWT to access getExplore for any explore', () => {
+            it('prevents chart JWT to access getExplore for explores outside the chart scope', () => {
                 cy.get<string>('@chartJwtToken').then((token) => {
                     // Try to access an explore (doesn't matter which one)
-                    const exploreName = 'orders';
+                    const exploreName = 'users';
                     cy.request({
                         url: `/api/v1/projects/${SEED_PROJECT.project_uuid}/explores/${exploreName}?projectUuid=${SEED_PROJECT.project_uuid}`,
                         headers: {
@@ -480,9 +480,8 @@ describe('Embed Chart JWT API', () => {
                         method: 'GET',
                         failOnStatusCode: false,
                     }).then((resp) => {
-                        // TODO: This should fail if token chartUuid doesn't match the requested explore
-                        expect(resp.status).to.eq(200);
-                        expect(resp.body).not.to.have.property('error');
+                        expect(resp.status).to.eq(403);
+                        expect(resp.body).to.have.property('error');
                     });
                 });
             });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: CENG-148

### Description:

Refactored the JWT authentication to use a more structured `EmbedContent` type instead of separate `contentUuid` and `contentType` fields. This change improves type safety and allows for more detailed content information to be passed around, including chart UUIDs, dashboard UUID, and available explores.

The new structure also enables more granular permissions checking, particularly for chart embeds where we can now properly check permissions against specific explores.

This lays the foundation for front-loading all dashboard charts so we can further implement strict permissions for dashboards and eventually AI Agents.

These changes should only affect single chart embeds and not dashboards, dashboard charts, underlydata, or explores (all dashboard related concerns)