### PR TITLE
feat: add dark mode support for SQL editors and fix UI color references

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
@@ -52,7 +52,7 @@ export const CustomSqlDimensionModal: FC<{
     item?: CustomSqlDimension;
 }> = ({ isEditing, table, item }) => {
     const theme = useMantineTheme();
-    const { colors } = theme;
+    const { colors, colorScheme } = theme;
     const { showToastSuccess, showToastError } = useToaster();
     const { setAceEditor } = useCustomDimensionsAceEditorCompleter();
 
@@ -198,7 +198,7 @@ export const CustomSqlDimensionModal: FC<{
             >
                 <Modal.Header
                     sx={(themeProps) => ({
-                        borderBottom: `1px solid ${themeProps.colors.gray[2]}`,
+                        borderBottom: `1px solid ${themeProps.colors.ldGray[2]}`,
                         padding: themeProps.spacing.sm,
                     })}
                 >
@@ -206,7 +206,7 @@ export const CustomSqlDimensionModal: FC<{
                         <Paper p="xs" withBorder radius="sm">
                             <MantineIcon icon={IconSql} size="sm" />
                         </Paper>
-                        <Text color="ldDark.7" fw={700} fz="md">
+                        <Text fw={700} fz="md">
                             {isEditing ? 'Edit' : 'Create'} Custom Dimension
                             {item ? (
                                 <Text span fw={400}>
@@ -264,14 +264,18 @@ export const CustomSqlDimensionModal: FC<{
                             </Group>
                             <Box
                                 sx={{
-                                    border: `1px solid ${colors.gray[2]}`,
+                                    border: `1px solid ${colors.ldGray[2]}`,
                                     borderRadius: theme.radius.sm,
                                 }}
                             >
                                 <SqlEditor
                                     mode="sql"
                                     placeholder="Enter SQL"
-                                    theme="github"
+                                    theme={
+                                        colorScheme === 'dark'
+                                            ? 'tomorrow_night'
+                                            : 'github'
+                                    }
                                     width="100%"
                                     maxLines={Infinity}
                                     minLines={isExpanded ? 25 : 8}
@@ -284,7 +288,7 @@ export const CustomSqlDimensionModal: FC<{
                                     enableBasicAutocompletion
                                     showPrintMargin={false}
                                     wrapEnabled={true}
-                                    gutterBackgroundColor={colors.gray['1']}
+                                    gutterBackgroundColor={colors.ldGray[0]}
                                     {...form.getInputProps('sql')}
                                 />
                             </Box>
@@ -293,9 +297,9 @@ export const CustomSqlDimensionModal: FC<{
 
                     <Box
                         sx={(themeProps) => ({
-                            borderTop: `1px solid ${themeProps.colors.gray[2]}`,
+                            borderTop: `1px solid ${themeProps.colors.ldGray[2]}`,
                             padding: themeProps.spacing.sm,
-                            backgroundColor: themeProps.white,
+                            backgroundColor: themeProps.colors.background,
                             position: 'sticky',
                             bottom: 0,
                             width: '100%',

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -65,7 +65,7 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
                 <Tooltip
                     label="Add a custom dimension with SQL"
                     variant="xs"
-                    position="bottom"
+                    position="left"
                 >
                     <Button
                         size="xs"

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -16,6 +16,7 @@ import { type TableCalculationForm } from '../types';
 import { useLocalStorage } from '@mantine/hooks';
 import 'ace-builds/src-noconflict/mode-sql';
 import 'ace-builds/src-noconflict/theme-github';
+import 'ace-builds/src-noconflict/theme-tomorrow_night';
 import { SqlEditorActions } from '../../../components/SqlRunner/SqlEditorActions';
 
 const SQL_PLACEHOLDER = '${table_name.field_name} + ${table_name.metric_name}';
@@ -93,7 +94,11 @@ export const SqlForm: FC<Props> = ({
             <ScrollArea h={isFullScreen ? '90%' : '150px'}>
                 <SqlEditor
                     mode="sql"
-                    theme="github"
+                    theme={
+                        theme.colorScheme === 'dark'
+                            ? 'tomorrow_night'
+                            : 'github'
+                    }
                     width="100%"
                     placeholder={SQL_PLACEHOLDER}
                     maxLines={Infinity}
@@ -108,7 +113,7 @@ export const SqlForm: FC<Props> = ({
                     showPrintMargin={false}
                     isFullScreen={isFullScreen}
                     wrapEnabled={isSoftWrapEnabled}
-                    gutterBackgroundColor={theme.colors.ldGray['1']}
+                    gutterBackgroundColor={theme.colors.ldGray[1]}
                     {...form.getInputProps('sql')}
                 />
                 <SqlEditorActions

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -324,7 +324,7 @@ const TableCalculationModal: FC<Props> = ({
             >
                 <Modal.Header
                     sx={(themeProps) => ({
-                        borderBottom: `1px solid ${themeProps.colors.gray[2]}`,
+                        borderBottom: `1px solid ${themeProps.colors.ldGray[2]}`,
                         padding: themeProps.spacing.sm,
                     })}
                 >
@@ -332,7 +332,7 @@ const TableCalculationModal: FC<Props> = ({
                         <Paper p="xs" withBorder radius="sm">
                             <MantineIcon icon={IconCalculator} size="sm" />
                         </Paper>
-                        <Text color="ldDark.7" fw={700} fz="md">
+                        <Text fw={700} fz="md">
                             {tableCalculation ? 'Edit' : 'Create'} Table
                             Calculation
                             {tableCalculation ? (
@@ -433,7 +433,7 @@ const TableCalculationModal: FC<Props> = ({
                                     radius="xs"
                                     styles={{
                                         panel: {
-                                            borderColor: colors.gray[2],
+                                            borderColor: colors.ldGray[2],
                                             borderWidth: 1,
                                             borderStyle: 'solid',
                                             borderTop: 'none',
@@ -523,9 +523,9 @@ const TableCalculationModal: FC<Props> = ({
 
                     <Box
                         sx={(themeProps) => ({
-                            borderTop: `1px solid ${themeProps.colors.gray[2]}`,
+                            borderTop: `1px solid ${themeProps.colors.ldGray[2]}`,
                             padding: themeProps.spacing.sm,
-                            backgroundColor: themeProps.white,
+                            backgroundColor: themeProps.colors.background,
                             position: 'sticky',
                             bottom: 0,
                             width: '100%',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added dark mode support for SQL editors in custom dimensions and table calculations. The SQL editor now uses the 'tomorrow_night' theme when in dark mode and 'github' theme in light mode. Also updated various UI elements to use theme-appropriate colors, replacing hardcoded colors with theme variables for better dark/light mode compatibility.

The PR also includes a small UX improvement by changing the tooltip position for the "Add custom dimension" button from "bottom" to "left" for better visibility.