### PR TITLE
feat: new slack channel selector component

### DIFF
--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -53,6 +53,7 @@ export class SlackController extends BaseController {
         @Query() excludeDms?: boolean,
         @Query() excludeGroups?: boolean,
         @Query() forceRefresh?: boolean,
+        @Query() includeChannelIds?: string,
     ): Promise<ApiSlackChannelsResponse> {
         this.setStatus(200);
         return {
@@ -65,6 +66,9 @@ export class SlackController extends BaseController {
                     excludeDms,
                     excludeGroups,
                     forceRefresh,
+                    includeChannelIds: includeChannelIds
+                        ? includeChannelIds.split(',').filter(Boolean)
+                        : undefined,
                 }),
         };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -32778,6 +32778,11 @@ export function RegisterRoutes(app: Router) {
             name: 'forceRefresh',
             dataType: 'boolean',
         },
+        includeChannelIds: {
+            in: 'query',
+            name: 'includeChannelIds',
+            dataType: 'string',
+        },
     };
     app.get(
         '/api/v1/slack/channels',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -28012,6 +28012,14 @@
                         "schema": {
                             "type": "boolean"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "includeChannelIds",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ]
             }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -131,6 +131,7 @@ export class SlackIntegrationService<
             excludeDms?: boolean;
             excludeGroups?: boolean;
             forceRefresh?: boolean;
