### PR TITLE
feat: dark mode for headway widget

### DIFF
--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.module.css
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.module.css
@@ -1,0 +1,17 @@
+:global(iframe[src*='headwayapp.co']) {
+    color-scheme: light dark;
+}
+
+/* Switch to dark mode when Mantine color scheme is dark */
+[data-mantine-color-scheme='dark'] :global(.HW_widget),
+[data-mantine-color-scheme='dark'] :global(.HW_frame_cont),
+[data-mantine-color-scheme='dark'] :global(iframe[src*='headwayapp.co']) {
+    filter: invert(0.9) hue-rotate(180deg);
+}
+
+/* Prevent double inversion on images within the inverted iframe */
+[data-mantine-color-scheme='dark'] :global(.HW_widget img),
+[data-mantine-color-scheme='dark'] :global(.HW_frame_cont img),
+[data-mantine-color-scheme='dark'] :global(iframe[src*='headwayapp.co'] img) {
+    filter: invert(0.9) hue-rotate(180deg);
+}

--- a/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/HeadwayMenuItem.tsx
@@ -6,6 +6,7 @@ import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
+import './HeadwayMenuItem.module.css';
 
 type Props = {
     projectUuid?: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18419

### Description:
Added dark mode support for the Headway changelog widget by ~~cheating~~ using color inversion filters when the Mantine color scheme is set to dark mode. 

_after_
![CleanShot 2025-12-03 at 14.30.49.png](https://app.graphite.com/user-attachments/assets/fac50623-a86b-4c9d-863b-0751d9c02f62.png)

_before_

![CleanShot 2025-12-03 at 14.35.07.png](https://app.graphite.com/user-attachments/assets/2b7b6e7b-0100-4b89-987e-d94de21d1e1b.png)

