### PR TITLE
feat: add tooltip for save chart button when no public spaces available

### DIFF
--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -16,7 +16,10 @@ import useSearchParams from '../../../hooks/useSearchParams';
 import MantineIcon from '../../common/MantineIcon';
 import ChartCreateModal from '../../common/modal/ChartCreateModal';
 
-const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
+const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
+    isExplorer,
+    disabled,
+}) => {
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
     const savedChart = useExplorerSelector(selectSavedChart);
@@ -59,6 +62,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean }> = ({ isExplorer }) => {
     }, [explore, unsavedChartVersion.metricQuery.additionalMetrics]);
 
     const isDisabled =
+        disabled ||
         !unsavedChartVersion.tableName ||
         !hasUnsavedChanges ||
         foundCustomMetricWithDuplicateId ||


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-224/users-cannot-save-charts-when-all-spaces-are-restricted-no-public

Improve UI when saving charts with no public spaces 

Before: 

Even editors don't get the `save chart` button

<img width="470" height="223" alt="Screenshot from 2025-12-01 15-06-11" src="https://github.com/user-attachments/assets/845ca3ab-1823-4d33-b70a-4eea87c2f8cc" />


Now:

## can save spaces (aka editors) 

editors can create new spaces, so there are no limitations
<img width="916" height="536" alt="Screenshot from 2025-12-01 15-18-16" src="https://github.com/user-attachments/assets/0da2ca58-b745-41e2-976c-2f40816e03c2" />

<img width="916" height="536" alt="Screenshot from 2025-12-01 15-18-31" src="https://github.com/user-attachments/assets/1274fac8-57a8-4707-8abb-e8a2fd268e3f" />


## Can save charts but can't create spaces (aka interactive viewers)

If no public spaces are available, and you can't create spaces, we disable the action and show the reason on a tooltip

<img width="916" height="536" alt="Screenshot from 2025-12-01 15-21-49" src="https://github.com/user-attachments/assets/28d1f9f1-22ee-48d6-98d5-d113dc7af841" />


### Description:
Improves the SaveChartButton UX by showing a tooltip when there are no public spaces to save a chart to. The button is now disabled when a user can't create charts, and a tooltip explains why. This change also adds a check for whether the user can create a space, which affects how the button is displayed.