### PR TITLE
fix: remove streaming error check from retry condition

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -73,10 +73,8 @@ const AssistantBubbleContent: FC<{
     const mdStyle = useMdEditorStyle();
 
     const isPending = message.status === 'pending';
-    const hasStreamingError =
-        streamingState?.error && streamingState?.messageUuid === message.uuid;
     const hasNoResponse = !isStreaming && !message.message && !isPending;
-    const shouldShowRetry = hasStreamingError || hasNoResponse;
+    const shouldShowRetry = hasNoResponse;
 
     const baseMessageContent =
         isStreaming && streamingState


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Simplified the retry logic in the `AgentChatAssistantBubble` component by removing the streaming error condition. Now, the retry button will only appear when there is no response, rather than also showing when there's a streaming error.
