### PR TITLE
feat: add custom label option to gauge charts

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -136,6 +136,7 @@ export type GaugeChart = {
     maxFieldId?: string;
     showAxisLabels?: boolean;
     sections?: GaugeSection[];
+    customLabel?: string;
 };
 
 export enum FunnelChartDataInput {

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -1,4 +1,4 @@
-import { getItemId } from '@lightdash/common';
+import { getItemId, getItemLabelWithoutTableName } from '@lightdash/common';
 import {
     Center,
     Checkbox,
@@ -6,6 +6,7 @@ import {
     NumberInput,
     SegmentedControl,
     Stack,
+    TextInput,
     Tooltip,
 } from '@mantine/core';
 import { memo, type FC } from 'react';
@@ -25,6 +26,7 @@ export const GaugeDisplayConfig: FC = memo(() => {
 
     const {
         chartConfig: {
+            selectedField: selectedFieldId,
             min,
             setMin,
             max,
@@ -34,6 +36,8 @@ export const GaugeDisplayConfig: FC = memo(() => {
             getField,
             showAxisLabels,
             setShowAxisLabels,
+            customLabel,
+            setCustomLabel,
         },
         numericMetrics,
     } = visualizationConfig;
@@ -42,6 +46,7 @@ export const GaugeDisplayConfig: FC = memo(() => {
         ? GaugeValueMode.FIELD
         : GaugeValueMode.FIXED;
     const maxField = getField(maxFieldId);
+    const selectedField = getField(selectedFieldId);
 
     const numericMetricsList = Object.values(numericMetrics ?? {});
 
@@ -144,6 +149,22 @@ export const GaugeDisplayConfig: FC = memo(() => {
                         checked={showAxisLabels}
                         onChange={(event) =>
                             setShowAxisLabels(event.currentTarget.checked)
+                        }
+                    />
+
+                    <TextInput
+                        label="Custom label"
+                        description="Override the default field label"
+                        value={customLabel || ''}
+                        onChange={(event) =>
+                            setCustomLabel(
+                                event.currentTarget.value || undefined,
+                            )
+                        }
+                        placeholder={
+                            selectedField
+                                ? getItemLabelWithoutTableName(selectedField)
+                                : "e.g. 'Sales'"
                         }
                     />
                 </Config.Section>

--- a/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
@@ -94,6 +94,7 @@ const useEchartsGaugeConfig = ({
             maxFieldId,
             showAxisLabels,
             sections,
+            customLabel,
         } = chartConfig.validConfig;
 
         // Get the first row of data
@@ -121,7 +122,8 @@ const useEchartsGaugeConfig = ({
             }
         }
 
-        const fieldLabel = getItemLabelWithoutTableName(fieldItem);
+        const fieldLabel =
+            customLabel || getItemLabelWithoutTableName(fieldItem);
 
         const sectionColors: [number, string][] = [];
         const defaultGapColor = theme.white;

--- a/packages/frontend/src/hooks/useGaugeChartConfig.ts
+++ b/packages/frontend/src/hooks/useGaugeChartConfig.ts
@@ -48,6 +48,9 @@ const useGaugeChartConfig = (
     const [sections, setSections] = useState<GaugeSection[]>(
         initialChartConfig?.sections ?? [],
     );
+    const [customLabel, setCustomLabel] = useState<string | undefined>(
+        initialChartConfig?.customLabel,
+    );
 
     // Get the effective selected field - use state value or fallback to first available
     const effectiveSelectedField = useMemo(() => {
@@ -77,6 +80,7 @@ const useGaugeChartConfig = (
             maxFieldId,
             showAxisLabels,
             sections,
+            customLabel,
         };
     }, [
         effectiveSelectedField,
@@ -85,6 +89,7 @@ const useGaugeChartConfig = (
         maxFieldId,
         showAxisLabels,
         sections,
+        customLabel,
     ]);
 
     return useMemo(
@@ -104,6 +109,8 @@ const useGaugeChartConfig = (
             setShowAxisLabels,
             sections,
             setSections,
+            customLabel,
+            setCustomLabel,
         }),
         [
             validConfig,
@@ -115,6 +122,7 @@ const useGaugeChartConfig = (
             maxFieldId,
             showAxisLabels,
             sections,
+            customLabel,
         ],
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/CENG-195/support-custom-label-in-gauge-chart

### Description:
Added the ability to set custom labels for gauge charts. This feature allows users to override the default field label with a custom one, making gauge charts more flexible and descriptive.

The implementation includes:
- Added a `customLabel` property to the `GaugeChart` type
- Added a text input field in the gauge display configuration panel
- Updated the chart rendering to use the custom label when provided

![CleanShot 2025-11-21 at 17 38 55](https://github.com/user-attachments/assets/4eed3526-d011-47cb-9688-71bd885474fb)