### PR TITLE
feat: implement explore analysis metrics

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/scorers/exploreAnalysisScorer.ts
+++ b/packages/backend/src/ee/services/ai/agents/scorers/exploreAnalysisScorer.ts
@@ -1,19 +1,104 @@
-import { ExploreAnalysisEvaluation, ScorerContext } from '@lightdash/common';
+import {
+    ExploreAnalysisEvaluation,
+    getFields,
+    ScorerContext,
+} from '@lightdash/common';
 import { type LanguageModel } from 'ai';
 
+const OPTIMAL_EXPLORE_COUNT = 20;
+const GOOD_EXPLORE_COUNT = 50;
+const FAIR_EXPLORE_COUNT = 60;
+const POOR_EXPLORE_COUNT = 100;
+
+const OPTIMAL_FIELD_COUNT_PER_EXPLORE = 30;
+
+const MAJOR_PENALTY_THRESHOLD = 50; // >50% of explores are too large
+const MINOR_PENALTY_THRESHOLD = 25; // >25% of explores are too large
+
+// Score adjustments
+const MAJOR_SCORE_PENALTY = 2;
+const MINOR_SCORE_PENALTY = 1;
+const MIN_SCORE = 1;
+
 /**
- * Analyzes explore structure, naming, and field organization
- * TODO: Implement - ZAP-123
+ * Analyzes whether the agent has a focused scope based on explore count and field distribution.
  */
 export async function evaluateExploreAnalysis(
-    model: LanguageModel,
+    _model: LanguageModel,
     context: ScorerContext,
 ): Promise<ExploreAnalysisEvaluation> {
+    const { explores } = context;
+    const exploreCount = explores.length;
+
+    if (exploreCount === 0) {
+        return {
+            score: 0,
+            recommendations: ['No explores found available for this agent'],
+            largeExplores: [],
+        };
+    }
+
+    const exploresWithFieldCounts = explores.map((explore) => ({
+        name: explore.label || explore.name,
+        fieldCount: getFields(explore).length,
+    }));
+
+    const largeExplores = exploresWithFieldCounts.filter(
+        (e) => e.fieldCount > OPTIMAL_FIELD_COUNT_PER_EXPLORE,
+    );
+
+    let score: number;
+    const recommendations: string[] = [];
+
+    if (exploreCount <= OPTIMAL_EXPLORE_COUNT) {
+        score = 5;
+        recommendations.push(
+            `Excellent! Your agent has a focused scope with ${OPTIMAL_EXPLORE_COUNT} or fewer explores`,
+        );
+    } else if (exploreCount <= GOOD_EXPLORE_COUNT) {
+        score = 4;
+        recommendations.push(
+            'Good scope - consider if all explores are necessary for this agent',
+            'Review if explores can be grouped by business area to create more specialized agents',
+        );
+    } else if (exploreCount <= FAIR_EXPLORE_COUNT) {
+        score = 3;
+        recommendations.push(
+            'Agent scope is getting broad - consider splitting into multiple specialized agents',
+            'Use tags to limit explores to specific business domains (e.g., marketing, sales, finance)',
+        );
+    } else if (exploreCount <= POOR_EXPLORE_COUNT) {
+        score = 2;
+        recommendations.push(
+            'Agent has access to too many explores - this significantly impacts response quality',
+            'Split into multiple specialized agents (e.g., "Marketing Assistant", "Sales Analytics")',
+            'Use tags to restrict access to relevant explores only',
+        );
+    } else {
+        score = 1;
+        recommendations.push(
+            `Critical: Agent has access to ${POOR_EXPLORE_COUNT}+ explores - this severely impacts performance and security`,
+            'Create multiple specialized agents instead of one general agent',
+            `Use tags to limit each agent to ${OPTIMAL_EXPLORE_COUNT} or fewer related explores`,
+        );
+    }
+
+    if (largeExplores.length > 0) {
+        const largeExplorePercentage =
+            (largeExplores.length / exploreCount) * 100;
+
+        if (largeExplorePercentage > MAJOR_PENALTY_THRESHOLD) {
+            score = Math.max(MIN_SCORE, score - MAJOR_SCORE_PENALTY);
+        } else if (largeExplorePercentage > MINOR_PENALTY_THRESHOLD) {
+            score = Math.max(MIN_SCORE, score - MINOR_SCORE_PENALTY);
+        }
+    }
+
     return {
-        score: 3,
-        recommendations: [
-            'Review explore naming conventions',
-            'Ensure appropriate field distribution',
-        ],
+        score,
+        recommendations,
+        largeExplores: largeExplores.map(
+            (e) => `${e.name} (${e.fieldCount} fields)`,
+        ),
     };
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5830,7 +5830,23 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ExploreAnalysisEvaluation: {
         dataType: 'refAlias',
-        type: { ref: 'ReadinessScoreEvaluation', validators: {} },
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ReadinessScoreEvaluation' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        largeExplores: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     InstructionQualityEvaluation: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6604,7 +6604,23 @@
                 "$ref": "#/components/schemas/ReadinessScoreEvaluation"
             },
             "ExploreAnalysisEvaluation": {
-                "$ref": "#/components/schemas/ReadinessScoreEvaluation"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ReadinessScoreEvaluation"
+                    },
+                    {
+                        "properties": {
+                            "largeExplores": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["largeExplores"],
+                        "type": "object"
+                    }
+                ]
             },
             "InstructionQualityEvaluation": {
                 "$ref": "#/components/schemas/ReadinessScoreEvaluation"

--- a/packages/common/src/ee/AiAgent/schemas/agentReadiness.ts
+++ b/packages/common/src/ee/AiAgent/schemas/agentReadiness.ts
@@ -43,12 +43,16 @@ export type ReadinessScoreEvaluation = {
 
 // Explicit types for each scorer (TSOA-compatible)
 export type MetadataCompletenessEvaluation = ReadinessScoreEvaluation;
-export type ExploreAnalysisEvaluation = ReadinessScoreEvaluation;
+export type ExploreAnalysisEvaluation = ReadinessScoreEvaluation & {
+    largeExplores: string[];
+};
 export type InstructionQualityEvaluation = ReadinessScoreEvaluation;
 
 // Zod schemas for validation (backend only)
 export const MetadataCompletenessSchema = BaseScorerSchema;
-export const ExploreAnalysisSchema = BaseScorerSchema;
+export const ExploreAnalysisSchema = BaseScorerSchema.extend({
+    largeExplores: z.array(z.string()),
+});
 export const InstructionQualitySchema = BaseScorerSchema;
 
 export interface ReadinessScore {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: ZAP-123

### Description:
Implemented the `evaluateExploreAnalysis` function to analyze agent scope based on explore count and field distribution. 

Analysis of an agent that has access to all Jaffle shop project:
(ignore `overalScore` as the other two evaluations are mocked)

![image.png](https://app.graphite.com/user-attachments/assets/4fed0493-d58f-4320-9c02-b105b3b7a06f.png)

