### PR TITLE
fix: remove quote char from created ctes on pop

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1282,8 +1282,8 @@ export class MetricQueryBuilder {
                     const popMinMaxCteParts = [
                         `SELECT`,
                         [
-                            `MIN(${fieldQuoteChar}${keysCteName}${fieldQuoteChar}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as min_date`,
-                            `MAX(${fieldQuoteChar}${keysCteName}${fieldQuoteChar}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as max_date`,
+                            `MIN(${keysCteName}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as min_date`,
+                            `MAX(${keysCteName}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as max_date`,
                         ].join(',\n'),
                         `FROM ${keysCteName}`,
                     ];
@@ -1320,7 +1320,7 @@ export class MetricQueryBuilder {
                         `WHERE ${getIntervalSyntax(
                             adapterType,
                             popField.compiledSql,
-                            `${fieldQuoteChar}${popMinMaxCteName}${fieldQuoteChar}.${fieldQuoteChar}min_date${fieldQuoteChar}`,
+                            `${popMinMaxCteName}.min_date`,
                             '>=',
                             periodOverPeriod.periodOffset || 1,
                             periodOverPeriod.granularity,
@@ -1328,7 +1328,7 @@ export class MetricQueryBuilder {
                         )} AND ${getIntervalSyntax(
                             adapterType,
                             popField.compiledSql,
-                            `${fieldQuoteChar}${popMinMaxCteName}${fieldQuoteChar}.${fieldQuoteChar}max_date${fieldQuoteChar}`,
+                            `${popMinMaxCteName}.max_date`,
                             '<=',
                             periodOverPeriod.periodOffset || 1,
                             periodOverPeriod.granularity,
@@ -1463,8 +1463,8 @@ export class MetricQueryBuilder {
                 const popUnaffectedMinMaxCteParts = [
                     `SELECT`,
                     [
-                        `MIN(${fieldQuoteChar}${unaffectedMetricsCteName}${fieldQuoteChar}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as min_date`,
-                        `MAX(${fieldQuoteChar}${unaffectedMetricsCteName}${fieldQuoteChar}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as max_date`,
+                        `MIN(${unaffectedMetricsCteName}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as min_date`,
+                        `MAX(${unaffectedMetricsCteName}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as max_date`,
                     ].join(',\n'),
                     `FROM ${unaffectedMetricsCteName}`,
                 ];
@@ -1505,7 +1505,7 @@ export class MetricQueryBuilder {
                     `WHERE ${getIntervalSyntax(
                         adapterType,
                         popField.compiledSql,
-                        `${fieldQuoteChar}${popUnaffectedMinMaxCteName}${fieldQuoteChar}.${fieldQuoteChar}min_date${fieldQuoteChar}`,
+                        `${popUnaffectedMinMaxCteName}.min_date`,
                         '>=',
                         periodOverPeriod.periodOffset || 1,
                         periodOverPeriod.granularity,
@@ -1513,7 +1513,7 @@ export class MetricQueryBuilder {
                     )} AND ${getIntervalSyntax(
                         adapterType,
                         popField.compiledSql,
-                        `${fieldQuoteChar}${popUnaffectedMinMaxCteName}${fieldQuoteChar}.${fieldQuoteChar}max_date${fieldQuoteChar}`,
+                        `${popUnaffectedMinMaxCteName}.max_date`,
                         '<=',
                         periodOverPeriod.periodOffset || 1,
                         periodOverPeriod.granularity,
@@ -2072,8 +2072,8 @@ export class MetricQueryBuilder {
             const popMinMaxCteParts = [
                 `SELECT`,
                 [
-                    `MIN(${fieldQuoteChar}${baseCteName}${fieldQuoteChar}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as min_date`,
-                    `MAX(${fieldQuoteChar}${baseCteName}${fieldQuoteChar}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as max_date`,
+                    `MIN(${baseCteName}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as min_date`,
+                    `MAX(${baseCteName}.${fieldQuoteChar}${popFieldId}${fieldQuoteChar}) as max_date`,
                 ].join(',\n'),
                 `FROM ${baseCteName}`,
             ];
@@ -2111,7 +2111,7 @@ export class MetricQueryBuilder {
                 `WHERE ${getIntervalSyntax(
                     adapterType,
                     popField.compiledSql,
-                    `${fieldQuoteChar}${popMinMaxCteName}${fieldQuoteChar}.${fieldQuoteChar}min_date${fieldQuoteChar}`,
+                    `${popMinMaxCteName}.min_date`,
                     '>=',
                     periodOverPeriod.periodOffset || 1,
                     periodOverPeriod.granularity,
@@ -2119,7 +2119,7 @@ export class MetricQueryBuilder {
                 )} AND ${getIntervalSyntax(
                     adapterType,
                     popField.compiledSql,
-                    `${fieldQuoteChar}${popMinMaxCteName}${fieldQuoteChar}.${fieldQuoteChar}max_date${fieldQuoteChar}`,
+                    `${popMinMaxCteName}.max_date`,
                     '<=',
                     periodOverPeriod.periodOffset || 1,
                     periodOverPeriod.granularity,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18441

### Description:

Fixed SQL query generation for period-over-period comparisons by removing unnecessary field quote characters around CTE table names. This change ensures proper SQL syntax when referencing CTE tables in MIN/MAX date calculations.

postgres

![Screenshot 2025-12-01 at 17.28.10.png](https://app.graphite.com/user-attachments/assets/e97d7e6b-1372-4074-a703-c6d00d2fd215.png)

snowflake

![image.png](https://app.graphite.com/user-attachments/assets/38766b45-0d3c-467a-bc8f-faf27fa666c9.png)

bigquery (ignore toast error - was from previous query)

![image.png](https://app.graphite.com/user-attachments/assets/315bf938-47f5-4da4-9932-e5f722dcb3fd.png)