### PR TITLE
fix: legend double click tooltip and funnel dark mode

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -99,6 +99,7 @@ const useEchartsFunnelConfig = (
                     meta,
                     itemStyle: {
                         color: colorOverrides?.[id] ?? colorDefaults[id],
+                        borderWidth: 0,
                     },
                 };
             }),

--- a/packages/frontend/src/hooks/echarts/useLegendDoubleClickTooltip.ts
+++ b/packages/frontend/src/hooks/echarts/useLegendDoubleClickTooltip.ts
@@ -6,12 +6,12 @@ export const useLegendDoubleClickTooltip = () => {
     return {
         tooltip: {
             show: true,
-            backgroundColor: theme.colors.ldGray[9],
-            borderColor: theme.colors.ldGray[9],
+            backgroundColor: theme.colors.background[0],
+            borderColor: theme.colors.ldGray[3],
             borderWidth: 0,
             borderRadius: 4,
             textStyle: {
-                color: theme.white,
+                color: theme.colors.ldGray[7],
                 fontSize: 12,
                 fontWeight: 400,
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
This PR makes two visual improvements to our charts:

1. Removes borders from funnel chart segments by setting `borderWidth: 0` in the item style configuration.
2. Updates the legend tooltip styling for dark mode

These changes improve the visual consistency of our charts with the rest of the application.

![CleanShot 2025-11-28 at 18.56.24@2x.png](https://app.graphite.com/user-attachments/assets/4c68ebf9-bd01-4134-9999-c90afc1722af.png)

![CleanShot 2025-11-28 at 18.56.09@2x.png](https://app.graphite.com/user-attachments/assets/084d08f6-9d7d-456f-b9a4-bcb101f4d9f8.png)

> [!NOTE]
> this pr doesn't fully fix funnel's labels, internal discussion [here](https://lightdash.slack.com/archives/C02NPFHF4F6/p1764352123096579)