### PR TITLE
fix: skip analytics tracking for zero-score AI agent feedback

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1522,16 +1522,18 @@ export class AiAgentService {
         humanScore: number,
         humanFeedback?: string | null,
     ) {
-        this.analytics.track<AiAgentPromptFeedbackEvent>({
-            event: 'ai_agent_prompt.feedback',
-            userId: user.userUuid,
-            properties: {
-                organizationId: user.organizationUuid,
-                humanScore,
-                messageId: messageUuid,
-                context: 'web_app',
-            },
-        });
+        if (humanScore !== 0) {
+            this.analytics.track<AiAgentPromptFeedbackEvent>({
+                event: 'ai_agent_prompt.feedback',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: user.organizationUuid,
+                    humanScore,
+                    messageId: messageUuid,
+                    context: 'web_app',
+                },
+            });
+        }
 
         await this.aiAgentModel.updateHumanScore({
             promptUuid: messageUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Only track AI agent prompt feedback events when the human score is not zero. This prevents tracking events for default or unintentional zero scores, while still updating the database record regardless of the score value.
