### PR TITLE
fix: add noWrap property to VirtualMissingField component

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
@@ -33,6 +33,7 @@ const VirtualMissingFieldComponent: FC<VirtualMissingFieldProps> = ({
                 onClick={handleClick}
                 ml={12}
                 my="xs"
+                noWrap
                 style={{ cursor: 'pointer' }}
             >
                 <MantineIcon


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes UI inconsistency

### Description:
Added `noWrap` property to the MantineText component in VirtualMissingField to prevent text from wrapping onto multiple lines, ensuring a more consistent and compact display in the explorer tree.

Before:

![Screenshot 2025-11-20 at 13.19.07.png](https://app.graphite.com/user-attachments/assets/db11ac22-2dda-4f8a-a1da-9b6ee443c147.png)

After:

![Screenshot 2025-11-20 at 13.18.55.png](https://app.graphite.com/user-attachments/assets/be115090-9a62-4997-b138-7aee070acbc7.png)

