### PR TITLE
fix: dark mode placeholder bg is white for ai agents admin page

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -590,7 +590,12 @@ const AiAgentAdminThreadsTable = ({
                 },
             },
         },
-        mantineTableBodyRowProps: ({ row }) => {
+        mantineTableBodyRowProps: ({ row, table: mantineTable }) => {
+            // Don't apply custom styling during skeleton loading
+            if (mantineTable.getState().showSkeletons) {
+                return {};
+            }
+
             const thread = row.original;
             const isSelected = selectedThread?.uuid === thread.uuid;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18416

### Description:
Fix styling issues during skeleton loading in AI Agent Admin Threads Table by skipping custom row styling when the table is in a loading state. This prevents styling conflicts that could occur when the skeleton UI is displayed.


_before_

![CleanShot 2025-12-01 at 17.39.52.png](https://app.graphite.com/user-attachments/assets/859e654a-3c15-47ce-8bf2-e03964861b1f.png)

_after_

[CleanShot 2025-12-01 at 17.41.00.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4fb643a6-de78-4810-b310-8f4419039ddb.mp4" />](https://app.graphite.com/user-attachments/video/4fb643a6-de78-4810-b310-8f4419039ddb.mp4)


