### PR TITLE
feat: use Tree multi-select on agent space access

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -2563,20 +2563,13 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     };
                 }
 
-                const contentWithRoots = await Promise.all(
-                    filteredResults.map(async (item) => {
-                        const rootSpaceUuid =
-                            await this.spaceModel.getSpaceRoot(item.spaceUuid);
-                        return { item, rootSpaceUuid };
-                    }),
-                );
-
                 return {
-                    content: contentWithRoots
-                        .filter(({ rootSpaceUuid }) =>
-                            agentSettings.spaceAccess.includes(rootSpaceUuid),
-                        )
-                        .map(({ item }) => item),
+                    content:
+                        agentSettings.spaceAccess.length === 0
+                            ? filteredResults
+                            : filteredResults.filter(({ spaceUuid }) =>
+                                  agentSettings.spaceAccess.includes(spaceUuid),
+                              ),
                 };
             });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -559,15 +559,9 @@ export const AiAgentFormSetup = ({
 
                             <SpaceAccessSelect
                                 projectUuid={projectUuid}
-                                value={
-                                    form.getInputProps('spaceAccess').value ??
-                                    []
-                                }
+                                value={form.values.spaceAccess}
                                 onChange={(value) => {
-                                    form.setFieldValue(
-                                        'spaceAccess',
-                                        value.length > 0 ? value : [],
-                                    );
+                                    form.setFieldValue('spaceAccess', value);
                                 }}
                             />
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/SpaceAccessSelect.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SpaceAccessSelect.module.css
@@ -1,0 +1,25 @@
+.selectTrigger {
+    cursor: pointer;
+}
+
+.selectTriggerDisabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.chevron {
+    transition: transform 0.2s ease;
+}
+
+.chevronExpanded {
+    transform: rotate(180deg);
+}
+
+.chevronCollapsed {
+    transform: rotate(0deg);
+}
+
+.treeContainer {
+    max-height: 300px;
+    overflow: auto;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/SpaceAccessSelect.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SpaceAccessSelect.tsx
@@ -1,6 +1,18 @@
-import { MultiSelect, Stack, Text } from '@mantine-8/core';
-import { useMemo, type FC } from 'react';
+import {
+    Box,
+    Button,
+    Collapse,
+    Group,
+    Paper,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { IconChevronDown, IconX } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import Tree from '../../../../components/common/Tree/Tree';
 import { useSpaceSummaries } from '../../../../hooks/useSpaces';
+import classes from './SpaceAccessSelect.module.css';
 
 type SpaceAccessSelectProps = {
     projectUuid: string;
@@ -13,37 +25,126 @@ export const SpaceAccessSelect: FC<SpaceAccessSelectProps> = ({
     value,
     onChange,
 }) => {
-    const { data: allSpaces, isLoading } = useSpaceSummaries(projectUuid, true);
+    const { data: spaces = [], isLoading: isLoadingSpaces } = useSpaceSummaries(
+        projectUuid,
+        true,
+    );
+    const [isExpanded, setIsExpanded] = useState(false);
 
-    const topLevelSpaces = useMemo(() => {
-        if (!allSpaces) return [];
-        return allSpaces.filter((space) => !space.parentSpaceUuid);
-    }, [allSpaces]);
-
-    const spaceOptions = topLevelSpaces.map((space) => ({
-        value: space.uuid,
-        label: space.name,
-    }));
+    if (isLoadingSpaces) {
+        return (
+            <Stack gap={4}>
+                <Text fz="sm" fw={500}>
+                    Space access
+                </Text>
+                <Text fz="xs" c="dimmed">
+                    Loading spaces...
+                </Text>
+            </Stack>
+        );
+    }
 
     return (
-        <Stack gap={4}>
-            <MultiSelect
-                variant="subtle"
-                label="Space access"
-                description="Agent will be able to find content only in the selected spaces and their nested spaces. Leave empty to allow access to all spaces."
-                placeholder={isLoading ? 'Loading spaces...' : 'Select spaces'}
-                data={spaceOptions}
-                value={value}
-                onChange={onChange}
-                searchable
-                clearable
-                disabled={isLoading}
-            />
-            {value.length > 0 && (
-                <Text fz="xs" c="dimmed">
-                    {value.length} space{value.length !== 1 ? 's' : ''} selected
+        <Stack gap="xs">
+            <Box>
+                <Group gap="xs" mb={4}>
+                    <Text fz="sm" fw={500}>
+                        Space access
+                    </Text>
+                </Group>
+                <Text fz="xs" c="dimmed" mb="xs">
+                    Select specific spaces to restrict access. Empty selection =
+                    access to all spaces.
                 </Text>
-            )}
+
+                <Paper
+                    withBorder
+                    p="xs"
+                    onClick={() =>
+                        !isLoadingSpaces && setIsExpanded(!isExpanded)
+                    }
+                    className={
+                        isLoadingSpaces
+                            ? classes.selectTriggerDisabled
+                            : classes.selectTrigger
+                    }
+                >
+                    <Group justify="space-between">
+                        <Text
+                            fz="sm"
+                            c={value.length === 0 ? 'dimmed' : undefined}
+                        >
+                            {isLoadingSpaces
+                                ? 'Loading spaces...'
+                                : value.length === 0
+                                ? 'All spaces (click to restrict)'
+                                : `${value.length} of ${spaces.length} space${
+                                      spaces.length !== 1 ? 's' : ''
+                                  } selected`}
+                        </Text>
+                        <MantineIcon
+                            icon={IconChevronDown}
+                            size={16}
+                            className={`${classes.chevron} ${
+                                isExpanded
+                                    ? classes.chevronExpanded
+                                    : classes.chevronCollapsed
+                            }`}
+                        />
+                    </Group>
+                </Paper>
+
+                <Collapse in={isExpanded && !isLoadingSpaces}>
+                    <Paper withBorder mt="xs" p="sm">
+                        <Stack gap="sm">
+                            {value.length > 0 && (
+                                <Group justify="space-between">
+                                    <Text fz="xs" c="dimmed">
+                                        {value.length} space
+                                        {value.length !== 1 ? 's' : ''} selected
+                                    </Text>
+                                    <Button
+                                        variant="subtle"
+                                        size="xs"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconX}
+                                                size={14}
+                                            />
+                                        }
+                                        onClick={() => onChange([])}
+                                    >
+                                        Clear selection
+                                    </Button>
+                                </Group>
+                            )}
+
+                            <Box className={classes.treeContainer}>
+                                {spaces.length === 0 ? (
+                                    <Text
+                                        fz="sm"
+                                        c="dimmed"
+                                        ta="center"
+                                        py="md"
+                                    >
+                                        No spaces found
+                                    </Text>
+                                ) : (
+                                    <Tree
+                                        type="multiple"
+                                        topLevelLabel="All spaces"
+                                        isExpanded={isExpanded}
+                                        data={spaces}
+                                        values={value}
+                                        onChangeMultiple={onChange}
+                                        withRootSelectable={true}
+                                    />
+                                )}
+                            </Box>
+                        </Stack>
+                    </Paper>
+                </Collapse>
+            </Box>
         </Stack>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Improved AI agent space access functionality with a more intuitive UI and fixed filtering logic:

1. Replaced the MultiSelect with a custom Tree-based space selector that:
   - Shows hierarchical space structure
   - Provides clear visual feedback on selection state
   - Includes a "Clear selection" button

2. Fixed space filtering logic in AiAgentService:
   - Now correctly handles the "all spaces" case (empty spaceAccess array)
   - Simplified filtering by removing unnecessary root space lookups

3. Fixed bidirectional state sync in Tree component:
   - Added a reference to track internal vs. external updates
   - Prevents infinite loops between selection state changes

[CleanShot 2025-11-13 at 13.52.30.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/1923b741-1ad3-48c6-941e-5ca42923dc56.mp4" />](https://app.graphite.com/user-attachments/video/1923b741-1ad3-48c6-941e-5ca42923dc56.mp4)

