### PR TITLE
fix: chart label readability in dark mode

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/themeColors.ts
+++ b/packages/common/src/visualizations/helpers/styles/themeColors.ts
@@ -18,6 +18,7 @@ export const GRAY_9 = 'var(--mantine-color-ldGray-9)';
 // White
 export const WHITE = 'var(--mantine-color-white)';
 
+export const FOREGROUND = 'var(--mantine-color-foreground-0)';
 export const BACKGROUND = 'var(--mantine-color-background-0)';
 export const TOOLTIP_BACKGROUND = 'var(--mantine-color-background-1)';
 

--- a/packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts
@@ -1,5 +1,5 @@
 import { CartesianSeriesType, type Series } from '../../../types/savedCharts';
-import { WHITE } from './themeColors';
+import { BACKGROUND, FOREGROUND } from './themeColors';
 
 /**
  * Get value label styling for any chart series (line, bar, area, scatter, etc.)
@@ -18,6 +18,7 @@ export const getValueLabelStyle = (
     const base = {
         fontSize: 11,
         fontWeight: isInside ? '400' : '500',
+        color: FOREGROUND,
     } as const;
 
     if (
@@ -27,7 +28,7 @@ export const getValueLabelStyle = (
     ) {
         return {
             ...base,
-            textBorderColor: WHITE,
+            textBorderColor: BACKGROUND,
             textBorderWidth: 1.5,
             textBorderType: 'solid',
         };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18421

### Description:
Added a new `FOREGROUND` color variable to the theme colors and updated value label styling to use `FOREGROUND` for text color and `BACKGROUND` instead of `WHITE` for text border color. This change ensures proper color contrast in different theme modes.

_after_
![CleanShot 2025-12-03 at 14.52.34.png](https://app.graphite.com/user-attachments/assets/9d9f2631-f71f-4ac4-94d8-9f87ce560ae5.png)


_before_

![CleanShot 2025-12-03 at 14.54.11.png](https://app.graphite.com/user-attachments/assets/cd0e923c-62b9-4d6f-8533-50731ef3748d.png)

