### PR TITLE
fix: create share urls per ai artifact slack url

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -112,7 +112,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     asyncQueryService: repository.getAsyncQueryService(),
                     userAttributesModel: models.getUserAttributesModel(),
                     searchModel: models.getSearchModel(),
-                    spaceModel: models.getSpaceModel(),
                     slackAuthenticationModel:
                         models.getSlackAuthenticationModel() as CommercialSlackAuthenticationModel,
                     schedulerClient:
@@ -122,6 +121,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectModel: models.getProjectModel(),
                     aiOrganizationSettingsService:
                         repository.getAiOrganizationSettingsService(),
+                    shareService: repository.getShareService(),
                     prometheusMetrics,
                 }),
             aiAgentAdminService: ({ models, context }) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18214

### Description:
Implemented short share URLs for AI-generated Slack responses to avoid the 3000 character URL limit. This change:

- Replaced `getExploreBlocks` with `getArtifactBlocks` that uses the ShareService to create short URLs
- Added ShareService as a dependency to AiAgentService
- Removed the unused SpaceModel dependency
- Added a fallback to full URLs if share creation fails

This ensures that AI-generated exploration links in Slack remain functional even when they would otherwise exceed Slack's URL character limits.


![image.png](https://app.graphite.com/user-attachments/assets/ed5a685f-cda0-42c9-a70d-3b2905b9d5ec.png)

![image.png](https://app.graphite.com/user-attachments/assets/1d72653e-1c4b-481d-9390-54f5389d9d90.png)

