### PR TITLE
fix: lightdash server crash when client fetch channels from big workspace

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -129,7 +129,7 @@ const DEFAULT_VALUES_ALERT = {
     notificationFrequency: NotificationFrequency.ONCE,
 };
 
-const MAX_SLACK_CHANNELS = 100000;
+const INITIAL_CHANNELS_LIMIT = 200; // Must match backend INITIAL_CHANNELS_LIMIT
 
 const thresholdOperatorOptions = [
     { label: 'is greater than', value: ThresholdOperator.GREATER_THAN },
@@ -555,8 +555,10 @@ const SchedulerForm: FC<Props> = ({
             .concat(privateChannels);
     }, [slackChannelsQuery?.data, privateChannels]);
 
-    let responsiveChannelsSearchEnabled =
-        slackChannels.length >= MAX_SLACK_CHANNELS || search.length > 0; // enable responvive channel search if there are more than MAX_SLACK_CHANNELS defined channels
+    // Always enable debounced search to reduce API calls
+    // With the 200 initial channel limit, search is needed to find specific channels
+    const responsiveChannelsSearchEnabled =
+        slackChannels.length >= INITIAL_CHANNELS_LIMIT || search.length > 0;
 
     const handleSendNow = useCallback(() => {
         if (form.isValid()) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8839

### Description:

This PR improves fetching slack channel list. It keeps backward compatibility with current endpoint but limits the returning list of channels to avoid crashing the ui

Ideally we would be using [conversation.search](https://docs.slack.dev/reference/methods/admin.conversations.search/) endpoint to search over channels, but this requires a new scope + reinstalling slack installations, which we want to avoid.

As we save cache in memory, another solution could be loading the cache in background after first response, do not block the UI while we load all channels