### PR TITLE
fix: disable embeddings in AI agent integration tests

### DIFF
--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -228,6 +228,9 @@ jobs:
                   DBT_DEMO_DIR: ${{ github.workspace }}/examples/full-jaffle-shop-demo
                   LD_SETUP_DBT_VERSION: v1.7
                   SKIP_TEST_MIGRATIONS: 'true'
+                  # TODO :: Support embeddings (Verifying Answers)
+                  AI_EMBEDDING_ENABLED: false
+                  AI_DEFAULT_EMBEDDING_PROVIDER: 'openai'
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -636,10 +636,7 @@ export const getAiConfig = () => ({
     embeddingEnabled: process.env.AI_EMBEDDING_ENABLED === 'true',
     defaultProvider:
         process.env.AI_DEFAULT_PROVIDER || DEFAULT_DEFAULT_AI_PROVIDER,
-    defaultEmbeddingModelProvider:
-        process.env.AI_DEFAULT_EMBEDDING_PROVIDER ||
-        process.env.AI_DEFAULT_PROVIDER ||
-        DEFAULT_DEFAULT_AI_PROVIDER,
+    defaultEmbeddingModelProvider: process.env.AI_DEFAULT_EMBEDDING_PROVIDER,
     providers: {
         azure: process.env.AZURE_AI_API_KEY
             ? {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Disabled embeddings in AI agent integration tests by adding environment variables `AI_EMBEDDING_ENABLED: false` and `AI_DEFAULT_EMBEDDING_PROVIDER: 'openai'` to the workflow configuration. Added a TODO comment to support embeddings for verifying answers in the future.
