### PR TITLE
fix: prevent login with conflicting OAuth identities

### DIFF
--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -672,8 +672,11 @@ export class UserService extends BaseService {
                 identities.map((identity) => identity.userUuid),
             );
             if (identitiesUsers.length > 1) {
-                this.logger.warn(
+                this.logger.error(
                     `Multiple openid identities found with the same email ${openIdUser.openId.email}`,
+                );
+                throw new AuthorizationError(
+                    'Multiple accounts found with this email address. Please contact your administrator to resolve this account conflict.',
                 );
             } else if (identitiesUsers.length === 1) {
                 const sessionUser = await this.userModel.findSessionUserByUUID(


### PR DESCRIPTION
When OIDC linking is enabled and multiple user accounts share the same email address with different OAuth identities, the authentication system now properly throws an error instead of logging a warning and continuing. This prevents authentication conflicts and improves security by requiring administrators to resolve account conflicts before users can log in.

The fix changes the behavior in UserService.ts to throw an AuthorizationError with a clear message directing users to contact their administrator when multiple OpenID identities are detected for the same email address.