### PR TITLE
fix: custom metric sql templates and filters not updated on rename

### DIFF
--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -536,7 +536,10 @@ export class RenameService extends BaseService {
                                 ...field,
                                 name: to,
                             }),
-                            fromReference: getFieldRef(field),
+                            fromReference: getFieldRef({
+                                ...field,
+                                name: from,
+                            }),
                             toReference: getFieldRef({
                                 ...field,
                                 name: to,
@@ -544,6 +547,10 @@ export class RenameService extends BaseService {
                             fromFieldName: from,
                             toFieldName: to,
                         };
+
+                        this.logger.info(
+                            `field.name="${field.name}", fieldInExplore="${fieldInExplore}", fromReference="${nameChanges.fromReference}", fromFieldName="${nameChanges.fromFieldName}"`,
+                        );
 
                         this.logger.debug(
                             `Rename resources: Renaming field id "${nameChanges.from}" to "${nameChanges.to}"`,


### PR DESCRIPTION
### Description:
when renaming a field, custom metric sql templates and filter `fieldRef` values were not being updated if the db project was deployed before running rename command. 
We were constructing the `fromReference` using the field name from the explore metadata. When the project was updated before running rename command, the explore already contained the new field name. This caused `fromReference` to be set to the new name instead of the old name, preventing the string matching from finding the old field referenced in charts