### PR TITLE
feat: key results cache on userUuid when using warehouse credentials

### DIFF
--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.test.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.test.ts
@@ -51,5 +51,63 @@ describe('QueryHistoryModel', () => {
             });
             expect(hash1).not.toBe(hash2);
         });
+
+        test('should generate same hash when userUuid is undefined (backward compatibility)', () => {
+            const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+            });
+            const hash2 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid: undefined,
+            });
+            expect(hash1).toBe(hash2);
+        });
+
+        test('should generate different hashes for different users', () => {
+            const userUuid1 = 'user-uuid-1';
+            const userUuid2 = 'user-uuid-2';
+            const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid: userUuid1,
+            });
+            const hash2 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid: userUuid2,
+            });
+            expect(hash1).not.toBe(hash2);
+        });
+
+        test('should generate same hash for same user', () => {
+            const userUuid = 'user-uuid-1';
+            const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid,
+            });
+            const hash2 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid,
+            });
+            expect(hash1).toBe(hash2);
+        });
+
+        test('should generate different hash with vs without user UUID', () => {
+            const userUuid = 'user-uuid-1';
+            const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+            });
+            const hash2 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid,
+            });
+            expect(hash1).not.toBe(hash2);
+        });
     });
 });

--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -64,12 +64,23 @@ export class QueryHistoryModel {
         resultsIdentifiers: {
             sql: string;
             timezone?: string;
+            userUuid?: string;
         },
     ) {
         const CACHE_VERSION = 'v3'; // change when we want to force invalidation
-        const queryHashKey = resultsIdentifiers.timezone
-            ? `${CACHE_VERSION}.${projectUuid}.${resultsIdentifiers.sql}.${resultsIdentifiers.timezone}`
-            : `${CACHE_VERSION}.${projectUuid}.${resultsIdentifiers.sql}`;
+        let queryHashKey = `${CACHE_VERSION}.${projectUuid}`;
+
+        // Include user UUID in cache key to prevent sharing cache between users
+        // when user-specific warehouse credentials are in use
+        if (resultsIdentifiers.userUuid) {
+            queryHashKey += `.${resultsIdentifiers.userUuid}`;
+        }
+
+        queryHashKey += `.${resultsIdentifiers.sql}`;
+
+        if (resultsIdentifiers.timezone) {
+            queryHashKey += `.${resultsIdentifiers.timezone}`;
+        }
 
         return crypto.createHash('sha256').update(queryHashKey).digest('hex');
     }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1787,11 +1787,16 @@ export class AsyncQueryService extends ProjectService {
                     }
 
                     // Generate cache key from project and query identifiers
+                    // Include user UUID to prevent cache sharing between users when user-specific credentials are in use
                     const cacheKey = QueryHistoryModel.getCacheKey(
                         projectUuid,
                         {
                             sql: query,
                             timezone: metricQuery.timezone,
+                            userUuid:
+                                warehouseCredentials.userWarehouseCredentialsUuid
+                                    ? account.user.id
+                                    : undefined,
                         },
                     );
 


### PR DESCRIPTION
This makes the query service write a query key including the user uuid when using warehouse credentials. 

The read operations are not changed, so effectively any cache result scoped to a user is never re-used, we could make this smarter in future.