### PR TITLE
refactor: update color variable names from gray to ldGray

### DIFF
--- a/packages/frontend/src/components/CompilationHistory/SourceFilter.module.css
+++ b/packages/frontend/src/components/CompilationHistory/SourceFilter.module.css
@@ -1,12 +1,12 @@
 .filterButton {
-    border: 1px dashed var(--mantine-color-gray-3);
+    border: 1px dashed var(--mantine-color-ldGray-3);
     background: var(--mantine-color-white);
     box-shadow: var(--mantine-shadow-subtle);
 }
 
 .filterButton:hover {
-    border: 1px dashed var(--mantine-color-gray-4);
-    background: var(--mantine-color-gray-0);
+    border: 1px dashed var(--mantine-color-ldGray-4);
+    background: var(--mantine-color-ldGray-0);
 }
 
 .filterButtonSelected {

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -490,7 +490,7 @@ const ProjectSwitcher = () => {
                             styles={{
                                 input: {
                                     backgroundColor: 'transparent',
-                                    border: `1px solid var(--mantine-color-dark-4)`,
+                                    border: `1px solid var(--mantine-color-ldDark-4)`,
                                     '&:focus': {
                                         borderColor:
                                             'var(--mantine-color-blue-6)',

--- a/packages/frontend/src/components/SchedulersView/SchedulersView.module.css
+++ b/packages/frontend/src/components/SchedulersView/SchedulersView.module.css
@@ -9,45 +9,48 @@
     transition: all 150ms ease;
     border-radius: var(--mantine-radius-md);
     border: 1px solid
-        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
-    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-1));
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-4));
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-1)
+    );
     background-color: light-dark(
         var(--mantine-color-white),
-        var(--mantine-color-dark-6)
+        var(--mantine-color-ldDark-6)
     );
 }
 
 .tab:hover {
     border-color: light-dark(
-        var(--mantine-color-gray-4),
-        var(--mantine-color-dark-3)
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldDark-3)
     );
     background-color: light-dark(
-        var(--mantine-color-gray-0),
-        var(--mantine-color-dark-5)
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-5)
     );
 }
 
 .tab[data-active='true'] {
     background-color: light-dark(
-        var(--mantine-color-gray-9),
-        var(--mantine-color-dark-4)
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldDark-4)
     );
     border-color: light-dark(
-        var(--mantine-color-gray-9),
-        var(--mantine-color-dark-4)
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldDark-4)
     );
     color: light-dark(var(--mantine-color-white), var(--mantine-color-white));
 }
 
 .tab[data-active='true']:hover {
     background-color: light-dark(
-        var(--mantine-color-gray-8),
-        var(--mantine-color-dark-3)
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldDark-3)
     );
     border-color: light-dark(
-        var(--mantine-color-gray-8),
-        var(--mantine-color-dark-3)
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldDark-3)
     );
 }
 

--- a/packages/frontend/src/components/SchedulersView/filters/FormatFilter.module.css
+++ b/packages/frontend/src/components/SchedulersView/filters/FormatFilter.module.css
@@ -1,12 +1,12 @@
 .filterButton {
-    border: 1px dashed var(--mantine-color-gray-3);
+    border: 1px dashed var(--mantine-color-ldGray-3);
     background: var(--mantine-color-white);
     box-shadow: var(--mantine-shadow-subtle);
 }
 
 .filterButton:hover {
-    border: 1px dashed var(--mantine-color-gray-4);
-    background: var(--mantine-color-gray-0);
+    border: 1px dashed var(--mantine-color-ldGray-4);
+    background: var(--mantine-color-ldGray-0);
 }
 
 .filterButtonSelected {
@@ -39,5 +39,5 @@
     font-size: var(--mantine-font-size-xs);
     font-weight: 500;
     cursor: pointer;
-    color: var(--mantine-color-gray-8);
+    color: var(--mantine-color-ldGray-8);
 }

--- a/packages/frontend/src/components/SchedulersView/filters/ResourceTypeFilter.module.css
+++ b/packages/frontend/src/components/SchedulersView/filters/ResourceTypeFilter.module.css
@@ -1,5 +1,5 @@
 .segmentedControl {
-    border: 1px solid var(--mantine-color-gray-3);
+    border: 1px solid var(--mantine-color-ldGray-3);
     background: var(--mantine-color-white);
     box-shadow: var(--mantine-shadow-subtle);
 }
