### PR TITLE
feat: add row grouping with visual cell merging for tables

### DIFF
--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -117,6 +117,8 @@ export type VizPieChartDisplay = {
 export type VizTableDisplay = {
     // TODO: split table display config out of table config
     // On vis column config, visible, label and frozen, at least seem like display options
+    mergeConsecutiveDuplicates?: boolean; // Enable/disable visual row merging
+    mergeColumns?: string[]; // Which columns to merge consecutive duplicate values
 };
 
 export type PivotIndexColum = { reference: string; type: VizIndexType };

--- a/packages/frontend/src/components/DataViz/config/TableVisConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/TableVisConfiguration.tsx
@@ -1,7 +1,13 @@
 import { type VizColumn } from '@lightdash/common';
-import { ActionIcon, ScrollArea, TextInput } from '@mantine/core';
+import {
+    ActionIcon,
+    MultiSelect,
+    ScrollArea,
+    Switch,
+    TextInput,
+} from '@mantine/core';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useMemo, type FC } from 'react';
 import {
     useAppDispatch as useVizDispatch,
     useAppSelector as useVizSelector,
@@ -11,6 +17,7 @@ import MantineIcon from '../../common/MantineIcon';
 import { TableFieldIcon } from '../Icons';
 import {
     updateColumnVisibility,
+    updateDisplay,
     updateFieldLabel,
 } from '../store/tableVisSlice';
 
@@ -20,6 +27,18 @@ const TableVisConfiguration: FC<{ columns: VizColumn[] }> = ({ columns }) => {
     const columnsConfig = useVizSelector(
         (state) => state.tableVisConfig.columns,
     );
+    const display = useVizSelector((state) => state.tableVisConfig.display);
+
+    // Get visible columns for merge column selection
+    const visibleColumnOptions = useMemo(() => {
+        if (!columnsConfig) return [];
+        return Object.keys(columnsConfig)
+            .filter((ref) => columnsConfig[ref].visible)
+            .map((ref) => ({
+                value: ref,
+                label: columnsConfig[ref].label,
+            }));
+    }, [columnsConfig]);
 
     if (!columnsConfig) {
         return null;
@@ -35,6 +54,43 @@ const TableVisConfiguration: FC<{ columns: VizColumn[] }> = ({ columns }) => {
             mb="md"
         >
             <Config>
+                <Config.Section>
+                    <Config.Heading>Display</Config.Heading>
+
+                    <Switch
+                        label="Merge consecutive duplicate values"
+                        description="Visually merge cells with consecutive duplicate values in selected columns"
+                        checked={display?.mergeConsecutiveDuplicates ?? false}
+                        onChange={(e) =>
+                            dispatch(
+                                updateDisplay({
+                                    mergeConsecutiveDuplicates:
+                                        e.currentTarget.checked,
+                                }),
+                            )
+                        }
+                    />
+
+                    {display?.mergeConsecutiveDuplicates && (
+                        <MultiSelect
+                            label="Columns to merge"
+                            description="Select which columns should have consecutive duplicates merged"
+                            placeholder="Select columns..."
+                            data={visibleColumnOptions}
+                            value={display?.mergeColumns ?? []}
+                            onChange={(value) =>
+                                dispatch(
+                                    updateDisplay({
+                                        mergeColumns: value,
+                                    }),
+                                )
+                            }
+                            searchable
+                            clearable
+                        />
+                    )}
+                </Config.Section>
+
                 <Config.Section>
                     <Config.Heading>Column labels</Config.Heading>
 

--- a/packages/frontend/src/components/DataViz/hooks/useTableDataModel.ts
+++ b/packages/frontend/src/components/DataViz/hooks/useTableDataModel.ts
@@ -114,5 +114,6 @@ export const useTableDataModel = ({
         getTableData,
         paddingTop,
         paddingBottom,
+        tableModel,
     };
 };

--- a/packages/frontend/src/components/DataViz/store/selectors.ts
+++ b/packages/frontend/src/components/DataViz/store/selectors.ts
@@ -1,7 +1,10 @@
 import {
     ChartKind,
     type AllVizChartConfig,
+    type CartesianChartDisplay,
     type PivotChartLayout,
+    type VizPieChartDisplay,
+    type VizTableDisplay,
 } from '@lightdash/common';
 import { createSelector } from 'reselect';
 import { type RootState } from '../../../features/sqlRunner/store';
@@ -134,16 +137,26 @@ export const selectCompleteConfigByKind = createSelector(
                 type: chartKind,
                 metadata: metadata,
                 columns: fieldConfig as NonNullable<TableVizState['columns']>,
-                display: display,
-            };
+                display: display as VizTableDisplay | undefined,
+            } satisfies AllVizChartConfig;
         }
 
+        if (chartKind === ChartKind.PIE) {
+            return {
+                type: chartKind,
+                metadata: metadata,
+                fieldConfig: fieldConfig as PivotChartLayout,
+                display: display as VizPieChartDisplay | undefined,
+            } satisfies AllVizChartConfig;
+        }
+
+        // ChartKind.VERTICAL_BAR or ChartKind.LINE
         return {
             type: chartKind,
             metadata: metadata,
             fieldConfig: fieldConfig as PivotChartLayout,
-            display: display,
-        };
+            display: display as CartesianChartDisplay | undefined,
+        } satisfies AllVizChartConfig;
     },
 );
 

