### PR TITLE
refactor: use isSupportedPeriodOverPeriodGranularity check on button

### DIFF
--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -823,7 +823,6 @@ export class SavedChartService
         account: Account,
     ): Promise<SavedChart> {
         const savedChart = await this.savedChartModel.get(savedChartUuidOrSlug);
-        // console.log('savedChart', JSON.stringify(savedChart, null, 2));
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,
         );

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -8,7 +8,7 @@ import type {
 import { type AnyType } from './any';
 import { CompileError } from './errors';
 import { type MetricFilterRule } from './filter';
-import { TimeFrames } from './timeFrames';
+import type { TimeFrames } from './timeFrames';
 
 export enum Compact {
     THOUSANDS = 'thousands',
@@ -591,24 +591,6 @@ export const isDimension = (
     field: ItemsMap[string] | AdditionalMetric | undefined, // NOTE: `ItemsMap converts AdditionalMetric to Metric
 ): field is Dimension =>
     isField(field) && field.fieldType === FieldType.DIMENSION;
-
-/**
- * Check if a dimension is a time dimension that can be used for previous period comparison
- * @param field - The dimension to check
- * @returns true if the dimension is a time dimension that can be used for previous period comparison
- */
-export const isPreviousPeriodableTimeDimension = (
-    field: ItemsMap[string] | AdditionalMetric | undefined,
-) =>
-    isDimension(field) &&
-    !!field.timeInterval &&
-    [
-        TimeFrames.DAY,
-        TimeFrames.WEEK,
-        TimeFrames.MONTH,
-        TimeFrames.QUARTER,
-        TimeFrames.YEAR,
-    ].includes(field.timeInterval);
 
 export interface FilterableDimension extends Dimension {
     type:

--- a/packages/frontend/src/components/PeriodOverPeriodButton.tsx
+++ b/packages/frontend/src/components/PeriodOverPeriodButton.tsx
@@ -1,7 +1,6 @@
 import {
     getItemId,
     isDimension,
-    isPreviousPeriodableTimeDimension,
     isSupportedPeriodOverPeriodGranularity,
     timeFrameConfigs,
     TimeFrames,
@@ -65,8 +64,11 @@ const PeriodOverPeriodButton: FC<Props> = memo(({ itemsMap, disabled }) => {
 
         const allTimeDimensions = selectedDimensions
             .map((dimId) => itemsMap[dimId])
-            .filter((item): item is Dimension =>
-                isPreviousPeriodableTimeDimension(item),
+            .filter(
+                (item): item is Dimension =>
+                    isDimension(item) &&
+                    !!item.timeInterval &&
+                    isSupportedPeriodOverPeriodGranularity(item.timeInterval),
             );
 
         if (allTimeDimensions.length <= 1) return allTimeDimensions;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Removed unused console.log in SavedChartService and refactored the period-over-period functionality by:

1. Removing the `isPreviousPeriodableTimeDimension` utility function from field.ts
2. Replacing its usage in PeriodOverPeriodButton with an inline filter that directly uses `isSupportedPeriodOverPeriodGranularity`
3. Changed the TimeFrames import to a type-only import in field.ts

This change simplifies the code by eliminating a redundant utility function and using the existing `isSupportedPeriodOverPeriodGranularity` function instead.