### PR TITLE
chore: disable telemetry on sentry vite plugin

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
             languageWorkers: ['json'],
         }),
         sentryVitePlugin({
+            telemetry: false,
             org: 'lightdash',
             project: 'lightdash-frontend',
             authToken: process.env.SENTRY_AUTH_TOKEN,


### PR DESCRIPTION
Prevents external API requests being made during the build process.