### PR TITLE
feat: support decimal values in gauge number inputs

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -56,6 +56,8 @@ export const GaugeDisplayConfig: FC = memo(() => {
                         value={min}
                         onChange={(value) => setMin(Number(value))}
                         placeholder="0"
+                        precision={2}
+                        removeTrailingZeros={true}
                     />
                     <Group spacing="xs" align="flex-end">
                         {maxValueMode === GaugeValueMode.FIXED ? (
@@ -65,6 +67,8 @@ export const GaugeDisplayConfig: FC = memo(() => {
                                 value={max}
                                 onChange={(value) => setMax(Number(value))}
                                 placeholder="100"
+                                precision={2}
+                                removeTrailingZeros={true}
                                 style={{ flex: 1 }}
                             />
                         ) : (

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSection.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSection.tsx
@@ -75,6 +75,8 @@ const GaugeSectionComponent: FC<Props> = memo(
                                         onUpdate(index, { min: Number(value) })
                                     }
                                     style={{ flex: 1 }}
+                                    precision={2}
+                                    removeTrailingZeros={true}
                                 />
                             ) : (
                                 <FieldSelect
@@ -148,6 +150,8 @@ const GaugeSectionComponent: FC<Props> = memo(
                                     onChange={(value) =>
                                         onUpdate(index, { max: Number(value) })
                                     }
+                                    precision={2}
+                                    removeTrailingZeros={true}
                                     style={{ flex: 1 }}
                                 />
                             ) : (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/18250

### Description:
Added precision and trailing zero removal to numeric inputs in the Gauge configuration. This enhances the user experience by allowing decimal values with up to 2 decimal places while automatically removing unnecessary trailing zeros for cleaner display.

<img width="3348" height="2574" alt="CleanShot 2025-11-21 at 16 28 21@2x" src="https://github.com/user-attachments/assets/96537eca-eeb8-4d1c-935f-9e8d94047d5e" />

