### PR TITLE
fix(frontend): remove verified answers feature flag

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -33,10 +33,7 @@ import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { useSetArtifactVersionVerified } from '../../hooks/useAiAgentArtifacts';
 import { useAiAgentPermission } from '../../hooks/useAiAgentPermission';
-import {
-    useProjectAiAgent,
-    useSavePromptQuery,
-} from '../../hooks/useProjectAiAgents';
+import { useSavePromptQuery } from '../../hooks/useProjectAiAgents';
 import { getOpenInExploreUrl } from '../../utils/getOpenInExploreUrl';
 
 type Props = {
@@ -88,12 +85,10 @@ export const AiChartQuickOptions = ({
         action: 'manage',
         projectUuid,
     });
-    const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
     const metricQuery = resultsData?.metricQuery;
     const type = chartConfig.type;
 
     const isVerified = artifactData?.verifiedByUserUuid !== null;
-    const isAgentVersion3 = agent?.version === 3;
 
     const isDisabled = !metricQuery || !type || !visualizationConfig;
     const onSaveChart = (savedData: SavedChart) => {
@@ -194,7 +189,7 @@ export const AiChartQuickOptions = ({
 
     return (
         <Fragment>
-            {artifactData && canManageAgent && isAgentVersion3 && (
+            {artifactData && canManageAgent && (
                 <Tooltip
                     label={
                         isVerified

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -317,7 +317,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                 Evals
                             </Button>
                         )}
-                        {!isCreateMode && agent?.version === 3 && (
+                        {!isCreateMode && (
                             <Button
                                 variant={
                                     activeTab === 'verified-artifacts'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removed version check for AI agent features, making the "Verify" button in AiChartQuickOptions and the "Verified Artifacts" tab in ProjectAiAgentEditPage available for all agent versions, not just version 3. Also removed the unused `useProjectAiAgent` import and `agent` data fetch.
