### PR TITLE
feat(backend): list available models and model selection for prompts

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -8,6 +8,7 @@ import {
     ApiAiAgentEvaluationRunSummaryListResponse,
     ApiAiAgentEvaluationSummaryListResponse,
     ApiAiAgentExploreAccessSummaryResponse,
+    ApiAiAgentModelOptionsResponse,
     ApiAiAgentResponse,
     ApiAiAgentSummaryResponse,
     ApiAiAgentThreadCreateRequest,
@@ -168,6 +169,27 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: agent,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentUuid}/models')
+    @OperationId('getModelOptions')
+    async getModelOptions(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+    ): Promise<ApiAiAgentModelOptionsResponse> {
+        this.setStatus(200);
+        const models = await this.getAiAgentService().getModelOptions(
+            req.user!,
+            projectUuid,
+            agentUuid,
+        );
+        return {
+            status: 'ok',
+            results: models,
         };
     }
 

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -79,13 +79,15 @@ export type DbAiPrompt = {
     human_feedback: string | null;
     metric_query: object | null;
     saved_query_uuid: string | null;
+    model_config: { modelId: string; modelProvider: string } | null;
 };
 
 export type AiPromptTable = Knex.CompositeTableType<
     // base
     DbAiPrompt,
     // insert
-    Pick<DbAiPrompt, 'ai_thread_uuid' | 'created_by_user_uuid' | 'prompt'>,
+    Pick<DbAiPrompt, 'ai_thread_uuid' | 'created_by_user_uuid' | 'prompt'> &
+        Partial<Pick<DbAiPrompt, 'model_config'>>,
     // update
     Partial<
         Pick<
@@ -97,6 +99,7 @@ export type AiPromptTable = Knex.CompositeTableType<
             | 'human_feedback'
             | 'metric_query'
             | 'saved_query_uuid'
+            | 'model_config'
         > & {
             responded_at: Knex.Raw;
         }

--- a/packages/backend/src/ee/database/migrations/20251203124345_add_model_config_to_ai_prompt.ts
+++ b/packages/backend/src/ee/database/migrations/20251203124345_add_model_config_to_ai_prompt.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const tableName = 'ai_prompt';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.jsonb('model_config').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(tableName, (table) => {
+        table.dropColumn('model_config');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2313,6 +2313,7 @@ export class AiAgentModel {
                 promptSlackTs: `${AiSlackPromptTableName}.prompt_slack_ts`,
                 slackThreadTs: `${AiSlackThreadTableName}.slack_thread_ts`,
                 humanScore: `${AiPromptTableName}.human_score`,
+                modelConfig: `${AiPromptTableName}.model_config`,
             })
             .where(`${AiPromptTableName}.ai_prompt_uuid`, promptUuid)
             .first();
@@ -2602,6 +2603,7 @@ export class AiAgentModel {
                 createdAt: `${AiPromptTableName}.created_at`,
                 response: `${AiPromptTableName}.response`,
                 humanScore: `${AiPromptTableName}.human_score`,
+                modelConfig: `${AiPromptTableName}.model_config`,
             })
             .where(`${AiPromptTableName}.ai_prompt_uuid`, promptUuid)
             .first();
@@ -2642,6 +2644,7 @@ export class AiAgentModel {
                     ai_thread_uuid: data.threadUuid,
                     created_by_user_uuid: data.createdByUserUuid,
                     prompt: data.prompt,
+                    ...(data.modelConfig && { model_config: data.modelConfig }),
                 })
                 .returning('ai_prompt_uuid');
 

--- a/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
+++ b/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
@@ -20,8 +20,18 @@ export const getAnthropicModel = (
     return {
         model,
         callOptions: preset.callOptions,
-        providerOptions: preset.providerOptions
-            ? { [PROVIDER]: preset.providerOptions }
-            : undefined,
+        providerOptions: {
+            [PROVIDER]: {
+                ...(preset.providerOptions || {}),
+                // TODO :: reasoning
+                // ...(preset.supportsReasoning && {
+                //     thinking: {
+                //         type: 'enabled',
+                //         /** @ref https://platform.claude.com/docs/en/build-with-claude/extended-thinking#working-with-thinking-budgets */
+                //         budgetTokens: 1024, // TODO :: low - 1024, medium - 4096, high - 16384
+                //     },
+                // }),
+            },
+        },
     };
 };

