### PR TITLE
fix: broken border on last row of virtualized tables

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -34,10 +34,11 @@ export const VirtualizedArea: FC<{ cellCount: number; padding: number }> = ({
     padding,
 }) => {
     return (
-        <tr>
+        <tr className="virtualized-padding-row">
             {[...Array(cellCount)].map((_, index) => (
                 <td
                     key={index}
+                    className="virtualized-padding-cell"
                     style={{
                         height: `${padding}px`,
                     }}

--- a/packages/frontend/src/components/common/Table/Table.styles.ts
+++ b/packages/frontend/src/components/common/Table/Table.styles.ts
@@ -97,6 +97,11 @@ export const Table = styled.table<{ $showFooter?: boolean }>`
         box-shadow: inset 1px 0 0 0 rgba(17, 20, 24, 0.15);
     }
 
+    /* Hide borders on virtualization padding rows */
+    tr.virtualized-padding-row td.virtualized-padding-cell {
+        box-shadow: none !important;
+    }
+
     /* FIXME: everything above this line is copied from blueprint's table css */
 
     thead {


### PR DESCRIPTION
Fixed a visual issue where the last row of tables appeared incomplete due to improper border rendering on virtualization padding rows. The virtualized table component adds empty padding rows for performance, but these rows were inheriting border styles meant for data rows, creating visual artifacts at the bottom of tables.

The fix adds CSS classes to identify virtualization padding rows and removes their borders, ensuring clean table borders that properly close at the bottom.