### PR TITLE
chore: enforce lodash method imports with ESLint plugin

### DIFF
--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
         'jest-dom',
         'testing-library',
         'react-refresh',
+        'lodash',
     ],
 
     settings: {
@@ -110,5 +111,6 @@ module.exports = {
             },
         ],
         'react-refresh/only-export-components': 'error',
+        'lodash/import-scope': [2, 'method'],
     },
 };

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -82,6 +82,7 @@
         "echarts-for-react": "3.0.2",
         "echarts-for-react-6": "npm:echarts-for-react@3.0.1",
         "emoji-picker-react": "^4.12.0",
+        "eslint-plugin-lodash": "^8.0.0",
         "fastest-levenshtein": "^1.0.16",
         "fuse.js": "^6.5.3",
         "hast": "^1.0.0",

--- a/packages/frontend/src/ee/components/UserAccessMultiSelect.tsx
+++ b/packages/frontend/src/ee/components/UserAccessMultiSelect.tsx
@@ -18,7 +18,7 @@ import {
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconInfoCircle } from '@tabler/icons-react';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import { LightdashUserAvatar } from '../../components/Avatar';
 import MantineIcon from '../../components/common/MantineIcon';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiProposeChangeToolCall/ChangeRenderer.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
-import { toPairs } from 'lodash';
+import toPairs from 'lodash/toPairs';
 import FieldIcon from '../../../../../../../components/common/Filters/FieldIcon';
 import MantineIcon from '../../../../../../../components/common/MantineIcon';
 import { OperationRenderer } from './OperationRenderer';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -960,6 +960,9 @@ importers:
       emoji-picker-react:
         specifier: ^4.12.0
         version: 4.12.0(react@19.2.0)
+      eslint-plugin-lodash:
+        specifier: ^8.0.0
+        version: 8.0.0(eslint@8.57.1)
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
@@ -1179,28 +1182,28 @@ importers:
         version: 4.4.1(vite@7.1.10(@types/node@24.3.1)(lightningcss@1.22.0)(tsx@4.19.4)(yaml@2.7.0))
       eslint-plugin-css-modules:
         specifier: ^2.11.0
-        version: 2.11.0(eslint@9.35.0)
+        version: 2.11.0(eslint@8.57.1)
       eslint-plugin-jest-dom:
         specifier: ^5.1.0
-        version: 5.1.0(@testing-library/dom@10.4.0)(eslint@9.35.0)
+        version: 5.1.0(@testing-library/dom@10.4.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y:
         specifier: ^6.6.1
-        version: 6.6.1(eslint@9.35.0)
+        version: 6.6.1(eslint@8.57.1)
       eslint-plugin-react:
         specifier: 7.32.2
-        version: 7.32.2(eslint@9.35.0)
+        version: 7.32.2(eslint@8.57.1)
       eslint-plugin-react-hooks:
         specifier: ^5.1.0
-        version: 5.1.0(eslint@9.35.0)
+        version: 5.1.0(eslint@8.57.1)
       eslint-plugin-react-refresh:
         specifier: ^0.4.16
-        version: 0.4.16(eslint@9.35.0)
+        version: 0.4.16(eslint@8.57.1)
       eslint-plugin-storybook:
         specifier: ^0.11.4
-        version: 0.11.4(eslint@9.35.0)(typescript@5.7.2)
+        version: 0.11.4(eslint@8.57.1)(typescript@5.7.2)
       eslint-plugin-testing-library:
         specifier: ^6.2.0
-        version: 6.2.0(eslint@9.35.0)(typescript@5.7.2)
+        version: 6.2.0(eslint@8.57.1)(typescript@5.7.2)
       isomorphic-fetch:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -10555,6 +10558,12 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
 
+  eslint-plugin-lodash@8.0.0:
+    resolution: {integrity: sha512-7DA8485FolmWRzh+8t4S8Pzin2TTuWfb0ZW3j/2fYElgk82ZanFz8vDcvc4BBPceYdX1p/za+tkbO68maDBGGw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: '>=9.0.0'
+
   eslint-plugin-prettier@4.2.1:
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
@@ -19617,7 +19626,7 @@ snapshots:
       '@babel/traverse': 7.26.4
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19637,7 +19646,7 @@ snapshots:
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.0
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19737,6 +19746,13 @@ snapshots:
       semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.24.7':
+    dependencies:
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.28.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.24.7(supports-color@5.5.0)':
     dependencies:
@@ -19988,6 +20004,18 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
 
+  '@babel/traverse@7.25.6':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.28.0
+      '@babel/parser': 7.28.0
+      '@babel/template': 7.25.0
+      '@babel/types': 7.28.2
+      debug: 4.4.0(supports-color@8.1.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/traverse@7.25.6(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -20019,7 +20047,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.0
       '@babel/types': 7.28.2
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -20245,7 +20273,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.10.6':
     dependencies:
-      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.24.7
       '@babel/runtime': 7.27.0
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
@@ -20700,11 +20728,6 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.35.0)':
-    dependencies:
-      eslint: 9.35.0
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.0(eslint@9.35.0)':
     dependencies:
       eslint: 9.35.0
@@ -20729,7 +20752,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.2.0
@@ -21106,7 +21129,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -26915,7 +26938,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.5.4)
     optionalDependencies:
@@ -26947,7 +26970,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -26961,7 +26984,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -27031,28 +27054,28 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@9.35.0)(typescript@5.7.2)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.35.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
       '@types/json-schema': 7.0.9
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.2)
-      eslint: 9.35.0
+      eslint: 8.57.1
       eslint-scope: 5.1.1
       semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.26.1(eslint@9.35.0)(typescript@5.7.2)':
