### PR TITLE
chore: update OpenAI model from gpt-5-2025-08-07 to gpt-5.1-2025-11-13 for CI Evals

### DIFF
--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -120,7 +120,7 @@ jobs:
                     - ai_provider: openai
                       model_name: gpt-4.1-2025-04-14
                     - ai_provider: openai
-                      model_name: gpt-5-2025-08-07
+                      model_name: gpt-5.1-2025-11-13
                     - ai_provider: anthropic
                       model_name: claude-sonnet-4-5-20250929
                     - ai_provider: anthropic


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updates the OpenAI model name in the AI agent integration tests workflow from `gpt-5-2025-08-07` to `gpt-5.1-2025-11-13` to use the latest model version.
