### PR TITLE
fix: missing bottom border on last row in pivoted tables

### DIFF
--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -73,19 +73,19 @@ export const useTableStyles = createStyles((theme) => {
                 },
             },
 
-            /* Body last row, last cell: no right or bottom border */
+            /* Body last row, last cell: no right border, keep bottom border */
             '> tbody:last-child > *:last-child > *:last-child': {
-                boxShadow: 'none',
+                boxShadow: `inset 0 -1px 0 0 ${borderColor}`,
                 '&:hover': {
-                    boxShadow: 'none !important',
+                    boxShadow: `inset 0 -1px 0 0 ${borderColor} !important`,
                 },
             },
 
-            /* Body last row, first cell: no left or bottom border */
+            /* Body last row, first cell: no left border, keep bottom border */
             '> tbody:last-child > *:last-child > *:first-child': {
-                boxShadow: 'none',
+                boxShadow: `inset 0 -1px 0 0 ${borderColor}`,
                 '&:hover': {
-                    boxShadow: 'none !important',
+                    boxShadow: `inset 0 -1px 0 0 ${borderColor} !important`,
                 },
             },
 
@@ -97,19 +97,19 @@ export const useTableStyles = createStyles((theme) => {
                 },
             },
 
-            /* Footer last row, last cell: no right or bottom border */
+            /* Footer last row, last cell: no right border, keep bottom border */
             '> tfoot:last-child > *:last-child > *:last-child': {
-                boxShadow: 'none',
+                boxShadow: `inset 0 -1px 0 0 ${borderColor}`,
                 '&:hover': {
-                    boxShadow: 'none !important',
+                    boxShadow: `inset 0 -1px 0 0 ${borderColor} !important`,
                 },
             },
 
-            /* Footer last row, first cell: no left or bottom border */
+            /* Footer last row, first cell: no left border, keep bottom border */
             '> tfoot:last-child > *:last-child > *:first-child': {
-                boxShadow: 'none',
+                boxShadow: `inset 0 -1px 0 0 ${borderColor}`,
                 '&:hover': {
-                    boxShadow: 'none !important',
+                    boxShadow: `inset 0 -1px 0 0 ${borderColor} !important`,
                 },
             },
         },


### PR DESCRIPTION
This fix addresses a visual bug where the last row of pivoted table charts appeared incomplete or broken due to missing bottom borders. The issue was caused by CSS rules that removed all borders (including the bottom border) from corner cells in the last row using `boxShadow: 'none'`. The fix ensures that last row cells maintain their bottom borders while still removing side borders to avoid double-borders with the container, providing proper visual closure for both body and footer table sections.