### PR TITLE
fix: add explicit frame clauses to FIRST_VALUE window functions

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -306,6 +306,47 @@ describe('PivotQueryBuilder', () => {
                 'DENSE_RANK() OVER (ORDER BY revenue_row_anchor."revenue_row_anchor_value" ASC, g."store_id" DESC, g."date" ASC) AS "row_index"',
             );
         });
+
+        test('Should include explicit frame clauses in FIRST_VALUE for Redshift compatibility', () => {
+            // Redshift requires explicit frame clauses for aggregate window functions with ORDER BY
+            // See: https://docs.aws.amazon.com/redshift/latest/dg/r_WF_first_value.html
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Both anchor CTEs should have explicit frame clauses
+            expect(result).toContain(
+                'ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
+            );
+
+            // Verify the complete FIRST_VALUE syntax in row anchor
+            expect(replaceWhitespace(result)).toContain(
+                'FIRST_VALUE("revenue_sum") OVER (PARTITION BY "date" ORDER BY "revenue_sum" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            );
+
+            // Verify the complete FIRST_VALUE syntax in column anchor
+            expect(replaceWhitespace(result)).toContain(
+                'FIRST_VALUE("revenue_sum") OVER (PARTITION BY "category" ORDER BY "revenue_sum" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            );
+        });
     });
 
     describe('Sort handling', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -381,7 +381,7 @@ export class PivotQueryBuilder {
                 .map((col) => `${q}${col.reference}${q}`)
                 .join(', ');
 
-            const rowAnchorSql = `SELECT DISTINCT ${indexColumnReferences}, FIRST_VALUE(${q}${fieldName}${q}) OVER (PARTITION BY ${indexColumnReferences} ORDER BY ${q}${fieldName}${q} ${sortDirection}) AS ${q}${rowAnchorCteName}_value${q} FROM group_by_query`;
+            const rowAnchorSql = `SELECT DISTINCT ${indexColumnReferences}, FIRST_VALUE(${q}${fieldName}${q}) OVER (PARTITION BY ${indexColumnReferences} ORDER BY ${q}${fieldName}${q} ${sortDirection} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${q}${rowAnchorCteName}_value${q} FROM group_by_query`;
 
             result[rowAnchorCteName] = {
                 cteName: rowAnchorCteName,
@@ -394,7 +394,7 @@ export class PivotQueryBuilder {
                 .map((col) => `${q}${col.reference}${q}`)
                 .join(', ');
 
-            const colAnchorSql = `SELECT DISTINCT ${groupColumnReferences}, FIRST_VALUE(${q}${fieldName}${q}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${q}${fieldName}${q} ${sortDirection}) AS ${q}${colAnchorCteName}_value${q} FROM group_by_query`;
+            const colAnchorSql = `SELECT DISTINCT ${groupColumnReferences}, FIRST_VALUE(${q}${fieldName}${q}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${q}${fieldName}${q} ${sortDirection} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${q}${colAnchorCteName}_value${q} FROM group_by_query`;
 
             result[colAnchorCteName] = {
                 cteName: colAnchorCteName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18064

### Description:
Added explicit frame clauses to FIRST_VALUE window functions in PivotQueryBuilder for Redshift compatibility. Redshift requires explicit frame clauses for aggregate window functions with ORDER BY, as documented in https://docs.aws.amazon.com/redshift/latest/dg/r_WF_first_value.html#r_WF_first_value-arguments

The changes add `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING` to the FIRST_VALUE functions in both row and column anchor SQL queries, ensuring proper functionality when using Redshift as a data warehouse.

**Before**
```sql
WITH original_query AS (
    WITH metrics AS (
        SELECT DATE_TRUNC('WEEK', `orders`.order_date) AS `orders_order_date_week`,
            `orders`.status AS `orders_status`,
            SUM(`orders`.amount) AS `orders_total_order_amount`
        FROM `lightdash_staging`.`jaffle`.`orders` AS `orders`
        GROUP BY 1,
            2
    )
    SELECT *,
        CAST(`orders_total_order_amount` AS FLOAT) / CAST(
            MAX(`orders_total_order_amount`) OVER (PARTITION BY `orders_order_date_week`) AS FLOAT
        ) AS `percent_change_from_previous_of_total_order_amount`
    FROM metrics
    ORDER BY `percent_change_from_previous_of_total_order_amount`
),
group_by_query AS (
    SELECT `orders_status`,
        `orders_order_date_week`,
        ANY_VALUE(`orders_total_order_amount`) AS `orders_total_order_amount_any`,
        ANY_VALUE(
            `percent_change_from_previous_of_total_order_amount`
        ) AS `percent_change_from_previous_of_total_order_amount_any`
    FROM original_query
    group by `orders_status`,
        `orders_order_date_week`
),
percent_change_from_previous_of_total_order_amount_row_anchor AS (
    SELECT DISTINCT `orders_order_date_week`,
        FIRST_VALUE(
            `percent_change_from_previous_of_total_order_amount_any`
        ) OVER (
            PARTITION BY `orders_order_date_week`
            ORDER BY `percent_change_from_previous_of_total_order_amount_any` ASC
        ) AS `percent_change_from_previous_of_total_order_amount_row_anchor_value`
    FROM group_by_query
),
percent_change_from_previous_of_total_order_amount_column_anchor AS (
    SELECT DISTINCT `orders_status`,
        FIRST_VALUE(
            `percent_change_from_previous_of_total_order_amount_any`
        ) OVER (
            PARTITION BY `orders_status`
            ORDER BY `percent_change_from_previous_of_total_order_amount_any` ASC
        ) AS `percent_change_from_previous_of_total_order_amount_column_anchor_value`
    FROM group_by_query
),
pivot_query AS (
    SELECT g.`orders_order_date_week`,
        g.`orders_status`,
        g.`orders_total_order_amount_any`,
        g.`percent_change_from_previous_of_total_order_amount_any`,
        DENSE_RANK() OVER (
            ORDER BY percent_change_from_previous_of_total_order_amount_row_anchor.`percent_change_from_previous_of_total_order_amount_row_anchor_value` ASC,
                g.`orders_order_date_week` ASC
        ) AS `row_index`,
        DENSE_RANK() OVER (
            ORDER BY percent_change_from_previous_of_total_order_amount_column_anchor.`percent_change_from_previous_of_total_order_amount_column_anchor_value` ASC,
                g.`orders_status` ASC
        ) AS `column_index`
    FROM group_by_query g
        JOIN percent_change_from_previous_of_total_order_amount_row_anchor ON g.`orders_order_date_week` = percent_change_from_previous_of_total_order_amount_row_anchor.`orders_order_date_week`
        JOIN percent_change_from_previous_of_total_order_amount_column_anchor ON g.`orders_status` = percent_change_from_previous_of_total_order_amount_column_anchor.`orders_status`
),
filtered_rows AS (
    SELECT *
    FROM pivot_query
    WHERE `row_index` <= 500
),
total_columns AS (
    SELECT COUNT(*) * 2 as total_columns
    FROM (
            SELECT DISTINCT `orders_status`
            FROM filtered_rows
        ) as distinct_groups
)
SELECT p.*,
    t.total_columns
FROM pivot_query p
    CROSS JOIN total_columns t
WHERE p.`row_index` <= 500
    and p.`column_index` <= 49
order by p.`row_index`,
    p.`column_index`
```

**After**
```sql
WITH original_query AS (
    WITH metrics AS (
        SELECT DATE_TRUNC('WEEK', `orders`.order_date) AS `orders_order_date_week`,
            `orders`.status AS `orders_status`,
            SUM(`orders`.amount) AS `orders_total_order_amount`
        FROM `lightdash_staging`.`jaffle`.`orders` AS `orders`
        GROUP BY 1,
            2
    )
    SELECT *,
        CAST(`orders_total_order_amount` AS FLOAT) / CAST(
            MAX(`orders_total_order_amount`) OVER (PARTITION BY `orders_order_date_week`) AS FLOAT
        ) AS `percent_change_from_previous_of_total_order_amount`
    FROM metrics
    ORDER BY `percent_change_from_previous_of_total_order_amount`
),
group_by_query AS (
    SELECT `orders_status`,
        `orders_order_date_week`,
        ANY_VALUE(`orders_total_order_amount`) AS `orders_total_order_amount_any`,
        ANY_VALUE(
            `percent_change_from_previous_of_total_order_amount`
        ) AS `percent_change_from_previous_of_total_order_amount_any`
    FROM original_query
    group by `orders_status`,
        `orders_order_date_week`
),
percent_change_from_previous_of_total_order_amount_row_anchor AS (
    SELECT DISTINCT `orders_order_date_week`,
        FIRST_VALUE(
            `percent_change_from_previous_of_total_order_amount_any`
        ) OVER (
            PARTITION BY `orders_order_date_week`
            ORDER BY `percent_change_from_previous_of_total_order_amount_any` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
        ) AS `percent_change_from_previous_of_total_order_amount_row_anchor_value`
    FROM group_by_query
),
percent_change_from_previous_of_total_order_amount_column_anchor AS (
    SELECT DISTINCT `orders_status`,
        FIRST_VALUE(
            `percent_change_from_previous_of_total_order_amount_any`
        ) OVER (
            PARTITION BY `orders_status`
            ORDER BY `percent_change_from_previous_of_total_order_amount_any` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
        ) AS `percent_change_from_previous_of_total_order_amount_column_anchor_value`
    FROM group_by_query
),
pivot_query AS (
    SELECT g.`orders_order_date_week`,
        g.`orders_status`,
        g.`orders_total_order_amount_any`,
        g.`percent_change_from_previous_of_total_order_amount_any`,
        DENSE_RANK() OVER (
            ORDER BY percent_change_from_previous_of_total_order_amount_row_anchor.`percent_change_from_previous_of_total_order_amount_row_anchor_value` ASC,
                g.`orders_order_date_week` ASC
        ) AS `row_index`,
        DENSE_RANK() OVER (
            ORDER BY percent_change_from_previous_of_total_order_amount_column_anchor.`percent_change_from_previous_of_total_order_amount_column_anchor_value` ASC,
                g.`orders_status` ASC
        ) AS `column_index`
    FROM group_by_query g
        JOIN percent_change_from_previous_of_total_order_amount_row_anchor ON g.`orders_order_date_week` = percent_change_from_previous_of_total_order_amount_row_anchor.`orders_order_date_week`
        JOIN percent_change_from_previous_of_total_order_amount_column_anchor ON g.`orders_status` = percent_change_from_previous_of_total_order_amount_column_anchor.`orders_status`
),
filtered_rows AS (
    SELECT *
    FROM pivot_query
    WHERE `row_index` <= 500
),
total_columns AS (
    SELECT COUNT(*) * 2 as total_columns
    FROM (
            SELECT DISTINCT `orders_status`
            FROM filtered_rows
        ) as distinct_groups
)
SELECT p.*,
    t.total_columns
FROM pivot_query p
    CROSS JOIN total_columns t
WHERE p.`row_index` <= 500
    and p.`column_index` <= 49
order by p.`row_index`,
    p.`column_index`
```