### PR TITLE
feat: apply field ordering within groups

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.test.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.test.ts
@@ -125,7 +125,11 @@ function createSectionNodeMaps(
         if (Object.keys(dimensionsMap).length > 0) {
             maps.set(
                 `${tableName}-dimensions`,
-                getNodeMapFromItemsMap(dimensionsMap, table.groupDetails),
+                getNodeMapFromItemsMap(
+                    dimensionsMap,
+                    table.groupDetails,
+                    table.orderFieldsBy,
+                ),
             );
         }
 
@@ -136,7 +140,11 @@ function createSectionNodeMaps(
         if (Object.keys(metricsMap).length > 0) {
             maps.set(
                 `${tableName}-metrics`,
-                getNodeMapFromItemsMap(metricsMap, table.groupDetails),
+                getNodeMapFromItemsMap(
+                    metricsMap,
+                    table.groupDetails,
+                    table.orderFieldsBy,
+                ),
             );
         }
 
@@ -150,7 +158,11 @@ function createSectionNodeMaps(
             );
             maps.set(
                 `${tableName}-custom-metrics`,
-                getNodeMapFromItemsMap(customMetricsMap, table.groupDetails),
+                getNodeMapFromItemsMap(
+                    customMetricsMap,
+                    table.groupDetails,
+                    table.orderFieldsBy,
+                ),
             );
         }
     });

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
@@ -565,7 +565,11 @@ export function getNodeMapsForVirtualization(
         if (Object.keys(dimensionsMap).length > 0) {
             maps.set(
                 `${tableName}-dimensions`,
-                getNodeMapFromItemsMap(dimensionsMap, table.groupDetails),
+                getNodeMapFromItemsMap(
+                    dimensionsMap,
+                    table.groupDetails,
+                    table.orderFieldsBy,
+                ),
             );
         }
 
@@ -576,7 +580,11 @@ export function getNodeMapsForVirtualization(
         if (Object.keys(metricsMap).length > 0) {
             maps.set(
                 `${tableName}-metrics`,
-                getNodeMapFromItemsMap(metricsMap, table.groupDetails),
+                getNodeMapFromItemsMap(
+                    metricsMap,
+                    table.groupDetails,
+                    table.orderFieldsBy,
+                ),
             );
         }
 
@@ -590,7 +598,11 @@ export function getNodeMapsForVirtualization(
             );
             maps.set(
                 `${tableName}-custom-metrics`,
-                getNodeMapFromItemsMap(customMetricsMap, table.groupDetails),
+                getNodeMapFromItemsMap(
+                    customMetricsMap,
+                    table.groupDetails,
+                    table.orderFieldsBy,
+                ),
             );
         }
 
@@ -603,7 +615,11 @@ export function getNodeMapsForVirtualization(
             );
             maps.set(
                 `${tableName}-custom-dimensions`,
-                getNodeMapFromItemsMap(customDimensionsMap, table.groupDetails),
+                getNodeMapFromItemsMap(
+                    customDimensionsMap,
+                    table.groupDetails,
+                    table.orderFieldsBy,
+                ),
             );
         }
     });


### PR DESCRIPTION
This change enables the `order_fields_by` configuration to control the ordering of fields within groups, not just at the top level. When users set `order_fields_by: 'index'` in their YAML configuration, fields within groups will now be ordered according to their definition sequence in the YAML file. Similarly, `order_fields_by: 'label'` will sort fields alphabetically within groups.

The fix modifies the tree building logic to apply the sorting strategy recursively to all children within group nodes, ensuring consistent ordering at every level of the field hierarchy.

[Source](https://lightdash.slack.com/archives/C03MCQ08UKS/p1763998427714749)

Closes #7125