### PR TITLE
refactor: make threadUuid and messageUuid optional in artifact panel

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactDetail.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactDetail.tsx
@@ -25,8 +25,6 @@ export const VerifiedArtifactDetail: FC = () => {
     );
 
     const versionUuid = searchParams.get('versionUuid');
-    const threadUuid = searchParams.get('threadUuid');
-    const promptUuid = searchParams.get('promptUuid');
 
     const { data: artifactData } = useAiAgentArtifact({
         projectUuid: projectUuid!,
@@ -44,22 +42,13 @@ export const VerifiedArtifactDetail: FC = () => {
     });
 
     useEffect(() => {
-        if (
-            projectUuid &&
-            agentUuid &&
-            artifactUuid &&
-            versionUuid &&
-            threadUuid &&
-            promptUuid
-        ) {
+        if (projectUuid && agentUuid && artifactUuid && versionUuid) {
             dispatch(
                 setArtifact({
                     projectUuid,
                     agentUuid,
                     artifactUuid,
                     versionUuid,
-                    messageUuid: promptUuid,
-                    threadUuid,
                 }),
             );
         }
@@ -67,15 +56,7 @@ export const VerifiedArtifactDetail: FC = () => {
         return () => {
             dispatch(clearArtifact());
         };
-    }, [
-        dispatch,
-        projectUuid,
-        agentUuid,
-        artifactUuid,
-        versionUuid,
-        threadUuid,
-        promptUuid,
-    ]);
+    }, [dispatch, projectUuid, agentUuid, artifactUuid, versionUuid]);
 
     const handleNavigateToVerifiedArtifacts = () => {
         void navigate(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsLayout.tsx
@@ -32,8 +32,6 @@ export const VerifiedArtifactsLayout: FC = () => {
                 agentUuid: agentUuid!,
                 artifactUuid: selectedArtifact.artifactUuid,
                 versionUuid: selectedArtifact.versionUuid,
-                messageUuid: selectedArtifact.promptUuid || '',
-                threadUuid: selectedArtifact.threadUuid,
             }),
         );
     };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanelContext.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanelContext.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable react-refresh/only-export-components */
