### PR TITLE
feat: add parameter interpolation support for dimension and metric labels

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -39,6 +39,7 @@ import {
     getAvailableParametersFromTables,
     getParameterReferences,
     getParameterReferencesFromSqlAndFormat,
+    getParameterReferencesFromSqlFormatAndLabel,
     validateParameterNames,
     validateParameterReferences,
 } from './parameters';
@@ -488,10 +489,11 @@ export class ExploreCompiler {
 
         const compiledSql = compiledMetric.sql;
 
-        // Extract parameter references from both SQL and format string
-        const parameterReferences = getParameterReferencesFromSqlAndFormat(
+        // Extract parameter references from SQL, format string, and label
+        const parameterReferences = getParameterReferencesFromSqlFormatAndLabel(
             compiledSql,
             typeof metric.format === 'string' ? metric.format : undefined,
+            metric.label,
         );
 
         validateParameterReferences(
@@ -655,10 +657,11 @@ export class ExploreCompiler {
 
         const compiledSql = compiledDimension.sql;
 
-        // Extract parameter references from both SQL and format string
-        const parameterReferences = getParameterReferencesFromSqlAndFormat(
+        // Extract parameter references from SQL, format string, and label
+        const parameterReferences = getParameterReferencesFromSqlFormatAndLabel(
             compiledSql,
             typeof dimension.format === 'string' ? dimension.format : undefined,
+            dimension.label,
         );
 
         validateParameterReferences(

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -64,6 +64,40 @@ export const getParameterReferencesFromSqlAndFormat = (
     );
 };
 
+/**
+ * Extracts and combines parameter references from SQL, format strings, and labels
+ * @param compiledSql - The compiled SQL to extract parameters from
+ * @param format - Optional format string to extract parameters from
+ * @param label - Optional label string to extract parameters from
+ * @returns An array of unique parameter names from all sources
+ */
+export const getParameterReferencesFromSqlFormatAndLabel = (
+    compiledSql: string,
+    format?: string,
+    label?: string,
+): string[] => {
+    const sqlParameterReferences = getParameterReferences(compiledSql);
+
+    const formatParameterReferences =
+        format && typeof format === 'string'
+            ? getParameterReferences(format, parameterReferencePattern)
+            : [];
+
+    const labelParameterReferences =
+        label && typeof label === 'string'
+            ? getParameterReferences(label, parameterReferencePattern)
+            : [];
+
+    // Combine and deduplicate parameter references from all sources
+    return Array.from(
+        new Set([
+            ...sqlParameterReferences,
+            ...formatParameterReferences,
+            ...labelParameterReferences,
+        ]),
+    );
+};
+
 export const validateParameterReferences = (
     tableName: string,
     parameterReferences: string[],

--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -23,6 +23,7 @@ import {
     isAdditionalMetric,
     type AdditionalMetric,
 } from '../types/metricQuery';
+import { evaluateConditionalFormatExpression } from './conditionalFormatExpressions';
 
 export const isNumericType = (
     type: DimensionType | MetricType | TableCalculationType,
@@ -59,16 +60,30 @@ export const getItemId = (
     return `${item.table}_${item.name.replaceAll('.', '__')}`;
 };
 
-export const getItemLabelWithoutTableName = (item: Item) => {
+export const getItemLabelWithoutTableName = (
+    item: Item,
+    parameters?: Record<string, unknown>,
+) => {
     if (isCustomDimension(item)) return item.name;
-    return isField(item) || isAdditionalMetric(item)
+
+    let label = isField(item) || isAdditionalMetric(item)
         ? `${item.label}`
         : item.displayName;
+
+    // Interpolate parameters in label if present
+    if (parameters && label.includes('${')) {
+        label = evaluateConditionalFormatExpression(label, parameters);
+    }
+
+    return label;
 };
 
-export const getItemLabel = (item: Item) =>
+export const getItemLabel = (
+    item: Item,
+    parameters?: Record<string, unknown>,
+) =>
     (isField(item) ? `${item.tableLabel} ` : '') +
-    getItemLabelWithoutTableName(item);
+    getItemLabelWithoutTableName(item, parameters);
 
 export function getItemType(
     item: ItemsMap[string] | AdditionalMetric,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -112,11 +112,18 @@ type TooltipOption = Omit<TooltipComponentOption, 'formatter'> & {
           >;
 };
 
-const getLabelFromField = (fields: ItemsMap, key: string | undefined) => {
+const getLabelFromField = (
+    fields: ItemsMap,
+    key: string | undefined,
+    parameters?: ParametersValuesMap,
+) => {
     const item = key ? fields[key] : undefined;
 
     if (item) {
-        return getDateGroupLabel(item) || getItemLabelWithoutTableName(item);
+        return (
+            getDateGroupLabel(item) ||
+            getItemLabelWithoutTableName(item, parameters)
+        );
     } else if (key) {
         return friendlyName(key);
     } else {
@@ -765,7 +772,7 @@ const getPivotSeries = ({
         dimensions: [
             {
                 name: xFieldHash,
-                displayName: getLabelFromField(itemsMap, xFieldHash),
+                displayName: getLabelFromField(itemsMap, xFieldHash, parameters),
             },
             {
                 name: yFieldHash,
@@ -775,6 +782,7 @@ const getPivotSeries = ({
                         ? `[${pivotLabel}] ${getLabelFromField(
                               itemsMap,
                               series.encode.yRef.field,
+                              parameters,
                           )}`
                         : pivotLabel,
             },
@@ -883,11 +891,11 @@ const getSimpleSeries = ({
     dimensions: [
         {
             name: xFieldHash,
-            displayName: getLabelFromField(itemsMap, xFieldHash),
+            displayName: getLabelFromField(itemsMap, xFieldHash, parameters),
         },
         {
             name: yFieldHash,
-            displayName: getLabelFromField(itemsMap, yFieldHash),
+            displayName: getLabelFromField(itemsMap, yFieldHash, parameters),
         },
     ],
     tooltip: {
@@ -1598,7 +1606,10 @@ const getEchartAxes = ({
                               : xAxisConfiguration?.[0]?.name ||
                                 (xAxisItem
                                     ? getDateGroupLabel(xAxisItem) ||
-                                      getItemLabelWithoutTableName(xAxisItem)
+                                      getItemLabelWithoutTableName(
+                                          xAxisItem,
+                                          parameters,
+                                      )
                                     : undefined),
                           nameLocation: 'center',
                           nameTextStyle: getAxisTitleStyle(),
@@ -1698,7 +1709,10 @@ const getEchartAxes = ({
                               ? yAxisConfiguration?.[0]?.name ||
                                 (yAxisItem
                                     ? getDateGroupLabel(yAxisItem) ||
-                                      getItemLabelWithoutTableName(yAxisItem)
+                                      getItemLabelWithoutTableName(
+                                          yAxisItem,
+                                          parameters,
+                                      )
                                     : undefined)
                               : getAxisName({
                                     isAxisTheSameForAllSeries,

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -1,6 +1,7 @@
 import {
     convertFormattedValue,
     getItemLabel,
+    getItemLabelWithoutTableName,
     isCustomDimension,
     isDimension,
     isField,
@@ -118,12 +119,12 @@ const useTableConfig = (
             const item = itemsMap[fieldId];
 
             if (isField(item) && !showTableNames) {
-                return item.label;
+                return getItemLabelWithoutTableName(item, parameters);
             } else {
-                return getItemLabel(item);
+                return getItemLabel(item, parameters);
             }
         },
-        [itemsMap, showTableNames],
+        [itemsMap, showTableNames, parameters],
     );
 
     const getFieldLabelOverride = useCallback(

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -201,10 +201,10 @@ const useBigNumberConfig = (
 
         return item
             ? shouldShowTableName
-                ? getItemLabel(item)
-                : getItemLabelWithoutTableName(item)
+                ? getItemLabel(item, parameters)
+                : getItemLabelWithoutTableName(item, parameters)
             : selectedField && friendlyName(selectedField);
-    }, [item, selectedField, showTableNamesInLabel]);
+    }, [item, selectedField, showTableNamesInLabel, parameters]);
 
     const [bigNumberLabel, setBigNumberLabel] = useState<
         BigNumber['label'] | undefined


### PR DESCRIPTION
This PR implements support for dynamic parameter-based labels in Lightdash, allowing users to use parameter values in dimension and metric labels via template strings like `${ld.parameters.parameter_name}`.

## Changes

### Backend

**Parameter Extraction (`packages/common/src/compiler/parameters.ts`)**
- Added `getParameterReferencesFromSqlFormatAndLabel()` function to extract parameter references from SQL, format strings, and labels
- This ensures labels with parameter references are validated at compile time

**Dimension/Metric Compilation (`packages/common/src/compiler/exploreCompiler.ts`)**
- Updated `compileDimension()` and `compileMetric()` to validate parameter references in labels using the new extraction function
- This prevents invalid parameter references in labels from causing runtime errors

**Label Interpolation (`packages/common/src/utils/item.ts`)**
- Updated `getItemLabel()` and `getItemLabelWithoutTableName()` to accept optional `parameters` argument
- Labels containing `${` are now interpolated using the existing `evaluateConditionalFormatExpression()` function
- Supports both simple substitution (`${ld.parameters.field}`) and ternary expressions (`${ld.parameters.currency=='USD'?'$':'€'}`)

### Frontend

**Updated hooks to pass parameters for label rendering:**
- `useBigNumberConfig.ts`: Pass parameters when rendering big number labels
- `useEchartsCartesianConfig.ts`: Pass parameters when rendering chart axis labels and series labels
- `useTableConfig.ts`: Pass parameters when rendering table column labels

## Backwards Compatibility

This change is fully backwards compatible:
- Labels without parameter references continue to work exactly as before
- Parameter interpolation only occurs when labels contain `${` template syntax
- Existing charts and dashboards are unaffected