### PR TITLE
fix: get whole height on thread preview eval

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -115,22 +115,21 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
 
             <Divider />
 
-            {evalUuid && runUuid && (
-                <EvalAssessmentDisplay
-                    projectUuid={projectUuid}
-                    agentUuid={agentUuid}
-                    evalUuid={evalUuid}
-                    runUuid={runUuid}
-                    threadUuid={threadUuid}
-                />
-            )}
-
             {threadData && (
                 <>
                     <Box
                         mah="calc(100vh - 150px)"
                         style={{ overflowY: 'auto' }}
                     >
+                        {evalUuid && runUuid && (
+                            <EvalAssessmentDisplay
+                                projectUuid={projectUuid}
+                                agentUuid={agentUuid}
+                                evalUuid={evalUuid}
+                                runUuid={runUuid}
+                                threadUuid={threadUuid}
+                            />
+                        )}
                         <AgentChatDisplay
                             thread={threadData}
                             projectUuid={projectUuid}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Moved the `EvalAssessmentDisplay` component inside the thread data conditional block to ensure it only renders when thread data is available. This prevents potential rendering issues when evaluation data exists but thread data is not yet loaded.

before

[CleanShot 2025-11-12 at 16.03.38.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3cad2e97-9b39-4c4b-98f2-c6cbd6ba3cd4.mp4" />](https://app.graphite.com/user-attachments/video/3cad2e97-9b39-4c4b-98f2-c6cbd6ba3cd4.mp4)

after

[CleanShot 2025-11-12 at 15.59.41.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/11d2ff13-c073-4464-866e-5246d96f4a84.mp4" />](https://app.graphite.com/user-attachments/video/11d2ff13-c073-4464-866e-5246d96f4a84.mp4)

