### PR TITLE
fix: validate CACHE_STALE_TIME_SECONDS as integer

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1533,10 +1533,9 @@ export const parseConfig = (): LightdashConfig => {
             cacheEnabled: process.env.RESULTS_CACHE_ENABLED === 'true',
             autocompleteEnabled:
                 process.env.AUTOCOMPLETE_CACHE_ENABLED === 'true',
-            cacheStateTimeSeconds: parseInt(
-                process.env.CACHE_STALE_TIME_SECONDS || '86400', // A day in seconds
-                10,
-            ),
+            cacheStateTimeSeconds:
+                getIntegerFromEnvironmentVariable('CACHE_STALE_TIME_SECONDS') ||
+                86400, // A day in seconds
             s3: parseResultsS3Config(),
         },
         slack: {


### PR DESCRIPTION
Fixes SQL Runner errors caused by invalid CACHE_STALE_TIME_SECONDS configuration. The environment variable now uses getIntegerFromEnvironmentVariable() helper to validate the value is a proper integer at startup, preventing NaN values from causing database insertion failures with invalid timestamps. If an invalid value is provided, the application will fail fast with a clear error message instead of failing later during query execution.