### PR TITLE
feat: beta tag + report issue for dark mode

### DIFF
--- a/packages/frontend/src/components/NavBar/ThemeSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher.tsx
@@ -1,10 +1,17 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Tooltip } from '@mantine-8/core';
+import { Anchor, Group, HoverCard, Stack, Text } from '@mantine-8/core';
+// Using button from mantine/core so it groups nicely with other elements in navbar
 import { Button, useMantineColorScheme } from '@mantine/core';
 import { IconMoonStars, IconSun } from '@tabler/icons-react';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { type FC } from 'react';
+import { BetaBadge } from '../common/BetaBadge';
 import MantineIcon from '../common/MantineIcon';
+
+const githubIssueUrl =
+    'https://github.com/lightdash/lightdash/issues/new?' +
+    'template=bug_report.yml&' +
+    'labels=%F0%9F%8C%92%20dark%20theme';
 
 export const ThemeSwitcher: FC<{}> = ({}) => {
     const isDarkModeEnabled = useFeatureFlagEnabled(FeatureFlags.DarkMode);
@@ -13,16 +20,41 @@ export const ThemeSwitcher: FC<{}> = ({}) => {
     if (!isDarkModeEnabled) return null;
 
     return (
-        <Tooltip label={colorScheme === 'dark' ? 'Light mode' : 'Dark mode'}>
-            <Button
-                variant="default"
-                size="xs"
-                onClick={() => toggleColorScheme()}
-            >
-                <MantineIcon
-                    icon={colorScheme === 'dark' ? IconSun : IconMoonStars}
-                />
-            </Button>
-        </Tooltip>
+        <HoverCard width={280} shadow="md" openDelay={400} withArrow>
+            <HoverCard.Target>
+                <Button
+                    variant="default"
+                    size="xs"
+                    onClick={() => toggleColorScheme()}
+                >
+                    <MantineIcon
+                        icon={colorScheme === 'dark' ? IconSun : IconMoonStars}
+                    />
+                </Button>
+            </HoverCard.Target>
+            <HoverCard.Dropdown>
+                <Stack gap="sm">
+                    <Group gap="xs">
+                        <Text fw={600} size="sm">
+                            Dark mode
+                        </Text>
+                        <BetaBadge />
+                    </Group>
+                    <Text size="xs" c="dimmed">
+                        Dark mode is currently in beta. If you encounter any
+                        visual issues or bugs, please help us improve by
+                        reporting them.
+                    </Text>
+                    <Anchor
+                        href={githubIssueUrl}
+                        target="_blank"
+                        size="xs"
+                        fw={500}
+                    >
+                        Report an issue →
+                    </Anchor>
+                </Stack>
+            </HoverCard.Dropdown>
+        </HoverCard>
     );
 };


### PR DESCRIPTION
### Description:

Added `Beta` tag + quick report button for dark mode 

<img width="305" height="199" alt="image" src="https://github.com/user-attachments/assets/240a844f-445e-4d91-900b-72bfcd496435" />

<img width="305" height="199" alt="image" src="https://github.com/user-attachments/assets/93ff7b88-29c1-41c5-a823-d629b11eab88" />
