### PR TITLE
feat: implement scorer functionality for AI Agent readiness evaluation

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/readinessScorer.ts
+++ b/packages/backend/src/ee/services/ai/agents/readinessScorer.ts
@@ -1,0 +1,60 @@
+import {
+    type Explore,
+    getFields,
+    ReadinessScore,
+    ScorerContext,
+} from '@lightdash/common';
+import { type LanguageModel } from 'ai';
+import clamp from 'lodash/clamp';
+import mean from 'lodash/mean';
+import sumBy from 'lodash/sumBy';
+import { evaluateExploreAnalysis } from './scorers/exploreAnalysisScorer';
+import { evaluateInstructionQuality } from './scorers/instructionQualityScorer';
+import { evaluateMetadataCompleteness } from './scorers/metadataCompletenessScorer';
+
+export async function evaluateAgentReadiness(
+    model: LanguageModel,
+    explores: Explore[],
+    agentInstructions: string | null,
+): Promise<ReadinessScore> {
+    const context: ScorerContext = {
+        explores,
+        agentInstructions,
+    };
+
+    const [metadataCompleteness, exploreAnalysis, instructionQuality] =
+        await Promise.all([
+            evaluateMetadataCompleteness(model, context),
+            evaluateExploreAnalysis(model, context),
+            evaluateInstructionQuality(model, context),
+        ]);
+
+    const overallScore = clamp(
+        Math.round(
+            mean([
+                metadataCompleteness.score,
+                exploreAnalysis.score,
+                instructionQuality.score,
+            ]),
+        ),
+        1,
+        5,
+    );
+
+    const projectSnapshot = {
+        exploreCount: context.explores.length,
+        fieldCount: sumBy(
+            context.explores,
+            (explore) => getFields(explore).length,
+        ),
+    };
+
+    return {
+        overallScore,
+        metadataCompleteness,
+        exploreAnalysis,
+        instructionQuality,
+        timestamp: new Date(),
+        projectSnapshot,
+    };
+}

--- a/packages/backend/src/ee/services/ai/agents/scorers/exploreAnalysisScorer.ts
+++ b/packages/backend/src/ee/services/ai/agents/scorers/exploreAnalysisScorer.ts
@@ -1,0 +1,19 @@
+import { ExploreAnalysisEvaluation, ScorerContext } from '@lightdash/common';
+import { type LanguageModel } from 'ai';
+
+/**
+ * Analyzes explore structure, naming, and field organization
+ * TODO: Implement - ZAP-123
+ */
+export async function evaluateExploreAnalysis(
+    model: LanguageModel,
+    context: ScorerContext,
+): Promise<ExploreAnalysisEvaluation> {
+    return {
+        score: 3,
+        recommendations: [
+            'Review explore naming conventions',
+            'Ensure appropriate field distribution',
+        ],
+    };
+}

--- a/packages/backend/src/ee/services/ai/agents/scorers/instructionQualityScorer.ts
+++ b/packages/backend/src/ee/services/ai/agents/scorers/instructionQualityScorer.ts
@@ -1,0 +1,19 @@
+import { InstructionQualityEvaluation, ScorerContext } from '@lightdash/common';
+import { type LanguageModel } from 'ai';
+
+/**
+ * Analyzes agent instruction quality and coverage
+ * TODO: Implement - ZAP-124
+ */
+export async function evaluateInstructionQuality(
+    model: LanguageModel,
+    context: ScorerContext,
+): Promise<InstructionQualityEvaluation> {
+    return {
+        score: 3,
+        recommendations: [
+            'Add agent instructions to guide AI behavior',
+            'Include specific explore references in instructions',
+        ],
+    };
+}

