### PR TITLE
feat: implement metadata completeness score - ai agent readiness

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/scorers/metadataCompletenessScorer.ts
+++ b/packages/backend/src/ee/services/ai/agents/scorers/metadataCompletenessScorer.ts
@@ -1,22 +1,205 @@
 import {
-    MetadataCompletenessEvaluation,
-    ScorerContext,
+    Explore,
+    type ExploreMetadataBreakdown,
+    getFields,
+    type MetadataCompletenessEvaluation,
+    type ScorerContext,
 } from '@lightdash/common';
 import { type LanguageModel } from 'ai';
 
+const EXCELLENT_THRESHOLD = 90;
+const GOOD_THRESHOLD = 70;
+const FAIR_THRESHOLD = 40;
+const POOR_THRESHOLD = 20;
+// Below 20% is very poor (score 1)
+
+const validString = (value?: string) =>
+    value ? value.trim().length > 0 : false;
+
+const getScore = (percentage: number): Score => {
+    if (percentage >= EXCELLENT_THRESHOLD) return 5;
+    if (percentage >= GOOD_THRESHOLD) return 4;
+    if (percentage >= FAIR_THRESHOLD) return 3;
+    if (percentage >= POOR_THRESHOLD) return 2;
+    return 1;
+};
+
 /**
- * Analyzes metadata completeness across explores and fields
- * TODO: Implement - ZAP-122
+ * Calculates a completeness score for a single explore based on its metadata
+ */
+function calculateExploreCompleteness(
+    explore: Explore,
+): ExploreMetadataBreakdown {
+    const exploreName = explore.label || explore.name;
+    const fields = getFields(explore);
+
+    const baseTable = explore.tables[explore.baseTable];
+    const hasDescription = validString(baseTable?.description);
+    const hasLabel = validString(explore.label);
+    let hasAiHint = false;
+    if (explore.aiHint) {
+        hasAiHint =
+            typeof explore.aiHint === 'string'
+                ? validString(explore.aiHint)
+                : explore.aiHint.length > 0;
+    }
+
+    let fieldsWithDescriptions = 0;
+    let fieldsWithLabels = 0;
+    let fieldsWithAiHints = 0;
+    let totalFieldScore = 0;
+
+    for (const field of fields) {
+        const hasFieldDescription = validString(field.description);
+        const hasFieldLabel = validString(field.label);
+        let hasFieldAiHint = false;
+        if (field.aiHint) {
+            hasFieldAiHint =
+                typeof field.aiHint === 'string'
+                    ? validString(field.aiHint)
+                    : field.aiHint.length > 0;
+        }
+
+        if (hasFieldDescription) fieldsWithDescriptions += 1;
+        if (hasFieldLabel) fieldsWithLabels += 1;
+        if (hasFieldAiHint) fieldsWithAiHints += 1;
+
+        const metadataCount =
+            (hasFieldDescription ? 1 : 0) +
+            (hasFieldLabel ? 1 : 0) +
+            (hasFieldAiHint ? 1 : 0);
+
+        let fieldScore = 0;
+        if (metadataCount === 0) {
+            fieldScore = 0;
+        } else if (metadataCount === 1) {
+            fieldScore = 40;
+        } else if (metadataCount === 2) {
+            fieldScore = 70;
+        } else {
+            fieldScore = 100;
+        }
+
+        totalFieldScore += fieldScore;
+    }
+
+    const totalFields = fields.length;
+    const fieldCompletenessPercentage =
+        totalFields > 0 ? totalFieldScore / totalFields : 0;
+
+    let exploreBonus = 0;
+    if (hasDescription) exploreBonus += 4;
+    if (hasLabel) exploreBonus += 2;
+    if (hasAiHint) exploreBonus += 4;
+
+    const completenessPercentage = Math.round(
+        Math.min(100, fieldCompletenessPercentage + exploreBonus),
+    );
+
+    return {
+        exploreName,
+        score: getScore(completenessPercentage),
+        completenessPercentage,
+        hasDescription,
+        hasLabel,
+        hasAiHint,
+        fieldStats: {
+            total: totalFields,
+            withDescriptions: fieldsWithDescriptions,
+            withLabels: fieldsWithLabels,
+            withAiHints: fieldsWithAiHints,
+        },
+    };
+}
+
+const scoreMessages = {
+    5: 'Excellent metadata coverage! This helps the AI agent provide accurate responses',
+    4: 'Good metadata coverage. Consider improving:',
+    3: 'Fair metadata coverage. Focus on improving:',
+    2: 'Poor metadata coverage. Prioritize adding metadata to:',
+    1: 'Critical: Very poor metadata coverage. Start by adding descriptions and AI hints to:',
+} as const;
+
+type Score = keyof typeof scoreMessages;
+const needsImprovementExplores = (explores: ExploreMetadataBreakdown[]) =>
+    explores.slice(0, 5).map((e) => `'${e.exploreName}'`);
+
+/**
+ * Analyzes metadata completeness across explores, tables, and fields.
+ * Calculates per-explore scores and aggregates them for an overall assessment.
  */
 export async function evaluateMetadataCompleteness(
-    model: LanguageModel,
+    _model: LanguageModel,
     context: ScorerContext,
 ): Promise<MetadataCompletenessEvaluation> {
+    const { explores } = context;
+
+    if (explores.length === 0) {
+        return {
+            score: 0,
+            recommendations: ['No explores found available for this agent'],
+            overallPercentage: 0,
+            exploreBreakdown: [],
+            overallMetrics: {
+                fieldDescriptionPercentage: 0,
+                exploreDescriptionPercentage: 0,
+                exploreAiHintPercentage: 0,
+            },
+        };
+    }
+
+    const exploreBreakdown: ExploreMetadataBreakdown[] = [];
+    let totalCompletenessPercentage = 0;
+    let exploresWithDescription = 0;
+    let exploresWithAiHint = 0;
+    let totalFields = 0;
+    let fieldsWithDescription = 0;
+
+    for (const explore of explores) {
+        const breakdown = calculateExploreCompleteness(explore);
+        exploreBreakdown.push(breakdown);
+
+        totalCompletenessPercentage += breakdown.completenessPercentage;
+        if (breakdown.hasDescription) exploresWithDescription += 1;
+        if (breakdown.hasAiHint) exploresWithAiHint += 1;
+        totalFields += breakdown.fieldStats.total;
+        fieldsWithDescription += breakdown.fieldStats.withDescriptions;
+    }
+
+    exploreBreakdown.sort((a, b) => a.score - b.score);
+
+    const overallPercentage = Math.round(
+        totalCompletenessPercentage / explores.length,
+    );
+
+    const overallMetrics = {
+        fieldDescriptionPercentage:
+            totalFields > 0
+                ? Math.round((fieldsWithDescription / totalFields) * 100)
+                : 0,
+        exploreDescriptionPercentage: Math.round(
+            (exploresWithDescription / explores.length) * 100,
+        ),
+        exploreAiHintPercentage: Math.round(
+            (exploresWithAiHint / explores.length) * 100,
+        ),
+    };
+
+    const score: Score = getScore(overallPercentage);
+
+    const scoreMessage = scoreMessages[score];
+    const needsImprovement =
+        score === 5
+            ? ''
+            : needsImprovementExplores(exploreBreakdown).join(', ');
+
+    const recommendations = [[scoreMessage, needsImprovement].join(' ')];
+
     return {
-        score: 3,
-        recommendations: [
-            'Add descriptions to fields',
-            'Add AI hints to explores',
-        ],
+        score,
+        recommendations,
+        overallPercentage,
+        exploreBreakdown,
+        overallMetrics,
     };
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5823,9 +5823,84 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExploreMetadataBreakdown: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                fieldStats: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        withAiHints: { dataType: 'double', required: true },
+                        withLabels: { dataType: 'double', required: true },
+                        withDescriptions: {
+                            dataType: 'double',
+                            required: true,
+                        },
+                        total: { dataType: 'double', required: true },
+                    },
+                    required: true,
+                },
+                hasAiHint: { dataType: 'boolean', required: true },
+                hasLabel: { dataType: 'boolean', required: true },
+                hasDescription: { dataType: 'boolean', required: true },
+                completenessPercentage: { dataType: 'double', required: true },
+                score: { dataType: 'double', required: true },
+                exploreName: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    OverallMetadataMetrics: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                exploreAiHintPercentage: { dataType: 'double', required: true },
+                exploreDescriptionPercentage: {
+                    dataType: 'double',
+                    required: true,
+                },
+                fieldDescriptionPercentage: {
+                    dataType: 'double',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MetadataCompletenessEvaluation: {
         dataType: 'refAlias',
-        type: { ref: 'ReadinessScoreEvaluation', validators: {} },
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'ReadinessScoreEvaluation' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        overallMetrics: {
+                            ref: 'OverallMetadataMetrics',
+                            required: true,
+                        },
+                        exploreBreakdown: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'ExploreMetadataBreakdown',
+                            },
+                            required: true,
+                        },
+                        overallPercentage: {
+                            dataType: 'double',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ExploreAnalysisEvaluation: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6600,8 +6600,118 @@
                 "required": ["recommendations", "score"],
                 "type": "object"
             },
