### PR TITLE
fix: handle gauge values above max in color calculation

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
@@ -24,10 +24,12 @@ const getValueColor = ({
     numericValue,
     sections,
     primaryColor,
+    gaugeMax,
 }: {
     numericValue: number;
     sections: GaugeSection[] | undefined;
     primaryColor: string;
+    gaugeMax: number;
 }) => {
     const defaultColours = {
         text: 'black',
@@ -41,6 +43,18 @@ const getValueColor = ({
     // Find the section that contains this value
     const sortedSections = [...sections].sort((a, b) => a.max - b.max);
 
+    // Check edge case where value is above max
+    if (numericValue > gaugeMax) {
+        const lastSection = sortedSections[sortedSections.length - 1];
+        if (lastSection && lastSection.max >= gaugeMax) {
+            return {
+                text: lastSection.color,
+                bar: lastSection.color,
+            };
+        }
+    }
+
+    // If value is in a section, return the section's color
     for (const section of sortedSections) {
         if (numericValue >= section.min && numericValue <= section.max) {
             return {
@@ -150,6 +164,7 @@ const useEchartsGaugeConfig = ({
             numericValue,
             sections: sectionsWithResolvedValues,
             primaryColor: theme.colors.blue[6],
+            gaugeMax: effectiveMax,
         });
 
         if (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-193/gauge-barvalue-color-incorrect-when-value-is-above-max

### Description:
Fix gauge chart color when value exceeds maximum

This PR fixes an edge case in the gauge chart where values exceeding the maximum weren't properly colored. Now, when a value is above the gauge maximum, it correctly uses the color of the last section that contains the maximum value.

### Before
<img width="4894" height="2576" alt="CleanShot 2025-11-21 at 17 24 47@2x" src="https://github.com/user-attachments/assets/21eb4656-446e-4c58-85d1-9d1b72a3ee85" />


### After

<img width="4894" height="2572" alt="CleanShot 2025-11-21 at 17 23 15@2x" src="https://github.com/user-attachments/assets/f03d3438-fb05-4dd6-86df-1e44b702dcdb" />

(if there is no section reaching the max, uses default color)
<img width="4892" height="2572" alt="CleanShot 2025-11-21 at 17 23 01@2x" src="https://github.com/user-attachments/assets/9a678afc-e001-4471-b66d-b336963394b8" />
