### PR TITLE
fix: show dashboard chart schedulers on schedulers list

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -342,15 +342,27 @@ export class SchedulerModel {
             });
         }
 
+        const dashboardChartsJoinTable = 'dashboard_charts';
+
         // Create a union of two queries: one for saved charts and one for dashboards
         let schedulerCharts = baseQuery
             .clone()
-            .leftJoin(SpaceTableName, function joinSpaces() {
+            // Join to get the dashboard that the chart belongs to (if any)
+            .leftJoin(
+                { [dashboardChartsJoinTable]: DashboardsTableName },
+                `${dashboardChartsJoinTable}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
+            )
+            .innerJoin(SpaceTableName, function joinSpaces() {
                 this.on(
                     `${SpaceTableName}.space_id`,
                     '=',
+                    `${dashboardChartsJoinTable}.space_id`,
+                ).orOn(
+                    `${SpaceTableName}.space_id`,
+                    '=',
                     `${SavedChartsTableName}.space_id`,
-                ).andOnNotNull(`${SavedChartsTableName}.space_id`);
+                );
             })
             .leftJoin(
                 ProjectTableName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixed the join logic in the SchedulerModel to correctly handle charts that belong to dashboards. The changes include:

1. Added a left join to the dashboard_charts table to retrieve dashboard information for charts
2. Modified the space join to use an inner join instead of a left join
3. Updated the join condition to check for space_id in both the dashboard_charts and SavedCharts tables using an OR condition

**Steps to reproduce**
1. Create a chart in dashboard
2. Create a scheduled delivery for said chart
3. Go to settings, scheduled deliveries page