### PR TITLE
feat: download content in folders per the Lightdash project structure

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -614,6 +614,11 @@ program
         undefined,
     )
     .option(
+        '--nested',
+        'organize downloads in nested folders by project and space (default: flat structure)',
+        false,
+    )
+    .option(
         '--project <project uuid>',
         'specify a project UUID to download',
         parseProjectArgument,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: CENG-208

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Updates the CLI's download/upload functionality to account for the folder structure customer's create in a given Lightdash project. Instead of downloading content into a flat folder structure, we now group by:

```
WorkingDir /
  ProjectName / 
    Space Name / 
      Maybe Child Space Name / 
        dashboards / DashboardName.yml
        charts / ChartName.yml
```

### Before

![Screen Shot 2025-11-20 at 4.43.51 PM.png](https://app.graphite.com/user-attachments/assets/11b12e25-ae5b-4454-8b7e-c3434f6a7c3b.png)

### After

![Screen Shot 2025-11-20 at 4.44.37 PM.png](https://app.graphite.com/user-attachments/assets/7f547713-4327-49ba-9f5a-429f024e3268.png)