+  '@typescript-eslint/utils@8.26.1(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.35.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.26.1
       '@typescript-eslint/types': 8.26.1
       '@typescript-eslint/typescript-estree': 8.26.1(typescript@5.7.2)
-      eslint: 9.35.0
+      eslint: 8.57.1
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -27435,7 +27458,7 @@ snapshots:
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -28831,7 +28854,7 @@ snapshots:
       '@actions/core': 1.11.1
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.47.9(@babel/core@7.28.4)
       globby: 11.1.0
@@ -29832,9 +29855,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-css-modules@2.11.0(eslint@9.35.0):
+  eslint-plugin-css-modules@2.11.0(eslint@8.57.1):
     dependencies:
-      eslint: 9.35.0
+      eslint: 8.57.1
       gonzales-pe: 4.3.0
       lodash: 4.17.21
 
@@ -29861,10 +29884,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest-dom@5.1.0(@testing-library/dom@10.4.0)(eslint@9.35.0):
+  eslint-plugin-jest-dom@5.1.0(@testing-library/dom@10.4.0)(eslint@8.57.1):
     dependencies:
       '@babel/runtime': 7.23.9
-      eslint: 9.35.0
+      eslint: 8.57.1
       requireindex: 1.2.0
     optionalDependencies:
       '@testing-library/dom': 10.4.0
@@ -29902,22 +29925,10 @@ snapshots:
       minimatch: 3.1.2
       semver: 6.3.1
 
-  eslint-plugin-jsx-a11y@6.6.1(eslint@9.35.0):
+  eslint-plugin-lodash@8.0.0(eslint@8.57.1):
     dependencies:
-      '@babel/runtime': 7.23.9
-      aria-query: 4.2.2
-      array-includes: 3.1.5
-      ast-types-flow: 0.0.7
-      axe-core: 4.4.3
-      axobject-query: 2.2.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 9.35.0
-      has: 1.0.3
-      jsx-ast-utils: 3.3.3
-      language-tags: 1.0.5
-      minimatch: 3.1.2
-      semver: 6.3.1
+      eslint: 8.57.1
+      lodash: 4.17.21
 
   eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.5.0(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.1):
     dependencies:
@@ -29931,17 +29942,17 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-react-hooks@5.1.0(eslint@9.35.0):
+  eslint-plugin-react-hooks@5.1.0(eslint@8.57.1):
     dependencies:
-      eslint: 9.35.0
+      eslint: 8.57.1
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.35.0):
     dependencies:
       eslint: 9.35.0
 
-  eslint-plugin-react-refresh@0.4.16(eslint@9.35.0):
+  eslint-plugin-react-refresh@0.4.16(eslint@8.57.1):
     dependencies:
-      eslint: 9.35.0
+      eslint: 8.57.1
 
   eslint-plugin-react-refresh@0.4.20(eslint@9.35.0):
     dependencies:
@@ -29966,30 +29977,11 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
 
-  eslint-plugin-react@7.32.2(eslint@9.35.0):
-    dependencies:
-      array-includes: 3.1.8
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      eslint: 9.35.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.3
-      minimatch: 3.1.2
-      object.entries: 1.1.8
-      object.fromentries: 2.0.8
-      object.hasown: 1.1.4
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-
-  eslint-plugin-storybook@0.11.4(eslint@9.35.0)(typescript@5.7.2):
+  eslint-plugin-storybook@0.11.4(eslint@8.57.1)(typescript@5.7.2):
     dependencies:
       '@storybook/csf': 0.1.13
-      '@typescript-eslint/utils': 8.26.1(eslint@9.35.0)(typescript@5.7.2)
-      eslint: 9.35.0
+      '@typescript-eslint/utils': 8.26.1(eslint@8.57.1)(typescript@5.7.2)
+      eslint: 8.57.1
       ts-dedent: 2.2.0
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -30003,10 +29995,10 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-testing-library@6.2.0(eslint@9.35.0)(typescript@5.7.2):
+  eslint-plugin-testing-library@6.2.0(eslint@8.57.1)(typescript@5.7.2):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@9.35.0)(typescript@5.7.2)
-      eslint: 9.35.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.2)
+      eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -30045,7 +30037,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.5
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -30563,7 +30555,7 @@ snapshots:
       '@actions/core': 1.11.1
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       find-test-names: 1.29.5(@babel/core@7.28.4)
       globby: 11.1.0
       minimatch: 3.1.2
@@ -31455,7 +31447,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31475,7 +31467,7 @@ snapshots:
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -36453,7 +36445,7 @@ snapshots:
   spec-change@1.11.11:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0(supports-color@8.1.1)
       deep-equal: 2.2.3
       dependency-tree: 11.0.1
       lazy-ass: 2.0.3


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Enforces lodash method imports to reduce bundle size. This PR:

1. Adds the `eslint-plugin-lodash` dependency
2. Configures ESLint to enforce method imports with the rule `'lodash/import-scope': [2, 'method']`
3. Updates existing imports from `import { isEmpty } from 'lodash'` to `import isEmpty from 'lodash/isEmpty'` pattern

This is to keep both frontend and SDK bundle size low