### PR TITLE
fix: optimize space loading with lazy fetching and conditional rendering

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -39,19 +39,21 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
     const { user } = useApp();
     const { data: hasSavedCharts } = useProjectSavedChartStatus(projectUuid);
 
+    // Only check permissions when in edit mode (when it's actually needed)
     const userCanCreateDashboard = useCreateInAnySpaceAccess(
         projectUuid,
         'Dashboard',
+        { enabled: isEditMode },
     );
 
     const dashboardEmptyStateTitle = () => {
         switch (emptyContainerType) {
             case 'dashboard':
-                return userCanCreateDashboard
+                return userCanCreateDashboard && isEditMode
                     ? 'Start building your dashboard!'
                     : 'Dashboard is empty.';
             case 'tab':
-                return userCanCreateDashboard
+                return userCanCreateDashboard && isEditMode
                     ? 'Add tiles to this tab'
                     : 'Tab is empty';
             default:

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -72,7 +72,6 @@ import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useProject } from '../../../hooks/useProject';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
-import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import {
@@ -163,7 +162,6 @@ const SavedChartsHeader: FC = () => {
         useDisclosure();
 
     const { user, health } = useApp();
-    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true);
     const { mutateAsync: contentAction, isLoading: isContentActionLoading } =
         useContentAction(projectUuid);
     const updateSavedChart = useUpdateMutation(
@@ -854,7 +852,6 @@ const SavedChartsHeader: FC = () => {
                               ]
                             : []),
                     ]}
