### PR TITLE
fix: replace hardcoded colors with theme variables in TileBase

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -39,8 +39,6 @@ interface TileTitleProps {
     $hovered?: boolean;
 }
 
-// FIXME: colors in this file are hardcoded to mantine values.
-// #FFF is white, #212529 is gray.9
 export const TitleWrapper = styled.div<TileTitleProps>`
     flex-grow: 1;
     overflow: hidden;
@@ -57,8 +55,9 @@ export const TitleWrapper = styled.div<TileTitleProps>`
                       z-index: 10;
 
                       a {
-                          outline: 4px solid #fff;
-                          background-color: #fff;
+                          outline: 4px solid var(--mantine-color-background-0);
+                          background-color: var(--mantine-color-background-0);
+                          color: var(--mantine-color-foreground-0);
                       }
                   `
                 : ''}
@@ -68,11 +67,11 @@ export const TitleWrapper = styled.div<TileTitleProps>`
 export const TileTitleLink = styled.a<TileTitleProps>`
     font-weight: 600;
     font-size: 16px;
-    color: #212529;
+    color: var(--mantine-color-foreground-0);
     text-decoration: none;
 
     :hover {
-        color: #212529 !important;
+        color: var(--mantine-color-foreground-0) !important;
         text-decoration: underline;
         text-wrap: wrap;
     }

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -114,8 +114,8 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 h="100%"
                 direction="column"
                 p="md"
-                bg="white"
                 radius="sm"
+                bg="background.0"
                 shadow={isEditMode ? 'xs' : undefined}
                 sx={(theme) => {
                     let border = `1px solid ${theme.colors.ldGray[1]}`;
@@ -146,7 +146,6 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                     $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
                     style={{
                         alignItems: 'flex-start',
-                        backgroundColor: 'white',
                         zIndex: isLoading ? getDefaultZIndex('modal') - 10 : 3,
                         borderRadius: '5px',
                     }}

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -200,11 +200,6 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                                 }
                             />
                             <ActionIcon
-                                color={
-                                    !form.values.prompt.trim()
-                                        ? 'ldGray.7'
-                                        : 'ldGray.9'
-                                }
                                 type="submit"
                                 disabled={!form.values.prompt.trim()}
                                 classNames={{

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.module.css
@@ -4,7 +4,13 @@
 
 .searchInput {
     flex: 1;
-    background-color: rgba(255, 255, 255, 0.3);
+
+    @mixin light {
+        background-color: alpha(var(--mantine-color-gray-1), 0.3);
+    }
+    @mixin dark {
+        background-color: alpha(var(--mantine-color-dark-5), 0.3);
+    }
 
     --input-bd-focus: var(--mantine-color-ldGray-7);
     &:focus {

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
@@ -44,7 +44,24 @@
 }
 
 .actionIcon {
-    background-color: var(--mantine-color-ldDark-5);
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-7);
+        &:hover {
+            background-color: var(--mantine-color-ldGray-8);
+        }
+        &:disabled {
+            background-color: var(--mantine-color-ldGray-3);
+        }
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-5);
+        &:hover {
+            background-color: var(--mantine-color-ldDark-4);
+        }
+        &:disabled {
+            background-color: var(--mantine-color-ldDark-7);
+        }
+    }
     box-sizing: content-box;
     width: 36px;
     height: 36px;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -100,7 +100,7 @@ export const AgentChatInput = ({
                 <Paper
                     px="sm"
                     py={rem(4)}
-                    bg={alpha('var(--mantine-color-ldGray-1)', 0.5)}
+                    bg={alpha('var(--mantine-color-gray-1)', 0.5)}
                     mx="md"
                     style={{
                         borderTopLeftRadius: rem(12),
@@ -152,7 +152,7 @@ export const AgentChatInput = ({
                             bottom: 12,
                             right: 12,
                         }}
-                        color="ldDark.5"
+                        color="dark.5"
                         disabled={disabled || isComposing}
                         loading={loading}
                         onClick={() => {
@@ -172,7 +172,7 @@ export const AgentChatInput = ({
                 <Paper
                     px="sm"
                     py={rem(4)}
-                    bg={alpha('var(--mantine-color-ldGray-1)', 0.5)}
+                    bg={alpha('var(--mantine-color-gray-1)', 0.5)}
                     mx="md"
                     style={{
                         borderTopLeftRadius: 0,

--- a/packages/frontend/src/hooks/echarts/useLegendDoubleClickTooltip.ts
+++ b/packages/frontend/src/hooks/echarts/useLegendDoubleClickTooltip.ts
@@ -7,7 +7,7 @@ export const useLegendDoubleClickTooltip = () => {
         tooltip: {
             show: true,
             backgroundColor: theme.colors.ldGray[9],
-            borderColor: theme.colors.ldGray[9],
+            borderColor: 'red',
             borderWidth: 0,
             borderRadius: 4,
             textStyle: {

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -8,6 +8,31 @@ import {
 type ColorTuple = Tuple<string, 10>;
 
 const lightModeColors = {
+    background: [
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+    ] as ColorTuple,
+    foreground: [
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+    ] as ColorTuple,
+
     ldDark: [
         '#C9C9C9',
         '#b8b8b8',
@@ -36,6 +61,31 @@ const lightModeColors = {
 };
 
 const darkModeColors = {
+    background: [
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+        '#1A1B1E',
+    ] as ColorTuple,
+    foreground: [
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+        '#FEFEFE',
+    ] as ColorTuple,
+
     ldDark: [
         '#C9C9C9',
         '#b8b8b8',


### PR DESCRIPTION
### Description:
Adds support for dark mode by replacing hardcoded color values with CSS variables. This includes:

- Replaced hardcoded colors in TileBase components with Mantine CSS variables
- Added background and foreground color tuples to both light and dark mode themes
- Updated AI search box styling to support dark mode with appropriate mixins
- Fixed tile title link colors to use theme variables
- Removed unnecessary background color specifications
- Updated agent chat input to use standard Mantine color variables

This change ensures consistent appearance across light and dark themes while maintaining the existing design.