### PR TITLE
fix: unable to remove deprecated dimensions/metrics from charts

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -76,6 +76,14 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         [dispatch],
     );
 
+    const removeFieldCallback = useCallback(
+        (fieldId: string, _isDimension: boolean) => {
+            // Always remove the field, regardless of dimension type
+            dispatch(explorerActions.removeField(fieldId));
+        },
+        [dispatch],
+    );
+
     const isVisualizationConfigOpen = useExplorerSelector(
         selectIsVisualizationConfigOpen,
     );
@@ -236,6 +244,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                     <ExploreTree
                         explore={explore}
                         onSelectedFieldChange={toggleActiveField}
+                        onRemoveMissingField={removeFieldCallback}
                     />
                 </ItemDetailProvider>
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeItem.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualTreeItem.tsx
@@ -12,6 +12,7 @@ interface VirtualTreeItemProps {
     onToggleTable: (tableName: string) => void;
     onToggleGroup: (groupKey: string) => void;
     onSelectedFieldChange: (fieldId: string, isDimension: boolean) => void;
+    onRemoveMissingField: (fieldId: string, isDimension: boolean) => void;
 }
 
 /**
@@ -24,6 +25,7 @@ const VirtualTreeItemComponent: FC<VirtualTreeItemProps> = ({
     onToggleTable,
     onToggleGroup,
     onSelectedFieldChange,
+    onRemoveMissingField,
 }) => {
     switch (item.type) {
         case 'table-header':
@@ -39,7 +41,7 @@ const VirtualTreeItemComponent: FC<VirtualTreeItemProps> = ({
             return (
                 <VirtualMissingField
                     item={item}
-                    onRemove={onSelectedFieldChange}
+                    onRemove={onRemoveMissingField}
                 />
             );
         case 'tree-node':

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualizedTreeList.tsx
@@ -11,6 +11,7 @@ interface VirtualizedTreeListProps {
     onToggleTable: (tableName: string) => void;
     onToggleGroup: (groupKey: string) => void;
     onSelectedFieldChange: (fieldId: string, isDimension: boolean) => void;
+    onRemoveMissingField: (fieldId: string, isDimension: boolean) => void;
 }
 
 const themeOverride = getMantineThemeOverride({
@@ -39,6 +40,7 @@ const VirtualizedTreeListComponent: FC<VirtualizedTreeListProps> = ({
     onToggleTable,
     onToggleGroup,
     onSelectedFieldChange,
+    onRemoveMissingField,
 }) => {
     const { items, sectionContexts } = data;
     const parentRef = useRef<HTMLDivElement>(null);
@@ -156,6 +158,7 @@ const VirtualizedTreeListComponent: FC<VirtualizedTreeListProps> = ({
                                     onSelectedFieldChange={
                                         onSelectedFieldChange
                                     }
+                                    onRemoveMissingField={onRemoveMissingField}
                                 />
                             </div>
                         );

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -38,6 +38,7 @@ import VirtualizedTreeList from './TableTree/Virtualization/VirtualizedTreeList'
 type ExploreTreeProps = {
     explore: Explore;
     onSelectedFieldChange: (fieldId: string, isDimension: boolean) => void;
+    onRemoveMissingField: (fieldId: string, isDimension: boolean) => void;
 };
 
 type Records = Record<string, AdditionalMetric | Dimension | Metric>;
@@ -45,6 +46,7 @@ type Records = Record<string, AdditionalMetric | Dimension | Metric>;
 const ExploreTreeComponent: FC<ExploreTreeProps> = ({
     explore,
     onSelectedFieldChange,
+    onRemoveMissingField,
 }) => {
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
     const customDimensions = useExplorerSelector(selectCustomDimensions);
@@ -237,6 +239,7 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
                 onToggleTable={toggleTable}
                 onToggleGroup={toggleGroup}
                 onSelectedFieldChange={onSelectedFieldChange}
+                onRemoveMissingField={onRemoveMissingField}
             />
         </>
     );


### PR DESCRIPTION
## Summary
Fixed a bug where clicking on deprecated/missing fields in the chart editor would not remove them from the chart. The issue was caused by using a toggle action instead of a direct remove action, which could add the field back depending on its state in the query.

## Changes
* Added `removeFieldCallback` in `ExplorePanel` that dispatches the `removeField` action
* Introduced `onRemoveMissingField` prop that is threaded through `ExploreTree`, `VirtualizedTreeList`, and `VirtualTreeItem` components
* Updated `VirtualTreeItem` to use `onRemoveMissingField` callback for missing-field items instead of `onSelectedFieldChange`
* This ensures missing fields are always removed, never toggled, while preserving toggle behavior for regular field selection

## Test plan
- [x] Typecheck passes
- [ ] Manual test: Open a chart with deprecated/missing fields
- [ ] Manual test: Click on a missing field alert to verify it's removed
- [ ] Manual test: Verify the field is removed from dimensions/metrics arrays
- [ ] Manual test: Ensure regular field selection still works with toggle behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)