### PR TITLE
fix: add noWrap to TileBase header Group component

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -201,6 +201,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                     spacing="xs"
                     className="non-draggable"
                     sx={{ marginLeft: 'auto' }}
+                    noWrap
                 >
                     {visibleHeaderElement && (
                         <Group spacing="xs" className="non-draggable">


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/18091

### Description:

Added `noWrap` property to the Group component in TileBase to prevent content from wrapping to the next line, ensuring all elements stay on a single row.