### PR TITLE
feat: add "Add to Evals" button for users with manage permission

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -4,6 +4,7 @@ import { useOutletContext, useParams } from 'react-router';
 import useApp from '../../../providers/App/useApp';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
+import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentThreadArtifact } from '../../features/aiCopilot/hooks/useAiAgentThreadArtifact';
 import {
     useProjectAiAgent as useAiAgent,
@@ -35,6 +36,11 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
 
     const agentQuery = useAiAgent(projectUuid!, agentUuid!);
     const { agent } = useOutletContext<AgentContext>();
+
+    const canManage = useAiAgentPermission({
+        action: 'manage',
+        projectUuid,
+    });
 
     const {
         mutateAsync: createAgentThreadMessage,
@@ -83,6 +89,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             debug={debug}
             projectUuid={projectUuid}
             agentUuid={agentUuid}
+            showAddToEvalsButton={canManage}
         >
             <AgentChatInput
                 disabled={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

#### Closes: #18039

### Description:

Added permission check for AI agent management to control the visibility of the "Add to Evals" button in the agent thread page. The button will now only be shown to users who have permission to manage AI agents in the project.