### PR TITLE
refactor: replace applyCustomFormat with formatItemValue in metric visualization components

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -2,7 +2,7 @@ import {
     ComparisonFormatTypes,
     MetricExplorerComparison,
     TimeFrames,
-    applyCustomFormat,
+    formatItemValue,
     type MetricExploreDataPointWithDateValue,
     type MetricExplorerDateRange,
     type MetricExplorerQuery,
@@ -231,14 +231,11 @@ const TooltipEntry: FC<{
 
     const formattedValue = useMemo(() => {
         if (entry.name === 'metric') {
-            return applyCustomFormat(
-                entryData?.value,
-                props.formatConfig.metric,
-            );
+            return formatItemValue(props.formatConfig.metric, entryData?.value);
         }
-        return applyCustomFormat(
+        return formatItemValue(
+            props.formatConfig.compareMetric ?? undefined,
             entryData?.value,
-            props.formatConfig.compareMetric,
         );
     }, [
         entry.name,

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -1,8 +1,8 @@
 import {
     MetricExplorerComparison,
-    applyCustomFormat,
     assertUnreachable,
     capitalize,
+    formatItemValue,
     friendlyName,
     getCustomFormat,
     type MetricExploreDataPointWithDateValue,
@@ -357,15 +357,16 @@ const MetricsVisualization: FC<Props> = ({
 
     const formatConfig = useMemo<MetricVisualizationFormatConfig>(() => {
         return {
-            metric: getCustomFormat(results?.metric),
-            compareMetric: getCustomFormat(results?.compareMetric ?? undefined),
+            metric: results?.metric,
+            compareMetric: results?.compareMetric,
         };
     }, [results]);
 
     const shouldSplitYAxis = useMemo(() => {
         return (
             query.comparison === MetricExplorerComparison.DIFFERENT_METRIC &&
-            formatConfig.compareMetric !== formatConfig.metric
+            getCustomFormat(formatConfig.compareMetric ?? undefined) !==
+                getCustomFormat(formatConfig.metric)
         );
     }, [query.comparison, formatConfig]);
 
@@ -695,9 +696,9 @@ const MetricsVisualization: FC<Props> = ({
                                         : undefined
                                 }
                                 tickFormatter={(value) => {
-                                    return applyCustomFormat(
-                                        value,
+                                    return formatItemValue(
                                         formatConfig.metric,
+                                        value,
                                     );
                                 }}
                                 style={{ userSelect: 'none' }}
@@ -780,9 +781,10 @@ const MetricsVisualization: FC<Props> = ({
                                             width={rightYAxisWidth}
                                             {...commonYAxisConfig}
                                             tickFormatter={(value) => {
-                                                return applyCustomFormat(
+                                                return formatItemValue(
+                                                    formatConfig.compareMetric ??
+                                                        undefined,
                                                     value,
-                                                    formatConfig.compareMetric,
                                                 );
                                             }}
                                             style={{ userSelect: 'none' }}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/types.ts
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/types.ts
@@ -1,4 +1,4 @@
-import type { CustomFormat } from '@lightdash/common';
+import type { MetricWithAssociatedTimeDimension } from '@lightdash/common';
 import dayjs from 'dayjs';
 
 export const DATE_FORMATS = {
@@ -15,6 +15,6 @@ export const DATE_FORMATS = {
 export const COMPARISON_OPACITY = 0.3;
 
 export type MetricVisualizationFormatConfig = {
-    metric: CustomFormat | undefined;
-    compareMetric: CustomFormat | undefined;
+    metric: MetricWithAssociatedTimeDimension | undefined;
+    compareMetric: MetricWithAssociatedTimeDimension | null | undefined;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18076

### Description:
Refactored the metric formatting approach in the metrics visualization components. Instead of passing around CustomFormat objects, we now pass the entire MetricWithAssociatedTimeDimension objects and use the `formatItemValue` function instead of `applyCustomFormat`. This change maintains the same functionality while making the code more consistent with our formatting patterns.

The PR updates both the MetricExploreTooltip and MetricsVisualization components to use the new approach, ensuring proper value formatting in charts and tooltips.

### Before:
<img width="1036" height="675" alt="Screenshot 2025-11-14 at 16 55 59" src="https://github.com/user-attachments/assets/b02f9402-cdbc-4479-b09b-1dc37c582dc4" />


### After:
<img width="1040" height="682" alt="Screenshot 2025-11-14 at 16 55 28" src="https://github.com/user-attachments/assets/854973fd-0315-46d0-b968-f2081693abb3" />
