### PR TITLE
feat: add scrollable chart option for category axes

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -304,6 +304,7 @@ type Axis = {
 
 export type XAxis = Axis & {
     sortType?: XAxisSortType;
+    enableDataZoom?: boolean;
 };
 
 export enum XAxisSortType {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -74,6 +74,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setShowAxisTicks,
         setXAxisSort,
         setXAxisLabelRotation,
+        setScrollableChart,
         dirtyChartType,
     } = visualizationConfig.chartConfig;
 
@@ -229,6 +230,19 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             </Group>
                         )}
                     </Group>
+
+                    {getAxisTypeFromField(xAxisField) === 'category' && (
+                        <Checkbox
+                            label="Enable scrollable chart"
+                            checked={
+                                dirtyEchartsConfig?.xAxis?.[0]
+                                    ?.enableDataZoom || false
+                            }
+                            onChange={(e) =>
+                                setScrollableChart(e.currentTarget.checked)
+                            }
+                        />
+                    )}
                 </Config.Section>
             </Config>
 

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -406,6 +406,15 @@ const useCartesianChartConfig = ({
             };
         });
     }, []);
+    const setScrollableChart = useCallback((enableDataZoom: boolean) => {
+        setDirtyEchartsConfig((prevState) => {
+            const [firstAxis, ...axes] = prevState?.xAxis || [];
+            return {
+                ...prevState,
+                xAxis: [{ ...firstAxis, enableDataZoom }, ...axes],
+            };
+        });
+    }, []);
     const addSingleSeries = useCallback((yField: string) => {
         setDirtyLayout((prev) => ({
             ...prev,
@@ -1065,6 +1074,7 @@ const useCartesianChartConfig = ({
         setShowAxisTicks,
         setXAxisSort,
         setXAxisLabelRotation,
+        setScrollableChart,
         updateSeries,
         referenceLines,
         setReferenceLines,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -66,6 +66,7 @@ import {
     type ResultRow,
     type Series,
     type TableCalculation,
+    type XAxis,
 } from '@lightdash/common';
 import { getLegendStyle } from '@lightdash/common/src/visualizations/helpers/styles/legendStyles';
 import { useMantineTheme } from '@mantine/core';
@@ -1573,6 +1574,19 @@ const getEchartAxes = ({
                             formatter: '{value}%',
                         },
                     }),
+                // Override axisLabel settings when scrollable is enabled (not flipped)
+                ...(!validCartesianConfig.layout.flipAxes &&
+                    (xAxisConfiguration?.[0] as XAxis | undefined)
+                        ?.enableDataZoom &&
+                    bottomAxisType === 'category' &&
+                    showXAxis && {
+                        axisLabel: {
+                            ...(bottomAxisConfigWithStyle.axisLabel || {}),
+                            interval: 0,
+                            // Keep hideOverlap true to avoid overlapping when labels are long on X axis
+                            hideOverlap: true,
+                        },
+                    }),
                 inverse: !!xAxisConfiguration?.[0].inverse,
                 ...bottomAxisExtraConfig,
                 min: bottomAxisBounds.min,
@@ -1662,6 +1676,19 @@ const getEchartAxes = ({
                     showYAxis && {
                         axisLabel: {
                             formatter: '{value}%',
+                        },
+                    }),
+                // Override axisLabel settings when scrollable is enabled and axes are flipped
+                ...(validCartesianConfig.layout.flipAxes &&
+                    (yAxisConfiguration?.[0] as XAxis | undefined)
+                        ?.enableDataZoom &&
+                    leftAxisType === 'category' &&
+                    showYAxis && {
+                        axisLabel: {
+                            ...(leftAxisConfigWithStyle.axisLabel || {}),
+                            interval: 0,
+                            // Set hideOverlap to false to avoid hiding labels
+                            hideOverlap: false,
                         },
                     }),
                 splitLine: validCartesianConfig.layout.flipAxes
@@ -2357,6 +2384,10 @@ const useEchartsCartesianConfig = (
     ]);
 
     const currentGrid = useMemo(() => {
+        const enableDataZoom =
+            validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.enableDataZoom;
+        const flipAxes = validCartesianConfig?.layout?.flipAxes;
+
         const grid = {
             ...defaultGrid,
             ...removeEmptyProperties(validCartesianConfig?.eChartsConfig.grid),
@@ -2364,6 +2395,7 @@ const useEchartsCartesianConfig = (
 
         const gridLeft = grid.left;
         const gridRight = grid.right;
+        const gridBottom = grid.bottom;
 
         // Check if any series has a markLine (reference line) and determine label positions
         let maxLeftLabelLength = 0;
@@ -2429,15 +2461,33 @@ const useEchartsCartesianConfig = (
                       extraLeftPadding
                   }px`
                 : grid.left,
-            right: gridRight.includes('px')
-                ? `${
-                      parseInt(gridRight.replace('px', '')) +
-                      defaultAxisLabelGap +
-                      extraRightPadding
-                  }px`
-                : grid.right,
+            right:
+                gridRight.includes('px') && !enableDataZoom
+                    ? `${
+                          parseInt(gridRight.replace('px', '')) +
+                          defaultAxisLabelGap +
+                          extraRightPadding
+                      }px`
+                    : gridRight.includes('px') && enableDataZoom && flipAxes
+                    ? `${
+                          parseInt(gridRight.replace('px', '')) +
+                          defaultAxisLabelGap +
+                          extraRightPadding +
+                          30
+                      }px`
+                    : grid.right,
+            // Add extra bottom spacing for dataZoom slider when not flipped
+            bottom:
+                enableDataZoom && !flipAxes && gridBottom.includes('px')
+                    ? `${parseInt(gridBottom.replace('px', '')) + 30}px`
+                    : grid.bottom,
         };
-    }, [validCartesianConfig?.eChartsConfig.grid, series]);
+    }, [
+        validCartesianConfig?.eChartsConfig.grid,
+        validCartesianConfig?.eChartsConfig?.xAxis,
+        validCartesianConfig?.layout?.flipAxes,
+        series,
+    ]);
 
     const { tooltip: legendDoubleClickTooltip } = useLegendDoubleClickTooltip();
 
@@ -2472,6 +2522,10 @@ const useEchartsCartesianConfig = (
     ]);
 
     const eChartsOptions = useMemo(() => {
+        const enableDataZoom =
+            validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.enableDataZoom;
+        const flipAxes = validCartesianConfig?.layout?.flipAxes;
+
         return {
             xAxis: axes.xAxis,
             yAxis: axes.yAxis,
@@ -2490,6 +2544,28 @@ const useEchartsCartesianConfig = (
             },
             // We assign colors per series, so we specify an empty list here.
             color: [],
+            ...(enableDataZoom && {
+                dataZoom: [
+                    {
+                        type: 'slider',
+                        show: true,
+                        [flipAxes ? 'yAxisIndex' : 'xAxisIndex']: 0,
+                        startValue: 0,
+                        endValue: 10,
+                        brushSelect: false,
+                        zoomLock: true,
+                        minValueSpan: 5,
+                        maxValueSpan: 30,
+                        // Reduce scroll bar size
+                        ...(flipAxes && {
+                            width: 20,
+                        }),
+                        ...(!flipAxes && {
+                            height: 20,
+                        }),
+                    },
+                ],
+            }),
         };
     }, [
         axes,
@@ -2501,6 +2577,7 @@ const useEchartsCartesianConfig = (
         tooltip,
         currentGrid,
         theme?.other.chartFont,
+        validCartesianConfig,
     ]);
 
     if (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-147/make-charts-scrollable-instead-of-removing-categorical-labels


DataZoom Configuration (useEchartsCartesianConfig.ts:2522-2536)

  - Configured ECharts dataZoom slider component:
    - startValue: 0, endValue: 14 - Shows 15 categories initially
    - minValueSpan: 5 - Minimum 5 categories visible
    - maxValueSpan: 30 - Maximum 30 categories when zooming out
    - zoomLock: true - Prevents zooming, only scrolling
    - Automatically handles both normal and flipped axes

[Screencast from 2025-11-17 11-49-36.webm](https://github.com/user-attachments/assets/db605f26-aeec-4604-8b5c-76a58c8c22de)

[Screencast from 2025-11-17 11-51-50.webm](https://github.com/user-attachments/assets/73e38474-22e0-4d44-bd32-74b2c5db9438)

[Screencast from 2025-11-17 12-55-14.webm](https://github.com/user-attachments/assets/78cc57d9-ba37-44ac-9184-a99b0606215f)


### Description:
Added a new feature to enable scrollable charts for categorical x-axes. This adds a checkbox in the chart configuration panel that allows users to enable a data zoom slider for better navigation of charts with many categories.

The implementation:
- Added `enableDataZoom` property to the XAxis type
- Added a checkbox in the Axes configuration panel to toggle the scrollable feature
- Implemented the `setXAxisScrollable` function to update the chart configuration
- Configured the ECharts dataZoom component with appropriate default settings
- Adjusted axis label display when scrolling is enabled to prevent label overlap

![Screenshot of scrollable chart feature](https://placeholder-for-screenshot.png)