### PR TITLE
fix: treemap not displaying upper label

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
@@ -107,6 +107,12 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
                 gapWidth: 4,
                 borderRadius: 4,
             },
+            upperLabel: {
+                show: true,
+                height: 30,
+                formatter: '{b}',
+                padding: [4, 8],
+            },
             label: {
                 show: true,
                 formatter: (params) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #18121

### Description:

Fix regression introduced in #17830 where not all dimensions where displayed.

_after_
![image.png](https://app.graphite.com/user-attachments/assets/55b41b94-50c4-433a-8bd1-98018558f6f2.png)

_before_

![image.png](https://app.graphite.com/user-attachments/assets/da03e4c1-d7b0-433b-b2cf-d6b53668b9e5.png)

