### PR TITLE
feat: add chronological sorting for time interval names in pivoted queries

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -97,7 +97,7 @@ models:
           meta:
             dimension:
               type: date
-              time_intervals: ["DAY", "WEEK", "MONTH", "YEAR"]
+              time_intervals: ["DAY", "WEEK", "MONTH", "YEAR", "MONTH_NAME", "DAY_OF_WEEK_NAME", "QUARTER_NAME"]
             metrics:
               date_of_first_order:
                 type: min

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1761,6 +1761,7 @@ export class AsyncQueryService extends ProjectService {
                             pivotConfiguration,
                             warehouseSqlBuilder,
                             args.metricQuery.limit,
+                            args.fields,
                         );
 
                         pivotedQuery = pivotQueryBuilder.toSql({

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -11,6 +11,7 @@ import {
     CustomBinDimension,
     CustomDimension,
     DbtModelJoinType,
+    Dimension,
     Explore,
     FieldId,
     FieldReferenceError,
@@ -339,7 +340,7 @@ export const getJoinType = (type: DbtModelJoinType = 'left') => {
 };
 
 export const sortMonthName = (
-    dimension: CompiledDimension,
+    dimension: Dimension,
     fieldQuoteChar: string,
     descending: Boolean,
 ) => {
@@ -361,10 +362,10 @@ export const sortMonthName = (
             WHEN ${fieldId} = 'December' THEN 12
             ELSE 0
         END
-        )${descending ? ' DESC' : ''}`;
+    )${descending ? ' DESC' : ''}`;
 };
 export const sortDayOfWeekName = (
-    dimension: CompiledDimension,
+    dimension: Dimension,
     startOfWeek: WeekDay | null | undefined,
     fieldQuoteChar: string,
     descending: Boolean,
@@ -383,6 +384,22 @@ export const sortDayOfWeekName = (
             WHEN ${fieldId} = 'Thursday' THEN ${calculateDayIndex(5)}
             WHEN ${fieldId} = 'Friday' THEN ${calculateDayIndex(6)}
             WHEN ${fieldId} = 'Saturday' THEN ${calculateDayIndex(7)}
+            ELSE 0
+        END
+    )${descending ? ' DESC' : ''}`;
+};
+export const sortQuarterName = (
+    dimension: Dimension,
+    fieldQuoteChar: string,
+    descending: boolean,
+) => {
+    const fieldId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
+    return `(
+        CASE
+            WHEN ${fieldId} = 'Q1' THEN 1
+            WHEN ${fieldId} = 'Q2' THEN 2
+            WHEN ${fieldId} = 'Q3' THEN 3
+            WHEN ${fieldId} = 'Q4' THEN 4
             ELSE 0
         END
     )${descending ? ' DESC' : ''}`;


### PR DESCRIPTION
Closes: [#18245](https://github.com/lightdash/lightdash/issues/18245)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added support for additional time intervals in pivot tables: `MONTH_NAME`, `DAY_OF_WEEK_NAME`, and `QUARTER_NAME`. This enhancement ensures proper chronological sorting when these time intervals are used in pivot tables.

The implementation:

1. Added the new time intervals to the orders model in the jaffle shop demo
2. Enhanced the `PivotQueryBuilder` to handle special sorting for named time intervals
3. Added a `sortQuarterName` utility function to properly sort quarters chronologically
4. Updated the `AsyncQueryService` to pass field metadata to the pivot query builder