### PR TITLE
fix: remove unnecessary parentheses in defaultChartType assignment

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -136,7 +136,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
 
     const defaultChartType =
         chartConfig.type === AiResultType.QUERY_RESULT
-            ? (chartConfig.chartConfig?.defaultVizType ?? 'table')
+            ? chartConfig.chartConfig?.defaultVizType ?? 'table'
             : 'table';
 
     const handleChartConfigChange = useCallback(


### PR DESCRIPTION
### Description:
Removed unnecessary parentheses around the ternary operation result in `AiVisualizationRenderer.tsx`. The expression `(chartConfig.chartConfig?.defaultVizType ?? 'table')` has been simplified to `chartConfig.chartConfig?.defaultVizType ?? 'table'` as the parentheses were redundant in this context.