### PR TITLE
fix: use field property instead of hashFieldReference for axis field IDs

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1225,7 +1225,7 @@ const getEchartAxes = ({
     const topAxisXFieldIds = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.eChartsConfig.series
               ?.filter((serie) => serie.yAxisIndex === 1)
-              .map((s) => hashFieldReference(s.encode.yRef))
+              .map((s) => s.encode.yRef.field)
         : undefined;
 
     const topAxisXId = topAxisXFieldIds?.[0] || undefined;
@@ -1233,7 +1233,7 @@ const getEchartAxes = ({
     const bottomAxisXFieldIds = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.eChartsConfig.series
               ?.filter((serie) => serie.yAxisIndex === 0)
-              .map((s) => hashFieldReference(s.encode.yRef))
+              .map((s) => s.encode.yRef.field)
         : [];
 
     const bottomAxisXId = bottomAxisXFieldIds?.[0] || xAxisItemId;
@@ -1254,14 +1254,14 @@ const getEchartAxes = ({
             : []
         : validCartesianConfig.eChartsConfig.series
               ?.filter((serie) => serie.yAxisIndex === 0)
-              .map((s) => hashFieldReference(s.encode.yRef));
+              .map((s) => s.encode.yRef.field);
 
     const leftAxisYId = leftAxisYFieldIds?.[0] || yAxisItemId;
 
     // There is no right Y axis when flipped
     const rightAxisYFieldIds = validCartesianConfig.eChartsConfig.series
         ?.filter((serie) => serie.yAxisIndex === 1)
-        .map((s) => hashFieldReference(s.encode.yRef));
+        .map((s) => s.encode.yRef.field);
 
     const rightAxisYId =
         rightAxisYFieldIds?.[0] || validCartesianConfig.layout?.yField?.[1];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Replaced `hashFieldReference(s.encode.yRef)` with direct field access `s.encode.yRef.field` in axis field ID mapping for ECharts cartesian configuration. This change simplifies the field reference handling for top, bottom, left, and right axes.
