### PR TITLE
fix: pass runQuery results when llm-as-judge-eval & data access

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -3992,6 +3992,7 @@ export class AiAgentModel {
             title: string | null;
             description: string | null;
         } | null;
+        toolResults: Pick<AiAgentToolResult, 'toolName' | 'result'>[];
     }> {
         const result = await this.database(AiEvalRunResultTableName)
             .leftJoin(
@@ -4028,6 +4029,7 @@ export class AiAgentModel {
                 dashboard_config: Record<string, unknown> | null;
                 title: string | null;
                 description: string | null;
+                ai_prompt_uuid: string | null;
             }>(
                 `${AiPromptTableName}.prompt`,
                 `${AiPromptTableName}.response`,
@@ -4037,6 +4039,7 @@ export class AiAgentModel {
                 `${AiArtifactVersionsTableName}.dashboard_config`,
                 `${AiArtifactVersionsTableName}.title`,
                 `${AiArtifactVersionsTableName}.description`,
+                `${AiPromptTableName}.ai_prompt_uuid`,
             )
             .first();
 
@@ -4058,6 +4061,15 @@ export class AiAgentModel {
             );
         }
 
+        // Fetch tool calls and results if there's a prompt UUID
+        let toolResults: Pick<AiAgentToolResult, 'toolName' | 'result'>[] = [];
+
+        if (result.ai_prompt_uuid) {
+            toolResults = await this.getToolResultsForPrompt(
+                result.ai_prompt_uuid,
+            );
+        }
+
         return {
             query: result.prompt,
             response: result.response,
@@ -4071,6 +4083,7 @@ export class AiAgentModel {
                       description: result.description,
                   }
                 : null,
+            toolResults,
         };
     }
 

--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -167,6 +167,17 @@ export async function llmAsAJudge({
                     'expectedAnswer is required for factuality scorer',
                 );
             }
+
+            // Build context section if context is provided (e.g., tool results with data)
+            const contextSection =
+                context && context.length > 0
+                    ? `
+      ************
+      [Context]: 
+      ${context.join('\n')}
+      ************`
+                    : '';
+
             const { object } = await generateObject({
                 model: judge,
                 ...defaultAgentOptions,
@@ -195,9 +206,17 @@ export async function llmAsAJudge({
       [Expert]: ${expectedAnswer}
       ************
       [Submission]: ${response}
-      ************
+      ************${contextSection}
       [END DATA]
-
+${
+    context && context.length > 0
+        ? `
+      Additional Context: The above context includes query results. 
+      Use this information to verify if the submitted answer correctly references or includes the data from these results.
+      When comparing factual content, check if numbers, metrics, or data points in the submission match those in the tool results.
+`
+        : ''
+}
       Compare the factual content of the submitted answer with the expert answer. Ignore any differences in style, grammar, or punctuation.
       The submitted answer may either be a subset or superset of the expert answer, or it may conflict with it. Determine which case applies. Answer the question by selecting one of the following options:
       (A) The submitted answer is a subset of the expert answer and is fully consistent with it.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18066

### Description:

Enhanced AI agent evaluation with data context integration. The assessment process now includes query results when data access is enabled, providing more accurate factuality and context relevancy scoring. 

The implementation:
- Adds tool results to evaluation data retrieval
- Conditionally includes query results in assessment context based on agent's data access permissions
- Updates the factuality scorer to consider data context when comparing answers
- Passes the data access flag from the agent configuration to the assessment process

This improvement allows the AI to make more informed judgments by referencing actual data when evaluating responses, particularly for data-driven questions.