+            "ExploreMetadataBreakdown": {
+                "properties": {
+                    "fieldStats": {
+                        "properties": {
+                            "withAiHints": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "withLabels": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "withDescriptions": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "total": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": [
+                            "withAiHints",
+                            "withLabels",
+                            "withDescriptions",
+                            "total"
+                        ],
+                        "type": "object"
+                    },
+                    "hasAiHint": {
+                        "type": "boolean"
+                    },
+                    "hasLabel": {
+                        "type": "boolean"
+                    },
+                    "hasDescription": {
+                        "type": "boolean"
+                    },
+                    "completenessPercentage": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "score": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "exploreName": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "fieldStats",
+                    "hasAiHint",
+                    "hasLabel",
+                    "hasDescription",
+                    "completenessPercentage",
+                    "score",
+                    "exploreName"
+                ],
+                "type": "object"
+            },
+            "OverallMetadataMetrics": {
+                "properties": {
+                    "exploreAiHintPercentage": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "exploreDescriptionPercentage": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "fieldDescriptionPercentage": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": [
+                    "exploreAiHintPercentage",
+                    "exploreDescriptionPercentage",
+                    "fieldDescriptionPercentage"
+                ],
+                "type": "object"
+            },
             "MetadataCompletenessEvaluation": {
-                "$ref": "#/components/schemas/ReadinessScoreEvaluation"
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ReadinessScoreEvaluation"
+                    },
+                    {
+                        "properties": {
+                            "overallMetrics": {
+                                "$ref": "#/components/schemas/OverallMetadataMetrics"
+                            },
+                            "exploreBreakdown": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ExploreMetadataBreakdown"
+                                },
+                                "type": "array"
+                            },
+                            "overallPercentage": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": [
+                            "overallMetrics",
+                            "exploreBreakdown",
+                            "overallPercentage"
+                        ],
+                        "type": "object"
+                    }
+                ]
             },
             "ExploreAnalysisEvaluation": {
                 "allOf": [
@@ -22586,7 +22696,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2184.0",
+        "version": "0.2185.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/schemas/agentReadiness.ts
+++ b/packages/common/src/ee/AiAgent/schemas/agentReadiness.ts
@@ -41,15 +41,67 @@ export type ReadinessScoreEvaluation = {
     recommendations: string[];
 };
 
+// Per-explore metadata breakdown
+export type ExploreMetadataBreakdown = {
+    exploreName: string;
+    score: number;
+    completenessPercentage: number;
+    hasDescription: boolean;
+    hasLabel: boolean;
+    hasAiHint: boolean;
+    fieldStats: {
+        total: number;
+        withDescriptions: number;
+        withLabels: number;
+        withAiHints: number;
+    };
+};
+
+// Aggregate metrics across all explores
+export type OverallMetadataMetrics = {
+    fieldDescriptionPercentage: number;
+    exploreDescriptionPercentage: number;
+    exploreAiHintPercentage: number;
+};
+
 // Explicit types for each scorer (TSOA-compatible)
-export type MetadataCompletenessEvaluation = ReadinessScoreEvaluation;
+export type MetadataCompletenessEvaluation = ReadinessScoreEvaluation & {
+    overallPercentage: number;
+    exploreBreakdown: ExploreMetadataBreakdown[];
+    overallMetrics: OverallMetadataMetrics;
+};
 export type ExploreAnalysisEvaluation = ReadinessScoreEvaluation & {
     largeExplores: string[];
 };
 export type InstructionQualityEvaluation = ReadinessScoreEvaluation;
 
 // Zod schemas for validation (backend only)
-export const MetadataCompletenessSchema = BaseScorerSchema;
+export const ExploreMetadataBreakdownSchema = z.object({
+    exploreName: z.string(),
+    score: ScoreSchema,
+    completenessPercentage: z.number().min(0).max(100),
+    hasDescription: z.boolean(),
+    hasLabel: z.boolean(),
+    hasAiHint: z.boolean(),
+    fieldStats: z.object({
+        total: z.number(),
+        withDescriptions: z.number(),
+        withLabels: z.number(),
+        withAiHints: z.number(),
+    }),
+});
+
+export const OverallMetadataMetricsSchema = z.object({
+    fieldDescriptionPercentage: z.number().min(0).max(100),
+    exploreDescriptionPercentage: z.number().min(0).max(100),
+    exploreAiHintPercentage: z.number().min(0).max(100),
+});
+
+export const MetadataCompletenessSchema = BaseScorerSchema.extend({
+    overallPercentage: z.number().min(0).max(100),
+    exploreBreakdown: z.array(ExploreMetadataBreakdownSchema),
+    overallMetrics: OverallMetadataMetricsSchema,
+});
 export const ExploreAnalysisSchema = BaseScorerSchema.extend({
     largeExplores: z.array(z.string()),
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: ZAP-122

### Description:
Implements the metadata completeness scorer for AI agents. This scorer evaluates how well explores and fields are documented with descriptions, labels, and AI hints.

I decided to do a deterministic approach for this evaluation, rather than using LLM judges to evaluate quality of descriptions. I'm thinking in terms of performance, if an agent has too many explores / complex explores with many fields, it might be difficult to analyze all data 

<details><summary>Metadata completeness result for agent with full access to Jaffle shop</summary>

```json
{
    "metadataCompleteness": {
      "score": 3,
      "recommendations": [
        "Fair metadata coverage. Focus on improving: 'Fanouts tracks', 'Fanouts accounts bridged fanout', 'Patient health scores', 'Visit analytics', 'Tracks'"
      ],
      "overallPercentage": 68,
      "exploreBreakdown": [
        {
          "exploreName": "Fanouts tracks",
          "score": 3,
          "completenessPercentage": 54,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 12,
            "withDescriptions": 3,
            "withLabels": 12,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Fanouts accounts bridged fanout",
          "score": 3,
          "completenessPercentage": 68,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 115,
            "withDescriptions": 85,
            "withLabels": 115,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Patient health scores",
          "score": 3,
          "completenessPercentage": 66,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 124,
            "withDescriptions": 83,
            "withLabels": 124,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Visit analytics",
          "score": 3,
          "completenessPercentage": 66,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 124,
            "withDescriptions": 83,
            "withLabels": 124,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Tracks",
          "score": 3,
          "completenessPercentage": 60,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 53,
            "withDescriptions": 25,
            "withLabels": 53,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Generated b",
          "score": 3,
          "completenessPercentage": 46,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 50,
            "withDescriptions": 0,
            "withLabels": 50,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Generated a",
          "score": 3,
          "completenessPercentage": 46,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 1050,
            "withDescriptions": 0,
            "withLabels": 1050,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Stg customers",
          "score": 3,
          "completenessPercentage": 46,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 10,
            "withDescriptions": 0,
            "withLabels": 10,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Stg payments",
          "score": 3,
          "completenessPercentage": 46,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 4,
            "withDescriptions": 0,
            "withLabels": 4,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Stg orders",
          "score": 3,
          "completenessPercentage": 46,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 9,
            "withDescriptions": 0,
            "withLabels": 9,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Fanouts users",
          "score": 3,
          "completenessPercentage": 60,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 51,
            "withDescriptions": 23,
            "withLabels": 51,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Fanouts accounts",
          "score": 3,
          "completenessPercentage": 61,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 47,
            "withDescriptions": 24,
            "withLabels": 47,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Stg patients",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 6,
            "withDescriptions": 6,
            "withLabels": 6,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Fanouts deals",
          "score": 4,
          "completenessPercentage": 73,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 19,
            "withDescriptions": 17,
            "withLabels": 19,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Users",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 10,
            "withDescriptions": 10,
            "withLabels": 10,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Payments",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 93,
            "withDescriptions": 90,
            "withLabels": 93,
            "withAiHints": 3
          }
        },
        {
          "exploreName": "Github pull requests",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 7,
            "withDescriptions": 7,
            "withLabels": 7,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Customers",
          "score": 4,
          "completenessPercentage": 80,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": true,
          "fieldStats": {
            "total": 29,
            "withDescriptions": 27,
            "withLabels": 29,
            "withAiHints": 2
          }
        },
        {
          "exploreName": "Orders",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 87,
            "withDescriptions": 84,
            "withLabels": 87,
            "withAiHints": 3
          }
        },
        {
          "exploreName": "Completed Orders",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 87,
            "withDescriptions": 84,
            "withLabels": 87,
            "withAiHints": 3
          }
        },
        {
          "exploreName": "Subscriptions",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 75,
            "withDescriptions": 73,
            "withLabels": 75,
            "withAiHints": 2
          }
        },
        {
          "exploreName": "Campaigns",
          "score": 4,
          "completenessPercentage": 74,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 112,
            "withDescriptions": 106,
            "withLabels": 112,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Generated budgets",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 10,
            "withDescriptions": 10,
            "withLabels": 10,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Marketing touchpoints",
          "score": 4,
          "completenessPercentage": 75,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 141,
            "withDescriptions": 133,
            "withLabels": 141,
            "withAiHints": 2
          }
        },
        {
          "exploreName": "Events",
          "score": 4,
          "completenessPercentage": 72,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": true,
          "fieldStats": {
            "total": 78,
            "withDescriptions": 33,
            "withLabels": 78,
            "withAiHints": 23
          }
        },
        {
          "exploreName": "Stg health visits",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 10,
            "withDescriptions": 10,
            "withLabels": 10,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Stg health vitals",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 4,
            "withDescriptions": 4,
            "withLabels": 4,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Stg health conditions",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 5,
            "withDescriptions": 5,
            "withLabels": 5,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Fanouts countries",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 4,
            "withDescriptions": 4,
            "withLabels": 4,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Fanouts user deals",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 5,
            "withDescriptions": 5,
            "withLabels": 5,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Fanouts addresses",
          "score": 4,
          "completenessPercentage": 70,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 29,
            "withDescriptions": 23,
            "withLabels": 29,
            "withAiHints": 0
          }
        },
        {
          "exploreName": "Fanouts sales targets",
          "score": 4,
          "completenessPercentage": 76,
          "hasDescription": true,
          "hasLabel": true,
          "hasAiHint": false,
          "fieldStats": {
            "total": 18,
            "withDescriptions": 18,
            "withLabels": 18,
            "withAiHints": 0
          }
        }
      ],
      "overallMetrics": {
        "fieldDescriptionPercentage": 43,
        "exploreDescriptionPercentage": 100,
        "exploreAiHintPercentage": 6
      }
    },
}
```

</details>