--- a/packages/backend/src/ee/services/ai/models/bedrock.ts
+++ b/packages/backend/src/ee/services/ai/models/bedrock.ts
@@ -41,9 +41,18 @@ export const getBedrockModel = (
     return {
         model,
         callOptions: preset.callOptions,
-        providerOptions: preset.providerOptions
-            ? { [PROVIDER]: preset.providerOptions }
-            : undefined,
+        providerOptions: {
+            [PROVIDER]: {
+                ...(preset.providerOptions || {}),
+                // TODO :: reasoning
+                // ...(preset.supportsReasoning && {
+                //     reasoningConfig: {
+                //         type: 'enabled',
+                //         budgetTokens: 1024, // TODO :: low - 1024, medium - 4096, high - 16384
+                //     },
+                // }),
+            },
+        },
     };
 };
 

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -10,9 +10,6 @@ export const getOpenaiGptmodel = (
         LightdashConfig['ai']['copilot']['providers']['openai']
     >,
     preset: ModelPreset<'openai'>,
-    options?: {
-        enableReasoning?: boolean;
-    },
 ): AiModel<typeof PROVIDER> => {
     const openai = createOpenAI({
         apiKey: config.apiKey,
@@ -23,12 +20,7 @@ export const getOpenaiGptmodel = (
 
     const isGpt5 = model.modelId.includes('gpt-5');
 
-    // Determine if reasoning should be enabled
-    const reasoningEnabled =
-        preset.supportsReasoning &&
-        (options?.enableReasoning !== undefined
-            ? options.enableReasoning
-            : false);
+    const reasoningEnabled = preset.supportsReasoning;
 
     return {
         model,
@@ -41,9 +33,11 @@ export const getOpenaiGptmodel = (
         providerOptions: {
             [PROVIDER]: {
                 ...(preset.providerOptions || {}),
+                // TODO :: reasoning
+                // Defaulting to Low as GPT-5 models without reasoning are not better than GPT-4.1
                 ...(reasoningEnabled && {
                     reasoningSummary: 'auto',
-                    reasoningEffort: 'medium',
+                    reasoningEffort: 'low',
                 }),
             },
         },

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1135,11 +1135,7 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                userUuid: { dataType: 'string', required: true },
-                firstName: { dataType: 'string', required: true },
-                lastName: { dataType: 'string', required: true },
-            },
+            nestedProperties: {},
             validators: {},
         },
     },
@@ -1168,7 +1164,13 @@ const models: TsoaRoute.Models = {
                 allowAllCharts: { dataType: 'boolean', required: true },
                 createdAt: { dataType: 'string', required: true },
                 user: {
-                    ref: 'Pick_LightdashUser.userUuid-or-firstName-or-lastName_',
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            ref: 'Pick_LightdashUser.userUuid-or-firstName-or-lastName_',
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
                     required: true,
                 },
             },
@@ -5936,6 +5938,42 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AIModelOption: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                default: { dataType: 'boolean', required: true },
+                provider: { dataType: 'string', required: true },
+                description: { dataType: 'string', required: true },
+                displayName: { dataType: 'string', required: true },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AIModelOption-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AIModelOption' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentModelOptionsResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AIModelOption-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ReadinessScoreEvaluation: {
         dataType: 'refAlias',
         type: {
@@ -6751,11 +6789,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6770,11 +6808,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6789,11 +6827,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6824,29 +6862,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 chartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -6870,6 +6885,36 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                tableName:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                 fieldType:
                                                                                                     {
                                                                                                         dataType:
@@ -6883,13 +6928,6 @@ const models: TsoaRoute.Models = {
                                                                                                     required:
                                                                                                         true,
                                                                                                 },
-                                                                                                tableName:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -6919,7 +6957,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -6927,7 +6965,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -6942,7 +6984,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -6950,11 +6992,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7009,11 +7047,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7093,29 +7131,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     chartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -7139,6 +7154,36 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
+                                                                                                    searchRank:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                        },
+                                                                                                    tableName:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required:
+                                                                                                                true,
+                                                                                                        },
                                                                                                     fieldType:
                                                                                                         {
                                                                                                             dataType:
@@ -7152,13 +7197,6 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
-                                                                                                    tableName:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required:
-                                                                                                                true,
-                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -7194,11 +7232,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7213,11 +7251,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7566,7 +7604,16 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: { prompt: { dataType: 'string' } },
+            nestedProperties: {
+                modelConfig: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        modelProvider: { dataType: 'string', required: true },
+                        modelId: { dataType: 'string', required: true },
+                    },
+                },
+                prompt: { dataType: 'string' },
+            },
             validators: {},
         },
     },
