### PR TITLE
feat: allow switching agents on multi-agent slack channel

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1312,6 +1312,21 @@ export type AiAgentPromptFeedbackEvent = BaseTrack & {
     };
 };
 
+export type AiAgentSwitchedInThreadEvent = BaseTrack & {
+    event: 'ai_agent.switched_in_thread';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        oldAgentId: string;
+        oldAgentName: string;
+        newAgentId: string;
+        newAgentName: string;
+        threadId: string;
+        wasCancelled: boolean;
+    };
+};
+
 export type AiAgentResponseStreamed = BaseTrack & {
     event: 'ai_agent.response_streamed';
     userId: string;
@@ -1542,6 +1557,7 @@ type TypedEvent =
     | AiAgentUpdatedEvent
     | AiAgentPromptCreatedEvent
     | AiAgentPromptFeedbackEvent
+    | AiAgentSwitchedInThreadEvent
     | AiAgentEvalCreatedEvent
     | AiAgentEvalRunEvent
     | AiAgentEvalAppendedEvent

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -3334,6 +3334,30 @@ export class AiAgentModel {
             });
     }
 
+    async getLatestPromptInThread(threadUuid: string): Promise<string | null> {
+        const result = await this.database(AiPromptTableName)
+            .select('ai_prompt_uuid')
+            .where('ai_thread_uuid', threadUuid)
+            .orderBy('created_at', 'desc')
+            .first();
+
+        return result?.ai_prompt_uuid ?? null;
+    }
+
+    async updateThreadAgent({
+        threadUuid,
+        agentUuid,
+    }: {
+        threadUuid: string;
+        agentUuid: string;
+    }): Promise<void> {
+        await this.database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .update({
+                agent_uuid: agentUuid,
+            });
+    }
+
     async appendInstruction(data: {
         agentUuid: string;
         instruction: string;

--- a/packages/backend/src/ee/services/SlackService/SlackService.ts
+++ b/packages/backend/src/ee/services/SlackService/SlackService.ts
@@ -32,6 +32,7 @@ export class CommercialSlackService extends SlackService {
             this.aiAgentService.handleMultiAgentChannelMessage(m),
         );
         this.aiAgentService.handleAgentSelection(slackApp);
+        this.aiAgentService.handleSwitchAgentInThread(slackApp);
         this.aiAgentService.handlePromptUpvote(slackApp);
         this.aiAgentService.handlePromptDownvote(slackApp);
         this.aiAgentService.handleClickExploreButton(slackApp);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Added the ability to switch AI agents within an existing Slack thread. Users can now select a different agent from a dropdown menu that appears at the bottom of agent responses. When switching agents:

- The dropdown groups agents by project when multiple projects are available
- Any running query is automatically cancelled
- A confirmation message replaces the dropdown after switching
- Analytics events track agent switches

This feature enhances flexibility by allowing users to change the AI agent they're interacting with without starting a new conversation thread.

**ignore the preview project there, that was before I pushed some changes**

![image.png](https://app.graphite.com/user-attachments/assets/955bab94-8599-499a-8fbd-a3a27ec56111.png)

