### PR TITLE
feat: add caching for getSpaceRoot with 30s TTL

### DIFF
--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -42,9 +42,13 @@ describe('SpaceService', () => {
 
     describe('_userCanActionSpace', () => {
         beforeEach(() => {
-            jest.spyOn(SpaceModel.prototype, 'getSpaceRoot').mockImplementation(
-                async (spaceUuid) => spaceUuid,
-            );
+            jest.spyOn(
+                SpaceModel.prototype,
+                'getSpaceRootFromCacheOrDB',
+            ).mockImplementation(async (spaceUuid) => ({
+                spaceRoot: spaceUuid,
+                cacheHit: false,
+            }));
         });
         describe('organization admins', () => {
             it.each([


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-220/cache-getspaceroot-results

<img width="1077" height="203" alt="image" src="https://github.com/user-attachments/assets/6354e020-f335-4373-9474-b5be91d9baa4" />


### Description:
Adds caching for space root lookups to improve performance. Implemented a `getSpaceRootFromCacheOrDB` method that first checks a NodeCache before querying the database. The cache has a 30-second TTL and is only enabled when the `EXPERIMENTAL_CACHE` environment variable is set to 'true'.