### PR TITLE
refactor: compute column order on result fetching

### DIFF
--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -18,6 +18,7 @@ import {
     MetricQuery,
     MetricType,
     PivotConfiguration,
+    POP_PREVIOUS_PERIOD_SUFFIX,
     TableCalculation,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
@@ -296,7 +297,7 @@ export const compileMetricQuery = ({
         ...metricQuery.metrics.reduce<string[]>((acc2, metric) => {
             acc2.push(metric);
             if (metricQuery.periodOverPeriod) {
-                acc2.push(`${metric}_previous`);
+                acc2.push(`${metric}${POP_PREVIOUS_PERIOD_SUFFIX}`);
             }
             return acc2;
         }, []),

--- a/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.ts
@@ -1,15 +1,39 @@
-import { ResultColumns, WarehouseResults } from '@lightdash/common';
+import {
+    getBaseFieldIdFromPop,
+    ResultColumns,
+    WarehouseResults,
+} from '@lightdash/common';
+
+type GetUnpivotedColumnsOptions = {
+    /**
+     * Set of metric field IDs that have period-over-period comparison enabled.
+     * When provided, columns matching the PoP naming convention will have
+     * popMetadata added to indicate their relationship to the base metric.
+     */
+    popEnabledMetrics?: Set<string>;
+};
 
 export function getUnpivotedColumns(
     unpivotedColumns: ResultColumns,
     fields: WarehouseResults['fields'],
+    options?: GetUnpivotedColumnsOptions,
 ): ResultColumns {
+    const { popEnabledMetrics } = options ?? {};
+
     if (!Object.keys(unpivotedColumns).length && fields) {
         return Object.entries(fields).reduce<ResultColumns>(
             (acc, [key, value]) => {
+                const baseFieldId = getBaseFieldIdFromPop(key);
+                const isPopColumn =
+                    baseFieldId !== null &&
+                    popEnabledMetrics?.has(baseFieldId) === true;
+
                 acc[key] = {
                     reference: key,
                     type: value.type,
+                    ...(isPopColumn && baseFieldId
+                        ? { popMetadata: { baseFieldId } }
+                        : {}),
                 };
                 return acc;
             },

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -159,4 +159,9 @@ export type RunAsyncWarehouseQueryArgs = {
     };
     pivotConfiguration?: PivotConfiguration;
     originalColumns?: ResultColumns;
+    /**
+     * Set of metric field IDs that have period-over-period comparison enabled.
+     * Used to add popMetadata to the corresponding ResultColumns.
+     */
+    popEnabledMetrics?: Set<string>;
 };

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -33,6 +33,7 @@ import {
     MetricFilterRule,
     parseAllReferences,
     PivotConfiguration,
+    POP_PREVIOUS_PERIOD_SUFFIX,
     QueryWarning,
     renderFilterRuleSqlFromField,
     renderTableCalculationFilterRuleSql,
@@ -1416,7 +1417,7 @@ export class MetricQueryBuilder {
                                         metric.compiledSql
                                     } AS ${fieldQuoteChar}${getItemId(
                                         metric,
-                                    )}_previous${fieldQuoteChar}`,
+                                    )}${POP_PREVIOUS_PERIOD_SUFFIX}${fieldQuoteChar}`,
                             ),
                         ].join(',\n'),
                         `FROM ${popKeysCteName}`,
@@ -1442,7 +1443,10 @@ export class MetricQueryBuilder {
                     popMetricCtes.push({
                         name: popMetricsCteName,
                         metrics: metricsInCte.map(
-                            (metric) => `${getItemId(metric)}_previous`,
+                            (metric) =>
+                                `${getItemId(
+                                    metric,
+                                )}${POP_PREVIOUS_PERIOD_SUFFIX}`,
                         ),
                     });
                 }
@@ -1543,7 +1547,7 @@ export class MetricQueryBuilder {
                                     metric.compiledSql
                                 } AS ${fieldQuoteChar}${getItemId(
                                     metric,
-                                )}_previous${fieldQuoteChar}`,
+                                )}${POP_PREVIOUS_PERIOD_SUFFIX}${fieldQuoteChar}`,
                         ),
                     ].join(',\n'),
                     sqlFrom,
@@ -1578,7 +1582,8 @@ export class MetricQueryBuilder {
                 popMetricCtes.push({
                     name: popUnaffectedMetricsCteName,
                     metrics: unaffectedMetrics.map(
-                        (metric) => `${getItemId(metric)}_previous`,
+                        (metric) =>
+                            `${getItemId(metric)}${POP_PREVIOUS_PERIOD_SUFFIX}`,
                     ),
                 });
             }
@@ -1618,7 +1623,11 @@ export class MetricQueryBuilder {
                         // excludes metrics only used for references
                         .filter((metric) =>
                             metricsObjects.find(
-                                (m) => metric === `${getItemId(m)}_previous`,
+                                (m) =>
+                                    metric ===
+                                    `${getItemId(
+                                        m,
+                                    )}${POP_PREVIOUS_PERIOD_SUFFIX}`,
                             ),
                         )
                         .map(
@@ -2149,7 +2158,7 @@ export class MetricQueryBuilder {
                         // rename metric to include pop prefix
                         select.replace(
                             new RegExp(`${fieldQuoteChar}$`),
-                            `_previous${fieldQuoteChar}`,
+                            `${POP_PREVIOUS_PERIOD_SUFFIX}${fieldQuoteChar}`,
                         ),
                     ),
                 ].join(',\n')}`,
@@ -2186,7 +2195,7 @@ export class MetricQueryBuilder {
             // Create new finalSelectParts that joins base CTE with pop CTE
             const popMetricSelects = compiledMetricQuery.metrics.map(
                 (metricId) =>
-                    `  ${popCteName}.${fieldQuoteChar}${metricId}_previous${fieldQuoteChar} AS ${fieldQuoteChar}${metricId}_previous${fieldQuoteChar}`,
+                    `  ${popCteName}.${fieldQuoteChar}${metricId}${POP_PREVIOUS_PERIOD_SUFFIX}${fieldQuoteChar} AS ${fieldQuoteChar}${metricId}${POP_PREVIOUS_PERIOD_SUFFIX}${fieldQuoteChar}`,
             );
             // Get dimension aliases from dimensionSelects
             const dimensionAlias = Object.keys(dimensionsSQL.selects).map(

--- a/packages/common/src/types/periodOverPeriodComparison.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.ts
@@ -50,3 +50,27 @@ export const periodOverPeriodGranularityLabels: Record<TimeFrames, string> = {
 export const isSupportedPeriodOverPeriodGranularity = (
     granularity: TimeFrames,
 ) => validPeriodOverPeriodGranularities.includes(granularity);
+
+/**
+ * Suffix used for period-over-period comparison columns.
+ * This is the single source of truth for the PoP column naming convention.
+ */
+export const POP_PREVIOUS_PERIOD_SUFFIX = '_previous';
+
+/**
+ * Gets the PoP field ID for a base metric field ID.
+ * @param baseFieldId - The field ID of the base metric (e.g., "orders_total_revenue")
+ * @returns The PoP field ID (e.g., "orders_total_revenue_previous")
+ */
+export const getPopFieldId = (baseFieldId: string): string =>
+    `${baseFieldId}${POP_PREVIOUS_PERIOD_SUFFIX}`;
+
+/**
+ * Gets the base field ID from a PoP field ID.
+ * @param fieldId - The field ID to check
+ * @returns The base field ID if this is a PoP field, null otherwise
+ */
+export const getBaseFieldIdFromPop = (fieldId: string): string | null =>
+    fieldId.endsWith(POP_PREVIOUS_PERIOD_SUFFIX)
+        ? fieldId.slice(0, -POP_PREVIOUS_PERIOD_SUFFIX.length)
+        : null;

--- a/packages/common/src/types/results.ts
+++ b/packages/common/src/types/results.ts
@@ -66,9 +66,23 @@ export function convertItemTypeToDimensionType(item: Item): DimensionType {
     }
 }
 
+/**
+ * Metadata for period-over-period comparison columns.
+ * This allows the frontend to identify PoP columns without string matching.
+ */
+export type PopColumnMetadata = {
+    /** The field ID of the base metric this PoP column compares against */
+    baseFieldId: string;
+};
+
 export type ResultColumn = {
     reference: string;
     type: DimensionType; // Lightdash simple type. In the future, we might introduce the warehouse type as well, which provides more detail.
+    /**
+     * Present when this column is a period-over-period comparison column.
+     * Contains metadata linking this column to its base metric.
+     */
+    popMetadata?: PopColumnMetadata;
 };
 
 export type ResultColumns = Record<string, ResultColumn>;

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -65,67 +65,14 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
         setColumnVisibility(calculateColumnVisibility(columns));
     }, [columns]);
 
-    // Derive full column order that includes columns not in columnOrder
-    // (e.g., _previous fields for period-over-period comparisons)
-    // These should be inserted after their base field
-    // Only apply this logic when columnOrder is explicitly provided
-    const derivedColumnOrder = useMemo(() => {
-        // If no columnOrder provided, preserve old behavior (empty order)
-        if (!columnOrder || columnOrder.length === 0) {
-            return [];
-        }
-
-        const columnIds = columns.map((col) => col.id).filter(Boolean);
-        const orderSet = new Set(columnOrder);
-
-        // Find columns not in columnOrder
-        const missingColumns = columnIds.filter(
-            (id): id is string => id !== undefined && !orderSet.has(id),
-        );
-
-        if (missingColumns.length === 0) {
-            return columnOrder;
-        }
-
-        // Build new order by inserting missing columns after their base field
-        const result: string[] = [];
-        const insertedMissing = new Set<string>();
-
-        for (const colId of columnOrder) {
-            result.push(colId);
-
-            // Check if any missing columns should follow this one
-            // (e.g., field_previous should follow field)
-            for (const missing of missingColumns) {
-                if (insertedMissing.has(missing)) continue;
-
-                // Check if this missing column is a derivative of the current column
-                // e.g., orders_total_order_amount_previous follows orders_total_order_amount
-                if (missing.startsWith(`${colId}_`)) {
-                    result.push(missing);
-                    insertedMissing.add(missing);
-                }
-            }
-        }
-
-        // Add any remaining missing columns at the end
-        for (const missing of missingColumns) {
-            if (!insertedMissing.has(missing)) {
-                result.push(missing);
-            }
-        }
-
-        return result;
-    }, [columnOrder, columns]);
-
     const [tempColumnOrder, setTempColumnOrder] = useState<ColumnOrderState>([
         ROW_NUMBER_COLUMN_ID,
-        ...derivedColumnOrder,
+        ...(columnOrder || []),
     ]);
 
     useEffect(() => {
-        setTempColumnOrder([ROW_NUMBER_COLUMN_ID, ...derivedColumnOrder]);
-    }, [derivedColumnOrder]);
+        setTempColumnOrder([ROW_NUMBER_COLUMN_ID, ...(columnOrder || [])]);
+    }, [columnOrder]);
 
     const withTotals = showColumnCalculation ? 60 : 0;
     const rowColumnWidth = hideRowNumbers

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -21,6 +21,7 @@ import {
     type ParameterValue,
     type PeriodOverPeriodComparison,
     type ReplaceCustomFields,
+    type ResultColumns,
     type SavedChart,
     type SortField,
     type TableCalculation,
@@ -44,7 +45,7 @@ import {
     getValidChartConfig,
 } from '../../../providers/Explorer/utils';
 
-import { calcColumnOrder } from './utils';
+import { calcColumnOrder, computeColumnOrderWithPoP } from './utils';
 
 export type ExplorerSliceState = ExplorerReduceState;
 
@@ -867,7 +868,19 @@ const explorerSlice = createSlice({
                 queryUuidHistory: [],
                 unpivotedQueryUuidHistory: [],
                 pendingFetch: false,
+                completeColumnOrder: [],
             };
+        },
+
+        setCompleteColumnOrder: (
+            state,
+            action: PayloadAction<ResultColumns>,
+        ) => {
+            const { completeColumnOrder } = computeColumnOrderWithPoP(
+                state.unsavedChartVersion.tableConfig.columnOrder,
+                action.payload,
+            );
+            state.queryExecution.completeColumnOrder = completeColumnOrder;
         },
 
         // Request a query execution (works regardless of auto-fetch setting)

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -154,6 +154,37 @@ export const selectParameterReferences = createSelector(
     (explorer) => explorer.parameterReferences,
 );
 
+// Query execution selectors
+const selectQueryExecution = createSelector(
+    [selectExplorerState],
+    (explorer) => explorer.queryExecution,
+);
+
+export const selectValidQueryArgs = createSelector(
+    [selectQueryExecution],
+    (queryExecution) => queryExecution.validQueryArgs,
+);
+
+export const selectUnpivotedQueryArgs = createSelector(
+    [selectQueryExecution],
+    (queryExecution) => queryExecution.unpivotedQueryArgs,
+);
+
+export const selectQueryUuidHistory = createSelector(
+    [selectQueryExecution],
+    (queryExecution) => queryExecution.queryUuidHistory,
+);
+
+export const selectUnpivotedQueryUuidHistory = createSelector(
+    [selectQueryExecution],
+    (queryExecution) => queryExecution.unpivotedQueryUuidHistory,
+);
+
+export const selectPendingFetch = createSelector(
+    [selectQueryExecution],
+    (queryExecution) => queryExecution.pendingFetch,
+);
+
 // TODO: REDUX-MIGRATION - Add missingRequiredParameters as a computed selector once all dependencies are in Redux
 // Currently missingRequiredParameters is computed state in Context, not stored in Redux
 
@@ -164,8 +195,11 @@ export const selectSorts = createSelector(
 );
 
 export const selectColumnOrder = createSelector(
-    [selectUnsavedChartVersion],
-    (unsavedChartVersion) => unsavedChartVersion.tableConfig.columnOrder,
+    [selectUnsavedChartVersion, selectQueryExecution],
+    (unsavedChartVersion, queryExecution) =>
+        queryExecution.completeColumnOrder.length > 0
+            ? queryExecution.completeColumnOrder
+            : unsavedChartVersion.tableConfig.columnOrder,
 );
 
 // Query limit selector
@@ -196,37 +230,6 @@ export const selectChartConfig = createSelector(
 export const selectPivotConfig = createSelector(
     [selectUnsavedChartVersion],
     (unsavedChartVersion) => unsavedChartVersion.pivotConfig,
-);
-
-// Query execution selectors
-const selectQueryExecution = createSelector(
-    [selectExplorerState],
-    (explorer) => explorer.queryExecution,
-);
-
-export const selectValidQueryArgs = createSelector(
-    [selectQueryExecution],
-    (queryExecution) => queryExecution.validQueryArgs,
-);
-
-export const selectUnpivotedQueryArgs = createSelector(
-    [selectQueryExecution],
-    (queryExecution) => queryExecution.unpivotedQueryArgs,
-);
-
-export const selectQueryUuidHistory = createSelector(
-    [selectQueryExecution],
-    (queryExecution) => queryExecution.queryUuidHistory,
-);
-
-export const selectUnpivotedQueryUuidHistory = createSelector(
-    [selectQueryExecution],
-    (queryExecution) => queryExecution.unpivotedQueryUuidHistory,
-);
-
-export const selectPendingFetch = createSelector(
-    [selectQueryExecution],
-    (queryExecution) => queryExecution.pendingFetch,
 );
 
 // Navigation context selectors

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -426,8 +426,8 @@ export const useColumns = (): TableColumn[] => {
         return result;
     }, [itemsMap, activeFields]);
 
-    // Find period-over-period _previous fields from resultsColumns
-    // Use the base field's metadata (from itemsMap) for labels and formatting
+    // Find period-over-period fields from resultsColumns using popMetadata
+    // This uses backend-provided metadata instead of string matching
     const popPreviousFields = useMemo<
         Map<string, { fieldId: string; item: ItemsMap[string] }>
     >(() => {
@@ -438,13 +438,13 @@ export const useColumns = (): TableColumn[] => {
             { fieldId: string; item: ItemsMap[string] }
         >();
 
-        // Find _previous fields in columns and map them by their base field ID
-        for (const fieldId of Object.keys(resultsColumns)) {
-            if (fieldId.endsWith('_previous')) {
-                const baseFieldId = fieldId.replace(/_previous$/, '');
+        // Find PoP fields using popMetadata from API response
+        for (const [fieldId, column] of Object.entries(resultsColumns)) {
+            if (column.popMetadata) {
+                const { baseFieldId } = column.popMetadata;
                 const baseItem = itemsMap[baseFieldId];
                 if (baseItem) {
-                    // Use the base item's metadata for formatting, but indicate it's a PoP column
+                    // Use the base item's metadata for formatting
                     previousFieldsMap.set(baseFieldId, {
                         fieldId,
                         item: baseItem,

--- a/packages/frontend/src/hooks/useExplorerQueryEffects.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryEffects.ts
@@ -137,5 +137,16 @@ export const useExplorerQueryEffects = ({
         }
     }, [validQueryArgs, needsUnpivotedData, isResultsOpen, dispatch]);
 
+    // Effect 4: Sync complete column order when query results change
+    const { queryResults } = useExplorerQueryManager();
+
+    useEffect(() => {
+        if (queryResults.columns) {
+            dispatch(
+                explorerActions.setCompleteColumnOrder(queryResults.columns),
+            );
+        }
+    }, [queryResults.columns, dispatch]);
+
     // No return - this hook just orchestrates effects
 };

--- a/packages/frontend/src/providers/Explorer/defaultState.ts
+++ b/packages/frontend/src/providers/Explorer/defaultState.ts
@@ -10,6 +10,7 @@ export const defaultQueryExecution: ExplorerSliceState['queryExecution'] = {
     queryUuidHistory: [],
     unpivotedQueryUuidHistory: [],
     pendingFetch: false,
+    completeColumnOrder: [],
 };
 
 const defaultFilters: Filters = {};

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -262,6 +262,9 @@ export interface ExplorerReduceState {
         unpivotedQueryUuidHistory: string[];
         // Flag to trigger a query execution from components (works regardless of auto-fetch setting)
         pendingFetch: boolean;
+        // Complete column order including PoP columns (derived from query results)
+        // This is synced when query results arrive with popMetadata
+        completeColumnOrder: string[];
     };
     fromDashboard?: string;
     isExploreFromHere?: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Improved period-over-period (PoP) column handling by adding proper metadata to identify PoP columns instead of relying on string matching.

Key changes:
- Added `POP_PREVIOUS_PERIOD_SUFFIX` constant as the single source of truth for PoP column naming
- Created utility functions for working with PoP field IDs
- Added `popMetadata` to `ResultColumn` type to explicitly identify PoP columns
- Modified backend to pass PoP metadata to the frontend
- Updated column ordering logic to use metadata instead of string matching
- Implemented Redux state for complete column order including PoP fields

