### PR TITLE
feat: env variables to enable multi-agent slack channels

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -982,6 +982,7 @@ export type SlackConfig = {
     socketMode?: boolean;
     channelsCachedTime: number;
     supportUrl: string;
+    multiAgentChannelEnabled: boolean;
 };
 export type HeadlessBrowserConfig = {
     host?: string;
@@ -1553,6 +1554,8 @@ export const parseConfig = (): LightdashConfig => {
                 10,
             ), // 10 minutes
             supportUrl: process.env.SLACK_SUPPORT_URL || '',
+            multiAgentChannelEnabled:
+                process.env.SLACK_MULTI_AGENT_CHANNEL_ENABLED === 'true',
         },
         scheduler: {
             enabled: process.env.SCHEDULER_ENABLED !== 'false',

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -21,6 +21,9 @@ export const BaseResponse: HealthState = {
     hasGitlab: false,
     hasHeadlessBrowser: false,
     hasSlack: false,
+    slack: {
+        multiAgentChannelEnabled: false,
+    },
     auth: {
         disablePasswordAuthentication: false,
         google: {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -110,6 +110,11 @@ export class HealthService extends BaseService {
             },
             pivotTable: this.lightdashConfig.pivotTable,
             hasSlack: this.hasSlackConfig(),
+            slack: {
+                multiAgentChannelEnabled:
+                    this.lightdashConfig.slack?.multiAgentChannelEnabled ??
+                    false,
+            },
             hasGithub: process.env.GITHUB_PRIVATE_KEY !== undefined,
             hasGitlab:
                 this.lightdashConfig.gitlab.clientId !== undefined &&

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -384,6 +384,9 @@ export type HealthState = {
         maxColumnLimit: number;
     };
     hasSlack: boolean;
+    slack: {
+        multiAgentChannelEnabled: boolean;
+    };
     hasGithub: boolean;
     hasGitlab: boolean;
     hasHeadlessBrowser: boolean;

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -27,13 +27,13 @@ import {
     IconDeviceFloppy,
     IconHelpCircle,
     IconRefresh,
-    IconSparkles,
     IconTrash,
 } from '@tabler/icons-react';
 import debounce from 'lodash/debounce';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import { z } from 'zod';
+import useHealth from '../../../hooks/health/useHealth';
 import {
     useDeleteSlack,
     useGetSlack,
@@ -43,6 +43,8 @@ import {
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import slackSvg from '../../../svgs/slack.svg';
+import { BetaBadge } from '../../common/BetaBadge';
+import { ComingSoonBadge } from '../../common/ComingSoonBadge';
 import { default as MantineIcon } from '../../common/MantineIcon';
 import { SettingsGridCard } from '../../common/Settings/SettingsCard';
 
@@ -75,8 +77,12 @@ const SlackSettingsPanel: FC = () => {
     const { data: aiCopilotFlag } = useFeatureFlag(
         CommercialFeatureFlags.AiCopilot,
     );
+    const { data: health } = useHealth();
     const { data: slackInstallation, isInitialLoading } = useGetSlack();
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
+
+    const isSlackMultiAgentChannelEnabled =
+        health?.slack?.multiAgentChannelEnabled ?? false;
 
     const [search, setSearch] = useState('');
 
@@ -350,32 +356,28 @@ const SlackSettingsPanel: FC = () => {
                                     </Stack>
 
                                     <Stack spacing="xs">
-                                        <Group spacing="two">
+                                        <Group spacing="xs">
                                             <Title order={6} fw={500}>
                                                 Multi-agent channel
                                             </Title>
 
-                                            <Tooltip
-                                                multiline
-                                                variant="xs"
-                                                maw={250}
-                                                label="Select a channel where users can interact with any AI agent (excluding from preview projects). When users start a thread in this channel, they'll see a dropdown to select which agent to use."
-                                            >
-                                                <MantineIcon
-                                                    icon={IconHelpCircle}
-                                                />
-                                            </Tooltip>
-                                            <Badge
-                                                color="indigo"
-                                                variant="light"
-                                                icon={
+                                            {isSlackMultiAgentChannelEnabled && (
+                                                <Tooltip
+                                                    multiline
+                                                    variant="xs"
+                                                    maw={250}
+                                                    label="Select a channel where users can interact with any AI agent (excluding from preview projects). When users start a thread in this channel, they'll see a dropdown to select which agent to use."
+                                                >
                                                     <MantineIcon
-                                                        icon={IconSparkles}
+                                                        icon={IconHelpCircle}
                                                     />
-                                                }
-                                            >
-                                                Coming soon
-                                            </Badge>
+                                                </Tooltip>
+                                            )}
+                                            {isSlackMultiAgentChannelEnabled ? (
+                                                <BetaBadge />
+                                            ) : (
+                                                <ComingSoonBadge />
+                                            )}
                                         </Group>
 
                                         <Text c="dimmed" fz="xs">
@@ -386,13 +388,21 @@ const SlackSettingsPanel: FC = () => {
 
                                         <Select
                                             size="xs"
-                                            placeholder="Select a channel (optional)"
-                                            searchable
-                                            clearable
+                                            placeholder={
+                                                isSlackMultiAgentChannelEnabled
+                                                    ? 'Select a channel (optional)'
+                                                    : 'Feature not available'
+                                            }
                                             limit={500}
-                                            disabled
                                             nothingFound="No channels found"
-                                            data={slackChannelOptions}
+                                            data={
+                                                isSlackMultiAgentChannelEnabled
+                                                    ? slackChannelOptions
+                                                    : []
+                                            }
+                                            disabled={
+                                                !isSlackMultiAgentChannelEnabled
+                                            }
                                             rightSection={
                                                 isLoadingSlackChannels ? (
                                                     <Loader size="xs" />

--- a/packages/frontend/src/components/common/ComingSoonBadge.tsx
+++ b/packages/frontend/src/components/common/ComingSoonBadge.tsx
@@ -1,0 +1,29 @@
+import { Badge, Tooltip } from '@mantine/core';
+import { IconSparkles } from '@tabler/icons-react';
+import type { FC } from 'react';
+import MantineIcon from './MantineIcon';
+
+type Props = {
+    tooltipLabel?: string;
+};
+
+/**
+ * A badge that displays a coming soon label and a tooltip when hovered.
+ * @param tooltipLabel - The label to display in the tooltip
+ * @returns A badge that displays a coming soon label and a tooltip when hovered.
+ */
+export const ComingSoonBadge: FC<Props> = ({
+    tooltipLabel = 'This feature is coming soon. Contact us if you are interested!',
+}) => {
+    return (
+        <Tooltip label={tooltipLabel}>
+            <Badge
+                color="indigo"
+                variant="light"
+                rightSection={<MantineIcon icon={IconSparkles} />}
+            >
+                Coming Soon
+            </Badge>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -46,6 +46,9 @@ export default function mockHealthResponse(
             maxColumnLimit: 100,
         },
         hasSlack: false,
+        slack: {
+            multiAgentChannelEnabled: false,
+        },
         auth: {
             disablePasswordAuthentication: false,
             google: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
Adds a new configuration option `multiAgentChannelEnabled` to the Slack integration, allowing users to select a channel where they can interact with any AI agent. This feature is controlled by the `SLACK_MULTI_AGENT_CHANNEL_ENABLED` environment variable.

The PR includes:
- Expose the feature flag status
- UI changes to conditionally show the multi-agent channel selector
- Added a reusable `ComingSoonBadge` component

#### Feature disabled
![image.png](https://app.graphite.com/user-attachments/assets/b1e4e42e-beb6-4084-98e3-7e013289e03a.png)

#### Feature enabled
![CleanShot 2025-12-01 at 12.16.59.png](https://app.graphite.com/user-attachments/assets/6cc9f9d3-dd74-455c-b328-f079fb378f3f.png)