### PR TITLE
fix: correct eye icon visibility logic in chart and table components

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -152,7 +152,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                             }}
                         >
                             <MantineIcon
-                                icon={series.hidden ? IconEye : IconEyeOff}
+                                icon={series.hidden ? IconEyeOff : IconEye}
                             />
                         </ActionIcon>
                     )}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -128,7 +128,7 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({ fieldId }) => {
                     >
                         <MantineIcon
                             icon={
-                                isColumnVisible(fieldId) ? IconEyeOff : IconEye
+                                isColumnVisible(fieldId) ? IconEye : IconEyeOff
                             }
                         />
                     </ActionIcon>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-152/the-eye-icon-in-chart-config-behaviour-is-inconsistent

### Description:
Fixed the eye icon toggle behavior in both the SingleSeriesConfiguration and ColumnConfiguration components. Previously, the eye icon state was inverted - showing the "eye off" icon when items were visible and the "eye" icon when they were hidden. This PR corrects the logic so that the eye icon properly reflects the visibility state.

When an item is visible, an eye icon is now shown.
When an item is hidden, an eye-off icon is now shown.