### PR TITLE
feat: group SD connection errors, improve message

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1142,13 +1142,19 @@ export class UnfurlService extends BaseService {
                         code: 2, // Error
                     });
 
+                    // All of these errors are related to connection issues and usually
+                    // arise because the headless browser either crashed while handling the request
+                    // or crash before and can't be reached. We are grouping them togther here
+                    // for a user-friendly error message, but we keep the original error message in the logs.
                     const isConnectionError =
-                        errorMessage.includes('ECONNREFUSED');
+                        errorMessage.includes('ECONNREFUSED') ||
+                        errorMessage.includes('ENOTFOUND') ||
+                        errorMessage.includes('ECONNRESET');
 
                     throw new ScreenshotError(
                         `Screenshot ${errorType}: ${
                             isConnectionError
-                                ? 'There was a connection error while capturing the screenshot. Please contact your admin or support team.'
+                                ? 'There was a connection error while capturing the screenshot. This often indicates a heavy load on the screenshot service and the delivery cannot be completed at this time.'
                                 : errorMessage
                         }`,
                         {


### PR DESCRIPTION
### Description:

Users currently see a cryptic call stack when scheduled deliveries fail because the headless browser crashes. We were already adding a more user-friendly message in some cases, but this adds a few more cases and makes the error message a bit more clear for most people. 

This is still not an especially useful error message and I am open to suggestions for improvement. Generally there is not much a user can do about this kind of error, so it doesn't have any call to action. Ideally very few people will see this. 
