### PR TITLE
fix: AI agent polling race condition causing repetition

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1149,6 +1149,16 @@ export class AiAgentService {
             );
         }
 
+        // Check if prompt already has a response (prevent duplicate processing)
+        if (prompt.response !== null) {
+            Logger.warn(
+                `Prompt ${prompt.promptUuid} already has a response, skipping duplicate stream request`,
+            );
+            throw new Error(
+                'This message has already been processed. Please refresh to see the response.',
+            );
+        }
+
         const chatHistoryMessages = await this.getChatHistoryFromThreadMessages(
             threadMessages,
             {


### PR DESCRIPTION
## Summary

Fixes a race condition in the AI agent thread polling mechanism that could cause the bot to appear stuck and repeat responses.

### Frontend Changes
- Added a 3-second cooldown period after streaming completes before polling can restart
- Prevents immediate polling restart that could trigger rapid refetches during the window when streaming finishes but the message status hasn't been updated yet
- Uses `useRef` to track when streaming stops and schedules a single refetch after the cooldown period

### Backend Changes  
- Added duplicate stream protection to check if a prompt already has a response before initiating a new stream
- Prevents multiple concurrent stream requests for the same message
- Returns clear error message when duplicate processing is attempted

## Test Plan

Typecheck passed for both frontend and backend:
- Frontend: `pnpm -F frontend typecheck` ✓
- Backend: `pnpm -F backend typecheck` ✓

Manual testing recommended:
1. Send a message to an AI agent
2. Monitor network tab to confirm polling stops after streaming completes
3. Verify no repeated GET requests to `/threads/{uuid}` endpoint
4. Test with slow network conditions to ensure race condition is handled
5. Verify error handling if duplicate stream request is attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)