### PR TITLE
feat: add dark mode support to visualization components

### DIFF
--- a/packages/frontend/src/components/DataViz/VisualizationSwitcher.tsx
+++ b/packages/frontend/src/components/DataViz/VisualizationSwitcher.tsx
@@ -21,9 +21,12 @@ type VisualizationActionIconProps = {
 
 const VisualizationActionIcon: FC<VisualizationActionIconProps> = memo(
     ({ chartKind, label, onClick, selected }) => {
-        const { colors } = useMantineTheme();
-        const ICON_SELECTED_COLOR = colors.violet[6];
-        const ICON_UNSELECTED_COLOR = colors.gray[7];
+        const { colors, colorScheme } = useMantineTheme();
+        const ICON_SELECTED_COLOR =
+            colorScheme === 'light' ? colors.violet[6] : colors.violet[2];
+        const ICON_SELECTED_BG_COLOR =
+            colorScheme === 'light' ? colors.violet[0] : colors.violet[6];
+        const ICON_UNSELECTED_COLOR = colors.ldGray[9];
 
         return (
             <Tooltip variant="xs" label={label} withinPortal>
@@ -44,8 +47,8 @@ const VisualizationActionIcon: FC<VisualizationActionIconProps> = memo(
                             shadow={selected ? 'sm' : 'none'}
                             sx={(theme) => ({
                                 backgroundColor: selected
-                                    ? theme.colors.violet[0]
-                                    : 'white',
+                                    ? ICON_SELECTED_BG_COLOR
+                                    : theme.colors.ldGray[0],
                                 '&[data-with-border]': {
                                     borderColor: selected
                                         ? ICON_SELECTED_COLOR

--- a/packages/frontend/src/components/DataViz/config/CartesianChartConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartConfiguration.tsx
@@ -26,7 +26,7 @@ export const CartesianChartConfig = ({
 
     return (
         <Stack spacing="xs" mb="lg">
-            <Tabs color="gray" defaultValue="data" keepMounted>
+            <Tabs defaultValue="data" keepMounted>
                 <Tabs.List>
                     <Tabs.Tab value="data">Data</Tabs.Tab>
                     <Tabs.Tab value="series">Series</Tabs.Tab>

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -215,9 +215,12 @@ export const CartesianChartSeries = ({
                           >
                               <Accordion.Item value={referenceField} m={0}>
                                   <Accordion.Control
-                                      sx={{
-                                          backgroundColor: 'white',
-                                      }}
+                                      sx={(theme) => ({
+                                          backgroundColor:
+                                              theme.colorScheme === 'light'
+                                                  ? 'white'
+                                                  : 'transparent',
+                                      })}
                                   >
                                       <Config.Subheading>
                                           {friendlyName(referenceField)}
@@ -225,7 +228,10 @@ export const CartesianChartSeries = ({
                                   </Accordion.Control>
                                   <Accordion.Panel
                                       sx={(theme) => ({
-                                          backgroundColor: 'white',
+                                          backgroundColor:
+                                              theme.colorScheme === 'light'
+                                                  ? 'white'
+                                                  : 'transparent',
                                           borderRadius: theme.radius.sm,
                                       })}
                                   >

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -80,10 +80,18 @@ export const DataVizAggregationConfig: FC<Props> = ({
     onChangeAggregation,
     aggregation,
 }) => {
-    const { colors } = useMantineTheme();
+    const {
+        colors,
+        colorScheme,
+        fn: { lighten },
+    } = useMantineTheme();
     const { classes } = usePillSelectStyles({
-        backgroundColor: colors.indigo[0],
-        textColor: colors.indigo[4],
+        backgroundColor:
+            colorScheme === 'light'
+                ? lighten(colors.indigo[0], 0.5)
+                : colors.indigo[5],
+        textColor:
+            colorScheme === 'light' ? colors.indigo[4] : colors.indigo[0],
     });
     const aggregationOptionsWithNone = options ?? [];
 

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -53,9 +53,9 @@ const SortItem = forwardRef<
 export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
     const { colors } = useMantineTheme();
     const { classes, cx } = usePillSelectStyles({
-        backgroundColor: colors.gray[2],
-        textColor: colors.gray[7],
-        hoverColor: colors.gray[3],
+        backgroundColor: colors.ldGray[2],
+        textColor: colors.ldGray[7],
+        hoverColor: colors.ldGray[3],
     });
 
     const selectOptions = [

--- a/packages/frontend/src/components/DataViz/hooks/usePillSelectStyles.tsx
+++ b/packages/frontend/src/components/DataViz/hooks/usePillSelectStyles.tsx
@@ -12,50 +12,50 @@ export const usePillSelectStyles = createStyles(
             textColor?: string;
             hoverColor?: string;
         } = {},
-    ) => ({
-        input: {
-            height: '24px',
-            minHeight: '24px',
-            padding: 0,
-            textAlign: 'center',
-            fontWeight: 500,
-            border: 'none',
-            borderRadius: theme.radius.sm,
-            fontSize: '13px',
-            backgroundColor: theme.fn.lighten(backgroundColor, 0.5),
-            color: textColor,
-            '&:hover': {
-                backgroundColor:
-                    hoverColor || theme.fn.lighten(backgroundColor, 0.1),
-            },
-            '&[data-with-icon]': {
+    ) => {
+        const modeFn =
+            theme.colorScheme === 'dark' ? theme.fn.darken : theme.fn.lighten;
+
+        return {
+            input: {
+                height: '24px',
+                minHeight: '24px',
                 padding: 0,
-                paddingLeft: '16px',
-            },
-            marginRight: '6px',
-        },
-        inputUnsetValue: {
-            color: theme.fn.lighten(textColor, 0.5),
-        },
-        rightSection: {
-            display: 'none',
-        },
-        dropdown: {
-            minWidth: 'fit-content',
-        },
-        item: {
-            '&[data-selected="true"]': {
-                color: textColor,
+                textAlign: 'center',
                 fontWeight: 500,
-                backgroundColor: theme.fn.lighten(backgroundColor, 0.5),
+                border: 'none',
+                borderRadius: theme.radius.sm,
+                fontSize: '13px',
+                backgroundColor: modeFn(backgroundColor, 0.5),
+                color: textColor,
+                '&:hover': {
+                    backgroundColor: hoverColor || modeFn(backgroundColor, 0.1),
+                },
+                '&[data-with-icon]': {
+                    padding: 0,
+                    paddingLeft: '16px',
+                },
+                marginRight: '6px',
             },
-            '&[data-selected="true"]:hover': {
-                backgroundColor:
-                    hoverColor || theme.fn.lighten(backgroundColor, 0.3),
+            inputUnsetValue: {
+                color: modeFn(textColor, 0.5),
             },
-            '&:hover': {
-                backgroundColor: theme.fn.lighten(backgroundColor, 0.7),
+            rightSection: {
+                display: 'none',
             },
-        },
-    }),
+            dropdown: {
+                minWidth: 'fit-content',
+            },
+            item: {
+                '&[data-selected="true"]': {
+                    color: textColor,
+                    fontWeight: 500,
+                    backgroundColor: modeFn(backgroundColor, 0.1),
+                },
+                '&[data-selected="true"]:hover': {
+                    backgroundColor: hoverColor || modeFn(backgroundColor, 0.3),
+                },
+            },
+        };
+    },
 );

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -83,7 +83,7 @@ const VisualizationCardOptions: FC = memo(() => {
                         icon: (
                             <MantineIcon
                                 icon={IconChartAreaLine}
-                                color="gray"
+                                color="ldGray"
                             />
                         ),
                     };
@@ -99,7 +99,7 @@ const VisualizationCardOptions: FC = memo(() => {
                             icon: (
                                 <MantineIcon
                                     icon={IconChartArea}
-                                    color="gray"
+                                    color="ldGray"
                                 />
                             ),
                         };
@@ -109,7 +109,7 @@ const VisualizationCardOptions: FC = memo(() => {
                             icon: (
                                 <MantineIcon
                                     icon={IconChartLine}
-                                    color="gray"
+                                    color="ldGray"
                                 />
                             ),
                         };
@@ -122,7 +122,7 @@ const VisualizationCardOptions: FC = memo(() => {
                                       <MantineIcon
                                           icon={IconChartBar}
                                           style={{ rotate: '90deg' }}
-                                          color="gray"
+                                          color="ldGray"
                                       />
                                   ),
                               }
@@ -131,7 +131,7 @@ const VisualizationCardOptions: FC = memo(() => {
                                   icon: (
                                       <MantineIcon
                                           icon={IconChartBar}
-                                          color="gray"
+                                          color="ldGray"
                                       />
                                   ),
                               };
@@ -141,7 +141,7 @@ const VisualizationCardOptions: FC = memo(() => {
                             icon: (
                                 <MantineIcon
                                     icon={IconChartDots}
-                                    color="gray"
+                                    color="ldGray"
                                 />
                             ),
                         };
@@ -155,32 +155,36 @@ const VisualizationCardOptions: FC = memo(() => {
             case ChartType.TABLE:
                 return {
                     text: 'Table',
-                    icon: <MantineIcon icon={IconTable} color="gray" />,
+                    icon: <MantineIcon icon={IconTable} color="ldGray" />,
                 };
             case ChartType.BIG_NUMBER:
                 return {
                     text: 'Big value',
-                    icon: <MantineIcon icon={IconSquareNumber1} color="gray" />,
+                    icon: (
+                        <MantineIcon icon={IconSquareNumber1} color="ldGray" />
+                    ),
                 };
             case ChartType.PIE:
                 return {
                     text: 'Pie chart',
-                    icon: <MantineIcon icon={IconChartPie} color="gray" />,
+                    icon: <MantineIcon icon={IconChartPie} color="ldGray" />,
                 };
             case ChartType.FUNNEL:
                 return {
                     text: 'Funnel chart',
-                    icon: <MantineIcon icon={IconFilter} color="gray" />,
+                    icon: <MantineIcon icon={IconFilter} color="ldGray" />,
                 };
             case ChartType.TREEMAP:
                 return {
                     text: 'Treemap',
-                    icon: <MantineIcon icon={IconChartTreemap} color="gray" />,
+                    icon: (
+                        <MantineIcon icon={IconChartTreemap} color="ldGray" />
+                    ),
                 };
             case ChartType.GAUGE:
                 return {
                     text: 'Gauge',
-                    icon: <MantineIcon icon={IconGauge} color="gray" />,
+                    icon: <MantineIcon icon={IconGauge} color="ldGray" />,
                 };
             case ChartType.MAP:
                 return {
@@ -190,7 +194,7 @@ const VisualizationCardOptions: FC = memo(() => {
             case ChartType.CUSTOM:
                 return {
                     text: 'Custom',
-                    icon: <MantineIcon icon={IconCode} color="gray" />,
+                    icon: <MantineIcon icon={IconCode} color="ldGray" />,
                 };
             default: {
                 return assertUnreachable(
@@ -217,7 +221,7 @@ const VisualizationCardOptions: FC = memo(() => {
                     disabled={disabled}
                     leftIcon={selectedChartType.icon}
                     rightIcon={
-                        <MantineIcon icon={IconChevronDown} color="gray" />
+                        <MantineIcon icon={IconChevronDown} color="ldGray" />
                     }
                     data-testid="VisualizationCardOptions"
                 >

--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -1,4 +1,4 @@
-import { Alert, Loader, Stack, Title } from '@mantine/core';
+import { Alert, Loader, Stack, Title, useMantineTheme } from '@mantine/core';
 import Editor, {
     type BeforeMount,
     type EditorProps,
@@ -9,8 +9,8 @@ import { useParams } from 'react-router';
 import { format } from 'sql-formatter';
 import { getLanguage } from '../features/sqlRunner/store/sqlRunnerSlice';
 import {
+    getLightdashMonacoTheme,
     getMonacoLanguage,
-    LIGHTDASH_THEME,
     MONACO_DEFAULT_OPTIONS,
     registerMonacoLanguage,
 } from '../features/sqlRunner/utils/monaco';
@@ -23,6 +23,7 @@ const MONACO_READ_ONLY: EditorProps['options'] = {
 };
 
 export const RenderedSql = () => {
+    const theme = useMantineTheme();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data: project } = useProject(projectUuid);
     const language = useMemo(
@@ -34,10 +35,15 @@ export const RenderedSql = () => {
     const beforeMount: BeforeMount = useCallback(
         (monaco) => {
             registerMonacoLanguage(monaco, language);
-            monaco.editor.defineTheme('lightdash', {
+            monaco.editor.defineTheme('lightdash-light', {
                 base: 'vs',
                 inherit: true,
-                ...LIGHTDASH_THEME,
+                ...getLightdashMonacoTheme('light'),
+            });
+            monaco.editor.defineTheme('lightdash-dark', {
+                base: 'vs-dark',
+                inherit: true,
+                ...getLightdashMonacoTheme('dark'),
             });
         },
         [language],
@@ -111,7 +117,11 @@ export const RenderedSql = () => {
             beforeMount={beforeMount}
             value={formattedSql}
             options={MONACO_READ_ONLY}
-            theme="lightdash"
+            theme={
+                theme.colorScheme === 'dark'
+                    ? 'lightdash-dark'
+                    : 'lightdash-light'
+            }
         />
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/common/UnitInputsGrid.tsx
@@ -57,11 +57,11 @@ export const UnitInputsGrid: FC<Props> = ({
             cols={3}
             spacing="xs"
             py="xs"
-            sx={{
-                border: '1px solid #E6E6E6',
+            sx={(theme) => ({
+                border: `1px solid ${theme.colors.ldGray['1']}`,
                 borderRadius: '4px',
-                backgroundColor: '#fafafa',
-            }}
+                backgroundColor: theme.colors.ldGray['0'],
+            })}
         >
             {/* Row 1 */}
             <EmptySpace />

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -47,7 +47,6 @@ export const TableContainer = styled.div<
 export const Table = styled.table<{ $showFooter?: boolean }>`
     border-spacing: 0;
     font-size: 14px;
-    //background-color: var(--mantine-color-ldGray1);
     width: 100%;
     border-radius: 4px;
 

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -396,7 +396,6 @@ export const ContentPanel: FC = () => {
                     radius={0}
                     px="md"
                     py={6}
-                    bg="ldGray.1"
                     sx={(theme) => ({
                         borderWidth: '0 0 1px 1px',
                         borderStyle: 'solid',
@@ -577,6 +576,10 @@ export const ContentPanel: FC = () => {
                                 borderStyle: 'solid',
                                 borderColor: theme.colors.ldGray[3],
                                 overflow: 'auto',
+                                backgroundColor:
+                                    theme.colorScheme === 'dark'
+                                        ? theme.colors.dark[6]
+                                        : 'white',
                             })}
                         >
                             <Box
@@ -744,7 +747,6 @@ export const ContentPanel: FC = () => {
                     <Box
                         hidden={hideResultsPanel}
                         component={PanelResizeHandle}
-                        bg="ldGray.1"
                         h={15}
                         sx={(theme) => ({
                             transition: 'background-color 0.2s ease-in-out',

--- a/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlEditor.tsx
@@ -1,4 +1,4 @@
-import { Center, Loader } from '@mantine/core';
+import { Center, Loader, useMantineTheme } from '@mantine/core';
 import Editor, {
     useMonaco,
     type BeforeMount,
@@ -21,8 +21,8 @@ import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setSql } from '../store/sqlRunnerSlice';
 import {
     generateTableCompletions,
+    getLightdashMonacoTheme,
     getMonacoLanguage,
-    LIGHTDASH_THEME,
     MONACO_DEFAULT_OPTIONS,
     registerCustomCompletionProvider,
     registerMonacoLanguage,
@@ -47,6 +47,7 @@ export const SqlEditor: FC<{
     highlightText?: MonacoHighlightLine;
     resetHighlightError?: () => void;
 }> = ({ onSubmit, highlightText, resetHighlightError }) => {
+    const theme = useMantineTheme();
     const sql = useAppSelector((state) => state.sqlRunner.sql);
     const dispatch = useAppDispatch();
     const quoteChar = useAppSelector((state) => state.sqlRunner.quoteChar);
@@ -114,10 +115,15 @@ export const SqlEditor: FC<{
     const beforeMount: BeforeMount = useCallback(
         (monaco) => {
             registerMonacoLanguage(monaco, language);
-            monaco.editor.defineTheme('lightdash', {
+            monaco.editor.defineTheme('lightdash-light', {
                 base: 'vs',
                 inherit: true,
-                ...LIGHTDASH_THEME,
+                ...getLightdashMonacoTheme('light'),
+            });
+            monaco.editor.defineTheme('lightdash-dark', {
+                base: 'vs-dark',
+                inherit: true,
+                ...getLightdashMonacoTheme('dark'),
             });
         },
         [language],
@@ -286,7 +292,11 @@ export const SqlEditor: FC<{
             value={sql}
             onChange={onChange}
             options={MONACO_DEFAULT_OPTIONS}
-            theme="lightdash"
+            theme={
+                theme.colorScheme === 'dark'
+                    ? 'lightdash-dark'
+                    : 'lightdash-light'
+            }
         />
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
@@ -7,6 +7,7 @@ import {
     Text,
     Tooltip,
     UnstyledButton,
+    useMantineTheme,
 } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { Editor } from '@monaco-editor/react';
@@ -29,12 +30,16 @@ type Props = {
 };
 
 const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
+    const mantineTheme = useMantineTheme();
     const dispatch = useAppDispatch();
 
     const { hovered, ref: hoverRef } = useHover<HTMLButtonElement>();
     const timeAgo = useTimeAgo(new Date(timestamp));
 
     const formattedDate = dayjs(timestamp).format('YYYY-MM-DD HH:mm:ss');
+
+    const openInQueryEditorLinkColor =
+        mantineTheme.colorScheme === 'dark' ? 'indigo.4' : 'indigo.6';
 
     return (
         <Stack w="100%">
@@ -56,13 +61,16 @@ const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
                         <Group spacing="xs" lh={1} noWrap>
                             <MantineIcon
                                 icon={hovered ? IconCornerDownLeft : IconClock}
-                                color="gray"
                             />
                             <Text
                                 fz="xs"
                                 fw={500}
                                 w={150}
-                                color={hovered ? 'indigo.7' : 'ldGray.8'}
+                                color={
+                                    hovered
+                                        ? openInQueryEditorLinkColor
+                                        : 'ldGray.8'
+                                }
                             >
                                 {hovered
                                     ? 'Open in query editor'
@@ -100,7 +108,11 @@ const SqlQueryHistoryItem: FC<Props> = ({ timestamp, sql }) => {
                             revealHorizontalRightPadding: 0,
                             roundedSelection: false,
                         }}
-                        theme="lightdash"
+                        theme={
+                            mantineTheme.colorScheme === 'dark'
+                                ? 'lightdash-dark'
+                                : 'lightdash-light'
+                        }
                     />
                 </HoverCard.Dropdown>
             </HoverCard>

--- a/packages/frontend/src/features/sqlRunner/utils/monaco.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/monaco.ts
@@ -1,4 +1,5 @@
 import { WarehouseTypes, type ParameterValue } from '@lightdash/common';
+import type { ColorScheme } from '@mantine/core';
 import type { EditorProps, Monaco } from '@monaco-editor/react';
 import {
     bigqueryLanguageDefinition,
@@ -74,29 +75,63 @@ export const registerMonacoLanguage = (monaco: Monaco, language: string) => {
     }
 };
 
-export const LIGHTDASH_THEME = {
-    rules: [
-        { token: '', foreground: '333333' },
-        { token: 'keyword', foreground: '7262FF', fontStyle: 'bold' },
-        { token: 'operator.sql', foreground: '#24cf62', fontStyle: 'bold' },
-        { token: 'number', foreground: '098658' },
-        { token: 'string', foreground: 'A31515' },
-        { token: 'delimiter', foreground: 'A31515' },
-        { token: 'identifier', foreground: '001080' },
-        { token: 'comment', foreground: '008000', fontStyle: 'italic' },
-    ],
-    colors: {
-        'editor.background': '#FFFFFF',
-        'editor.foreground': '#333333',
-        'editor.lineHighlightBackground': '#f8f8f8',
-        'editor.lineHighlight': '#e0e0e0',
-        'editorCursor.foreground': '#7262FF',
-        'editorWhitespace.foreground': '#efefef',
-        'editor.selectionBackground': '#E6E3FF',
-        'editor.selectionForeground': '#333333',
-        'editor.wordHighlightBackground': '#bcfeff',
-        'editor.selectionHighlightBorder': '#7262FF',
-    },
+export const getLightdashMonacoTheme = (colorScheme: ColorScheme) => {
+    if (colorScheme === 'dark') {
+        return {
+            rules: [
+                { token: '', foreground: 'd4d4d4' },
+                { token: 'keyword', foreground: '569cd6', fontStyle: 'bold' },
+                {
+                    token: 'operator.sql',
+                    foreground: 'd4d4d4',
+                    fontStyle: 'bold',
+                },
+                { token: 'number', foreground: 'b5cea8' },
+                { token: 'string', foreground: 'ce9178' },
+                { token: 'delimiter', foreground: 'ce9178' },
+                { token: 'identifier', foreground: '9cdcfe' },
+                { token: 'comment', foreground: '6a9955', fontStyle: 'italic' },
+            ],
+            colors: {
+                'editor.background': '#25262b',
+                'editor.foreground': '#d4d4d4',
+                'editor.lineHighlightBackground': '#2a2a2a',
+                'editor.lineHighlight': '#2a2a2a',
+                'editorCursor.foreground': '#569cd6',
+                'editorWhitespace.foreground': '#3b3b3b',
+                'editor.selectionBackground': '#264f78',
+                'editor.selectionForeground': '#ffffff',
+                'editor.wordHighlightBackground': '#575757',
+                'editor.selectionHighlightBorder': '#569cd6',
+            },
+        };
+    }
+
+    // Light theme (default)
+    return {
+        rules: [
+            { token: '', foreground: '333333' },
+            { token: 'keyword', foreground: '7262FF', fontStyle: 'bold' },
+            { token: 'operator.sql', foreground: '#24cf62', fontStyle: 'bold' },
+            { token: 'number', foreground: '098658' },
+            { token: 'string', foreground: 'A31515' },
+            { token: 'delimiter', foreground: 'A31515' },
+            { token: 'identifier', foreground: '001080' },
+            { token: 'comment', foreground: '008000', fontStyle: 'italic' },
+        ],
+        colors: {
+            'editor.background': '#FFFFFF',
+            'editor.foreground': '#333333',
+            'editor.lineHighlightBackground': '#f8f8f8',
+            'editor.lineHighlight': '#e0e0e0',
+            'editorCursor.foreground': '#7262FF',
+            'editorWhitespace.foreground': '#efefef',
+            'editor.selectionBackground': '#E6E3FF',
+            'editor.selectionForeground': '#333333',
+            'editor.wordHighlightBackground': '#bcfeff',
+            'editor.selectionHighlightBorder': '#7262FF',
+        },
+    };
 };
 
 export const registerCustomCompletionProvider = (

--- a/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
@@ -126,7 +126,7 @@ const useEchartsGaugeConfig = ({
             customLabel || getItemLabelWithoutTableName(fieldItem);
 
         const sectionColors: [number, string][] = [];
-        const defaultGapColor = theme.white;
+        const defaultGapColor = 'transparent';
 
         // Resolve dynamic section values from metrics
         const sectionsWithResolvedValues = sections?.map((section) => {
@@ -260,6 +260,7 @@ const useEchartsGaugeConfig = ({
             },
             axisLabel: {
                 show: showAxisLabels ?? false,
+                color: theme.colors.ldGray[9],
                 fontSize: detailsFontSize / 4,
                 distance:
                     lineSize *
@@ -280,6 +281,7 @@ const useEchartsGaugeConfig = ({
                 show: true,
                 offsetCenter: [0, '-25%'],
                 fontSize: tileFontSize,
+                color: theme.colors.ldGray[9],
             },
             detail: {
                 valueAnimation: true,
@@ -316,7 +318,10 @@ const useEchartsGaugeConfig = ({
                 itemStyle: {
                     color: 'transparent', // we only want the border
                     borderWidth: Math.max(lineSize * 0.06, 2),
-                    borderColor: 'white',
+                    borderColor:
+                        theme.colorScheme === 'light'
+                            ? 'white'
+                            : theme.colors.dark[6],
                 },
             },
             data: [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR adds dark mode support to various visualization components and the SQL editor. The changes include:

- Updated color schemes in VisualizationSwitcher to support dark mode
- Fixed background colors in CartesianChartSeries and CartesianChartConfiguration
- Enhanced usePillSelectStyles to properly handle dark mode with appropriate color adjustments
- Updated Monaco editor themes to support both light and dark modes
- Fixed icon colors in VisualizationCardOptions to use ldGray instead of gray
- Improved UnitInputsGrid styling for dark mode compatibility
- Updated SQL editor components (ContentPanel, SqlEditor, SqlQueryHistory) to support dark mode
- Enhanced gauge chart visualization to work properly in dark mode

These changes ensure a consistent visual experience across both light and dark themes throughout the application.