### PR TITLE
feat: show latest SD run status

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -2,6 +2,8 @@ import {
     assertUnreachable,
     SchedulerFormat,
     SchedulerJobStatus,
+    type SchedulerAndTargets,
+    type SchedulerRun,
     type SchedulerWithLogs,
 } from '@lightdash/common';
 import { Tooltip, type MantineTheme } from '@mantine-8/core';
@@ -19,7 +21,9 @@ import { GSheetsIconFilled } from '../../components/common/GSheetsIcon';
 import MantineIcon from '../common/MantineIcon';
 import { IconBox } from '../common/ResourceIcon';
 
-export type SchedulerItem = SchedulerWithLogs['schedulers'][number];
+export type SchedulerItem = SchedulerAndTargets & {
+    latestRun?: SchedulerRun | null;
+};
 export type Log = SchedulerWithLogs['logs'][number];
 
 export type SchedulerColumnName =


### PR DESCRIPTION
### Description:

Show the last run status for each scheduler on the main scheduler list.

<img width="912" height="488" alt="Screenshot 2025-11-17 at 20 28 50" src="https://github.com/user-attachments/assets/55b23bf0-846e-48ef-b6f0-6050cb25f081" />

