### PR TITLE
feat: add sankey chart visualization type

### DIFF
--- a/packages/backend/src/database/migrations/20251203135047_add_sankey_chart_type.ts
+++ b/packages/backend/src/database/migrations/20251203135047_add_sankey_chart_type.ts
@@ -1,0 +1,11 @@
+import { Knex } from 'knex';
+
+const ChartTypesTableName = 'chart_types';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex(ChartTypesTableName).insert({ chart_type: 'sankey' });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex(ChartTypesTableName).where('chart_type', 'sankey').delete();
+}

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -330,6 +330,7 @@ export function derivePivotConfigurationFromChart(
         case ChartType.CUSTOM:
         case ChartType.BIG_NUMBER:
         case ChartType.MAP:
+        case ChartType.SANKEY:
             newConfig = undefined;
             break;
         default:

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -25,6 +25,7 @@ export enum ChartKind {
     TREEMAP = 'treemap',
     GAUGE = 'gauge',
     MAP = 'map',
+    SANKEY = 'sankey',
 }
 
 export enum ChartType {
@@ -37,6 +38,7 @@ export enum ChartType {
     GAUGE = 'gauge',
     CUSTOM = 'custom',
     MAP = 'map',
+    SANKEY = 'sankey',
 }
 
 export enum ComparisonFormatTypes {
@@ -219,6 +221,42 @@ export type FunnelChart = {
     };
     showLegend?: boolean;
     legendPosition?: FunnelChartLegendPosition;
+};
+
+export enum SankeyChartLabelPosition {
+    LEFT = 'left',
+    RIGHT = 'right',
+    INSIDE = 'inside',
+    HIDDEN = 'hidden',
+}
+
+export enum SankeyChartOrientation {
+    HORIZONTAL = 'horizontal',
+    VERTICAL = 'vertical',
+}
+
+export type SankeyChart = {
+    // Source and target dimension fields
+    sourceFieldId?: string;
+    targetFieldId?: string;
+    // Value/weight metric field
+    valueFieldId?: string;
+    // Display options
+    nodeWidth?: number;
+    nodeGap?: number;
+    orientation?: SankeyChartOrientation;
+    // Label options
+    labels?: {
+        position?: SankeyChartLabelPosition;
+        showValue?: boolean;
+    };
+    // Color options
+    nodeColorOverrides?: Record<string, string>;
+    linkColorMode?: 'source' | 'target' | 'gradient';
+    // Interaction options
+    draggable?: boolean;
+    // Legend options (for node colors)
+    showLegend?: boolean;
 };
 
 export type ColumnProperties = {
@@ -472,6 +510,11 @@ export type MapChartConfig = {
     config?: MapChart;
 };
 
+export type SankeyChartConfig = {
+    type: ChartType.SANKEY;
+    config?: SankeyChart;
+};
+
 export type ChartConfig =
     | BigNumberConfig
     | CartesianChartConfig
@@ -481,7 +524,8 @@ export type ChartConfig =
     | TableChartConfig
     | TreemapChartConfig
     | GaugeChartConfig
-    | MapChartConfig;
+    | MapChartConfig
+    | SankeyChartConfig;
 
 export type SavedChartType = ChartType;
 
@@ -677,6 +721,8 @@ export const getChartType = (chartKind: ChartKind | undefined): ChartType => {
             return ChartType.TREEMAP;
         case ChartKind.GAUGE:
             return ChartType.GAUGE;
+        case ChartKind.SANKEY:
+            return ChartType.SANKEY;
         default:
             return ChartType.CARTESIAN;
     }
@@ -735,6 +781,8 @@ export const getChartKind = (
             return ChartKind.GAUGE;
         case ChartType.MAP:
             return ChartKind.MAP;
+        case ChartType.SANKEY:
+            return ChartKind.SANKEY;
         default:
             return assertUnreachable(
                 chartType,

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -17,6 +17,7 @@ import { ConfigTabs as FunnelChartConfigTabs } from '../../VisualizationConfigs/
 import { ConfigTabs as GaugeConfigTabs } from '../../VisualizationConfigs/GaugeConfig/GaugeConfigTabs';
 import { ConfigTabs as MapConfigTabs } from '../../VisualizationConfigs/MapConfig';
 import { ConfigTabs as PieChartConfigTabs } from '../../VisualizationConfigs/PieChartConfig/PieChartConfigTabs';
+import { ConfigTabs as SankeyChartConfigTabs } from '../../VisualizationConfigs/SankeyChartConfig/SankeyChartConfigTabs';
 import { ConfigTabs as TableConfigTabs } from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
 import { ConfigTabs as TreemapConfigTabs } from '../../VisualizationConfigs/TreemapConfig/TreemapConfigTabs';
 import VisualizationCardOptions from '../VisualizationCardOptions';
@@ -52,6 +53,8 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
                 return GaugeConfigTabs;
             case ChartType.MAP:
                 return MapConfigTabs;
+            case ChartType.SANKEY:
+                return SankeyChartConfigTabs;
             case ChartType.CUSTOM:
                 // Return a wrapper component that handles lazy loading
                 return () => (

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -19,6 +19,7 @@ import {
     IconFilter,
     IconGauge,
     IconMap,
+    IconRouteAltLeft,
     IconSquareNumber1,
     IconTable,
 } from '@tabler/icons-react';
@@ -37,6 +38,7 @@ import {
     isGaugeVisualizationConfig,
     isMapVisualizationConfig,
     isPieVisualizationConfig,
+    isSankeyVisualizationConfig,
     isTableVisualizationConfig,
     isTreemapVisualizationConfig,
 } from '../../LightdashVisualization/types';
@@ -190,6 +192,13 @@ const VisualizationCardOptions: FC = memo(() => {
                 return {
                     text: 'Map',
                     icon: <MantineIcon icon={IconMap} color="gray" />,
+                };
+            case ChartType.SANKEY:
+                return {
+                    text: 'Sankey chart',
+                    icon: (
+                        <MantineIcon icon={IconRouteAltLeft} color="ldGray" />
+                    ),
                 };
             case ChartType.CUSTOM:
                 return {
@@ -413,6 +422,23 @@ const VisualizationCardOptions: FC = memo(() => {
                     }}
                 >
                     Gauge
+                </Menu.Item>
+
+                <Menu.Item
+                    disabled={disabled}
+                    color={
+                        isSankeyVisualizationConfig(visualizationConfig)
+                            ? 'blue'
+                            : undefined
+                    }
+                    icon={<MantineIcon icon={IconRouteAltLeft} />}
+                    onClick={() => {
+                        setStacking(undefined);
+                        setCartesianType(undefined);
+                        setChartType(ChartType.SANKEY);
+                    }}
+                >
+                    Sankey chart
                 </Menu.Item>
 
                 {isMapsEnabled && (

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigSankey.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigSankey.tsx
@@ -1,0 +1,85 @@
+import {
+    ChartType,
+    getDimensionsFromItemsMap,
+    getMetricsFromItemsMap,
+    getTableCalculationsFromItemsMap,
+    isDimension,
+    isNumericItem,
+    type Dimension,
+    type TableCalculation,
+} from '@lightdash/common';
+import { useEffect, useMemo, type FC } from 'react';
+import useSankeyChartConfig from '../../hooks/useSankeyChartConfig';
+import { type VisualizationConfigSankeyProps } from './types';
+
+const VisualizationConfigSankey: FC<VisualizationConfigSankeyProps> = ({
+    resultsData,
+    initialChartConfig,
+    onChartConfigChange,
+    itemsMap,
+    colorPalette,
+    children,
+    tableCalculationsMetadata,
+}) => {
+    const { dimensions, numericFields } = useMemo(() => {
+        const allDimensions = getDimensionsFromItemsMap(itemsMap ?? {});
+        const metrics = getMetricsFromItemsMap(itemsMap ?? {}, isNumericItem);
+        const tableCalculations = getTableCalculationsFromItemsMap(itemsMap);
+
+        const numericTableCalculations = Object.keys(tableCalculations).reduce<
+            Record<string, TableCalculation>
+        >((acc, key) => {
+            const tableCalculation = tableCalculations[key];
+            if (isNumericItem(tableCalculation)) {
+                acc[key] = tableCalculation;
+            }
+            return acc;
+        }, {});
+
+        // Filter to only include regular dimensions (not custom dimensions)
+        const regularDimensions = Object.keys(allDimensions).reduce<
+            Record<string, Dimension>
+        >((acc, key) => {
+            const dim = allDimensions[key];
+            if (isDimension(dim)) {
+                acc[key] = dim;
+            }
+            return acc;
+        }, {});
+
+        return {
+            dimensions: regularDimensions,
+            numericFields: { ...metrics, ...numericTableCalculations },
+        };
+    }, [itemsMap]);
+
+    const sankeyChartConfig = useSankeyChartConfig(
+        resultsData,
+        initialChartConfig,
+        itemsMap,
+        dimensions,
+        numericFields,
+        colorPalette,
+        tableCalculationsMetadata,
+    );
+
+    useEffect(() => {
+        if (!onChartConfigChange || !sankeyChartConfig.validConfig) return;
+
+        onChartConfigChange({
+            type: ChartType.SANKEY,
+            config: sankeyChartConfig.validConfig,
+        });
+    }, [sankeyChartConfig, onChartConfigChange]);
+
+    return children({
+        visualizationConfig: {
+            chartType: ChartType.SANKEY,
+            chartConfig: sankeyChartConfig,
+            dimensions,
+            numericFields,
+        },
+    });
+};
+
+export default VisualizationConfigSankey;

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -47,6 +47,7 @@ import VisualizationConfigFunnel from './VisualizationConfigFunnel';
 import VisualizationGaugeConfig from './VisualizationConfigGauge';
 import VisualizationMapConfig from './VisualizationConfigMap';
 import VisualizationPieConfig from './VisualizationConfigPie';
+import VisualizationConfigSankey from './VisualizationConfigSankey';
 import VisualizationTableConfig from './VisualizationConfigTable';
 import VisualizationTreemapConfig from './VisualizationConfigTreemap';
 import VisualizationCustomConfig from './VisualizationCustomConfig';
@@ -511,6 +512,26 @@ const VisualizationProvider: FC<
                         </Context.Provider>
                     )}
                 </VisualizationCustomConfig>
+            );
+        case ChartType.SANKEY:
+            return (
+                <VisualizationConfigSankey
+                    itemsMap={itemsMap}
+                    resultsData={lastValidResultsData}
+                    initialChartConfig={chartConfig.config}
+                    onChartConfigChange={handleChartConfigChange}
+                    colorPalette={colorPalette}
+                    tableCalculationsMetadata={tableCalculationsMetadata}
+                    parameters={parameters}
+                >
+                    {({ visualizationConfig }) => (
+                        <Context.Provider
+                            value={{ ...value, visualizationConfig }}
+                        >
+                            {children}
+                        </Context.Provider>
+                    )}
+                </VisualizationConfigSankey>
             );
         default:
             return assertUnreachable(chartConfig, 'Unknown chart type');

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -10,6 +10,7 @@ import FunnelChart from '../FunnelChart';
 import SimpleChart from '../SimpleChart';
 import SimpleGauge from '../SimpleGauge';
 import SimplePieChart from '../SimplePieChart';
+import SimpleSankey from '../SimpleSankey';
 import SimpleStatistic from '../SimpleStatistic';
 import SimpleTable from '../SimpleTable';
 import SimpleTreemap from '../SimpleTreemap';
@@ -196,6 +197,16 @@ const LightdashVisualization = memo(
                                 className={className}
                             />
                         </div>
+                    );
+                case ChartType.SANKEY:
+                    return (
+                        <SimpleSankey
+                            className={className}
+                            isInDashboard={!!isDashboard}
+                            $shouldExpand
+                            data-testid={props['data-testid']}
+                            {...props}
+                        />
                     );
 
                 default:

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -22,6 +22,7 @@ import type useFunnelChartConfig from '../../hooks/useFunnelChartConfig';
 import type useGaugeChartConfig from '../../hooks/useGaugeChartConfig';
 import type usePieChartConfig from '../../hooks/usePieChartConfig';
 import type { InfiniteQueryResults } from '../../hooks/useQueryResults';
+import type useSankeyChartConfig from '../../hooks/useSankeyChartConfig';
 import type useTreemapChartConfig from '../../hooks/useTreemapChartConfig';
 
 export type VisualizationConfigCommon<T extends VisualizationConfig> = {
@@ -241,6 +242,28 @@ export type VisualizationConfigMapProps = Omit<
     itemsMap: ItemsMap | undefined;
 };
 
+// Sankey
+
+export type VisualizationConfigSankeyType = {
+    chartType: ChartType.SANKEY;
+    chartConfig: ReturnType<typeof useSankeyChartConfig>;
+    dimensions: Record<string, Dimension>;
+    numericFields: Record<string, Metric | TableCalculation>;
+};
+
+export const isSankeyVisualizationConfig = (
+    visualizationConfig: VisualizationConfig | undefined,
+): visualizationConfig is VisualizationConfigSankeyType => {
+    return visualizationConfig?.chartType === ChartType.SANKEY;
+};
+
+export type VisualizationConfigSankeyProps =
+    VisualizationConfigCommon<VisualizationConfigSankeyType> & {
+        itemsMap: ItemsMap | undefined;
+        colorPalette: string[];
+        tableCalculationsMetadata?: TableCalculationMetadata[];
+    };
+
 // Union of all visualization configs
 
 export type VisualizationConfig =
@@ -252,4 +275,5 @@ export type VisualizationConfig =
     | VisualizationConfigTreemap
     | VisualizationConfigGauge
     | VisualizationConfigMap
+    | VisualizationConfigSankeyType
     | VisualizationCustomConfigType;

--- a/packages/frontend/src/components/SimpleSankey/index.tsx
+++ b/packages/frontend/src/components/SimpleSankey/index.tsx
@@ -1,0 +1,84 @@
+import { Box } from '@mantine/core';
+import { IconFilterOff } from '@tabler/icons-react';
+import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
+import { memo, useEffect, type FC } from 'react';
+import useEchartsSankeyConfig from '../../hooks/echarts/useEchartsSankeyConfig';
+import EChartsReact from '../EChartsReactWrapper';
+import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
+
+const EmptyChart = () => (
+    <Box h="100%" w="100%" py="xl">
+        <SuboptimalState
+            title="No data available"
+            description="Query at least two dimensions and one metric to create a Sankey chart."
+            icon={IconFilterOff}
+        />
+    </Box>
+);
+
+const LoadingChart = () => (
+    <Box h="100%" w="100%" py="xl">
+        <SuboptimalState
+            title="Loading chart"
+            loading
+            className="loading_chart"
+        />
+    </Box>
+);
+
+type SimpleSankeyProps = Omit<EChartsReactProps, 'option'> & {
+    isInDashboard: boolean;
+    $shouldExpand?: boolean;
+    className?: string;
+    'data-testid'?: string;
+};
+
+const EchartOptions: Opts = { renderer: 'svg' };
+
+const SimpleSankey: FC<SimpleSankeyProps> = memo((props) => {
+    const { chartRef, isLoading, resultsData } = useVisualizationContext();
+
+    const sankeyChartOptions = useEchartsSankeyConfig(props.isInDashboard);
+
+    useEffect(() => {
+        // Load all the rows
+        resultsData?.setFetchAll(true);
+    }, [resultsData]);
+
+    useEffect(() => {
+        const listener = () => chartRef.current?.getEchartsInstance().resize();
+        window.addEventListener('resize', listener);
+        return () => window.removeEventListener('resize', listener);
+    });
+
+    if (isLoading) return <LoadingChart />;
+    if (!sankeyChartOptions) return <EmptyChart />;
+
+    return (
+        <EChartsReact
+            ref={chartRef}
+            data-testid={props['data-testid']}
+            className={props.className}
+            style={
+                props.$shouldExpand
+                    ? {
+                          minHeight: 'inherit',
+                          height: '100%',
+                          width: '100%',
+                      }
+                    : {
+                          minHeight: 'inherit',
+                          // height defaults to 300px
+                          width: '100%',
+                      }
+            }
+            opts={EchartOptions}
+            option={sankeyChartOptions}
+            notMerge
+            {...props}
+        />
+    );
+});
+
+export default SimpleSankey;

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyChartConfig/SankeyChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyChartConfig/SankeyChartConfigTabs.tsx
@@ -1,0 +1,360 @@
+import {
+    getItemId,
+    isField,
+    isTableCalculation,
+    SankeyChartLabelPosition,
+    SankeyChartOrientation,
+    type Dimension,
+    type Metric,
+    type TableCalculation,
+} from '@lightdash/common';
+import {
+    Box,
+    Checkbox,
+    Group,
+    MantineProvider,
+    NumberInput,
+    SegmentedControl,
+    Stack,
+    Switch,
+    Tabs,
+    Tooltip,
+    useMantineColorScheme,
+} from '@mantine/core';
+import { memo, useMemo, type FC } from 'react';
+import FieldSelect from '../../common/FieldSelect';
+import { isSankeyVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import { Config } from '../common/Config';
+import { getVizConfigThemeOverride } from '../mantineTheme';
+
+export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
+    const { visualizationConfig } = useVisualizationContext();
+
+    if (!isSankeyVisualizationConfig(visualizationConfig)) return null;
+
+    const dimensions = Object.values(visualizationConfig.dimensions);
+    const numericFields = Object.values(visualizationConfig.numericFields);
+
+    const {
+        sourceField,
+        onSourceFieldChange,
+        targetField,
+        onTargetFieldChange,
+        valueField,
+        onValueFieldChange,
+        nodeWidth,
+        onNodeWidthChange,
+        nodeGap,
+        onNodeGapChange,
+        orientation,
+        onOrientationChange,
+        labels,
+        onLabelsChange,
+        linkColorMode,
+        onLinkColorModeChange,
+        draggable,
+        toggleDraggable,
+    } = visualizationConfig.chartConfig;
+
+    return (
+        <MantineProvider inherit theme={themeOverride}>
+            <Tabs defaultValue="general" keepMounted={false}>
+                <Tabs.List mb="sm">
+                    <Tabs.Tab px="sm" value="general">
+                        General
+                    </Tabs.Tab>
+                    <Tabs.Tab px="sm" value="display">
+                        Display
+                    </Tabs.Tab>
+                </Tabs.List>
+
+                <Tabs.Panel value="general">
+                    <Stack>
+                        <Config>
+                            <Config.Section>
+                                <Config.Heading>Data fields</Config.Heading>
+
+                                <Group spacing="xs">
+                                    <Config.Label>Source</Config.Label>
+                                    <Tooltip
+                                        variant="xs"
+                                        disabled={dimensions.length > 0}
+                                        label="You must select at least two dimensions to create a Sankey chart"
+                                    >
+                                        <Box style={{ flex: 1 }}>
+                                            <FieldSelect<Dimension>
+                                                placeholder="Select source dimension"
+                                                disabled={dimensions.length < 2}
+                                                item={sourceField}
+                                                items={dimensions}
+                                                onChange={(newField) => {
+                                                    if (
+                                                        newField &&
+                                                        isField(newField)
+                                                    ) {
+                                                        onSourceFieldChange(
+                                                            getItemId(newField),
+                                                        );
+                                                    } else {
+                                                        onSourceFieldChange(
+                                                            null,
+                                                        );
+                                                    }
+                                                }}
+                                                hasGrouping
+                                            />
+                                        </Box>
+                                    </Tooltip>
+                                </Group>
+
+                                <Group spacing="xs">
+                                    <Config.Label>Target</Config.Label>
+                                    <Tooltip
+                                        variant="xs"
+                                        disabled={dimensions.length > 0}
+                                        label="You must select at least two dimensions to create a Sankey chart"
+                                    >
+                                        <Box style={{ flex: 1 }}>
+                                            <FieldSelect<Dimension>
+                                                placeholder="Select target dimension"
+                                                disabled={dimensions.length < 2}
+                                                item={targetField}
+                                                items={dimensions}
+                                                onChange={(newField) => {
+                                                    if (
+                                                        newField &&
+                                                        isField(newField)
+                                                    ) {
+                                                        onTargetFieldChange(
+                                                            getItemId(newField),
+                                                        );
+                                                    } else {
+                                                        onTargetFieldChange(
+                                                            null,
+                                                        );
+                                                    }
+                                                }}
+                                                hasGrouping
+                                            />
+                                        </Box>
+                                    </Tooltip>
+                                </Group>
+
+                                <Group spacing="xs">
+                                    <Config.Label>Value</Config.Label>
+                                    <Tooltip
+                                        variant="xs"
+                                        disabled={numericFields.length > 0}
+                                        label="You must select at least one numeric metric"
+                                    >
+                                        <Box style={{ flex: 1 }}>
+                                            <FieldSelect<
+                                                Metric | TableCalculation
+                                            >
+                                                placeholder="Select value metric"
+                                                disabled={
+                                                    numericFields.length === 0
+                                                }
+                                                item={valueField}
+                                                items={numericFields}
+                                                onChange={(newField) => {
+                                                    if (
+                                                        newField &&
+                                                        isField(newField)
+                                                    ) {
+                                                        onValueFieldChange(
+                                                            getItemId(newField),
+                                                        );
+                                                    } else if (
+                                                        newField &&
+                                                        isTableCalculation(
+                                                            newField,
+                                                        )
+                                                    ) {
+                                                        onValueFieldChange(
+                                                            newField.name,
+                                                        );
+                                                    } else {
+                                                        onValueFieldChange(
+                                                            null,
+                                                        );
+                                                    }
+                                                }}
+                                                hasGrouping
+                                            />
+                                        </Box>
+                                    </Tooltip>
+                                </Group>
+                            </Config.Section>
+                        </Config>
+
+                        <Config>
+                            <Config.Section>
+                                <Config.Heading>Orientation</Config.Heading>
+                                <SegmentedControl
+                                    value={orientation}
+                                    data={[
+                                        {
+                                            value: SankeyChartOrientation.HORIZONTAL,
+                                            label: 'Horizontal',
+                                        },
+                                        {
+                                            value: SankeyChartOrientation.VERTICAL,
+                                            label: 'Vertical',
+                                        },
+                                    ]}
+                                    onChange={(value) =>
+                                        onOrientationChange(
+                                            value as SankeyChartOrientation,
+                                        )
+                                    }
+                                />
+                            </Config.Section>
+                        </Config>
+                    </Stack>
+                </Tabs.Panel>
+
+                <Tabs.Panel value="display">
+                    <Stack>
+                        <Config>
+                            <Config.Section>
+                                <Config.Heading>Labels</Config.Heading>
+
+                                <Group spacing="xs">
+                                    <Config.Label>Position</Config.Label>
+                                    <SegmentedControl
+                                        value={labels?.position}
+                                        data={[
+                                            {
+                                                value: SankeyChartLabelPosition.LEFT,
+                                                label: 'Left',
+                                            },
+                                            {
+                                                value: SankeyChartLabelPosition.INSIDE,
+                                                label: 'Inside',
+                                            },
+                                            {
+                                                value: SankeyChartLabelPosition.RIGHT,
+                                                label: 'Right',
+                                            },
+                                            {
+                                                value: SankeyChartLabelPosition.HIDDEN,
+                                                label: 'Hidden',
+                                            },
+                                        ]}
+                                        onChange={(
+                                            newPosition: SankeyChartLabelPosition,
+                                        ) =>
+                                            onLabelsChange({
+                                                position: newPosition,
+                                            })
+                                        }
+                                    />
+                                </Group>
+
+                                <Checkbox
+                                    checked={labels?.showValue}
+                                    onChange={(newValue) =>
+                                        onLabelsChange({
+                                            showValue:
+                                                newValue.currentTarget.checked,
+                                        })
+                                    }
+                                    label="Show value in labels"
+                                />
+                            </Config.Section>
+                        </Config>
+
+                        <Config>
+                            <Config.Section>
+                                <Config.Heading>Node styling</Config.Heading>
+
+                                <Group spacing="xs">
+                                    <Config.Label>Node width</Config.Label>
+                                    <NumberInput
+                                        value={nodeWidth}
+                                        onChange={(value) =>
+                                            onNodeWidthChange(
+                                                typeof value === 'number'
+                                                    ? value
+                                                    : 20,
+                                            )
+                                        }
+                                        min={5}
+                                        max={100}
+                                        step={5}
+                                        style={{ width: 80 }}
+                                    />
+                                </Group>
+
+                                <Group spacing="xs">
+                                    <Config.Label>Node gap</Config.Label>
+                                    <NumberInput
+                                        value={nodeGap}
+                                        onChange={(value) =>
+                                            onNodeGapChange(
+                                                typeof value === 'number'
+                                                    ? value
+                                                    : 10,
+                                            )
+                                        }
+                                        min={0}
+                                        max={100}
+                                        step={5}
+                                        style={{ width: 80 }}
+                                    />
+                                </Group>
+                            </Config.Section>
+                        </Config>
+
+                        <Config>
+                            <Config.Section>
+                                <Config.Heading>Link color</Config.Heading>
+                                <SegmentedControl
+                                    value={linkColorMode}
+                                    data={[
+                                        { value: 'source', label: 'Source' },
+                                        { value: 'target', label: 'Target' },
+                                        {
+                                            value: 'gradient',
+                                            label: 'Gradient',
+                                        },
+                                    ]}
+                                    onChange={(value) =>
+                                        onLinkColorModeChange(
+                                            value as
+                                                | 'source'
+                                                | 'target'
+                                                | 'gradient',
+                                        )
+                                    }
+                                />
+                            </Config.Section>
+                        </Config>
+
+                        <Config>
+                            <Config.Section>
+                                <Group>
+                                    <Config.Heading>
+                                        Allow node dragging
+                                    </Config.Heading>
+                                    <Switch
+                                        checked={draggable}
+                                        onChange={toggleDraggable}
+                                    />
+                                </Group>
+                            </Config.Section>
+                        </Config>
+                    </Stack>
+                </Tabs.Panel>
+            </Tabs>
+        </MantineProvider>
+    );
+});

--- a/packages/frontend/src/components/common/ResourceIcon/utils.ts
+++ b/packages/frontend/src/components/common/ResourceIcon/utils.ts
@@ -11,6 +11,7 @@ import {
     IconFilter,
     IconGauge,
     IconMap,
+    IconRouteAltLeft,
     IconSquareNumber1,
     IconTable,
 } from '@tabler/icons-react';
@@ -46,6 +47,8 @@ export const getChartIcon = (chartKind: ChartKind | undefined) => {
             return IconCode;
         case ChartKind.MAP:
             return IconMap;
+        case ChartKind.SANKEY:
+            return IconRouteAltLeft;
         default:
             return assertUnreachable(
                 chartKind,

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -45,6 +45,8 @@ export const getResourceTypeName = (item: ResourceViewItem) => {
                     return 'Custom visualization';
                 case ChartKind.MAP:
                     return 'Map';
+                case ChartKind.SANKEY:
+                    return 'Sankey chart';
                 default:
                     return assertUnreachable(
                         item.data.chartKind,

--- a/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
@@ -1,0 +1,186 @@
+import {
+    formatColorIndicator,
+    formatItemValue,
+    formatTooltipRow,
+    formatTooltipValue,
+    getTooltipStyle,
+    SankeyChartLabelPosition,
+    SankeyChartOrientation,
+} from '@lightdash/common';
+import { useMantineTheme } from '@mantine/core';
+import { useMemo } from 'react';
+import { isSankeyVisualizationConfig } from '../../components/LightdashVisualization/types';
+import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
+
+export type SankeySeriesDataPoint = {
+    name: string;
+    value?: number;
+    itemStyle?: {
+        color?: string;
+    };
+};
+
+export type SankeySeriesLink = {
+    source: string;
+    target: string;
+    value: number;
+};
+
+const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
+    const { visualizationConfig, parameters } = useVisualizationContext();
+
+    const theme = useMantineTheme();
+
+    const chartConfig = useMemo(() => {
+        if (!isSankeyVisualizationConfig(visualizationConfig)) return;
+        return visualizationConfig.chartConfig;
+    }, [visualizationConfig]);
+
+    const seriesData = useMemo(() => {
+        if (!chartConfig) return;
+
+        const { data } = chartConfig;
+
+        return data.nodes.length > 0 && data.links.length > 0
+            ? data
+            : undefined;
+    }, [chartConfig]);
+
+    const sankeySeriesOptions = useMemo(() => {
+        if (!chartConfig || !seriesData) return undefined;
+
+        const {
+            validConfig: {
+                nodeColorOverrides,
+                nodeWidth,
+                nodeGap,
+                orientation,
+                labels,
+                linkColorMode,
+                draggable,
+            },
+            nodeColorDefaults,
+            valueField,
+        } = chartConfig;
+
+        // Build nodes with colors
+        const nodes: SankeySeriesDataPoint[] = seriesData.nodes.map((node) => ({
+            name: node.name,
+            itemStyle: {
+                color:
+                    nodeColorOverrides?.[node.name] ??
+                    nodeColorDefaults[node.name],
+            },
+        }));
+
+        // Build links
+        const links: SankeySeriesLink[] = seriesData.links.map((link) => ({
+            source: link.source,
+            target: link.target,
+            value: link.value,
+        }));
+
+        return {
+            type: 'sankey' as const,
+            data: nodes,
+            links,
+            nodeWidth: nodeWidth ?? 20,
+            nodeGap: nodeGap ?? 10,
+            orient:
+                orientation === SankeyChartOrientation.VERTICAL
+                    ? ('vertical' as const)
+                    : ('horizontal' as const),
+            draggable: draggable ?? false,
+            emphasis: {
+                focus: 'adjacency' as const,
+            },
+            lineStyle: {
+                color: linkColorMode ?? 'source',
+                curveness: 0.5,
+            },
+            label: {
+                show: labels?.position !== SankeyChartLabelPosition.HIDDEN,
+                position:
+                    labels?.position === SankeyChartLabelPosition.LEFT
+                        ? ('left' as const)
+                        : labels?.position === SankeyChartLabelPosition.INSIDE
+                        ? ('inside' as const)
+                        : ('right' as const),
+                formatter: (params: Record<string, unknown>) => {
+                    const name = params.name as string;
+                    const value = params.value as number | undefined;
+                    if (labels?.showValue && value !== undefined) {
+                        const formattedValue = formatItemValue(
+                            valueField,
+                            value,
+                            false,
+                            parameters,
+                        );
+                        return `${name}: ${formattedValue}`;
+                    }
+                    return name;
+                },
+            },
+            tooltip: {
+                trigger: 'item' as const,
+                triggerOn: 'mousemove' as const,
+                formatter: (params: Record<string, unknown>) => {
+                    const dataType = params.dataType as string | undefined;
+                    const name = params.name as string;
+                    const value = params.value as number | undefined;
+                    const data = params.data as
+                        | { source?: string; target?: string; value?: number }
+                        | undefined;
+                    const color = params.color as string | undefined;
+
+                    if (dataType === 'edge' && data) {
+                        // Link tooltip
+                        const formattedValue = formatItemValue(
+                            valueField,
+                            data.value,
+                            false,
+                            parameters,
+                        );
+                        return `${data.source} → ${data.target}: ${formattedValue}`;
+                    }
+                    // Node tooltip
+                    const formattedValue = formatItemValue(
+                        valueField,
+                        value,
+                        false,
+                        parameters,
+                    );
+                    const colorIndicator = formatColorIndicator(
+                        typeof color === 'string' ? color : '',
+                    );
+                    const valuePill = formatTooltipValue(formattedValue);
+                    return formatTooltipRow(colorIndicator, name, valuePill);
+                },
+            },
+        };
+    }, [chartConfig, seriesData, parameters]);
+
+    const eChartsOptions = useMemo(() => {
+        if (!chartConfig || !sankeySeriesOptions || !seriesData)
+            return undefined;
+
+        return {
+            textStyle: {
+                fontFamily: theme?.other.chartFont as string | undefined,
+            },
+            tooltip: {
+                ...getTooltipStyle(),
+                trigger: 'item' as const,
+                triggerOn: 'mousemove' as const,
+            },
+            series: [sankeySeriesOptions],
+            animation: !isInDashboard,
+        };
+    }, [chartConfig, sankeySeriesOptions, seriesData, isInDashboard, theme]);
+
+    if (!eChartsOptions) return;
+
+    return eChartsOptions;
+};
+
+export default useEchartsSankeyConfig;

--- a/packages/frontend/src/hooks/useSankeyChartConfig.ts
+++ b/packages/frontend/src/hooks/useSankeyChartConfig.ts
@@ -1,0 +1,367 @@
+import {
+    isField,
+    isMetric,
+    isTableCalculation,
+    SankeyChartLabelPosition,
+    SankeyChartOrientation,
+    type Dimension,
+    type ItemsMap,
+    type Metric,
+    type SankeyChart,
+    type TableCalculation,
+    type TableCalculationMetadata,
+} from '@lightdash/common';
+import { useDebouncedValue } from '@mantine/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type InfiniteQueryResults } from './useQueryResults';
+
+export type SankeyNode = {
+    name: string;
+};
+
+export type SankeyLink = {
+    source: string;
+    target: string;
+    value: number;
+};
+
+export type SankeySeriesData = {
+    nodes: SankeyNode[];
+    links: SankeyLink[];
+};
+
+type SankeyChartConfig = {
+    validConfig: SankeyChart;
+
+    // Source field
+    sourceFieldId: string | null;
+    onSourceFieldChange: (fieldId: string | null) => void;
+    sourceField: Dimension | undefined;
+
+    // Target field
+    targetFieldId: string | null;
+    onTargetFieldChange: (fieldId: string | null) => void;
+    targetField: Dimension | undefined;
+
+    // Value field
+    valueFieldId: string | null;
+    onValueFieldChange: (fieldId: string | null) => void;
+    valueField: Metric | TableCalculation | undefined;
+
+    // Display options
+    nodeWidth: number;
+    onNodeWidthChange: (width: number) => void;
+    nodeGap: number;
+    onNodeGapChange: (gap: number) => void;
+    orientation: SankeyChartOrientation;
+    onOrientationChange: (orientation: SankeyChartOrientation) => void;
+
+    // Label options
+    labels: SankeyChart['labels'];
+    onLabelsChange: (labels: SankeyChart['labels']) => void;
+
+    // Color options
+    nodeColorDefaults: Record<string, string>;
+    nodeColorOverrides: Record<string, string>;
+    onNodeColorOverridesChange: (key: string, value: string) => void;
+    linkColorMode: 'source' | 'target' | 'gradient';
+    onLinkColorModeChange: (mode: 'source' | 'target' | 'gradient') => void;
+
+    // Interaction options
+    draggable: boolean;
+    toggleDraggable: () => void;
+
+    // Legend options
+    showLegend: boolean;
+    toggleShowLegend: () => void;
+
+    // Computed data
+    data: SankeySeriesData;
+};
+
+export type SankeyChartConfigFn = (
+    resultsData: InfiniteQueryResults | undefined,
+    sankeyChartConfig: SankeyChart | undefined,
+    itemsMap: ItemsMap | undefined,
+    dimensions: Record<string, Dimension>,
+    numericFields: Record<string, Metric | TableCalculation>,
+    colorPalette: string[],
+    tableCalculationsMetadata?: TableCalculationMetadata[],
+) => SankeyChartConfig;
+
+const useSankeyChartConfig: SankeyChartConfigFn = (
+    resultsData,
+    sankeyChartConfig,
+    itemsMap,
+    dimensions,
+    numericFields,
+    colorPalette,
+    tableCalculationsMetadata,
+) => {
+    // Source field state
+    const [sourceFieldId, setSourceFieldId] = useState(
+        sankeyChartConfig?.sourceFieldId ?? null,
+    );
+
+    // Target field state
+    const [targetFieldId, setTargetFieldId] = useState(
+        sankeyChartConfig?.targetFieldId ?? null,
+    );
+
+    // Value field state
+    const [valueFieldId, setValueFieldId] = useState(
+        sankeyChartConfig?.valueFieldId ?? null,
+    );
+
+    // Display options state
+    const [nodeWidth, setNodeWidth] = useState(
+        sankeyChartConfig?.nodeWidth ?? 20,
+    );
+    const [nodeGap, setNodeGap] = useState(sankeyChartConfig?.nodeGap ?? 10);
+    const [orientation, setOrientation] = useState(
+        sankeyChartConfig?.orientation ?? SankeyChartOrientation.HORIZONTAL,
+    );
+
+    // Label options state
+    const [labels, setLabels] = useState<SankeyChart['labels']>(
+        sankeyChartConfig?.labels ?? {
+            position: SankeyChartLabelPosition.RIGHT,
+            showValue: true,
+        },
+    );
+
+    // Color options state
+    const [nodeColorOverrides, setNodeColorOverrides] = useState(
+        sankeyChartConfig?.nodeColorOverrides ?? {},
+    );
+    const [debouncedNodeColorOverrides] = useDebouncedValue(
+        nodeColorOverrides,
+        500,
+    );
+    const [linkColorMode, setLinkColorMode] = useState<
+        'source' | 'target' | 'gradient'
+    >(sankeyChartConfig?.linkColorMode ?? 'source');
+
+    // Interaction options state
+    const [draggable, setDraggable] = useState(
+        sankeyChartConfig?.draggable ?? false,
+    );
+
+    // Legend options state
+    const [showLegend, setShowLegend] = useState(
+        sankeyChartConfig?.showLegend ?? false,
+    );
+
+    // Get all dimension field IDs
+    const allDimensionFieldIds = useMemo(
+        () => (dimensions ? Object.keys(dimensions) : []),
+        [dimensions],
+    );
+
+    // Get all numeric field IDs
+    const allNumericFieldIds = useMemo(
+        () => (numericFields ? Object.keys(numericFields) : []),
+        [numericFields],
+    );
+
+    // Get selected fields
+    const sourceField = useMemo(() => {
+        if (!itemsMap || !sourceFieldId || !(sourceFieldId in itemsMap))
+            return undefined;
+        const item = itemsMap[sourceFieldId];
+        if (isField(item) && !isMetric(item)) return item as Dimension;
+        return undefined;
+    }, [itemsMap, sourceFieldId]);
+
+    const targetField = useMemo(() => {
+        if (!itemsMap || !targetFieldId || !(targetFieldId in itemsMap))
+            return undefined;
+        const item = itemsMap[targetFieldId];
+        if (isField(item) && !isMetric(item)) return item as Dimension;
+        return undefined;
+    }, [itemsMap, targetFieldId]);
+
+    const valueField = useMemo(() => {
+        if (!itemsMap || !valueFieldId || !(valueFieldId in itemsMap))
+            return undefined;
+        const item = itemsMap[valueFieldId];
+        if ((isField(item) && isMetric(item)) || isTableCalculation(item))
+            return item;
+        return undefined;
+    }, [itemsMap, valueFieldId]);
+
+    const isLoading = !resultsData;
+
+    // Auto-select fields if not set
+    useEffect(() => {
+        if (isLoading || allDimensionFieldIds.length < 2) return;
+
+        // Handle table calculation name changes
+        if (tableCalculationsMetadata && valueFieldId) {
+            const metricTcIndex = tableCalculationsMetadata.findIndex(
+                (tc) => tc.oldName === valueFieldId,
+            );
+            if (metricTcIndex !== -1) {
+                setValueFieldId(tableCalculationsMetadata[metricTcIndex].name);
+                return;
+            }
+        }
+
+        // Auto-select source field
+        if (!sourceFieldId || !allDimensionFieldIds.includes(sourceFieldId)) {
+            setSourceFieldId(allDimensionFieldIds[0] ?? null);
+        }
+
+        // Auto-select target field (second dimension if available)
+        if (!targetFieldId || !allDimensionFieldIds.includes(targetFieldId)) {
+            setTargetFieldId(allDimensionFieldIds[1] ?? null);
+        }
+
+        // Auto-select value field
+        if (!valueFieldId || !allNumericFieldIds.includes(valueFieldId)) {
+            setValueFieldId(allNumericFieldIds[0] ?? null);
+        }
+    }, [
+        allDimensionFieldIds,
+        allNumericFieldIds,
+        sourceFieldId,
+        targetFieldId,
+        valueFieldId,
+        isLoading,
+        tableCalculationsMetadata,
+    ]);
+
+    // Compute Sankey data from results
+    const data: SankeySeriesData = useMemo(() => {
+        if (
+            !resultsData ||
+            !sourceFieldId ||
+            !targetFieldId ||
+            !valueFieldId ||
+            resultsData.rows.length === 0
+        ) {
+            return { nodes: [], links: [] };
+        }
+
+        const nodesSet = new Set<string>();
+        const links: SankeyLink[] = [];
+
+        resultsData.rows.forEach((row) => {
+            const sourceValue = row[sourceFieldId]?.value?.formatted;
+            const targetValue = row[targetFieldId]?.value?.formatted;
+            const value = Number(row[valueFieldId]?.value?.raw ?? 0);
+
+            if (sourceValue && targetValue && !isNaN(value)) {
+                nodesSet.add(sourceValue);
+                nodesSet.add(targetValue);
+                links.push({
+                    source: sourceValue,
+                    target: targetValue,
+                    value,
+                });
+            }
+        });
+
+        const nodes = Array.from(nodesSet).map((name) => ({ name }));
+
+        return { nodes, links };
+    }, [resultsData, sourceFieldId, targetFieldId, valueFieldId]);
+
+    // Compute default colors for nodes
+    const nodeColorDefaults = useMemo(() => {
+        return Object.fromEntries(
+            data.nodes.map((node, index) => {
+                return [node.name, colorPalette[index % colorPalette.length]];
+            }),
+        );
+    }, [data.nodes, colorPalette]);
+
+    // Callbacks for updating state
+    const onLabelsChange = useCallback((labelsProps: SankeyChart['labels']) => {
+        setLabels((prevLabels: SankeyChart['labels']) => ({
+            ...prevLabels,
+            ...labelsProps,
+        }));
+    }, []);
+
+    const onNodeColorOverridesChange = useCallback(
+        (key: string, value: string) => {
+            setNodeColorOverrides(({ [key]: _, ...rest }) => {
+                return value.trim() === '' ? rest : { ...rest, [key]: value };
+            });
+        },
+        [],
+    );
+
+    // Build valid config
+    const validConfig: SankeyChart = useMemo(
+        () => ({
+            sourceFieldId: sourceFieldId ?? undefined,
+            targetFieldId: targetFieldId ?? undefined,
+            valueFieldId: valueFieldId ?? undefined,
+            nodeWidth,
+            nodeGap,
+            orientation,
+            labels,
+            nodeColorOverrides: debouncedNodeColorOverrides,
+            linkColorMode,
+            draggable,
+            showLegend,
+        }),
+        [
+            sourceFieldId,
+            targetFieldId,
+            valueFieldId,
+            nodeWidth,
+            nodeGap,
+            orientation,
+            labels,
+            debouncedNodeColorOverrides,
+            linkColorMode,
+            draggable,
+            showLegend,
+        ],
+    );
+
+    return {
+        validConfig,
+
+        sourceFieldId,
+        onSourceFieldChange: setSourceFieldId,
+        sourceField,
+
+        targetFieldId,
+        onTargetFieldChange: setTargetFieldId,
+        targetField,
+
+        valueFieldId,
+        onValueFieldChange: setValueFieldId,
+        valueField,
+
+        nodeWidth,
+        onNodeWidthChange: setNodeWidth,
+        nodeGap,
+        onNodeGapChange: setNodeGap,
+        orientation,
+        onOrientationChange: setOrientation,
+
+        labels,
+        onLabelsChange,
+
+        nodeColorDefaults,
+        nodeColorOverrides,
+        onNodeColorOverridesChange,
+        linkColorMode,
+        onLinkColorModeChange: setLinkColorMode,
+
+        draggable,
+        toggleDraggable: () => setDraggable((prev: boolean) => !prev),
+
+        showLegend,
+        toggleShowLegend: () => setShowLegend((prev: boolean) => !prev),
+
+        data,
+    };
+};
+
+export default useSankeyChartConfig;

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -21,6 +21,7 @@ import {
     type ParameterDefinitions,
     type PieChartConfig,
     type ReplaceCustomFields,
+    type SankeyChartConfig,
     type SavedChart,
     type TableCalculation,
     type TableCalculationMetadata,
@@ -83,6 +84,7 @@ export type ConfigCacheMap = {
     [ChartType.TREEMAP]: ChartConfigCache<TreemapChartConfig['config']>;
     [ChartType.GAUGE]: ChartConfigCache<GaugeChartConfig['config']>;
     [ChartType.MAP]: ChartConfigCache<MapChartConfig['config']>;
+    [ChartType.SANKEY]: ChartConfigCache<SankeyChartConfig['config']>;
     [ChartType.CUSTOM]: ChartConfigCache<CustomVisConfig['config']>;
 };
 

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -12,6 +12,7 @@ const DEFAULTS = {
     [ChartType.TREEMAP]: () => ({}),
     [ChartType.GAUGE]: () => ({}),
     [ChartType.MAP]: () => ({}),
+    [ChartType.SANKEY]: () => ({}),
     [ChartType.CUSTOM]: () => ({}),
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #1234

### Description:
Added Sankey chart visualization type to Lightdash. This new chart type allows users to visualize flow data between nodes, showing relationships between source and target dimensions with weighted connections.

The implementation includes:
- Database migration to add the new chart type
- New Sankey chart configuration UI with options for:
  - Source and target dimension fields
  - Value/weight metric field
  - Node styling (width, gap, colors)
  - Link color modes (source, target, gradient)
  - Label positioning and formatting
  - Node dragging functionality
- ECharts integration for rendering the Sankey diagram
- Type definitions and supporting utilities

![sankey-chart-example](https://user-images.githubusercontent.com/12345/example-sankey.png)