### PR TITLE
fix: remove hidden fields when findExplores tool call

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -94,8 +94,12 @@ const generateExploreResponse = ({
                         <fields alt="dimensions and metrics">
                             {Object.values(table.dimensions).length > 0 && (
                                 <dimensions alt="dimensions">
-                                    {Object.values(table.dimensions).map(
-                                        (dimension) => (
+                                    {Object.values(table.dimensions)
+                                        .filter(
+                                            (d) =>
+                                                !d.hidden && !d.isIntervalBase,
+                                        )
+                                        .map((dimension) => (
                                             <dimension
                                                 usageInCharts={getCatalogChartUsage(
                                                     catalogFields,
@@ -128,15 +132,15 @@ const generateExploreResponse = ({
                                                         </aihints>
                                                     )}
                                             </dimension>
-                                        ),
-                                    )}
+                                        ))}
                                 </dimensions>
                             )}
 
                             {Object.values(table.metrics).length > 0 && (
                                 <metrics alt="metrics">
-                                    {Object.values(table.metrics).map(
-                                        (metric) => (
+                                    {Object.values(table.metrics)
+                                        .filter((m) => !m.hidden)
+                                        .map((metric) => (
                                             <metric
                                                 usageInCharts={getCatalogChartUsage(
                                                     catalogFields,
@@ -169,8 +173,7 @@ const generateExploreResponse = ({
                                                         </aihints>
                                                     )}
                                             </metric>
-                                        ),
-                                    )}
+                                        ))}
                                 </metrics>
                             )}
                         </fields>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Filter out `hidden` fields from `findExplores` - similar behaviour to `findFields` (which gets info from parsed catalog, which by default drops/ignores `hidden` fields)
