### PR TITLE
fix: missing bottom border on table chart last row

### DIFF
--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -97,6 +97,17 @@ export const Table = styled.table<{ $showFooter?: boolean }>`
         box-shadow: inset 1px 0 0 0 rgba(17, 20, 24, 0.15);
     }
 
+    /* Add bottom border to last row to close the table */
+    tbody tr:last-child td {
+        box-shadow: inset 0 1px 0 0 rgba(17, 20, 24, 0.15),
+                    inset 0 -1px 0 0 rgba(17, 20, 24, 0.15) !important;
+    }
+
+    tbody tr:last-child td:not(:first-child) {
+        box-shadow: inset 1px 1px 0 0 rgba(17, 20, 24, 0.15),
+                    inset 0 -1px 0 0 rgba(17, 20, 24, 0.15) !important;
+    }
+
     /* FIXME: everything above this line is copied from blueprint's table css */
 
     thead {


### PR DESCRIPTION
This fix adds a bottom border to the last row of table charts by extending the existing box-shadow border system. The table was appearing visually "open" at the bottom because only top borders were applied to each row, leaving the final row without a closing border. The fix adds CSS rules that apply bottom borders (using `inset 0 -1px` box-shadow) to all cells in the last row, maintaining consistency with the existing Blueprint CSS pattern used throughout the table component.