### PR TITLE
fix: remove threadUuid and promptUuid from artifact URL

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -39,8 +39,7 @@ export function getReferencedArtifactsBlocks(
             type: 'actions',
             elements: referencedArtifacts.map((artifact) => {
                 const title = artifact.title || artifact.artifactType;
-                // TODO :: threadUuid and promptUuid should not be required
-                const url = `${siteUrl}/projects/${projectUuid}/ai-agents/${agentUuid}/edit/verified-artifacts/${artifact.artifactUuid}?versionUuid=${artifact.versionUuid}&threadUuid=${threadUuid}&promptUuid=${promptUuid}`;
+                const url = `${siteUrl}/projects/${projectUuid}/ai-agents/${agentUuid}/edit/verified-artifacts/${artifact.artifactUuid}?versionUuid=${artifact.versionUuid}`;
                 return {
                     type: 'button',
                     url,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removes unnecessary query parameters (`threadUuid` and `promptUuid`) from the URL used in Slack blocks for referenced artifacts. These parameters were previously marked as "should not be required" in a TODO comment, and this change implements that simplification.
