### PR TITLE
fix: timezone conversion for DATE literals in Snowflake

### DIFF
--- a/packages/frontend/src/components/DataViz/formatters/formatRowValueFromWarehouse.ts
+++ b/packages/frontend/src/components/DataViz/formatters/formatRowValueFromWarehouse.ts
@@ -9,5 +9,12 @@ export const formatRowValueFromWarehouse = (value: RawResultRow[string]) => {
     if (value === null) return '∅';
     if (value === undefined) return '-';
     if (value instanceof Date) return value.toISOString();
+
+    // Date strings in YYYY-MM-DD format are already properly formatted
+    // They don't need conversion as they represent calendar dates without timezone
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return value;
+    }
+
     return `${value}`;
 };


### PR DESCRIPTION
Fixed an issue where DATE type values from Snowflake queries were being incorrectly converted by timezone offsets, causing dates to shift (e.g., '2025-01-01' appearing as '2024-12-31'). The fix converts Snowflake DATE types to YYYY-MM-DD string format before they undergo timezone conversion, preserving the calendar date as intended.