### PR TITLE
feat: scheduler modals and more usage of "background" color

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -264,13 +264,13 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                             separator: {
                                 position: 'sticky',
                                 top: 0,
-                                backgroundColor: 'white',
+                                backgroundColor: theme.colors.background,
                                 zIndex: getDefaultZIndex('modal'),
                             },
                             separatorLabel: {
                                 color: theme.colors.ldGray[6],
                                 fontWeight: 500,
-                                backgroundColor: 'white',
+                                backgroundColor: theme.colors.background,
                             },
                             item: {
                                 paddingTop: 4,

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -148,7 +148,8 @@ const ChartUpdateModal = ({
                                     separator: {
                                         position: 'sticky',
                                         top: 0,
-                                        backgroundColor: 'white',
+                                        backgroundColor:
+                                            theme.colors.background,
                                     },
                                     separatorLabel: {
                                         color: theme.colors.ldGray[6],

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -413,7 +413,7 @@ const UserAttributeModal: FC<{
                     position="right"
                     sx={(theme) => ({
                         position: 'sticky',
-                        backgroundColor: 'white',
+                        backgroundColor: theme.colors.background,
                         borderTop: `1px solid ${theme.colors.ldGray[4]}`,
                         bottom: 0,
                         zIndex: 2,

--- a/packages/frontend/src/components/common/TagInput/TagInput.styles.ts
+++ b/packages/frontend/src/components/common/TagInput/TagInput.styles.ts
@@ -61,7 +61,7 @@ export default createStyles(
                     ? theme.colors.red[theme.colorScheme === 'dark' ? 6 : 7]
                     : theme.colorScheme === 'dark'
                     ? theme.colors.ldDark[3]
-                    : theme.colors.ldGray[5],
+                    : theme.colors.ldGray?.[5],
             },
 
             '&:disabled': {

--- a/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
@@ -105,7 +105,7 @@ export const CatalogGroup: FC<React.PropsWithChildren<Props>> = ({
                     sx={(theme) => ({
                         border: `1px solid ${theme.colors.ldGray[2]}`,
                         borderRadius: theme.radius.md,
-                        backgroundColor: 'white',
+                        backgroundColor: theme.colors.background,
                     })}
                 >
                     {children}

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -144,7 +144,7 @@ export const CatalogMetadata: FC = () => {
                         },
                         placeholder: {
                             color: theme.colors.ldGray[7],
-                            backgroundColor: 'white',
+                            backgroundColor: theme.colors.background,
                         },
                     })}
                 >
@@ -387,7 +387,7 @@ export const CatalogMetadata: FC = () => {
                             <Paper
                                 withBorder
                                 sx={(theme) => ({
-                                    backgroundColor: 'white',
+                                    backgroundColor: theme.colors.background,
                                     border: `1px solid ${theme.colors.ldGray[9]}`,
                                     borderRadius: theme.radius.sm,
                                     padding: 4,
@@ -404,7 +404,7 @@ export const CatalogMetadata: FC = () => {
                             <Paper
                                 withBorder
                                 sx={(theme) => ({
-                                    backgroundColor: 'white',
+                                    backgroundColor: theme.colors.background,
                                     border: `1px solid ${theme.colors.ldGray[9]}`,
                                     borderRadius: theme.radius.sm,
                                     padding: 4,
@@ -416,7 +416,7 @@ export const CatalogMetadata: FC = () => {
                             <Paper
                                 withBorder
                                 sx={(theme) => ({
-                                    backgroundColor: 'white',
+                                    backgroundColor: theme.colors.background,
                                     border: `1px solid ${theme.colors.ldGray[9]}`,
                                     borderRadius: theme.radius.sm,
                                     padding: 4,

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
@@ -100,7 +100,8 @@ export const SuggestionList = forwardRef<
                                         fontSize: theme.fontSizes.xs,
                                         fontWeight: 400,
                                         textAlign: 'left',
-                                        backgroundColor: 'white',
+                                        backgroundColor:
+                                            theme.colors.background,
                                         color:
                                             index === selectedIndex
                                                 ? theme.colors.blue[6]

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
@@ -134,7 +134,7 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
             fz={14}
             sx={(theme) => ({
                 '&[data-with-border]': {
-                    backgroundColor: 'white',
+                    backgroundColor: theme.colors.background,
                     borderRadius: theme.radius.md,
                     border: `1px solid ${
                         selected ? theme.colors.blue[5] : theme.colors.ldGray[3]

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -85,12 +85,12 @@ const EditPopover: FC<EditPopoverProps> = ({
         >
             <Popover.Target>
                 <ActionIcon
-                    sx={{
+                    sx={(theme) => ({
                         visibility: hovered || opened ? 'visible' : 'hidden',
                         '&:hover': {
-                            backgroundColor: 'white',
+                            backgroundColor: theme.colors.background,
                         },
-                    }}
+                    })}
                     size="sm"
                     onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                         e.stopPropagation();

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -565,7 +565,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             indicator: {
                                 borderRadius: theme.radius.md,
                                 border: `1px solid ${theme.colors.ldGray[2]}`,
-                                backgroundColor: 'white',
+                                backgroundColor: theme.colors.background,
                                 boxShadow: theme.shadows.subtle,
                             },
                         })}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -129,7 +129,7 @@ const TooltipContainer: FC<{
         p="sm"
         spacing="xs"
         sx={(theme) => ({
-            backgroundColor: 'white',
+            backgroundColor: theme.colors.background,
             borderRadius: theme.radius.md,
             border: `1px solid ${theme.colors.ldGray[2]}`,
             boxShadow:

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -637,7 +637,7 @@ const SchedulerForm: FC<Props> = ({
                 <Tabs.Panel value="setup" mt="md">
                     <Stack
                         sx={(theme) => ({
-                            backgroundColor: theme.white,
+                            backgroundColor: theme.colors.background,
                             paddingRight: theme.spacing.xl,
                         })}
                         spacing="xl"

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
@@ -31,7 +31,7 @@ const SchedulersModalFooter = ({
             position="apart"
             sx={(theme) => ({
                 position: 'sticky',
-                backgroundColor: 'white',
+                backgroundColor: theme.colors.background,
                 borderTop: `1px solid ${theme.colors.ldGray[4]}`,
                 bottom: 0,
                 zIndex: 2,

--- a/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
@@ -55,7 +55,7 @@ const SchedulersList: FC<Props> = ({
         (isThresholdAlertList && alertSchedulers.length <= 0)
     ) {
         return (
-            <Stack color="gray" align="center" mt="xxl">
+            <Stack align="center" mt="xxl">
                 <Title order={4} color="ldGray.6">
                     {`There are no existing ${
                         isThresholdAlertList ? 'alerts' : 'scheduled deliveries'

--- a/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
@@ -65,7 +65,7 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
                         {scheduler.name}
                     </Text>
                     <Group spacing="sm">
-                        <Text color="gray" size={12}>
+                        <Text color="ldGray" size={12}>
                             {getHumanReadableCronExpression(
                                 scheduler.cron,
                                 scheduler.timezone || project.schedulerTimezone,
@@ -76,7 +76,7 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
                             <MantineIcon icon={IconCircleFilled} size={5} />
                         </Box>
 
-                        <Text color="gray" size={12}>
+                        <Text color="ldGray" size={12}>
                             {scheduler.targets.length} recipients
                         </Text>
                     </Group>

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -228,7 +228,7 @@ export const SyncModalView: FC<{ chartUuid: string }> = ({ chartUuid }) => {
             <Flex
                 sx={(theme) => ({
                     position: 'sticky',
-                    backgroundColor: 'white',
+                    backgroundColor: theme.colors.background,
                     borderTop: `1px solid ${theme.colors.ldGray[4]}`,
                     bottom: 0,
                     zIndex: 2,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Replace hardcoded white background colors with theme.colors.background to improve dark mode support across multiple components. This change affects various UI elements including modals, popovers, separators, and containers in the dashboard tiles, user settings, catalog, comments, metrics catalog, and scheduler features.