### PR TITLE
fix: cartesian charts with sql pivot results not going over reference line

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1200,10 +1200,11 @@ const getEchartAxes = ({
         : getLineChartGridStyle();
 
     // There is no Top x axis when no flipped
+    // Use hashFieldReference to get the same hash used in series encoding (includes pivot values)
     const topAxisXFieldIds = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.eChartsConfig.series
               ?.filter((serie) => serie.yAxisIndex === 1)
-              .map((s) => s.encode.yRef.field)
+              .map((s) => hashFieldReference(s.encode.yRef))
         : undefined;
 
     const topAxisXId = topAxisXFieldIds?.[0] || undefined;
@@ -1211,7 +1212,7 @@ const getEchartAxes = ({
     const bottomAxisXFieldIds = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.eChartsConfig.series
               ?.filter((serie) => serie.yAxisIndex === 0)
-              .map((s) => s.encode.yRef.field)
+              .map((s) => hashFieldReference(s.encode.yRef))
         : [];
 
     const bottomAxisXId = bottomAxisXFieldIds?.[0] || xAxisItemId;
@@ -1232,14 +1233,14 @@ const getEchartAxes = ({
             : []
         : validCartesianConfig.eChartsConfig.series
               ?.filter((serie) => serie.yAxisIndex === 0)
-              .map((s) => s.encode.yRef.field);
+              .map((s) => hashFieldReference(s.encode.yRef));
 
     const leftAxisYId = leftAxisYFieldIds?.[0] || yAxisItemId;
 
     // There is no right Y axis when flipped
     const rightAxisYFieldIds = validCartesianConfig.eChartsConfig.series
         ?.filter((serie) => serie.yAxisIndex === 1)
-        .map((s) => s.encode.yRef.field);
+        .map((s) => hashFieldReference(s.encode.yRef));
 
     const rightAxisYId =
         rightAxisYFieldIds?.[0] || validCartesianConfig.layout?.yField?.[1];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18024

### Description:
Fixed axis identification in cartesian charts by using `hashFieldReference` to get consistent hash values for field references. This ensures that the same hash is used in both series encoding and axis identification, which is particularly important when pivot values are involved.

**Steps to test**
1. Set `USE_SQL_PIVOT_RESULTS` to true
2. Create cartesian chart with reference line


**Before**

![image.png](https://app.graphite.com/user-attachments/assets/81a84c3d-e424-40af-9d39-0018d7e16c5b.png)

**After**

![image.png](https://app.graphite.com/user-attachments/assets/85413062-9f4e-45be-8a82-8d49ff73afb1.png)

