### PR TITLE
fix: change greater than to greater than or equal in chart filter condition

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2147,7 +2147,7 @@ const useEchartsCartesianConfig = (
                       const isGreaterThan =
                           min === undefined ||
                           typeof min !== 'string' ||
-                          value > min;
+                          value >= min;
 
                       return isGreaterThan;
                   })


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18142

### Description:
Fixed a bug in the chart filtering logic where values equal to the minimum were being excluded. Changed the comparison operator from `>` to `>=` to include values that are equal to the minimum threshold.