### PR TITLE
feat: add table column width support for image dimensions

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -120,7 +120,14 @@ models:
                 # Template combines value (the URL from SQL) with other row fields
                 # Use liquidjs to combine the URL with the event name and upcase
                 url: "https://${value.raw}-${row.events.event.raw | upcase}"
-
+            image_dynamic_width:
+              groups: [ 'image' ]
+              description: "Build a width dynamic image"
+              type: string
+              sql: |
+                'https://placehold.co/' || ${event_id} || 'x100?text=image'
+              image:
+                url: "${value.raw}"
             image_invalid_protocol:
               groups: [ 'image' ]
               description: "Invalid URL protocol"

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -2,6 +2,7 @@ import {
     formatItemValue,
     getSubtotalKey,
     isCustomDimension,
+    isDimension,
     isField,
     type ItemsMap,
     type ParametersValuesMap,
@@ -75,6 +76,23 @@ export function getSubtotalValueFromGroup(
     return subtotal?.[columnId];
 }
 
+const getImageSize = (item: ItemsMap[string] | undefined) => {
+    if (isDimension(item) && item.image?.url) {
+        const defaultWidth = 100;
+        const defaultPadding = 8 * 2;
+        const width = (item.image?.width || defaultWidth) + defaultPadding;
+
+        return {
+            style: {
+                width,
+                minWidth: width,
+                maxWidth: width,
+            },
+        };
+    }
+    return {};
+};
+
 const getDataAndColumns = ({
     itemsMap,
     selectedItemIds,
@@ -99,7 +117,7 @@ const getDataAndColumns = ({
             const headerOverride = getFieldLabelOverride(itemId);
 
             const column: TableHeader | TableColumn = columnHelper.accessor(
-                (row) => row[itemId],
+                (row: ResultRow) => row[itemId],
                 {
                     id: itemId,
                     header: () => (
@@ -148,6 +166,8 @@ const getDataAndColumns = ({
                         item,
                         isVisible: isColumnVisible(itemId),
                         frozen: isColumnFrozen(itemId),
+                        // For image columns with explicit width: set fixed width constraints
+                        ...getImageSize(item),
                     },
                     // Some features work in the TanStack Table demos but not here, for unknown reasons.
                     // For example, setting grouping value here does not work. The workaround is to use


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

Before

<img width="977" height="299" alt="Screenshot from 2025-11-14 10-17-37" src="https://github.com/user-attachments/assets/03cd2e2b-7229-4f77-b685-47226737d670" />


After

<img width="940" height="403" alt="Screenshot from 2025-11-14 11-18-49" src="https://github.com/user-attachments/assets/162e2a99-66c1-4d68-ab42-9229d1debf55" />


### Description:
Added support for dynamic width images in table visualizations. This PR introduces a new `getImageSize` function that extracts width information from dimension items with image URLs and applies appropriate styling constraints to the column. The implementation includes:

1. A new example in the jaffle-shop demo with a dynamic width image field
2. Logic to set fixed width constraints for image columns with explicit width values
3. Proper type annotation for the row parameter in the accessor function

This enhancement allows for better control over image sizing in table visualizations, improving the overall display of image content.