### PR TITLE
feat: only load charts in viewport for dashboards

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1049,8 +1049,6 @@ export class SavedChartModel {
                     return ECHARTS_DEFAULT_COLORS;
                 };
 
-                console.log('savedQuery', JSON.stringify(savedQuery, null, 2));
-
                 return {
                     uuid: savedQuery.saved_query_uuid,
                     projectUuid: savedQuery.project_uuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR optimizes dashboard performance by implementing viewport-based chart loading. Charts now only poll for results when they are visible in the viewport, while still warming up all queries immediately.

Key changes:
- Added `useIntersection` hook to detect when chart tiles enter/exit the viewport
- Modified `useInfiniteQueryResults` to accept a `pollingEnabled` parameter that controls polling behavior
- Added intersection observers to both regular and embedded dashboard chart tiles
- Removed a debug console.log statement from SavedChartModel
- Added logic to resume polling when a chart re-enters the viewport

This optimization significantly improves dashboard loading performance, especially for dashboards with many charts, by reducing unnecessary network requests and processing for off-screen content.

**Before**


https://github.com/user-attachments/assets/465c9f53-1639-4539-9b4d-58864a8bcb1e



**After**



https://github.com/user-attachments/assets/ca93487a-a7c0-4d77-93f0-d82e8ef516f2



