### PR TITLE
fix: re-allow removing missing fields

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
@@ -1,5 +1,5 @@
-import { Group, Text, Tooltip } from '@mantine/core';
-import { IconAlertTriangle } from '@tabler/icons-react';
+import { ActionIcon, Group, Text, Tooltip } from '@mantine-8/core';
+import { IconAlertTriangle, IconTrash } from '@tabler/icons-react';
 import { memo, useCallback, type FC } from 'react';
 import MantineIcon from '../../../../common/MantineIcon';
 import type { MissingFieldItem } from './types';
@@ -23,27 +23,44 @@ const VirtualMissingFieldComponent: FC<VirtualMissingFieldProps> = ({
     }, [onRemove, fieldId, isDimension]);
 
     return (
-        <Tooltip
-            withinPortal
-            label={`Field ${fieldId} not found on this chart. Click here to remove it.`}
-            position="bottom-start"
-            maw={700}
+        <Group
+            ml={32}
+            mr={16}
+            my="xs"
+            gap="xs"
+            wrap="nowrap"
+            style={{ overflow: 'hidden' }}
         >
-            <Group
-                onClick={handleClick}
-                ml={12}
-                my="xs"
-                noWrap
-                style={{ cursor: 'pointer' }}
+            <MantineIcon
+                icon={IconAlertTriangle}
+                color="yellow.9"
+                style={{ flexShrink: 0 }}
+            />
+
+            <Text truncate size="sm" style={{ flex: 1, minWidth: 0 }}>
+                {fieldId}
+            </Text>
+
+            <Tooltip
+                withinPortal
+                label={
+                    <Text size="xs" style={{ wordBreak: 'break-all' }}>
+                        Remove missing field "{fieldId}".
+                    </Text>
+                }
+                maw={300}
+                multiline
             >
-                <MantineIcon
-                    icon={IconAlertTriangle}
-                    color="yellow.9"
+                <ActionIcon
+                    color="gray"
+                    variant="transparent"
                     style={{ flexShrink: 0 }}
-                />
-                <Text truncate>{fieldId}</Text>
-            </Group>
-        </Tooltip>
+                    onClick={handleClick}
+                >
+                    <MantineIcon icon={IconTrash} style={{ flexShrink: 0 }} />
+                </ActionIcon>
+            </Tooltip>
+        </Group>
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.test.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.test.ts
@@ -172,6 +172,7 @@ describe('flattenTreeForVirtualization', () => {
         missingCustomMetrics: [],
         missingCustomDimensions: [],
         missingFieldIds: [],
+        selectedDimensions: [],
         activeFields: new Set(),
         sectionNodeMaps: createSectionNodeMaps([mockTable]),
     };

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
@@ -255,7 +255,7 @@ function flattenTable(
             estimatedHeight: ITEM_HEIGHTS.SECTION_HEADER,
             data: {
                 tableName,
-                treeSection: TreeSection.Dimensions, // Arbitrary, missing fields aren't tied to a section
+                treeSection: TreeSection.MissingFields, // Arbitrary, missing fields aren't tied to a section
                 label: 'Missing fields',
                 color: 'ldGray.6',
                 depth: baseDepth,
@@ -270,7 +270,7 @@ function flattenTable(
                 data: {
                     fieldId,
                     tableName,
-                    isDimension: true, // Will be determined by the component
+                    isDimension: options.selectedDimensions.includes(fieldId),
                 },
             } satisfies MissingFieldItem);
         });

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/types.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/types.ts
@@ -14,6 +14,7 @@ export enum TreeSection {
     Metrics = 'metrics',
     CustomMetrics = 'custom-metrics',
     CustomDimensions = 'custom-dimensions',
+    MissingFields = 'missing-fields',
 }
 
 /**
@@ -177,6 +178,9 @@ export interface FlattenTreeOptions {
     missingCustomMetrics: AdditionalMetric[];
     missingCustomDimensions: CustomDimension[];
     missingFieldIds: string[];
+
+    // Selected fields (for determining if missing field is dimension or metric)
+    selectedDimensions: string[];
 
     // Active fields (for pinning selected items to top)
     activeFields: Set<string>;

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -22,6 +22,7 @@ import {
     selectActiveFields,
     selectAdditionalMetrics,
     selectCustomDimensions,
+    selectDimensions,
     selectMissingCustomDimensions,
     selectMissingCustomMetrics,
     selectMissingFieldIds,
@@ -59,6 +60,7 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
         selectMissingFieldIds(state, explore),
     );
     const activeFields = useExplorerSelector(selectActiveFields);
+    const selectedDimensions = useExplorerSelector(selectDimensions);
 
     const [search, setSearch] = useState<string>('');
     const [isPending, startTransition] = useTransition();
@@ -190,6 +192,7 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
             missingCustomMetrics,
             missingCustomDimensions,
             missingFieldIds,
+            selectedDimensions,
             activeFields,
             sectionNodeMaps,
         });
@@ -207,6 +210,7 @@ const ExploreTreeComponent: FC<ExploreTreeProps> = ({
         missingFieldIds,
         searchResultsMap,
         sectionNodeMaps,
+        selectedDimensions,
         tableTrees,
     ]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18458

### Description:
Improved the missing fields UI in the Explorer tree by:

- Redesigned the missing field component with a cleaner layout
- Added a trash icon button for removing missing fields instead of clicking the entire row
- Fixed the detection of whether a missing field is a dimension or metric
- Created a dedicated TreeSection enum for missing fields
- Improved tooltips to be more descriptive and handle long field names better

Before (**whenever you select to remove, it will duplicate the same missing field**) You can also see the + add button that doesn't make sense there

![Screenshot 2025-12-01 at 18.25.56.png](https://app.graphite.com/user-attachments/assets/bbbc0267-64c8-4649-bed1-71d9d8540409.png)

after (**just as it used to work + truncation of text and truncation on the tooltip + an action icon**

![Screenshot 2025-12-01 at 18.23.19.png](https://app.graphite.com/user-attachments/assets/0be36497-1b14-4b65-8c89-f5ba99ab08f7.png)


