### PR TITLE
feat: add multiselect space selector

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -2538,6 +2538,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                         args.searchQuery.label,
                         undefined,
                         'OR',
+                        // TODO: add space access filter
                     );
 
                 const chartSearchResults =
@@ -2545,6 +2546,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                         projectUuid,
                         args.searchQuery.label,
                         'OR',
+                        // TODO: add space access filter
                     );
 
                 const allContent = [
@@ -2568,20 +2570,13 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     };
                 }
 
-                const contentWithRoots = await Promise.all(
-                    filteredResults.map(async (item) => {
-                        const rootSpaceUuid =
-                            await this.spaceModel.getSpaceRoot(item.spaceUuid);
-                        return { item, rootSpaceUuid };
-                    }),
-                );
-
                 return {
-                    content: contentWithRoots
-                        .filter(({ rootSpaceUuid }) =>
-                            agentSettings.spaceAccess.includes(rootSpaceUuid),
-                        )
-                        .map(({ item }) => item),
+                    content:
+                        agentSettings.spaceAccess.length === 0
+                            ? filteredResults
+                            : filteredResults.filter(({ spaceUuid }) =>
+                                  agentSettings.spaceAccess.includes(spaceUuid),
+                              ),
                 };
             });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/SpaceAccessSelect.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SpaceAccessSelect.module.css
@@ -1,0 +1,34 @@
+.selectTrigger {
+    cursor: pointer;
+}
+
+.selectTriggerDisabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.chevron {
+    transition: transform 0.2s ease;
+}
+
+.chevronExpanded {
+    transform: rotate(180deg);
+}
+
+.chevronCollapsed {
+    transform: rotate(0deg);
+}
+
+.expandableGroup {
+    cursor: pointer;
+}
+
+.nonExpandableGroup {
+    cursor: default;
+}
+
+.treeContainer {
+    max-height: 300px;
+    overflow: auto;
+}
+

--- a/packages/frontend/src/ee/features/aiCopilot/components/SpaceAccessSelect.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SpaceAccessSelect.tsx
@@ -1,11 +1,33 @@
-import { MultiSelect, Stack, Text } from '@mantine-8/core';
-import { useMemo, type FC } from 'react';
+import {
+    Box,
+    Button,
+    Checkbox,
+    Collapse,
+    Group,
+    Paper,
+    rem,
+    Stack,
+    Text,
+    Tree,
+    useTree,
+    type RenderTreeNodePayload,
+} from '@mantine-8/core';
+import { IconChevronDown, IconX } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { type NestableItem } from '../../../../components/common/Tree/types';
+import { convertNestableListToTree } from '../../../../components/common/Tree/utils';
 import { useSpaceSummaries } from '../../../../hooks/useSpaces';
