### PR TITLE
fix: scheduled alerts auto-disabling after first run

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -126,7 +126,7 @@ const DEFAULT_VALUES_ALERT = {
             value: 0,
         },
     ],
-    notificationFrequency: NotificationFrequency.ONCE,
+    notificationFrequency: NotificationFrequency.ALWAYS,
 };
 
 const MAX_SLACK_CHANNELS = 100000;


### PR DESCRIPTION
Changed the default notification frequency for threshold alerts from ONCE to ALWAYS. Previously, alerts would automatically disable after the first successful notification, which was unexpected behavior for users. With this change, alerts will continue to run on their scheduled interval unless explicitly disabled by the user.