### PR TITLE
feat: display tool result output in debug drawer for findExplores & findFields

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -126,6 +126,27 @@ export const getFindExplores = ({
                     }),
                     metadata: {
                         status: 'success',
+                        ranking: {
+                            searchQuery: args.searchQuery,
+                            exploreSearchResults: exploreSearchResults?.map(
+                                (result) => ({
+                                    name: result.name,
+                                    label: result.label,
+                                    searchRank: result.searchRank,
+                                    joinedTables: result.joinedTables ?? [],
+                                }),
+                            ),
+                            topMatchingFields: topMatchingFields?.map(
+                                (field) => ({
+                                    name: field.name,
+                                    label: field.label,
+                                    tableName: field.tableName,
+                                    fieldType: field.fieldType,
+                                    searchRank: field.searchRank,
+                                    chartUsage: field.chartUsage,
+                                }),
+                            ),
+                        },
                     },
                 };
             } catch (error) {

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -146,6 +146,25 @@ export const getFindFields = ({
                     ).toString(),
                     metadata: {
                         status: 'success',
+                        ranking: {
+                            searchQueries: fieldSearchQueryResults.map(
+                                (fieldSearchQueryResult) => ({
+                                    label: fieldSearchQueryResult.searchQuery,
+                                    results: fieldSearchQueryResult.fields.map(
+                                        (field) => ({
+                                            name: field.name,
+                                            label: field.label,
+                                            tableName: field.tableName,
+                                            fieldType: field.fieldType,
+                                            searchRank: field.searchRank,
+                                            chartUsage: field.chartUsage,
+                                        }),
+                                    ),
+                                    pagination:
+                                        fieldSearchQueryResult.pagination,
+                                }),
+                            ),
+                        },
                     },
                 };
             } catch (error) {

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -65,9 +65,37 @@ export const toolFindExploresArgsSchema = z.discriminatedUnion('type', [
 
 export const toolFindExploresArgsSchemaTransformed = toolFindExploresArgsSchema;
 
+export const findExploresRankingMetadataSchema = z.object({
+    searchQuery: z.string(),
+    exploreSearchResults: z
+        .array(
+            z.object({
+                name: z.string(),
+                label: z.string(),
+                searchRank: z.number().nullable().optional(),
+                joinedTables: z.array(z.string()).nullable().optional(),
+            }),
+        )
+        .optional(),
+    topMatchingFields: z
+        .array(
+            z.object({
+                name: z.string(),
+                label: z.string(),
+                tableName: z.string(),
+                fieldType: z.string(),
+                searchRank: z.number().nullable().optional(),
+                chartUsage: z.number().nullable().optional(),
+            }),
+        )
+        .optional(),
+});
+
 export const toolFindExploresOutputSchema = z.object({
     result: z.string(),
-    metadata: baseOutputMetadataSchema,
+    metadata: baseOutputMetadataSchema.extend({
+        ranking: findExploresRankingMetadataSchema.optional(),
+    }),
 });
 
 export type ToolFindExploresArgsV1 = z.infer<

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindFieldsArgs.ts
@@ -33,9 +33,37 @@ export const toolFindFieldsArgsSchema = createToolSchema({
 
 export const toolFindFieldsArgsSchemaTransformed = toolFindFieldsArgsSchema;
 
+export const findFieldsRankingMetadataSchema = z.object({
+    searchQueries: z.array(
+        z.object({
+            label: z.string(),
+            results: z.array(
+                z.object({
+                    name: z.string(),
+                    label: z.string(),
+                    tableName: z.string(),
+                    fieldType: z.string(),
+                    searchRank: z.number().nullable().optional(),
+                    chartUsage: z.number().nullable().optional(),
+                }),
+            ),
+            pagination: z
+                .object({
+                    page: z.number(),
+                    pageSize: z.number(),
+                    totalResults: z.number(),
+                    totalPageCount: z.number(),
+                })
+                .optional(),
+        }),
+    ),
+});
+
 export const toolFindFieldsOutputSchema = z.object({
     result: z.string(),
-    metadata: baseOutputMetadataSchema,
+    metadata: baseOutputMetadataSchema.extend({
+        ranking: findFieldsRankingMetadataSchema.optional(),
+    }),
 });
 
 export type ToolFindFieldsArgs = z.infer<typeof toolFindFieldsArgsSchema>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -578,6 +578,7 @@ export const AssistantBubble: FC<Props> = memo(
                     projectUuid={projectUuid}
                     artifacts={message.artifacts}
                     toolCalls={message.toolCalls}
+                    toolResults={message.toolResults}
                     isVisualizationAvailable={isArtifactAvailable}
                     isDrawerOpen={isDrawerOpen}
                     onClose={closeDrawer}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingDisplay.tsx
@@ -1,0 +1,281 @@
+import {
+    findExploresRankingMetadataSchema,
+    findFieldsRankingMetadataSchema,
+    type ToolFindExploresOutput,
+    type ToolFindFieldsOutput,
+} from '@lightdash/common';
+import { Box, Stack, Text } from '@mantine-8/core';
+import { RankingTable, TableCellText } from './RankingTable';
+
+type FieldResult = {
+    label: string;
+    name: string;
+    tableName: string;
+    fieldType: string;
+    searchRank?: number | null | undefined;
+    chartUsage?: number | null | undefined;
+};
+
+type ExploreResult = {
+    label: string;
+    name: string;
+    searchRank?: number | null | undefined;
+    joinedTables?: string[] | null;
+};
+
+export const RankingDisplay: React.FC<{
+    ranking:
+        | ToolFindFieldsOutput['metadata']['ranking']
+        | ToolFindExploresOutput['metadata']['ranking'];
+    type: 'findFields' | 'findExplores';
+}> = ({ ranking, type }) => {
+    if (type === 'findFields') {
+        const findFieldsRanking =
+            findFieldsRankingMetadataSchema.safeParse(ranking);
+        if (!findFieldsRanking.success) {
+            return null;
+        }
+
+        const parsedRanking = findFieldsRanking.data;
+
+        if (!parsedRanking.searchQueries) {
+            return null;
+        }
+
+        return (
+            <Box>
+                <Text fw={500} size="xs" c="dark" mb="xs">
+                    Ranking Metadata
+                </Text>
+                <Stack gap="xs">
+                    {parsedRanking.searchQueries.map((query, queryIndex) => (
+                        <Box key={queryIndex}>
+                            <Text fw={500} size="xs" c="dark" mb="xs">
+                                Search: "{query.label}"
+                            </Text>
+                            {query.pagination && (
+                                <Text size="xs" c="dimmed" mb="xs">
+                                    Page {query.pagination.page} of{' '}
+                                    {query.pagination.totalPageCount} (
+                                    {query.pagination.totalResults} total
+                                    results)
+                                </Text>
+                            )}
+                            <RankingTable<FieldResult>
+                                columns={[
+                                    {
+                                        header: 'Field',
+                                        render: (field) => (
+                                            <Box>
+                                                <TableCellText>
+                                                    {field.label}
+                                                </TableCellText>
+                                                <TableCellText dimmed>
+                                                    {field.name}
+                                                </TableCellText>
+                                            </Box>
+                                        ),
+                                    },
+                                    {
+                                        header: 'Table',
+                                        render: (field) => (
+                                            <TableCellText>
+                                                {field.tableName}
+                                            </TableCellText>
+                                        ),
+                                    },
+                                    {
+                                        header: 'Type',
+                                        render: (field) => (
+                                            <TableCellText>
+                                                {field.fieldType}
+                                            </TableCellText>
+                                        ),
+                                    },
+                                    {
+                                        header: 'Rank',
+                                        render: (field) => (
+                                            <TableCellText>
+                                                {field.searchRank !== null &&
+                                                field.searchRank !== undefined
+                                                    ? field.searchRank.toFixed(
+                                                          3,
+                                                      )
+                                                    : 'N/A'}
+                                            </TableCellText>
+                                        ),
+                                    },
+                                    {
+                                        header: 'Usage',
+                                        render: (field) => (
+                                            <TableCellText>
+                                                {field.chartUsage ?? 'N/A'}
+                                            </TableCellText>
+                                        ),
+                                    },
+                                ]}
+                                data={query.results}
+                                maxHeight={300}
+                            />
+                        </Box>
+                    ))}
+                </Stack>
+            </Box>
+        );
+    }
+
+    if (type === 'findExplores') {
+        const findExploresRanking =
+            findExploresRankingMetadataSchema.safeParse(ranking);
+        if (!findExploresRanking.success) {
+            return null;
+        }
+
+        const parsedRanking = findExploresRanking.data;
+
+        if (!parsedRanking.searchQuery) {
+            return null;
+        }
+
+        return (
+            <Box>
+                <Text fw={500} size="xs" c="dark" mb="xs">
+                    Ranking Metadata
+                </Text>
+                <Stack gap="md">
+                    <Text size="xs" c="dimmed">
+                        Search Query: "{parsedRanking.searchQuery}"
+                    </Text>
+
+                    {parsedRanking.exploreSearchResults &&
+                        parsedRanking.exploreSearchResults.length > 0 && (
+                            <Box>
+                                <Text fw={500} size="xs" c="dark" mb="xs">
+                                    Explore Results (
+                                    {parsedRanking.exploreSearchResults.length})
+                                </Text>
+                                <RankingTable<ExploreResult>
+                                    columns={[
+                                        {
+                                            header: 'Explore',
+                                            render: (explore) => (
+                                                <Box>
+                                                    <TableCellText>
+                                                        {explore.label}
+                                                    </TableCellText>
+                                                    <TableCellText dimmed>
+                                                        {explore.name}
+                                                    </TableCellText>
+                                                </Box>
+                                            ),
+                                        },
+                                        {
+                                            header: 'Rank',
+                                            render: (explore) => (
+                                                <TableCellText>
+                                                    {explore.searchRank !==
+                                                        null &&
+                                                    explore.searchRank !==
+                                                        undefined
+                                                        ? explore.searchRank.toFixed(
+                                                              3,
+                                                          )
+                                                        : 'N/A'}
+                                                </TableCellText>
+                                            ),
+                                        },
+                                        {
+                                            header: 'Joined Tables',
+                                            render: (explore) => (
+                                                <TableCellText>
+                                                    {explore.joinedTables &&
+                                                    explore.joinedTables
+                                                        .length > 0
+                                                        ? explore.joinedTables.join(
+                                                              ', ',
+                                                          )
+                                                        : 'None'}
+                                                </TableCellText>
+                                            ),
+                                        },
+                                    ]}
+                                    data={parsedRanking.exploreSearchResults}
+                                    maxHeight={200}
+                                />
+                            </Box>
+                        )}
+
+                    {parsedRanking.topMatchingFields &&
+                        parsedRanking.topMatchingFields.length > 0 && (
+                            <Box>
+                                <Text fw={500} size="xs" c="dark" mb="xs">
+                                    Top Matching Fields (
+                                    {parsedRanking.topMatchingFields.length})
+                                </Text>
+                                <RankingTable<FieldResult>
+                                    columns={[
+                                        {
+                                            header: 'Field',
+                                            render: (field) => (
+                                                <Box>
+                                                    <TableCellText>
+                                                        {field.label}
+                                                    </TableCellText>
+                                                    <TableCellText dimmed>
+                                                        {field.name}
+                                                    </TableCellText>
+                                                </Box>
+                                            ),
+                                        },
+                                        {
+                                            header: 'Explore',
+                                            render: (field) => (
+                                                <TableCellText>
+                                                    {field.tableName}
+                                                </TableCellText>
+                                            ),
+                                        },
+                                        {
+                                            header: 'Type',
+                                            render: (field) => (
+                                                <TableCellText>
+                                                    {field.fieldType}
+                                                </TableCellText>
+                                            ),
+                                        },
+                                        {
+                                            header: 'Rank',
+                                            render: (field) => (
+                                                <TableCellText>
+                                                    {field.searchRank !==
+                                                        null &&
+                                                    field.searchRank !==
+                                                        undefined
+                                                        ? field.searchRank.toFixed(
+                                                              3,
+                                                          )
+                                                        : 'N/A'}
+                                                </TableCellText>
+                                            ),
+                                        },
+                                        {
+                                            header: 'Usage',
+                                            render: (field) => (
+                                                <TableCellText>
+                                                    {field.chartUsage ?? 'N/A'}
+                                                </TableCellText>
+                                            ),
+                                        },
+                                    ]}
+                                    data={parsedRanking.topMatchingFields}
+                                    maxHeight={300}
+                                />
+                            </Box>
+                        )}
+                </Stack>
+            </Box>
+        );
+    }
+
+    return null;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingTable.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingTable.module.css
@@ -1,0 +1,36 @@
+.tableContainer {
+    background-color: var(--mantine-color-white);
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid var(--mantine-color-gray-2);
+}
+
+.table {
+    background-color: var(--mantine-color-white);
+}
+
+.tableHeader {
+    background-color: var(--mantine-color-white);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: var(--mantine-font-weight-500);
+}
+
+.tableRow {
+    transition: background-color 0.15s ease;
+}
+
+.tableRow:hover {
+    background-color: var(--mantine-color-gray-0);
+}
+
+.tableCell {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+}
+
+.tableCellText {
+    font-size: var(--mantine-font-size-xs);
+}
+
+.tableCellTextDimmed {
+    font-size: var(--mantine-font-size-xs);
+    color: var(--mantine-color-gray-6);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingTable.tsx
@@ -1,0 +1,79 @@
+import { ScrollArea, Table, Text } from '@mantine-8/core';
+import type { ReactNode } from 'react';
+import classes from './RankingTable.module.css';
+
+type Column<T> = {
+    header: string;
+    render: (row: T, index: number) => ReactNode;
+};
+
+type RankingTableProps<T> = {
+    columns: Column<T>[];
+    data: T[];
+    maxHeight?: number;
+    className?: string;
+};
+
+export const RankingTable = <T,>({
+    columns,
+    data,
+    maxHeight = 300,
+    className,
+}: RankingTableProps<T>) => {
+    if (data.length === 0) {
+        return null;
+    }
+
+    return (
+        <ScrollArea.Autosize
+            mah={maxHeight}
+            className={className || classes.tableContainer}
+        >
+            <Table
+                striped
+                highlightOnHover
+                stickyHeader
+                className={classes.table}
+            >
+                <Table.Thead className={classes.tableHeader}>
+                    <Table.Tr>
+                        {columns.map((column, index) => (
+                            <Table.Th key={index}>{column.header}</Table.Th>
+                        ))}
+                    </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                    {data.map((row, rowIndex) => (
+                        <Table.Tr key={rowIndex} className={classes.tableRow}>
+                            {columns.map((column, colIndex) => (
+                                <Table.Td
+                                    key={colIndex}
+                                    className={classes.tableCell}
+                                >
+                                    {column.render(row, rowIndex)}
+                                </Table.Td>
+                            ))}
+                        </Table.Tr>
+                    ))}
+                </Table.Tbody>
+            </Table>
+        </ScrollArea.Autosize>
+    );
+};
+
+export const TableCellText: React.FC<{
+    children: ReactNode;
+    dimmed?: boolean;
+}> = ({ children, dimmed }) => {
+    return (
+        <Text
+            size="xs"
+            c={dimmed ? 'dimmed' : undefined}
+            className={
+                dimmed ? classes.tableCellTextDimmed : classes.tableCellText
+            }
+        >
+            {children}
+        </Text>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/ToolResults.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/ToolResults.tsx
@@ -1,0 +1,44 @@
+import type { AiAgentToolCall, AiAgentToolResult } from '@lightdash/common';
+import { Divider, Stack } from '@mantine-8/core';
+import { RankingDisplay } from './RankingDisplay';
+import { parseToolResultMetadata } from './utils';
+
+export const ToolResults: React.FC<{
+    toolCall: AiAgentToolCall;
+    toolResult: AiAgentToolResult | undefined;
+}> = ({ toolCall, toolResult }) => {
+    const toolResultMetadata = parseToolResultMetadata(
+        toolResult,
+        toolCall.toolName,
+    );
+
+    if (!toolResultMetadata) {
+        return null;
+    }
+
+    if (toolCall.toolName === 'findFields') {
+        return (
+            <Stack>
+                <Divider />
+                <RankingDisplay
+                    ranking={toolResultMetadata.metadata.ranking}
+                    type="findFields"
+                />
+            </Stack>
+        );
+    }
+
+    if (toolCall.toolName === 'findExplores') {
+        return (
+            <Stack>
+                <Divider />
+                <RankingDisplay
+                    ranking={toolResultMetadata.metadata.ranking}
+                    type="findExplores"
+                />
+            </Stack>
+        );
+    }
+
+    return null;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/index.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/index.ts
@@ -1,0 +1,1 @@
+export { ToolResults } from './ToolResults';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/utils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/utils.ts
@@ -1,0 +1,30 @@
+import type {
+    AiAgentToolResult,
+    ToolFindExploresOutput,
+    ToolFindFieldsOutput,
+} from '@lightdash/common';
+import {
+    toolFindExploresOutputSchema,
+    toolFindFieldsOutputSchema,
+} from '@lightdash/common';
+
+export const parseToolResultMetadata = (
+    toolResult: AiAgentToolResult | undefined,
+    toolName: string,
+): ToolFindFieldsOutput | ToolFindExploresOutput | null => {
+    if (!toolResult?.metadata) {
+        return null;
+    }
+
+    if (toolName === 'findFields') {
+        const result = toolFindFieldsOutputSchema.safeParse(toolResult);
+        return result.success ? result.data : null;
+    }
+
+    if (toolName === 'findExplores') {
+        const result = toolFindExploresOutputSchema.safeParse(toolResult);
+        return result.success ? result.data : null;
+    }
+
+    return null;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
This PR adds ranking metadata to the AI Copilot debug drawer, enhancing transparency in search results. It displays detailed ranking information for the `findFields` and `findExplores` tools, showing how results are scored and prioritized.

The implementation includes:
- Adding ranking metadata to tool results in backend services
- Creating new UI components to display search rankings in a tabular format
- Showing field search ranks, chart usage metrics, and explore search results
- Passing tool results to the debug drawer for visualization

This helps users understand why certain fields or explores are suggested by the AI, improving the explainability of the system's recommendations.

[CleanShot 2025-11-21 at 12.53.19.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/232269d0-d6aa-43a8-88ef-4c9cef83626f.mp4" />](https://app.graphite.com/user-attachments/video/232269d0-d6aa-43a8-88ef-4c9cef83626f.mp4)

