### PR TITLE
feat: add description fields to ai agent settings

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -201,6 +201,7 @@ export class AiAgentModel {
                 organizationUuid: `${AiAgentTableName}.organization_uuid`,
                 projectUuid: `${AiAgentTableName}.project_uuid`,
                 name: `${AiAgentTableName}.name`,
+                description: `${AiAgentTableName}.description`,
                 tags: `${AiAgentTableName}.tags`,
                 integrations: this.database.raw(`
                     COALESCE(
@@ -324,6 +325,7 @@ export class AiAgentModel {
                 organizationUuid: `${AiAgentTableName}.organization_uuid`,
                 projectUuid: `${AiAgentTableName}.project_uuid`,
                 name: `${AiAgentTableName}.name`,
+                description: `${AiAgentTableName}.description`,
                 tags: `${AiAgentTableName}.tags`,
                 integrations: this.database.raw(`
                     COALESCE(
@@ -429,6 +431,7 @@ export class AiAgentModel {
         args: Pick<
             ApiCreateAiAgent,
             | 'name'
+            | 'description'
             | 'projectUuid'
             | 'tags'
             | 'integrations'
@@ -451,7 +454,7 @@ export class AiAgentModel {
                     project_uuid: args.projectUuid,
                     organization_uuid: args.organizationUuid,
                     tags: args.tags,
-                    description: null,
+                    description: args.description ?? null,
                     image_url: null,
                     enable_data_access: args.enableDataAccess,
                     enable_self_improvement: args.enableSelfImprovement,
@@ -522,6 +525,7 @@ export class AiAgentModel {
             return {
                 uuid: agent.ai_agent_uuid,
                 name: agent.name,
+                description: agent.description,
                 projectUuid: agent.project_uuid,
                 organizationUuid: agent.organization_uuid,
                 tags: agent.tags,
@@ -557,6 +561,9 @@ export class AiAgentModel {
                     updated_at: trx.fn.now(),
                     ...(args.tags !== undefined ? { tags: args.tags } : {}),
                     ...(args.name !== undefined ? { name: args.name } : {}),
+                    ...(args.description !== undefined
+                        ? { description: args.description }
+                        : {}),
                     ...(args.imageUrl !== undefined
                         ? { image_url: args.imageUrl }
                         : {}),
@@ -658,6 +665,7 @@ export class AiAgentModel {
             return {
                 uuid: agent.ai_agent_uuid,
                 name: agent.name,
+                description: agent.description,
                 projectUuid: agent.project_uuid,
                 organizationUuid: agent.organization_uuid,
                 tags: agent.tags,

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -929,6 +929,7 @@ export class AiAgentService {
 
         const agent = await this.aiAgentModel.createAgent({
             name: body.name,
+            description: body.description,
             projectUuid: body.projectUuid,
             organizationUuid,
             tags: body.tags,
@@ -988,6 +989,7 @@ export class AiAgentService {
         const updatedAgent = await this.aiAgentModel.updateAgent({
             agentUuid,
             name: body.name,
+            description: body.description,
             projectUuid: body.projectUuid,
             organizationUuid,
             tags: body.tags,

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -62,6 +62,7 @@ describeOrSkip.concurrent('agent integration tests', () => {
             context.testUser,
             {
                 name: 'Integration Test Agent',
+                description: null,
                 projectUuid: SEED_PROJECT.project_uuid,
                 tags: ['ai'],
                 integrations: [],

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -39,7 +39,7 @@ export const baseAgentSchema = z.object({
     organizationUuid: z.string(),
 
     name: z.string(),
-    description: z.string(),
+    description: z.string().nullable(),
     imageUrl: z.string().url().nullable(),
 
     tags: z.array(z.string()).nullable(),
@@ -85,6 +85,7 @@ export type AiAgent = Pick<
     | 'integrations'
     | 'tags'
     | 'name'
+    | 'description'
     | 'createdAt'
     | 'updatedAt'
     | 'instruction'
@@ -102,6 +103,7 @@ export type AiAgentSummary = Pick<
     AiAgent,
     | 'uuid'
     | 'name'
+    | 'description'
     | 'integrations'
     | 'tags'
     | 'projectUuid'
@@ -207,6 +209,7 @@ export type ApiCreateAiAgent = Pick<
     | 'integrations'
     | 'tags'
     | 'name'
+    | 'description'
     | 'instruction'
     | 'imageUrl'
     | 'groupAccess'
@@ -225,6 +228,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'integrations'
         | 'tags'
         | 'name'
+        | 'description'
         | 'instruction'
         | 'imageUrl'
         | 'groupAccess'

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -64,6 +64,7 @@ import { SpaceAccessSelect } from './SpaceAccessSelect';
 
 const formSchema = z.object({
     name: z.string().min(1),
+    description: z.string().nullable(),
     integrations: z.array(
         z.object({
             type: z.literal('slack'),
@@ -239,6 +240,22 @@ export const AiAgentFormSetup = ({
                                     />
                                 </Tooltip>
                             </Group>
+                            <Textarea
+                                variant="subtle"
+                                label="Description"
+                                description="A brief description of what this agent does and its purpose."
+                                placeholder="Describe what this agent specializes in..."
+                                minRows={3}
+                                maxRows={6}
+                                {...form.getInputProps('description')}
+                                onChange={(e) => {
+                                    const value = e.target.value;
+                                    form.setFieldValue(
+                                        'description',
+                                        value ? value : null,
+                                    );
+                                }}
+                            />
                             <TextInput
                                 style={{ flexGrow: 1 }}
                                 miw={200}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -94,6 +94,17 @@ const AiAgentNewThreadPage: FC = () => {
                                 </Popover>
                             )}
                         </Group>
+                        {agent.description && (
+                            <Text
+                                size="sm"
+                                c="gray.6"
+                                ta="center"
+                                maw={600}
+                                style={{ whiteSpace: 'pre-wrap' }}
+                            >
+                                {agent.description}
+                            </Text>
+                        )}
                         {agent.tags && (
                             <Group gap="xxs">
                                 {agent.tags.map((tag, i) => (

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -45,6 +45,7 @@ import { EvalsSetup } from './EvalsSetup';
 
 const formSchema = z.object({
     name: z.string().min(1),
+    description: z.string().nullable(),
     integrations: z.array(
         z.object({
             type: z.literal('slack'),
@@ -99,6 +100,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
     const form = useForm<z.infer<typeof formSchema>>({
         initialValues: {
             name: '',
+            description: null,
             integrations: [],
             tags: null,
             instruction: null,
@@ -122,6 +124,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
         if (!form.initialized) {
             const values = {
                 name: agent.name,
+                description: agent.description,
                 integrations: agent.integrations,
                 tags: agent.tags && agent.tags.length > 0 ? agent.tags : null,
                 instruction: agent.instruction,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: ZAP-131

### Description:
Added support for agent descriptions in the AI Agent system. This change allows users to add and edit descriptions for their AI agents, which are displayed on the agent's page. The description field is optional and can be set to null.

The description field is now included in:
- Agent creation and update operations
- API responses for agent data
- Form interfaces for creating and editing agents
- The agent details page where it's displayed to users

![CleanShot 2025-11-20 at 15.16.38.png](https://app.graphite.com/user-attachments/assets/4710417b-d672-488b-a55c-86043fac1152.png)

![CleanShot 2025-11-20 at 15.18.21.png](https://app.graphite.com/user-attachments/assets/9405f26b-5a95-41fa-b9f0-9d2e773c9dda.png)