+import classes from './SpaceAccessSelect.module.css';
 
 type SpaceAccessSelectProps = {
     projectUuid: string;
     value: string[];
     onChange: (value: string[]) => void;
+};
+
+type SpaceNestableItem = NestableItem & {
+    parentUuid: string | null;
 };
 
 export const SpaceAccessSelect: FC<SpaceAccessSelectProps> = ({
@@ -14,36 +36,291 @@ export const SpaceAccessSelect: FC<SpaceAccessSelectProps> = ({
     onChange,
 }) => {
     const { data: allSpaces, isLoading } = useSpaceSummaries(projectUuid, true);
+    const [isOpen, setIsOpen] = useState(false);
 
-    const topLevelSpaces = useMemo(() => {
+    // Convert spaces to nestable items with proper paths
+    const spaceItems = useMemo<SpaceNestableItem[]>(() => {
         if (!allSpaces) return [];
-        return allSpaces.filter((space) => !space.parentSpaceUuid);
+
+        // Build a map of space UUID to space for quick lookup
+        const spaceMap = new Map(allSpaces.map((space) => [space.uuid, space]));
+
+        // Build path for each space by traversing up the parent chain
+        const buildPath = (spaceUuid: string): string => {
+            const space = spaceMap.get(spaceUuid);
+            if (!space) return spaceUuid;
+
+            if (!space.parentSpaceUuid) {
+                return space.uuid;
+            }
+
+            const parentPath = buildPath(space.parentSpaceUuid);
+            return `${parentPath}.${space.uuid}`;
+        };
+
+        return allSpaces.map((space) => ({
+            uuid: space.uuid,
+            name: space.name,
+            path: buildPath(space.uuid),
+            parentUuid: space.parentSpaceUuid ?? null,
+        }));
     }, [allSpaces]);
 
-    const spaceOptions = topLevelSpaces.map((space) => ({
-        value: space.uuid,
-        label: space.name,
-    }));
+    const treeData = useMemo(
+        () => convertNestableListToTree(spaceItems),
+        [spaceItems],
+    );
+
+    // Convert UUIDs to paths for tree state
+    const checkedPaths = useMemo(() => {
+        return value
+            .map((uuid) => {
+                const item = spaceItems.find((s) => s.uuid === uuid);
+                return item?.path;
+            })
+            .filter((path): path is string => path !== undefined);
+    }, [value, spaceItems]);
+
+    // Convert paths to UUIDs helper
+    const pathsToUuids = useCallback(
+        (paths: string[]): string[] => {
+            return paths
+                .map((path) => {
+                    const item = spaceItems.find((s) => s.path === path);
+                    return item?.uuid;
+                })
+                .filter((uuid): uuid is string => uuid !== undefined);
+        },
+        [spaceItems],
+    );
+
+    const tree = useTree({ multiple: true });
+
+    // Get all descendant paths for a given node path
+    const getDescendantPaths = useCallback(
+        (nodePath: string): string[] => {
+            return spaceItems
+                .filter((item) => item.path.startsWith(`${nodePath}.`))
+                .map((item) => item.path);
+        },
+        [spaceItems],
+    );
+
+    // Get all ancestor paths for a given node path
+    const getAncestorPaths = useCallback((nodePath: string): string[] => {
+        const parts = nodePath.split('.');
+        const ancestors: string[] = [];
+        for (let i = 1; i < parts.length; i++) {
+            ancestors.push(parts.slice(0, i).join('.'));
+        }
+        return ancestors;
+    }, []);
+
+    // Handle node click and update parent state
+    const handleNodeClick = useCallback(
+        (nodeValue: string, checked: boolean) => {
+            const descendants = getDescendantPaths(nodeValue);
+            const pathsToToggle = [nodeValue, ...descendants];
+
+            let newCheckedPaths: string[];
+            if (checked) {
+                // Unchecking: remove node, descendants, and ancestors
+                const ancestors = getAncestorPaths(nodeValue);
+                const pathsToRemove = [...pathsToToggle, ...ancestors];
+                newCheckedPaths = checkedPaths.filter(
+                    (p) => !pathsToRemove.includes(p),
+                );
+            } else {
+                // Checking: add node and descendants
+                newCheckedPaths = [
+                    ...new Set([...checkedPaths, ...pathsToToggle]),
+                ];
+            }
+
+            const checkedUuids = pathsToUuids(newCheckedPaths);
+            onChange(checkedUuids);
+        },
+        [
+            checkedPaths,
+            onChange,
+            pathsToUuids,
+            getDescendantPaths,
+            getAncestorPaths,
+        ],
+    );
+
+    const renderTreeNode = useCallback(
+        ({
+            node,
+            expanded,
+            hasChildren,
+            elementProps,
+            tree: treeInstance,
+        }: RenderTreeNodePayload) => {
+            let checked = checkedPaths.includes(node.value);
+            let indeterminate = false;
+
+            // For parent nodes, check if descendants affect the checked/indeterminate state
+            if (hasChildren) {
+                const descendants = getDescendantPaths(node.value);
+                if (descendants.length > 0) {
+                    const checkedDescendants = descendants.filter((d) =>
+                        checkedPaths.includes(d),
+                    );
+
+                    // If all descendants are checked, parent is checked
+                    if (checkedDescendants.length === descendants.length) {
+                        checked = true;
+                        indeterminate = false;
+                    }
+                    // If some descendants are checked, parent is indeterminate
+                    else if (checkedDescendants.length > 0) {
+                        checked = false;
+                        indeterminate = true;
+                    }
+                }
+            }
+
+            return (
+                <Group gap="xs" {...elementProps}>
+                    <Checkbox.Indicator
+                        checked={checked}
+                        indeterminate={indeterminate}
+                        onClick={() => handleNodeClick(node.value, checked)}
+                    />
+
+                    <Group
+                        gap={5}
+                        onClick={() =>
+                            hasChildren &&
+                            treeInstance.toggleExpanded(node.value)
+                        }
+                        className={
+                            hasChildren
+                                ? classes.expandableGroup
+                                : classes.nonExpandableGroup
+                        }
+                    >
+                        <span>{node.label}</span>
+
+                        {hasChildren && (
+                            <MantineIcon
+                                icon={IconChevronDown}
+                                className={`${classes.chevron} ${
+                                    expanded
+                                        ? classes.chevronExpanded
+                                        : classes.chevronCollapsed
+                                }`}
+                            />
+                        )}
+                    </Group>
+                </Group>
+            );
+        },
+        [checkedPaths, handleNodeClick, getDescendantPaths],
+    );
+
+    const selectedCount = value.length;
+    const totalSpaces = spaceItems.length;
 
     return (
-        <Stack gap={4}>
-            <MultiSelect
-                variant="subtle"
-                label="Space access"
-                description="Agent will be able to find content only in the selected spaces and their nested spaces. Leave empty to allow access to all spaces."
-                placeholder={isLoading ? 'Loading spaces...' : 'Select spaces'}
-                data={spaceOptions}
-                value={value}
-                onChange={onChange}
-                searchable
-                clearable
-                disabled={isLoading}
-            />
-            {value.length > 0 && (
-                <Text fz="xs" c="dimmed">
-                    {value.length} space{value.length !== 1 ? 's' : ''} selected
+        <Stack gap="xs">
+            <Box>
+                <Group gap="xs" mb={4}>
+                    <Text fz="sm" fw={500}>
+                        Space access
+                    </Text>
+                </Group>
+                <Text fz="xs" c="dimmed" mb="xs">
+                    Select specific spaces to restrict access. Empty selection =
+                    access to all spaces.
                 </Text>
-            )}
+
+                <Paper
+                    withBorder
+                    p="xs"
+                    onClick={() => !isLoading && setIsOpen(!isOpen)}
+                    className={
+                        isLoading
+                            ? classes.selectTriggerDisabled
+                            : classes.selectTrigger
+                    }
+                >
+                    <Group justify="space-between">
+                        <Text
+                            fz="sm"
+                            c={selectedCount === 0 ? 'dimmed' : undefined}
+                        >
+                            {isLoading
+                                ? 'Loading spaces...'
+                                : selectedCount === 0
+                                ? 'All spaces (click to restrict)'
+                                : `${selectedCount} of ${totalSpaces} space${
+                                      totalSpaces !== 1 ? 's' : ''
+                                  } selected`}
+                        </Text>
+                        <MantineIcon
+                            icon={IconChevronDown}
+                            size={16}
+                            className={`${classes.chevron} ${
+                                isOpen
+                                    ? classes.chevronExpanded
+                                    : classes.chevronCollapsed
+                            }`}
+                        />
+                    </Group>
+                </Paper>
+
+                <Collapse in={isOpen && !isLoading}>
+                    <Paper withBorder mt="xs" p="sm">
+                        <Stack gap="sm">
+                            {selectedCount > 0 && (
+                                <Group justify="space-between">
+                                    <Text fz="xs" c="dimmed">
+                                        {selectedCount} space
+                                        {selectedCount !== 1 ? 's' : ''}{' '}
+                                        selected
+                                    </Text>
+                                    <Button
+                                        variant="subtle"
+                                        size="xs"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconX}
+                                                size={14}
+                                            />
+                                        }
+                                        onClick={() => onChange([])}
+                                    >
+                                        Clear selection
+                                    </Button>
+                                </Group>
+                            )}
+
+                            <Box className={classes.treeContainer}>
+                                {treeData.length === 0 ? (
+                                    <Text
+                                        fz="sm"
+                                        c="dimmed"
+                                        ta="center"
+                                        py="md"
+                                    >
+                                        No spaces found
+                                    </Text>
+                                ) : (
+                                    <Tree
+                                        data={treeData}
+                                        tree={tree}
+                                        levelOffset={rem(23)}
+                                        expandOnClick={false}
+                                        renderNode={renderTreeNode}
+                                    />
+                                )}
+                            </Box>
+                        </Stack>
+                    </Paper>
+                </Collapse>
+            </Box>
         </Stack>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Improved the AI agent space access selection UI and optimized space filtering logic. The changes include:

1. Replaced the simple MultiSelect with a hierarchical tree view for space selection
2. Added support for parent/child relationships in space selection
3. Implemented indeterminate checkbox states for better UX
4. Optimized backend filtering to directly check space UUIDs instead of fetching root spaces
5. Added clear visual feedback about selected spaces and access restrictions

The new UI makes it easier to understand and manage which spaces an AI agent can access, with a more intuitive hierarchical selection that shows the parent-child relationships between spaces.

[CleanShot 2025-11-12 at 20.08.10.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a9e1c955-47c1-4af9-b14b-b39cd19d3305.mp4" />](https://app.graphite.com/user-attachments/video/a9e1c955-47c1-4af9-b14b-b39cd19d3305.mp4)

