### PR TITLE
feat: allow embed content via configuration

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -229,6 +229,10 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     embedding: {
         enabled: false,
+        allowAll: {
+            dashboards: false,
+            charts: false,
+        },
         events: undefined,
     },
     scim: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -860,6 +860,10 @@ export type LightdashConfig = {
     };
     embedding: {
         enabled: boolean;
+        allowAll: {
+            dashboards: boolean;
+            charts: boolean;
+        };
         events?: {
             enabled: boolean;
             rateLimiting: {
@@ -1634,6 +1638,13 @@ export const parseConfig = (): LightdashConfig => {
         },
         embedding: {
             enabled: process.env.EMBEDDING_ENABLED === 'true',
+            allowAll: {
+                dashboards:
+                    process.env.EMBED_ALLOW_ALL_DASHBOARDS_BY_DEFAULT ===
+                    'true',
+                charts:
+                    process.env.EMBED_ALLOW_ALL_CHARTS_BY_DEFAULT === 'true',
+            },
             events: {
                 enabled: process.env.EMBED_EVENT_SYSTEM_ENABLED === 'true',
                 rateLimiting: {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -245,9 +245,9 @@ export class EmbedService extends BaseService {
             encodedSecret,
             user.userUuid,
             data.dashboardUuids,
-            false,
+            this.lightdashConfig.embedding.allowAll.dashboards,
             data.chartUuids,
-            false,
+            this.lightdashConfig.embedding.allowAll.charts,
         );
 
         return this.getConfig(user, projectUuid);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: CENG-185

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Allows customers to configure new embeds in a project to be created with allowing all content: either for dashboards and/or charts. 

![Screen Cast 2025-11-19 at 6.46.31 PM.gif](https://app.graphite.com/user-attachments/assets/e557ebc6-dec6-4f94-8b12-625890ba3fbf.gif)

