### PR TITLE
fix: dark-mode for Storybook

### DIFF
--- a/packages/frontend/.storybook/preview.tsx
+++ b/packages/frontend/.storybook/preview.tsx
@@ -1,9 +1,9 @@
 import '@mantine-8/core/styles.css';
 
-import { MantineProvider } from '@mantine/core';
 import React from 'react';
 import { getMantineThemeOverride } from '../src/mantineTheme';
 import Mantine8Provider from '../src/providers/Mantine8Provider';
+import MantineProvider from '../src/providers/MantineProvider';
 
 // All stories will have the Mantine theme applied
 const ThemeWrapper = (props: { children: React.ReactNode }) => (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the Storybook preview to use the local MantineProvider component instead of importing directly from @mantine/core. This ensures that stories use the same provider configuration as the main application.
