### PR TITLE
feat: add multiple selection support to Tree component

### DIFF
--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -104,6 +104,7 @@ const SpaceSelector = ({
                     onChange={onSelectSpace}
                     topLevelLabel="Spaces"
                     isExpanded={fuzzyFilteredSpaces !== undefined}
+                    type="single"
                 />
             </Paper>
 

--- a/packages/frontend/src/stories/Tree.stories.tsx
+++ b/packages/frontend/src/stories/Tree.stories.tsx
@@ -25,89 +25,103 @@ const meta: Meta<typeof Tree> = {
 export default meta;
 type Story = StoryObj<typeof Tree>;
 
+const data = [
+    {
+        uuid: 'fake0',
+        name: 'The most main space',
+        path: 'the_most_main_space',
+    },
+    {
+        uuid: 'fake1',
+        name: 'Main space',
+        path: 'main_space',
+    },
+    {
+        uuid: 'fake2',
+        name: 'Sub space',
+        path: 'main_space.sub',
+    },
+    {
+        uuid: 'fake3',
+        name: 'Sub space 2',
+        path: 'main_space.sub2',
+    },
+    {
+        uuid: 'fake4',
+        name: 'Sub space 3',
+        path: 'main_space.sub3',
+    },
+    {
+        uuid: 'fake5',
+        name: 'Sub of sub space',
+        path: 'main_space.sub.sub_of_sub',
+    },
+    {
+        uuid: 'fake6',
+        name: 'Sub of sub space 2',
+        path: 'main_space.sub.sub_of_sub2',
+    },
+    {
+        uuid: 'fake7',
+        name: 'Sub of sub space 3',
+        path: 'main_space.sub.sub_of_sub3',
+    },
+    {
+        uuid: 'fake10',
+        name: 'Sub of sub of sub space',
+        path: 'main_space.sub.sub_of_sub.sub_of_sub_of_sub',
+    },
+    {
+        uuid: 'fake11',
+        name: 'Sub of sub of sub space 2',
+        path: 'main_space.sub.sub_of_sub.sub_of_sub_of_sub2',
+    },
+    {
+        uuid: 'fake12',
+        name: 'Sub of sub of sub sub space',
+        path: 'main_space.sub.sub_of_sub.sub_of_sub_of_sub.sub_of_sub_of_sub_of_sub',
+    },
+    {
+        uuid: 'fake13',
+        name: 'Sub of sub of sub sub space 2',
+        path: 'main_space.sub.sub_of_sub.sub_of_sub_of_sub.sub_of_sub_of_sub_of_sub2',
+    },
+    {
+        uuid: 'fake14',
+        name: 'Kinda top level space',
+        path: 'kinda_top_level_space',
+    },
+    {
+        uuid: 'fake15',
+        name: 'Kinda top level space 2',
+        path: 'kinda_top_level_space2',
+    },
+    {
+        uuid: 'fake16',
+        name: 'Kinda top level space 3',
+        path: 'kinda_top_level_space3',
+    },
+];
+
 export const Primary: Story = {
     args: {
         value: 'fake11',
         topLevelLabel: 'All spaces',
-        data: [
-            {
-                uuid: 'fake0',
-                name: 'The most main space',
-                path: 'the_most_main_space',
-            },
-            {
-                uuid: 'fake1',
-                name: 'Main space',
-                path: 'main_space',
-            },
-            {
-                uuid: 'fake2',
-                name: 'Sub space',
-                path: 'main_space.sub',
-            },
-            {
-                uuid: 'fake3',
-                name: 'Sub space 2',
-                path: 'main_space.sub2',
-            },
-            {
-                uuid: 'fake4',
-                name: 'Sub space 3',
-                path: 'main_space.sub3',
-            },
-            {
-                uuid: 'fake5',
-                name: 'Sub of sub space',
-                path: 'main_space.sub.sub_of_sub',
-            },
-            {
-                uuid: 'fake6',
-                name: 'Sub of sub space 2',
-                path: 'main_space.sub.sub_of_sub2',
-            },
-            {
-                uuid: 'fake7',
-                name: 'Sub of sub space 3',
-                path: 'main_space.sub.sub_of_sub3',
-            },
-            {
-                uuid: 'fake10',
-                name: 'Sub of sub of sub space',
-                path: 'main_space.sub.sub_of_sub.sub_of_sub_of_sub',
-            },
-            {
-                uuid: 'fake11',
-                name: 'Sub of sub of sub space 2',
-                path: 'main_space.sub.sub_of_sub.sub_of_sub_of_sub2',
-            },
-            {
-                uuid: 'fake12',
-                name: 'Sub of sub of sub sub space',
-                path: 'main_space.sub.sub_of_sub.sub_of_sub_of_sub.sub_of_sub_of_sub_of_sub',
-            },
-            {
-                uuid: 'fake13',
-                name: 'Sub of sub of sub sub space 2',
-                path: 'main_space.sub.sub_of_sub.sub_of_sub_of_sub.sub_of_sub_of_sub_of_sub2',
-            },
-            {
-                uuid: 'fake14',
-                name: 'Kinda top level space',
-                path: 'kinda_top_level_space',
-            },
-            {
-                uuid: 'fake15',
-                name: 'Kinda top level space 2',
-                path: 'kinda_top_level_space2',
-            },
-            {
-                uuid: 'fake16',
-                name: 'Kinda top level space 3',
-                path: 'kinda_top_level_space3',
-            },
-        ],
+        data,
         onChange: (selectedUuid) => {
             console.info('Selected item UUID:', selectedUuid);
+        },
+    },
+};
+
+export const Multiple: Story = {
+    args: {
+        type: 'multiple',
+        topLevelLabel: 'All spaces',
+        values: ['fake16'],
+        data,
+        onChangeMultiple: (selectedUuids) => {
+            console.info('Selected items UUIDs:', selectedUuids);
         },
     },
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added multi-select functionality to the Tree component, allowing users to select multiple items in a tree structure. This enhancement includes:

- Added a new `type` prop to specify whether the tree supports single or multiple selection
- Implemented recursive selection/deselection of child nodes when a parent is selected in multi-select mode
- Updated the SpaceSelector component to explicitly use single selection mode
- Added a new story to demonstrate the multi-select functionality

[CleanShot 2025-11-13 at 12.22.06.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4dde0a9f-34c1-4def-b7be-9da78261bd4d.mp4" />](https://app.graphite.com/user-attachments/video/4dde0a9f-34c1-4def-b7be-9da78261bd4d.mp4)

