### PR TITLE
fix: improve isFetchingFirstPage condition in useInfiniteQueryResults

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -550,7 +550,8 @@ export const useInfiniteQueryResults = (
             isInitialLoading: isInitialLoading || dependenciesChanged,
             isFetchingFirstPage:
                 dependenciesChanged ||
-                (!fetchedPages.length && nextPage.isFetching),
+                (!!queryUuid && !fetchedPages.length) ||
+                (!!queryUuid && fetchedPages[0]?.totalResults === undefined),
             isFetchingAllPages: !!queryUuid && fetchAll && !hasFetchedAllRows,
             fetchAll,
             error: nextPage.error,
@@ -567,7 +568,6 @@ export const useInfiniteQueryResults = (
             fetchMoreRows,
             totalClientFetchTimeMs,
             isInitialLoading,
-            nextPage.isFetching,
             nextPage.error,
             fetchAll,
         ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18215

### Description:
Fixed the `isFetchingFirstPage` condition in `useInfiniteQueryResults` to properly handle cases when the query has a UUID but no fetched pages or when the first page's total results are undefined. Also removed an unused dependency from the dependency array.

This change ensures that the loading state is correctly displayed when a query is being executed but hasn't returned any results yet.