### PR TITLE
feat: add image dimension and sizing controls

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -87,6 +87,17 @@ models:
             groups: [ 'image' ]
             image: 
                 url: "${value.raw}" 
+          additional_dimensions:
+            image_with_size:
+              groups: [ 'image' ]
+              description: "Image URL with size"
+              type: string
+              sql: ${image_url}
+              image:
+                url: "${value.raw}" 
+                width: 128 # squared, do not preserve aspect ratio
+                height: 128
+                fit: cover
       - name: event_id
         description: ""
         meta:
@@ -108,7 +119,8 @@ models:
               image:
                 # Template combines value (the URL from SQL) with other row fields
                 # Use liquidjs to combine the URL with the event name and upcase
-                url: "https://${value.raw}-${row.events.event.raw | upcase}" 
+                url: "https://${value.raw}-${row.events.event.raw | upcase}"
+
             image_invalid_protocol:
               groups: [ 'image' ]
               description: "Invalid URL protocol"

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -89,6 +89,15 @@
                 "url": {
                     "type": "string",
                     "description": "Liquidjs template for the image URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}. Only fields selected in the query are available in row context."
+                },
+                "width": {
+                    "type": "number"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "fit": {
+                    "type": "string"
                 }
             },
             "required": ["url"]

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -249,6 +249,15 @@
                                                     "url": {
                                                         "type": "string",
                                                         "description": "Liquidjs template for the image URL. Available variables: ${value.raw}, ${value.formatted}, ${row.table_name.field_name.raw}, ${row.table_name.field_name.formatted}. Only fields selected in the query are available in row context."
+                                                    },
+                                                    "width": {
+                                                        "type": "number"
+                                                    },
+                                                    "height": {
+                                                        "type": "number"
+                                                    },
+                                                    "fit": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": ["url"]

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -170,6 +170,9 @@ export type DbtColumnLightdashDimension = {
     ai_hint?: string | string[];
     image?: {
         url: string;
+        width?: number;
+        height?: number;
+        fit?: string;
     };
 } & DbtLightdashFieldTags;
 

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -568,6 +568,9 @@ export interface Dimension extends Field {
     aiHint?: string | string[];
     image?: {
         url: string;
+        width?: number;
+        height?: number;
+        fit?: string;
     };
 }
 

--- a/packages/frontend/src/components/common/Table/ImageCell.tsx
+++ b/packages/frontend/src/components/common/Table/ImageCell.tsx
@@ -29,6 +29,7 @@ export const BrokenImageCell = ({
 };
 
 export const ImageCell = ({
+    item,
     imageUrl,
 }: {
     item: Dimension;
@@ -39,6 +40,29 @@ export const ImageCell = ({
     if (isBroken) {
         return <BrokenImageCell imageUrl={imageUrl} />;
     }
+
+    // Get dimensions and objectFit from item.image configuration
+    const width = item.image?.width;
+    const height = item.image?.height;
+
+    const size =
+        width || height
+            ? {
+                  width: width ? `${width}px` : 'auto',
+                  height: height ? `${height}px` : 'auto',
+              }
+            : { height: '32px', width: 'auto' };
+
+    // Cast fit to allow any string value
+    // If fit is not a valid value, this will not cause any error
+    const objectFit = (item.image?.fit ??
+        'cover') as React.CSSProperties['objectFit'];
+
+    const imageStyle: React.CSSProperties = {
+        display: 'block',
+        objectFit,
+        ...size,
+    };
 
     return (
         <Tooltip
@@ -56,12 +80,7 @@ export const ImageCell = ({
             <img
                 src={imageUrl}
                 alt=""
-                style={{
-                    height: '32px',
-                    width: 'auto',
-                    display: 'block',
-                    objectFit: 'contain',
-                }}
+                style={imageStyle}
                 onError={() => setIsBroken(true)}
             />
         </Tooltip>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-172/adjust-image-on-table-size-on-yml

### Fit


- cover (default)

<img width="977" height="299" alt="image" src="https://github.com/user-attachments/assets/e2d1f0cb-9315-44bd-93e7-d51e89b88ee7" />

- none

<img width="977" height="299" alt="image" src="https://github.com/user-attachments/assets/9bc19044-b620-4b47-9349-a52f656151ea" />

- Fill /contain (will depend on the size)

<img width="977" height="299" alt="image" src="https://github.com/user-attachments/assets/aa68850c-f3bc-4248-86b5-fd56e93feb5a" />


### Description:
Added support for configuring image dimensions and object-fit properties in table cells. This enhancement allows users to specify width, height, and fit options for images displayed in tables.

The PR adds:
- New schema properties for image configuration (width, height, objectFit)
- Updated types to support these new properties
- Enhanced ImageCell component to respect the configured dimensions and fit options
- Added example in the jaffle-shop demo showing how to use the new image sizing options

This makes image display more flexible, allowing for consistent sizing and proper image fitting within table cells.