### PR TITLE
fix: improve copy capture zoom on maps

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
@@ -9,9 +9,10 @@ import {
     Stack,
     Switch,
     Text,
+    Tooltip,
 } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
-import { IconCamera, IconPlus, IconX } from '@tabler/icons-react';
+import { IconLockAccess, IconPlus, IconX } from '@tabler/icons-react';
 import { memo, useCallback, type FC } from 'react';
 import { DEFAULT_MAP_COLORS } from '../../../hooks/useMapChartConfig';
 import { isMapVisualizationConfig } from '../../LightdashVisualization/types';
@@ -282,15 +283,21 @@ export const Display: FC = memo(() => {
                             precision={2}
                         />
                     </Group>
-                    <Button
-                        variant="light"
-                        leftIcon={<IconCamera size={16} />}
-                        mt="sm"
-                        fullWidth
-                        onClick={handleCaptureCurrentView}
+                    <Tooltip
+                        label="Set the default view of the map to the current zoom and center"
+                        withinPortal
+                        position="bottom"
                     >
-                        Capture current view
-                    </Button>
+                        <Button
+                            variant="light"
+                            leftIcon={<IconLockAccess size={16} />}
+                            mt="sm"
+                            fullWidth
+                            onClick={handleCaptureCurrentView}
+                        >
+                            Lock current view
+                        </Button>
+                    </Tooltip>
                 </Config.Section>
             </Config>
         </Stack>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Improved the map view capture button by:
- Changing the button text from "Capture current view" to "Lock current view" for better clarity
- Replacing the camera icon with a lock icon to better represent the action
- Adding a tooltip that explains the button's functionality: "Set the default view of the map to the current zoom and center"