### PR TITLE
fix: add dark mode support for grid item borders

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -52,12 +52,15 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
                 align="center"
                 spacing="md"
                 noWrap
-                sx={{
+                sx={(t) => ({
                     flexGrow: 1,
                     borderBottomWidth: 1,
                     borderBottomStyle: 'solid',
-                    borderBottomColor: theme.colors.ldGray[3],
-                }}
+                    borderBottomColor:
+                        t.colorScheme === 'dark'
+                            ? t.colors.ldDark[8]
+                            : t.colors.ldGray[3],
+                })}
             >
                 {dragIcon}
                 <ResourceIcon item={item} />

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -52,12 +52,15 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
                 align="center"
                 spacing="md"
                 noWrap
-                sx={{
+                sx={(t) => ({
                     flexGrow: 1,
                     borderBottomWidth: 1,
                     borderBottomStyle: 'solid',
-                    borderBottomColor: theme.colors.ldGray[3],
-                }}
+                    borderBottomColor:
+                        t.colorScheme === 'dark'
+                            ? t.colors.ldDark[8]
+                            : t.colors.ldGray[3],
+                })}
             >
                 {dragIcon}
                 <ResourceIcon item={item} />


### PR DESCRIPTION
### Description:
Updated the border color in ResourceViewGridChartItem and ResourceViewGridDashboardItem components to support dark mode. The border now uses `ldDark[8]` color when in dark mode and maintains the original `ldGray[3]` in light mode.