-                    spaces={spaces}
                     isLoading={isMovingChart || isContentActionLoading}
                     onClose={transferToSpaceModalHandlers.close}
                     onConfirm={async (newSpaceUuid) => {

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -6,7 +6,7 @@ import {
     IconFolders,
     IconLayoutDashboard,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { type FC, useState } from 'react';
 import { Link } from 'react-router';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
 import { useSpaceSummaries } from '../../hooks/useSpaces';
@@ -18,11 +18,15 @@ interface Props {
 }
 
 const BrowseMenu: FC<Props> = ({ projectUuid }) => {
+    // Track if menu has ever been opened to defer loading spaces
+    const [hasBeenOpened, setHasBeenOpened] = useState(false);
+
     const { data: spaces, isInitialLoading } = useSpaceSummaries(
         projectUuid,
         true,
         {
             select: (data) => data.filter((space) => !space.parentSpaceUuid),
+            enabled: hasBeenOpened,
         },
     );
     const { data: hasMetrics } = useHasMetricsInCatalog({
@@ -37,6 +41,11 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
             position="bottom-start"
             arrowOffset={16}
             offset={-2}
+            onChange={(opened) => {
+                if (opened && !hasBeenOpened) {
+                    setHasBeenOpened(true);
+                }
+            }}
         >
             <Menu.Target>
                 <Button

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -10,7 +10,6 @@ import {
 } from '@tabler/icons-react';
 import { memo, useState, type FC } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
-import useCreateInAnySpaceAccess from '../../hooks/user/useCreateInAnySpaceAccess';
 import { Can } from '../../providers/Ability';
 import useApp from '../../providers/App/useApp';
 import LargeMenuItem from '../common/LargeMenuItem';
@@ -28,11 +27,6 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
     const location = useLocation();
 
     const { user } = useApp();
-
-    const userCanCreateDashboards = useCreateInAnySpaceAccess(
-        projectUuid,
-        'Dashboard',
-    );
 
     const [isOpen, setIsOpen] = useState(false);
     const [isCreateSpaceOpen, setIsCreateSpaceOpen] = useState(false);
@@ -112,17 +106,14 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 icon={IconTerminal2}
                             />
                         </Can>
-
-                        {userCanCreateDashboards && (
-                            <LargeMenuItem
-                                title="Dashboard"
-                                description="Arrange multiple charts into a single view."
-                                onClick={() => setIsCreateDashboardOpen(true)}
-                                icon={IconLayoutDashboard}
-                                data-testid="ExploreMenu/NewDashboardButton"
-                            />
-                        )}
-
+                        <LargeMenuItem
+                            // Users who manage explores should be able to create dashboards in any space
+                            title="Dashboard"
+                            description="Arrange multiple charts into a single view."
+                            onClick={() => setIsCreateDashboardOpen(true)}
+                            icon={IconLayoutDashboard}
+                            data-testid="ExploreMenu/NewDashboardButton"
+                        />
                         <Can
                             I="create"
                             this={subject('Space', {
@@ -158,19 +149,20 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                     parentSpaceUuid={null}
                 />
             )}
+            {isCreateDashboardOpen && (
+                <DashboardCreateModal
+                    projectUuid={projectUuid}
+                    opened={isCreateDashboardOpen}
+                    onClose={() => setIsCreateDashboardOpen(false)}
+                    onConfirm={(dashboard) => {
+                        void navigate(
+                            `/projects/${projectUuid}/dashboards/${dashboard.uuid}/edit`,
+                        );
 
-            <DashboardCreateModal
-                projectUuid={projectUuid}
-                opened={isCreateDashboardOpen}
-                onClose={() => setIsCreateDashboardOpen(false)}
-                onConfirm={(dashboard) => {
-                    void navigate(
-                        `/projects/${projectUuid}/dashboards/${dashboard.uuid}/edit`,
-                    );
-
-                    setIsCreateDashboardOpen(false);
-                }}
-            />
+                        setIsCreateDashboardOpen(false);
+                    }}
+                />
+            )}
         </>
     );
 });

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -157,6 +157,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
     const { data: spaces, isInitialLoading: isLoadingSpaces } =
         useSpaceSummaries(projectUuid, true, {
             staleTime: 0,
+            enabled: isOpen, // Only fetch when modal is open
             onSuccess: (data) => {
                 if (data.length === 0) {
                     setIsCreatingNewSpace(true);

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -3,7 +3,6 @@ import {
     ResourceViewItemType,
     type Dashboard,
     type FeatureFlags,
-    type SpaceSummary,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -67,7 +66,6 @@ import { DashboardRefreshButton } from './DashboardRefreshButton';
 import ShareLinkButton from './ShareLinkButton';
 
 type DashboardHeaderProps = {
-    spaces?: SpaceSummary[];
     dashboard: Dashboard;
     organizationUuid?: string;
     hasDashboardChanged: boolean;
@@ -92,7 +90,6 @@ type DashboardHeaderProps = {
 };
 
 const DashboardHeader = ({
-    spaces = [],
     dashboard,
     organizationUuid,
     hasDashboardChanged,
@@ -313,7 +310,6 @@ const DashboardHeader = ({
                                 type: ResourceViewItemType.DASHBOARD,
                             },
                         ]}
-                        spaces={spaces}
                         isLoading={isMovingDashboardToSpace}
                         onConfirm={async (spaceUuid) => {
                             if (!spaceUuid) {

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -840,7 +840,6 @@ const InfiniteResourceTable = ({
                     onClose={closeTransferItemsModal}
                     projectUuid={filters.projectUuid}
                     items={selectedItems}
-                    spaces={spaces}
                     isLoading={isFetching || isContentBulkActionLoading}
                     onConfirm={async (spaceUuid) => {
                         await handleBulkMoveContent(selectedItems, spaceUuid);

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -19,7 +19,6 @@ import { useChartPinningMutation } from '../../../hooks/pinning/useChartPinningM
 import { useDashboardPinningMutation } from '../../../hooks/pinning/useDashboardPinningMutation';
 import { useSpacePinningMutation } from '../../../hooks/pinning/useSpaceMutation';
 import { useContentAction } from '../../../hooks/useContent';
-import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
 import SpaceActionModal from '../SpaceActionModal';
 import { ActionType } from '../SpaceActionModal/types';
@@ -45,7 +44,6 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
     onAction,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { data: spaces } = useSpaceSummaries(projectUuid, true, {});
 
     const { mutateAsync: contentAction, isLoading: isContentActionLoading } =
         useContentAction(projectUuid);
@@ -301,7 +299,6 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                     opened
                     onClose={handleReset}
                     items={[action.item]}
-                    spaces={spaces ?? []}
                     isLoading={isContentActionLoading}
                     onConfirm={async (spaceUuid) => {
                         await moveToSpace(action.item, spaceUuid);

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -75,6 +75,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
         isSuccess,
     } = useSpaceSummaries(projectUuid, true, {
         staleTime: 0,
+        enabled: modalProps.opened, // Only fetch when modal is open
         select: (data) => {
             // Only get spaces that the user can create dashboards to
             return data.filter((space) =>
@@ -187,6 +188,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
                 title="Create Dashboard"
                 icon={IconLayoutDashboard}
                 onClose={() => handleClose()}
+                modalRootProps={{ keepMounted: false }}
                 actions={
                     <Group position="right" w="100%">
                         {shouldShowNewSpaceButton && (

--- a/packages/frontend/src/hooks/user/useCreateInAnySpaceAccess.ts
+++ b/packages/frontend/src/hooks/user/useCreateInAnySpaceAccess.ts
@@ -5,9 +5,12 @@ import { useSpaceSummaries } from '../useSpaces';
 const useCreateInAnySpaceAccess = (
     projectUuid: string | undefined,
     subjectName: 'Dashboard' | 'SavedChart',
+    options?: { enabled?: boolean },
 ): boolean => {
     const { user } = useApp();
-    const spaces = useSpaceSummaries(projectUuid, true);
+    const spaces = useSpaceSummaries(projectUuid, true, {
+        enabled: options?.enabled && !!projectUuid,
+    });
 
     if (!projectUuid) {
         return false;

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -32,7 +32,6 @@ import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
-import { useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
@@ -46,7 +45,6 @@ const Dashboard: FC = () => {
         dashboardUuid: string;
         mode?: string;
     }>();
-    const { data: spaces } = useSpaceSummaries(projectUuid, true);
 
     const { clearIsEditingDashboardChart, clearDashboardStorage } =
         useDashboardStorage();
@@ -615,7 +613,6 @@ const Dashboard: FC = () => {
                 title={dashboard.name}
                 header={
                     <DashboardHeader
-                        spaces={spaces}
                         dashboard={dashboard}
                         organizationUuid={organization?.organizationUuid}
                         isEditMode={isEditMode}

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -9,7 +9,6 @@ import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import InfiniteResourceTable from '../components/common/ResourceView/InfiniteResourceTable';
 import DashboardCreateModal from '../components/common/modal/DashboardCreateModal';
 import { useDashboards } from '../hooks/dashboard/useDashboards';
-import { useSpaceSummaries } from '../hooks/useSpaces';
 import useCreateInAnySpaceAccess from '../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../providers/App/useApp';
 
@@ -23,9 +22,6 @@ const SavedDashboards = () => {
 
     const { health } = useApp();
     const isDemo = health.data?.mode === LightdashMode.DEMO;
-    const { data: spaces, isInitialLoading: isLoadingSpaces } =
-        useSpaceSummaries(projectUuid);
-    const hasNoSpaces = spaces && spaces.length === 0;
 
     const userCanCreateDashboards = useCreateInAnySpaceAccess(
         projectUuid,
@@ -36,7 +32,7 @@ const SavedDashboards = () => {
         return null;
     }
 
-    if (isInitialLoading || isLoadingSpaces) {
+    if (isInitialLoading) {
         return <LoadingState title="Loading dashboards" />;
     }
 
@@ -67,7 +63,6 @@ const SavedDashboards = () => {
                             <Button
                                 leftIcon={<IconPlus size={18} />}
                                 onClick={handleCreateDashboard}
-                                disabled={hasNoSpaces}
                             >
                                 Create dashboard
                             </Button>

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -36,7 +36,7 @@ import TransferItemsModal from '../components/common/TransferItemsModal/Transfer
 import DashboardCreateModal from '../components/common/modal/DashboardCreateModal';
 import { useSpacePinningMutation } from '../hooks/pinning/useSpaceMutation';
 import { useContentAction } from '../hooks/useContent';
-import { useSpace, useSpaceSummaries } from '../hooks/useSpaces';
+import { useSpace } from '../hooks/useSpaces';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import useTracking from '../providers/Tracking/useTracking';
@@ -85,7 +85,6 @@ const Space: FC = () => {
     const [addToSpace, setAddToSpace] = useState<AddToSpaceResources>();
     const [createToSpace, setCreateToSpace] = useState<AddToSpaceResources>();
 
-    const { data: spaces } = useSpaceSummaries(projectUuid, true, {});
     const { mutateAsync: contentAction, isLoading: isContentActionLoading } =
         useContentAction(projectUuid);
 
@@ -413,7 +412,6 @@ const Space: FC = () => {
                                 type: ResourceViewItemType.SPACE,
                             } satisfies ResourceViewSpaceItem,
                         ]}
-                        spaces={spaces ?? []}
                         isLoading={isContentActionLoading}
                         onClose={closeTransferToSpace}
                         onConfirm={async (newSpaceUuid) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [#1234](https://linear.app/lightdash/issue/CENG-222/investigate-why-dashboards-is-requesting-getspaceroot-for-all-the)

We found out `getSpaceRoot` is an expensive method that was locking the database, and scales with the number of spaces in the project. This is used on `getspacesummaries` . Which is used by a lot of components in the UI, but none of them are required to initially load the dashboard.


Before:

<img width="2413" height="368" alt="Screenshot from 2025-11-21 10-57-21" src="https://github.com/user-attachments/assets/e99dfbd3-4766-4804-bb66-3291505bb272" />

Now:

:rocket: 

<img width="1717" height="459" alt="image" src="https://github.com/user-attachments/assets/79fd5d5e-e940-45ec-8c2a-5817d10139dc" />


### Description:
Optimized performance by deferring space data loading until needed. Added console warning for `getSpaceRoot` function. Improved empty state handling in dashboards by only checking permissions when in edit mode.

Key improvements:
- Only fetch spaces when modals are opened or menus are expanded
- Removed unnecessary space prop passing between components
- Fixed conditional rendering in dashboard empty states
- Added loading state handling for space data in transfer modals