### PR TITLE
fix: add guards for null values in explore filtering

### DIFF
--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -629,3 +629,17 @@ export class LightdashProjectConfigError extends LightdashError {
         });
     }
 }
+
+export class CorruptedExploreError extends LightdashError {
+    constructor(
+        message = 'Explore has corrupted or missing data',
+        data: Record<string, AnyType> = {},
+    ) {
+        super({
+            message,
+            name: 'CorruptedExploreError',
+            statusCode: 500,
+            data,
+        });
+    }
+}


### PR DESCRIPTION
### Description:
Added defensive null/undefined checks to prevent crashes when processing explores with corrupted cache data. The changes guard against null values in `exploreHasFilteredAttribute` and `getFilteredExplore` by validating tables, dimensions, metrics, and baseTable references before accessing their properties.


```
TypeError: Cannot read properties of undefined (reading 'requiredAttributes')
    at /usr/app/packages/backend/dist/services/UserAttributesService/UserAttributeUtils.js:23:67
    at Array.some (<anonymous>)
    at /usr/app/packages/backend/dist/services/UserAttributesService/UserAttributeUtils.js:23:37
    at Array.some (<anonymous>)
    at exploreHasFilteredAttribute (/usr/app/packages/backend/dist/services/UserAttributesService/UserAttributeUtils.js:22:80)
    at /usr/app/packages/backend/dist/services/ProjectService/ProjectService.js:2375:102
    at Array.reduce (<anonymous>)
    at /usr/app/packages/backend/dist/services/ProjectService/ProjectService.js:2370:44
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 1)
    at async /usr/app/packages/backend/dist/services/ProjectService/ProjectService.js:2593:69
    at async ProjectService.getAvailableFiltersForSavedQueries (/usr/app/packages/backend/dist/services/ProjectService/ProjectService.js:2581:22)
    at async /usr/app/packages/backend/dist/routers/dashboardRouter.js:103:25
```

This seems to be an edge case where an `exploreError` slips past our `isExploreError` check. I couldn't reproduce it locally, but adding these safeguards ensures the code handles it gracefully at runtime