@@ -12,5 +12,5 @@
 .label {
     font-size: var(--mantine-font-size-xs);
     font-weight: 500;
-    color: var(--mantine-color-gray-7);
+    color: var(--mantine-color-ldGray-7);
 }

--- a/packages/frontend/src/components/SchedulersView/filters/SearchFilter.module.css
+++ b/packages/frontend/src/components/SchedulersView/filters/SearchFilter.module.css
@@ -4,13 +4,13 @@
     text-overflow: ellipsis;
     font-size: var(--mantine-font-size-sm);
     font-weight: 400;
-    color: var(--mantine-color-gray-5);
+    color: var(--mantine-color-ldGray-5);
     box-shadow: var(--mantine-shadow-subtle);
-    border: 1px solid var(--mantine-color-gray-3);
+    border: 1px solid var(--mantine-color-ldGray-3);
 }
 
 .searchInput:hover {
-    border: 1px solid var(--mantine-color-gray-4);
+    border: 1px solid var(--mantine-color-ldGray-4);
 }
 
 .searchInput:focus {
@@ -23,13 +23,13 @@
     text-overflow: ellipsis;
     font-size: var(--mantine-font-size-sm);
     font-weight: 400;
-    color: var(--mantine-color-gray-8);
+    color: var(--mantine-color-ldGray-8);
     box-shadow: var(--mantine-shadow-subtle);
-    border: 1px solid var(--mantine-color-gray-3);
+    border: 1px solid var(--mantine-color-ldGray-3);
 }
 
 .searchInputWithValue:hover {
-    border: 1px solid var(--mantine-color-gray-4);
+    border: 1px solid var(--mantine-color-ldGray-4);
 }
 
 .searchInputWithValue:focus {

--- a/packages/frontend/src/components/SimpleStatistic/SimpleStatistic.module.css
+++ b/packages/frontend/src/components/SimpleStatistic/SimpleStatistic.module.css
@@ -21,7 +21,7 @@
 }
 
 .trendPillNeutral {
-    color: var(--mantine-color-gray-7);
-    background-color: var(--mantine-color-gray-0);
-    border-color: var(--mantine-color-gray-3);
+    color: var(--mantine-color-ldGray-7);
+    background-color: var(--mantine-color-ldGray-0);
+    border-color: var(--mantine-color-ldGray-3);
 }

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersAndGroupsPanel.module.css
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersAndGroupsPanel.module.css
@@ -9,45 +9,48 @@
     transition: all 150ms ease;
     border-radius: var(--mantine-radius-md);
     border: 1px solid
-        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
-    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-1));
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-4));
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-1)
+    );
     background-color: light-dark(
         var(--mantine-color-white),
-        var(--mantine-color-dark-6)
+        var(--mantine-color-ldDark-6)
     );
 }
 
 .tab:hover {
     border-color: light-dark(
-        var(--mantine-color-gray-4),
-        var(--mantine-color-dark-3)
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldDark-3)
     );
     background-color: light-dark(
-        var(--mantine-color-gray-0),
-        var(--mantine-color-dark-5)
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-5)
     );
 }
 
 .tab[data-active='true'] {
     background-color: light-dark(
-        var(--mantine-color-gray-9),
-        var(--mantine-color-dark-4)
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldDark-4)
     );
     border-color: light-dark(
-        var(--mantine-color-gray-9),
-        var(--mantine-color-dark-4)
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldDark-4)
     );
     color: light-dark(var(--mantine-color-white), var(--mantine-color-white));
 }
 
 .tab[data-active='true']:hover {
     background-color: light-dark(
-        var(--mantine-color-gray-8),
-        var(--mantine-color-dark-3)
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldDark-3)
     );
     border-color: light-dark(
-        var(--mantine-color-gray-8),
-        var(--mantine-color-dark-3)
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldDark-3)
     );
 }
 

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/DndList.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/DndList.module.css
@@ -3,12 +3,12 @@
     align-items: center;
     border-radius: var(--mantine-radius-md);
     border: 1px solid
