### PR TITLE
style: improve dark mode compatibility in dashboard components

### DIFF
--- a/packages/frontend/src/components/DashboardFilter/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/components/DashboardFilter/ActiveFilters/Filter.tsx
@@ -6,9 +6,9 @@ import {
     type FilterableDimension,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Box,
     Button,
-    CloseButton,
     createStyles,
     Indicator,
     Popover,
@@ -16,7 +16,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { useDisclosure, useId } from '@mantine/hooks';
-import { IconGripVertical } from '@tabler/icons-react';
+import { IconGripVertical, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import {
@@ -29,9 +29,6 @@ import FilterConfiguration from '../FilterConfiguration';
 import { hasFilterValueSet } from '../FilterConfiguration/utils';
 
 const useDashboardFilterStyles = createStyles((theme) => ({
-    root: {
-        backgroundColor: 'white',
-    },
     unsetRequiredFilter: {
         borderStyle: 'solid',
         borderWidth: '3px',
@@ -40,7 +37,7 @@ const useDashboardFilterStyles = createStyles((theme) => ({
         borderStyle: 'dashed',
         borderWidth: '1px',
         borderColor: theme.fn.rgba(theme.colors.ldGray[5], 0.7),
-        backgroundColor: theme.fn.rgba(theme.white, 0.7),
+        backgroundColor: theme.fn.rgba(theme.colors.background[0], 0.7),
     },
 }));
 
@@ -242,7 +239,7 @@ const Filter: FC<Props> = ({
                                         ? 'outline'
                                         : 'default'
                                 }
-                                className={`${classes.root} ${
+                                className={`${
                                     hasUnsetRequiredFilter
                                         ? classes.unsetRequiredFilter
                                         : ''
@@ -255,7 +252,6 @@ const Filter: FC<Props> = ({
                                     isDraggable && (
                                         <MantineIcon
                                             icon={IconGripVertical}
-                                            color="gray"
                                             cursor="grab"
                                             size="sm"
                                         />
@@ -263,16 +259,18 @@ const Filter: FC<Props> = ({
                                 }
                                 rightIcon={
                                     (isEditMode || isTemporary) && (
-                                        <CloseButton
-                                            size="sm"
+                                        <ActionIcon
                                             onClick={onRemove}
-                                        />
+                                            size="xs"
+                                        >
+                                            <MantineIcon
+                                                size="sm"
+                                                icon={IconX}
+                                            />
+                                        </ActionIcon>
                                     )
                                 }
                                 styles={{
-                                    inner: {
-                                        color: 'black',
-                                    },
                                     label: {
                                         maxWidth: '800px',
                                         whiteSpace: 'nowrap',

--- a/packages/frontend/src/components/DashboardTabs/Tab.tsx
+++ b/packages/frontend/src/components/DashboardTabs/Tab.tsx
@@ -1,6 +1,14 @@
 import { Draggable } from '@hello-pangea/dnd';
 import type { DashboardTab } from '@lightdash/common';
-import { ActionIcon, Box, Menu, Tabs, Title, Tooltip } from '@mantine/core';
+import {
+    ActionIcon,
+    Box,
+    Menu,
+    Tabs,
+    Title,
+    Tooltip,
+    useMantineColorScheme,
+} from '@mantine/core';
 import { mergeRefs, useHover } from '@mantine/hooks';
 import {
     IconCopy,
@@ -38,6 +46,7 @@ const DraggableTab: FC<DraggableTabProps> = ({
     handleDuplicateTab,
     setDeletingTab,
 }) => {
+    const { colorScheme } = useMantineColorScheme();
     const { hovered: isHovered, ref: hoverRef } = useHover();
     const { ref, isTruncated } = useIsTruncated();
 
@@ -64,7 +73,13 @@ const DraggableTab: FC<DraggableTabProps> = ({
                         <Tabs.Tab
                             key={idx}
                             value={tab.uuid}
-                            bg={isActive ? 'white' : 'ldGray.0'}
+                            bg={
+                                isActive
+                                    ? colorScheme === 'dark'
+                                        ? undefined
+                                        : 'white'
+                                    : 'ldGray.0'
+                            }
                             icon={
                                 isEditMode ? (
                                     <Box {...provided.dragHandleProps} w={'sm'}>

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -107,6 +107,7 @@ const MarkdownTile: FC<Props> = (props) => {
                     overflow: 'auto',
                     '.wmde-markdown': {
                         fontSize: '14px',
+                        backgroundColor: 'transparent',
                     },
                 }}
             >

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -264,13 +264,19 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                             separator: {
                                 position: 'sticky',
                                 top: 0,
-                                backgroundColor: theme.colors.background,
+                                backgroundColor:
+                                    theme.colorScheme === 'dark'
+                                        ? 'var(--mantine-color-dark-6)'
+                                        : 'var(--mantine-color-white)',
                                 zIndex: getDefaultZIndex('modal'),
                             },
                             separatorLabel: {
                                 color: theme.colors.ldGray[6],
                                 fontWeight: 500,
-                                backgroundColor: theme.colors.background,
+                                backgroundColor:
+                                    theme.colorScheme === 'dark'
+                                        ? 'var(--mantine-color-dark-6)'
+                                        : 'var(--mantine-color-white)',
                             },
                             item: {
                                 paddingTop: 4,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -53,6 +53,7 @@ export const ItemDetailMarkdown: FC<{ source: string }> = ({ source }) => {
             style={{
                 fontSize: theme.fontSizes.sm,
                 color: theme.colors.ldGray[7],
+                backgroundColor: 'transparent',
             }}
         />
     );

--- a/packages/frontend/src/ee/features/aiDashboardSummary/SummaryPreview.tsx
+++ b/packages/frontend/src/ee/features/aiDashboardSummary/SummaryPreview.tsx
@@ -36,6 +36,9 @@ const SummaryPreview: FC<SummaryPreviewProps> = ({
             <ReactMarkdownPreview
                 source={summary.summary}
                 rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
+                style={{
+                    backgroundColor: 'transparent',
+                }}
             />
             <Flex align="center" justify="space-between" mt="md" w="100%">
                 <Text

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
@@ -2,7 +2,7 @@
 .addDateZoomButton {
     border-style: dashed;
     border-width: 1px;
-    border-color: var(--mantine-color-ldGray-4);
+    border-color: var(--mantine-color-gray-4);
 }
 
 /* Positioned close button on date zoom */
@@ -11,8 +11,6 @@
     top: -6px;
     left: -6px;
     z-index: 1;
-    color: var(--mantine-color-ldGray-6);
-    background-color: var(--mantine-color-white);
 }
 
 /* Active date zoom button with blue border */
@@ -24,6 +22,6 @@
 .menuItemDisabled {
     color: white;
     &:not([data-disabled='false']) {
-        color: var(--mantine-color-ldGray-6);
+        color: var(--mantine-color-gray-6);
     }
 }

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -70,7 +70,7 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                     {isEditMode && (
                         <ActionIcon
                             size="xs"
-                            variant="subtle"
+                            variant="default"
                             onClick={() => setIsDateZoomDisabled(true)}
                             className={styles.closeButton}
                         >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Improves dark mode compatibility across dashboard components by:

- Replacing hardcoded white backgrounds with theme-aware colors
- Making markdown components transparent to respect the theme background
- Updating filter styling to use theme colors instead of hardcoded values
- Fixing tab background colors to properly handle dark mode
- Enhancing ActionIcon and button styling for better dark/light mode contrast
- Updating CSS variables to use Mantine's standard color variables

These changes ensure dashboard components like filters, tabs, markdown tiles, and date zoom controls display correctly in both light and dark themes.