### PR TITLE
fix: support dark theme in filter components and dropdowns

### DIFF
--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -16,6 +16,7 @@ import {
     Select,
     Text,
     Tooltip,
+    useMantineTheme,
     type SelectProps,
 } from '@mantine/core';
 import {
@@ -105,6 +106,7 @@ const FieldSelectComponent = <T extends Item = Item>({
     focusOnRender = false,
     ...rest
 }: FieldSelectProps<T>) => {
+    const theme = useMantineTheme();
     const inputRef = useRef<HTMLInputElement | null>(null); // Input ref for focus handling
     useEffect(() => {
         if (focusOnRender) {
@@ -234,7 +236,10 @@ const FieldSelectComponent = <T extends Item = Item>({
                     position: 'sticky',
                     top: 0,
                     zIndex: 1,
-                    backgroundColor: 'white',
+                    backgroundColor:
+                        theme.colorScheme === 'dark'
+                            ? theme.colors.dark[6]
+                            : 'white',
                 },
                 separatorLabel: {
                     fontWeight: 600,

--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -173,7 +173,7 @@ const FilterGroupForm: FC<Props> = memo(
                 )}
 
                 <Group spacing="xs">
-                    <Box bg="white" pos="relative" style={{ zIndex: 3 }}>
+                    <Box pos="relative" style={{ zIndex: 3 }}>
                         <Select
                             limit={FILTER_SELECT_LIMIT}
                             size="xs"
@@ -263,7 +263,16 @@ const FilterGroupForm: FC<Props> = memo(
                 {isEditMode &&
                     !hideButtons &&
                     availableFieldsForGroupRules.length > 0 && (
-                        <Box bg="white" pos="relative" style={{ zIndex: 2 }}>
+                        <Box
+                            pos="relative"
+                            sx={(theme) => ({
+                                zIndex: 2,
+                                backgroundColor:
+                                    theme.colorScheme === 'dark'
+                                        ? theme.colors.dark[6]
+                                        : 'white',
+                            })}
+                        >
                             <Button
                                 variant="outline"
                                 size="xs"

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -206,14 +206,7 @@ const FilterStringAutoComplete: FC<Props> = ({
             <Stack w="100%" spacing={0}>
                 <ScrollArea {...props}>
                     {searchedMaxResults ? (
-                        <Text
-                            color="dimmed"
-                            size="xs"
-                            px="sm"
-                            pt="xs"
-                            pb="xxs"
-                            bg="white"
-                        >
+                        <Text color="dimmed" size="xs" px="sm" pt="xs" pb="xxs">
                             Showing first {MAX_AUTOCOMPLETE_RESULTS} results.{' '}
                             {search ? 'Continue' : 'Start'} typing...
                         </Text>

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -61,6 +61,7 @@ const getInvalidFilterRules = (
     }, []);
 
 const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
+    // const theme = useMantineTheme();
     const { itemsMap, baseTable } = useFiltersContext<FieldsWithSuggestions>();
     const [isOpen, toggleFieldInput] = useToggle(false);
     const fields = useMemo<FieldWithSuggestions[]>(() => {
@@ -246,7 +247,16 @@ const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
                 ))}
 
             {isEditMode && (
-                <Box bg="white" pos="relative" style={{ zIndex: 2 }}>
+                <Box
+                    pos="relative"
+                    sx={(theme) => ({
+                        zIndex: 2,
+                        backgroundColor:
+                            theme.colorScheme === 'dark'
+                                ? theme.colors.dark[6]
+                                : 'white',
+                    })}
+                >
                     {!isOpen ? (
                         <Group align="center" position="apart" sx={{ flex: 1 }}>
                             <Button


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added dark mode support for filter components by replacing hardcoded white backgrounds with theme-aware colors. The changes include:

1. Added theme detection in FieldSelect component to set appropriate background colors based on color scheme
2. Updated FilterGroupForm to use theme-based background colors instead of hardcoded white
3. Removed hardcoded white backgrounds from FilterStringAutoComplete and other filter components
4. Used Mantine's theme system to dynamically set background colors based on dark/light mode

These changes ensure filter components display correctly in both light and dark themes.