### PR TITLE
fix: allow sql_from if no model_name

### DIFF
--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -678,9 +678,6 @@ export const convertTable = (
         throw new ParseError(`${message} ${duplicatedNames}`);
     }
 
-    if (!model.relation_name) {
-        throw new Error(`Model "${model.name}" has no table relation`);
-    }
     const groupDetails: Record<string, GroupType> = {};
     if (meta.group_details) {
         Object.entries(meta.group_details).forEach(([key, data]) => {
@@ -696,6 +693,9 @@ export const convertTable = (
     }
 
     const sqlTable = meta.sql_from || model.relation_name;
+    if (sqlTable === null || sqlTable === undefined || sqlTable === '') {
+        throw new Error(`Model "${model.name}" is missing a table reference.`);
+    }
     return {
         name: model.name,
         label: tableLabel,


### PR DESCRIPTION
If a dbt_model has `relation_name` it'll error - but now it won't _if_ you have the `meta.from_sql` field.