### PR TITLE
feat: add a page to view a single verified answer from a link

### DIFF
--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -122,6 +122,10 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                         path: 'verified-artifacts',
                         element: <ProjectAiAgentEditPage />,
                     },
+                    {
+                        path: 'verified-artifacts/:artifactUuid',
+                        element: <ProjectAiAgentEditPage />,
+                    },
                 ],
             },
             {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactDetail.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactDetail.tsx
@@ -1,0 +1,134 @@
+import { Anchor, Box, Breadcrumbs, Stack, Text } from '@mantine-8/core';
+import { type FC, useEffect } from 'react';
+import { Panel, PanelGroup } from 'react-resizable-panels';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
+import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
+import { useAiAgentArtifact } from '../../hooks/useAiAgentArtifacts';
+import { clearArtifact, setArtifact } from '../../store/aiArtifactSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
+import { AiArtifactPanel } from '../ChatElements/AiArtifactPanel';
+
+export const VerifiedArtifactDetail: FC = () => {
+    const navigate = useNavigate();
+    const { projectUuid, agentUuid, artifactUuid } = useParams<{
+        projectUuid: string;
+        agentUuid: string;
+        artifactUuid: string;
+    }>();
+    const [searchParams] = useSearchParams();
+    const dispatch = useAiAgentStoreDispatch();
+    const artifact = useAiAgentStoreSelector(
+        (state) => state.aiArtifact.artifact,
+    );
+
+    const versionUuid = searchParams.get('versionUuid');
+    const threadUuid = searchParams.get('threadUuid');
+    const promptUuid = searchParams.get('promptUuid');
+
+    const { data: artifactData } = useAiAgentArtifact({
+        projectUuid: projectUuid!,
+        agentUuid: agentUuid!,
+        artifactUuid,
+        versionUuid: versionUuid!,
+        options: {
+            enabled: !!(
+                projectUuid &&
+                agentUuid &&
+                artifactUuid &&
+                versionUuid
+            ),
+        },
+    });
+
+    useEffect(() => {
+        if (
+            projectUuid &&
+            agentUuid &&
+            artifactUuid &&
+            versionUuid &&
+            threadUuid &&
+            promptUuid
+        ) {
+            dispatch(
+                setArtifact({
+                    projectUuid,
+                    agentUuid,
+                    artifactUuid,
+                    versionUuid,
+                    messageUuid: promptUuid,
+                    threadUuid,
+                }),
+            );
+        }
+
+        return () => {
+            dispatch(clearArtifact());
+        };
+    }, [
+        dispatch,
+        projectUuid,
+        agentUuid,
+        artifactUuid,
+        versionUuid,
+        threadUuid,
+        promptUuid,
+    ]);
+
+    const handleNavigateToVerifiedArtifacts = () => {
+        void navigate(
+            `/projects/${projectUuid}/ai-agents/${agentUuid}/edit/verified-artifacts`,
+        );
+    };
+
+    const breadcrumbItems = [
+        <Anchor
+            key="verified-answers"
+            size="lg"
+            onClick={handleNavigateToVerifiedArtifacts}
+            td="none"
+            fw={500}
+        >
+            Verified Answers
+        </Anchor>,
+        <Text key="artifact" size="lg" fw={500}>
+            {artifactData?.title || 'Artifact'}
+        </Text>,
+    ];
+
+    return (
+        <PanelGroup
+            direction="horizontal"
+            style={{ height: `calc(100vh - ${NAVBAR_HEIGHT}px)` }}
+        >
+            <Panel
+                id="artifact-preview"
+                defaultSize={60}
+                minSize={25}
+                maxSize={70}
+            >
+                <Stack gap="sm" mt="lg" pr="md">
+                    <Stack gap="xs">
+                        <Breadcrumbs separator="/">
+                            {breadcrumbItems}
+                        </Breadcrumbs>
+                        <Text size="sm" c="dimmed">
+                            {artifactData?.description ||
+                                'View verified answer'}
+                        </Text>
+                    </Stack>
+                    {artifact && (
+                        <Box h="800px" pos="relative" bg="white">
+                            <AiArtifactPanel
+                                artifact={artifact}
+                                showCloseButton={true}
+                            />
+                        </Box>
+                    )}
+                </Stack>
+            </Panel>
+        </PanelGroup>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
@@ -11,14 +11,14 @@ import {
     useMantineTheme,
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
-import { IconCircleX, IconDots } from '@tabler/icons-react';
+import { IconCircleX, IconDots, IconEye } from '@tabler/icons-react';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
 } from 'mantine-react-table';
 import { useCallback, useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
@@ -37,7 +37,7 @@ export const VerifiedArtifactsTable: FC<Props> = ({
 }) => {
     const theme = useMantineTheme();
     const { projectUuid, agentUuid } = useParams();
-
+    const navigate = useNavigate();
     const canManageAgent = useAiAgentPermission({
         action: 'manage',
         projectUuid: projectUuid!,
@@ -94,6 +94,15 @@ export const VerifiedArtifactsTable: FC<Props> = ({
         closeUnverifyModal();
         setArtifactToUnverify(null);
     }, [artifactToUnverify, closeUnverifyModal, setVerified]);
+
+    const handleViewArtifact = useCallback(
+        (artifact: AiAgentVerifiedArtifact) => {
+            void navigate(
+                `/projects/${projectUuid}/ai-agents/${agentUuid}/edit/verified-artifacts/${artifact.artifactUuid}?versionUuid=${artifact.versionUuid}&threadUuid=${artifact.threadUuid}&promptUuid=${artifact.promptUuid}`,
+            );
+        },
+        [navigate, projectUuid, agentUuid],
+    );
 
     const columns: MRT_ColumnDef<AiAgentVerifiedArtifact>[] = useMemo(
         () => [
@@ -218,13 +227,23 @@ export const VerifiedArtifactsTable: FC<Props> = ({
                                 >
                                     Remove from verified answers
                                 </Menu.Item>
+
+                                <Menu.Item
+                                    leftSection={<MantineIcon icon={IconEye} />}
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleViewArtifact(row.original);
+                                    }}
+                                >
+                                    View artifact
+                                </Menu.Item>
                             </Menu.Dropdown>
                         </Menu>
                     );
                 },
             },
         ],
-        [canManageAgent, handleUnverify],
+        [canManageAgent, handleUnverify, handleViewArtifact],
     );
 
     const table = useMantineReactTable({

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../../components/common/Page/constants';
 import { useProjects } from '../../../hooks/useProjects';
 import useApp from '../../../providers/App/useApp';
+import { VerifiedArtifactDetail } from '../../features/aiCopilot/components/Admin/VerifiedArtifactDetail';
 import { VerifiedArtifactsLayout } from '../../features/aiCopilot/components/Admin/VerifiedArtifactsLayout';
 import { AiAgentFormSetup } from '../../features/aiCopilot/components/AiAgentFormSetup';
 import { EvalDetail } from '../../features/aiCopilot/components/Evals/EvalDetail';
@@ -67,12 +68,14 @@ type Props = {
 
 const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
     const navigate = useNavigate();
-    const { agentUuid, projectUuid, evalUuid, runUuid } = useParams<{
-        agentUuid: string;
-        projectUuid: string;
-        evalUuid?: string;
-        runUuid?: string;
-    }>();
+    const { agentUuid, projectUuid, evalUuid, runUuid, artifactUuid } =
+        useParams<{
+            agentUuid: string;
+            projectUuid: string;
+            evalUuid?: string;
+            runUuid?: string;
+            artifactUuid?: string;
+        }>();
     const location = useLocation();
     const canManageAgents = useAiAgentPermission({
         action: 'manage',
@@ -394,7 +397,13 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                     )}
 
                     {activeTab === 'verified-artifacts' && (
-                        <VerifiedArtifactsLayout />
+                        <>
+                            {artifactUuid ? (
+                                <VerifiedArtifactDetail />
+                            ) : (
+                                <VerifiedArtifactsLayout />
+                            )}
+                        </>
                     )}
                 </Box>
             </AppShell.Main>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added the ability to view verified artifacts in AI Agents. Users can now click on "View artifact" in the verified artifacts table to see the full details of a specific artifact. This includes:

- Added a new route for viewing individual verified artifacts
- Created a new `VerifiedArtifactDetail` component to display the artifact content
- Added a "View artifact" action in the verified artifacts table
- Updated the ProjectAiAgentEditPage to conditionally render either the artifacts list or a specific artifact detail



![image.png](https://app.graphite.com/user-attachments/assets/7c926404-c0e1-4a1e-8117-46ce026337b4.png)

