### PR TITLE
fix: add version 2 to geo.yml model

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/geo.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/geo.yml
@@ -1,3 +1,4 @@
+version: 2
 models:
   - name: geo
     columns:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added `version: 2` to the geo.yml file in the full-jaffle-shop-demo dbt models. This ensures the model configuration file follows the current dbt specification format.

cli-test