--- a/packages/backend/src/ee/services/ai/agents/scorers/metadataCompletenessScorer.ts
+++ b/packages/backend/src/ee/services/ai/agents/scorers/metadataCompletenessScorer.ts
@@ -1,0 +1,22 @@
+import {
+    MetadataCompletenessEvaluation,
+    ScorerContext,
+} from '@lightdash/common';
+import { type LanguageModel } from 'ai';
+
+/**
+ * Analyzes metadata completeness across explores and fields
+ * TODO: Implement - ZAP-122
+ */
+export async function evaluateMetadataCompleteness(
+    model: LanguageModel,
+    context: ScorerContext,
+): Promise<MetadataCompletenessEvaluation> {
+    return {
+        score: 3,
+        recommendations: [
+            'Add descriptions to fields',
+            'Add AI hints to explores',
+        ],
+    };
+}

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -28,6 +28,7 @@ export * from './filterExploreByTags';
 export * from './followUpTools';
 export * from './requestTypes';
 export * from './schemas';
+export * from './schemas/agentReadiness';
 export * from './types';
 export * from './utils';
 export * from './validators';

--- a/packages/common/src/ee/AiAgent/schemas/agentReadiness.ts
+++ b/packages/common/src/ee/AiAgent/schemas/agentReadiness.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import { type ApiSuccess } from '../../../types/api/success';
+import { type Explore } from '../../../types/explore';
+
+export interface ScorerContext {
+    explores: Explore[];
+    agentInstructions: string | null;
+}
+
+export const ScoreSchema = z
+    .number()
+    .min(1)
+    .max(5)
+    .describe(
+        'Score from 1-5 where 1=very poor, 2=poor, 3=fair, 4=good, 5=excellent',
+    );
+
+export const RecommendationsSchema = z
+    .array(z.string())
+    .min(2)
+    .max(5)
+    .describe(
+        'List of 2-5 specific, actionable recommendations for improvement',
+    );
+
+export const BaseScorerSchema = z.object({
+    score: ScoreSchema,
+    recommendations: RecommendationsSchema,
+});
+
+export type BaseScorerEvaluation = z.infer<typeof BaseScorerSchema>;
+
+export interface Scorer<
+    ScoreEvaluationResult extends BaseScorerEvaluation = BaseScorerEvaluation,
+> {
+    evaluate(context: ScorerContext): Promise<ScoreEvaluationResult>;
+}
+export type ReadinessScoreEvaluation = {
+    score: number;
+    recommendations: string[];
+};
+
+const ExploreAnalysisSchema = BaseScorerSchema;
+export type ExploreAnalysisEvaluation = z.infer<typeof ExploreAnalysisSchema>;
+
+const InstructionQualitySchema = BaseScorerSchema;
+export type InstructionQualityEvaluation = z.infer<
+    typeof InstructionQualitySchema
+>;
+
+const MetadataCompletenessSchema = BaseScorerSchema;
+
+export type MetadataCompletenessEvaluation = z.infer<
+    typeof MetadataCompletenessSchema
+>;
+
+export interface ReadinessScore {
+    overallScore: number;
+    metadataCompleteness: MetadataCompletenessEvaluation;
+    exploreAnalysis: ExploreAnalysisEvaluation;
+    instructionQuality: InstructionQualityEvaluation;
+    timestamp: Date;
+    projectSnapshot: {
+        exploreCount: number;
+        fieldCount: number;
+    };
+}
+
+export type ApiAgentReadinessScoreResponse = ApiSuccess<ReadinessScore>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: ZAP-121

### Description:
This PR implements the ReadinessScorer system for evaluating AI agent readiness. The implementation includes:

- A main `evaluateAgentReadiness` function that calculates an overall readiness score based on three categories
- Three **placeholder** specialized scorers with TODOs linked to future tickets:
  - `evaluateMetadataCompleteness` 
  - `evaluateExploreAnalysis` 
  - `evaluateInstructionQuality` 

The system calculates a 1-5 score for each category and provides specific recommendations for improvement. The overall score is the rounded average of the three category scores, clamped between 1-5. 