### PR TITLE
fix: respect max column limit config for backend pivoted results

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1475,7 +1475,7 @@ export const parseConfig = (): LightdashConfig => {
             maxColumnLimit:
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_PIVOT_TABLE_MAX_COLUMN_LIMIT',
-                ) || 60,
+                ) || 200,
         },
         headlessBrowser: {
             port: process.env.HEADLESS_BROWSER_PORT,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1743,7 +1743,10 @@ export class AsyncQueryService extends ProjectService {
                             args.metricQuery.limit,
                         );
 
-                        pivotedQuery = pivotQueryBuilder.toSql();
+                        pivotedQuery = pivotQueryBuilder.toSql({
+                            columnLimit:
+                                this.lightdashConfig.pivotTable.maxColumnLimit,
+                        });
                     }
 
                     const query = pivotedQuery || compiledQuery;

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -852,7 +852,9 @@ export class CsvService extends BaseService {
                 sqlChart.limit,
             );
 
-            sql = pivotQueryBuilder.toSql();
+            sql = pivotQueryBuilder.toSql({
+                columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+            });
         }
 
         const resultsFileUrl = await this.projectService.runSqlQuery(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -103,7 +103,6 @@ import {
     JobType,
     LightdashError,
     LightdashProjectConfig,
-    MAX_PIVOT_COLUMN_LIMIT,
     maybeOverrideDbtConnection,
     maybeOverrideWarehouseConnection,
     maybeReplaceFieldsInChartVersion,
@@ -3422,7 +3421,9 @@ export class ProjectService extends BaseService {
             limit,
         );
 
-        const pivotedSql = pivotQueryBuilder.toSql();
+        const pivotedSql = pivotQueryBuilder.toSql({
+            columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+        });
 
         this.logger.debug(`Stream query against warehouse`);
         const queryTags: RunQueryTags = {

--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -92,7 +92,9 @@ const pivotBuilder = new PivotQueryBuilder(
     warehouseSqlBuilder,
     500
 );
-const pivotSql = pivotBuilder.toSql();
+const pivotSql = pivotBuilder.toSql({
+    columnLimit: lightdashConfig.pivotTable.maxColumnLimit  // From LIGHTDASH_PIVOT_TABLE_MAX_COLUMN_LIMIT env var (default: 100)
+});
 
 // 3. Execute and transform results (in AsyncQueryService)
 const { columns, pivotDetails } = await AsyncQueryService.runQueryAndTransformRows({
@@ -141,7 +143,10 @@ const { replacedSql, usedParameters } = safeReplaceParametersWithSqlBuilder(
 **Key Technical Details:**
 
 -   **MetricQueryBuilder** handles complex joins, window functions, and warehouse-specific SQL generation
--   Maximum 60 pivot columns (MAX_PIVOT_COLUMN_LIMIT) to prevent performance issues
+-   Pivot column limit is configurable via `LIGHTDASH_PIVOT_TABLE_MAX_COLUMN_LIMIT` (default: 100)
+    -   When set, the limit is passed to `PivotQueryBuilder.toSql({ columnLimit })`
+    -   If `columnLimit` is provided, SQL adds `column_index <= maxColumnsPerValueColumn` filter
+    -   If `columnLimit` is undefined, no column filtering is applied (unlimited columns)
 -   Pivot results are streamed and transformed during processing, not after loading all data
 -   Parameter replacement supports both safe (typed) and raw replacement modes
 -   The module supports multiple warehouse dialects (BigQuery, Snowflake, Postgres, etc.)

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -134,7 +134,7 @@ describe('PivotQueryBuilder', () => {
                 100,
             );
 
-            const result = builder.toSql();
+            const result = builder.toSql({ columnLimit: 100 });
 
             // Should contain all CTEs
             expect(result).toContain(
@@ -219,10 +219,38 @@ describe('PivotQueryBuilder', () => {
                 mockWarehouseSqlBuilder,
             );
 
-            const result = builder.toSql();
+            const result = builder.toSql({ columnLimit: 100 });
 
             // With 3 value columns: (100-1)/3 = 33 max columns per value column
             expect(result).toContain('"column_index" <= 33');
+        });
+
+        test('Should not apply column limit when columnLimit is not provided', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'event_id',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'event_type' }],
+                sortBy: undefined,
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+                100,
+            );
+
+            const result = builder.toSql(); // No columnLimit provided
+
+            // Should NOT contain column_index filtering
+            expect(result).not.toContain('"column_index" <=');
+            // Should still contain row_index filtering
+            expect(result).toContain('"row_index" <= 100');
         });
     });
 

--- a/packages/common/src/constants/pivot.ts
+++ b/packages/common/src/constants/pivot.ts
@@ -1,6 +1,0 @@
-/**
- * The maximum number of columns that can be generated from a pivot operation.
- * This limit is enforced to prevent performance issues and memory overload
- * when a GROUP BY query results in too many pivot columns.
- */
-export const MAX_PIVOT_COLUMN_LIMIT = 100;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -59,7 +59,6 @@ export * from './compiler/exploreCompiler';
 export * from './compiler/filtersCompiler';
 export * from './compiler/parameters';
 export * from './compiler/translator';
-export * from './constants/pivot';
 export * from './constants/sessionStorageKeys';
 export * from './constants/sqlRunner';
 export { default as DbtSchemaEditor } from './dbt/DbtSchemaEditor/DbtSchemaEditor';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -535,7 +535,7 @@ export type ReadyQueryResultsPage = ResultsPaginationMetadata<ResultRow> & {
     resultsPageExecutionMs: number;
     status: QueryHistoryStatus.READY;
     pivotDetails: {
-        // Unlimited total column count, this is used to display a warning to the user in the frontend when the number of columns is over MAX_PIVOT_COLUMN_LIMIT
+        // Unlimited total column count, this is used to display a warning to the user in the frontend when the number of columns is over maxColumnLimit
         totalColumnCount: number | null;
         indexColumn: PivotConfiguration['indexColumn'] | undefined;
         valuesColumns: PivotValuesColumn[];

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -3,7 +3,6 @@ import {
     getFirstIndexColumns,
     getParameterReferences,
     isVizTableConfig,
-    MAX_PIVOT_COLUMN_LIMIT,
     MAX_SAFE_INTEGER,
     type VizTableConfig,
     type VizTableHeaderSortConfig,
@@ -273,11 +272,16 @@ export const ContentPanel: FC = () => {
         selectPivotChartDataByKind(state, selectedChartType),
     );
 
+    const maxColumnLimit = useMemo(
+        () => health.data?.pivotTable.maxColumnLimit,
+        [health],
+    );
     const hasReachedPivotColumnLimit = useMemo(
         () =>
             pivotedChartInfo?.data?.columnCount &&
-            pivotedChartInfo?.data?.columnCount > MAX_PIVOT_COLUMN_LIMIT,
-        [pivotedChartInfo],
+            maxColumnLimit &&
+            pivotedChartInfo.data.columnCount > maxColumnLimit,
+        [pivotedChartInfo, maxColumnLimit],
     );
 
     useEffect(() => {
@@ -828,39 +832,41 @@ export const ContentPanel: FC = () => {
                                             pivotedChartInfo?.data
                                                 ?.tableData && (
                                                 <>
-                                                    {hasReachedPivotColumnLimit && (
-                                                        <Group
-                                                            position="center"
-                                                            spacing="xs"
-                                                        >
-                                                            <MantineIcon
-                                                                color="gray"
-                                                                icon={
-                                                                    IconAlertCircle
-                                                                }
-                                                            />
-                                                            <Text
-                                                                fz="xs"
-                                                                fw={400}
-                                                                c="gray.7"
-                                                                ta="center"
+                                                    {hasReachedPivotColumnLimit &&
+                                                        maxColumnLimit && (
+                                                            <Group
+                                                                position="center"
+                                                                spacing="xs"
                                                             >
-                                                                This query
-                                                                exceeds the
-                                                                maximum number
-                                                                of columns (
-                                                                {
-                                                                    MAX_PIVOT_COLUMN_LIMIT
-                                                                }
-                                                                ). Showing the
-                                                                first{' '}
-                                                                {
-                                                                    MAX_PIVOT_COLUMN_LIMIT
-                                                                }{' '}
-                                                                columns.
-                                                            </Text>
-                                                        </Group>
-                                                    )}
+                                                                <MantineIcon
+                                                                    color="gray"
+                                                                    icon={
+                                                                        IconAlertCircle
+                                                                    }
+                                                                />
+                                                                <Text
+                                                                    fz="xs"
+                                                                    fw={400}
+                                                                    c="gray.7"
+                                                                    ta="center"
+                                                                >
+                                                                    This query
+                                                                    exceeds the
+                                                                    maximum
+                                                                    number of
+                                                                    columns (
+                                                                    {
+                                                                        maxColumnLimit
+                                                                    }
+                                                                    ). Showing
+                                                                    the first{' '}
+                                                                    {
+                                                                        maxColumnLimit
+                                                                    }{' '}
+                                                                    columns.
+                                                                </Text>
+                                                            </Group>
+                                                        )}
                                                     <ChartDataTable
                                                         columnNames={
                                                             pivotedChartInfo


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18101

### Description:
Increases the default pivot table column limit from 60 to 200 and makes the limit configurable throughout the application. The PR:

- Increases the default `LIGHTDASH_PIVOT_TABLE_MAX_COLUMN_LIMIT` from 60 to 200
- Removes the hardcoded `MAX_PIVOT_COLUMN_LIMIT` constant
- Passes the configured column limit to `PivotQueryBuilder.toSql()` in all relevant services
- Updates the `PivotQueryBuilder` to conditionally apply column limiting only when a limit is provided
- Updates the frontend to use the dynamic column limit from the health endpoint
- Updates documentation to reflect the configurable nature of the column limit

This change allows users to work with larger pivot tables while maintaining the ability to limit columns for performance reasons.