### PR TITLE
fix: cache message is too dark in dark mode

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -326,7 +326,7 @@ const DashboardHeader = ({
 
             {oldestCacheTime && (
                 <Text
-                    color="gray"
+                    color="ldGray"
                     mr="sm"
                     sx={{ fontSize: '11px', textAlign: 'end' }}
                 >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18425

### Description:
Changed the text color in the DashboardHeader component from "gray" to "ldGray" to ensure consistent styling across the dashboard interface.