### PR TITLE
feat: add dark mode support to Omnibar components

### DIFF
--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -12,6 +12,7 @@ import {
     rem,
     Stack,
     Transition,
+    useMantineColorScheme,
     useMantineTheme,
 } from '@mantine/core';
 import {
@@ -59,6 +60,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     const { data: projectData } = useProject(projectUuid);
     const { track } = useTracking();
     const theme = useMantineTheme();
+    const { colorScheme } = useMantineColorScheme();
     const canUserManageValidation = useValidationUserAbility(projectUuid);
     const [searchFilters, setSearchFilters] = useState<SearchFilters>();
     const [query, setQuery] = useState<string>();
@@ -199,7 +201,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
                 )}
             </Transition>
 
-            <MantineProvider inherit theme={{ colorScheme: 'light' }}>
+            <MantineProvider inherit theme={{ colorScheme }}>
                 <Modal
                     withCloseButton={false}
                     size={`calc(${rem(PAGE_CONTENT_WIDTH)} - ${

--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
@@ -22,10 +22,16 @@ const useStyles = createStyles<string, null>((theme) => ({
         paddingRight: theme.spacing.xs,
         borderRadius: theme.radius.sm,
         '&:hover, &[data-hovered]': {
-            backgroundColor: theme.colors.blue[0],
+            backgroundColor:
+                theme.colorScheme === 'dark'
+                    ? theme.colors.blue[8]
+                    : theme.colors.blue[0],
         },
         '&:active': {
-            backgroundColor: theme.colors.blue[1],
+            backgroundColor:
+                theme.colorScheme === 'dark'
+                    ? theme.colors.blue[9]
+                    : theme.colors.blue[1],
         },
     },
     item: {},

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.tsx
@@ -76,7 +76,7 @@ const OmnibarItemGroups: FC<Props> = ({
             {groupedItems.map(([groupType, groupItems], groupIndex) => (
                 <Accordion.Item key={groupType} value={groupType}>
                     <Accordion.Control>
-                        <Text color="dark" fw={500} fz="xs">
+                        <Text color="dimmed" fw={500} fz="xs">
                             {getSearchItemLabel(groupType)}
                         </Text>
                     </Accordion.Control>

--- a/packages/frontend/src/features/omnibar/components/OmnibarTarget.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarTarget.tsx
@@ -1,4 +1,11 @@
-import { Badge, em, getBreakpointValue, Group, Text } from '@mantine/core';
+import {
+    Badge,
+    em,
+    getBreakpointValue,
+    Group,
+    Text,
+    useMantineColorScheme,
+} from '@mantine/core';
 import { useOs } from '@mantine/hooks';
 import { IconSearch } from '@tabler/icons-react';
 import { type CSSProperties, type FC, type MouseEvent } from 'react';
@@ -11,6 +18,7 @@ type Props = {
 };
 
 const OmnibarTarget: FC<Props> = ({ placeholder, style, onOpen }) => {
+    const { colorScheme } = useMantineColorScheme();
     const os = useOs();
 
     return (
@@ -41,8 +49,16 @@ const OmnibarTarget: FC<Props> = ({ placeholder, style, onOpen }) => {
                 borderRadius: theme.radius.sm,
                 cursor: 'pointer',
                 transition: 'all 100ms ease',
-                backgroundColor: theme.colors.ldDark[4],
-                '&:hover': { backgroundColor: theme.colors.ldDark[3] },
+                backgroundColor:
+                    colorScheme === 'dark'
+                        ? theme.colors.ldDark[8]
+                        : theme.colors.ldDark[4],
+                '&:hover': {
+                    backgroundColor:
+                        colorScheme === 'dark'
+                            ? theme.colors.ldDark[7]
+                            : theme.colors.ldDark[3],
+                },
                 overflow: 'hidden',
             })}
         >


### PR DESCRIPTION
### Description:
Added dark mode support to the Omnibar component by:
- Using the current color scheme instead of forcing "light" theme in the Omnibar modal
- Updated hover and active states in OmnibarItem to use appropriate colors for dark mode
- Changed the group header text color from "dark" to "dimmed" for better contrast in both modes
- Enhanced OmnibarTarget to use different background colors based on the current color scheme

This ensures the Omnibar component respects the user's preferred color scheme and maintains proper contrast and visual hierarchy in both light and dark modes.