### PR TITLE
feat(CENG-144): allow date type parameters

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
+++ b/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
@@ -68,3 +68,17 @@ parameters:
       - "usd"
       - "eur"
       - "gbp"
+  date_dim_parameter:
+    label: A dimension date parameter
+    options_from_dimension:
+      dimension: order_date
+      model: orders
+    description: "The first date in comparing who's moved from segment to segment"
+    default: '2025-07-06'
+    type: date
+  date_custom_parameter:
+    label: A custom date parameter
+    allow_custom_values: true
+    description: "The first date in comparing who's moved from segment to segment"
+    default: '2025-08-06'
+    type: date

--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -91,6 +91,30 @@ models:
         meta:
           dimension:
             type: number
+      - name: date_dim_param_test
+        description: "Example of date based on another dimension"
+        meta:
+          dimension:
+            sql: |
+              CASE
+                WHEN ${TABLE}.order_date <= ${lightdash.parameters.date_dim_parameter}
+                  THEN 'param is greater'
+                WHEN ${TABLE}.order_date >= ${lightdash.parameters.date_dim_parameter}
+                  THEN 'param is smaller'
+              END
+        type: string
+      - name: date_custom_param_test
+        description: "Example of custom date"
+        meta:
+          dimension:
+            sql: |
+              CASE
+                WHEN ${TABLE}.order_date <= ${lightdash.parameters.date_custom_parameter}
+                  THEN 'I feel less than...'
+                WHEN ${TABLE}.order_date >= ${lightdash.parameters.date_custom_parameter}
+                  THEN 'I feel great!!!'
+              END
+        type: string
       - name: order_date
         description: Date (UTC) that the order was placed
         config:

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4995,6 +4995,7 @@ const models: TsoaRoute.Models = {
                     subSchemas: [
                         { dataType: 'enum', enums: ['string'] },
                         { dataType: 'enum', enums: ['number'] },
+                        { dataType: 'enum', enums: ['date'] },
                     ],
                 },
                 description: { dataType: 'string' },
