### PR TITLE
fix: preserve explorer state when loading saved chart

### DIFF
--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -81,10 +81,10 @@ const SavedExplorer = () => {
     useEffect(() => {
         if (!data) return;
 
-        const currentState = store.getState().explorer;
-        const isInitialized = currentState.savedChart !== undefined;
+        const currentSavedChart = store.getState().explorer.savedChart;
+        const isNewChart = currentSavedChart?.uuid !== data.uuid;
 
-        if (!isInitialized) {
+        if (isNewChart) {
             const initialState = buildInitialExplorerState({
                 savedChart: data,
                 isEditMode,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18268

### Description:
Improved state management in SavedExplorer to prevent resetting the explorer state when it's already initialized. Now, when a saved chart is loaded, the component checks if the explorer state is already initialized before resetting it. Additionally, separated the edit mode state update into its own effect to ensure it's properly updated when changed.

This change prevents unnecessary state resets when navigating between saved charts, maintaining the user's current state when appropriate.