### PR TITLE
feat: add dark mode feature flag and theme switcher

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -69,6 +69,11 @@ export enum FeatureFlags {
      * Enable period-over-period comparisons option
      */
     PeriodOverPeriod = 'pop',
+
+    /**
+     * Dark mode
+     */
+    DarkMode = 'dark-mode',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/NavBar/ThemeSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher.tsx
@@ -1,11 +1,16 @@
+import { FeatureFlags } from '@lightdash/common';
 import { Tooltip } from '@mantine-8/core';
 import { Button, useMantineColorScheme } from '@mantine/core';
 import { IconMoonStars, IconSun } from '@tabler/icons-react';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
 
 export const ThemeSwitcher: FC<{}> = ({}) => {
+    const isDarkModeEnabled = useFeatureFlagEnabled(FeatureFlags.DarkMode);
     const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+
+    if (!isDarkModeEnabled) return null;
 
     return (
         <Tooltip label={colorScheme === 'dark' ? 'Light mode' : 'Dark mode'}>


### PR DESCRIPTION
### Description:
Added a new feature flag for Dark Mode and updated the ThemeSwitcher component to only render when the feature flag is enabled. This allows us to gradually roll out the dark mode feature to users.

diff --git packages/common/src/types/featureFlags.ts packages/common/src/types/featureFlags.ts