### PR TITLE
fix: remove long sql transaction lock for getSpaceRoot

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1960,32 +1960,30 @@ export class SpaceModel {
      * @returns Root space UUID (or itself if it's already a root space)
      */
     async getSpaceRoot(spaceUuid: string): Promise<string> {
-        return this.database.transaction(async (trx) => {
-            const space = await trx(SpaceTableName)
-                .select(['path', 'project_id'])
-                .where('space_uuid', spaceUuid)
-                .first();
+        const space = await this.database(SpaceTableName)
+            .select(['path', 'project_id'])
+            .where('space_uuid', spaceUuid)
+            .first();
 
-            if (!space || !space.path) {
-                throw new NotFoundError(
-                    `Space with uuid ${spaceUuid} does not exist`,
-                );
-            }
+        if (!space || !space.path) {
+            throw new NotFoundError(
+                `Space with uuid ${spaceUuid} does not exist`,
+            );
+        }
 
-            const root = await trx(SpaceTableName)
-                .select('space_uuid')
-                .whereRaw('nlevel(path) = 1')
-                .andWhereRaw('path @> ?', [space.path])
-                .andWhere('project_id', space.project_id)
-                .first();
+        const root = await this.database(SpaceTableName)
+            .select('space_uuid')
+            .whereRaw('nlevel(path) = 1')
+            .andWhereRaw('path @> ?', [space.path])
+            .andWhere('project_id', space.project_id)
+            .first();
 
-            if (!root) {
-                throw new NotFoundError(
-                    `Root space for space for ${spaceUuid} not found`,
-                );
-            }
+        if (!root) {
+            throw new NotFoundError(
+                `Root space for space for ${spaceUuid} not found`,
+            );
+        }
 
-            return root.space_uuid;
-        });
+        return root.space_uuid;
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-141/dashboards-are-slow-to-load-with-many-tiles
Closes: https://linear.app/lightdash/issue/CENG-219/remove-expensive-database-transaction-on-getspaceroot

Full investigation here:  https://www.notion.so/lightdash/Javi-performance-investigation-2025-11-20-2b1a63207a7a802b8676e210422e9a95

### What the issue is (tl;dr)

- We have **dozens of `idle in transaction` sessions** with the same `spaces` query.
- That is **a transaction leak** in your app, and it will absolutely:
    - tie up connections,
    - cause connection-acquire time spikes,
    - and make simple HTTP requests randomly take 5–9 seconds.

### What does this fix ?

This PR removes the unnecesary transaction lock. There might be some others, but this was the most obvious one in the code, and a quick-fix with potentially huge impact. 

If this doesn't solve the issue, we can keep investigating

### How many connections do we have per pod ? 

Set on knexfile.ts
$PGMAXCONNECTIONS = 50
So each pod can have up to **50 concurrent DB connections** for `analytics`.

### How to see transactions 

By running this SQL on the instance, while it is under heavy load. We can see what transactions are pending, active or locked. 

```jsx
SELECT
  pid, usename, datname,
  state, wait_event_type, wait_event,
  now() - query_start AS query_age,
  query
FROM pg_stat_activity
WHERE backend_type = 'client backend'
  AND state <> 'idle'
ORDER BY query_age DESC
LIMIT 50;
```

After a few tries , I found MANY transactions that was `idle in transaction` 

```jsx
    {
      pid: 3576002,
      usename: 'analytics',
      datname: 'analytics',
      state: 'idle in transaction',
      wait_event_type: 'Client',
      wait_event: 'ClientRead',
      query_age: [PostgresInterval],
      query: 'select "path", "project_id" from "spaces" where "space_uuid" = $1 limit $2'
    },
```

### Next step / extra optimization

cache the `getSpaceRoot` method (in memory should be enough)

### Goal 

We should see this chart going down after this is released

<img width="595" height="331" alt="image" src="https://github.com/user-attachments/assets/e31ac2de-7f1c-41a6-888c-37c3f08989c9" />


### Description:
Removed unnecessary transaction from `getSpaceRoot` method in `SpaceModel`. This operation only performs read queries and doesn't require a transaction, which improves performance by reducing database overhead.