### PR TITLE
chore: add index for scheduler job group

### DIFF
--- a/packages/backend/src/database/migrations/20251117182514_add_delivery_job_group_index.ts
+++ b/packages/backend/src/database/migrations/20251117182514_add_delivery_job_group_index.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+const SchedulerLogTableName = 'scheduler_log';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(SchedulerLogTableName)) {
+        await knex.schema.alterTable(SchedulerLogTableName, (table) => {
+            // Add composite index on (job_group, job_id)
+            table.index(['job_group', 'job_id']);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(SchedulerLogTableName)) {
+        await knex.schema.alterTable(SchedulerLogTableName, (table) => {
+            table.dropIndex(['job_group', 'job_id']);
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Add composite index on (job_group, job_id) to optimize:
- WHERE job_group = ? queries (e.g., fetching all jobs in a run)
- GROUP BY job_group operations (e.g., aggregating child job counts) 
- Combined filtering on job_group and job_id