@@ -7599,6 +7646,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                modelConfig: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        modelProvider: { dataType: 'string', required: true },
+                        modelId: { dataType: 'string', required: true },
+                    },
+                },
                 prompt: { dataType: 'string', required: true },
             },
             validators: {},
@@ -25627,6 +25681,72 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getAgent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getModelOptions: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/models',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getModelOptions,
+        ),
+
+        async function AiAgentController_getModelOptions(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getModelOptions,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiAgentController>(
+                    AiAgentController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getModelOptions',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1210,18 +1210,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "Pick_LightdashUser.userUuid-or-firstName-or-lastName_": {
-                "properties": {
-                    "userUuid": {
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "lastName": {
-                        "type": "string"
-                    }
-                },
-                "required": ["userUuid", "firstName", "lastName"],
+                "properties": {},
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -1255,7 +1244,12 @@
                         "type": "string"
                     },
                     "user": {
-                        "$ref": "#/components/schemas/Pick_LightdashUser.userUuid-or-firstName-or-lastName_"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Pick_LightdashUser.userUuid-or-firstName-or-lastName_"
+                            }
+                        ],
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -6748,6 +6742,53 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "AIModelOption": {
+                "properties": {
+                    "default": {
+                        "type": "boolean"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "default",
+                    "provider",
+                    "description",
+                    "displayName",
+                    "id"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AIModelOption-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AIModelOption"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentModelOptionsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AIModelOption-Array_"
+            },
             "ReadinessScoreEvaluation": {
                 "properties": {
                     "recommendations": {
@@ -7549,20 +7590,36 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
+                                                                        "tableName": {
+                                                                            "type": "string"
                                                                         },
                                                                         "fieldType": {
                                                                             "type": "string"
@@ -7570,17 +7627,14 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "tableName",
                                                                         "fieldType",
                                                                         "label",
-                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -7590,16 +7644,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -7629,8 +7683,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -7674,15 +7728,18 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
+                                                                                    "tableName": {
+                                                                                        "type": "string"
                                                                                     },
                                                                                     "fieldType": {
                                                                                         "type": "string"
@@ -7690,17 +7747,14 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "tableName",
                                                                                     "fieldType",
                                                                                     "label",
-                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -7728,8 +7782,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -7965,6 +8019,18 @@
             },
             "ApiAiAgentThreadCreateRequest": {
                 "properties": {
+                    "modelConfig": {
+                        "properties": {
+                            "modelProvider": {
+                                "type": "string"
+                            },
+                            "modelId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["modelProvider", "modelId"],
+                        "type": "object"
+                    },
                     "prompt": {
                         "type": "string"
                     }
@@ -7990,6 +8056,18 @@
             },
             "ApiAiAgentThreadMessageCreateRequest": {
                 "properties": {
+                    "modelConfig": {
+                        "properties": {
+                            "modelProvider": {
+                                "type": "string"
+                            },
+                            "modelId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["modelProvider", "modelId"],
+                        "type": "object"
+                    },
                     "prompt": {
                         "type": "string"
                     }
@@ -22994,7 +23072,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2225.0",
+        "version": "0.2229.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -260,12 +260,14 @@ export type ApiAiAgentThreadResponse = {
 
 export type ApiAiAgentThreadCreateRequest = {
     prompt?: string;
+    modelConfig?: { modelId: string; modelProvider: string };
 };
 
 export type ApiAiAgentThreadCreateResponse = ApiSuccess<AiAgentThreadSummary>;
 
 export type ApiAiAgentThreadMessageCreateRequest = {
     prompt: string;
+    modelConfig?: { modelId: string; modelProvider: string };
 };
 
 export type ApiAiAgentThreadMessageCreateResponse = ApiSuccess<
@@ -607,3 +609,13 @@ export type AgentSummaryContext = {
 export type AiAgentWithContext = AiAgentSummary & {
     context: AgentSummaryContext;
 };
+
+export type AIModelOption = {
+    id: string;
+    displayName: string;
+    description: string;
+    provider: string;
+    default: boolean;
+};
+
+export type ApiAiAgentModelOptionsResponse = ApiSuccess<AIModelOption[]>;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -38,6 +38,7 @@ export type AiPrompt = {
     createdAt: Date;
     response: string | null;
     humanScore: number | null;
+    modelConfig: { modelId: string; modelProvider: string } | null;
 };
 
 export type SlackPrompt = AiPrompt & {
@@ -68,6 +69,7 @@ export type CreateWebAppPrompt = {
     threadUuid: string;
     createdByUserUuid: string;
     prompt: string;
+    modelConfig?: { modelId: string; modelProvider: string };
 };
 
 export type UpdateSlackResponse = {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useModelOptions.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useModelOptions.ts
@@ -1,0 +1,39 @@
+import type {
+    AIModelOption,
+    ApiAiAgentModelOptionsResponse,
+    ApiError,
+} from '@lightdash/common';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+const MODEL_OPTIONS_KEY = 'modelOptions';
+
+const getModelOptions = async (
+    projectUuid: string,
+    agentUuid: string,
+): Promise<ApiAiAgentModelOptionsResponse['results']> =>
+    lightdashApi<ApiAiAgentModelOptionsResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/models`,
+        method: 'GET',
+        body: undefined,
+    });
+
+type UseModelOptionsProps = {
+    projectUuid: string | undefined;
+    agentUuid: string | undefined;
+    options?: UseQueryOptions<AIModelOption[], ApiError>;
+};
+
+export const useModelOptions = ({
+    projectUuid,
+    agentUuid,
+    options,
+}: UseModelOptionsProps) => {
+    return useQuery<AIModelOption[], ApiError>({
+        queryKey: [MODEL_OPTIONS_KEY, projectUuid, agentUuid],
+        queryFn: () => getModelOptions(projectUuid!, agentUuid!),
+        ...options,
+        enabled: !!projectUuid && !!agentUuid && options?.enabled !== false,
+    });
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -484,7 +484,14 @@ export const useCreateAgentThreadMutation = (
     >({
         mutationFn: (data) =>
             agentUuid
-                ? createAgentThread(projectUuid, agentUuid, data)
+                ? createAgentThread(projectUuid, agentUuid, {
+                      ...data,
+                      //   TODO :: pass model config from the UI
+                      //   modelConfig: {
+                      //       modelId: 'gpt-5.1-2025-11-13',
+                      //       modelProvider: 'openai',
+                      //   },
+                  })
                 : Promise.reject(),
         onSuccess: async (thread) => {
             // Invalidate both user-specific and all-users thread queries

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -10,7 +10,7 @@ import {
     Title,
 } from '@mantine-8/core';
 import { IconInfoCircle } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { type FC, useCallback } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -18,6 +18,7 @@ import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
 import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultAgentButton/DefaultAgentButton';
 import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
+import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
 import {
     useCreateAgentThreadMutation,
     useVerifiedQuestions,
@@ -33,10 +34,18 @@ const AiAgentNewThreadPage: FC = () => {
         projectUuid,
         agentUuid,
     );
+    const { data: modelOptions } = useModelOptions({ projectUuid, agentUuid });
 
-    const onSubmit = (prompt: string) => {
-        void createAgentThread({ prompt });
-    };
+    if (import.meta.env.DEV) {
+        console.log('modelOptions', modelOptions);
+    }
+
+    const onSubmit = useCallback(
+        (prompt: string) => {
+            void createAgentThread({ prompt });
+        },
+        [createAgentThread],
+    );
 
     return (
         <Center h="100%">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR adds support for model selection in AI agents. It introduces a new endpoint to fetch available AI models for an agent and adds a `model_config` field to the AI prompt table to store the selected model information.

Key changes:

- Added a new GET endpoint `/aiAgents/{agentUuid}/models` to retrieve available model options
- Created a database migration to add `model_config` column to the `ai_prompt` table
- Updated the AI agent service to support model configuration when creating prompts
- Added model selection logic in the AI service to use the specified model when available
- Created a new React hook `useModelOptions` to fetch available models from the frontend
