### PR TITLE
fix: `EvalHtmlReporter` Cannot read properties of null exception

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/tests/eval-reporter.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/eval-reporter.ts
@@ -494,7 +494,11 @@ export default class EvalHtmlReporter implements Reporter {
 </html>`;
     }
 
-    private static escapeHtml(text: string): string {
+    private static escapeHtml(text: string | null): string {
+        if (!text) {
+            return 'null';
+        }
+
         const map: Record<string, string> = {
             '&': '&amp;',
             '<': '&lt;',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes:  
  
```sh
⎯⎯⎯⎯⎯⎯ **Unhandled Error** ⎯⎯⎯⎯⎯⎯⎯

**TypeError**: Cannot read properties of null (reading 'replace')

❯ _EvalHtmlReporter.escapeHtml vitest.config.integration.ts:429:17

❯ vitest.config.integration.ts:402:164

❯ vitest.config.integration.ts:401:150

❯ _EvalHtmlReporter.generateHtml vitest.config.integration.ts:369:27

❯ _EvalHtmlReporter.generateReport vitest.config.integration.ts:132:36

❯ _EvalHtmlReporter.onFinished vitest.config.integration.ts:72:14

❯ ../../node_modules/.pnpm/vitest@3.2.4_@types+node@24.3.1_jsdom@24.0.0_canvas@2.11.2_encoding@0.1.13___lightningcss@1.22.0_tsx@4.19.4_yaml@2.7.0/node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:9948:56  
```

### Description:

Fix HTML escaping in evaluation reporter to handle null values. The `escapeHtml` method now properly checks for null inputs and returns 'null' as a string instead of attempting to process a null value, which would cause errors.