### PR TITLE
fix: respect color scheme in modals and UI components

### DIFF
--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -22,6 +22,7 @@ import {
     Textarea,
     TextInput,
     Tooltip,
+    useMantineColorScheme,
 } from '@mantine/core';
 import {
     IconExternalLink,
@@ -197,6 +198,7 @@ type Props = {
 
 const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
     const { user } = useApp();
+    const { colorScheme } = useMantineColorScheme();
 
     const { isInitialLoading: isLoadingProjects, data: projects } =
         useProjects();
@@ -391,7 +393,7 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
     const branches = useBranches(selectedProjectUuid);
 
     return (
-        <MantineProvider inherit theme={{ colorScheme: 'light' }}>
+        <MantineProvider inherit theme={{ colorScheme }}>
             <Modal
                 size="lg"
                 opened={isOpened}

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -42,7 +42,7 @@ import MantineIcon from '../common/MantineIcon';
 import { CreatePreviewModal } from './CreatePreviewProjectModal';
 
 const MENU_TEXT_PROPS = {
-    c: 'ldGray.1',
+    c: 'gray.1',
     fz: 'xs',
     fw: 500,
 };
@@ -78,7 +78,7 @@ const GroupHeader: FC<{
         >
             <Group spacing="xs" position="apart" noWrap>
                 <Group spacing="xs" noWrap>
-                    <Text {...MENU_TEXT_PROPS} fw={600} c="ldGray.4">
+                    <Text {...MENU_TEXT_PROPS} fw={600} c="gray.4">
                         {title}
                     </Text>
                     <Badge
@@ -97,7 +97,7 @@ const GroupHeader: FC<{
                 <MantineIcon
                     icon={isExpanded ? IconChevronDown : IconChevronRight}
                     size="sm"
-                    color="ldGray.5"
+                    color="gray.5"
                 />
             </Group>
         </UnstyledButton>
@@ -139,7 +139,7 @@ const ProjectItem: FC<{
                         truncate
                         maw={350}
                         fw={isActive ? 600 : 500}
-                        c={isActive ? 'ldGray.5' : 'inherit'}
+                        c={isActive ? 'gray.5' : 'inherit'}
                     >
                         {item.name}
                     </Highlight>
@@ -461,11 +461,11 @@ const ProjectSwitcher = () => {
                     <Box
                         pos="sticky"
                         top={0}
-                        bg="ldGray.9"
+                        bg="gray.9"
                         p="sm"
                         sx={(theme) => ({
-                            boxShadow: `0 2px 8px ${theme.colors.ldGray[9]}`,
-                            borderBottom: `1px solid ${theme.colors.ldDark[4]}`,
+                            boxShadow: `0 2px 8px ${theme.colors.gray[9]}`,
+                            borderBottom: `1px solid ${theme.colors.dark[4]}`,
                         })}
                     >
                         <TextInput
@@ -490,7 +490,7 @@ const ProjectSwitcher = () => {
                             styles={{
                                 input: {
                                     backgroundColor: 'transparent',
-                                    border: `1px solid var(--mantine-color-ldDark-4)`,
+                                    border: `1px solid var(--mantine-color-dark-4)`,
                                     '&:focus': {
                                         borderColor:
                                             'var(--mantine-color-blue-6)',
@@ -594,7 +594,7 @@ const ProjectSwitcher = () => {
                                         <MantineIcon
                                             icon={IconSearch}
                                             size="lg"
-                                            color="ldGray.5"
+                                            color="gray.5"
                                         />
                                         <Text {...MENU_TEXT_PROPS}>
                                             {debouncedSearchQuery.length >= 2
@@ -610,10 +610,10 @@ const ProjectSwitcher = () => {
                         <Box
                             pos="sticky"
                             bottom={0}
-                            bg="ldGray.9"
+                            bg="gray.9"
                             sx={(theme) => ({
                                 // fixes scroll overlap
-                                boxShadow: `0 4px ${theme.colors.ldGray[9]}`,
+                                boxShadow: `0 4px ${theme.colors.gray[9]}`,
                             })}
                         >
                             {(baseProjects.length > 0 ||

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -1,4 +1,11 @@
-import { ActionIcon, MantineProvider, Menu, Text, Title } from '@mantine/core';
+import {
+    ActionIcon,
+    MantineProvider,
+    Menu,
+    Text,
+    Title,
+    useMantineTheme,
+} from '@mantine/core';
 import { IconCheck, IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
@@ -24,6 +31,7 @@ const routesThatNeedWarehouseCredentials = [
 
 const UserCredentialsSwitcher = () => {
     const { user } = useApp();
+    const theme = useMantineTheme();
     const location = useLocation();
     const [showCreateModalOnPageLoad, setShowCreateModalOnPageLoad] =
         useState(false);
@@ -183,7 +191,10 @@ const UserCredentialsSwitcher = () => {
                 </Menu.Dropdown>
             </Menu>
             {isCreatingCredentials && (
-                <MantineProvider inherit theme={{ colorScheme: 'light' }}>
+                <MantineProvider
+                    inherit
+                    theme={{ colorScheme: theme.colorScheme }}
+                >
                     <CreateCredentialsModal
                         opened={isCreatingCredentials}
                         title={

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -117,7 +117,6 @@ const MantineModal: React.FC<MantineModalProps> = ({
                             width: '100%',
                             zIndex: 10,
                         })}
-                        bg="white"
                         px="xl"
                         py="md"
                         justify="flex-end"

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -8,6 +8,7 @@ import {
     Button,
     Group,
     MantineProvider,
+    useMantineColorScheme,
     type DefaultMantineColor,
 } from '@mantine/core';
 import { useForm, zodResolver, type UseFormReturnType } from '@mantine/form';
@@ -91,6 +92,8 @@ const SpaceModal: FC<ActionModalProps> = ({
     rootSpace,
 }) => {
     const { showToastError } = useToaster();
+    const { colorScheme } = useMantineColorScheme();
+
     const { data: organizationUsers } = useOrganizationUsers();
     const [privateAccessType, setPrivateAccessType] = useState(
         SpacePrivateAccessType.PRIVATE,
@@ -142,7 +145,7 @@ const SpaceModal: FC<ActionModalProps> = ({
     }
 
     return (
-        <MantineProvider inherit theme={{ colorScheme: 'light' }}>
+        <MantineProvider inherit theme={{ colorScheme }}>
             <MantineModal
                 opened
                 size="lg"

--- a/packages/frontend/src/components/common/Tree/TreeItem.module.css
+++ b/packages/frontend/src/components/common/Tree/TreeItem.module.css
@@ -11,6 +11,10 @@
 
         &:is([data-selected='true']) {
             background-color: var(--mantine-color-blue-0);
+
+            @mixin dark {
+                background-color: var(--mantine-color-blue-9);
+            }
         }
     }
 }

--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -8,6 +8,7 @@ import {
     Stack,
     TextInput,
     Textarea,
+    useMantineColorScheme,
     type ModalProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
@@ -43,6 +44,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
     ...modalProps
 }) => {
     const { user } = useApp();
+    const { colorScheme } = useMantineColorScheme();
     const { mutateAsync: createDashboard, isLoading: isCreatingDashboard } =
         useCreateMutation(projectUuid);
 
@@ -182,7 +184,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
     if (isLoadingSpaces || !spaces) return null;
 
     return (
-        <MantineProvider inherit theme={{ colorScheme: 'light' }}>
+        <MantineProvider inherit theme={{ colorScheme }}>
             <MantineModal
                 {...modalProps}
                 title="Create Dashboard"

--- a/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
@@ -25,14 +25,16 @@ const getValueColor = ({
     sections,
     primaryColor,
     gaugeMax,
+    foregroundColor,
 }: {
     numericValue: number;
     sections: GaugeSection[] | undefined;
     primaryColor: string;
     gaugeMax: number;
+    foregroundColor: string;
 }) => {
     const defaultColours = {
-        text: 'black',
+        text: foregroundColor,
         bar: primaryColor,
     };
     if (!sections || sections.length === 0) {
@@ -163,6 +165,7 @@ const useEchartsGaugeConfig = ({
         });
 
         const valueColor = getValueColor({
+            foregroundColor: theme.colors.foreground[0],
             numericValue,
             sections: sectionsWithResolvedValues,
             primaryColor: theme.colors.blue[6],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR fixes the dark mode appearance in various modals and components. Previously, some modals were hardcoded to use the light theme regardless of the user's preference. Now, all modals respect the user's color scheme setting.

Key changes:
- Updated `CreatePreviewModal`, `UserCredentialsSwitcher`, `SpaceActionModal`, and `DashboardCreateModal` to use the current color scheme instead of hardcoding to light mode
- Fixed color references in `ProjectSwitcher` by replacing `ldGray` and `ldDark` with standard Mantine color tokens
- Added dark mode styling for selected items in the tree component
- Updated the gauge chart to use the appropriate foreground color based on the theme

These changes ensure a consistent appearance across the application in both light and dark modes.