### PR TITLE
feat: show scheduler logs as a details view

### DIFF
--- a/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
@@ -1,0 +1,519 @@
+import {
+    SchedulerFormat,
+    SchedulerJobStatus,
+    type SchedulerRun,
+    type SchedulerRunLog,
+} from '@lightdash/common';
+import {
+    Box,
+    Center,
+    Code,
+    Divider,
+    Group,
+    Loader,
+    Modal,
+    Stack,
+    Text,
+    useMantineTheme,
+    type MantineTheme,
+} from '@mantine-8/core';
+import {
+    IconAlertTriangleFilled,
+    IconChartBar,
+    IconLayoutDashboard,
+} from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import { useMemo, type FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+import {
+    formatTaskName,
+    formatTime,
+    getLogStatusIconWithoutTooltip,
+    getSchedulerIcon,
+} from './SchedulersViewUtils';
+
+type JobSummary = {
+    jobId: string;
+    task: string;
+    targetType: SchedulerRunLog['targetType'];
+    target: SchedulerRunLog['target'];
+    startedAt: Date | null;
+    completedAt: Date | null;
+    finalStatus: SchedulerRunLog['status'];
+    errorDetails: string | null;
+};
+
+type RunDetailsModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    run: SchedulerRun | null;
+    childLogs: SchedulerRunLog[] | undefined;
+    isLoading: boolean;
+    getSlackChannelName: (channelId: string) => string | null;
+};
+
+// Helper to format time only (no date)
+const formatTimeOnly = (date: Date): string => {
+    return dayjs(date).format('hh:mm A');
+};
+
+// Helper to format duration between two dates
+const formatDuration = (start: Date, end: Date): string => {
+    const durationSeconds = dayjs(end).diff(dayjs(start), 'second');
+
+    if (durationSeconds < 1) {
+        return '<1s';
+    } else if (durationSeconds < 60) {
+        return `${durationSeconds}s`;
+    } else {
+        const minutes = Math.floor(durationSeconds / 60);
+        const seconds = durationSeconds % 60;
+        return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+    }
+};
+
+// Component for job timing display
+const JobTimingInfo: FC<{
+    startedAt: Date | null;
+    completedAt: Date | null;
+    status: SchedulerJobStatus;
+}> = ({ startedAt, completedAt, status }) => {
+    const endLabel =
+        status === SchedulerJobStatus.ERROR ? 'failed' : 'completed';
+
+    return (
+        <Group gap="md" wrap="nowrap" w={240}>
+            <Stack gap={4}>
+                <Text fz="xs" c="gray.6">
+                    started
+                </Text>
+                <Text fz="xs" style={{ whiteSpace: 'nowrap' }}>
+                    {startedAt ? formatTimeOnly(startedAt) : '-'}
+                </Text>
+            </Stack>
+            <Stack gap={4}>
+                <Text fz="xs" c="gray.6">
+                    {endLabel}
+                </Text>
+                <Text fz="xs" style={{ whiteSpace: 'nowrap' }}>
+                    {completedAt ? formatTimeOnly(completedAt) : '-'}
+                </Text>
+            </Stack>
+            <Stack gap={4}>
+                <Text fz="xs" c="gray.6">
+                    duration
+                </Text>
+                <Text fz="xs" style={{ whiteSpace: 'nowrap' }}>
+                    {startedAt && completedAt
+                        ? formatDuration(startedAt, completedAt)
+                        : '-'}
+                </Text>
+            </Stack>
+        </Group>
+    );
+};
+
+// Component for successful job row
+const SuccessfulJobRow: FC<{
+    job: JobSummary;
+    run: SchedulerRun;
+    theme: MantineTheme;
+    getTargetDisplayName: (
+        target: string | null,
+        targetType: SchedulerRunLog['targetType'],
+    ) => string | null;
+    getFormatDisplayName: (format: SchedulerFormat) => string;
+}> = ({ job, run, theme, getTargetDisplayName, getFormatDisplayName }) => {
+    return (
+        <Group
+            gap="md"
+            p="sm"
+            wrap="nowrap"
+            style={{
+                borderRadius: theme.radius.sm,
+                border: `1px solid ${theme.colors.gray[2]}`,
+            }}
+        >
+            {getLogStatusIconWithoutTooltip(job.finalStatus, theme)}
+            <Stack gap={4} style={{ flex: 1 }}>
+                <Box>
+                    <Text fz="sm" fw={500}>
+                        {formatTaskName(job.task)}
+                    </Text>
+                    {job.task === 'handleScheduledDelivery'
+                        ? run && (
+                              <Text fz="xs" c="gray.6">
+                                  {`Generate ${getFormatDisplayName(
+                                      run.format,
+                                  )}`}
+                              </Text>
+                          )
+                        : job.target && (
+                              <Text fz="xs" c="gray.6">
+                                  {getTargetDisplayName(
+                                      job.target,
+                                      job.targetType,
+                                  )}
+                              </Text>
+                          )}
+                </Box>
+                <Text fz="xs" c="green.7">
+                    Completed successfully
+                </Text>
+            </Stack>
+            <Box style={{ alignSelf: 'flex-start' }}>
+                <JobTimingInfo
+                    startedAt={job.startedAt}
+                    completedAt={job.completedAt}
+                    status={job.finalStatus}
+                />
+            </Box>
+        </Group>
+    );
+};
+
+// Component for failed job row
+const FailedJobRow: FC<{
+    job: JobSummary;
+    run: SchedulerRun;
+    theme: MantineTheme;
+    getTargetDisplayName: (
+        target: string | null,
+        targetType: SchedulerRunLog['targetType'],
+    ) => string | null;
+    getFormatDisplayName: (format: SchedulerFormat) => string;
+}> = ({ job, run, theme, getTargetDisplayName, getFormatDisplayName }) => {
+    return (
+        <Stack
+            gap="sm"
+            p="sm"
+            style={{
+                borderRadius: theme.radius.sm,
+                border: `1px solid ${theme.colors.gray[2]}`,
+            }}
+        >
+            <Group gap="md" wrap="nowrap" align="flex-start">
+                {getLogStatusIconWithoutTooltip(job.finalStatus, theme)}
+                <Stack gap={4} style={{ flex: 1 }}>
+                    <Box>
+                        <Text fz="sm" fw={500}>
+                            {formatTaskName(job.task)}
+                        </Text>
+                        {job.task === 'handleScheduledDelivery'
+                            ? run && (
+                                  <Text fz="xs" c="gray.6">
+                                      {`Generate ${getFormatDisplayName(
+                                          run.format,
+                                      )}`}
+                                  </Text>
+                              )
+                            : job.target && (
+                                  <Text fz="xs" c="gray.6">
+                                      {getTargetDisplayName(
+                                          job.target,
+                                          job.targetType,
+                                      )}
+                                  </Text>
+                              )}
+                    </Box>
+                    <Text fz="xs" c="red.7">
+                        Job failed
+                    </Text>
+                </Stack>
+                <JobTimingInfo
+                    startedAt={job.startedAt}
+                    completedAt={job.completedAt}
+                    status={job.finalStatus}
+                />
+            </Group>
+            {job.errorDetails && (
+                <Code block c="red.9" bg="red.0" style={{ fontSize: '11px' }}>
+                    {job.errorDetails}
+                </Code>
+            )}
+        </Stack>
+    );
+};
+
+const RunDetailsModal: FC<RunDetailsModalProps> = ({
+    opened,
+    onClose,
+    run,
+    childLogs,
+    isLoading,
+    getSlackChannelName,
+}) => {
+    const theme = useMantineTheme();
+
+    // Helper to format SchedulerFormat enum
+    const getFormatDisplayName = (format: SchedulerFormat): string => {
+        switch (format) {
+            case SchedulerFormat.CSV:
+                return 'CSV';
+            case SchedulerFormat.XLSX:
+                return 'Excel';
+            case SchedulerFormat.IMAGE:
+                return 'Image';
+            case SchedulerFormat.GSHEETS:
+                return 'Google Sheets';
+            default:
+                return format;
+        }
+    };
+
+    // Helper to get friendly target name
+    const getTargetDisplayName = (
+        target: string | null,
+        targetType: SchedulerRunLog['targetType'],
+    ): string | null => {
+        if (!target) return null;
+
+        // For Slack, try to map ID to channel name
+        if (targetType === 'slack') {
+            return getSlackChannelName(target) || target;
+        }
+
+        // For other types, return as-is
+        return target;
+    };
+
+    // Group logs by jobId and extract start/end times
+    const jobSummaries = useMemo<JobSummary[]>(() => {
+        if (!childLogs) return [];
+
+        // Group by jobId
+        const jobsMap = new Map<string, SchedulerRunLog[]>();
+        childLogs.forEach((log) => {
+            if (!jobsMap.has(log.jobId)) {
+                jobsMap.set(log.jobId, []);
+            }
+            jobsMap.get(log.jobId)!.push(log);
+        });
+
+        // Create summary for each job
+        return Array.from(jobsMap.entries())
+            .map(([jobId, logs]): JobSummary => {
+                // Find started event
+                const startedLog = logs.find(
+                    (log) => log.status === SchedulerJobStatus.STARTED,
+                );
+
+                // Find completed or error event (final status)
+                const completedLog = logs.find(
+                    (log) =>
+                        log.status === SchedulerJobStatus.COMPLETED ||
+                        log.status === SchedulerJobStatus.ERROR,
+                );
+
+                // Get target info from started log (or first log with target, or first log)
+                const logWithTarget =
+                    startedLog ||
+                    logs.find((log) => log.target !== null) ||
+                    logs[0];
+
+                return {
+                    jobId,
+                    task: logWithTarget.task,
+                    targetType: logWithTarget.targetType,
+                    target: logWithTarget.target,
+                    startedAt: startedLog
+                        ? new Date(startedLog.createdAt)
+                        : null,
+                    completedAt: completedLog
+                        ? new Date(completedLog.createdAt)
+                        : null,
+                    finalStatus: completedLog
+                        ? completedLog.status
+                        : logWithTarget.status,
+                    errorDetails:
+                        completedLog?.status === SchedulerJobStatus.ERROR
+                            ? (completedLog.details?.error as string) || null
+                            : null,
+                };
+            })
+            .sort((a, b) => {
+                // Sort by start time, or createdAt if no start time
+                const aTime = a.startedAt ? a.startedAt.getTime() : 0;
+                const bTime = b.startedAt ? b.startedAt.getTime() : 0;
+                return aTime - bTime;
+            });
+    }, [childLogs]);
+
+    // Calculate job status summary based on jobSummaries
+    const jobStatusSummary = useMemo(() => {
+        const completedCount = jobSummaries.filter(
+            (job) => job.finalStatus === SchedulerJobStatus.COMPLETED,
+        ).length;
+        const errorCount = jobSummaries.filter(
+            (job) => job.finalStatus === SchedulerJobStatus.ERROR,
+        ).length;
+
+        return { completedCount, errorCount, totalCount: jobSummaries.length };
+    }, [jobSummaries]);
+
+    if (!run) return null;
+
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            title={
+                <Group gap="sm">
+                    {getSchedulerIcon(run)}
+                    <Text fw={600}>{run.schedulerName}</Text>
+                </Group>
+            }
+            size="lg"
+        >
+            <Stack gap="lg">
+                {/* Run metadata */}
+                <Stack gap="xs">
+                    <Group gap="xl">
+                        <Box>
+                            <Group gap={4}>
+                                <MantineIcon
+                                    icon={
+                                        run.resourceType === 'chart'
+                                            ? IconChartBar
+                                            : IconLayoutDashboard
+                                    }
+                                    size="sm"
+                                    color="gray.6"
+                                />
+                                <Text fz="xs" c="gray.6">
+                                    {run.resourceType === 'chart'
+                                        ? 'Chart'
+                                        : 'Dashboard'}
+                                </Text>
+                            </Group>
+                            <Text fz="sm" fw={500}>
+                                {run.resourceName}
+                            </Text>
+                        </Box>
+                        <Box>
+                            <Text fz="xs" c="gray.6">
+                                Created by
+                            </Text>
+                            <Text fz="sm" fw={500}>
+                                {run.createdByUserName}
+                            </Text>
+                        </Box>
+                    </Group>
+                    <Group gap="xl">
+                        <Box>
+                            <Text fz="xs" c="gray.6">
+                                Scheduled
+                            </Text>
+                            <Text fz="sm" fw={500}>
+                                {formatTime(run.scheduledTime)}
+                            </Text>
+                        </Box>
+                        <Box>
+                            <Text fz="xs" c="gray.6">
+                                Started
+                            </Text>
+                            <Text fz="sm" fw={500}>
+                                {formatTime(run.createdAt)}
+                            </Text>
+                        </Box>
+                    </Group>
+                </Stack>
+
+                <Divider />
+
+                {/* Jobs */}
+                <Box>
+                    <Group gap="xs" mb="md">
+                        {jobStatusSummary.errorCount === 0 &&
+                        jobStatusSummary.completedCount > 0 ? (
+                            <>
+                                {getLogStatusIconWithoutTooltip(
+                                    SchedulerJobStatus.COMPLETED,
+                                    theme,
+                                )}
+                                <Text fz="sm" fw={600}>
+                                    {jobStatusSummary.completedCount} job
+                                    {jobStatusSummary.completedCount > 1
+                                        ? 's'
+                                        : ''}{' '}
+                                    completed successfully
+                                </Text>
+                            </>
+                        ) : jobStatusSummary.completedCount === 0 &&
+                          jobStatusSummary.errorCount > 0 ? (
+                            <>
+                                {getLogStatusIconWithoutTooltip(
+                                    SchedulerJobStatus.ERROR,
+                                    theme,
+                                )}
+                                <Text fz="sm" fw={600}>
+                                    All jobs failed
+                                </Text>
+                            </>
+                        ) : jobStatusSummary.completedCount > 0 &&
+                          jobStatusSummary.errorCount > 0 ? (
+                            <>
+                                <MantineIcon
+                                    icon={IconAlertTriangleFilled}
+                                    color="orange.6"
+                                    style={{ color: theme.colors.orange[6] }}
+                                />
+                                <Text fz="sm" fw={600}>
+                                    {jobStatusSummary.completedCount} completed,{' '}
+                                    {jobStatusSummary.errorCount} failed
+                                </Text>
+                            </>
+                        ) : (
+                            <Text fz="sm" fw={600}>
+                                Jobs ({jobStatusSummary.totalCount})
+                            </Text>
+                        )}
+                    </Group>
+                    {isLoading ? (
+                        <Center p="xl">
+                            <Loader size="md" />
+                        </Center>
+                    ) : jobSummaries.length > 0 ? (
+                        <Stack gap="xs">
+                            {jobSummaries.map((job) =>
+                                job.finalStatus === SchedulerJobStatus.ERROR ? (
+                                    <FailedJobRow
+                                        key={job.jobId}
+                                        job={job}
+                                        run={run}
+                                        theme={theme}
+                                        getTargetDisplayName={
+                                            getTargetDisplayName
+                                        }
+                                        getFormatDisplayName={
+                                            getFormatDisplayName
+                                        }
+                                    />
+                                ) : (
+                                    <SuccessfulJobRow
+                                        key={job.jobId}
+                                        job={job}
+                                        run={run}
+                                        theme={theme}
+                                        getTargetDisplayName={
+                                            getTargetDisplayName
+                                        }
+                                        getFormatDisplayName={
+                                            getFormatDisplayName
+                                        }
+                                    />
+                                ),
+                            )}
+                        </Stack>
+                    ) : (
+                        <Text fz="sm" c="gray.6">
+                            No jobs found
+                        </Text>
+                    )}
+                </Box>
+            </Stack>
+        </Modal>
+    );
+};
+
+export default RunDetailsModal;

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -2,12 +2,11 @@ import {
     assertUnreachable,
     SchedulerFormat,
     SchedulerJobStatus,
-    SchedulerRunStatus,
     type SchedulerAndTargets,
     type SchedulerRun,
     type SchedulerWithLogs,
 } from '@lightdash/common';
