### PR TITLE
fix: update popover position and add portal rendering

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -253,9 +253,10 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                         onClose?.();
                     }
                 }}
-                position="bottom"
+                position="top"
                 width={300}
                 withArrow
+                withinPortal
                 trapFocus={!hasOpenSubPopover}
                 closeOnClickOutside={!hasOpenSubPopover} // Prevent closing when sub-popover is open
             >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18483

### Description:
Improves the MetricsCatalogCategoryForm popover by:
1. Changing position from "bottom" to "top" for better visibility
2. Adding `withinPortal` prop to ensure proper rendering in complex layouts

This change helps prevent UI issues where the popover might be cut off or positioned awkwardly when appearing at the bottom of the component.

Before:
![Screenshot 2025-12-02 at 15.49.57.png](https://app.graphite.com/user-attachments/assets/f55b6b0e-6bce-4e96-9b9c-5eae8289053a.png)

After:
![Screenshot 2025-12-02 at 16.31.30.png](https://app.graphite.com/user-attachments/assets/72dc1251-48fb-46b7-9260-6fb9907fe337.png)

