### PR TITLE
feat: add theme switcher to navbar

### DIFF
--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -13,6 +13,7 @@ import { MetricsLink } from './MetricsLink';
 import { NotificationsMenu } from './NotificationsMenu';
 import ProjectSwitcher from './ProjectSwitcher';
 import SettingsMenu from './SettingsMenu';
+import { ThemeSwitcher } from './ThemeSwitcher';
 import UserCredentialsSwitcher from './UserCredentialsSwitcher';
 import UserMenu from './UserMenu';
 
@@ -63,6 +64,8 @@ export const MainNavBarContent: FC<Props> = ({
 
             <Group sx={{ flexShrink: 0 }}>
                 <Button.Group>
+                    <ThemeSwitcher />
+
                     <SettingsMenu />
 
                     {!isLoadingActiveProject && activeProjectUuid && (

--- a/packages/frontend/src/components/NavBar/ThemeSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher.tsx
@@ -1,0 +1,23 @@
+import { Tooltip } from '@mantine-8/core';
+import { Button, useMantineColorScheme } from '@mantine/core';
+import { IconMoonStars, IconSun } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+
+export const ThemeSwitcher: FC<{}> = ({}) => {
+    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+
+    return (
+        <Tooltip label={colorScheme === 'dark' ? 'Light mode' : 'Dark mode'}>
+            <Button
+                variant="default"
+                size="xs"
+                onClick={() => toggleColorScheme()}
+            >
+                <MantineIcon
+                    icon={colorScheme === 'dark' ? IconSun : IconMoonStars}
+                />
+            </Button>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/providers/Mantine8Provider.tsx
+++ b/packages/frontend/src/providers/Mantine8Provider.tsx
@@ -2,6 +2,7 @@ import {
     MantineProvider as MantineProviderBase,
     type MantineThemeOverride,
 } from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { type FC } from 'react';
 
 import { getMantine8ThemeOverride } from '../mantine8Theme';
@@ -17,10 +18,12 @@ const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
     theme = getMantine8ThemeOverride(),
     themeOverride = {},
 }) => {
+    const { colorScheme } = useMantineColorScheme();
+
     return (
         <MantineProviderBase
             theme={{ ...theme, ...themeOverride }}
-            forceColorScheme="light"
+            forceColorScheme={colorScheme}
             classNamesPrefix="mantine-8"
         >
             {children}

--- a/packages/frontend/src/providers/MantineProvider.tsx
+++ b/packages/frontend/src/providers/MantineProvider.tsx
@@ -1,9 +1,11 @@
 import {
+    type ColorScheme,
+    ColorSchemeProvider,
     MantineProvider as MantineProviderBase,
     type MantineThemeOverride,
 } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import { type FC } from 'react';
+import { type FC, useState } from 'react';
 
 import { getMantineThemeOverride } from '../mantineTheme';
 
@@ -21,21 +23,34 @@ const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
     withGlobalStyles = false,
     withNormalizeCSS = false,
     withCSSVariables = false,
-    theme = getMantineThemeOverride(),
+
     themeOverride = {},
     notificationsLimit,
 }) => {
-    return (
-        <MantineProviderBase
-            withGlobalStyles={withGlobalStyles}
-            withNormalizeCSS={withNormalizeCSS}
-            withCSSVariables={withCSSVariables}
-            theme={{ ...theme, ...themeOverride }}
-        >
-            {children}
+    const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
 
-            <Notifications limit={notificationsLimit} />
-        </MantineProviderBase>
+    const theme = getMantineThemeOverride({ colorScheme });
+
+    const toggleColorScheme = (value?: ColorScheme) => {
+        setColorScheme(value || (colorScheme === 'dark' ? 'light' : 'dark'));
+    };
+
+    return (
+        <ColorSchemeProvider
+            colorScheme={colorScheme}
+            toggleColorScheme={toggleColorScheme}
+        >
+            <MantineProviderBase
+                withGlobalStyles={withGlobalStyles}
+                withNormalizeCSS={withNormalizeCSS}
+                withCSSVariables={withCSSVariables}
+                theme={{ ...theme, ...themeOverride }}
+            >
+                {children}
+
+                <Notifications limit={notificationsLimit} />
+            </MantineProviderBase>
+        </ColorSchemeProvider>
     );
 };
 


### PR DESCRIPTION
### Description:
Added a theme switcher to toggle between light and dark mode in the UI. The switcher appears in the navbar with sun/moon icons and includes a tooltip indicating the mode that will be activated when clicked. The theme state is managed through Mantine's ColorSchemeProvider and properly propagates to both Mantine and Mantine8 providers.