+            includeChannelIds?: string[];
         },
     ): Promise<SlackChannel[] | undefined> {
         const organizationUuid = user?.organizationUuid;

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -72,6 +72,7 @@ import {
 interface SchedulersTableProps {
     projectUuid: string;
     getSlackChannelName: (channelId: string) => string | null;
+    onSlackChannelIdsChange?: (channelIds: string[]) => void;
 }
 
 const fetchSize = 50;
@@ -100,6 +101,7 @@ const getRunStatusConfig = (status: SchedulerRunStatus) => {
 const SchedulersTable: FC<SchedulersTableProps> = ({
     projectUuid,
     getSlackChannelName,
+    onSlackChannelIdsChange,
 }) => {
     const theme = useMantineTheme();
     const { data: project } = useProject(projectUuid);
@@ -180,6 +182,21 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
             a.name.localeCompare(b.name),
         );
     }, [flatData]);
+
+    // Extract unique Slack channel IDs from loaded schedulers and report them
+    useEffect(() => {
+        if (!onSlackChannelIdsChange) return;
+
+        const channelIds = new Set<string>();
+        flatData.forEach((scheduler) => {
+            scheduler.targets.forEach((target) => {
+                if (isSlackTarget(target)) {
+                    channelIds.add(target.channel);
+                }
+            });
+        });
+        onSlackChannelIdsChange(Array.from(channelIds));
+    }, [flatData, onSlackChannelIdsChange]);
 
     // Callback to fetch more data when scrolling
     const fetchMoreOnBottomReached = useCallback(

--- a/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
+++ b/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
@@ -1,0 +1,156 @@
+import {
+    ActionIcon,
+    Loader,
+    MultiSelect,
+    Select,
+    Tooltip,
+    type MultiSelectProps,
+    type SelectProps,
+} from '@mantine/core';
+import { IconRefresh } from '@tabler/icons-react';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
+import { useSlackChannels } from '../../../hooks/slack/useSlack';
+import MantineIcon from '../MantineIcon';
+
+type CommonProps = {
+    disabled?: SelectProps['disabled'];
+    placeholder?: SelectProps['placeholder'];
+    label?: SelectProps['label'];
+    size?: SelectProps['size'];
+    /** Show refresh button to force re-fetch channels from Slack */
+    withRefresh?: boolean;
+};
+
+type SingleSelectProps = CommonProps & {
+    multiple?: false;
+    value: string | null | undefined;
+    onChange: (value: string | null) => void;
+};
+
+type MultiSelectComponentProps = CommonProps & {
+    multiple: true;
+    value: string[];
+    onChange: (value: string[]) => void;
+};
+
+export const SlackChannelSelect: FC<
+    SingleSelectProps | MultiSelectComponentProps
+> = (props) => {
+    const {
+        disabled = false,
+        placeholder = 'Select a channel',
+        label,
+        size = 'xs',
+        withRefresh = false,
+    } = props;
+
+    const [search, setSearch] = useState<string | undefined>(undefined);
+
+    // Accumulate channels across searches so selected channels remain in options
+    const channelCacheRef = useRef<Map<string, string>>(new Map());
+
+    const includeChannelIds = useMemo(() => {
+        if (props.multiple) {
+            return props.value.length > 0 ? props.value : undefined;
+        }
+        return props.value ? [props.value] : undefined;
+    }, [props.multiple, props.value]);
+
+    const {
+        data: slackChannels,
+        isFetching: isLoading,
+        refresh,
+        isRefreshing,
+    } = useSlackChannels(
+        search || '',
+        {
+            excludeArchived: true,
+            excludeDms: true,
+            excludeGroups: true,
+            includeChannelIds,
+        },
+        { enabled: !disabled },
+    );
+
+    // Add fetched channels to cache
+    useEffect(() => {
+        slackChannels?.forEach((channel) => {
+            channelCacheRef.current.set(channel.id, channel.name);
+        });
+    }, [slackChannels]);
+
+    const options = useMemo(() => {
+        const optionsMap = new Map<string, string>();
+
+        // Add all cached channels first
+        channelCacheRef.current.forEach((name, id) => {
+            optionsMap.set(id, name);
+        });
+
+        // Add/update with current search results
+        slackChannels?.forEach((channel) => {
+            optionsMap.set(channel.id, channel.name);
+        });
+
+        return Array.from(optionsMap.entries()).map(([id, name]) => ({
+            value: id,
+            label: name,
+        }));
+    }, [slackChannels]);
+
+    const isBusy = isLoading || isRefreshing;
+
+    const rightSection = withRefresh ? (
+        isBusy ? (
+            <Loader size="xs" />
+        ) : (
+            <Tooltip label="Refresh Slack channels" withArrow withinPortal>
+                <ActionIcon variant="transparent" onClick={refresh}>
+                    <MantineIcon icon={IconRefresh} />
+                </ActionIcon>
+            </Tooltip>
+        )
+    ) : isBusy ? (
+        <Loader size="xs" />
+    ) : undefined;
+
+    const commonProps = {
+        label,
+        size,
+        rightSection,
+        placeholder: isBusy ? 'Loading channels...' : placeholder,
+        nothingFound: 'No channels found',
+        data: options,
+        searchable: true,
+        clearable: true,
+        disabled,
+        onSearchChange: setSearch,
+    };
+
+    return props.multiple ? (
+        <MultiSelect
+            {...(commonProps as MultiSelectProps)}
+            creatable
+            getCreateLabel={(query) => `Send to private channel #${query}`}
+            onCreate={(newItem) => {
+                // Add private channel to cache with # prefix for display
+                channelCacheRef.current.set(newItem, `#${newItem}`);
+                return newItem;
+            }}
+            value={props.value}
+            onChange={(newValue) => {
+                props.onChange(newValue);
+                setSearch(undefined);
+            }}
+        />
+    ) : (
+        <Select
+            {...(commonProps as SelectProps)}
+            value={props.value ?? null}
+            onChange={(newValue) => {
+                props.onChange(newValue);
+                setSearch(undefined);
+            }}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -56,7 +56,21 @@ const AiAgentAdminAgentsTable = () => {
         [],
     );
 
-    const { data: slackInstallation } = useGetSlack();
+    const {
+        data: slackInstallation,
+        isInitialLoading: isLoadingSlackInstallation,
+    } = useGetSlack();
+
+    // Include all channel IDs used by agents to ensure they're in the response
+    const includeChannelIds = useMemo(() => {
+        if (!agents) return undefined;
+        const ids = agents.flatMap((agent) =>
+            agent.integrations
+                .filter((i) => i.type === 'slack' && i.channelId)
+                .map((i) => i.channelId),
+        );
+        return ids.length > 0 ? ids : undefined;
+    }, [agents]);
 
     const { data: slackChannels } = useSlackChannels(
         '',
@@ -64,9 +78,13 @@ const AiAgentAdminAgentsTable = () => {
             excludeArchived: true,
             excludeDms: true,
             excludeGroups: true,
+            includeChannelIds,
         },
         {
-            enabled: !!slackInstallation?.organizationUuid && !!agents,
+            enabled:
+                !!slackInstallation?.organizationUuid &&
+                !!agents &&
+                !isLoadingSlackInstallation,
         },
     );
 

--- a/packages/frontend/src/hooks/slack/useSlack.ts
+++ b/packages/frontend/src/hooks/slack/useSlack.ts
@@ -61,12 +61,14 @@ const getSlackChannels = async ({
     excludeDms,
     excludeGroups,
     forceRefresh,
+    includeChannelIds,
 }: {
     search: string;
     excludeArchived: boolean;
     excludeDms: boolean;
     excludeGroups: boolean;
     forceRefresh: boolean;
+    includeChannelIds?: string[];
 }) => {
     const queryString = new URLSearchParams();
     queryString.set('search', search);
@@ -74,6 +76,9 @@ const getSlackChannels = async ({
     queryString.set('excludeDms', excludeDms.toString());
     queryString.set('excludeGroups', excludeGroups.toString());
     queryString.set('forceRefresh', forceRefresh.toString());
+    if (includeChannelIds && includeChannelIds.length > 0) {
+        queryString.set('includeChannelIds', includeChannelIds.join(','));
+    }
 
     return lightdashApi<SlackChannel[] | undefined>({
         url: `/slack/channels?${queryString.toString()}`,
@@ -84,7 +89,17 @@ const getSlackChannels = async ({
 
 export const useSlackChannels = (
     search: string,
-    { excludeArchived = true, excludeDms = false, excludeGroups = false },
+    {
+        excludeArchived = true,
+        excludeDms = false,
+        excludeGroups = false,
+        includeChannelIds,
+    }: {
+        excludeArchived?: boolean;
+        excludeDms?: boolean;
+        excludeGroups?: boolean;
+        includeChannelIds?: string[];
+    },
     useQueryOptions?: UseQueryOptions<SlackChannel[] | undefined, ApiError>,
 ) => {
     const queryClient = useQueryClient();
@@ -97,6 +112,7 @@ export const useSlackChannels = (
             excludeArchived,
             excludeDms,
             excludeGroups,
+            includeChannelIds,
         ],
         queryFn: () =>
             getSlackChannels({
@@ -105,6 +121,7 @@ export const useSlackChannels = (
                 excludeDms,
                 excludeGroups,
                 forceRefresh: false,
+                includeChannelIds,
             }),
         ...useQueryOptions,
     });
@@ -117,6 +134,7 @@ export const useSlackChannels = (
             excludeDms,
             excludeGroups,
             forceRefresh: true,
+            includeChannelIds,
         });
         queryClient.setQueryData(
             [
@@ -125,11 +143,19 @@ export const useSlackChannels = (
                 excludeArchived,
                 excludeDms,
                 excludeGroups,
+                includeChannelIds,
             ],
             slackChannelsAfterRefresh,
         );
         setIsRefreshing(false);
-    }, [search, excludeArchived, excludeDms, excludeGroups, queryClient]);
+    }, [
+        search,
+        excludeArchived,
+        excludeDms,
+        excludeGroups,
+        includeChannelIds,
+        queryClient,
+    ]);
 
     return {
         ...query,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Improved Slack channel selection by ensuring currently selected channels are always included in the results, even when the channel list is limited. This fixes issues where users couldn't see their previously selected channels when the total number of channels exceeded the display limit.

Key changes:

- Added `includeChannelIds` parameter to ensure selected channels are always returned
- Simplified channel limit logic by removing the unused `MAX_CHANNELS_LIMIT` constant
- Improved search behavior in UI components to avoid triggering searches when displaying selected channel names
- Updated Slack channel selection in scheduler forms, AI agent setup, and user settings to use the new functionality
- Replaced debounce implementation with Mantine's `useDebouncedValue` hook for consistency

This change ensures a better user experience when working with Slack integrations in organizations with many channels.