### PR TITLE
fix: prevent duplicate changeset application to explores

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -976,7 +976,9 @@ export class CatalogModel {
             {
                 catalogSize: paginatedCatalogItems.data.length,
             },
-            async () =>
+            async () => {
+                const exploresWithChangesetApplied = new Set();
+
                 paginatedCatalogItems.data.map((item) => {
                     // Use the explore from filteredExplores if available, otherwise use from DB
                     let explore = exploreByTableName
@@ -993,12 +995,16 @@ export class CatalogModel {
                         );
                     }
 
-                    if (changeset) {
+                    if (
+                        changeset &&
+                        !exploresWithChangesetApplied.has(explore.name)
+                    ) {
                         const exploreWithChanges =
                             ChangesetUtils.applyChangeset(changeset, {
                                 [explore.name]: explore,
                             })[explore.name] as Explore; // at this point we know the explore is valid
                         explore = exploreWithChanges;
+                        exploresWithChangesetApplied.add(explore.name);
                     }
                     return parseCatalog({
                         ...item,
@@ -1006,7 +1012,8 @@ export class CatalogModel {
                         catalog_tags:
                             tagsPerItem[item.catalog_search_uuid] ?? [],
                     });
-                }),
+                });
+            },
         );
 
         return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes: ![image.png](https://app.graphite.com/user-attachments/assets/a3ad6d6e-fe93-4d86-981c-f8ad5f8c3612.png)



### Description:

Fixed a bug where changesets were being applied multiple times to the same explore in the catalog. Now we track which explores have already had a changeset applied using a Set to ensure each explore only has the changeset applied once.