-        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-5));
     padding: var(--mantine-spacing-xs);
     padding-left: calc(var(--mantine-spacing-xl) - var(--mantine-spacing-md));
     background-color: light-dark(
         var(--mantine-color-white),
-        var(--mantine-color-dark-5)
+        var(--mantine-color-ldDark-5)
     );
     margin-bottom: var(--mantine-spacing-xs);
 }
@@ -22,6 +22,9 @@
     align-items: center;
     justify-content: center;
     height: 100%;
-    color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-1));
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldDark-1)
+    );
     cursor: grab;
 }

--- a/packages/frontend/src/components/common/Tree/Tree.module.css
+++ b/packages/frontend/src/components/common/Tree/Tree.module.css
@@ -9,7 +9,7 @@
         content: '';
         width: 1px;
         height: 100%;
-        background-color: var(--mantine-color-gray-1);
+        background-color: var(--mantine-color-ldGray-1);
     }
 }
 

--- a/packages/frontend/src/components/common/Tree/TreeItem.module.css
+++ b/packages/frontend/src/components/common/Tree/TreeItem.module.css
@@ -6,7 +6,7 @@
         cursor: pointer;
 
         &:hover {
-            background-color: var(--mantine-color-gray-0);
+            background-color: var(--mantine-color-ldGray-0);
         }
 
         &:is([data-selected='true']) {

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.module.css
@@ -6,9 +6,9 @@
     flex: 1;
     background-color: rgba(255, 255, 255, 0.3);
 
-    --input-bd-focus: var(--mantine-color-gray-7);
+    --input-bd-focus: var(--mantine-color-ldGray-7);
     &:focus {
-        outline: 4px solid var(--mantine-color-gray-2);
+        outline: 4px solid var(--mantine-color-ldGray-2);
     }
 }
 
@@ -19,7 +19,7 @@
 .comboboxOption:hover > div,
 .comboboxOption[data-combobox-selected],
 .comboboxOption[data-combobox-selected] > div {
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
     color: inherit;
 }
 

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
@@ -35,7 +35,7 @@
     visibility: hidden;
     background-color: var(--mantine-color-white);
     border-radius: var(--mantine-radius-sm);
-    border: 1px solid var(--mantine-color-gray-2);
+    border: 1px solid var(--mantine-color-ldGray-2);
     flex-shrink: 0;
 }
 
