### PR TITLE
feat: support configuring multiple models per provider

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 
 export const DEFAULT_OPENAI_MODEL_NAME = 'gpt-4.1-2025-04-14';
-export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-20250514';
+export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-5-20250929';
 export const DEFAULT_DEFAULT_AI_PROVIDER = 'openai';
 export const DEFAULT_OPENROUTER_MODEL_NAME = 'openai/gpt-4.1-2025-04-14';
 export const DEFAULT_BEDROCK_MODEL_NAME =
-    'eu.anthropic.claude-sonnet-4-5-20250929-v1:0';
+    'anthropic.claude-sonnet-4-5-20250929-v1:0';
 
 export const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const DEFAULT_BEDROCK_EMBEDDING_MODEL = 'cohere.embed-english-v3';
@@ -27,24 +27,7 @@ export const aiCopilotConfigSchema = z
                         .string()
                         .default(DEFAULT_OPENAI_EMBEDDING_MODEL),
                     baseUrl: z.string().optional(),
-                    temperature: z.number().min(0).max(2).default(0.2),
-                    responsesApi: z.boolean().default(false),
-                    reasoning: z
-                        .object({
-                            enabled: z.boolean().default(false),
-                            reasoningSummary: z
-                                .enum(['auto', 'detailed'])
-                                .default('auto'),
-                            reasoningEffort: z
-                                .enum(['minimal', 'low', 'medium', 'high'])
-                                .default('medium'),
-                        })
-                        .optional()
-                        .default({
-                            enabled: false,
-                            reasoningSummary: 'auto',
-                            reasoningEffort: 'low',
-                        }),
+                    availableModels: z.array(z.string()).optional(),
                 })
                 .optional(),
             azure: z
@@ -53,14 +36,13 @@ export const aiCopilotConfigSchema = z
                     apiKey: z.string(),
                     apiVersion: z.string(),
                     deploymentName: z.string(),
-                    temperature: z.number().min(0).max(2).default(0.2),
                 })
                 .optional(),
             anthropic: z
                 .object({
                     apiKey: z.string(),
                     modelName: z.string().default(DEFAULT_ANTHROPIC_MODEL_NAME),
-                    temperature: z.number().min(0).max(2).default(0.2),
+                    availableModels: z.array(z.string()).optional(),
                 })
                 .optional(),
             openrouter: z
@@ -77,7 +59,6 @@ export const aiCopilotConfigSchema = z
                     modelName: z
                         .string()
                         .default(DEFAULT_OPENROUTER_MODEL_NAME),
-                    temperature: z.number().min(0).max(2).default(0.2),
                 })
                 .optional(),
             bedrock: z
@@ -91,7 +72,7 @@ export const aiCopilotConfigSchema = z
                         embeddingModelName: z
                             .string()
                             .default(DEFAULT_BEDROCK_EMBEDDING_MODEL),