--- a/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/tableVisSlice.ts
@@ -57,6 +57,15 @@ export const tableVisSlice = createSlice({
                 columns[reference].visible = visible;
             }
         },
+        updateDisplay: (
+            state,
+            action: PayloadAction<Partial<VizTableDisplay>>,
+        ) => {
+            state.display = {
+                ...state.display,
+                ...action.payload,
+            };
+        },
     },
     extraReducers: (builder) => {
         builder.addCase(setChartOptionsAndConfig, (state, action) => {
@@ -86,5 +95,5 @@ export const tableVisSlice = createSlice({
     },
 });
 
-export const { updateFieldLabel, updateColumnVisibility } =
+export const { updateFieldLabel, updateColumnVisibility, updateDisplay } =
     tableVisSlice.actions;

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -3,6 +3,7 @@ import {
     type IResultsRunner,
     type RawResultRow,
     type VizColumnsConfig,
+    type VizTableDisplay,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
 import { Badge, Flex, Group, type FlexProps } from '@mantine/core';
@@ -25,6 +26,7 @@ type TableProps<T extends IResultsRunner> = {
     flexProps?: FlexProps;
     thSortConfig?: VizTableHeaderSortConfig;
     onTHClick?: (fieldName: string) => void;
+    display?: VizTableDisplay;
 };
 
 export const Table = <T extends IResultsRunner>({
@@ -33,6 +35,7 @@ export const Table = <T extends IResultsRunner>({
     flexProps,
     thSortConfig,
     onTHClick,
+    display,
 }: TableProps<T>) => {
     const {
         tableWrapperRef,
@@ -40,6 +43,7 @@ export const Table = <T extends IResultsRunner>({
         getTableData,
         paddingTop,
         paddingBottom,
+        tableModel,
     } = useTableDataModel({
         config: {
             columns: columnsConfig,
@@ -49,6 +53,7 @@ export const Table = <T extends IResultsRunner>({
 
     const columnsCount = getColumnsCount();
     const { headerGroups, virtualRows, rowModelRows } = getTableData();
+    const rowSpanMap = tableModel.getRowSpanMap(display);
 
     return (
         <Flex
@@ -149,6 +154,12 @@ export const Table = <T extends IResultsRunner>({
                                             | RawResultRow[0]
                                             | undefined;
 
+                                        const spanKey = `${cell.column.id}-${index}`;
+                                        const spanInfo = rowSpanMap.get(spanKey);
+
+                                        // Skip cells that are part of a merged group
+                                        if (spanInfo?.skip) return null;
+
                                         return (
                                             <BodyCell
                                                 key={cell.id}
@@ -162,6 +173,7 @@ export const Table = <T extends IResultsRunner>({
                                                         ''
                                                     ).length > SMALL_TEXT_LENGTH
                                                 }
+                                                rowSpan={spanInfo?.rowspan || 1}
                                             >
                                                 {cell.getIsPlaceholder()
                                                     ? null

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -27,7 +27,7 @@ import { type CellContextMenuProps } from '../types';
 import CellMenu from './CellMenu';
 import CellTooltip from './CellTooltip';
 
-interface CommonBodyCellProps {
+export interface CommonBodyCellProps {
     cell: Cell<ResultRow, unknown> | Cell<RawResultRow, unknown>;
     index: number;
     isNumericItem: boolean;
@@ -40,6 +40,7 @@ interface CommonBodyCellProps {
     isLargeText?: boolean;
     tooltipContent?: string;
     minimal?: boolean;
+    rowSpan?: number;
 }
 
 const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
@@ -56,6 +57,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
     style,
     tooltipContent,
     minimal = false,
+    rowSpan,
 }) => {
     const elementRef = useRef<HTMLTableCellElement>(null);
     const { showToastSuccess } = useToaster();
@@ -155,6 +157,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                     typeof displayValue === 'string' &&
                     displayValue.includes('\n')
                 }
+                rowSpan={rowSpan}
                 onClick={canHaveMenu ? toggleMenu : undefined}
                 onMouseEnter={canHaveTooltip ? startTooltipTimer : undefined}
                 onMouseLeave={

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -726,6 +726,11 @@ export const ContentPanel: FC = () => {
                                                                             ?.columns ??
                                                                         {}
                                                                     }
+                                                                    display={
+                                                                        activeConfigs
+                                                                            .tableConfig
+                                                                            ?.display
+                                                                    }
                                                                     flexProps={{
                                                                         mah: '100%',
                                                                     }}


### PR DESCRIPTION
Implements visual row grouping/merging functionality for table visualizations. Users can now configure tables to visually merge cells with consecutive duplicate values, similar to merged cells in Excel or Google Sheets.

## Changes

### Core Data Model (packages/common)
- Added `mergeConsecutiveDuplicates` and `mergeColumns` fields to `VizTableDisplay` type
- Implemented `getRowSpanMap()` method in `TableDataModel` to calculate rowspan information for consecutive duplicate values
- Added `RowSpanInfo` type to track cell spanning metadata

### Frontend Components (packages/frontend)
- Updated `Table` component to support rowspan attribute on table cells
- Modified `BodyCell` component to accept and pass through `rowSpan` prop
- Enhanced `useTableDataModel` hook to expose `tableModel` for rowspan calculations

### Configuration UI (packages/frontend)
- Added "Display" section in `TableVisConfiguration` with:
  - Toggle switch to enable/disable row merging
  - Multi-select dropdown to choose which columns should have consecutive duplicates merged
- Added `updateDisplay` action to `tableVisSlice` Redux slice

### State Management (packages/frontend)
- Updated Redux selectors with proper TypeScript type narrowing for display configs
- Enhanced `TableVizState` to include display configuration

## Implementation Details

- The rowspan calculation algorithm iterates through all rows and detects consecutive cells with identical values
- Cells in the first occurrence of a duplicate group receive the appropriate rowspan value
- Subsequent cells in the group are marked to be skipped during rendering
- Only visible columns can be selected for merging
- Feature is opt-in and disabled by default

## Technical Notes

- All TypeScript type checks pass
- Compatible with existing table features (sorting, filtering, virtualization)
- No breaking changes to existing APIs

https://lightdash.slack.com/archives/C03MCQ08UKS/p1764153846228709