### PR TITLE
chore: use runs endpoint for schedulers run list

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -9,6 +9,7 @@ import {
     Scheduler,
     SchedulerAndTargets,
     SchedulerEmailTarget,
+    SchedulerFormat,
     SchedulerJobStatus,
     SchedulerLog,
     SchedulerMsTeamsTarget,
@@ -1401,6 +1402,7 @@ export class SchedulerModel {
                 'distinct_runs.created_at',
                 'distinct_runs.details',
                 `${SchedulerTableName}.name as scheduler_name`,
+                `${SchedulerTableName}.format`,
                 this.database.raw(
                     `CASE WHEN ${SchedulerTableName}.saved_chart_uuid IS NOT NULL THEN 'chart' ELSE 'dashboard' END as resource_type`,
                 ),
@@ -1518,6 +1520,7 @@ export class SchedulerModel {
             run_id: string;
             scheduler_uuid: string;
             scheduler_name: string;
+            format: SchedulerFormat;
             scheduled_time: Date;
             status: SchedulerJobStatus;
             run_status: SchedulerRunStatus; // Computed in SQL
@@ -1560,6 +1563,7 @@ export class SchedulerModel {
                     resourceName: row.resource_name,
                     createdByUserUuid: row.created_by_user_uuid,
                     createdByUserName: row.created_by_user_name,
+                    format: row.format as SchedulerFormat,
                 };
             },
         );

--- a/packages/common/src/types/schedulerLog.ts
+++ b/packages/common/src/types/schedulerLog.ts
@@ -1,7 +1,11 @@
 import { type AnyType } from './any';
 import { type ApiSuccess } from './api/success';
 import { type KnexPaginatedData } from './knex-paginate';
-import { type SchedulerAndTargets, type SchedulerJobStatus } from './scheduler';
+import {
+    type SchedulerAndTargets,
+    type SchedulerFormat,
+    type SchedulerJobStatus,
+} from './scheduler';
 import { type SchedulerTaskName } from './schedulerTaskList';
 
 export type SchedulerTargetType = 'email' | 'slack' | 'gsheets' | 'msteams';
@@ -77,6 +81,7 @@ export type SchedulerRun = {
     resourceName: string;
     createdByUserUuid: string;
     createdByUserName: string;
+    format: SchedulerFormat; // Scheduler format (CSV, IMAGE, GSHEETS, etc)
 };
 
 export type ApiSchedulerRunsResponse = ApiSuccess<

--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -1,4 +1,8 @@
-import { SchedulerJobStatus } from '@lightdash/common';
+import {
+    SchedulerRunStatus,
+    type SchedulerRun,
+    type SchedulerRunLog,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -20,7 +24,6 @@ import {
     IconSend,
     IconTextCaption,
 } from '@tabler/icons-react';
-import groupBy from 'lodash/groupBy';
 import {
     MantineReactTable,
     useMantineReactTable,
@@ -44,7 +47,8 @@ import {
     type DestinationType,
 } from '../../features/scheduler/hooks/useLogsFilters';
 import {
-    useSchedulerLogs,
+    useFetchRunLogs,
+    useSchedulerRuns,
     useSendNowSchedulerByUuid,
 } from '../../features/scheduler/hooks/useScheduler';
 import useHealth from '../../hooks/health/useHealth';
@@ -55,34 +59,32 @@ import {
     formatTaskName,
     formatTime,
     getLogStatusIcon,
+    getRunStatusIcon,
     getSchedulerIcon,
     getSchedulerLink,
-    type Log,
-    type SchedulerItem,
 } from './SchedulersViewUtils';
 
 type LogsTableProps = {
     projectUuid: string;
 };
 
-type LogGroup = {
+type RunGroup = {
     type: 'group';
-    jobGroup: string;
-    scheduler: SchedulerItem;
-    logs: Log[];
-    subRows: LogRow[];
+    run: SchedulerRun;
+    subRows?: RunLogRow[];
+    childLogs?: SchedulerRunLog[];
 };
 
-type LogRow = {
+type RunLogRow = {
     type: 'log';
-    log: Log;
-    scheduler: SchedulerItem;
+    log: SchedulerRunLog;
+    run: SchedulerRun;
 };
 
-type TableRow = LogGroup | LogRow;
+type TableRow = RunGroup | RunLogRow;
 
-const isLogGroup = (row: TableRow): row is LogGroup => row.type === 'group';
-const isLogRow = (row: TableRow): row is LogRow => row.type === 'log';
+const isRunGroup = (row: TableRow): row is RunGroup => row.type === 'group';
+const isRunLogRow = (row: TableRow): row is RunLogRow => row.type === 'log';
 
 const fetchSize = 50;
 
@@ -126,31 +128,31 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
     );
 
     const { data, fetchNextPage, isError, isFetching, isLoading } =
-        useSchedulerLogs({
+        useSchedulerRuns({
             projectUuid,
             paginateArgs: { page: 1, pageSize: fetchSize },
             searchQuery: debouncedSearchAndFilters.search,
-            filters: debouncedSearchAndFilters.filters,
+            sortBy: 'scheduledTime',
+            sortDirection: 'desc',
+            filters: {
+                statuses: debouncedSearchAndFilters.filters.statuses,
+                createdByUserUuids:
+                    debouncedSearchAndFilters.filters.createdByUserUuids,
+                destinations: debouncedSearchAndFilters.filters.destinations,
+            },
         });
 
     // Flatten paginated data
-    const schedulerLogsData = useMemo(() => {
+    const schedulerRunsData = useMemo(() => {
         if (!data?.pages) return undefined;
 
-        const allLogs = data.pages.flatMap((page) => page.data.logs);
-        const firstPage = data.pages[0];
+        const allRuns = data.pages.flatMap((page) => page.data);
 
-        return {
-            schedulers: firstPage?.data.schedulers || [],
-            users: firstPage?.data.users || [],
-            charts: firstPage?.data.charts || [],
-            dashboards: firstPage?.data.dashboards || [],
-            logs: allLogs,
-        };
+        return allRuns;
     }, [data]);
 
     const totalDBRowCount = data?.pages?.[0]?.pagination?.totalResults ?? 0;
-    const totalFetched = schedulerLogsData?.logs.length ?? 0;
+    const totalFetched = schedulerRunsData?.length ?? 0;
 
     // Callback to fetch more data when scrolling
     const fetchMoreOnBottomReached = useCallback(
@@ -194,10 +196,52 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
         name: string;
     } | null>(null);
     const [expanded, setExpanded] = useState<MRT_ExpandedState>({});
+    const [childLogsMap, setChildLogsMap] = useState<
+        Map<string, SchedulerRunLog[]>
+    >(new Map());
 
     const sendNowMutation = useSendNowSchedulerByUuid(
         selectedScheduler?.uuid ?? '',
     );
+
+    const fetchRunLogsMutation = useFetchRunLogs();
+
+    // Fetch child logs when rows are expanded
+    useEffect(() => {
+        const expandedRowIds = Object.keys(expanded).filter(
+            (key) => expanded[key as keyof typeof expanded],
+        );
+
+        expandedRowIds.forEach((rowId) => {
+            const rowIndex = parseInt(rowId, 10);
+            const run = schedulerRunsData?.[rowIndex];
+
+            if (run && !childLogsMap.has(run.runId)) {
+                // Fetch child logs for this run using the hook
+                void fetchRunLogsMutation
+                    .mutateAsync(run.runId)
+                    .then((childLogs) => {
+                        console.log(
+                            `Fetched ${childLogs.length} logs for run ${run.runId}:`,
+                            childLogs.map((l) => ({
+                                task: l.task,
+                                isParent: l.isParent,
+                                status: l.status,
+                                createdAt: l.createdAt,
+                            })),
+                        );
+                        setChildLogsMap((prev) => {
+                            const newMap = new Map(prev);
+                            newMap.set(run.runId, childLogs);
+                            return newMap;
+                        });
+                    })
+                    .catch((error) => {
+                        console.error('Error fetching child logs:', error);
+                    });
+            }
+        });
+    }, [expanded, schedulerRunsData, childLogsMap, fetchRunLogsMutation]);
 
     const health = useHealth();
     const slack = useGetSlack();
@@ -218,69 +262,50 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
         return destinations;
     }, [health.data, organizationHasSlack]);
 
-    // Compute available users from schedulers (only users who created schedulers)
+    // Compute available users from runs (only users who created schedulers)
     const availableUsers = useMemo(() => {
-        const userMap = new Map<
-            string,
-            { userUuid: string; firstName: string; lastName: string }
-        >();
-        schedulerLogsData?.schedulers.forEach((scheduler) => {
-            const user = schedulerLogsData?.users.find(
-                (u) => u.userUuid === scheduler.createdBy,
-            );
-            if (user) {
-                userMap.set(user.userUuid, {
-                    userUuid: user.userUuid,
-                    firstName: user.firstName,
-                    lastName: user.lastName,
-                });
-            }
+        const userMap = new Map<string, { userUuid: string; name: string }>();
+        schedulerRunsData?.forEach((run) => {
+            userMap.set(run.createdByUserUuid, {
+                userUuid: run.createdByUserUuid,
+                name: run.createdByUserName,
+            });
         });
         return Array.from(userMap.values()).sort((a, b) =>
-            `${a.firstName} ${a.lastName}`.localeCompare(
-                `${b.firstName} ${b.lastName}`,
-            ),
+            a.name.localeCompare(b.name),
         );
-    }, [schedulerLogsData]);
+    }, [schedulerRunsData]);
 
-    const groupedLogData = useMemo<LogGroup[]>(() => {
-        // Logs are already filtered by the backend
-        const logs = schedulerLogsData?.logs ?? [];
+    const runGroupData = useMemo<RunGroup[]>(() => {
+        // Runs are already filtered and sorted by the backend
+        const runs = schedulerRunsData ?? [];
 
-        const grouped = Object.entries(groupBy(logs, 'jobGroup'));
-        return grouped
-            .map(([jobGroup, schedulerLogs]): LogGroup | null => {
-                const schedulerItem = schedulerLogsData?.schedulers.find(
-                    (item) =>
-                        item.schedulerUuid === schedulerLogs[0].schedulerUuid,
-                );
-                if (!schedulerItem) return null;
-
-                // Create sub-rows for each log
-                const subRows: LogRow[] = schedulerLogs.map((log) => ({
+        return runs.map((run): RunGroup => {
+            const childLogs = childLogsMap.get(run.runId);
+            const subRows = childLogs?.map(
+                (log): RunLogRow => ({
                     type: 'log',
                     log,
-                    scheduler: schedulerItem,
-                }));
+                    run,
+                }),
+            );
 
-                return {
-                    type: 'group',
-                    jobGroup,
-                    scheduler: schedulerItem,
-                    logs: schedulerLogs,
-                    subRows,
-                };
-            })
-            .filter((item): item is LogGroup => item !== null);
-    }, [schedulerLogsData]);
+            return {
+                type: 'group',
+                run,
+                subRows,
+                childLogs,
+            };
+        });
+    }, [schedulerRunsData, childLogsMap]);
 
     // Temporary workaround to resolve a memoization issue with react-mantine-table.
     // In certain scenarios, the content fails to render properly even when the data is updated.
     // This issue may be addressed in a future library update.
-    const [tableData, setTableData] = useState<LogGroup[]>([]);
+    const [tableData, setTableData] = useState<RunGroup[]>([]);
     useEffect(() => {
-        setTableData(groupedLogData);
-    }, [groupedLogData]);
+        setTableData(runGroupData);
+    }, [runGroupData]);
 
     const columns: MRT_ColumnDef<TableRow>[] = useMemo(
         () => [
@@ -299,52 +324,32 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                     const rowData = row.original;
 
                     // Only show name for parent rows
-                    if (isLogRow(rowData)) {
+                    if (isRunLogRow(rowData)) {
                         return null;
                     }
 
-                    const { scheduler } = rowData;
-                    const user = schedulerLogsData?.users.find(
-                        (u) => u.userUuid === scheduler.createdBy,
-                    );
-                    const chartOrDashboard = scheduler.savedChartUuid
-                        ? schedulerLogsData?.charts.find(
-                              (chart) =>
-                                  chart.savedChartUuid ===
-                                  scheduler.savedChartUuid,
-                          )
-                        : schedulerLogsData?.dashboards.find(
-                              (dashboard) =>
-                                  dashboard.dashboardUuid ===
-                                  scheduler.dashboardUuid,
-                          );
+                    const { run } = rowData;
 
                     return (
                         <Group wrap="nowrap">
-                            {getSchedulerIcon(scheduler)}
+                            {getSchedulerIcon(run)}
                             <Stack gap="two">
                                 <Anchor
                                     component={Link}
-                                    to={getSchedulerLink(
-                                        scheduler,
-                                        projectUuid,
-                                    )}
+                                    to={getSchedulerLink(run, projectUuid)}
                                     target="_blank"
                                 >
                                     <Tooltip
                                         label={
                                             <Stack gap="two" fz="xs">
                                                 <Text c="gray.5" fz="xs">
-                                                    Schedule type:{' '}
+                                                    Scheduler:{' '}
                                                     <Text
                                                         c="white"
                                                         span
                                                         fz="xs"
                                                     >
-                                                        {scheduler.format ===
-                                                        'csv'
-                                                            ? 'CSV'
-                                                            : 'Image'}
+                                                        {run.schedulerName}
                                                     </Text>
                                                 </Text>
                                                 <Text c="gray.5" fz="xs">
@@ -354,8 +359,7 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                                                         span
                                                         fz="xs"
                                                     >
-                                                        {user?.firstName}{' '}
-                                                        {user?.lastName}
+                                                        {run.createdByUserName}
                                                     </Text>
                                                 </Text>
                                             </Stack>
@@ -370,12 +374,12 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                                                 cursor: 'pointer',
                                             }}
                                         >
-                                            {scheduler.name}
+                                            {run.schedulerName}
                                         </Text>
                                     </Tooltip>
                                 </Anchor>
                                 <Text fz="xs" c="gray.6" maw="190px" truncate>
-                                    {chartOrDashboard?.name}
+                                    {run.resourceName}
                                 </Text>
                             </Stack>
                         </Group>
@@ -390,11 +394,13 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                 Cell: ({ row }) => {
                     const rowData = row.original;
 
-                    if (isLogGroup(rowData)) {
-                        // Parent row: show "All jobs"
+                    if (isRunGroup(rowData)) {
+                        // Parent row: show aggregated counts
+                        const { logCounts } = rowData.run;
                         return (
                             <Text fz="xs" fw={500} c="gray.7">
-                                All jobs
+                                {logCounts.total}{' '}
+                                {logCounts.total === 1 ? 'job' : 'jobs'}
                             </Text>
                         );
                     } else {
@@ -438,13 +444,10 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                 Cell: ({ row }) => {
                     const rowData = row.original;
 
-                    if (isLogGroup(rowData)) {
-                        const firstLog = rowData.logs[0];
+                    if (isRunGroup(rowData)) {
                         return (
                             <Text fz="xs" c="gray.6">
-                                {firstLog
-                                    ? formatTime(firstLog.scheduledTime)
-                                    : '-'}
+                                {formatTime(rowData.run.scheduledTime)}
                             </Text>
                         );
                     } else {
@@ -470,13 +473,10 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                 Cell: ({ row }) => {
                     const rowData = row.original;
 
-                    if (isLogGroup(rowData)) {
-                        const firstLog = rowData.logs[0];
+                    if (isRunGroup(rowData)) {
                         return (
                             <Text fz="xs" c="gray.6">
-                                {firstLog
-                                    ? formatTime(firstLog.createdAt)
-                                    : '-'}
+                                {formatTime(rowData.run.createdAt)}
                             </Text>
                         );
                     } else {
@@ -495,25 +495,18 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                 size: 90,
                 Cell: ({ row }) => {
                     const rowData = row.original;
-                    const { scheduler } = rowData;
 
                     return (
                         <Group>
-                            {isLogGroup(rowData) ? (
-                                rowData.logs[0] ? (
-                                    getLogStatusIcon(rowData.logs[0], theme)
-                                ) : (
-                                    <Text fz="xs" c="gray.6">
-                                        -
-                                    </Text>
-                                )
-                            ) : (
-                                getLogStatusIcon(rowData.log, theme)
-                            )}
+                            {isRunGroup(rowData)
+                                ? getRunStatusIcon(rowData.run.runStatus, theme)
+                                : getLogStatusIcon(rowData.log, theme)}
 
-                            {isLogGroup(rowData) &&
-                                rowData.logs[0]?.status ===
-                                    SchedulerJobStatus.ERROR && (
+                            {isRunGroup(rowData) &&
+                                (rowData.run.runStatus ===
+                                    SchedulerRunStatus.FAILED ||
+                                    rowData.run.runStatus ===
+                                        SchedulerRunStatus.PARTIAL_FAILURE) && (
                                     <Box
                                         component="div"
                                         onClick={(
@@ -556,8 +549,10 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                                                     }
                                                     onClick={() => {
                                                         setSelectedScheduler({
-                                                            uuid: scheduler.schedulerUuid,
-                                                            name: scheduler.name,
+                                                            uuid: rowData.run
+                                                                .schedulerUuid,
+                                                            name: rowData.run
+                                                                .schedulerName,
                                                         });
                                                         setIsConfirmOpen(true);
                                                     }}
@@ -573,14 +568,16 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
                 },
             },
         ],
-        [schedulerLogsData, projectUuid, theme],
+        [projectUuid, theme],
     );
 
     const table = useMantineReactTable({
         columns,
         data: tableData,
         enableExpanding: true,
-        getSubRows: (row) => (isLogGroup(row) ? row.subRows : undefined),
+        enableExpandAll: false,
+        getSubRows: (row) => (isRunGroup(row) ? row.subRows : undefined),
+        getRowCanExpand: (row) => isRunGroup(row.original),
         enableColumnResizing: false,
         enableRowNumbers: false,
         enablePagination: false,
@@ -699,6 +696,7 @@ const LogsTable: FC<LogsTableProps> = ({ projectUuid }) => {
         displayColumnDefOptions: {
             'mrt-row-expand': {
                 size: 40,
+                header: '',
             },
         },
     });

--- a/packages/frontend/src/components/SchedulersView/LogsTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTopToolbar.tsx
@@ -19,8 +19,7 @@ import StatusFilter from './filters/StatusFilter';
 
 type User = {
     userUuid: string;
-    firstName: string;
-    lastName: string;
+    name: string;
 };
 
 interface LogsTopToolbarProps

--- a/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
@@ -21,8 +21,7 @@ import { SearchFilter } from './filters/SearchFilter';
 
 type User = {
     userUuid: string;
-    firstName: string;
-    lastName: string;
+    name: string;
 };
 
 type SchedulerTopToolbarProps = GroupProps &

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -162,26 +162,17 @@ const SchedulersTable: FC<SchedulersTableProps> = ({ projectUuid }) => {
 
     // Compute available users from loaded schedulers
     const availableUsers = useMemo(() => {
-        const userMap = new Map<
-            string,
-            { userUuid: string; firstName: string; lastName: string }
-        >();
+        const userMap = new Map<string, { userUuid: string; name: string }>();
         flatData.forEach((scheduler) => {
             if (scheduler.createdBy && scheduler.createdByName) {
-                const nameParts = scheduler.createdByName.split(' ');
-                const firstName = nameParts[0] || '';
-                const lastName = nameParts.slice(1).join(' ') || '';
                 userMap.set(scheduler.createdBy, {
                     userUuid: scheduler.createdBy,
-                    firstName,
-                    lastName,
+                    name: scheduler.createdByName,
                 });
             }
         });
         return Array.from(userMap.values()).sort((a, b) =>
-            `${a.firstName} ${a.lastName}`.localeCompare(
-                `${b.firstName} ${b.lastName}`,
-            ),
+            a.name.localeCompare(b.name),
         );
     }, [flatData]);
 
@@ -402,7 +393,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({ projectUuid }) => {
                 enableSorting: false,
                 size: 160,
                 Header: ({ column }) => (
-                    <Group gap="two">
+                    <Group gap="two" wrap="nowrap">
                         <MantineIcon icon={IconRun} color="gray.6" />
                         {column.columnDef.header}
                     </Group>

--- a/packages/frontend/src/components/SchedulersView/filters/CreatedByFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/CreatedByFilter.tsx
@@ -13,8 +13,7 @@ import classes from './FormatFilter.module.css';
 
 type User = {
     userUuid: string;
-    firstName: string;
-    lastName: string;
+    name: string;
 };
 
 interface CreatedByFilterProps {
@@ -89,7 +88,7 @@ const CreatedByFilter: FC<CreatedByFilterProps> = ({
                             {availableUsers.map((user) => (
                                 <Checkbox
                                     key={user.userUuid}
-                                    label={`${user.firstName} ${user.lastName}`}
+                                    label={user.name}
                                     checked={selectedCreatedByUserUuids.includes(
                                         user.userUuid,
                                     )}

--- a/packages/frontend/src/components/SchedulersView/filters/StatusFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/StatusFilter.tsx
@@ -1,4 +1,4 @@
-import { SchedulerJobStatus } from '@lightdash/common';
+import { SchedulerRunStatus } from '@lightdash/common';
 import {
     Badge,
     Button,
@@ -18,18 +18,21 @@ type StatusFilterProps = Pick<
     'selectedStatuses' | 'setSelectedStatuses'
 >;
 
-const STATUS_LABELS: Record<SchedulerJobStatus, string> = {
-    [SchedulerJobStatus.SCHEDULED]: 'Scheduled',
-    [SchedulerJobStatus.STARTED]: 'Started',
-    [SchedulerJobStatus.COMPLETED]: 'Completed',
-    [SchedulerJobStatus.ERROR]: 'Error',
+const STATUS_LABELS: Record<SchedulerRunStatus, string> = {
+    [SchedulerRunStatus.COMPLETED]: 'Completed',
+    [SchedulerRunStatus.PARTIAL_FAILURE]: 'Partial Failure',
+    [SchedulerRunStatus.FAILED]: 'Failed',
+    [SchedulerRunStatus.RUNNING]: 'Running',
+    [SchedulerRunStatus.SCHEDULED]: 'Scheduled',
 };
 
 const StatusFilter: FC<StatusFilterProps> = ({
     selectedStatuses,
     setSelectedStatuses,
 }) => {
-    const allStatuses = Object.values(SchedulerJobStatus);
+    const filterableStatuses = Object.values(SchedulerRunStatus).filter(
+        (status) => status !== SchedulerRunStatus.SCHEDULED,
+    );
     const hasSelectedStatuses = selectedStatuses.length > 0;
 
     return (
@@ -38,7 +41,7 @@ const StatusFilter: FC<StatusFilterProps> = ({
                 <Tooltip
                     withinPortal
                     variant="xs"
-                    label="Filter logs by status"
+                    label="Filter runs by status"
                 >
                     <Button
                         h={32}
@@ -88,7 +91,7 @@ const StatusFilter: FC<StatusFilterProps> = ({
 
                     <ScrollArea.Autosize mah={200} type="always" scrollbars="y">
                         <Stack gap="xs">
-                            {allStatuses.map((status) => (
+                            {filterableStatuses.map((status) => (
                                 <Checkbox
                                     key={status}
                                     label={STATUS_LABELS[status]}

--- a/packages/frontend/src/features/scheduler/hooks/useLogsFilters.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useLogsFilters.ts
@@ -1,4 +1,4 @@
-import { type SchedulerJobStatus } from '@lightdash/common';
+import { type SchedulerRunStatus } from '@lightdash/common';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
@@ -10,7 +10,7 @@ export const useLogsFilters = () => {
     // Initialize from URL params
     const initialSearch = searchParams.get('nameSearch') || '';
     const initialStatuses = searchParams.get('status')
-        ? (searchParams.get('status')!.split(',') as SchedulerJobStatus[])
+        ? (searchParams.get('status')!.split(',') as SchedulerRunStatus[])
         : [];
     const initialCreators = searchParams.get('creator')
         ? searchParams.get('creator')!.split(',')
@@ -21,7 +21,7 @@ export const useLogsFilters = () => {
 
     const [search, setSearchState] = useState<string>(initialSearch);
     const [selectedStatuses, setSelectedStatusesState] =
-        useState<SchedulerJobStatus[]>(initialStatuses);
+        useState<SchedulerRunStatus[]>(initialStatuses);
     const [selectedCreatedByUserUuids, setSelectedCreatedByUserUuidsState] =
         useState<string[]>(initialCreators);
     const [selectedDestinations, setSelectedDestinationsState] =
@@ -42,7 +42,7 @@ export const useLogsFilters = () => {
     );
 
     const setSelectedStatuses = useCallback(
-        (statuses: SchedulerJobStatus[]) => {
+        (statuses: SchedulerRunStatus[]) => {
             setSelectedStatusesState(statuses);
             const newParams = new URLSearchParams(searchParams);
             if (statuses.length > 0) {


### PR DESCRIPTION
### Description:

Uses the new `runs` endpoint to render the list of scheduler runs. Then the `runs/:runId/logs` endpoint to get details. This improves the fetching semantics and stability of the schedulers run history. Before we were fetching all logs and filtering and grouping on the FE. Now we fetch a paginated list of scheduler runs which include a computed status at the top level. When a user clicks to expand a run, we fetch its details. 

Improves performance by:
- Fetching a paginated list of runs initially, instead of all logs
- Relying on filtering and computed status from the BE

Also updates the UI a bit:
- Fixes incorrect/confusing run sort order
- Lists the jobs in a run in chronological order

Test by looking at the Run History. Runs will be listed and can be expanded to see child jobs. 

<img width="1187" height="688" alt="Screenshot 2025-11-19 at 18 54 11" src="https://github.com/user-attachments/assets/db3fbe6b-d38e-419e-ad8e-6522f49a7a06" />