-import { Tooltip, type MantineTheme } from '@mantine-8/core';
+import { type MantineTheme } from '@mantine-8/core';
 import {
     IconAlertTriangleFilled,
     IconCircleCheckFilled,
@@ -62,113 +61,45 @@ export const getSchedulerIcon = (item: { format: SchedulerFormat }) => {
     }
 };
 
-export const getLogStatusIcon = (log: LogForIcon, theme: MantineTheme) => {
-    switch (log.status) {
+export const getLogStatusIconWithoutTooltip = (
+    status: SchedulerJobStatus,
+    theme: MantineTheme,
+) => {
+    switch (status) {
         case SchedulerJobStatus.SCHEDULED:
             return (
-                <Tooltip label={SchedulerJobStatus.SCHEDULED}>
-                    <MantineIcon
-                        icon={IconClockFilled}
-                        color="blue.3"
-                        style={{ color: theme.colors.blue[3] }}
-                    />
-                </Tooltip>
+                <MantineIcon
+                    icon={IconClockFilled}
+                    color="blue.3"
+                    style={{ color: theme.colors.blue[3] }}
+                />
             );
         case SchedulerJobStatus.STARTED:
             return (
-                <Tooltip label={SchedulerJobStatus.STARTED}>
-                    <MantineIcon
-                        icon={IconProgress}
-                        color="yellow.6"
-                        style={{ color: theme.colors.yellow[6] }}
-                    />
-                </Tooltip>
+                <MantineIcon
+                    icon={IconProgress}
+                    color="yellow.6"
+                    style={{ color: theme.colors.yellow[6] }}
+                />
             );
         case SchedulerJobStatus.COMPLETED:
             return (
-                <Tooltip label={SchedulerJobStatus.COMPLETED}>
-                    <MantineIcon
-                        icon={IconCircleCheckFilled}
-                        color="green.6"
-                        style={{ color: theme.colors.green[6] }}
-                    />
-                </Tooltip>
+                <MantineIcon
+                    icon={IconCircleCheckFilled}
+                    color="green.6"
+                    style={{ color: theme.colors.green[6] }}
+                />
             );
         case SchedulerJobStatus.ERROR:
             return (
-                <Tooltip label={log?.details?.error} multiline>
-                    <MantineIcon
-                        icon={IconAlertTriangleFilled}
-                        color="red.6"
-                        style={{ color: theme.colors.red[6] }}
-                    />
-                </Tooltip>
+                <MantineIcon
+                    icon={IconAlertTriangleFilled}
+                    color="red.6"
+                    style={{ color: theme.colors.red[6] }}
+                />
             );
         default:
-            return assertUnreachable(log.status, 'Resource type not supported');
-    }
-};
-
-export const getRunStatusIcon = (
-    runStatus: SchedulerRunStatus,
-    theme: MantineTheme,
-) => {
-    switch (runStatus) {
-        case SchedulerRunStatus.SCHEDULED:
-            return (
-                <Tooltip label="Scheduled">
-                    <MantineIcon
-                        icon={IconClockFilled}
-                        color="blue.3"
-                        style={{ color: theme.colors.blue[3] }}
-                    />
-                </Tooltip>
-            );
-        case SchedulerRunStatus.RUNNING:
-            return (
-                <Tooltip label="Running">
-                    <MantineIcon
-                        icon={IconProgress}
-                        color="yellow.6"
-                        style={{ color: theme.colors.yellow[6] }}
-                    />
-                </Tooltip>
-            );
-        case SchedulerRunStatus.COMPLETED:
-            return (
-                <Tooltip label="Completed">
-                    <MantineIcon
-                        icon={IconCircleCheckFilled}
-                        color="green.6"
-                        style={{ color: theme.colors.green[6] }}
-                    />
-                </Tooltip>
-            );
-        case SchedulerRunStatus.PARTIAL_FAILURE:
-            return (
-                <Tooltip label="Partial failure - some jobs failed">
-                    <MantineIcon
-                        icon={IconAlertTriangleFilled}
-                        color="orange.6"
-                        style={{ color: theme.colors.orange[6] }}
-                    />
-                </Tooltip>
-            );
-        case SchedulerRunStatus.FAILED:
-            return (
-                <Tooltip label="Failed">
-                    <MantineIcon
-                        icon={IconAlertTriangleFilled}
-                        color="red.6"
-                        style={{ color: theme.colors.red[6] }}
-                    />
-                </Tooltip>
-            );
-        default:
-            return assertUnreachable(
-                runStatus,
-                'Run status type not supported',
-            );
+            return assertUnreachable(status, 'Resource type not supported');
     }
 };
 


### PR DESCRIPTION
Closes: GLITCH-87, GLITCH-88

### Refactor Scheduled Deliveries Run History UI

This updates the Scheduled Deliveries **Run History** experience by replacing the expandable table rows with a clearer two-step layout: a list of runs and a dedicated details view. Sub-jobs contain information that parent runs do not, so showing them all in the same table was confusing. This refactor separates the concerns and improves clarity.

### Specifically
- The Run History table is now a simple list of runs.
- Added a `status` column with text explanations (replacing the status icon + tooltip).
- Clicking a row opens a **Run Details** modal.
- The Run Details modal shows the job configuration (delivery target + schedule) and the list of sub-jobs.
- Introduces a computed run-level status: **success**, **failure**, or **partial success**.
- Each sub-job now displays its own timing and status.
- Failures show detailed error information.

**Demo**
![Kapture 2025-11-21 at 17 11 37](https://github.com/user-attachments/assets/cdd3b376-447e-4b1b-8506-cd286ce294a5)

**Success log**
<img width="629" height="475" alt="success" src="https://github.com/user-attachments/assets/5f26e974-a85e-4211-8995-d9b2496ffdf2" />

**Failure**
<img width="630" height="473" alt="failure" src="https://github.com/user-attachments/assets/943ad69e-cee7-4a57-9b55-b6833a644e64" />

**Partial**
<img width="627" height="1074" alt="partial" src="https://github.com/user-attachments/assets/aca8130f-538d-4a9f-91cd-a62498a1fac6" />
