### PR TITLE
style: update SimpleStatistic border-radius and spacing

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/SimpleStatistic.module.css
+++ b/packages/frontend/src/components/SimpleStatistic/SimpleStatistic.module.css
@@ -3,7 +3,7 @@
     align-items: center;
     gap: 2px;
     padding: 2px 6px;
-    border-radius: 8px;
+    border-radius: 100px;
     border: 1px solid;
     font-weight: 500;
 }

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -324,7 +324,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                     mt={
                         showBigNumberLabel
                             ? labelFontSize * 0.85 * spacingMultiplier
-                            : valueFontSize * 0.15 * spacingMultiplier
+                            : valueFontSize * 0.5 * spacingMultiplier
                     }
                     gap="xs"
                 >
@@ -346,6 +346,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                         >
                             <Text
                                 fz={comparisonPillFontSize}
+                                fw={600}
                                 {...(spacingMultiplier === 0 && { lh: 0 })}
                             >
                                 {comparisonValue}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/18033

### Description:
Updated the SimpleStatistic component styling by changing the border-radius from 8px to 100px for a more rounded appearance. Also adjusted the spacing by increasing the margin-top multiplier from 0.15 to 0.5 when the big number label is not shown, and added a font weight of 600 to the comparison value text to make it more prominent.
