### PR TITLE
fix: validate table calculations on runQuery and alike

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -37,6 +37,7 @@ import {
     validateMetricDimensionFilterPlacement,
     validateSelectedFieldsExistence,
     validateSortFieldsAreSelected,
+    validateTableCalculations,
 } from '../utils/validators';
 
 type Dependencies = {
@@ -114,6 +115,15 @@ export const validateRunQueryTool = (
         queryTool.queryConfig.metrics,
         queryTool.customMetrics,
         queryTool.tableCalculations,
+    );
+
+    // Validate table calculations
+    validateTableCalculations(
+        explore,
+        queryTool.tableCalculations,
+        queryTool.queryConfig.dimensions,
+        queryTool.queryConfig.metrics,
+        queryTool.customMetrics,
     );
 };
 

--- a/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateBarVizConfig.ts
@@ -59,6 +59,7 @@ export const validateBarVizConfig = (
     validateTableCalculations(
         explore,
         vizTool.tableCalculations,
+        selectedDimensions,
         vizTool.vizConfig.yMetrics,
         vizTool.customMetrics,
     );

--- a/packages/backend/src/ee/services/ai/utils/validateTableCalculations.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableCalculations.test.ts
@@ -11,11 +11,17 @@ describe('validateTableCalculations', () => {
     describe('Edge Cases', () => {
         it('should not throw for null or empty tableCalcs array', () => {
             expect(() =>
-                validateTableCalculations(mockOrdersExplore, null, [], null),
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    null,
+                    [],
+                    [],
+                    null,
+                ),
             ).not.toThrow();
 
             expect(() =>
-                validateTableCalculations(mockOrdersExplore, [], [], null),
+                validateTableCalculations(mockOrdersExplore, [], [], [], null),
             ).not.toThrow();
         });
     });
@@ -37,6 +43,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -59,6 +66,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -94,6 +102,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     customMetrics,
                 ),
@@ -102,7 +111,7 @@ describe('validateTableCalculations', () => {
     });
 
     describe('Window Functions', () => {
-        it('should not throw for nillary window function without fieldId', () => {
+        it('should not throw for nullary window function without fieldId', () => {
             const tableCalcs: TableCalcsSchema = [
                 {
                     type: 'window_function',
@@ -124,6 +133,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -144,6 +154,7 @@ describe('validateTableCalculations', () => {
                 },
             ];
 
+            const selectedDimensions = ['orders_customer_name'];
             const selectedMetrics = [
                 'orders_total_revenue',
                 'orders_order_count',
@@ -153,6 +164,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    selectedDimensions,
                     selectedMetrics,
                     null,
                 ),
@@ -179,6 +191,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -212,6 +225,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -244,6 +258,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -272,6 +287,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -296,6 +312,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -318,6 +335,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -341,6 +359,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
@@ -364,10 +383,63 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),
             ).toThrow(/neither in the explore nor in the custom metrics/);
+        });
+
+        it('should throw when partitionBy field is not selected in query', () => {
+            const tableCalcs: TableCalcsSchema = [
+                {
+                    type: 'percent_of_column_total',
+                    name: 'percent_of_total',
+                    displayName: 'Percent of Total',
+                    fieldId: 'orders_total_revenue',
+                    partitionBy: ['orders_customer_name'],
+                },
+            ];
+
+            const selectedMetrics = ['orders_total_revenue'];
+
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    tableCalcs,
+                    [], // orders_customer_name is not selected
+                    selectedMetrics,
+                    null,
+                ),
+            ).toThrow(
+                /uses partitionBy field "orders_customer_name" which is not selected in the query/,
+            );
+        });
+
+        it('should throw when orderBy field is not selected in query', () => {
+            const tableCalcs: TableCalcsSchema = [
+                {
+                    type: 'percent_change_from_previous',
+                    name: 'percent_change',
+                    displayName: 'Percent Change',
+                    fieldId: 'orders_total_revenue',
+                    orderBy: [{ fieldId: 'orders_order_count', order: 'asc' }],
+                },
+            ];
+
+            const selectedMetrics = ['orders_total_revenue']; // orders_order_count is not selected
+
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    tableCalcs,
+                    [],
+                    selectedMetrics,
+                    null,
+                ),
+            ).toThrow(
+                /uses orderBy field "orders_order_count" which is not selected in the query/,
+            );
         });
     });
 
@@ -389,6 +461,7 @@ describe('validateTableCalculations', () => {
                 validateTableCalculations(
                     mockOrdersExplore,
                     tableCalcs,
+                    [],
                     selectedMetrics,
                     null,
                 ),

--- a/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableVizConfig.ts
@@ -55,6 +55,7 @@ export const validateTableVizConfig = (
     validateTableCalculations(
         explore,
         vizTool.tableCalculations,
+        vizTool.vizConfig.dimensions,
         vizTool.vizConfig.metrics,
         vizTool.customMetrics,
     );

--- a/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTimeSeriesVizConfig.ts
@@ -59,6 +59,7 @@ export const validateTimeSeriesVizConfig = (
     validateTableCalculations(
         explore,
         vizTool.tableCalculations,
+        selectedDimensions,
         vizTool.vizConfig.yMetrics,
         vizTool.customMetrics,
     );

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -325,7 +325,7 @@ export enum WindowFunctionType {
     MAX = 'max',
 }
 
-export const nillaryWindowFunctions: WindowFunctionType[] = [
+export const nullaryWindowFunctions: WindowFunctionType[] = [
     WindowFunctionType.ROW_NUMBER,
     WindowFunctionType.PERCENT_RANK,
     WindowFunctionType.CUME_DIST,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18199

### Description:
Enhanced table calculation validation to ensure all referenced fields are selected in the query. This PR:

- Adds validation for `partitionBy` and `orderBy` fields in table calculations to verify they are included in the selected dimensions or metrics
- Adds the new validation to all visualization tools (bar, table, time series) and the run query tool
- Updates tests to cover the new validation scenarios

This change prevents users from creating invalid table calculations that reference fields not included in their query, which would lead to runtime errors.

![image.png](https://app.graphite.com/user-attachments/assets/1c9eb918-309c-4249-a4a6-34881d63ff60.png)

![Screenshot 2025-11-19 at 11.20.34.png](https://app.graphite.com/user-attachments/assets/971fc9f4-5ebe-4143-8d62-0b09f3e63c91.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens table calculation validation to require `partitionBy`/`orderBy` (and window function refs) be selected, applies it across `runQuery` and bar/table/time-series viz tools, updates tests, and renames `nillary` to `nullary` window functions.
> 
> - **Validation**:
>   - Enforce `validateTableCalculations` to check `partitionBy`/`orderBy` fields are selected in `dimensions`/`metrics`/table calcs, not just existing.
>   - Add `selectedDimensions` param to `validateTableCalculations` and invoke it in `runQuery`, `validateBarVizConfig`, `validateTableVizConfig`, and `validateTimeSeriesVizConfig` with appropriate selections.
>   - Continue checks for field existence, type compatibility, and circular deps.
> - **API/Types**:
>   - Rename `nillaryWindowFunctions` to `nullaryWindowFunctions` in `@lightdash/common` and validators.
> - **Tests**:
>   - Update `validateTableCalculations.test.ts` to pass `selectedDimensions` and add cases for unselected `partitionBy`/`orderBy`; minor wording fix to "nullary".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6869734e43fc75626cd970d1a7df9011a4168224. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->