### PR TITLE
fix: use threshold_uuid parameter for scheduler links with thresholds

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -99,13 +99,18 @@ export const getLogStatusIcon = (log: Log, theme: MantineTheme) => {
 };
 
 export const getSchedulerLink = (item: SchedulerItem, projectUuid: string) => {
+    const paramName =
+        item.thresholds && item.thresholds.length > 0
+            ? 'threshold_uuid'
+            : 'scheduler_uuid';
+
     return item.savedChartUuid
         ? `/projects/${projectUuid}/saved/${
               item.savedChartUuid
-          }/view/?scheduler_uuid=${item.schedulerUuid}${
+          }/view/?${paramName}=${item.schedulerUuid}${
               item.format === SchedulerFormat.GSHEETS ? `&isSync=true` : ``
           }`
-        : `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view/?scheduler_uuid=${item.schedulerUuid}`;
+        : `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view/?${paramName}=${item.schedulerUuid}`;
 };
 export const getItemLink = (item: SchedulerItem, projectUuid: string) => {
     return item.savedChartUuid


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18056

### Description:
Updated the scheduler link generation to use the appropriate parameter name based on whether the scheduler item has thresholds. If thresholds are present, the URL will use `threshold_uuid` instead of `scheduler_uuid` as the parameter name.

This change ensures that threshold-based schedulers are properly linked and can be accessed with the correct URL parameter.