### PR TITLE
fix: move Intercom app ID fallback to env variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -107,6 +107,9 @@ S3_FORCE_PATH_STYLE=true # needed when using MinIO since it only supports path s
 
 DEV_SSH_PUBLIC_KEY=
 
+# Intercom Configuration
+INTERCOM_APP_ID=zppxyjpp
+
 # Prometheus Configuration
 LIGHTDASH_PROMETHEUS_ENABLED=true
 LIGHTDASH_PROMETHEUS_PORT=9090

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1447,10 +1447,7 @@ export const parseConfig = (): LightdashConfig => {
             },
         },
         intercom: {
-            appId:
-                process.env.INTERCOM_APP_ID === undefined
-                    ? 'zppxyjpp'
-                    : process.env.INTERCOM_APP_ID,
+            appId: process.env.INTERCOM_APP_ID || '',
             apiBase:
                 process.env.INTERCOM_APP_BASE || 'https://api-iam.intercom.io',
         },


### PR DESCRIPTION
## Summary
- Remove hardcoded Intercom app ID fallback (`zppxyjpp`) from `parseConfig.ts`
- Add `INTERCOM_APP_ID=zppxyjpp` to `.env.development` for Lightdash developers
- Self-hosted users now won't have Intercom enabled unless they explicitly set `INTERCOM_APP_ID`

## Test plan
- [ ] Verify Intercom loads in development (with `.env.development`)
- [ ] Verify Intercom is disabled when `INTERCOM_APP_ID` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)