### PR TITLE
feat: add beta badge next to PoP button

### DIFF
--- a/packages/frontend/src/components/PeriodOverPeriodButton.tsx
+++ b/packages/frontend/src/components/PeriodOverPeriodButton.tsx
@@ -29,6 +29,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../features/explorer/store';
+import { BetaBadge } from './common/BetaBadge';
 import { COLLAPSABLE_CARD_BUTTON_PROPS } from './common/CollapsableCard/constants';
 import MantineIcon from './common/MantineIcon';
 
@@ -233,6 +234,7 @@ const PeriodOverPeriodButton: FC<Props> = memo(({ itemsMap, disabled }) => {
                         }}
                         variant={periodOverPeriod ? 'light' : 'subtle'}
                         color={periodOverPeriod ? 'blue' : 'gray'}
+                        rightIcon={<BetaBadge />}
                         styles={(theme) => ({
                             root: periodOverPeriod
                                 ? {}
@@ -241,7 +243,7 @@ const PeriodOverPeriodButton: FC<Props> = memo(({ itemsMap, disabled }) => {
                                   },
                         })}
                     >
-                        {buttonLabel}
+                        {buttonLabel}{' '}
                     </Button>
                 </Tooltip>
             </Popover.Target>

--- a/packages/frontend/src/components/common/BetaBadge.tsx
+++ b/packages/frontend/src/components/common/BetaBadge.tsx
@@ -1,0 +1,23 @@
+import { Badge, Tooltip } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type Props = {
+    tooltipLabel?: string;
+};
+
+/**
+ * A badge that displays a beta label and a tooltip when hovered.
+ * @param tooltipLabel - The label to display in the tooltip
+ * @returns A badge that displays a beta label and a tooltip when hovered.
+ */
+export const BetaBadge: FC<Props> = ({
+    tooltipLabel = 'This feature is currently in beta. It might cause unexpected results and is subject to change.',
+}) => {
+    return (
+        <Tooltip label={tooltipLabel}>
+            <Badge color="indigo" size="xs" radius="sm" fz="xs">
+                Beta
+            </Badge>
+        </Tooltip>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Added a Beta badge to the Period Over Period button to indicate that this feature is in beta. The badge includes a tooltip that warns users the feature might cause unexpected results and is subject to change.

The new `BetaBadge` component is reusable and can be applied to other beta features with customizable tooltip text.


![image.png](https://app.graphite.com/user-attachments/assets/d47efed4-fc33-4595-b571-23805bc2b98a.png)

