### PR TITLE
chore: show warning on explore viz when column limit is exceeded

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -282,6 +282,9 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                                 chartConfig={unsavedChartVersion.chartConfig}
                                 resultsData={resultsData}
                                 isLoading={isLoadingQueryResults}
+                                maxColumnLimit={
+                                    health.data?.pivotTable?.maxColumnLimit
+                                }
                             />
                         )
                     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #18101

### Description:
Added a warning message when a pivot table query exceeds the maximum column limit. The warning informs users that only the first N columns will be displayed, where N is the maximum column limit configured in the health data.

The implementation:
1. Passes the `maxColumnLimit` from health data to the `VisualizationWarning` component
2. Adds logic to detect when the total column count exceeds this limit
3. Displays a warning message to users when the limit is exceeded

![Screenshot 2025-11-13 at 15.20.02.png](https://app.graphite.com/user-attachments/assets/980fd781-49ff-4c7a-83e1-2f6526145d43.png)

Steps to test:
1. Enable `USE_SQL_PIVOT_RESULTS`
2. Go to explore [chart with > 200 series](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/events?create_saved_chart_version=%7B%22tableName%22%3A%22events%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22events%22%2C%22dimensions%22%3A%5B%22events_event_tier%22%2C%22events_timestamp_tz_raw%22%5D%2C%22metrics%22%3A%5B%22events_count%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22events_timestamp_tz_raw%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A5000%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22events_timestamp_tz_raw%22%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22events_event_tier%22%2C%22events_timestamp_tz_raw%22%2C%22events_count%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22events_event_tier%22%2C%22yField%22%3A%5B%22events_count%22%5D%2C%22flipAxes%22%3Afalse%2C%22stack%22%3A%22stack%22%7D%2C%22eChartsConfig%22%3A%7B%7D%7D%7D%7D&isExploreFromHere=true)