### PR TITLE
fix: exclude seed org from AI agent prompt feedback tracking

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -41,6 +41,7 @@ import {
     ParameterError,
     parseVizConfig,
     QueryExecutionContext,
+    SEED_ORG_1,
     SlackPrompt,
     ToolDashboardArgs,
     toolDashboardArgsSchema,
@@ -1527,7 +1528,10 @@ export class AiAgentService {
         humanScore: number,
         humanFeedback?: string | null,
     ) {
-        if (humanScore !== 0) {
+        if (
+            humanScore !== 0 &&
+            user.organizationUuid !== SEED_ORG_1.organization_uuid
+        ) {
             this.analytics.track<AiAgentPromptFeedbackEvent>({
                 event: 'ai_agent_prompt.feedback',
                 userId: user.userUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Exclude seed organization users from AI agent prompt feedback analytics tracking. This change ensures that feedback events from the seed organization (SEED_ORG_1) are not tracked in analytics, while maintaining tracking for all other organizations.
