### PR TITLE
style: make SD settings section match the list

### DIFF
--- a/packages/frontend/src/components/SettingsScheduler/SchedulerSettingsForm.tsx
+++ b/packages/frontend/src/components/SettingsScheduler/SchedulerSettingsForm.tsx
@@ -41,14 +41,18 @@ export const SchedulerSettingsForm: FC<Props> = ({
                             <Tooltip
                                 maw={400}
                                 label={
-                                    <Text fw={400}>
+                                    <Text fz="xs">
                                         Default time zone for the project's
                                         scheduled deliveries
                                     </Text>
                                 }
                                 multiline
                             >
-                                <MantineIcon icon={IconHelp} color="gray.6" />
+                                <MantineIcon
+                                    icon={IconHelp}
+                                    color="gray.6"
+                                    size="sm"
+                                />
                             </Tooltip>
                         </Group>
                     }

--- a/packages/frontend/src/components/SettingsScheduler/index.tsx
+++ b/packages/frontend/src/components/SettingsScheduler/index.tsx
@@ -53,7 +53,7 @@ const SettingsScheduler: FC<SettingsSchedulerProps> = ({ projectUuid }) => {
             <LoadingOverlay visible={isLoadingProject} />
             <Card>
                 <Group justify="space-between">
-                    <Title order={4}>Settings</Title>
+                    <Title order={5}>Settings</Title>
 
                     <SchedulerSettingsForm
                         isLoading={false}


### PR DESCRIPTION
### Description:

Minor style updates to make Scheduled Delivery settings match the rest of the page
- Change header size
- Change tool tip size to match other tooltips on this page

**Before**
<img width="869" height="528" alt="Screenshot 2025-11-14 at 15 56 13" src="https://github.com/user-attachments/assets/53230a4f-113c-477d-ac3c-420259f77a71" />

**After**
<img width="857" height="616" alt="Screenshot 2025-11-14 at 15 55 40" src="https://github.com/user-attachments/assets/bda1d674-e000-4756-8ea2-a886ad783a68" />
