### PR TITLE
feat: display referenced artifacts in slack response

### DIFF
--- a/packages/backend/src/ee/services/SlackService/SlackService.ts
+++ b/packages/backend/src/ee/services/SlackService/SlackService.ts
@@ -31,6 +31,7 @@ export class CommercialSlackService extends SlackService {
         this.aiAgentService.handlePromptUpvote(slackApp);
         this.aiAgentService.handlePromptDownvote(slackApp);
         this.aiAgentService.handleClickExploreButton(slackApp);
+        this.aiAgentService.handleViewArtifact(slackApp);
         this.aiAgentService.handleClickOAuthButton(slackApp);
         this.aiAgentService.handleExecuteFollowUpTool(slackApp);
         this.aiAgentService.handleViewChangesetsButtonClick(slackApp);

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -1,4 +1,5 @@
 import {
+    AiAgentMessageAssistantArtifact,
     AiAgentToolResult,
     AiArtifact,
     FollowUpTools,
@@ -8,6 +9,52 @@ import {
 } from '@lightdash/common';
 import { Block, KnownBlock } from '@slack/bolt';
 import { partition } from 'lodash';
+
+export function getReferencedArtifactsBlocks(
+    agentUuid: string,
+    projectUuid: string,
+    siteUrl: string,
+    referencedArtifacts: AiAgentMessageAssistantArtifact[],
+    threadUuid: string,
+    promptUuid: string,
+): (Block | KnownBlock)[] {
+    if (!referencedArtifacts || referencedArtifacts.length === 0) {
+        return [];
+    }
+
+    return [
+        {
+            type: 'divider',
+        },
+        {
+            type: 'context',
+            elements: [
+                {
+                    type: 'plain_text',
+                    text: '✨ Referenced answers:',
+                },
+            ],
+        },
+        {
+            type: 'actions',
+            elements: referencedArtifacts.map((artifact) => {
+                const title = artifact.title || artifact.artifactType;
+                // TODO :: threadUuid and promptUuid should not be required
+                const url = `${siteUrl}/projects/${projectUuid}/ai-agents/${agentUuid}/edit/verified-artifacts/${artifact.artifactUuid}?versionUuid=${artifact.versionUuid}&threadUuid=${threadUuid}&promptUuid=${promptUuid}`;
+                return {
+                    type: 'button',
+                    url,
+                    text: {
+                        type: 'plain_text',
+                        text: `📊 ${title}`,
+                        emoji: true,
+                    },
+                    action_id: 'view_artifact',
+                };
+            }),
+        },
+    ];
+}
 
 export function getFollowUpToolBlocks(
     slackPrompt: SlackPrompt,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added support for displaying referenced artifacts in Slack responses. When an AI agent references artifacts in its response, these are now shown as clickable buttons in the Slack message, allowing users to easily access the referenced data.

The implementation includes:

- New function `getReferencedArtifactsBlocks` to generate Slack blocks for referenced artifacts
- Added handler for artifact view button clicks in Slack
- Updated the message composition logic to fetch and include referenced artifacts

![CleanShot 2025-11-12 at 16.55.03@2x.png](https://app.graphite.com/user-attachments/assets/a0d94ad8-171a-4f7a-acb2-e87c54e61d6d.png)



