### PR TITLE
fix: get joined fields/tables when findExplores & findFields

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/visit_analytics.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/visit_analytics.yml
@@ -287,7 +287,7 @@ models:
               type: string
 
       - name: risk_category
-        description: Patient's risk classification
+        description: Patient's risk classification (Low, Medium, High)
         config:
           meta:
             dimension:

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -2443,6 +2443,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                         description: table.description,
                         aiHints: table.aiHints ?? undefined,
                         searchRank: table.searchRank,
+                        joinedTables: table.joinedTables ?? undefined,
                     }));
 
                 const fieldSearchResults =
@@ -2521,7 +2522,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     (item) => item.type === CatalogType.Field,
                 );
 
-                return { fields: catalogFields, pagination };
+                return { fields: catalogFields, pagination, explore };
             });
 
         const updateProgress: UpdateProgressFn = (progress) =>

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -940,6 +940,7 @@ export class McpService extends BaseService {
                         description: table.description,
                         aiHints: table.aiHints ?? undefined,
                         searchRank: table.searchRank,
+                        joinedTables: table.joinedTables ?? undefined,
                     }));
 
                 const fieldSearchResults =

--- a/packages/backend/src/ee/services/ai/agents/tests/testCases.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/testCases.ts
@@ -62,12 +62,14 @@ export const testCases: TestCase[] = [
         ].join('\n'),
     },
     {
+        name: 'should use a base table, and add a filter from a joined table',
+        // IMPORTANT: This test case is crucial because it tests the ability of the agent to use filters from joined tables (uses payments explore but filters on orders table).
         prompt: 'Revenue from the last 3 months for the "credit_card" and "coupon" payment methods, displayed as a bar chart.',
         expectedAnswer: [
             `The response included the following information:`,
             `explore: payments`,
             `metrics: total revenue`,
-            `breakdown by dimension: payment method`,
+            `breakdown by dimension: payment method, but also states there is no data in the last 3 months`,
         ].join('\n'),
         expectedToolOutcome: [
             `runQuery tool args should have filters: Order date from last 3 months or from ${moment()
@@ -80,6 +82,23 @@ export const testCases: TestCase[] = [
             'Should use a date filter (from orders explore) for the last 3 months',
             'Should use filter for filtering the payment method',
             'Default visualization should be a bar chart',
+        ].join('\n'),
+    },
+    {
+        // IMPORTANT: This test case is crucial because it tests the ability of the agent to use filters from joined tables (uses payments explore but filters on customers table).
+        name: 'should use a field from a base table, but add a filter from another joined table',
+        prompt: 'payments from credit cards that were from customers created in the last 5 years',
+        expectedAnswer:
+            'Replies with payments from credit cards that were from customers created in the last 5 years',
+        expectedToolOutcome: [
+            `runQuery tool args should have filters: Customer creation date from last 5 years or from ${moment()
+                .subtract(5, 'years')
+                .format('YYYY-MM-DD')} to ${moment().format(
+                'YYYY-MM-DD',
+            )} and Payment method (credit_card)`,
+            'Should use a date filter (from customers explore) for the last 5 years',
+            'Should use filter for filtering the payment method',
+            'Default visualization could be a table or a bar chart',
         ].join('\n'),
     },
     {

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -18,12 +18,16 @@ type Dependencies = {
 };
 
 const generateExploreResponse = ({
+    searchQuery,
     exploreSearchResults,
     topMatchingFields,
-}: Awaited<ReturnType<FindExploresFn>>) => {
+}: Awaited<ReturnType<FindExploresFn>> & { searchQuery: string }) => {
     const searchResultsXml =
         exploreSearchResults && exploreSearchResults.length > 0 ? (
-            <searchResults count={exploreSearchResults.length}>
+            <searchResults
+                searchQuery={searchQuery}
+                count={exploreSearchResults.length}
+            >
                 <note>
                     {exploreSearchResults.length === 1
                         ? 'One explore matched your search. Call findFields for this explore to get all its dimensions and metrics.'
@@ -45,6 +49,20 @@ const generateExploreResponse = ({
                                 ))}
                             </aiHints>
                         )}
+                        {result.joinedTables &&
+                            result.joinedTables.length > 0 && (
+                                <joinedTables
+                                    count={result.joinedTables.length}
+                                >
+                                    <note>
+                                        Fields from these joined tables are
+                                        available when querying this explore
+                                    </note>
+                                    {result.joinedTables.map((tableName) => (
+                                        <table>{tableName}</table>
+                                    ))}
+                                </joinedTables>
+                            )}
                     </alternative>
                 ))}
             </searchResults>
@@ -102,6 +120,7 @@ export const getFindExplores = ({
 
                 return {
                     result: generateExploreResponse({
+                        searchQuery: args.searchQuery,
                         exploreSearchResults,
                         topMatchingFields,
                     }),

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -1,6 +1,7 @@
 import {
     CatalogField,
     convertToAiHints,
+    Explore,
     getFilterTypeFromItemType,
     getItemId,
     isEmojiIcon,
@@ -22,7 +23,14 @@ type Dependencies = {
     pageSize: number;
 };
 
-const renderField = (catalogField: CatalogField) => {
+const renderField = (catalogField: CatalogField, explore?: Explore) => {
+    const isFromJoinedTable =
+        explore &&
+        catalogField.tableName !== explore.baseTable &&
+        explore.joinedTables.some(
+            (join) => join.table === catalogField.tableName,
+        );
+
     const aiHints = convertToAiHints(catalogField.aiHints ?? undefined);
 
     return (
@@ -40,7 +48,16 @@ const renderField = (catalogField: CatalogField) => {
             )}
             searchRank={catalogField.searchRank}
             chartUsage={catalogField.chartUsage}
+            isFromJoinedTable={isFromJoinedTable}
         >
+            {isFromJoinedTable && explore && (
+                <note>
+                    This field is from the "{catalogField.tableName}" table,
+                    which is joined to the "{explore.name}" explore. You can use
+                    this field in queries and filters just like fields from the
+                    base table.
+                </note>
+            )}
             <label>{catalogField.label}</label>
             {aiHints && aiHints.length > 0 ? (
                 <aihints>
@@ -66,6 +83,7 @@ const renderField = (catalogField: CatalogField) => {
 
 const getFieldsText = (
     args: Awaited<ReturnType<FindFieldFn>> & { searchQuery: string },
+    explore?: Explore,
 ) => (
     <searchresult
         searchQuery={args.searchQuery}
@@ -74,7 +92,7 @@ const getFieldsText = (
         totalPageCount={args.pagination?.totalPageCount}
         totalResults={args.pagination?.totalResults}
     >
-        {args.fields.map((field) => renderField(field))}
+        {args.fields.map((field) => renderField(field, explore))}
     </searchresult>
 );
 
@@ -99,20 +117,26 @@ export const getFindFields = ({
                 );
 
                 const fieldSearchQueryResults = await Promise.all(
-                    args.fieldSearchQueries.map(async (fieldSearchQuery) => ({
-                        searchQuery: fieldSearchQuery.label,
-                        ...(await findFields({
+                    args.fieldSearchQueries.map(async (fieldSearchQuery) => {
+                        const result = await findFields({
                             table: args.table,
                             fieldSearchQuery,
                             page: args.page ?? 1,
                             pageSize,
-                        })),
-                    })),
+                        });
+                        return {
+                            searchQuery: fieldSearchQuery.label,
+                            ...result,
+                        };
+                    }),
                 );
+
+                // Use explore from the first result (all should have the same explore for the same table)
+                const explore = fieldSearchQueryResults[0]?.explore;
 
                 const fieldsText = fieldSearchQueryResults
                     .map((fieldSearchQueryResult) =>
-                        getFieldsText(fieldSearchQueryResult),
+                        getFieldsText(fieldSearchQueryResult, explore),
                     )
                     .join('\n\n');
 

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -44,6 +44,7 @@ export type FindExploresFn = (args: {
         description?: string;
         aiHints?: string[];
         searchRank?: number;
+        joinedTables?: string[] | null;
     }>;
     topMatchingFields?: Array<{
         name: string;
@@ -64,6 +65,7 @@ export type FindFieldFn = (
 ) => Promise<{
     fields: CatalogField[];
     pagination: Pagination | undefined;
+    explore?: Explore;
 }>;
 
 export type FindContentFn = (args: {

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -102,9 +102,13 @@ export const parseCatalog = (
         };
     }
 
+    // Find the correct table that contains this field
+    // This is important for fields from joined tables which may not be in the base table
+    const catalogTable = dbCatalog.explore.tables[dbCatalog.table_name];
+
     const dimensionsAndMetrics = [
-        ...Object.values(baseTable.dimensions),
-        ...Object.values(baseTable.metrics),
+        ...Object.values(catalogTable.dimensions),
+        ...Object.values(catalogTable.metrics),
     ];
     // This is the most computationally expensive part of the code
     // Perhaps we should add metadata (requiredAttributes) to the catalog database
@@ -114,10 +118,10 @@ export const parseCatalog = (
     );
     if (!findField) {
         throw new Error(
-            `Field ${dbCatalog.name} not found in explore ${dbCatalog.explore.name}`,
+            `Field ${dbCatalog.name} not found in table ${dbCatalog.table_name} of explore ${dbCatalog.explore.name}`,
         );
     }
-    return parseFieldFromMetricOrDimension(baseTable, findField, {
+    return parseFieldFromMetricOrDimension(catalogTable, findField, {
         label: dbCatalog.label,
         description: dbCatalog.description,
         catalogSearchUuid: dbCatalog.catalog_search_uuid,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -6,13 +6,13 @@ export const TOOL_FIND_EXPLORES_DESCRIPTION = `Tool: findExplores
 
 Purpose:
 Returns an explore with all its fields, joined tables, AI hints and descriptions. When multiple explores match your search, also returns alternative explores and top 50 matching fields across ALL explores.
+IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
-- exploreName: Name of the explore to retrieve
 - searchQuery: Full user query for finding relevant explores
 
 Output:
-- Selected explore with all fields and metadata
+- Selected explore with all fields and metadata (including fields from joined tables)
 - Alternative explores (if multiple matches) with searchRank scores
 - Top matching fields with their explore names and searchRank scores
 `;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -155,6 +155,7 @@ Configuration Tips:
 - For funnel charts: set funnelDataInput to 'row' (each row = stage) or 'column' (multiple funnels)
 - Users can switch between visualization types in the UI after creation
 - xAxisLabel and yAxisLabel provide helpful context for chart axes
+- filters can contain filters on fields from joined tables as well as the base table
 `;
 
 export const toolRunQueryArgsSchema = createToolSchema({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

This PR enhances the AI agent's ability to handle queries involving joined tables by:

1. Adding `joinedTables` information to explore search results, allowing the agent to see which tables are joined to each explore
2. Updating the system prompt to prioritize explores with joined tables that match entities mentioned in user queries
3. Improving field search to properly handle fields from joined tables, including adding metadata to indicate when a field comes from a joined table
4. Adding critical test cases that verify the agent can use filters from joined tables (e.g., filtering payments by customer creation date)
5. Enhancing date filtering guidance to explicitly support date fields from joined tables
6. Ensuring the catalog model correctly handles fields from joined tables when searching

These changes allow the agent to make smarter explore selections when multiple tables are mentioned in a query, and properly use fields from joined tables in filters and dimensions.

Questions you can ask:
- what payments from credit cards that were from customers created in the last 3 years
- can I get Revenue from the last 6 days for the "coupon" payment methods, displayed as a line chart.
- can I get Revenue from the last 6 months for the "credit_card" and "coupon" payment methods, displayed as a bar chart.