### PR TITLE
feat: dbt cloud project

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -5,9 +5,6 @@
  * If the feature flag is no longer in use, remove it from this enum.
  */
 export enum FeatureFlags {
-    /**/
-    ShowDbtCloudProjectOption = 'show-dbt-cloud-project-option',
-
     /* Show user groups */
     UserGroupsEnabled = 'user-groups-enabled',
 

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -2,12 +2,10 @@ import {
     assertUnreachable,
     DbtProjectType,
     DbtProjectTypeLabels,
-    FeatureFlags,
     WarehouseTypes,
 } from '@lightdash/common';
 import { Anchor, Select, Stack, TextInput } from '@mantine/core';
 import { useMemo, useState, type FC } from 'react';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import useApp from '../../providers/App/useApp';
 import AzureDevOpsForm from './DbtForms/AzureDevOpsForm';
 import BitBucketForm from './DbtForms/BitBucketForm';
@@ -55,9 +53,6 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
     const toggleAdvancedSettingsOpen = () =>
         setIsAdvancedSettingsOpen((open) => !open);
     const { health } = useApp();
-    const isEnabled = useFeatureFlagEnabled(
-        FeatureFlags.ShowDbtCloudProjectOption,
-    );
     const options = useMemo(() => {
         const enabledTypes = [
             DbtProjectType.GITHUB,
@@ -66,19 +61,17 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
             DbtProjectType.AZURE_DEVOPS,
             DbtProjectType.NONE,
             DbtProjectType.MANIFEST,
+            DbtProjectType.DBT_CLOUD_IDE,
         ];
         if (health.data?.localDbtEnabled) {
             enabledTypes.push(DbtProjectType.DBT);
-        }
-        if (isEnabled || type === DbtProjectType.DBT_CLOUD_IDE) {
-            enabledTypes.push(DbtProjectType.DBT_CLOUD_IDE);
         }
 
         return enabledTypes.map((value) => ({
             value,
             label: DbtProjectTypeLabels[value],
         }));
-    }, [isEnabled, health, type]);
+    }, [health]);
 
     const DbtForm = useMemo(() => {
         switch (type) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Removes the `ShowDbtCloudProjectOption` feature flag and makes the dbt Cloud IDE option permanently available in the project connection settings. Previously, this option was only shown if the feature flag was enabled or if the project was already using dbt Cloud IDE.

Context: https://lightdash.slack.com/archives/C04E1CCKN64/p1763370567169819