### PR TITLE
fix: chart duplication for dashboard tab duplication

### DIFF
--- a/packages/backend/src/routers/dashboardRouter.ts
+++ b/packages/backend/src/routers/dashboardRouter.ts
@@ -147,6 +147,30 @@ dashboardRouter.post(
 );
 
 dashboardRouter.post(
+    '/:dashboardUuid/tabs/:tabUuid/duplicate',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+    async (req, res, next) => {
+        try {
+            res.json({
+                status: 'ok',
+                results: await req.services
+                    .getDashboardService()
+                    .duplicateTab(
+                        req.user!,
+                        req.params.dashboardUuid,
+                        req.params.tabUuid,
+                        req.body.name,
+                    ),
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
+
+dashboardRouter.post(
     '/availableFilters',
     allowApiKeyAuthentication,
     isAuthenticated,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -62,6 +62,7 @@ import {
     type DashboardAvailableFilters,
     type DashboardBasicDetails,
     type DashboardSummary,
+    type DashboardTab,
 } from './dashboard';
 import { type DbtExposure } from './dbt';
 import { type EmailStatusExpiring } from './email';
@@ -680,6 +681,18 @@ export type ApiAiGenerateCustomVizResponse = {
     results: string;
 };
 
+export type ApiDuplicateTabRequest = {
+    name: string;
+};
+
+export type ApiDuplicateTabResponse = {
+    status: 'ok';
+    results: {
+        tab: DashboardTab;
+        tiles: Dashboard['tiles'];
+    };
+};
+
 type ApiResults =
     | ApiQueryResults
     | ApiSqlQueryResults
@@ -764,6 +777,7 @@ type ApiResults =
     | ApiCreateProjectResults
     | ApiAiDashboardSummaryResponse['results']
     | ApiAiGetDashboardSummaryResponse['results']
+    | ApiDuplicateTabResponse['results']
     | ApiCatalogMetadataResults
     | ApiCatalogAnalyticsResults
     | ApiPromotionChangesResponse['results']


### PR DESCRIPTION
This PR fixes a bug where duplicating a dashboard tab would cause charts to be shared between tabs instead of being properly duplicated.

## Changes

- Added backend `duplicateTab` method to `DashboardService` that properly duplicates charts that belong to the dashboard
- Added new API endpoint `POST /dashboards/:dashboardUuid/tabs/:tabUuid/duplicate` for tab duplication
- Updated frontend tab duplication logic to call the new backend endpoint instead of duplicating tiles locally
- Added API types `ApiDuplicateTabRequest` and `ApiDuplicateTabResponse` to common package

## Technical Details

The previous implementation only duplicated tile entities on the frontend, causing both the original and duplicated tiles to reference the same `savedChartUuid`. This meant edits to a chart in one tab would appear in the other tab.

The new implementation follows the same pattern as dashboard duplication: when a chart has `belongsToDashboard: true`, it creates a new chart entity in the database with a unique UUID, ensuring each tab has independent charts.