### PR TITLE
fix: underlying data table colapses all rows

### DIFF
--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -68,9 +68,15 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
     // Derive full column order that includes columns not in columnOrder
     // (e.g., _previous fields for period-over-period comparisons)
     // These should be inserted after their base field
+    // Only apply this logic when columnOrder is explicitly provided
     const derivedColumnOrder = useMemo(() => {
+        // If no columnOrder provided, preserve old behavior (empty order)
+        if (!columnOrder || columnOrder.length === 0) {
+            return [];
+        }
+
         const columnIds = columns.map((col) => col.id).filter(Boolean);
-        const orderSet = new Set(columnOrder || []);
+        const orderSet = new Set(columnOrder);
 
         // Find columns not in columnOrder
         const missingColumns = columnIds.filter(
@@ -78,14 +84,14 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
         );
 
         if (missingColumns.length === 0) {
-            return columnOrder || [];
+            return columnOrder;
         }
 
         // Build new order by inserting missing columns after their base field
         const result: string[] = [];
         const insertedMissing = new Set<string>();
 
-        for (const colId of columnOrder || []) {
+        for (const colId of columnOrder) {
             result.push(colId);
 
             // Check if any missing columns should follow this one


### PR DESCRIPTION
Closes: #18398

### Description:

**The bug**
The underlying data table collapses all values in a row into children of the first column.

**The fix**
`derivedColumnOrder` logic changed behavior when columnOrder is undefined/empty. Before, an empty columnOrder meant `tempColumnOrder` only had the row number column. Now, it includes ALL columns from the columns prop, causing the grouping logic in `TableHeader.tsx` to find dimension columns to group by, causing rows to collapse.

This fix just only applies the derivedColumnOrder logic when columnOrder is actually provided (not undefined/empty), preserving the old behavior otherwise. 

**Repro:**
- Create a chart
- View underlying data 💀 

<img width="1857" height="1183" alt="Screenshot 2025-11-28 at 13 54 24" src="https://github.com/user-attachments/assets/d9f3a43b-85c5-4185-b919-89ce236daa52" />

