### PR TITLE
feat: persist color scheme in local storage

### DIFF
--- a/packages/frontend/src/providers/MantineProvider.tsx
+++ b/packages/frontend/src/providers/MantineProvider.tsx
@@ -5,8 +5,9 @@ import {
     type MantineThemeOverride,
 } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import { type FC, useEffect, useMemo, useState } from 'react';
+import { type FC, useEffect, useMemo } from 'react';
 
+import { useLocalStorage } from '@mantine-8/hooks';
 import { getMantineThemeOverride } from '../mantineTheme';
 
 type Props = {
@@ -27,7 +28,10 @@ const MantineProvider: FC<React.PropsWithChildren<Props>> = ({
     themeOverride = {},
     notificationsLimit,
 }) => {
-    const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
+    const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({
+        key: 'color-scheme',
+        defaultValue: 'light',
+    });
 
     const theme = useMemo(
         () => getMantineThemeOverride(colorScheme),


### PR DESCRIPTION
### Description:
Replaced the useState hook with useLocalStorage from Mantine 8 hooks to persist the color scheme preference. This ensures that the user's theme preference is remembered across sessions.