@@ -44,7 +44,7 @@
 }
 
 .actionIcon {
-    background-color: var(--mantine-color-dark-5);
+    background-color: var(--mantine-color-ldDark-5);
     box-sizing: content-box;
     width: 36px;
     height: 36px;
@@ -60,11 +60,11 @@
 
 .paperRoot {
     overflow: hidden;
-    border-color: var(--mantine-color-gray-3) !important;
+    border-color: var(--mantine-color-ldGray-3) !important;
 }
 
 .adminSettingsButtonLabel {
-    color: var(--mantine-color-gray-7);
+    color: var(--mantine-color-ldGray-7);
 }
 
 .adminSettingsButtonSection {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.module.css
@@ -1,12 +1,12 @@
 .filterButton {
-    border: 1px dashed var(--mantine-color-gray-3);
+    border: 1px dashed var(--mantine-color-ldGray-3);
     background-color: transparent;
     text-overflow: ellipsis;
     box-shadow: var(--mantine-shadow-subtle);
 }
 
 .filterButton:hover {
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
     transition: background-color var(--mantine-other-transitionDuration)
         var(--mantine-other-transitionTimingFunction);
 }
@@ -19,7 +19,7 @@
 }
 
 .filterButtonSelected:hover {
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
     transition: background-color var(--mantine-other-transitionDuration)
         var(--mantine-other-transitionTimingFunction);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.module.css
@@ -3,11 +3,11 @@
 }
 
 .resizeHandle:hover {
-    background-color: var(--mantine-color-gray-2) !important;
+    background-color: var(--mantine-color-ldGray-2) !important;
 }
 
 .resizeHandle[data-resize-handle-state='drag'] {
-    background-color: var(--mantine-color-gray-3) !important;
+    background-color: var(--mantine-color-ldGray-3) !important;
 }
 
 .threadsTable {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.module.css
@@ -6,7 +6,7 @@
 
 .indicator {
     border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-gray-2);
+    border: 1px solid var(--mantine-color-ldGray-2);
     background-color: white;
     box-shadow: var(--mantine-shadow-subtle);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.module.css
@@ -1,12 +1,12 @@
 .filterButton {
-    border: 1px dashed var(--mantine-color-gray-3);
+    border: 1px dashed var(--mantine-color-ldGray-3);
     background-color: transparent;
     text-overflow: ellipsis;
     box-shadow: var(--mantine-shadow-subtle);
 }
 
 .filterButton:hover {
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
     transition: background-color var(--mantine-other-transitionDuration)
         var(--mantine-other-transitionTimingFunction);
 }
@@ -19,7 +19,7 @@
 }
 
 .filterButtonSelected:hover {
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
     transition: background-color var(--mantine-other-transitionDuration)
         var(--mantine-other-transitionTimingFunction);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SearchFilter.module.css
@@ -4,13 +4,13 @@
     text-overflow: ellipsis;
     font-size: var(--mantine-font-size-sm);
     font-weight: 400;
-    color: var(--mantine-color-gray-5);
+    color: var(--mantine-color-ldGray-5);
     box-shadow: var(--mantine-shadow-subtle);
-    border: 1px solid var(--mantine-color-gray-3);
+    border: 1px solid var(--mantine-color-ldGray-3);
 }
 
 .searchInput:hover {
-    border: 1px solid var(--mantine-color-gray-4);
+    border: 1px solid var(--mantine-color-ldGray-4);
 }
 
 .searchInput:focus {
@@ -23,13 +23,13 @@
     text-overflow: ellipsis;
     font-size: var(--mantine-font-size-sm);
     font-weight: 400;
-    color: var(--mantine-color-gray-8);
+    color: var(--mantine-color-ldGray-8);
     box-shadow: var(--mantine-shadow-subtle);
-    border: 1px solid var(--mantine-color-gray-3);
+    border: 1px solid var(--mantine-color-ldGray-3);
 }
 
 .searchInputWithValue:hover {
-    border: 1px solid var(--mantine-color-gray-4);
+    border: 1px solid var(--mantine-color-ldGray-4);
 }
 
 .searchInputWithValue:focus {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.module.css
@@ -6,7 +6,7 @@
 
 .indicator {
     border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-gray-2);
+    border: 1px solid var(--mantine-color-ldGray-2);
     background-color: white;
     box-shadow: var(--mantine-shadow-subtle);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsLayout.module.css
@@ -3,9 +3,9 @@
 }
 
 .resizeHandle:hover {
-    background-color: var(--mantine-color-gray-2) !important;
+    background-color: var(--mantine-color-ldGray-2) !important;
 }
 
 .resizeHandle[data-resize-handle-state='drag'] {
-    background-color: var(--mantine-color-gray-3) !important;
+    background-color: var(--mantine-color-ldGray-3) !important;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
@@ -262,7 +262,7 @@ export const VerifiedArtifactsTable: FC<Props> = ({
                 cursor: 'pointer',
                 backgroundColor:
                     selectedArtifactVersionUuid === row.original.versionUuid
-                        ? 'var(--mantine-color-gray-1)'
+                        ? 'var(--mantine-color-ldGray-1)'
                         : undefined,
             },
         }),

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
@@ -9,7 +9,7 @@
     overflow-y: auto;
 
     padding: var(--mantine-spacing-xs);
-    background: var(--mantine-color-gray-0);
+    background: var(--mantine-color-ldGray-0);
     &[data-panel-size='0.0'] {
         min-width: 3rem;
     }
@@ -33,7 +33,7 @@
     z-index: 1;
     background-color: white;
     padding: var(--mantine-spacing-md);
-    border-bottom: 1px solid var(--mantine-color-gray-2);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
 }
 
 .chatContent {
@@ -43,14 +43,14 @@
 
 .resizeHandle {
     width: 1px;
-    background-color: var(--mantine-color-gray-2);
+    background-color: var(--mantine-color-ldGray-2);
     cursor: col-resize;
     transition: all 0.2s ease;
 
     &[data-resize-handle-state='hover'],
     &[data-resize-handle-state='drag'] {
-        background-color: var(--mantine-color-gray-4);
-        box-shadow: 0 0 0 1px var(--mantine-color-gray-4);
+        background-color: var(--mantine-color-ldGray-4);
+        box-shadow: 0 0 0 1px var(--mantine-color-ldGray-4);
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
@@ -1,8 +1,8 @@
 .feedbackInput {
     background-color: rgba(255, 255, 255, 0.3) !important;
 
-    --input-bd-focus: var(--mantine-color-gray-7);
+    --input-bd-focus: var(--mantine-color-ldGray-7);
     &:focus {
-        outline: 4px solid var(--mantine-color-gray-2);
+        outline: 4px solid var(--mantine-color-ldGray-2);
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDebugDrawer.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDebugDrawer.module.css
@@ -1,27 +1,27 @@
 .codeBlock {
     border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-gray-2);
+    border: 1px solid var(--mantine-color-ldGray-2);
     overflow: hidden;
 }
 
 .toolCallItem {
     border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-gray-2);
+    border: 1px solid var(--mantine-color-ldGray-2);
     overflow: hidden;
     transition: background-color 0.2s ease;
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
 }
 
 .toolCallHeader {
     padding: 8px 12px;
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
     cursor: pointer;
     user-select: none;
     transition: background-color 0.15s ease;
 }
 
 .toolCallHeader:hover {
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
 }
 
 .toolCallName {
@@ -31,8 +31,8 @@
 .emptyState {
     text-align: center;
     border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-gray-2);
-    background-color: var(--mantine-color-gray-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    background-color: var(--mantine-color-ldGray-0);
 }
 
 .emptyStateIcon {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -8,8 +8,8 @@
 .input {
     background-color: rgba(255, 255, 255, 0.3) !important;
 
-    --input-bd-focus: var(--mantine-color-gray-7);
+    --input-bd-focus: var(--mantine-color-ldGray-7);
     &:focus {
-        outline: 4px solid var(--mantine-color-gray-2);
+        outline: 4px solid var(--mantine-color-ldGray-2);
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -100,7 +100,7 @@ export const AgentChatInput = ({
                 <Paper
                     px="sm"
                     py={rem(4)}
-                    bg={alpha('var(--mantine-color-gray-1)', 0.5)}
+                    bg={alpha('var(--mantine-color-ldGray-1)', 0.5)}
                     mx="md"
                     style={{
                         borderTopLeftRadius: rem(12),
@@ -172,7 +172,7 @@ export const AgentChatInput = ({
                 <Paper
                     px="sm"
                     py={rem(4)}
-                    bg={alpha('var(--mantine-color-gray-1)', 0.5)}
+                    bg={alpha('var(--mantine-color-ldGray-1)', 0.5)}
                     mx="md"
                     style={{
                         borderTopLeftRadius: 0,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationFilters.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationFilters.module.css
@@ -1,7 +1,7 @@
 .filterButton {
     background-color: white;
     cursor: default;
-    border: 1px solid var(--mantine-color-gray-3);
+    border: 1px solid var(--mantine-color-ldGray-3);
 }
 
 .filterButton:hover {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ArtifactButton/AiArtifactButton.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ArtifactButton/AiArtifactButton.module.css
@@ -75,13 +75,13 @@
 }
 
 .title {
-    color: var(--mantine-color-gray-8);
+    color: var(--mantine-color-ldGray-8);
     line-height: 1.4;
     transition: color 0.12s ease;
 }
 
 .artifactButton:hover .title {
-    color: var(--mantine-color-gray-9);
+    color: var(--mantine-color-ldGray-9);
 }
 
 .artifactButton[data-artifact-open='true'] .title {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
@@ -5,14 +5,14 @@
     gap: var(--mantine-spacing-xxs);
     padding: var(--mantine-spacing-two) var(--mantine-spacing-xs);
     border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-gray-3);
+    border: 1px solid var(--mantine-color-ldGray-3);
     cursor: pointer;
     transition: all 0.2s ease;
     position: relative;
     vertical-align: middle;
     margin-right: var(--mantine-spacing-two);
     &:hover {
-        background-color: var(--mantine-color-gray-1) !important;
+        background-color: var(--mantine-color-ldGray-1) !important;
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiReasoning.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiReasoning.tsx
@@ -61,7 +61,7 @@ export const AiReasoning: FC<AiReasoningProps> = ({
                     ...mdStyle,
                     padding: '0.5rem 0',
                     fontSize: 'var(--mantine-font-size-xs)',
-                    color: 'var(--mantine-color-gray-7)',
+                    color: 'var(--mantine-color-ldGray-7)',
                 }}
                 components={mdEditorComponents}
             />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingTable.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/RankingTable.module.css
@@ -1,7 +1,7 @@
 .tableContainer {
     background-color: var(--mantine-color-white);
     border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-gray-2);
+    border: 1px solid var(--mantine-color-ldGray-2);
 }
 
 .table {
@@ -19,7 +19,7 @@
 }
 
 .tableRow:hover {
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
 }
 
 .tableCell {
@@ -32,5 +32,5 @@
 
 .tableCellTextDimmed {
     font-size: var(--mantine-font-size-xs);
-    color: var(--mantine-color-gray-6);
+    color: var(--mantine-color-ldGray-6);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalRunDetails.tsx
@@ -216,7 +216,7 @@ export const EvalRunDetails: FC<Props> = ({
                 style: {
                     cursor: isClickable ? 'pointer' : 'default',
                     backgroundColor: selected
-                        ? 'var(--mantine-color-gray-1)'
+                        ? 'var(--mantine-color-ldGray-1)'
                         : undefined,
                 },
             };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.module.css
@@ -3,11 +3,11 @@
 }
 
 .resizeHandle:hover {
-    background-color: var(--mantine-color-gray-2) !important;
+    background-color: var(--mantine-color-ldGray-2) !important;
 }
 
 .resizeHandle[data-resize-handle-state='drag'] {
-    background-color: var(--mantine-color-gray-3) !important;
+    background-color: var(--mantine-color-ldGray-3) !important;
 }
 
 .threadPanel {

--- a/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions.module.css
@@ -6,7 +6,7 @@
     border-radius: var(--mantine-radius-md);
     transition: background-color 0.15s ease;
     display: block;
-    color: var(--mantine-color-gray-7);
+    color: var(--mantine-color-ldGray-7);
 }
 
 .questionCard:hover {
@@ -14,5 +14,5 @@
 }
 
 .questionCard:hover:not(:disabled) {
-    background-color: var(--mantine-color-gray-0);
+    background-color: var(--mantine-color-ldGray-0);
 }

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.module.css
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.module.css
@@ -14,7 +14,7 @@
 }
 
 .scopeItem {
-    border-bottom: 1px solid var(--mantine-color-gray-2);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
 }
 
 .scopeItem:last-child {

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
@@ -2,7 +2,7 @@
 .addDateZoomButton {
     border-style: dashed;
     border-width: 1px;
-    border-color: var(--mantine-color-gray-4);
+    border-color: var(--mantine-color-ldGray-4);
 }
 
 /* Positioned close button on date zoom */
@@ -11,7 +11,7 @@
     top: -6px;
     left: -6px;
     z-index: 1;
-    color: var(--mantine-color-gray-6);
+    color: var(--mantine-color-ldGray-6);
     background-color: var(--mantine-color-white);
 }
 
@@ -24,6 +24,6 @@
 .menuItemDisabled {
     color: white;
     &:not([data-disabled='false']) {
-        color: var(--mantine-color-gray-6);
+        color: var(--mantine-color-ldGray-6);
     }
 }

--- a/packages/frontend/src/features/parameters/components/ParameterInput.module.css
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.module.css
@@ -1,7 +1,7 @@
 .refreshItem {
     font-size: var(--mantine-font-size-xs);
-    color: var(--mantine-color-gray-6);
-    border-top: 1px solid var(--mantine-color-gray-2);
+    color: var(--mantine-color-ldGray-6);
+    border-top: 1px solid var(--mantine-color-ldGray-2);
     padding: var(--mantine-spacing-xs) var(--mantine-spacing-xs) 0;
     cursor: pointer;
     width: 100%;

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -235,7 +235,7 @@ export const getMantine8ThemeOverride = (
             Modal: Modal.extend({
                 styles: () => ({
                     header: {
-                        borderBottom: `1px solid var(--mantine-color-gray-4)`,
+                        borderBottom: `1px solid var(--mantine-color-ldGray-4)`,
                         paddingBottom: 'var(--mantine-spacing-sm)',
                     },
                     body: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Updated CSS color variable naming to use `ldGray` and `ldDark` prefixes instead of direct `gray` and `dark` references. This change ensures consistent theming across light and dark modes by using the light-dark specific color variables throughout the frontend components.

The update affects multiple UI components including filters, buttons, tables, and layout elements to maintain visual consistency across the application.