### PR TITLE
feat: update BitBucket form to support API tokens and add deprecation notice

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
@@ -1,5 +1,5 @@
 import { DbtProjectType } from '@lightdash/common';
-import { Anchor, PasswordInput, TextInput } from '@mantine/core';
+import { Alert, Anchor, PasswordInput, TextInput } from '@mantine/core';
 import React, { type FC } from 'react';
 import { useFormContext } from '../formContext';
 import DbtVersionSelect from '../Inputs/DbtVersion';
@@ -13,6 +13,22 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
     const form = useFormContext();
     return (
         <>
+            <Alert
+                variant="light"
+                color="yellow"
+                title="Bitbucket app passwords deprecation"
+                mb="md"
+            >
+                <Anchor
+                    href="https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    Bitbucket Cloud transitions to API tokens
+                </Anchor>
+                . Existing app passwords will continue working until June 9,
+                2026.
+            </Alert>
             <TextInput
                 name="dbt.username"
                 {...form.getInputProps('dbt.username')}
@@ -25,18 +41,18 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
             <PasswordInput
                 name="dbt.personal_access_token"
                 {...form.getInputProps('dbt.personal_access_token')}
-                label="HTTP access token"
+                label="API Token"
                 description={
                     <>
                         <p>
                             Bitbucket Cloud users should
                             <Anchor
-                                href="https://support.atlassian.com/bitbucket-cloud/docs/create-an-app-password/"
+                                href="https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/"
                                 target="_blank"
                                 rel="noreferrer"
                             >
                                 {' '}
-                                follow instructions for creating an App Password
+                                follow instructions for creating an API Token
                             </Anchor>
                         </p>
                         <p>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18031

### Description:
Updates the BitBucket form to reflect Bitbucket's transition from app passwords to API tokens. Added an alert notifying users about the deprecation of app passwords, updated the label from "HTTP access token" to "API Token", and changed the documentation link to point to the API token creation instructions instead of app password creation.

### Quick demo:
<img width="460" height="495" alt="Screenshot 2025-11-13 at 18 27 04" src="https://github.com/user-attachments/assets/31f2fc6d-0c17-461e-b69b-ea823e159974" />
