### PR TITLE
feat: add Databricks OAuth token refresh for U2M authentication

### DIFF
--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -568,3 +568,48 @@ export const exchangeDatabricksOAuthCredentials = async (
         refreshToken: data.refresh_token,
     };
 };
+
+/**
+ * Refresh Databricks OAuth U2M access token using refresh token
+ */
+export const refreshDatabricksOAuthToken = async (
+    host: string,
+    clientId: string,
+    refreshToken: string,
+): Promise<{
+    accessToken: string;
+    refreshToken: string;
+    expiresIn: number;
+}> => {
+    const tokenUrl = `https://${host}/oidc/v1/token`;
+
+    const response = await fetch(tokenUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: clientId,
+        }).toString(),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+            `Failed to refresh Databricks OAuth token: ${response.status} ${errorText}`,
+        );
+    }
+
+    const data = (await response.json()) as {
+        access_token: string;
+        refresh_token: string;
+        expires_in: number;
+    };
+    return {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+        expiresIn: data.expires_in,
+    };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

When app token expires after using U2M databricks oauth, we get an error. We need to refresh the token. 
We copied most of the logic from M2M (but we don't reuse, to keep it flexible, in case we need to introduce changes) 

Before

<img width="743" height="425" alt="Screenshot from 2025-11-13 14-14-17" src="https://github.com/user-attachments/assets/0c309539-e1c5-42dc-a5c3-3e9b4655fc54" />


After

I didn't reauthenticate, token was refreshed automatically  (expired in 5 mins)

<img width="800" height="138" alt="Screenshot from 2025-11-13 14-19-19" src="https://github.com/user-attachments/assets/52f1eae2-2e8c-4546-9ac9-4d8947654ccb" />

<img width="963" height="639" alt="Screenshot from 2025-11-13 14-20-21" src="https://github.com/user-attachments/assets/e70f6bcb-cfc4-4432-b95b-974e57789121" />


### Description:
Adds token refresh functionality for Databricks OAuth User-to-Machine (U2M) authentication. This implementation:

1. Creates a new `refreshDatabricksOAuthToken` function that exchanges a refresh token for a new access token
2. Adds token refresh logic in two places:
   - When building the warehouse adapter to ensure tokens are fresh before queries
   - In the credentials processing flow to handle token rotation

This ensures that long-running Databricks OAuth U2M connections remain valid by automatically refreshing expired tokens using the stored refresh token.