### PR TITLE
fix: reset create-query cache when saving query to sync with Redux state

### DIFF
--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -494,6 +494,9 @@ export const useAddVersionMutation = () => {
                     data.uuid,
                     dashboardUuid,
                 ]);
+                // Reset create-query cache to sync with Redux state reset
+                // This ensures auto-fetch triggers when returning to view mode
+                await queryClient.resetQueries(['create-query']);
             }
 
             if (dashboardUuid)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18212

### Description:
Reset the create-query cache when adding a new version to ensure auto-fetch triggers properly when returning to view mode. This fixes an issue where the query state wasn't properly synchronized between Redux and React Query after saving a version.

Before:

[Screen Recording 2025-11-19 at 17.23.50.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/044e78a6-3233-45b8-9489-7d66a43fc9e7.mov" />](https://app.graphite.com/user-attachments/video/044e78a6-3233-45b8-9489-7d66a43fc9e7.mov)

After:

[Screen Recording 2025-11-19 at 17.23.19.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/30b1f338-503f-4f9a-baeb-f999b1985f0e.mov" />](https://app.graphite.com/user-attachments/video/30b1f338-503f-4f9a-baeb-f999b1985f0e.mov)