### PR TITLE
fix: simple statistic comparison colors in dark theme

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/SimpleStatistic.module.css
+++ b/packages/frontend/src/components/SimpleStatistic/SimpleStatistic.module.css
@@ -6,21 +6,18 @@
     border-radius: 100px;
     border: 1px solid;
     font-weight: 500;
-    @mixin dark {
-        filter: brightness(0.5) contrast(2);
-    }
 }
 
 .trendPillUp {
-    color: var(--mantine-color-green-7);
-    background-color: var(--mantine-color-green-0);
-    border-color: var(--mantine-color-green-3);
+    color: var(--mantine-color-green-light-color);
+    border-color: var(--mantine-color-green-outline);
+    background-color: var(--mantine-color-green-light);
 }
 
 .trendPillDown {
-    color: var(--mantine-color-red-7);
-    background-color: var(--mantine-color-red-0);
-    border-color: var(--mantine-color-red-3);
+    color: var(--mantine-color-red-light-color);
+    border-color: var(--mantine-color-red-outline);
+    background-color: var(--mantine-color-red-light);
 }
 
 .trendPillNeutral {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18426

### Description:
Updated the color variables in SimpleStatistic component to use Mantine theme variables for better dark mode support. Removed the custom dark mode filter as it's no longer needed with the new color variables.

The changes ensure consistent styling for trend pills (up, down, neutral) across both light and dark themes by using the appropriate Mantine color variables.


_after_

![CleanShot 2025-12-03 at 15.21.24.png](https://app.graphite.com/user-attachments/assets/6ac6f2f3-af3d-4df7-9ed4-f1d4448394d3.png)

_before_

![CleanShot 2025-12-03 at 15.23.05.png](https://app.graphite.com/user-attachments/assets/d1bc907e-2d96-4004-b04d-977937ec5a5d.png)

