### PR TITLE
fix: don't apply changesets multiple times

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -996,7 +996,8 @@ export class CatalogModel {
                     if (changeset) {
                         const exploreWithChanges =
                             ChangesetUtils.applyChangeset(changeset, {
-                                [explore.name]: explore,
+                                // we need to clone the explore to avoid mutating the original explore object
+                                [explore.name]: structuredClone(explore),
                             })[explore.name] as Explore; // at this point we know the explore is valid
                         explore = exploreWithChanges;
                     }

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -262,10 +262,12 @@ export class CatalogService<
         fullTextSearchOperator?: 'OR' | 'AND';
         filteredExplores?: Explore[];
     }): Promise<KnexPaginatedData<CatalogItem[]>> {
-        const changeset =
-            await this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
-                args.projectUuid,
-            );
+        const changeset = args.filteredExplores
+            ? // Do not pass changeset as we expect `filteredExplores` to have changeset already applied
+              undefined
+            : await this.changesetModel.findActiveChangesetWithChangesByProjectUuid(
+                  args.projectUuid,
+              );
         return wrapSentryTransaction(
             'CatalogService.searchCatalog',
             {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR fixes an issue with changesets being applied multiple times to explores. The changes include:

1. Using `structuredClone` to create a deep copy of the explore object before applying the changeset, preventing mutations to the original object.
2. Skipping changeset application in `searchCatalog` when `filteredExplores` are provided, as these explores are expected to already have the changeset applied.



Fixes this issue:  
  
![image.png](https://app.graphite.com/user-attachments/assets/304d10f1-47b2-4dc3-8aa8-6980720e65c5.png)

  
to reproduce:  
  
\- create a metric in changesets: "**can you create a avg_payment_amount metric for average payment amount?"  
\-** **then** **prompt** **the** **agent:** "**give me orders by order status"**