### PR TITLE
feat: display agent selector when agent router confidence is low

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -508,24 +508,7 @@ export function getAgentConfirmationBlocks(
         },
     ];
 
-    // Add agent image if available
-    if (agent.imageUrl) {
-        blocks[0] = {
-            type: 'section',
-            text: {
-                type: 'mrkdwn',
-                text: instructionText,
-            },
-            accessory: {
-                type: 'image',
-                image_url: agent.imageUrl,
-                alt_text: agent.name,
-            },
-        };
-    }
-
-    // Add agent instruction/description if available
-    if (agent.instruction) {
+    if (agent.description) {
         const truncateDescription = (text: string): string => {
             // Slack context elements have a limit of ~3000 chars
             const maxLength = 500;
@@ -534,13 +517,20 @@ export function getAgentConfirmationBlocks(
         };
 
         blocks.push({
-            type: 'context',
-            elements: [
-                {
-                    type: 'mrkdwn',
-                    text: truncateDescription(agent.instruction),
-                },
-            ],
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: truncateDescription(agent.description),
+            },
+            ...(agent.imageUrl
+                ? {
+                      accessory: {
+                          type: 'image',
+                          image_url: agent.imageUrl,
+                          alt_text: agent.name,
+                      },
+                  }
+                : {}),
         });
     }
 


### PR DESCRIPTION

### Description:
Updated Agent router to display agent selector when llm confidence in choosing agent is low

Also updated slack elements to display agent description instead of instruction if available

![CleanShot 2025-11-21 at 12.53.09.png](https://app.graphite.com/user-attachments/assets/e721c9a5-56e1-40be-8c85-1833cef70ebb.png)

---

![CleanShot 2025-11-21 at 12.53.43.png](https://app.graphite.com/user-attachments/assets/669ad006-6c01-441b-aae5-795696cca150.png)

---
![CleanShot 2025-11-21 at 12.54.18.png](https://app.graphite.com/user-attachments/assets/1cc899df-7726-46c7-a704-84ba71ab53f9.png)

