### PR TITLE
fix: show drag icon on hover of dashboard tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -105,3 +105,25 @@ export const ChartContainer = styled.div`
     overflow: hidden;
     display: flex;
 `;
+
+export const TileCardWrapper = styled.div`
+    height: 100%;
+
+    &:hover .drag-handle-icon {
+        opacity: 1;
+    }
+`;
+
+export const DragHandle = styled.div`
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    cursor: grab;
+    z-index: 10;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+
+    &:active {
+        cursor: grabbing;
+    }
+`;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -21,6 +21,7 @@ import {
     IconArrowAutofitContent,
     IconDots,
     IconEdit,
+    IconGripVertical,
     IconTrash,
 } from '@tabler/icons-react';
 import { useState, type ReactNode } from 'react';
@@ -33,7 +34,9 @@ import TileUpdateModal from '../TileForms/TileUpdateModal';
 
 import {
     ChartContainer,
+    DragHandle,
     HeaderContainer,
+    TileCardWrapper,
     TileTitleLink,
     TitleWrapper,
 } from './TileBase.styles';
@@ -103,288 +106,316 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
         tile.type === DashboardTileTypes.MARKDOWN && !title;
 
     return (
-        <Card
-            component={Flex}
-            className="tile-base"
-            ref={containerRef}
-            h="100%"
-            direction="column"
-            p="md"
-            bg="white"
-            radius="sm"
-            shadow={isEditMode ? 'xs' : undefined}
-            sx={(theme) => {
-                let border = `1px solid ${theme.colors.gray[1]}`;
-                if (isEditMode) {
-                    border = `1px dashed ${theme.colors.blue[5]}`;
-                }
-                return {
-                    overflow: 'unset',
-                    border: border,
-                };
-            }}
-        >
-            <LoadingOverlay
-                // ! Very important to have this class name on the tile loading overlay, otherwise the unfurl service will not be able to find it
-                className="loading_chart_overlay"
-                visible={isLoading ?? false}
-                zIndex={getDefaultZIndex('modal') - 10}
-            />
-            <HeaderContainer
-                $isEditMode={isEditMode}
-                $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
-                style={{
-                    alignItems: 'flex-start',
-                    backgroundColor: 'white',
-                    zIndex: isLoading ? getDefaultZIndex('modal') - 10 : 3,
-                    borderRadius: '5px',
+        <TileCardWrapper>
+            <Card
+                component={Flex}
+                className="tile-base"
+                ref={containerRef}
+                h="100%"
+                direction="column"
+                p="md"
+                bg="white"
+                radius="sm"
+                shadow={isEditMode ? 'xs' : undefined}
+                sx={(theme) => {
+                    let border = `1px solid ${theme.colors.gray[1]}`;
+                    if (isEditMode) {
+                        border = `1px dashed ${theme.colors.blue[5]}`;
+                    }
+                    return {
+                        overflow: 'unset',
+                        border: border,
+                    };
                 }}
             >
-                {minimal ? (
-                    !hideTitle ? (
-                        <Text fw={600} size="md">
-                            {title}
-                        </Text>
-                    ) : (
-                        <Box />
-                    )
-                ) : (
-                    <Group
-                        spacing="xs"
-                        noWrap
-                        align="start"
-                        sx={{ overflow: 'hidden' }}
-                    >
-                        {titleLeftIcon}
-
-                        <TitleWrapper $hovered={titleHovered}>
-                            <Tooltip
-                                disabled={!description}
-                                label={
-                                    <Text style={{ whiteSpace: 'pre-line' }}>
-                                        {description}
-                                    </Text>
-                                }
-                                multiline
-                                position="top-start"
-                                withinPortal
-                                maw={400}
-                            >
-                                {isEditMode ||
-                                tile.type === DashboardTileTypes.MARKDOWN ? (
-                                    <Text fw={600} fz="md" hidden={hideTitle}>
-                                        {title}
-                                    </Text>
-                                ) : (
-                                    <Text
-                                        component={TileTitleLink}
-                                        href={titleHref}
-                                        onMouseEnter={() =>
-                                            setTitleHovered(true)
-                                        }
-                                        onMouseLeave={() =>
-                                            setTitleHovered(false)
-                                        }
-                                        $hovered={titleHovered}
-                                        target="_blank"
-                                        className="non-draggable"
-                                        hidden={hideTitle}
-                                    >
-                                        {title}
-                                    </Text>
-                                )}
-                            </Tooltip>
-                        </TitleWrapper>
-                    </Group>
+                <LoadingOverlay
+                    // ! Very important to have this class name on the tile loading overlay, otherwise the unfurl service will not be able to find it
+                    className="loading_chart_overlay"
+                    visible={isLoading ?? false}
+                    zIndex={getDefaultZIndex('modal') - 10}
+                />
+                {isEditMode && !minimal && (
+                    <DragHandle className="drag-handle-icon">
+                        <ActionIcon size="sm" color="gray" variant="subtle">
+                            <MantineIcon icon={IconGripVertical} />
+                        </ActionIcon>
+                    </DragHandle>
                 )}
-                <Group
-                    spacing="xs"
-                    className="non-draggable"
-                    sx={{ marginLeft: 'auto' }}
-                    noWrap
+                <HeaderContainer
+                    $isEditMode={isEditMode}
+                    $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
+                    style={{
+                        alignItems: 'flex-start',
+                        backgroundColor: 'white',
+                        zIndex: isLoading ? getDefaultZIndex('modal') - 10 : 3,
+                        borderRadius: '5px',
+                    }}
                 >
-                    {visibleHeaderElement && (
-                        <Group spacing="xs" className="non-draggable">
-                            {visibleHeaderElement}
+                    {minimal ? (
+                        !hideTitle ? (
+                            <Text fw={600} size="md">
+                                {title}
+                            </Text>
+                        ) : (
+                            <Box />
+                        )
+                    ) : (
+                        <Group
+                            spacing="xs"
+                            noWrap
+                            align="start"
+                            sx={{ overflow: 'hidden' }}
+                        >
+                            {titleLeftIcon}
+
+                            <TitleWrapper $hovered={titleHovered}>
+                                <Tooltip
+                                    disabled={!description}
+                                    label={
+                                        <Text
+                                            style={{ whiteSpace: 'pre-line' }}
+                                        >
+                                            {description}
+                                        </Text>
+                                    }
+                                    multiline
+                                    position="top-start"
+                                    withinPortal
+                                    maw={400}
+                                >
+                                    {isEditMode ||
+                                    tile.type ===
+                                        DashboardTileTypes.MARKDOWN ? (
+                                        <Text
+                                            fw={600}
+                                            fz="md"
+                                            hidden={hideTitle}
+                                        >
+                                            {title}
+                                        </Text>
+                                    ) : (
+                                        <Text
+                                            component={TileTitleLink}
+                                            href={titleHref}
+                                            onMouseEnter={() =>
+                                                setTitleHovered(true)
+                                            }
+                                            onMouseLeave={() =>
+                                                setTitleHovered(false)
+                                            }
+                                            $hovered={titleHovered}
+                                            target="_blank"
+                                            className="non-draggable"
+                                            hidden={hideTitle}
+                                        >
+                                            {title}
+                                        </Text>
+                                    )}
+                                </Tooltip>
+                            </TitleWrapper>
                         </Group>
                     )}
-                    {(containerHovered && !titleHovered && !chartHovered) ||
-                    isMenuOpen ||
-                    lockHeaderVisibility ? (
-                        <>
-                            {extraHeaderElement}
-
-                            {(isEditMode ||
-                                (!isEditMode && extraMenuItems)) && (
-                                <Menu
-                                    withArrow
-                                    withinPortal
-                                    shadow="md"
-                                    position="bottom-end"
-                                    offset={4}
-                                    arrowOffset={10}
-                                    opened={isMenuOpen}
-                                    onOpen={() => toggleMenu(true)}
-                                    onClose={() => toggleMenu(false)}
-                                >
-                                    <Menu.Dropdown>
-                                        {extraMenuItems}
-                                        {isEditMode && extraMenuItems && (
-                                            <Menu.Divider />
-                                        )}
-                                        {isEditMode && (
-                                            <>
-                                                <Box>
-                                                    <Menu.Item
-                                                        icon={
-                                                            <MantineIcon
-                                                                icon={IconEdit}
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            setIsEditingTileContent(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Edit tile content
-                                                    </Menu.Item>
-                                                </Box>
-                                                {tabs && tabs.length > 1 && (
-                                                    <Menu.Item
-                                                        icon={
-                                                            <MantineIcon
-                                                                icon={
-                                                                    IconArrowAutofitContent
-                                                                }
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            setIsMovingTabs(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Move to another tab
-                                                    </Menu.Item>
-                                                )}
-                                                <Menu.Divider />
-                                                {belongsToDashboard ? (
-                                                    <Menu.Item
-                                                        color="red"
-                                                        onClick={() =>
-                                                            setIsDeletingChartThatBelongsToDashboard(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Delete chart
-                                                    </Menu.Item>
-                                                ) : (
-                                                    <Menu.Item
-                                                        color="red"
-                                                        icon={
-                                                            <MantineIcon
-                                                                icon={IconTrash}
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            onDelete(tile)
-                                                        }
-                                                    >
-                                                        Remove tile
-                                                    </Menu.Item>
-                                                )}
-                                            </>
-                                        )}
-                                    </Menu.Dropdown>
-
-                                    <Menu.Target>
-                                        <ActionIcon
-                                            size="sm"
-                                            style={{
-                                                position: 'relative',
-                                                zIndex: 1,
-                                            }}
-                                        >
-                                            <MantineIcon
-                                                data-testid="tile-icon-more"
-                                                icon={IconDots}
-                                            />
-                                        </ActionIcon>
-                                    </Menu.Target>
-                                </Menu>
-                            )}
-                        </>
-                    ) : null}
-                </Group>
-            </HeaderContainer>
-            <ChartContainer
-                className="non-draggable sentry-block ph-no-capture"
-                onMouseEnter={
-                    hideTitle ? chartHoveredProps.handleMouseEnter : undefined
-                }
-                onMouseLeave={
-                    hideTitle ? chartHoveredProps.handleMouseLeave : undefined
-                }
-            >
-                {children}
-            </ChartContainer>
-            {isEditingTileContent &&
-                (tile.type === DashboardTileTypes.SAVED_CHART ||
-                tile.type === DashboardTileTypes.SQL_CHART ? (
-                    <ChartUpdateModal
-                        opened={isEditingTileContent}
-                        tile={tile}
-                        onClose={() => setIsEditingTileContent(false)}
-                        onConfirm={(newTitle, newUuid, shouldHideTitle) => {
-                            onEdit({
-                                ...tile,
-                                properties: {
-                                    ...tile.properties,
-                                    title: newTitle,
-                                    savedChartUuid: newUuid,
-                                    hideTitle: shouldHideTitle,
-                                },
-                            });
-                            setIsEditingTileContent(false);
-                        }}
-                        hideTitle={!!hideTitle}
-                    />
-                ) : (
-                    <TileUpdateModal
+                    <Group
+                        spacing="xs"
                         className="non-draggable"
-                        opened={isEditingTileContent}
-                        tile={tile}
-                        onClose={() => setIsEditingTileContent(false)}
-                        onConfirm={(newTile) => {
-                            onEdit(newTile);
-                            setIsEditingTileContent(false);
-                        }}
-                    />
-                ))}
-            <DeleteChartTileThatBelongsToDashboardModal
-                className={'non-draggable'}
-                name={chartName ?? ''}
-                opened={isDeletingChartThatBelongsToDashboard}
-                onClose={() => setIsDeletingChartThatBelongsToDashboard(false)}
-                onConfirm={() => {
-                    onDelete(tile);
-                    setIsDeletingChartThatBelongsToDashboard(false);
-                }}
-            />
-            <MoveTileToTabModal
-                className="non-draggable"
-                opened={isMovingTabs}
-                onConfirm={(newTile) => {
-                    onEdit(newTile as T);
-                    setIsMovingTabs(false);
-                }}
-                tabs={tabs}
-                tile={tile}
-                onClose={() => setIsMovingTabs(false)}
-            />
-        </Card>
+                        sx={{ marginLeft: 'auto' }}
+                        noWrap
+                    >
+                        {visibleHeaderElement && (
+                            <Group spacing="xs" className="non-draggable">
+                                {visibleHeaderElement}
+                            </Group>
+                        )}
+                        {(containerHovered && !titleHovered && !chartHovered) ||
+                        isMenuOpen ||
+                        lockHeaderVisibility ? (
+                            <>
+                                {extraHeaderElement}
+
+                                {(isEditMode ||
+                                    (!isEditMode && extraMenuItems)) && (
+                                    <Menu
+                                        withArrow
+                                        withinPortal
+                                        shadow="md"
+                                        position="bottom-end"
+                                        offset={4}
+                                        arrowOffset={10}
+                                        opened={isMenuOpen}
+                                        onOpen={() => toggleMenu(true)}
+                                        onClose={() => toggleMenu(false)}
+                                    >
+                                        <Menu.Dropdown>
+                                            {extraMenuItems}
+                                            {isEditMode && extraMenuItems && (
+                                                <Menu.Divider />
+                                            )}
+                                            {isEditMode && (
+                                                <>
+                                                    <Box>
+                                                        <Menu.Item
+                                                            icon={
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconEdit
+                                                                    }
+                                                                />
+                                                            }
+                                                            onClick={() =>
+                                                                setIsEditingTileContent(
+                                                                    true,
+                                                                )
+                                                            }
+                                                        >
+                                                            Edit tile content
+                                                        </Menu.Item>
+                                                    </Box>
+                                                    {tabs &&
+                                                        tabs.length > 1 && (
+                                                            <Menu.Item
+                                                                icon={
+                                                                    <MantineIcon
+                                                                        icon={
+                                                                            IconArrowAutofitContent
+                                                                        }
+                                                                    />
+                                                                }
+                                                                onClick={() =>
+                                                                    setIsMovingTabs(
+                                                                        true,
+                                                                    )
+                                                                }
+                                                            >
+                                                                Move to another
+                                                                tab
+                                                            </Menu.Item>
+                                                        )}
+                                                    <Menu.Divider />
+                                                    {belongsToDashboard ? (
+                                                        <Menu.Item
+                                                            color="red"
+                                                            onClick={() =>
+                                                                setIsDeletingChartThatBelongsToDashboard(
+                                                                    true,
+                                                                )
+                                                            }
+                                                        >
+                                                            Delete chart
+                                                        </Menu.Item>
+                                                    ) : (
+                                                        <Menu.Item
+                                                            color="red"
+                                                            icon={
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconTrash
+                                                                    }
+                                                                />
+                                                            }
+                                                            onClick={() =>
+                                                                onDelete(tile)
+                                                            }
+                                                        >
+                                                            Remove tile
+                                                        </Menu.Item>
+                                                    )}
+                                                </>
+                                            )}
+                                        </Menu.Dropdown>
+
+                                        <Menu.Target>
+                                            <ActionIcon
+                                                size="sm"
+                                                style={{
+                                                    position: 'relative',
+                                                    zIndex: 1,
+                                                }}
+                                            >
+                                                <MantineIcon
+                                                    data-testid="tile-icon-more"
+                                                    icon={IconDots}
+                                                />
+                                            </ActionIcon>
+                                        </Menu.Target>
+                                    </Menu>
+                                )}
+                            </>
+                        ) : null}
+                    </Group>
+                </HeaderContainer>
+                <ChartContainer
+                    className="non-draggable sentry-block ph-no-capture"
+                    onMouseEnter={
+                        hideTitle
+                            ? chartHoveredProps.handleMouseEnter
+                            : undefined
+                    }
+                    onMouseLeave={
+                        hideTitle
+                            ? chartHoveredProps.handleMouseLeave
+                            : undefined
+                    }
+                >
+                    {children}
+                </ChartContainer>
+                {isEditingTileContent &&
+                    (tile.type === DashboardTileTypes.SAVED_CHART ||
+                    tile.type === DashboardTileTypes.SQL_CHART ? (
+                        <ChartUpdateModal
+                            opened={isEditingTileContent}
+                            tile={tile}
+                            onClose={() => setIsEditingTileContent(false)}
+                            onConfirm={(newTitle, newUuid, shouldHideTitle) => {
+                                onEdit({
+                                    ...tile,
+                                    properties: {
+                                        ...tile.properties,
+                                        title: newTitle,
+                                        savedChartUuid: newUuid,
+                                        hideTitle: shouldHideTitle,
+                                    },
+                                });
+                                setIsEditingTileContent(false);
+                            }}
+                            hideTitle={!!hideTitle}
+                        />
+                    ) : (
+                        <TileUpdateModal
+                            className="non-draggable"
+                            opened={isEditingTileContent}
+                            tile={tile}
+                            onClose={() => setIsEditingTileContent(false)}
+                            onConfirm={(newTile) => {
+                                onEdit(newTile);
+                                setIsEditingTileContent(false);
+                            }}
+                        />
+                    ))}
+                <DeleteChartTileThatBelongsToDashboardModal
+                    className={'non-draggable'}
+                    name={chartName ?? ''}
+                    opened={isDeletingChartThatBelongsToDashboard}
+                    onClose={() =>
+                        setIsDeletingChartThatBelongsToDashboard(false)
+                    }
+                    onConfirm={() => {
+                        onDelete(tile);
+                        setIsDeletingChartThatBelongsToDashboard(false);
+                    }}
+                />
+                <MoveTileToTabModal
+                    className="non-draggable"
+                    opened={isMovingTabs}
+                    onConfirm={(newTile) => {
+                        onEdit(newTile as T);
+                        setIsMovingTabs(false);
+                    }}
+                    tabs={tabs}
+                    tile={tile}
+                    onClose={() => setIsMovingTabs(false)}
+                />
+            </Card>
+        </TileCardWrapper>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXX

### Description:
Added drag handle functionality to dashboard tiles for improved tile management. The drag handle appears in the top-left corner of tiles when in edit mode and becomes visible on hover.

ℹ️ it's useful specially when tiles have no title. It's hard to know where to grab

[CleanShot 2025-11-12 at 18.38.51.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/6da8a1f6-c8c2-4834-8a6b-b0245c7691be.mp4" />](https://app.graphite.com/user-attachments/video/6da8a1f6-c8c2-4834-8a6b-b0245c7691be.mp4)