@@ -6876,6 +6877,12 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -6883,12 +6890,6 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7145,6 +7146,12 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -7152,12 +7159,6 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5646,7 +5646,7 @@
                     },
                     "type": {
                         "type": "string",
-                        "enum": ["string", "number"]
+                        "enum": ["string", "number", "date"]
                     },
                     "description": {
                         "type": "string"
@@ -7567,10 +7567,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -7579,8 +7579,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -7687,10 +7687,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -7699,8 +7699,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -22994,7 +22994,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2218.2",
+        "version": "0.2221.6",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -161,9 +161,11 @@ export const replaceLightdashValues = (
         throwOnMissing = true,
         // ! This is only for error messages so we can reuse the same function for user attributes and parameters
         replacementName = 'user attribute',
+        cast,
     }: {
         throwOnMissing?: boolean;
         replacementName?: 'user attribute' | 'parameter';
+        cast?: 'DATE';
     } = {},
 ): {
     replacedSql: string;
@@ -221,7 +223,11 @@ export const replaceLightdashValues = (
             } else if (typeof attributeValues === 'number') {
                 valueString = String(attributeValues);
             } else {
-                valueString = `${quoteChar}${attributeValues}${quoteChar}`;
+                const quotedValue = `${quoteChar}${attributeValues}${quoteChar}`;
+                valueString =
+                    cast === 'DATE'
+                        ? `CAST(${quotedValue} AS DATE)`
+                        : quotedValue;
             }
 
             return acc.replace(sqlAttribute, valueString);

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -443,7 +443,11 @@
                                             "type": {
                                                 "description": "The data type of the parameter (defaults to 'string' for backwards compatibility)",
                                                 "type": "string",
-                                                "enum": ["string", "number"],
+                                                "enum": [
+                                                    "string",
+                                                    "number",
+                                                    "date"
+                                                ],
                                                 "default": "string"
                                             },
                                             "description": {

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -60,7 +60,7 @@
                         "type": {
                             "description": "The data type of the parameter (defaults to 'string' for backwards compatibility)",
                             "type": "string",
-                            "enum": ["string", "number"],
+                            "enum": ["string", "number", "date"],
                             "default": "string"
                         },
                         "description": {

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -16,7 +16,7 @@ type SpotlightConfig = {
 export type LightdashProjectParameter = {
     label: string;
     description?: string;
-    type?: 'string' | 'number'; // defaults to 'string' for backwards compatibility
+    type?: 'string' | 'number' | 'date'; // defaults to 'string' for backwards compatibility
     default?: ParameterValue;
     multiple?: boolean; // the parameter input will be a multi select
     allow_custom_values?: boolean; // allows users to input custom values beyond predefined options

--- a/packages/common/src/utils/loadLightdashProjectConfig.mock.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.mock.ts
@@ -136,3 +136,29 @@ parameters:
       - Bob
       - Alice
 `;
+
+export const validConfigWithDateParameter = `
+spotlight:
+  default_visibility: show
+parameters:
+  start_date:
+    label: Start Date
+    type: date
+    default: '2025-08-06'
+    options:
+      - '2025-08-06'
+      - '2025-08-07'
+      - '2025-08-08'
+`;
+
+export const validConfigWithDateParameterFromDimension = `
+spotlight:
+  default_visibility: show
+parameters:
+  order_date:
+    label: Order Date
+    type: date
+    options_from_dimension:
+      model: orders
+      dimension: order_date
+`;

--- a/packages/common/src/utils/loadLightdashProjectConfig.test.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.test.ts
@@ -7,6 +7,8 @@ import {
     invalidConfigWithIncompleteOptionsFromDimension,
     invalidConfigWithNoOptions,
     validConfigWithAllowCustomValues,
+    validConfigWithDateParameter,
+    validConfigWithDateParameterFromDimension,
     validConfigWithMixedArrayTypes,
     validConfigWithNumberArrayParameter,
     validConfigWithNumberParameter,
@@ -178,6 +180,46 @@ describe('loadLightdashProjectConfig', () => {
                     multiple: true,
                     default: ['John', 'Jane'],
                     options: ['John', 'Jane', 'Bob', 'Alice'],
+                },
+            },
+        });
+    });
+
+    it('should load a valid config with date parameter', async () => {
+        const config = await loadLightdashProjectConfig(
+            validConfigWithDateParameter,
+        );
+        expect(config).toEqual({
+            spotlight: {
+                default_visibility: 'show',
+            },
+            parameters: {
+                start_date: {
+                    label: 'Start Date',
+                    type: 'date',
+                    default: '2025-08-06',
+                    options: ['2025-08-06', '2025-08-07', '2025-08-08'],
+                },
+            },
+        });
+    });
+
+    it('should load a valid config with date parameter using options_from_dimension', async () => {
+        const config = await loadLightdashProjectConfig(
+            validConfigWithDateParameterFromDimension,
+        );
+        expect(config).toEqual({
+            spotlight: {
+                default_visibility: 'show',
+            },
+            parameters: {
+                order_date: {
+                    label: 'Order Date',
+                    type: 'date',
+                    options_from_dimension: {
+                        model: 'orders',
+                        dimension: 'order_date',
+                    },
                 },
             },
         });

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -157,7 +157,10 @@ export const useFieldValues = (
             // make sure we don't cache for too long
             cacheTime: 60 * 1000, // 1 minute
             ...useQueryOptions,
-            enabled: !!tableName && !!projectId,
+            enabled:
+                !!tableName &&
+                !!projectId &&
+                useQueryOptions?.enabled !== false,
             staleTime: 0,
             onSuccess: (data) => {
                 const { results: newResults, search: newSearch } = data;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/16740
Closes CENG-144

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Adds the date type for Lightdash parameters. This makes it easier to use dates as a parameter without workarounds to manually cast the datestring as a Date in the data warehouse. 

![Screen Cast 2025-11-18 at 5.36.23 PM.gif](https://app.graphite.com/user-attachments/assets/ecbe7acc-719f-4ba2-80a5-2fea745b0bf2.gif)

