### PR TITLE
fix: allow empty roles array in SCIM service validation

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -687,12 +687,10 @@ describe('ScimService', () => {
             }).not.toThrow();
         });
 
-        test('should throw error for empty roles array', () => {
+        test('should not throw error for empty roles array (skip updates)', () => {
             expect(() => {
                 ScimService.validateRolesArray([], validRoleValues);
-            }).toThrow(
-                'Roles array must contain at least one role when provided',
-            );
+            }).not.toThrow();
         });
 
         test('should throw error for invalid role values', () => {

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1542,11 +1542,9 @@ export class ScimService extends BaseService {
         roles: ScimUserRole[],
         validRoleValues: string[],
     ): void {
-        // If roles array is provided, it must have at least 1 entry
+        // For backwards compatibility, when array is empty, skip validation and let caller skip updates
         if (roles.length === 0) {
-            throw new ParameterError(
-                'Roles array must contain at least one role when provided',
-            );
+            return;
         }
 
         // Check for invalid role values


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/18124

### Description:
Allow empty roles array in SCIM service validation to support skipping role updates. Previously, an empty roles array would throw an error requiring at least one role, but this change makes the validation more flexible by treating an empty array as a signal to skip role updates entirely.