-                        temperature: z.number().min(0).max(2).default(0.2),
+                        availableModels: z.array(z.string()).optional(),
                     }),
                     z.object({
                         region: z.string(),
@@ -104,7 +85,7 @@ export const aiCopilotConfigSchema = z
                         embeddingModelName: z
                             .string()
                             .default(DEFAULT_BEDROCK_EMBEDDING_MODEL),
-                        temperature: z.number().min(0).max(2).default(0.2),
+                        availableModels: z.array(z.string()).optional(),
                     }),
                 ])
                 .optional(),

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -212,15 +212,8 @@ export const lightdashConfigMock: LightdashConfig = {
             providers: {
                 openai: {
                     apiKey: 'mock_api_key',
-                    modelName: 'mock_model_name',
+                    modelName: 'gpt-4.1-2025-04-14',
                     embeddingModelName: 'text-embedding-3-small',
-                    temperature: 0.2,
-                    responsesApi: false,
-                    reasoning: {
-                        enabled: false,
-                        reasoningSummary: 'auto',
-                        reasoningEffort: 'medium',
-                    },
                 },
             },
             verifiedAnswerSimilarityThreshold: 0.6,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -656,9 +656,6 @@ export const getAiConfig = () => ({
                   apiKey: process.env.AZURE_AI_API_KEY,
                   apiVersion: process.env.AZURE_AI_API_VERSION,
                   deploymentName: process.env.AZURE_AI_DEPLOYMENT_NAME,
-                  temperature: getFloatFromEnvironmentVariable(
-                      'AZURE_AI_TEMPERATURE',
-                  ),
               }
             : undefined,
         openai: process.env.OPENAI_API_KEY
@@ -671,14 +668,9 @@ export const getAiConfig = () => ({
                       process.env.OPENAI_EMBEDDING_MODEL ||
                       DEFAULT_OPENAI_EMBEDDING_MODEL,
                   baseUrl: process.env.OPENAI_BASE_URL,
-                  temperature:
-                      getFloatFromEnvironmentVariable('OPENAI_TEMPERATURE'),
-                  responsesApi: process.env.OPENAI_RESPONSES_API === 'true',
-                  reasoning: {
-                      enabled: process.env.OPENAI_REASONING_ENABLED === 'true',
-                      reasoningSummary: process.env.OPENAI_REASONING_SUMMARY,
-                      reasoningEffort: process.env.OPENAI_REASONING_EFFORT,
-                  },
+                  availableModels: getArrayFromCommaSeparatedList(
+                      'OPENAI_AVAILABLE_MODELS',
+                  ),
               }
             : undefined,
         anthropic: process.env.ANTHROPIC_API_KEY
@@ -687,8 +679,8 @@ export const getAiConfig = () => ({
                   modelName:
                       process.env.ANTHROPIC_MODEL_NAME ||
                       DEFAULT_ANTHROPIC_MODEL_NAME,
-                  temperature: getFloatFromEnvironmentVariable(
-                      'ANTHROPIC_TEMPERATURE',
+                  availableModels: getArrayFromCommaSeparatedList(
+                      'ANTHROPIC_AVAILABLE_MODELS',
                   ),
               }
             : undefined,
@@ -701,9 +693,6 @@ export const getAiConfig = () => ({
                   sortOrder: process.env.OPENROUTER_SORT_ORDER,
                   allowedProviders: getArrayFromCommaSeparatedList(
                       'OPENROUTER_ALLOWED_PROVIDERS',
-                  ),
-                  temperature: getFloatFromEnvironmentVariable(
-                      'OPENROUTER_TEMPERATURE',
                   ),
               }
             : undefined,
@@ -719,8 +708,8 @@ export const getAiConfig = () => ({
                           process.env.BEDROCK_MODEL_NAME ||
                           DEFAULT_BEDROCK_MODEL_NAME,
                       embeddingModelName: process.env.BEDROCK_EMBEDDING_MODEL,
-                      temperature: getFloatFromEnvironmentVariable(
-                          'BEDROCK_TEMPERATURE',
+                      availableModels: getArrayFromCommaSeparatedList(
+                          'BEDROCK_AVAILABLE_MODELS',
                       ),
                   }
                 : undefined,

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -40,18 +40,25 @@ describeOrSkip.concurrent('agent integration tests', () => {
     };
 
     // Creating model to be used as judge
-    const { model: judge, callOptions } = getOpenaiGptmodel({
-        apiKey: process.env.OPENAI_API_KEY!,
-        modelName: 'gpt-4.1-2025-04-14',
-        embeddingModelName: 'text-embedding-3-small',
-        temperature: 0.2,
-        responsesApi: true,
-        reasoning: {
-            enabled: false,
-            reasoningEffort: 'medium',
-            reasoningSummary: 'auto',
+    const { model: judge, callOptions } = getOpenaiGptmodel(
+        {
+            apiKey: process.env.OPENAI_API_KEY!,
+            modelName: 'gpt-4.1-2025-04-14',
+            embeddingModelName: 'text-embedding-3-small',
         },
-    });
+        {
+            provider: 'openai',
+            modelId: 'gpt-4.1-2025-04-14',
+            displayName: 'GPT-4.1',
+            description: 'Reliable OpenAI model',
+            supportsReasoning: false,
+            callOptions: { temperature: 0.2 },
+            providerOptions: {
+                strictJsonSchema: true,
+                parallelToolCalls: false,
+            },
+        },
+    );
 
     beforeAll(async () => {
         if (!process.env.OPENAI_API_KEY) {

--- a/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
+++ b/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
@@ -1,5 +1,6 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { LightdashConfig } from '../../../../config/parseConfig';
+import { ModelPreset } from './presets';
 import { AiModel } from './types';
 
 const PROVIDER = 'anthropic';
@@ -8,18 +9,19 @@ export const getAnthropicModel = (
     config: NonNullable<
         LightdashConfig['ai']['copilot']['providers']['anthropic']
     >,
+    preset: ModelPreset<'anthropic'>,
 ): AiModel<typeof PROVIDER> => {
     const anthropic = createAnthropic({
         apiKey: config.apiKey,
     });
 
-    const model = anthropic(config.modelName);
+    const model = anthropic(preset.modelId);
 
     return {
         model,
-        callOptions: {
-            temperature: config.temperature,
-        },
-        providerOptions: undefined,
+        callOptions: preset.callOptions,
+        providerOptions: preset.providerOptions
+            ? { [PROVIDER]: preset.providerOptions }
+            : undefined,
     };
 };

--- a/packages/backend/src/ee/services/ai/models/azure-openai-gpt-4.1.ts
+++ b/packages/backend/src/ee/services/ai/models/azure-openai-gpt-4.1.ts
@@ -18,7 +18,7 @@ export const getAzureGpt41Model = (
     return {
         model,
         callOptions: {
-            temperature: config.temperature,
+            temperature: 0.2,
         },
         providerOptions: {
             [PROVIDER]: {

--- a/packages/backend/src/ee/services/ai/models/bedrock.ts
+++ b/packages/backend/src/ee/services/ai/models/bedrock.ts
@@ -4,6 +4,7 @@ import {
 } from '@ai-sdk/amazon-bedrock';
 import type { EmbeddingModel } from 'ai';
 import { LightdashConfig } from '../../../../config/parseConfig';
+import { ModelPreset } from './presets';
 import { AiModel } from './types';
 
 const PROVIDER = 'bedrock';
@@ -31,16 +32,18 @@ export const getBedrockModel = (
     config: NonNullable<
         LightdashConfig['ai']['copilot']['providers']['bedrock']
     >,
+    preset: ModelPreset<'bedrock'>,
 ): AiModel<typeof PROVIDER> => {
     const bedrock = getBedrockProvider(config);
-    const model = bedrock(config.modelName);
+    /** @ref https://platform.claude.com/docs/en/build-with-claude/claude-on-amazon-bedrock#accessing-bedrock */
+    const model = bedrock(`${config.region}.${preset.modelId}`);
 
     return {
         model,
-        callOptions: {
-            temperature: config.temperature,
-        },
-        providerOptions: undefined,
+        callOptions: preset.callOptions,
+        providerOptions: preset.providerOptions
+            ? { [PROVIDER]: preset.providerOptions }
+            : undefined,
     };
 };
 

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -5,34 +5,71 @@ import { getAzureGpt41Model } from './azure-openai-gpt-4.1';
 import { getBedrockModel } from './bedrock';
 import { getOpenaiGptmodel } from './openai-gpt';
 import { getOpenRouterModel } from './openrouter';
+import { MODEL_PRESETS, ModelPreset } from './presets';
+
+const getModelPreset = <T extends 'openai' | 'anthropic' | 'bedrock'>(
+    provider: T,
+    config: LightdashConfig['ai']['copilot'],
+): {
+    config: NonNullable<LightdashConfig['ai']['copilot']['providers'][T]>;
+    preset: ModelPreset<T>;
+} => {
+    const providerConfig = config.providers[provider];
+    if (!providerConfig) {
+        throw new ParameterError(
+            `${provider} provider configuration is required`,
+        );
+    }
+
+    // TODO :: for now we just use default model to preserve current behavior
+    const modelId = providerConfig.modelName;
+    const preset = MODEL_PRESETS[modelId];
+    if (!preset) {
+        throw new ParameterError(
+            `Model preset not found for model: ${modelId}`,
+        );
+    }
+    if (preset.provider !== provider) {
+        throw new ParameterError(`Model ${modelId} is not a ${provider} model`);
+    }
+
+    return {
+        config: providerConfig,
+        preset: preset as ModelPreset<T>,
+    };
+};
 
 export const getModel = (
     config: LightdashConfig['ai']['copilot'],
     options?: {
         enableReasoning?: boolean;
+        modelId?: string;
+        provider?: 'openai' | 'anthropic' | 'bedrock' | 'azure' | 'openrouter';
     },
 ) => {
-    switch (config.defaultProvider) {
+    const provider = options?.provider ?? config.defaultProvider;
+    switch (provider) {
         case 'openai': {
-            const openaiConfig = config.providers.openai;
-            if (!openaiConfig) {
-                throw new ParameterError('OpenAI configuration is required');
-            }
-            return getOpenaiGptmodel(openaiConfig, options);
+            const { config: openaiConfig, preset } = getModelPreset(
+                'openai',
+                config,
+            );
+            return getOpenaiGptmodel(openaiConfig, preset, options);
         }
         case 'azure': {
             const azureConfig = config.providers.azure;
             if (!azureConfig) {
                 throw new ParameterError('Azure configuration is required');
             }
+            // Azure doesn't use presets - uses deployment name directly
             return getAzureGpt41Model(azureConfig);
         }
         case 'anthropic': {
-            const anthropicConfig = config.providers.anthropic;
-            if (!anthropicConfig) {
-                throw new ParameterError('Anthropic configuration is required');
-            }
-            return getAnthropicModel(anthropicConfig);
+            const { config: anthropicConfig, preset } = getModelPreset(
+                'anthropic',
+                config,
+            );
+            return getAnthropicModel(anthropicConfig, preset);
         }
         case 'openrouter': {
             const openrouterConfig = config.providers.openrouter;
@@ -41,19 +78,17 @@ export const getModel = (
                     'OpenRouter configuration is required',
                 );
             }
+            // OpenRouter doesn't use presets - uses model name directly
             return getOpenRouterModel(openrouterConfig);
         }
         case 'bedrock': {
-            const bedrockConfig = config.providers.bedrock;
-            if (!bedrockConfig) {
-                throw new ParameterError('Bedrock configuration is required');
-            }
-            return getBedrockModel(bedrockConfig);
+            const { config: bedrockConfig, preset } = getModelPreset(
+                'bedrock',
+                config,
+            );
+            return getBedrockModel(bedrockConfig, preset);
         }
         default:
-            return assertUnreachable(
-                config.defaultProvider,
-                'Invalid provider',
-            );
+            return assertUnreachable(provider, `Invalid provider: ${provider}`);
     }
 };

--- a/packages/backend/src/ee/services/ai/models/openrouter.ts
+++ b/packages/backend/src/ee/services/ai/models/openrouter.ts
@@ -30,7 +30,7 @@ export const getOpenRouterModel = (
     return {
         model,
         callOptions: {
-            temperature: config.temperature,
+            temperature: 0.2,
         },
         providerOptions: undefined,
     };

--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -1,0 +1,103 @@
+import { CallSettings } from 'ai';
+import { ProviderOptionsMap } from './types';
+
+export type ModelPreset<P extends 'openai' | 'anthropic' | 'bedrock'> = {
+    provider: P;
+    modelId: string;
+    displayName: string;
+    description: string;
+    supportsReasoning: boolean;
+    callOptions: CallSettings;
+    providerOptions: ProviderOptionsMap[P] | undefined;
+};
+
+export const MODEL_PRESETS: Record<
+    string,
+    ModelPreset<'openai'> | ModelPreset<'anthropic'> | ModelPreset<'bedrock'>
+> = {
+    // OpenAI models
+    'gpt-5.1-2025-11-13': {
+        provider: 'openai',
+        modelId: 'gpt-5.1-2025-11-13',
+        displayName: 'GPT-5.1',
+        description: 'Intelligent reasoning model',
+        supportsReasoning: true,
+        callOptions: { temperature: 0.2 },
+        providerOptions: {
+            strictJsonSchema: true,
+            parallelToolCalls: false,
+        },
+    },
+    'gpt-4.1-2025-04-14': {
+        provider: 'openai',
+        modelId: 'gpt-4.1-2025-04-14',
+        displayName: 'GPT-4.1',
+        description: 'Smartest non-reasoning model',
+        supportsReasoning: false,
+        callOptions: { temperature: 0.2 },
+        providerOptions: {
+            strictJsonSchema: true,
+            parallelToolCalls: false,
+        },
+    },
+
+    // Anthropic models
+    'claude-sonnet-4-5-20250929': {
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4-5-20250929',
+        displayName: 'Claude Sonnet 4.5',
+        description: 'Most capable model for daily tasks',
+        supportsReasoning: true,
+        callOptions: { temperature: 0.2 },
+        providerOptions: undefined,
+    },
+    // 'claude-opus-4-5-20251101': {
+    //     provider: 'anthropic',
+    //     modelId: 'claude-opus-4-5-20251101',
+    //     displayName: 'Claude Opus 4.5',
+    //     description: 'Most capable Anthropic model with reasoning',
+    //     supportsReasoning: true,
+    //     callOptions: { temperature: 0.2 },
+    //     providerOptions: undefined,
+    // },
+    'claude-haiku-4-5-20251001': {
+        provider: 'anthropic',
+        modelId: 'claude-haiku-4-5-20251001',
+        displayName: 'Claude Haiku 4.5',
+        description: 'Fastest model with near-frontier AI capabilities',
+        supportsReasoning: true,
+        callOptions: { temperature: 0.2 },
+        providerOptions: undefined,
+    },
+
+    // Bedrock models
+    'anthropic.claude-sonnet-4-5-20250929-v1:0': {
+        provider: 'bedrock',
+        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        displayName: 'Claude Sonnet 4.5 (Bedrock)',
+        description: 'Most capable model for daily tasks',
+        supportsReasoning: true,
+        callOptions: { temperature: 0.2 },
+        providerOptions: undefined,
+    },
+    // 'anthropic.claude-opus-4-5-20251101-v1:0': {
+    //     provider: 'bedrock',
+    //     modelId: 'anthropic.claude-opus-4-5-20251101-v1:0',
+    //     displayName: 'Claude Opus 4.5 (Bedrock)',
+    //     description: 'Most capable model for daily tasks',
+    //     supportsReasoning: true,
+    //     callOptions: { temperature: 0.2 },
+    //     providerOptions: undefined,
+    // },
+    'anthropic.claude-haiku-4-5-20251001-v1:0': {
+        provider: 'bedrock',
+        modelId: 'anthropic.claude-haiku-4-5-20251001-v1:0',
+        displayName: 'Claude Haiku 4.5 (Bedrock)',
+        description: 'Fastest model with near-frontier AI capabilities',
+        supportsReasoning: true,
+        callOptions: { temperature: 0.2 },
+        providerOptions: undefined,
+    },
+};
+
+export type ModelPresetId = keyof typeof MODEL_PRESETS;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updates AI model configuration to support model presets and available models. This PR:

- Updates the default Anthropic model to `claude-sonnet-4-5-20250929`
- Fixes the Bedrock model name format by removing the region prefix
- Replaces hardcoded temperature settings with model-specific presets
- Adds support for available models configuration via environment variables
- Introduces a model preset system with standardized configuration for each model
- Removes OpenAI reasoning configuration in favor of model-specific capabilities
- Updates model initialization to use the new preset-based approach
