### PR TITLE
fix: replace hardcoded colors with theme variables in table components

### DIFF
--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
@@ -4,7 +4,14 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Badge, Flex, Group, Tooltip, type FlexProps } from '@mantine/core';
+import {
+    Badge,
+    Flex,
+    Group,
+    Tooltip,
+    useMantineTheme,
+    type FlexProps,
+} from '@mantine/core';
 import { IconArrowDown, IconArrowUp } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import { useMemo } from 'react';
@@ -12,11 +19,7 @@ import { SMALL_TEXT_LENGTH } from '../../common/LightTable/constants';
 import MantineIcon from '../../common/MantineIcon';
 import BodyCell from '../../common/Table/ScrollableTable/BodyCell';
 import { VirtualizedArea } from '../../common/Table/ScrollableTable/TableBody';
-import {
-    TABLE_HEADER_BG,
-    Table as TableStyled,
-    Tr,
-} from '../../common/Table/Table.styles';
+import { Table as TableStyled, Tr } from '../../common/Table/Table.styles';
 import { useVirtualTable } from '../hooks/useVirtualTable';
 
 type TableProps = {
@@ -40,6 +43,7 @@ export const ChartDataTable = ({
     thSortConfig,
     onTHClick,
 }: TableProps) => {
+    const theme = useMantineTheme();
     const { tableWrapperRef, getTableData, paddingTop, paddingBottom } =
         useVirtualTable({ columnNames, rows, config: columnsConfig });
 
@@ -84,11 +88,13 @@ export const ChartDataTable = ({
                                                     ? {
                                                           cursor: 'pointer',
                                                           backgroundColor:
-                                                              TABLE_HEADER_BG,
+                                                              theme.colors
+                                                                  .ldGray[0],
                                                       }
                                                     : {
                                                           backgroundColor:
-                                                              TABLE_HEADER_BG,
+                                                              theme.colors
+                                                                  .ldGray[0],
                                                       }
                                             }
                                         >

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -5,18 +5,20 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Badge, Flex, Group, type FlexProps } from '@mantine/core';
+import {
+    Badge,
+    Flex,
+    Group,
+    useMantineTheme,
+    type FlexProps,
+} from '@mantine/core';
 import { IconArrowDown, IconArrowUp } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import { SMALL_TEXT_LENGTH } from '../../common/LightTable/constants';
 import MantineIcon from '../../common/MantineIcon';
 import BodyCell from '../../common/Table/ScrollableTable/BodyCell';
 import { VirtualizedArea } from '../../common/Table/ScrollableTable/TableBody';
-import {
-    TABLE_HEADER_BG,
-    Table as TableStyled,
-    Tr,
-} from '../../common/Table/Table.styles';
+import { Table as TableStyled, Tr } from '../../common/Table/Table.styles';
 import { useTableDataModel } from '../hooks/useTableDataModel';
 
 type TableProps<T extends IResultsRunner> = {
@@ -34,6 +36,7 @@ export const Table = <T extends IResultsRunner>({
     thSortConfig,
     onTHClick,
 }: TableProps<T>) => {
+    const theme = useMantineTheme();
     const {
         tableWrapperRef,
         getColumnsCount,
@@ -85,11 +88,13 @@ export const Table = <T extends IResultsRunner>({
                                                 ? {
                                                       cursor: 'pointer',
                                                       backgroundColor:
-                                                          TABLE_HEADER_BG,
+                                                          theme.colors
+                                                              .ldGray[0],
                                                   }
                                                 : {
                                                       backgroundColor:
-                                                          TABLE_HEADER_BG,
+                                                          theme.colors
+                                                              .ldGray[0],
                                                   }
                                         }
                                     >

--- a/packages/frontend/src/components/SortButton/SortItem.tsx
+++ b/packages/frontend/src/components/SortButton/SortItem.tsx
@@ -66,7 +66,6 @@ const SortItem = forwardRef<HTMLDivElement, SortItemProps>(
                 {...draggableProps}
                 noWrap
                 position="apart"
-                bg="white"
                 pl="xs"
                 pr="xxs"
                 py="two"

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -103,7 +103,7 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                             {...COLLAPSABLE_CARD_ACTION_ICON_PROPS}
                             disabled={disabled}
                         >
-                            <MantineIcon icon={IconShare2} color="gray" />
+                            <MantineIcon icon={IconShare2} />
                         </ActionIcon>
                     </Popover.Target>
 

--- a/packages/frontend/src/components/common/PaginateControl.tsx
+++ b/packages/frontend/src/components/common/PaginateControl.tsx
@@ -24,11 +24,11 @@ const PaginateControl: FC<PaginateControlProps> = ({
         <Group {...rest}>
             <Text color="ldGray.7" size="xs">
                 Page{' '}
-                <Text span fw={600} color="black">
+                <Text span fw={600}>
                     {currentPage}
                 </Text>{' '}
                 of{' '}
-                <Text span fw={600} color="black">
+                <Text span fw={600}>
                     {totalPages}
                 </Text>
             </Text>

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -1,11 +1,10 @@
 import { Draggable } from '@hello-pangea/dnd';
 import { isCustomDimension, isDimension, isField } from '@lightdash/common';
-import { Tooltip } from '@mantine/core';
+import { Tooltip, useMantineTheme } from '@mantine/core';
 import { flexRender } from '@tanstack/react-table';
 import isEqual from 'lodash/isEqual';
 import React, { useEffect, type FC } from 'react';
 import {
-    TABLE_HEADER_BG,
     Th,
     ThActionsContainer,
     ThContainer,
@@ -23,6 +22,7 @@ const TableHeader: FC<TableHeaderProps> = ({
     minimal = false,
     showSubtotals = true,
 }) => {
+    const theme = useMantineTheme();
     const { table, headerContextMenu, columns } = useTableContext();
     const HeaderContextMenu = headerContextMenu;
     const currentColOrder = React.useRef<Array<string>>([]);
@@ -86,7 +86,8 @@ const TableHeader: FC<TableHeaderProps> = ({
                                         ...meta?.style,
                                         width: meta?.width,
                                         backgroundColor:
-                                            meta?.bgColor ?? TABLE_HEADER_BG,
+                                            meta?.bgColor ??
+                                            theme.colors.ldGray[0],
                                     }}
                                     className={meta?.className}
                                 >

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -1,12 +1,5 @@
-import { DEFAULT_THEME } from '@mantine/core';
-import { transparentize } from 'polished';
 import { type ReactNode } from 'react';
 import styled, { css } from 'styled-components';
-
-// FIXME: these colors are coming from the mantine's default theme.
-// TODO: use mantine theme and new ldGray
-// We should use the theme from the app instead.
-export const TABLE_HEADER_BG = DEFAULT_THEME.colors.gray[0];
 
 // Needed for virtualization. Matches value from Pivot table.
 export const ROW_HEIGHT_PX = 34;
@@ -19,7 +12,7 @@ export const TableScrollableWrapper = styled.div`
     overflow: auto;
     min-width: 100%;
     border-radius: 4px;
-    border: 1px solid #dcdcdd;
+    border: 1px solid var(--mantine-color-ldGray-3);
 `;
 
 interface TableContainerProps {
@@ -54,7 +47,7 @@ export const TableContainer = styled.div<
 export const Table = styled.table<{ $showFooter?: boolean }>`
     border-spacing: 0;
     font-size: 14px;
-    background-color: white;
+    //background-color: var(--mantine-color-ldGray1);
     width: 100%;
     border-radius: 4px;
 
@@ -69,11 +62,9 @@ export const Table = styled.table<{ $showFooter?: boolean }>`
     }
 
     th {
-        color: #1c2127;
         font-weight: 600;
     }
     td {
-        color: #1c2127;
     }
 
     /* Inner cell borders using box-shadow (from Blueprint CSS) */
@@ -127,7 +118,7 @@ export const Table = styled.table<{ $showFooter?: boolean }>`
         border-top: none !important;
         border-bottom: none !important;
         /* Footer cell border: top separator between body and footer */
-        box-shadow: inset 0 1px 0 #dcdcdd !important;
+        box-shadow: inset 0 1px 0 var(--mantine-color-ldGray-3) !important;
     }
 
     .sticky-column {
@@ -173,18 +164,12 @@ export const Tr = styled.tr<{
     ${({ $index = 0 }) =>
         $index % 2 === 1
             ? `
-                background-color: ${transparentize(
-                    0.7,
-                    DEFAULT_THEME.colors.gray[1],
-                )};
+                background-color: var(--mantine-color-ldGray-0);
             `
             : ''}
 
     :hover {
-        background-color: ${transparentize(
-            0.3,
-            DEFAULT_THEME.colors.gray[1],
-        )} !important;
+        background-color: var(--mantine-color-ldGray-1) !important;
     }
 
     :hover td {
@@ -266,11 +251,11 @@ export const Td = styled.td<{
     ${({ $isInteractive, $isSelected, $hasData, $backgroundColor }) =>
         $isInteractive && $isSelected && $hasData
             ? `
-                    box-shadow: inset 0 0 0 1px #4170CB !important;
+                    box-shadow: inset 0 0 0 1px var(--table-selected-border) !important;
                     ${
                         $backgroundColor
                             ? 'filter: saturate(1) brightness(0.8) !important;'
-                            : `background-color: #ECF6FE !important;`
+                            : `background-color: var(--table-selected-bg) !important;`
                     }
                 `
             : ''}
@@ -282,8 +267,8 @@ export const Td = styled.td<{
 `;
 
 export const FooterCell = styled.th<{ $isNaN: boolean }>`
-    ${CellStyles}
-    background-color: white;
+    ${CellStyles};
+    background-color: var(--mantine-color-ldGray-0);
 `;
 
 export const Th = styled.th``;

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -248,6 +248,17 @@ export const getMantineThemeOverride = (
         },
 
         globalStyles: (theme) => ({
+            ':root': {
+                '--table-selected-bg':
+                    theme.colorScheme === 'dark'
+                        ? theme.colors.blue[9]
+                        : '#ECF6FE',
+                '--table-selected-border':
+                    theme.colorScheme === 'dark'
+                        ? theme.colors.blue[5]
+                        : '#4170CB',
+            },
+
             'html, body': {
                 backgroundColor: theme.colors.ldGray[0],
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR updates table styling to use Mantine theme variables instead of hardcoded colors. The changes include:

- Replaced hardcoded `TABLE_HEADER_BG` constant with theme-based colors
- Updated table borders and backgrounds to use Mantine theme variables
- Added CSS variables for table selection styling to support dark mode
- Removed explicit color="black" and bg="white" properties to allow proper theme inheritance
- Fixed icon color in ChartDownloadMenu to use theme colors

These changes improve theme consistency and prepare the tables for better dark mode support.