### PR TITLE
fix: spaces pinned item tooltip illegible in dark mode

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -63,7 +63,7 @@ const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
                     withArrow
                     label={
                         <Stack spacing={4}>
-                            <Text lineClamp={1} fz="xs" fw={600} color="white">
+                            <Text lineClamp={1} fz="xs" fw={600}>
                                 {tooltipText}
                             </Text>
                             <Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18415

### Description:
Removed the hardcoded white color from the tooltip text in ResourceViewGridSpaceItem component to allow the text to inherit its color from the theme, improving accessibility and theme consistency.