### PR TITLE
fix: show explore error on tile instead of loading

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -100,9 +100,7 @@ export const useDashboardChartReadyQuery = (
         id: chartUuid ?? undefined,
     });
 
-    const error = chartQuery.error;
-
-    const { data: explore } = useExplore(
+    const { data: explore, error: exploreError } = useExplore(
         chartQuery.data?.metricQuery?.exploreName,
     );
 
@@ -283,5 +281,8 @@ export const useDashboardChartReadyQuery = (
         queryResult.error,
     ]);
 
-    return { ...queryResult, error: error || queryResult.error };
+    return {
+        ...queryResult,
+        error: chartQuery.error || exploreError || queryResult.error,
+    };
 };


### PR DESCRIPTION
### Description:

**The problem:** errors in models resulted in dashboard tiles showing loading forever. This caused scheduled deliveries to show loading spinners when there were model errors. Not that errors in the query were already displayed properly. 

<img width="1231" height="827" alt="Screenshot 2025-11-12 at 14 34 15" src="https://github.com/user-attachments/assets/fbb4125e-6898-4584-98f1-10d4b904a153" />

**Fix:** propagate errors from useExplore to the tiles

**Repro:**
- Create a chart
- Add it to a dashboard
- Change the model to break the chart and refresh dbt
- Chart tile will load forever
