### PR TITLE
chore: remove transaction 'ProjectModel.convertMetricFiltersFieldIdsToFieldRef'

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -963,37 +963,32 @@ export class ProjectModel {
 
     static convertMetricFiltersFieldIdsToFieldRef = (
         explore: Explore | ExploreError,
-    ) =>
-        wrapSentryTransactionSync(
-            'ProjectModel.convertMetricFiltersFieldIdsToFieldRef',
-            { exploreName: explore.name },
-            () => {
-                if (isExploreError(explore)) return explore;
-                const convertedExplore = { ...explore };
-                if (convertedExplore.tables) {
-                    Object.values(convertedExplore.tables).forEach((table) => {
-                        if (table.metrics) {
-                            Object.values(table.metrics).forEach((metric) => {
-                                if (metric.filters) {
-                                    metric.filters.forEach((filter) => {
-                                        // @ts-expect-error cached explore types might not be up to date
-                                        const { fieldId, fieldRef, ...rest } =
-                                            filter.target;
-                                        // eslint-disable-next-line no-param-reassign
-                                        filter.target = {
-                                            ...rest,
-                                            fieldRef: fieldRef ?? fieldId,
-                                        };
-                                    });
-                                }
+    ) => {
+        if (isExploreError(explore)) return explore;
+        const convertedExplore = { ...explore };
+        if (convertedExplore.tables) {
+            Object.values(convertedExplore.tables).forEach((table) => {
+                if (table.metrics) {
+                    Object.values(table.metrics).forEach((metric) => {
+                        if (metric.filters) {
+                            metric.filters.forEach((filter) => {
+                                // @ts-expect-error cached explore types might not be up to date
+                                const { fieldId, fieldRef, ...rest } =
+                                    filter.target;
+                                // eslint-disable-next-line no-param-reassign
+                                filter.target = {
+                                    ...rest,
+                                    fieldRef: fieldRef ?? fieldId,
+                                };
                             });
                         }
                     });
                 }
+            });
+        }
 
-                return convertedExplore;
-            },
-        );
+        return convertedExplore;
+    };
 
     /**
      * Find explores from cache (cached_explore) from a project.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A
Relates to: https://github.com/lightdash/lightdash/pull/17504/files

### Description:

Removed the `wrapSentryTransactionSync` wrapper from the `convertMetricFiltersFieldIdsToFieldRef` method in the ProjectModel class. This simplifies the code by directly handling the conversion logic without the Sentry transaction tracking.

The core functionality remains unchanged - the method still converts field IDs to field references in metric filters within explores.