### PR TITLE
docs - grammar nitpick

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -253,7 +253,7 @@ ${styles.bold('Examples:')}
   ${styles.title('⚡')}️lightdash ${styles.bold(
             'dbt run',
         )} -s +mymodel ${styles.secondary(
-            "-- runs mymodel and it's parents and generates .yml",
+            "-- runs mymodel and its parents and generates .yml",
         )}
 `,
     )


### PR DESCRIPTION
### Description:
Grammar nitpick. `it's` -> `its`. `it's` is for contractions if the original phrase was "it is". `its` is possessive.

<img width="945" height="995" alt="image" src="https://github.com/user-attachments/assets/6f8f98dc-fb8b-4f2b-9368-f68f2cdd17f4" />
