### PR TITLE
fix: update theme.colors.background references to use array index

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -149,7 +149,7 @@ const ChartUpdateModal = ({
                                         position: 'sticky',
                                         top: 0,
                                         backgroundColor:
-                                            theme.colors.background,
+                                            theme.colors.background[0],
                                     },
                                     separatorLabel: {
                                         color: theme.colors.ldGray[6],

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -413,7 +413,7 @@ const UserAttributeModal: FC<{
                     position="right"
                     sx={(theme) => ({
                         position: 'sticky',
-                        backgroundColor: theme.colors.background,
+                        backgroundColor: theme.colors.background[0],
                         borderTop: `1px solid ${theme.colors.ldGray[4]}`,
                         bottom: 0,
                         zIndex: 2,

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Menu, Text, Tooltip } from '@mantine/core';
+import { Button, Menu, Text, Tooltip, useMantineTheme } from '@mantine/core';
 import { useInterval } from '@mantine/hooks';
 import { IconChevronDown, IconRefresh } from '@tabler/icons-react';
 import {
@@ -45,6 +45,7 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
     ({ onIntervalChange }) => {
         const { showToastSuccess } = useToaster();
         const [isOpen, setIsOpen] = useState(false);
+        const theme = useMantineTheme();
         const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(
             null,
         );
@@ -182,14 +183,16 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
                             }}
                             disabled={refreshInterval === undefined}
                             bg={
-                                refreshInterval === undefined ? 'blue' : 'white'
+                                refreshInterval === undefined
+                                    ? 'blue'
+                                    : theme.colors.foreground[0]
                             }
                             sx={{
                                 '&[disabled]': {
                                     color:
                                         refreshInterval === undefined
-                                            ? 'white'
-                                            : 'black',
+                                            ? theme.colors.foreground[0]
+                                            : theme.colors.background[0],
                                 },
                             }}
                         >
@@ -216,15 +219,15 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
                                 bg={
                                     refreshInterval === +value
                                         ? 'blue'
-                                        : 'white'
+                                        : theme.colors.background[0]
                                 }
                                 disabled={refreshInterval === +value}
                                 sx={{
                                     '&[disabled]': {
                                         color:
                                             refreshInterval === +value
-                                                ? 'white'
-                                                : 'black',
+                                                ? theme.colors.foreground[0]
+                                                : theme.colors.background[0],
                                     },
                                 }}
                             >

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -3,6 +3,7 @@ import {
     Box,
     Text,
     Tooltip,
+    useMantineTheme,
     type BoxProps as BoxPropsBase,
 } from '@mantine/core';
 import { getHotkeyHandler, useClipboard, useId } from '@mantine/hooks';
@@ -152,6 +153,7 @@ const TableProvider: FC<
 const TableComponent = forwardRef<HTMLTableElement, TableProps>(
     ({ children, component = 'table', containerRef, ...rest }, ref) => {
         const { cx, classes } = useTableStyles();
+        const theme = useMantineTheme();
 
         const [isContainerInitialized, setIsContainerInitialized] =
             useState(false);
@@ -189,7 +191,7 @@ const TableComponent = forwardRef<HTMLTableElement, TableProps>(
                 pos="relative"
                 sx={{
                     overflow: 'auto',
-                    border: '1px solid #dcdcdd',
+                    border: `1px solid ${theme.colors.ldGray[3]}`,
                     borderRadius: '4px',
                 }}
             >

--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -235,7 +235,7 @@ export const useTableRowStyles = createStyles<
 
     return {
         root: {
-            backgroundColor: theme.white,
+            backgroundColor: theme.colors.background[0],
 
             ':hover':
                 sectionType === SectionType.Body
@@ -274,9 +274,18 @@ export const useTableCellStyles = createStyles<
         },
     ) => {
         const cellHeadBackground = theme.colors.ldGray[0];
-        const selectedDefaultBackground = theme.colors.blue[2];
-        const selectedDefaultBorder = theme.colors.blue[4];
-        const copyingBackground = theme.colors.blue[3];
+        const selectedDefaultBackground =
+            theme.colorScheme === 'dark'
+                ? theme.colors.blue[9]
+                : theme.colors.blue[2];
+        const selectedDefaultBorder =
+            theme.colorScheme === 'dark'
+                ? theme.colors.blue[5]
+                : theme.colors.blue[4];
+        const copyingBackground =
+            theme.colorScheme === 'dark'
+                ? theme.colors.blue[8]
+                : theme.colors.blue[3];
         const withBackgroundSelected = withBackground
             ? darken(0.05, withBackground)
             : undefined;

--- a/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogGroup.tsx
@@ -105,7 +105,7 @@ export const CatalogGroup: FC<React.PropsWithChildren<Props>> = ({
                     sx={(theme) => ({
                         border: `1px solid ${theme.colors.ldGray[2]}`,
                         borderRadius: theme.radius.md,
-                        backgroundColor: theme.colors.background,
+                        backgroundColor: theme.colors.background[0],
                     })}
                 >
                     {children}

--- a/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
+++ b/packages/frontend/src/features/catalog/components/CatalogMetadata.tsx
@@ -144,7 +144,7 @@ export const CatalogMetadata: FC = () => {
                         },
                         placeholder: {
                             color: theme.colors.ldGray[7],
-                            backgroundColor: theme.colors.background,
+                            backgroundColor: theme.colors.background[0],
                         },
                     })}
                 >
@@ -387,7 +387,7 @@ export const CatalogMetadata: FC = () => {
                             <Paper
                                 withBorder
                                 sx={(theme) => ({
-                                    backgroundColor: theme.colors.background,
+                                    backgroundColor: theme.colors.background[0],
                                     border: `1px solid ${theme.colors.ldGray[9]}`,
                                     borderRadius: theme.radius.sm,
                                     padding: 4,
@@ -404,7 +404,7 @@ export const CatalogMetadata: FC = () => {
                             <Paper
                                 withBorder
                                 sx={(theme) => ({
-                                    backgroundColor: theme.colors.background,
+                                    backgroundColor: theme.colors.background[0],
                                     border: `1px solid ${theme.colors.ldGray[9]}`,
                                     borderRadius: theme.radius.sm,
                                     padding: 4,
@@ -416,7 +416,7 @@ export const CatalogMetadata: FC = () => {
                             <Paper
                                 withBorder
                                 sx={(theme) => ({
-                                    backgroundColor: theme.colors.background,
+                                    backgroundColor: theme.colors.background[0],
                                     border: `1px solid ${theme.colors.ldGray[9]}`,
                                     borderRadius: theme.radius.sm,
                                     padding: 4,

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
@@ -101,7 +101,7 @@ export const SuggestionList = forwardRef<
                                         fontWeight: 400,
                                         textAlign: 'left',
                                         backgroundColor:
-                                            theme.colors.background,
+                                            theme.colors.background[0],
                                         color:
                                             index === selectedIndex
                                                 ? theme.colors.blue[6]

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
@@ -134,7 +134,7 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
             fz={14}
             sx={(theme) => ({
                 '&[data-with-border]': {
-                    backgroundColor: theme.colors.background,
+                    backgroundColor: theme.colors.background[0],
                     borderRadius: theme.radius.md,
                     border: `1px solid ${
                         selected ? theme.colors.blue[5] : theme.colors.ldGray[3]

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -88,7 +88,7 @@ const EditPopover: FC<EditPopoverProps> = ({
                     sx={(theme) => ({
                         visibility: hovered || opened ? 'visible' : 'hidden',
                         '&:hover': {
-                            backgroundColor: theme.colors.background,
+                            backgroundColor: theme.colors.background[0],
                         },
                     })}
                     size="sm"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -565,7 +565,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             indicator: {
                                 borderRadius: theme.radius.md,
                                 border: `1px solid ${theme.colors.ldGray[2]}`,
-                                backgroundColor: theme.colors.background,
+                                backgroundColor: theme.colors.background[0],
                                 boxShadow: theme.shadows.subtle,
                             },
                         })}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -129,7 +129,7 @@ const TooltipContainer: FC<{
         p="sm"
         spacing="xs"
         sx={(theme) => ({
-            backgroundColor: theme.colors.background,
+            backgroundColor: theme.colors.background[0],
             borderRadius: theme.radius.md,
             border: `1px solid ${theme.colors.ldGray[2]}`,
             boxShadow:

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -637,7 +637,7 @@ const SchedulerForm: FC<Props> = ({
                 <Tabs.Panel value="setup" mt="md">
                     <Stack
                         sx={(theme) => ({
-                            backgroundColor: theme.colors.background,
+                            backgroundColor: theme.colors.background[0],
                             paddingRight: theme.spacing.xl,
                         })}
                         spacing="xl"

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalFooter.tsx
@@ -31,7 +31,7 @@ const SchedulersModalFooter = ({
             position="apart"
             sx={(theme) => ({
                 position: 'sticky',
-                backgroundColor: theme.colors.background,
+                backgroundColor: theme.colors.background[0],
                 borderTop: `1px solid ${theme.colors.ldGray[4]}`,
                 bottom: 0,
                 zIndex: 2,

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -228,7 +228,7 @@ export const SyncModalView: FC<{ chartUuid: string }> = ({ chartUuid }) => {
             <Flex
                 sx={(theme) => ({
                     position: 'sticky',
-                    backgroundColor: theme.colors.background,
+                    backgroundColor: theme.colors.background[0],
                     borderTop: `1px solid ${theme.colors.ldGray[4]}`,
                     bottom: 0,
                     zIndex: 2,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Updated theme color references to use indexed notation for background and foreground colors. This change ensures proper color rendering in both light and dark themes by accessing colors through their array indices (e.g., `theme.colors.background[0]` instead of `theme.colors.background`).

Also improved color contrast in the LightTable component by using theme-aware color selections for selected states and borders, with specific adjustments for dark mode.