### PR TITLE
feat: support dark mode in visualization config panels

### DIFF
--- a/packages/frontend/.storybook/preview.tsx
+++ b/packages/frontend/.storybook/preview.tsx
@@ -8,7 +8,7 @@ import Mantine8Provider from '../src/providers/Mantine8Provider';
 // All stories will have the Mantine theme applied
 const ThemeWrapper = (props: { children: React.ReactNode }) => (
     <MantineProvider
-        theme={getMantineThemeOverride()}
+        theme={getMantineThemeOverride('light')}
         withGlobalStyles
         withNormalizeCSS
     >

--- a/packages/frontend/src/components/DataViz/VisualizationConfigPanel.tsx
+++ b/packages/frontend/src/components/DataViz/VisualizationConfigPanel.tsx
@@ -1,8 +1,8 @@
 import { ChartKind, type VizColumn } from '@lightdash/common';
-import { MantineProvider } from '@mantine/core';
-import { type FC } from 'react';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
+import { type FC, useMemo } from 'react';
 import { Config } from '../VisualizationConfigs/common/Config';
-import { themeOverride } from '../VisualizationConfigs/mantineTheme';
+import { getVizConfigThemeOverride } from '../VisualizationConfigs/mantineTheme';
 import { VisualizationSwitcher } from './VisualizationSwitcher';
 import { CartesianChartConfig } from './config/CartesianChartConfiguration';
 import { PieChartConfiguration } from './config/PieChartConfiguration';
@@ -13,6 +13,12 @@ export const VisualizationConfigPanel: FC<{
     setSelectedChartType: (chartKind: ChartKind) => void;
     columns: VizColumn[];
 }> = ({ selectedChartType, setSelectedChartType, columns }) => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
     return (
         <MantineProvider inherit theme={themeOverride}>
             <Config>

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
@@ -1,10 +1,16 @@
-import { MantineProvider, Tabs } from '@mantine/core';
-import { memo } from 'react';
-import { themeOverride } from '../mantineTheme';
+import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { type FC, memo, useMemo } from 'react';
+import { getVizConfigThemeOverride } from '../mantineTheme';
 import { Comparison } from './BigNumberComparison';
 import { Layout } from './BigNumberLayout';
 
-export const ConfigTabs = memo(() => {
+export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
     return (
         <MantineProvider inherit theme={themeOverride}>
             <Tabs defaultValue="layout" keepMounted={false}>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ConfigTabs/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ConfigTabs/index.tsx
@@ -1,7 +1,7 @@
-import { MantineProvider, Tabs } from '@mantine/core';
+import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
-import { themeOverride } from '../../mantineTheme';
+import { getVizConfigThemeOverride } from '../../mantineTheme';
 import { Axes } from '../Axes';
 import { Grid } from '../Grid';
 import { Layout } from '../Layout';
@@ -9,6 +9,12 @@ import { Legend } from '../Legend';
 import { Series } from '../Series';
 
 export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
     const { itemsMap } = useVisualizationContext();
 
     const items = useMemo(() => Object.values(itemsMap || {}), [itemsMap]);

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -19,16 +19,23 @@ import {
     Switch,
     Tabs,
     Tooltip,
+    useMantineColorScheme,
 } from '@mantine/core';
-import { memo, type FC } from 'react';
+import { memo, useMemo, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import { isFunnelVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
-import { themeOverride } from '../mantineTheme';
+import { getVizConfigThemeOverride } from '../mantineTheme';
 import { StepConfig } from './StepConfig';
 
 export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
     const { visualizationConfig } = useVisualizationContext();
 
     if (!isFunnelVisualizationConfig(visualizationConfig)) return null;

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeConfigTabs.tsx
@@ -1,10 +1,16 @@
-import { MantineProvider, Tabs } from '@mantine/core';
-import { memo, type FC } from 'react';
-import { themeOverride } from '../mantineTheme';
+import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { memo, useMemo, type FC } from 'react';
+import { getVizConfigThemeOverride } from '../mantineTheme';
 import { GaugeDisplayConfig } from './GaugeDisplayConfig';
 import { GaugeFieldsConfig } from './GaugeFieldsConfig';
 
 export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
     return (
         <MantineProvider inherit theme={themeOverride}>
             <Tabs defaultValue="fields" keepMounted={false}>

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartConfigTabs.tsx
@@ -1,11 +1,17 @@
-import { MantineProvider, Tabs } from '@mantine/core';
-import { memo, type FC } from 'react';
-import { themeOverride } from '../mantineTheme';
+import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { memo, useMemo, type FC } from 'react';
+import { getVizConfigThemeOverride } from '../mantineTheme';
 import { Display } from './PieChartDisplayConfig';
 import { Layout } from './PieChartLayoutConfig';
 import { Series } from './PieChartSeriesConfig';
 
 export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
     return (
         <MantineProvider inherit theme={themeOverride}>
             <Tabs defaultValue="layout" keepMounted={false}>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
@@ -1,34 +1,42 @@
-import { MantineProvider, Tabs } from '@mantine/core';
-import { memo, type FC } from 'react';
-import { themeOverride } from '../mantineTheme';
+import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { memo, useMemo, type FC } from 'react';
+import { getVizConfigThemeOverride } from '../mantineTheme';
 import { ColumnCellDisplay } from './ColumnCellDisplay';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
 
-export const ConfigTabs: FC = memo(() => (
-    <MantineProvider inherit theme={themeOverride}>
-        <Tabs defaultValue="general" keepMounted={false}>
-            <Tabs.List mb="sm">
-                <Tabs.Tab px="sm" value="general">
-                    General
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="conditional-formatting">
-                    Conditional formatting
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="cell-display">
-                    Cell display
-                </Tabs.Tab>
-            </Tabs.List>
+export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
 
-            <Tabs.Panel value="general">
-                <GeneralSettings />
-            </Tabs.Panel>
-            <Tabs.Panel value="conditional-formatting">
-                <ConditionalFormattingList />
-            </Tabs.Panel>
-            <Tabs.Panel value="cell-display">
-                <ColumnCellDisplay />
-            </Tabs.Panel>
-        </Tabs>
-    </MantineProvider>
-));
+    return (
+        <MantineProvider inherit theme={themeOverride}>
+            <Tabs defaultValue="general" keepMounted={false}>
+                <Tabs.List mb="sm">
+                    <Tabs.Tab px="sm" value="general">
+                        General
+                    </Tabs.Tab>
+                    <Tabs.Tab px="sm" value="conditional-formatting">
+                        Conditional formatting
+                    </Tabs.Tab>
+                    <Tabs.Tab px="sm" value="cell-display">
+                        Cell display
+                    </Tabs.Tab>
+                </Tabs.List>
+
+                <Tabs.Panel value="general">
+                    <GeneralSettings />
+                </Tabs.Panel>
+                <Tabs.Panel value="conditional-formatting">
+                    <ConditionalFormattingList />
+                </Tabs.Panel>
+                <Tabs.Panel value="cell-display">
+                    <ColumnCellDisplay />
+                </Tabs.Panel>
+            </Tabs>
+        </MantineProvider>
+    );
+});

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapConfigTabs.tsx
@@ -1,10 +1,16 @@
-import { MantineProvider, Tabs } from '@mantine/core';
-import { memo, type FC } from 'react';
-import { themeOverride } from '../mantineTheme';
+import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { memo, useMemo, type FC } from 'react';
+import { getVizConfigThemeOverride } from '../mantineTheme';
 import { Display } from './TreemapDisplayConfig';
 import { Layout } from './TreemapLayoutConfig';
 
 export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
     return (
         <MantineProvider inherit theme={themeOverride}>
             <Tabs defaultValue="layout" keepMounted={false}>

--- a/packages/frontend/src/components/VisualizationConfigs/mantineTheme.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/mantineTheme.ts
@@ -1,74 +1,76 @@
+import { type ColorScheme } from '@mantine/styles';
 import { getMantineThemeOverride } from '../../mantineTheme';
 
-export const themeOverride = getMantineThemeOverride({
-    components: {
-        Select: {
-            styles: (theme) => ({
-                label: {
-                    fontSize: theme.fontSizes.xs,
-                    fontWeight: 500,
-                    color: theme.colors.ldGray['6'],
+export const getVizConfigThemeOverride = (colorScheme: ColorScheme) =>
+    getMantineThemeOverride(colorScheme, {
+        components: {
+            Select: {
+                styles: (theme) => ({
+                    label: {
+                        fontSize: theme.fontSizes.xs,
+                        fontWeight: 500,
+                        color: theme.colors.ldGray['6'],
+                    },
+                }),
+                defaultProps: {
+                    size: 'xs',
                 },
-            }),
-            defaultProps: {
-                size: 'xs',
             },
-        },
-        TextInput: {
-            defaultProps: {
-                size: 'xs',
-            },
-        },
-        Switch: {
-            styles: (theme) => ({
-                label: {
-                    fontSize: theme.fontSizes.xs,
-                    fontWeight: 500,
-                    color: theme.colors.ldGray['6'],
-                    paddingLeft: 4,
+            TextInput: {
+                defaultProps: {
+                    size: 'xs',
                 },
-            }),
-            defaultProps: {
-                size: 'xs',
             },
-        },
-        SegmentedControl: {
-            defaultProps: {
-                size: 'xs',
-            },
-        },
-        Button: {
-            defaultProps: {
-                size: 'xs',
-            },
-        },
-        CloseButton: {
-            defaultProps: {
-                size: 'xs',
-            },
-        },
-        NumberInput: {
-            defaultProps: {
-                size: 'xs',
-            },
-        },
-        Checkbox: {
-            styles: (theme) => ({
-                label: {
-                    fontSize: theme.fontSizes.xs,
-                    fontWeight: 500,
-                    color: theme.colors.ldGray['6'],
-                    paddingLeft: 4,
+            Switch: {
+                styles: (theme) => ({
+                    label: {
+                        fontSize: theme.fontSizes.xs,
+                        fontWeight: 500,
+                        color: theme.colors.ldGray['6'],
+                        paddingLeft: 4,
+                    },
+                }),
+                defaultProps: {
+                    size: 'xs',
                 },
-            }),
-            defaultProps: {
-                size: 'xs',
+            },
+            SegmentedControl: {
+                defaultProps: {
+                    size: 'xs',
+                },
+            },
+            Button: {
+                defaultProps: {
+                    size: 'xs',
+                },
+            },
+            CloseButton: {
+                defaultProps: {
+                    size: 'xs',
+                },
+            },
+            NumberInput: {
+                defaultProps: {
+                    size: 'xs',
+                },
+            },
+            Checkbox: {
+                styles: (theme) => ({
+                    label: {
+                        fontSize: theme.fontSizes.xs,
+                        fontWeight: 500,
+                        color: theme.colors.ldGray['6'],
+                        paddingLeft: 4,
+                    },
+                }),
+                defaultProps: {
+                    size: 'xs',
+                },
+            },
+            ActionIcon: {
+                defaultProps: {
+                    size: 'sm',
+                },
             },
         },
-        ActionIcon: {
-            defaultProps: {
-                size: 'sm',
-            },
-        },
-    },
-});
+    });

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -11,18 +11,14 @@ import {
     Textarea,
     TextInput,
     type ButtonVariant,
+    type DefaultMantineColor,
+    type MantineColorsTuple,
     type MantineTheme,
     type MantineThemeOverride,
 } from '@mantine-8/core';
+import { type ColorScheme } from '@mantine/styles';
 import { DotsLoader } from './ee/features/aiCopilot/components/ChatElements/DotsLoader/DotsLoader';
-import { getMantineThemeOverride as getLegacyTheme } from './mantineTheme';
-
-const { colors, components, ...legacyTheme } = getLegacyTheme();
-const {
-    Button: _Button,
-    ScrollArea: _ScrollArea,
-    ...legacyComponentsTheme
-} = components;
+import { getMantineThemeOverride as getMantine6ThemeOverride } from './mantineTheme';
 
 declare module '@mantine-8/core' {
     export interface ButtonProps {
@@ -35,7 +31,13 @@ declare module '@mantine-8/core' {
          */
         delayedMessage?: string;
     }
+
+    export interface MantineThemeColorsOverride {
+        colors: Record<ExtendedCustomColors, MantineColorsTuple>;
+    }
 }
+
+type ExtendedCustomColors = 'ldGray' | 'ldDark' | DefaultMantineColor;
 
 const subtleInputStyles = (theme: MantineTheme) => ({
     input: {
@@ -55,9 +57,19 @@ const subtleInputStyles = (theme: MantineTheme) => ({
 });
 
 export const getMantine8ThemeOverride = (
+    colorScheme: ColorScheme,
     overrides?: Partial<MantineThemeOverride>,
-) =>
-    ({
+) => {
+    const { colors, components, ...legacyTheme } =
+        getMantine6ThemeOverride(colorScheme);
+
+    const {
+        Button: _Button,
+        ScrollArea: _ScrollArea,
+        ...legacyComponentsTheme
+    } = components;
+
+    return {
         ...legacyTheme,
         ...overrides,
         colors,
@@ -235,4 +247,5 @@ export const getMantine8ThemeOverride = (
             }),
             ...overrides?.components,
         },
-    } satisfies MantineThemeOverride);
+    } satisfies MantineThemeOverride;
+};

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -62,10 +62,12 @@ const darkModeColors = {
     ] as ColorTuple,
 };
 
-export const getMantineThemeOverride = (overrides?: {
-    colorScheme?: ColorScheme;
-    components?: Partial<MantineThemeOverride['components']>;
-}) =>
+export const getMantineThemeOverride = (
+    colorScheme: ColorScheme,
+    overrides?: {
+        components?: Partial<MantineThemeOverride['components']>;
+    },
+) =>
     ({
         ...overrides,
 
@@ -75,10 +77,7 @@ export const getMantineThemeOverride = (overrides?: {
         // Without it things look a little darker than before.
         black: '#111418',
 
-        colors:
-            overrides?.colorScheme === 'dark'
-                ? darkModeColors
-                : lightModeColors,
+        colors: colorScheme === 'dark' ? darkModeColors : lightModeColors,
 
         spacing: {
             one: rem(1),

--- a/packages/frontend/src/pages/MetricsCatalog.tsx
+++ b/packages/frontend/src/pages/MetricsCatalog.tsx
@@ -1,5 +1,9 @@
-import { MantineProvider, type MantineTheme } from '@mantine/core';
-import { type FC } from 'react';
+import {
+    MantineProvider,
+    type MantineTheme,
+    useMantineColorScheme,
+} from '@mantine/core';
+import { type FC, useMemo } from 'react';
 import { Provider } from 'react-redux';
 import Page from '../components/common/Page/Page';
 import { MetricsCatalogPanel } from '../features/metricsCatalog';
@@ -14,17 +18,21 @@ type MetricsCatalogProps = {
 const MetricsCatalog: FC<MetricsCatalogProps> = ({
     metricCatalogView = MetricCatalogView.LIST,
 }) => {
+    const { colorScheme } = useMantineColorScheme();
+    const theme = useMemo(
+        () => getMantineThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
     return (
         <Provider store={store}>
             <MantineProvider
                 theme={{
                     // TODO: Introduce Inter as a font in the theme globally
-                    ...getMantineThemeOverride(),
-                    fontFamily: `Inter, ${
-                        getMantineThemeOverride().fontFamily
-                    }`,
+                    ...theme,
+                    fontFamily: `Inter, ${theme.fontFamily}`,
                     components: {
-                        ...getMantineThemeOverride().components,
+                        ...theme.components,
                         Tooltip: {
                             defaultProps: {
                                 openDelay: 200,
@@ -47,9 +55,9 @@ const MetricsCatalog: FC<MetricsCatalogProps> = ({
                                 radius: 'md',
                                 shadow: 'subtle',
                                 withBorder: true,
-                                sx: (theme: MantineTheme) => ({
+                                sx: (t: MantineTheme) => ({
                                     '&[data-with-border]': {
-                                        border: `1px solid ${theme.colors.ldGray[2]}`,
+                                        border: `1px solid ${t.colors.ldGray[2]}`,
                                     },
                                 }),
                             },

--- a/packages/frontend/src/providers/Mantine8Provider.tsx
+++ b/packages/frontend/src/providers/Mantine8Provider.tsx
@@ -3,22 +3,24 @@ import {
     type MantineThemeOverride,
 } from '@mantine-8/core';
 import { useMantineColorScheme } from '@mantine/core';
-import { type FC } from 'react';
+import { useMemo, type FC } from 'react';
 
 import { getMantine8ThemeOverride } from '../mantine8Theme';
 
 type Props = {
-    theme?: MantineThemeOverride;
     themeOverride?: MantineThemeOverride;
     notificationsLimit?: number;
 };
 
 const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
     children,
-    theme = getMantine8ThemeOverride(),
     themeOverride = {},
 }) => {
     const { colorScheme } = useMantineColorScheme();
+    const theme = useMemo(
+        () => getMantine8ThemeOverride(colorScheme),
+        [colorScheme],
+    );
 
     return (
         <MantineProviderBase

--- a/packages/frontend/src/providers/MantineProvider.tsx
+++ b/packages/frontend/src/providers/MantineProvider.tsx
@@ -29,7 +29,7 @@ const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
 }) => {
     const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
 
-    const theme = getMantineThemeOverride({ colorScheme });
+    const theme = getMantineThemeOverride(colorScheme);
 
     const toggleColorScheme = (value?: ColorScheme) => {
         setColorScheme(value || (colorScheme === 'dark' ? 'light' : 'dark'));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Added support for dark mode in visualization configuration panels by refactoring the Mantine theme implementation. The `getMantineThemeOverride` function now accepts a `colorScheme` parameter to generate the appropriate theme based on the current color scheme. This ensures that visualization config panels properly respect the user's dark/light mode preference.

The changes include:
- Created a new `getVizConfigThemeOverride` function that accepts the color scheme
- Updated all visualization config components to use the current color scheme
- Modified theme provider components to pass the color scheme to theme generation functions
- Ensured consistent theming across all visualization configuration panels