### PR TITLE
fix: apply distinctOn find() chart model

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1464,7 +1464,10 @@ export class SavedChartModel {
                                                 ),
                                         );
                                 });
-                        });
+                        })
+                        // Deduplicate results since dashboard_versions JOIN can produce
+                        // multiple rows when a chart appears in multiple dashboard versions
+                        .distinctOn('saved_queries.saved_query_uuid');
                 }
 
                 if (filters.spaceUuids) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18436

### Description:

Added `.distinctOn('saved_queries.saved_query_uuid')` to deduplicate results in the SavedChartModel query. This fixes an issue where the dashboard_versions JOIN was producing duplicate rows when a chart appeared in multiple dashboard versions.


  Summary:
  | Scenario                                 | distinctOn applied?               |
  |------------------------------------------|-----------------------------------|
  | Default (no filters)                     | ✅ Yes                             |
  | excludeChartsSavedInDashboard: true      | ✅ Yes                             |
  | includeOrphanChartsWithinDashboard: true | ❌ No (no dashboard_versions JOIN) |
  | exploreName filter                       | ✅ Yes (existing behavior)         |
  | exploreNames filter                      | ✅ Yes (existing behavior)         |