### PR TITLE
fix: prevent onChange calls during intermediate number input states

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberInput.tsx
@@ -71,9 +71,14 @@ const FilterNumberInput: FC<Props> = ({
             const parsedNumber = parseNumberInput(inputText);
             const normalizedPropValue = value ?? null;
 
+            const isIntermediateState =
+                inputText.endsWith('.') ||
+                inputText === '-' ||
+                inputText === '.';
+
             // Only notify parent if the parsed value differs from current prop
             // This prevents infinite loops from unnecessary onChange calls
-            if (parsedNumber !== normalizedPropValue) {
+            if (!isIntermediateState && parsedNumber !== normalizedPropValue) {
                 onChange(parsedNumber);
             }
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18270

### Description:
Prevents onChange events from firing during intermediate states when typing numbers in FilterNumberInput. This fix handles cases where users are in the middle of typing decimal points or negative numbers (e.g., when the input contains only '-', '.', or ends with a decimal point).