+import type { AiAgentMessageAssistant, AiArtifact } from '@lightdash/common';
+import { createContext, useContext, type FC, type ReactNode } from 'react';
+
+type AiArtifactPanelContextType = {
+    message?: AiAgentMessageAssistant;
+    artifactData?: AiArtifact;
+};
+
+const AiArtifactPanelContext = createContext<
+    AiArtifactPanelContextType | undefined
+>(undefined);
+
+type AiArtifactPanelProviderProps = {
+    children: ReactNode;
+    value: AiArtifactPanelContextType;
+};
+
+export const AiArtifactPanelProvider: FC<AiArtifactPanelProviderProps> = ({
+    children,
+    value,
+}) => {
+    return (
+        <AiArtifactPanelContext.Provider value={value}>
+            {children}
+        </AiArtifactPanelContext.Provider>
+    );
+};
+
+export const useAiArtifactPanelContext = (): AiArtifactPanelContextType => {
+    const context = useContext(AiArtifactPanelContext);
+    if (context === undefined) {
+        throw new Error(
+            'useAiArtifactPanelContext must be used within AiArtifactPanelProvider',
+        );
+    }
+    return context;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -1,8 +1,4 @@
-import {
-    type AiAgentMessageAssistant,
-    type AiArtifact,
-    type SavedChart,
-} from '@lightdash/common';
+import { type SavedChart } from '@lightdash/common';
 import {
     ActionIcon,
     Button,
@@ -38,6 +34,7 @@ import {
     useSavePromptQuery,
 } from '../../hooks/useProjectAiAgents';
 import { getOpenInExploreUrl } from '../../utils/getOpenInExploreUrl';
+import { useAiArtifactPanelContext } from './AiArtifactPanelContext';
 
 type Props = {
     projectUuid: string;
@@ -46,18 +43,15 @@ type Props = {
         description: string | null;
         linkToMessage: boolean;
     };
-    message: AiAgentMessageAssistant;
     compiledSql?: string;
-    artifactData?: AiArtifact;
 };
 
 export const AiChartQuickOptions = ({
     projectUuid,
     saveChartOptions = { name: '', description: '', linkToMessage: true },
-    message,
     compiledSql,
-    artifactData,
 }: Props) => {
+    const { message, artifactData } = useAiArtifactPanelContext();
     const { track } = useTracking();
     const { user } = useApp();
     const { agentUuid } = useParams();
@@ -77,8 +71,8 @@ export const AiChartQuickOptions = ({
     const { mutate: savePromptQuery } = useSavePromptQuery(
         projectUuid,
         agentUuid!,
-        message.threadUuid,
-        message.uuid,
+        message?.threadUuid ?? '',
+        message?.uuid ?? '',
     );
     const { mutate: setVerified } = useSetArtifactVersionVerified(
         projectUuid,
@@ -97,7 +91,7 @@ export const AiChartQuickOptions = ({
 
     const isDisabled = !metricQuery || !type || !visualizationConfig;
     const onSaveChart = (savedData: SavedChart) => {
-        if (!saveChartOptions.linkToMessage) {
+        if (!saveChartOptions.linkToMessage || !message) {
             close();
             return;
         }
@@ -158,8 +152,8 @@ export const AiChartQuickOptions = ({
                     organizationId: user.data.organizationUuid,
                     projectId: projectUuid,
                     aiAgentId: agentUuid,
-                    threadId: message.threadUuid,
-                    messageId: message.uuid,
+                    threadId: message?.threadUuid ?? '',
+                    messageId: message?.uuid ?? '',
                     tableName: metricQuery.exploreName,
                 },
             });
@@ -227,27 +221,31 @@ export const AiChartQuickOptions = ({
                 </Menu.Target>
                 <Menu.Dropdown>
                     <Menu.Label>Quick actions</Menu.Label>
-                    {message.savedQueryUuid ? (
-                        <Menu.Item
-                            component={Link}
-                            to={`/projects/${projectUuid}/saved/${message.savedQueryUuid}`}
-                            target="_blank"
-                            leftSection={
-                                <MantineIcon icon={IconTableShortcut} />
-                            }
-                        >
-                            View saved chart
-                        </Menu.Item>
-                    ) : (
-                        <Menu.Item
-                            onClick={() => open()}
-                            leftSection={
-                                <MantineIcon icon={IconDeviceFloppy} />
-                            }
-                        >
-                            Save
-                        </Menu.Item>
-                    )}
+                    {message ? (
+                        <>
+                            {message.savedQueryUuid ? (
+                                <Menu.Item
+                                    component={Link}
+                                    to={`/projects/${projectUuid}/saved/${message.savedQueryUuid}`}
+                                    target="_blank"
+                                    leftSection={
+                                        <MantineIcon icon={IconTableShortcut} />
+                                    }
+                                >
+                                    View saved chart
+                                </Menu.Item>
+                            ) : (
+                                <Menu.Item
+                                    onClick={() => open()}
+                                    leftSection={
+                                        <MantineIcon icon={IconDeviceFloppy} />
+                                    }
+                                >
+                                    Save
+                                </Menu.Item>
+                            )}
+                        </>
+                    ) : null}
 
                     <Menu.Item
                         component={Link}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -1,8 +1,4 @@
-import {
-    parseVizConfig,
-    type AiAgentMessageAssistant,
-    type AiArtifact,
-} from '@lightdash/common';
+import { parseVizConfig, type AiArtifact } from '@lightdash/common';
 import {
     ActionIcon,
     Center,
@@ -32,7 +28,6 @@ type Props = {
     agentUuid: string;
     artifactUuid: string;
     versionUuid: string;
-    message: AiAgentMessageAssistant;
     showCloseButton?: boolean;
 };
 
@@ -42,7 +37,6 @@ export const AiChartVisualization: FC<Props> = ({
     agentUuid,
     artifactUuid,
     versionUuid,
-    message,
     showCloseButton = true,
 }) => {
     const dispatch = useAiAgentStoreDispatch();
@@ -141,9 +135,7 @@ export const AiChartVisualization: FC<Props> = ({
                         <Group gap="sm" display={isMobile ? 'none' : 'flex'}>
                             <ViewSqlButton sql={compiledSql?.query} />
                             <AiChartQuickOptions
-                                message={message}
                                 projectUuid={projectUuid}
-                                artifactData={artifactData}
                                 saveChartOptions={{
                                     name: queryExecutionHandle.data.metadata
                                         .title,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
@@ -1,8 +1,4 @@
-import {
-    type AiAgentMessageAssistant,
-    type AiArtifact,
-    type ToolDashboardArgs,
-} from '@lightdash/common';
+import { type AiArtifact, type ToolDashboardArgs } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -27,7 +23,6 @@ type Props = {
     projectUuid: string;
     agentUuid: string;
     dashboardConfig: ToolDashboardArgs;
-    message: AiAgentMessageAssistant;
     showCloseButton?: boolean;
 };
 
@@ -37,7 +32,6 @@ export const AiDashboardVisualization: FC<Props> = memo(
         projectUuid,
         agentUuid,
         dashboardConfig,
-        message,
         showCloseButton = true,
     }) => {
         const dispatch = useAiAgentStoreDispatch();
@@ -118,7 +112,6 @@ export const AiDashboardVisualization: FC<Props> = memo(
                                             versionUuid={
                                                 artifactData.versionUuid
                                             }
-                                            message={message}
                                             index={index}
                                         />
                                     </ErrorBoundary>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualizationItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualizationItem.tsx
@@ -1,6 +1,5 @@
 import {
     type AiAgentChartTypeOption,
-    type AiAgentMessageAssistant,
     type ApiAiAgentThreadMessageVizQuery,
     type ChartConfig,
     type ToolTableVizArgs,
@@ -40,7 +39,6 @@ type Props = {
     threadUuid: string;
     artifactUuid: string;
     versionUuid: string;
-    message: AiAgentMessageAssistant;
     index: number;
 };
 
@@ -52,7 +50,6 @@ export const AiDashboardVisualizationItem: FC<Props> = memo(
         threadUuid: _threadUuid,
         artifactUuid,
         versionUuid,
-        message,
         index,
     }) => {
         const queryClient = useQueryClient();
@@ -180,7 +177,6 @@ export const AiDashboardVisualizationItem: FC<Props> = memo(
                             description: visualization.description ?? null,
                             linkToMessage: false,
                         }}
-                        message={message}
                         compiledSql={compiledSql?.query}
                     />
                 </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
@@ -3,8 +3,8 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 export interface ArtifactData {
     artifactUuid: string;
     versionUuid: string;
-    messageUuid: string;
-    threadUuid: string;
+    messageUuid?: string;
+    threadUuid?: string;
     projectUuid: string;
     agentUuid: string;
 }
@@ -26,8 +26,8 @@ export const aiArtifactSlice = createSlice({
             action: PayloadAction<{
                 artifactUuid: string;
                 versionUuid: string;
-                messageUuid: string;
-                threadUuid: string;
+                messageUuid?: string;
+                threadUuid?: string;
                 projectUuid: string;
                 agentUuid: string;
             }>,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR refactors the AI artifact panel to make it more flexible by:

1. Making `threadUuid` and `messageUuid` optional in the artifact data structure
2. Creating a new `AiArtifactPanelContext` to share data between components
3. Implementing a context provider pattern to avoid prop drilling
4. Updating the artifact visualization components to use the context
5. Removing the requirement for a message to display an artifact
