### PR TITLE
chore: allow user attribute overrides on mcp session

### DIFF
--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -10,19 +10,17 @@ import {
     ForbiddenError,
     getErrorMessage,
     LightdashError,
-    LightdashSessionUser,
     MissingConfigError,
-    NotImplementedError,
     OauthAccount,
-    OauthAuth,
+    UserAttributeValueMap,
 } from '@lightdash/common';
 import {
     allowApiKeyAuthentication,
     allowOauthAuthentication,
-    isAuthenticated,
 } from '../controllers/authentication';
 import { ExtraContext, McpService } from '../ee/services/McpService/McpService';
 import Logger from '../logging/logger';
+import { userAttributeOverridesSchema } from '../services/UserAttributesService/UserAttributeUtils';
 
 const mcpRouter: Router = express.Router({ mergeParams: true });
 
@@ -31,6 +29,43 @@ function getMcpService(req: express.Request): McpService {
         return req.services.getMcpService();
     } catch (e) {
         throw new MissingConfigError('MCP service not available');
+    }
+}
+
+const MCP_USER_ATTRIBUTE_HEADER = 'X-Lightdash-User-Attributes';
+
+/**
+ * Extracts user attribute overrides from the X-Lightdash-User-Attributes header.
+ * Header value should be a JSON object with string or string[] values.
+ * Example: {"organizer_id": "123"} or {"organizer_id": ["123", "456"]}
+ */
+function extractUserAttributesFromHeader(
+    req: express.Request,
+): UserAttributeValueMap | undefined {
+    const headerValue = req.headers[MCP_USER_ATTRIBUTE_HEADER.toLowerCase()];
+    if (!headerValue || typeof headerValue !== 'string') {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(headerValue);
+        const result = userAttributeOverridesSchema.safeParse(parsed);
+
+        if (!result.success) {
+            Logger.warn(
+                `Invalid ${MCP_USER_ATTRIBUTE_HEADER} header: ${result.error.message}`,
+            );
+            return undefined;
+        }
+
+        return Object.keys(result.data).length > 0 ? result.data : undefined;
+    } catch (e) {
+        Logger.warn(
+            `Failed to parse ${MCP_USER_ATTRIBUTE_HEADER} header: ${getErrorMessage(
+                e,
+            )}`,
+        );
+        return undefined;
     }
 }
 
@@ -112,6 +147,10 @@ mcpRouter.all(
                 });
                 await mcpServer.connect(transport);
 
+                // Extract user attributes from header (for row-level security)
+                const headerUserAttributes =
+                    extractUserAttributesFromHeader(req);
+
                 // Add auth info to request for the transport
                 // The token details is loaded on the authentication middleware allowOauthAuthentication
                 const authReq: IncomingMessage & {
@@ -123,6 +162,7 @@ mcpRouter.all(
                     const extra: ExtraContext = {
                         user: req.user,
                         account: oauthAuth,
+                        headerUserAttributes,
                     };
                     authReq.auth = {
                         token: oauthAuth.authentication.token,
@@ -137,6 +177,7 @@ mcpRouter.all(
                     const extra: ExtraContext = {
                         user: req.user,
                         account: apiKeyAuth,
+                        headerUserAttributes,
                     };
                     authReq.auth = {
                         token: apiKeyAuth.authentication.source,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3126,6 +3126,7 @@ export class ProjectService extends BaseService {
         dateZoom,
         chartUuid,
         parameters,
+        userAttributeOverrides,
     }: {
         account: Account;
         metricQuery: MetricQuery;
@@ -3139,6 +3140,7 @@ export class ProjectService extends BaseService {
         dateZoom?: DateZoom;
         chartUuid: string | undefined; // for analytics
         parameters?: ParametersValuesMap;
+        userAttributeOverrides?: UserAttributeValueMap; // EXPERIMENTAL: used to override user attributes for MCP
     }): Promise<{
         rows: Record<string, AnyType>[];
         cacheMetadata: CacheMetadata;
@@ -3199,6 +3201,13 @@ export class ProjectService extends BaseService {
                             account,
                         });
 
+                    const mergedUserAttributes = userAttributeOverrides
+                        ? {
+                              ...userAttributes,
+                              ...userAttributeOverrides,
+                          }
+                        : userAttributes;
+
                     const availableParameterDefinitions =
                         await this.getAvailableParameters(projectUuid, explore);
 
@@ -3207,7 +3216,7 @@ export class ProjectService extends BaseService {
                         explore,
                         warehouseSqlBuilder: warehouseClient,
                         intrinsicUserAttributes,
-                        userAttributes,
+                        userAttributes: mergedUserAttributes,
                         timezone: this.lightdashConfig.query.timezone || 'UTC',
                         dateZoom,
                         parameters,
@@ -3775,6 +3784,7 @@ export class ProjectService extends BaseService {
         filters: AndFilterGroup | undefined,
         forceRefresh: boolean = false,
         parameters?: ParametersValuesMap,
+        userAttributeOverrides?: UserAttributeValueMap, // EXPERIMENTAL: used to override user attributes for MCP
     ) {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -3814,6 +3824,13 @@ export class ProjectService extends BaseService {
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes({ user });
 
+        const mergedUserAttributes = userAttributeOverrides
+            ? {
+                  ...userAttributes,
+                  ...userAttributeOverrides,
+              }
+            : userAttributes;
+
         const availableParameterDefinitions = await this.getAvailableParameters(
             projectUuid,
             explore,
@@ -3824,7 +3841,7 @@ export class ProjectService extends BaseService {
             explore,
             warehouseSqlBuilder: warehouseClient,
             intrinsicUserAttributes,
-            userAttributes,
+            userAttributes: mergedUserAttributes,
             timezone: this.lightdashConfig.query.timezone || 'UTC',
             parameters,
             availableParameterDefinitions,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:

Adds support for user attribute overrides via the `X-Lightdash-User-Attributes` header in MCP requests. This allows organization admins to narrow the scope of user attributes for specific API requests.

Key changes:

- Added header parsing in `mcpRouter.ts` to extract user attributes from the `X-Lightdash-User-Attributes` header
- Implemented validation to ensure only org admins can use the header and that overrides can only narrow access
- Modified `McpService` to incorporate header-provided user attributes when executing queries
- Updated `ProjectService` to support user attribute overrides in query execution

This feature enables more flexible API integrations while maintaining security by enforcing that attribute overrides can only restrict access, not expand it.