### PR TITLE
refactor: use pop metadata to render series

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1049,8 +1049,6 @@ export class SavedChartModel {
                     return ECHARTS_DEFAULT_COLORS;
                 };
 
-                console.log('savedQuery', JSON.stringify(savedQuery, null, 2));
-
                 return {
                     uuid: savedQuery.saved_query_uuid,
                     projectUuid: savedQuery.project_uuid,

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -741,19 +741,14 @@ export const buildCartesianTooltipFormatter =
                     '';
 
                 // For period-over-period series, use the base field's format
-                // (strip _previous suffix to find the base field)
+                // using baseFieldId from metadata instead of string matching
                 let effectiveFormatKey = formatKey as string;
-                if (
-                    effectiveFormatKey.endsWith('_previous') &&
-                    seriesOption?.periodOverPeriodMetadata
-                ) {
-                    const baseFieldKey = effectiveFormatKey.replace(
-                        /_previous$/,
-                        '',
-                    );
+                if (seriesOption?.periodOverPeriodMetadata?.baseFieldId) {
+                    const { baseFieldId } =
+                        seriesOption.periodOverPeriodMetadata;
                     // Use base field format if it exists in itemsMap
-                    if (itemsMap[baseFieldKey]) {
-                        effectiveFormatKey = baseFieldKey;
+                    if (itemsMap[baseFieldId]) {
+                        effectiveFormatKey = baseFieldId;
                     }
                 }
 

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -367,6 +367,8 @@ export type EChartsSeries = {
         siblingSeriesIndex: number;
         periodOffset: number;
         granularity: string;
+        /** The field ID of the base metric this PoP series compares against */
+        baseFieldId: string;
     };
 };
 

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -974,6 +974,7 @@ const useCartesianChartConfig = ({
                 const newSeries = mergeExistingAndExpectedSeries({
                     expectedSeriesMap,
                     existingSeries: prev?.series || [],
+                    resultsColumns: resultsData.columns,
                 });
 
                 const seriesWithReferenceLines = applyReferenceLines(

--- a/packages/frontend/src/hooks/echarts/popSeriesUtils.ts
+++ b/packages/frontend/src/hooks/echarts/popSeriesUtils.ts
@@ -1,0 +1,291 @@
+import {
+    CartesianSeriesType,
+    getBaseFieldIdFromPop,
+    type EChartsSeries,
+    type PeriodOverPeriodComparison,
+    type ResultColumns,
+} from '@lightdash/common';
+import { lighten } from 'polished';
+
+const POP_LIGHTEN_AMOUNT = 0.25;
+
+/**
+ * Builds a map of base field ID -> PoP field ID using popMetadata from ResultColumns.
+ * This uses the explicit API metadata rather than relying on naming conventions.
+ */
+const buildPopFieldsMap = (
+    resultsColumns: ResultColumns | undefined,
+): Map<string, string> => {
+    const popFieldsByBase = new Map<string, string>();
+
+    if (!resultsColumns) return popFieldsByBase;
+
+    for (const [fieldId, column] of Object.entries(resultsColumns)) {
+        if (column.popMetadata) {
+            popFieldsByBase.set(column.popMetadata.baseFieldId, fieldId);
+        }
+    }
+
+    return popFieldsByBase;
+};
+
+/**
+ * Builds a human-readable period label based on granularity and offset
+ * e.g., "Previous month" or "2 months ago"
+ */
+const buildPeriodLabel = (
+    periodOffset: number,
+    granularity: string,
+): string => {
+    return periodOffset === 1
+        ? `Previous ${granularity.toLowerCase()}`
+        : `${periodOffset} ${granularity.toLowerCase()}s ago`;
+};
+
+// ============================================================================
+// Series Creation Utilities
+// ============================================================================
+
+type CreatePopSeriesArgs = {
+    baseSerie: EChartsSeries;
+    baseSeriesIndex: number;
+    previousFieldKey: string;
+    periodLabel: string;
+    periodOffset: number;
+    granularity: string;
+    yField: string;
+};
+
+/**
+ * Creates a PoP series based on a base series
+ * Applies visual distinction (dashed lines, transparent bars, etc.)
+ */
+const createPopSeries = ({
+    baseSerie,
+    baseSeriesIndex,
+    previousFieldKey,
+    periodLabel,
+    periodOffset,
+    granularity,
+    yField,
+}: CreatePopSeriesArgs): EChartsSeries => {
+    const metricDisplayName =
+        baseSerie.dimensions?.[1]?.displayName || baseSerie.name || yField;
+
+    const xField = baseSerie.encode?.x;
+    const seriesType = baseSerie.type || CartesianSeriesType.LINE;
+    const isLineType = seriesType === CartesianSeriesType.LINE;
+    const isAreaChart = isLineType && !!baseSerie.areaStyle;
+
+    return {
+        ...baseSerie,
+        name: `${metricDisplayName} (${periodLabel})`,
+        encode: {
+            x: xField!,
+            y: previousFieldKey,
+            tooltip: [previousFieldKey],
+            seriesName: previousFieldKey,
+            // Preserve xRef and yRef from original series for color config
+            xRef: baseSerie.encode?.xRef,
+            yRef: baseSerie.encode?.yRef
+                ? {
+                      ...baseSerie.encode.yRef,
+                      field: previousFieldKey,
+                  }
+                : { field: previousFieldKey },
+        },
+        // Keep same type as sibling
+        type: seriesType,
+        // Style based on chart type for visual distinction
+        ...(isLineType &&
+            !isAreaChart && {
+                lineStyle: {
+                    type: 'dashed',
+                    width: 1.4,
+                },
+            }),
+        ...(isAreaChart && {
+            areaStyle: {
+                ...baseSerie.areaStyle,
+            },
+            lineStyle: {
+                type: 'dashed',
+                width: 1.4,
+            },
+        }),
+        // Remove area style only for non-area line charts
+        ...(!isAreaChart && { areaStyle: undefined }),
+        // Update dimensions for tooltip
+        dimensions: [
+            baseSerie.dimensions?.[0] || {
+                name: xField!,
+                displayName: baseSerie.dimensions?.[0]?.displayName || '',
+            },
+            {
+                name: previousFieldKey,
+                displayName: `${metricDisplayName} (${periodLabel})`,
+            },
+        ],
+        // Show symbols for line types (not area)
+        ...(isLineType &&
+            !isAreaChart && {
+                showSymbol: false,
+            }),
+        // Metadata for period-over-period: link to sibling series index
+        periodOverPeriodMetadata: {
+            siblingSeriesIndex: baseSeriesIndex,
+            periodOffset,
+            granularity,
+            baseFieldId: yField,
+        },
+    };
+};
+
+// ============================================================================
+// Series Interleaving
+// ============================================================================
+
+type PreviousSeriesEntry = {
+    index: number;
+    series: EChartsSeries;
+};
+
+/**
+ * Interleaves PoP series with their base series siblings.
+ * For bars: previous comes BEFORE current (appears on left)
+ * For others: previous comes AFTER current
+ */
+const interleaveSeries = (
+    baseSeries: EChartsSeries[],
+    previousSeriesList: PreviousSeriesEntry[],
+): EChartsSeries[] => {
+    const result: EChartsSeries[] = [];
+
+    baseSeries.forEach((serie, idx) => {
+        const previousEntry = previousSeriesList.find((p) => p.index === idx);
+        const isBarType = serie.type === CartesianSeriesType.BAR;
+
+        if (previousEntry && isBarType) {
+            // For bars: previous first, then current
+            result.push(previousEntry.series);
+            result.push(serie);
+        } else {
+            // For other types: current first, then previous
+            result.push(serie);
+            if (previousEntry) {
+                result.push(previousEntry.series);
+            }
+        }
+    });
+
+    return result;
+};
+
+// ============================================================================
+// Main PoP Series Generation
+// ============================================================================
+
+type GeneratePopSeriesArgs = {
+    baseSeries: EChartsSeries[];
+    periodOverPeriod: PeriodOverPeriodComparison;
+    /** Result columns from API containing popMetadata */
+    resultsColumns: ResultColumns | undefined;
+    metrics: string[];
+};
+
+/**
+ * Generates period-over-period comparison series for ECharts.
+ * Creates visually distinct series (dashed lines, semi-transparent bars)
+ * for the previous period data and interleaves them with base series.
+ *
+ * Uses popMetadata from ResultColumns to identify PoP relationships.
+ *
+ * @returns The combined series array with PoP series interleaved
+ */
+export const generatePopSeries = ({
+    baseSeries,
+    periodOverPeriod,
+    resultsColumns,
+    metrics,
+}: GeneratePopSeriesArgs): EChartsSeries[] => {
+    const popFieldsByBase = buildPopFieldsMap(resultsColumns);
+
+    // If no PoP columns found in metadata, return base series unchanged
+    if (popFieldsByBase.size === 0) return baseSeries;
+
+    const periodOffset = periodOverPeriod.periodOffset ?? 1;
+    const { granularity } = periodOverPeriod;
+    const periodLabel = buildPeriodLabel(periodOffset, granularity);
+
+    const previousSeriesList: PreviousSeriesEntry[] = [];
+
+    baseSeries.forEach((serie, index) => {
+        // Skip series without proper encode configuration
+        const xField = serie.encode?.x;
+        const yField = serie.encode?.y;
+        if (!xField || !yField) return;
+        if (!metrics.includes(yField)) return;
+
+        // Check if PoP column exists for this metric
+        const previousFieldKey = popFieldsByBase.get(yField);
+        if (!previousFieldKey) return;
+
+        const popSeries = createPopSeries({
+            baseSerie: serie,
+            baseSeriesIndex: index,
+            previousFieldKey,
+            periodLabel,
+            periodOffset,
+            granularity,
+            yField,
+        });
+
+        previousSeriesList.push({ index, series: popSeries });
+    });
+
+    return interleaveSeries(baseSeries, previousSeriesList);
+};
+
+// ============================================================================
+// Color Assignment for PoP Series
+// ============================================================================
+
+type ApplyPopColorsArgs = {
+    series: EChartsSeries[];
+    getSeriesColor: (serie: EChartsSeries) => string;
+};
+
+/**
+ * Computes colors for all series, applying a lightened color to PoP series
+ * to create visual distinction while maintaining color consistency with siblings.
+ *
+ * @returns Array of computed colors matching series order
+ */
+export const computeSeriesColorsWithPop = ({
+    series,
+    getSeriesColor,
+}: ApplyPopColorsArgs): string[] => {
+    const baseColors = series.map((serie) => getSeriesColor(serie));
+
+    return series.map((serie, index) => {
+        if (serie.periodOverPeriodMetadata) {
+            // Find sibling by matching field name (without _previous suffix)
+            const previousField = serie.encode?.y;
+            if (!previousField) return baseColors[index];
+            const baseField = getBaseFieldIdFromPop(previousField);
+            const siblingIdx = series.findIndex(
+                (s) => s.encode?.y === baseField && !s.periodOverPeriodMetadata,
+            );
+            const siblingColor =
+                siblingIdx >= 0 ? baseColors[siblingIdx] : undefined;
+            const colorToUse = siblingColor || baseColors[index];
+            if (!colorToUse) {
+                console.error('No color to use for series', serie);
+                return baseColors[index];
+            }
+            return lighten(POP_LIGHTEN_AMOUNT, colorToUse);
+        }
+
+        return baseColors[index];
+    });
+};

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -93,6 +93,10 @@ import {
     type RowKeyMap,
 } from '../plottedData/getPlottedData';
 import { type InfiniteQueryResults } from '../useQueryResults';
+import {
+    computeSeriesColorsWithPop,
+    generatePopSeries,
+} from './popSeriesUtils';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
 // NOTE: CallbackDataParams type doesn't have axisValue, axisValueLabel properties: https://github.com/apache/echarts/issues/17561
@@ -2045,142 +2049,12 @@ const useEchartsCartesianConfig = (
             return baseSeries;
         }
 
-        const periodOverPeriod = resultsData.metricQuery.periodOverPeriod;
-
-        // Find metrics that have _previous counterparts in the data
-        const metrics = resultsData.metricQuery?.metrics || [];
-        const firstRow = resultsData.rows?.[0];
-        if (!firstRow) return baseSeries;
-
-        const previousSeriesList: { index: number; series: EChartsSeries }[] =
-            [];
-
-        baseSeries.forEach((serie, index) => {
-            // Skip series without proper encode configuration
-            const xField = serie.encode?.x;
-            const yField = serie.encode?.y;
-            if (!xField || !yField) return;
-            if (!metrics.includes(yField)) return;
-
-            // Check if _previous data exists
-            const previousFieldKey = `${yField}_previous`;
-            if (!firstRow[previousFieldKey]) return;
-
-            // Get the metric display name from dimensions
-            const metricDisplayName =
-                serie.dimensions?.[1]?.displayName || serie.name || yField;
-
-            // Build period label based on granularity and offset
-            const periodOffset = periodOverPeriod.periodOffset ?? 1;
-            const granularity = periodOverPeriod.granularity;
-            const periodLabel =
-                periodOffset === 1
-                    ? `Previous ${granularity.toLowerCase()}`
-                    : `${periodOffset} ${granularity.toLowerCase()}s ago`;
-
-            // Create a new series for the previous period data
-            // Keep the same chart type as sibling, with visual distinction
-            const seriesType = serie.type || CartesianSeriesType.LINE;
-            const isBarType = seriesType === CartesianSeriesType.BAR;
-            const isLineType = seriesType === CartesianSeriesType.LINE;
-            const isAreaChart = isLineType && !!serie.areaStyle;
-
-            const previousSeries: EChartsSeries = {
-                ...serie,
-                name: `${metricDisplayName} (${periodLabel})`,
-                encode: {
-                    x: xField,
-                    y: previousFieldKey,
-                    tooltip: [previousFieldKey],
-                    seriesName: previousFieldKey,
-                    // Preserve xRef and yRef from original series for color config
-                    xRef: serie.encode?.xRef,
-                    yRef: serie.encode?.yRef
-                        ? {
-                              ...serie.encode.yRef,
-                              field: previousFieldKey,
-                          }
-                        : { field: previousFieldKey },
-                },
-                // Keep same type as sibling
-                type: seriesType,
-                // Style based on chart type for visual distinction
-                ...(isLineType &&
-                    !isAreaChart && {
-                        lineStyle: {
-                            type: 'dashed',
-                            width: 1.4,
-                            opacity: 0.7,
-                        },
-                    }),
-                ...(isBarType && {
-                    itemStyle: {
-                        opacity: 0.5,
-                    },
-                }),
-                // For area charts, keep areaStyle with lower opacity
-                ...(isAreaChart && {
-                    areaStyle: {
-                        ...serie.areaStyle,
-                        opacity: 0.3,
-                    },
-                    lineStyle: {
-                        type: 'dashed',
-                        width: 1.4,
-                    },
-                }),
-                // Remove area style only for non-area line charts
-                ...(!isAreaChart && { areaStyle: undefined }),
-                // Update dimensions for tooltip
-                dimensions: [
-                    serie.dimensions?.[0] || {
-                        name: xField,
-                        displayName: serie.dimensions?.[0]?.displayName || '',
-                    },
-                    {
-                        name: previousFieldKey,
-                        displayName: `${metricDisplayName} (${periodLabel})`,
-                    },
-                ],
-                // Show symbols for line types (not area)
-                ...(isLineType &&
-                    !isAreaChart && {
-                        showSymbol: false,
-                    }),
-                // Metadata for period-over-period: link to sibling series index
-                periodOverPeriodMetadata: {
-                    siblingSeriesIndex: index,
-                    periodOffset,
-                    granularity,
-                },
-            };
-
-            previousSeriesList.push({ index, series: previousSeries });
+        return generatePopSeries({
+            baseSeries,
+            periodOverPeriod: resultsData.metricQuery.periodOverPeriod,
+            resultsColumns: resultsData.columns,
+            metrics: resultsData.metricQuery.metrics || [],
         });
-
-        // Interleave previous series with their siblings
-        // For bars: previous comes BEFORE current (appears on left)
-        // For others: previous comes after current
-        const result: EChartsSeries[] = [];
-        baseSeries.forEach((serie, idx) => {
-            const previousEntry = previousSeriesList.find(
-                (p) => p.index === idx,
-            );
-            const isBarType = serie.type === CartesianSeriesType.BAR;
-
-            if (previousEntry && isBarType) {
-                // For bars: previous first, then current
-                result.push(previousEntry.series);
-                result.push(serie);
-            } else {
-                // For other types: current first, then previous
-                result.push(serie);
-                if (previousEntry) {
-                    result.push(previousEntry.series);
-                }
-            }
-        });
-        return result;
     }, [baseSeries, resultsData]);
 
     const resultsAndMinsAndMaxes = useMemo(
@@ -2231,85 +2105,20 @@ const useEchartsCartesianConfig = (
             isHorizontal,
         );
 
-        // First pass: compute colors for all series (we need sibling colors for PoP series)
-        const seriesColors = series.map((serie) => getSeriesColor(serie));
-
-        // Helper to apply opacity to a color (hex or rgb)
-        const applyOpacityToColor = (
-            color: string,
-            opacity: number,
-        ): string => {
-            if (!color) return 'rgba(0, 0, 0, 0)';
-            // Handle hex colors
-            if (color.startsWith('#')) {
-                const hex = color.slice(1);
-                const r = parseInt(
-                    hex.length === 3 ? hex[0] + hex[0] : hex.slice(0, 2),
-                    16,
-                );
-                const g = parseInt(
-                    hex.length === 3 ? hex[1] + hex[1] : hex.slice(2, 4),
-                    16,
-                );
-                const b = parseInt(
-                    hex.length === 3 ? hex[2] + hex[2] : hex.slice(4, 6),
-                    16,
-                );
-                return `rgba(${r}, ${g}, ${b}, ${opacity})`;
-            }
-            // Handle rgb/rgba colors
-            if (color.startsWith('rgb')) {
-                const match = color.match(
-                    /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)/,
-                );
-                if (match) {
-                    return `rgba(${match[1]}, ${match[2]}, ${match[3]}, ${opacity})`;
-                }
-            }
-            return color;
-        };
-
-        const POP_OPACITY = 0.5;
+        // Compute colors for all series (handles PoP series with sibling color + opacity)
+        const seriesColors = computeSeriesColorsWithPop({
+            series,
+            getSeriesColor,
+        });
 
         const seriesWithValidStack = series.map<EChartsSeries>(
             (serie, index) => {
-                // For period-over-period series, use sibling color with opacity
-                let computedColor: string;
-                let lineStyleOverride: EChartsSeries['lineStyle'] | undefined;
-
-                if (serie.periodOverPeriodMetadata) {
-                    // Find sibling by matching field name (without _previous suffix)
-                    const previousField = serie.encode?.y;
-                    const baseField = previousField?.replace(/_previous$/, '');
-                    const siblingIdx = series.findIndex(
-                        (s) =>
-                            s.encode?.y === baseField &&
-                            !s.periodOverPeriodMetadata,
-                    );
-                    const siblingColor =
-                        siblingIdx >= 0 ? seriesColors[siblingIdx] : undefined;
-                    const baseColor =
-                        siblingColor || seriesColors[index] || '#888888';
-
-                    // Apply opacity to the color for consistent legend/tooltip appearance
-                    computedColor = applyOpacityToColor(baseColor, POP_OPACITY);
-
-                    // Apply same color to lineStyle (opacity already in color)
-                    lineStyleOverride = {
-                        ...serie.lineStyle,
-                        color: computedColor,
-                        opacity: 1, // Color already has opacity
-                    };
-                } else {
-                    computedColor = seriesColors[index];
-                }
+                const computedColor = seriesColors[index];
 
                 const baseConfig = {
                     ...serie,
                     color: computedColor,
                     stack: getValidStack(serie),
-                    // Apply lineStyle override for PoP series
-                    ...(lineStyleOverride && { lineStyle: lineStyleOverride }),
                     // Ensure label styles are applied after color is known
                     ...(serie.label?.show && {
                         label: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Improved period-over-period (PoP) chart functionality by refactoring how comparison series are handled:

1. Removed console.log statement from SavedChartModel
2. Enhanced tooltip formatting for PoP series by using explicit baseFieldId from metadata instead of string matching
3. Added baseFieldId to periodOverPeriodMetadata type to properly track relationships
4. Created dedicated popSeriesUtils.ts with utilities for:
   - Building PoP field maps using explicit metadata
   - Generating visually distinct PoP series with proper styling
   - Computing appropriate colors for PoP series
   - Interleaving PoP series with base series
5. Improved visual distinction between base and comparison series using lighten function instead of opacity

This approach is more robust as it relies on explicit metadata rather than string pattern matching, making the code more maintainable and less prone to errors.