### PR TITLE
fix: respect series order from the echartsConfig

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -955,26 +955,10 @@ const getEchartsSeriesFromPivotedData = (
 
     const allSeries = cartesianChart.eChartsConfig.series || [];
 
+    // Don't sort here - series order is already set correctly by useCartesianChartConfig
+    // which respects the user's columnOrder preference
     const resultSeries = allSeries
         .filter((s) => !s.hidden)
-        .sort((a, b) => {
-            const aColumnName = findMatchingColumnName(a);
-            const bColumnName = findMatchingColumnName(b);
-
-            if (aColumnName && bColumnName && pivotValuesColumnsMap) {
-                const aColumn = pivotValuesColumnsMap[aColumnName];
-                const bColumn = pivotValuesColumnsMap[bColumnName];
-
-                if (
-                    aColumn?.columnIndex !== undefined &&
-                    bColumn?.columnIndex !== undefined
-                ) {
-                    return aColumn.columnIndex - bColumn.columnIndex;
-                }
-            }
-
-            return 0;
-        })
         .map<EChartsSeries>((series) => {
             const { flipAxes } = cartesianChart.layout;
             const xFieldHash = hashFieldReference(series.encode.xRef);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18078

### Description:
Removes unnecessary series sorting in `useEchartsCartesianConfig.ts`. The series order is already correctly set by `useCartesianChartConfig` which respects the user's series order preference, making this additional sorting incorrect.

https://github.com/user-attachments/assets/fa1784bb-5c8b-4239-9df9-af22021ea35d

This was introduced here: https://github.com/lightdash/lightdash/pull/16656#issuecomment-3245138781