### PR TITLE
fix: improve null/undefined handling for dbt metrics

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -243,7 +243,7 @@ export const compile = async (options: CompileHandlerOptions) => {
         console.error('');
 
         explores = [...validExplores, ...failedExplores];
-        dbtMetrics = manifest.metrics;
+        dbtMetrics = manifest.metrics ?? null;
     }
 
     explores.forEach((e) => {
@@ -264,7 +264,7 @@ export const compile = async (options: CompileHandlerOptions) => {
     );
 
     const metricsCount =
-        dbtMetrics === null ? 0 : Object.values(dbtMetrics).length;
+        dbtMetrics == null ? 0 : Object.values(dbtMetrics).length;
     await LightdashAnalytics.track({
         event: 'compile.completed',
         properties: {


### PR DESCRIPTION
Enhances the existing fix for handling empty/undefined dbt metrics in the manifest by using more robust null checking. This ensures the CLI doesn't crash with TypeError when dbt projects have no metrics defined.

Changes:
- Use nullish coalescing operator (??) when assigning dbtMetrics to explicitly convert undefined to null
- Replace strict equality (=== null) with loose equality (== null) to catch both null and undefined cases

This builds on the previous fix in commit 4e12b00 and provides additional safety against edge cases.