### PR TITLE
feat: add explore-scoped additional dimensions

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -30,6 +30,23 @@ models:
         default_time_dimension:
           field: order_date
           interval: MONTH
+        explores:
+          orders_with_custom_dims:
+            label: Orders with Custom Dimensions
+            # No need to specify joins - they are inherited from the parent model
+            additional_dimensions:
+              full_name:
+                type: string
+                sql: "CONCAT(${customers.first_name}, ' ', ${customers.last_name})"
+                label: Customer Full Name
+              order_value_category:
+                type: string
+                sql: "CASE WHEN ${orders.amount} > 100 THEN 'high' ELSE 'low' END"
+                label: Order Value Category
+              order_month:
+                type: date
+                sql: DATE(${orders.order_date})
+                time_intervals: [MONTH]
     columns:
       - name: order_id
         tests:

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -75,11 +75,34 @@ type DbtLightdashFieldTags = {
 
 export type DbtModelMetadata = DbtModelLightdashConfig & {};
 
+/**
+ * Additional dimension definition for explore-scoped dimensions.
+ * These dimensions are only available within a specific explore.
+ * They can reference fields from joined tables using ${table.field} syntax.
+ *
+ * Unlike column-level additional dimensions, explore-scoped dimensions
+ * require `type` and `sql` since there's no underlying column to infer from.
+ */
+export type DbtExploreLightdashAdditionalDimension =
+    DbtColumnLightdashAdditionalDimension & {
+        type: DimensionType; // Required for explore-scoped dimensions
+        sql: string; // Required for explore-scoped dimensions
+    };
+
 type ExploreConfig = {
     label?: string;
     description?: string;
     group_label?: string;
     joins?: DbtModelJoin[];
+    /**
+     * Explore-scoped custom dimensions.
+     * These dimensions are only available within this specific explore
+     * and can reference fields from any joined table.
+     */
+    additional_dimensions?: Record<
+        string,
+        DbtExploreLightdashAdditionalDimension
+    >;
 };
 
 export type SharedDbtModelLightdashConfig = {

--- a/packages/common/src/types/lightdashModel.ts
+++ b/packages/common/src/types/lightdashModel.ts
@@ -10,6 +10,7 @@ import type {
     DbtColumnLightdashAdditionalDimension,
     DbtColumnLightdashDimension,
     DbtColumnLightdashMetric,
+    DbtExploreLightdashAdditionalDimension,
     DbtModelJoin,
     DbtModelLightdashConfig,
 } from './dbt';
@@ -53,6 +54,15 @@ export type LightdashModelExplore = {
     joins?: DbtModelJoin[]; // Reuses DbtModelJoin directly
     required_filters?: RequiredFilter[];
     default_filters?: RequiredFilter[];
+    /**
+     * Explore-scoped custom dimensions.
+     * These dimensions are only available within this specific explore
+     * and can reference fields from any joined table.
+     */
+    additional_dimensions?: Record<
+        string,
+        DbtExploreLightdashAdditionalDimension
+    >;
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/CENG-228/support-defining-custom-dimensions-scoped-to-a-single-explore

Explore extended model inherits all properties and joins from the main model  (eg: orders)

<img width="790" height="296" alt="image" src="https://github.com/user-attachments/assets/deb68192-c97f-47fc-b1cf-693712869817" />

<img width="1328" height="767" alt="Screenshot from 2025-12-02 16-57-03" src="https://github.com/user-attachments/assets/f4a0ae4d-8303-4b3f-8176-7d806d8df9b9" />


### Description:
Adds support for explore-scoped additional dimensions, allowing users to define custom dimensions that are only available within specific explores. These dimensions can reference fields from any joined table using `${table.field}` syntax.

This feature enables more flexible data modeling by:
- Creating explore-specific dimensions without modifying the base model
- Supporting complex calculations that combine fields from multiple tables
- Maintaining a clean base model while offering specialized views for specific use cases

The implementation includes:
- Support for all dimension types, including date dimensions with time intervals
- Full test coverage for the new functionality
- An example in the jaffle-shop demo showing how to define custom dimensions like "Customer Full Name" and "Order Value Category"

![image](https://github.com/lightdash/lightdash/assets/12345678/abcd1234-5678-90ab-cdef-1234567890ab)