### PR TITLE
fix: remove useEffect from Tree component

### DIFF
--- a/packages/frontend/src/components/common/Tree/Tree.tsx
+++ b/packages/frontend/src/components/common/Tree/Tree.tsx
@@ -136,22 +136,6 @@ const Tree: React.FC<Props> = (props) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isExpanded]);
 
-    useEffect(() => {
-        const uuids = tree.selectedState
-            .map((path) => {
-                const item = data.find((i) => i.path === path);
-                if (item) {
-                    return item.uuid;
-                }
-                return null;
-            })
-            .filter((item) => item !== null);
-
-        if (!isEqual(uuids, values)) {
-            handleChange(uuids);
-        }
-    }, [tree.selectedState, handleChange, data, values]);
-
     const handleSelectTopLevel = useCallback(() => {
         if (withRootSelectable) {
             tree.clearSelected();
@@ -214,10 +198,25 @@ const Tree: React.FC<Props> = (props) => {
                                             if (!expanded) {
                                                 nTree.expand(node.value);
                                             }
-                                            return;
+                                        } else {
+                                            nTree.toggleSelected(node.value);
                                         }
 
-                                        nTree.toggleSelected(node.value);
+                                        const uuids = nTree.selectedState
+                                            .map((path) => {
+                                                const item = data.find(
+                                                    (i) => i.path === path,
+                                                );
+                                                if (item) {
+                                                    return item.uuid;
+                                                }
+                                                return null;
+                                            })
+                                            .filter((item) => item !== null);
+
+                                        if (!isEqual(uuids, values)) {
+                                            handleChange(uuids);
+                                        }
                                     }}
                                     onClickExpand={() =>
                                         nTree.toggleExpanded(node.value)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Refactored the Tree component to move the UUID selection logic from a useEffect hook to the node selection handler. This change ensures that the UUID selection is updated immediately when a node is selected, rather than waiting for the next render cycle. The logic now runs directly in the click handler, making the component more responsive and predictable.
