### PR TITLE
feat: send clear error when all charts fail

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -589,6 +589,9 @@ export default class EmailClient {
                   )
             : undefined;
 
+        const allChartsFailed =
+            csvUrls.length === 0 && failures && failures.length > 0;
+
         return this.sendEmail({
             to: recipient,
             subject,
@@ -613,6 +616,7 @@ export default class EmailClient {
                 attachmentCount: emailAttachments?.length || 0,
                 failures,
                 hasFailures: failures && failures.length > 0,
+                allChartsFailed,
             },
             text: title,
             attachments: emailAttachments,

--- a/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
@@ -1463,6 +1463,133 @@
                                                                                                     </tr>
                                                                                                     {{/truncatedCsvUrls}}
                                                                                                     {{#if
+                                                                                                    allChartsFailed}}
+                                                                                                    <tr>
+                                                                                                        <td>
+                                                                                                            <div
+                                                                                                                style="
+                                                                                                                    padding: 16px;
+                                                                                                                    margin-top: 16px;
+                                                                                                                    background-color: #f8d7da;
+                                                                                                                    border-left: 4px
+                                                                                                                        solid
+                                                                                                                        #dc3545;
+                                                                                                                    border-radius: 4px;
+                                                                                                                    font-family: BlinkMacSystemFont,
+                                                                                                                        Segoe
+                                                                                                                            UI,
+                                                                                                                        Helvetica
+                                                                                                                            Neue,
+                                                                                                                        Arial,
+                                                                                                                        sans-serif,
+                                                                                                                        'Inter';
+                                                                                                                "
+                                                                                                            >
+                                                                                                                <p
+                                                                                                                    style="
+                                                                                                                        margin: 0
+                                                                                                                            0
+                                                                                                                            8px
+                                                                                                                            0;
+                                                                                                                        font-weight: 700;
+                                                                                                                        color: #721c24;
+                                                                                                                        font-size: 14px;
+                                                                                                                        font-family: BlinkMacSystemFont,
+                                                                                                                            Segoe
+                                                                                                                                UI,
+                                                                                                                            Helvetica
+                                                                                                                                Neue,
+                                                                                                                            Arial,
+                                                                                                                            sans-serif,
+                                                                                                                            'Inter';
+                                                                                                                    "
+                                                                                                                >
+                                                                                                                    ❌
+                                                                                                                    Error:
+                                                                                                                    All
+                                                                                                                    charts
+                                                                                                                    in
+                                                                                                                    this
+                                                                                                                    scheduled
+                                                                                                                    delivery
+                                                                                                                    failed
+                                                                                                                    to
+                                                                                                                    export
+                                                                                                                </p>
+                                                                                                                <p
+                                                                                                                    style="
+                                                                                                                        margin: 0
+                                                                                                                            0
+                                                                                                                            8px
+                                                                                                                            0;
+                                                                                                                        color: #721c24;
+                                                                                                                        font-size: 12px;
+                                                                                                                        font-family: BlinkMacSystemFont,
+                                                                                                                            Segoe
+                                                                                                                                UI,
+                                                                                                                            Helvetica
+                                                                                                                                Neue,
+                                                                                                                            Arial,
+                                                                                                                            sans-serif,
+                                                                                                                            'Inter';
+                                                                                                                        line-height: 18px;
+                                                                                                                    "
+                                                                                                                >
+                                                                                                                    No
+                                                                                                                    data
+                                                                                                                    could
+                                                                                                                    be
+                                                                                                                    exported
+                                                                                                                    from
+                                                                                                                    this
+                                                                                                                    dashboard.
+                                                                                                                    Please
+                                                                                                                    check
+                                                                                                                    the
+                                                                                                                    errors
+                                                                                                                    below
+                                                                                                                    and
+                                                                                                                    verify
+                                                                                                                    your
+                                                                                                                    data
+                                                                                                                    model.
+                                                                                                                </p>
+                                                                                                                <ul
+                                                                                                                    style="
+                                                                                                                        margin: 0;
+                                                                                                                        padding-left: 20px;
+                                                                                                                        color: #721c24;
+                                                                                                                        font-size: 12px;
+                                                                                                                        font-family: BlinkMacSystemFont,
+                                                                                                                            Segoe
+                                                                                                                                UI,
+                                                                                                                            Helvetica
+                                                                                                                                Neue,
+                                                                                                                            Arial,
+                                                                                                                            sans-serif,
+                                                                                                                            'Inter';
+                                                                                                                        line-height: 18px;
+                                                                                                                    "
+                                                                                                                >
+                                                                                                                    {{#failures}}
+                                                                                                                    <li
+                                                                                                                        style="
+                                                                                                                            margin-bottom: 6px;
+                                                                                                                            line-height: 18px;
+                                                                                                                        "
+                                                                                                                    >
+                                                                                                                        <strong
+                                                                                                                            >{{chartName}}:</strong
+                                                                                                                        >
+                                                                                                                        {{error}}
+                                                                                                                    </li>
+                                                                                                                    {{/failures}}
+                                                                                                                </ul>
+                                                                                                            </div>
+                                                                                                        </td>
+                                                                                                    </tr>
+                                                                                                    {{else}}
+                                                                                                    {{#if
                                                                                                     hasFailures}}
                                                                                                     <tr>
                                                                                                         <td>
@@ -1546,6 +1673,7 @@
                                                                                                             </div>
                                                                                                         </td>
                                                                                                     </tr>
+                                                                                                    {{/if}}
                                                                                                     {{/if}}
                                                                                                 </table>
                                                                                             </td>

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -326,8 +326,41 @@ export const getDashboardCsvResultsBlocks = ({
     footerMarkdown,
     ctaUrl,
     failures,
-}: GetDashboardCsvResultsBlocksArgs): KnownBlock[] =>
-    getBlocks([
+}: GetDashboardCsvResultsBlocksArgs): KnownBlock[] => {
+    const getFailureBlock = ():
+        | { type: 'section'; text: { type: 'mrkdwn'; text: string } }
+        | undefined => {
+        if (!failures || failures.length === 0) {
+            return undefined;
+        }
+
+        const allChartsFailed = csvUrls.length === 0;
+        if (allChartsFailed) {
+            return {
+                type: 'section',
+                text: {
+                    type: 'mrkdwn',
+                    text: `:x: *Error: All charts in this scheduled delivery failed to export*\n\nNo data could be exported from this dashboard. Please check the errors below and verify your data model.\n\n${failures
+                        .map((f) => `\t• *${f.chartName}:* ${f.error}`)
+                        .join('\n')}`,
+                },
+            };
+        }
+
+        return {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: `:warning: *Warning:* ${
+                    failures.length
+                } chart(s) failed to export:\n${failures
+                    .map((f) => `\t• ${f.chartName}: ${f.error}`)
+                    .join('\n')}`,
+            },
+        };
+    };
+
+    return getBlocks([
         {
             type: 'header',
             text: {
@@ -388,19 +421,7 @@ export const getDashboardCsvResultsBlocks = ({
                       },
                   },
         ),
-        failures && failures.length > 0
-            ? {
-                  type: 'section',
-                  text: {
-                      type: 'mrkdwn',
-                      text: `:warning: *Warning:* ${
-                          failures.length
-                      } chart(s) failed to export:\n${failures
-                          .map((f) => `\t• ${f.chartName}: ${f.error}`)
-                          .join('\n')}`,
-                  },
-              }
-            : undefined,
+        getFailureBlock(),
         footerMarkdown
             ? {
                   type: 'context',
@@ -413,6 +434,7 @@ export const getDashboardCsvResultsBlocks = ({
               }
             : undefined,
     ]);
+};
 
 const getExploreBlocks = (
     title: string,


### PR DESCRIPTION
### Description:

If all charts in a dashboard fail to export, send a clear error. We were showing warnings for each, but this makes it more clear that no charts succeed
<img width="691" height="229" alt="Screenshot 2025-11-12 at 17 53 23" src="https://github.com/user-attachments/assets/da1207a1-6c4e-4483-9137-f269e24a337c" />
