### PR TITLE
fix: set max-height on pivot table instead of inheriting h

### DIFF
--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -187,7 +187,7 @@ const TableComponent = forwardRef<HTMLTableElement, TableProps>(
             <Box
                 ref={containerRef}
                 miw="inherit"
-                h="inherit"
+                mah="100%"
                 pos="relative"
                 sx={{
                     overflow: 'auto',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18327

### Description:
Fixed the table container height by replacing `h="inherit"` with `mah="100%"` in the LightTable component. This ensures the table doesn't overflow its container while still maintaining proper scrolling behavior.