### PR TITLE
feat: show all charts and dashboards a user has access to in the home page

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5297,10 +5297,19 @@ export class ProjectService extends BaseService {
         }
 
         const spaces = await this.spaceModel.find({ projectUuid });
+        const spacesAccess = await this.spaceModel.getUserSpacesAccess(
+            user.userUuid,
+            spaces.map((s) => s.uuid),
+        );
         const allowedSpaces = spaces.filter(
             (space) =>
-                space.projectUuid === projectUuid &&
-                hasDirectAccessToSpace(user, space), // NOTE: We don't check for admin access to the space - exclude private spaces from this panel if admin
+                (space.projectUuid === projectUuid &&
+                    hasDirectAccessToSpace(user, space)) ||
+                hasViewAccessToSpace(
+                    user,
+                    space,
+                    spacesAccess[space.uuid] ?? [],
+                ),
         );
 
         const mostPopular = await this.getMostPopular(allowedSpaces);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18390

### Description:
Fix project dashboard to show spaces where user has view access

This PR updates the project dashboard to include spaces where the user has view access, not just direct access. It now checks both direct access and view access when filtering spaces to display in the dashboard's most popular section.

**Steps to reproduce**
1. Create a new user
2. With the new user, create a new private space and add a chart to it
3. Using the admin user of the org - should inherit access to the space - go to the home page and confirm whether the chart shows in the most recent/popular list