### PR TITLE
'fix: missing bottom border on last row in pivoted tables'

### DIFF
--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -112,6 +112,40 @@ export const useTableStyles = createStyles((theme) => {
                     boxShadow: 'none !important',
                 },
             },
+
+            /* Virtual padding rows (used for virtualized scrolling) should have no borders */
+            '.virtual-padding-row, .virtual-padding-row > *': {
+                boxShadow: 'none !important',
+                '&:hover': {
+                    boxShadow: 'none !important',
+                },
+            },
+
+            /* When virtual padding row exists, ensure the last data row has no bottom border */
+            '> tbody:last-child > *:nth-last-child(2):not(.virtual-padding-row) > *': {
+                boxShadow: `inset -1px 0 0 0 ${borderColor}`,
+                '&:hover': {
+                    boxShadow: `inset -1px 0 0 0 ${borderColor} !important`,
+                },
+            },
+
+            /* Last data row, last cell when virtual padding exists */
+            '> tbody:last-child > *:nth-last-child(2):not(.virtual-padding-row) > *:last-child':
+                {
+                    boxShadow: 'none',
+                    '&:hover': {
+                        boxShadow: 'none !important',
+                    },
+                },
+
+            /* Last data row, first cell when virtual padding exists */
+            '> tbody:last-child > *:nth-last-child(2):not(.virtual-padding-row) > *:first-child':
+                {
+                    boxShadow: 'none',
+                    '&:hover': {
+                        boxShadow: 'none !important',
+                    },
+                },
         },
     };
 });

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -77,7 +77,7 @@ const VirtualizedArea: FC<{
     height: number;
 }> = ({ cellCount, height }) => {
     return (
-        <Table.Row index={-1}>
+        <Table.Row index={-1} className="virtual-padding-row">
             {[...Array(cellCount)].map((_, index) => (
                 <Table.Cell key={index} h={height} />
             ))}


### PR DESCRIPTION
'Fixed a visual rendering issue where the last visible row in pivoted table charts was missing its bottom border when virtual scrolling was enabled. The issue occurred because virtual padding rows were being rendered as the last child of the table body, preventing the CSS :last-child selector from properly removing borders on the actual last data row. Added a 'virtual-padding-row' class to identify virtual padding elements and updated CSS selectors to correctly handle border styling when virtual scrolling is present.'