### PR TITLE
feat: only get non-preview agents for multi-agent slack channels

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -42,6 +42,7 @@ import {
     OpenIdIdentityIssuerType,
     ParameterError,
     parseVizConfig,
+    ProjectType,
     QueryExecutionContext,
     ReadinessScore,
     ShareUrl,
@@ -571,7 +572,9 @@ export class AiAgentService {
 
         const agents = await this.aiAgentModel.findAllAgents({
             organizationUuid,
-            projectUuid,
+            filter: {
+                projectUuid,
+            },
         });
 
         const agentsWithAccess = (
@@ -3842,11 +3845,11 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         organizationUuid: string,
         userUuid: string,
         slackSettings: { aiRequireOAuth?: boolean },
-        options?: { projectUuid?: string },
+        filter?: { projectType?: ProjectType; projectUuid?: string },
     ): Promise<AiAgentWithContext[]> {
         const allAgents = await this.aiAgentModel.findAllAgents({
             organizationUuid,
-            projectUuid: options?.projectUuid,
+            filter,
         });
 
         const user = await this.userModel.findSessionUserAndOrgByUuid(
@@ -4142,6 +4145,9 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 organizationUuid,
                 userUuid,
                 slackSettings,
+                {
+                    projectType: ProjectType.DEFAULT,
+                },
             );
 
             if (availableAgents.length === 0) {

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -359,7 +359,7 @@ const SlackSettingsPanel: FC = () => {
                                                 multiline
                                                 variant="xs"
                                                 maw={250}
-                                                label="Select a channel where users can interact with any AI agent. When users start a thread in this channel, they'll see a dropdown to select which agent to use."
+                                                label="Select a channel where users can interact with any AI agent (excluding from preview projects). When users start a thread in this channel, they'll see a dropdown to select which agent to use."
                                             >
                                                 <MantineIcon
                                                     icon={IconHelpCircle}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

This PR updates the AI agent filtering functionality to exclude agents from preview projects in Slack interactions. The changes include:

1. Enhancing the `findAllAgents` method to filter by project type in addition to project UUID
2. Adding a join with the Project table to enable filtering by project type
3. Modifying the `getAllAgentsWithContext` method to accept a project type filter
4. Adding a default project type filter to the Slack integration to only show agents from default projects
5. Updating the Slack settings UI to clarify that agents from preview projects are excluded from the channel selection

This ensures that when users interact with AI agents through Slack, they only see agents from default projects, not preview ones.