### PR TITLE
fix: ValidateError returns empty message

### DIFF
--- a/packages/backend/src/errors.ts
+++ b/packages/backend/src/errors.ts
@@ -11,12 +11,26 @@ import { ValidateError } from '@tsoa/runtime';
 import { NextFunction, Request, Response } from 'express';
 import Logger from './logging/logger';
 
+const messageFromValidateError = (error: ValidateError) => {
+    // error message might come empty even though it's not supposed to 😠
+    if (error.message && error.message.length > 0) return error.message;
+    let errorMessage = `Validation failed`;
+    const fieldErrors = error.fields;
+    if (fieldErrors && typeof fieldErrors === 'object') {
+        errorMessage = Object.entries(fieldErrors)
+            .map(([name, e]) => `${name}: ${e.message}`)
+            .join(', ');
+    }
+    return errorMessage;
+};
+
 export const errorHandler = (error: Error): LightdashError => {
     if (error instanceof ValidateError) {
+        const errorMessage = messageFromValidateError(error);
         return new LightdashError({
             statusCode: 422,
             name: error.name,
-            message: error.message,
+            message: errorMessage,
             data: error.fields,
         });
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18036

### Description:
Improves error messages for validation failures by extracting field-specific error details. When the main error message is empty, the code now constructs a more descriptive message by combining individual field validation errors.

This change ensures users receive clearer feedback when API validation fails, rather than generic or empty error messages.


### Example using CLI

_after_
![image.png](https://app.graphite.com/user-attachments/assets/aec6bd01-09c3-469b-ba24-34d6a25b967f.png)

_before_
![image.png](https://app.graphite.com/user-attachments/assets/932be600-c79e-4f0e-b568-85e9fed4be83.png)

