### PR TITLE
fix: conditional formatting support for dark theme

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -40,6 +40,7 @@ interface CommonBodyCellProps {
     isLargeText?: boolean;
     tooltipContent?: string;
     minimal?: boolean;
+    isDarkTheme?: boolean;
 }
 
 const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
@@ -56,6 +57,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
     style,
     tooltipContent,
     minimal = false,
+    isDarkTheme = false,
 }) => {
     const elementRef = useRef<HTMLTableCellElement>(null);
     const { showToastSuccess } = useToaster();
@@ -151,6 +153,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                 $hasData={hasData}
                 $isNaN={!hasData || !isNumericItem}
                 $hasUrls={hasUrls}
+                $isDarkTheme={isDarkTheme}
                 $hasNewlines={
                     typeof displayValue === 'string' &&
                     displayValue.includes('\n')

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,6 +14,7 @@ import {
     Loader,
     Skeleton,
     Tooltip,
+    useMantineColorScheme,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { flexRender, type Row } from '@tanstack/react-table';
@@ -65,6 +66,9 @@ const TableRow: FC<TableRowProps> = ({
     minMaxMap,
     minimal = false,
 }) => {
+    const { colorScheme } = useMantineColorScheme();
+    const isDarkTheme = colorScheme === 'dark';
+
     const rowFields = useMemo(
         () =>
             row
@@ -156,6 +160,7 @@ const TableRow: FC<TableRowProps> = ({
                             SMALL_TEXT_LENGTH
                         }
                         tooltipContent={tooltipContent}
+                        isDarkTheme={isDarkTheme}
                     >
                         {cell.getIsGrouped() ? (
                             <Group spacing="xxs">

--- a/packages/frontend/src/components/common/Table/Table.styles.tsx
+++ b/packages/frontend/src/components/common/Table/Table.styles.tsx
@@ -185,6 +185,7 @@ export const Td = styled.td<{
     $isMinimal: boolean;
     $hasNewlines: boolean;
     $hasUrls: boolean;
+    $isDarkTheme?: boolean;
 }>`
     max-width: 300px;
     white-space: pre;
@@ -224,10 +225,15 @@ export const Td = styled.td<{
         // this is important because click-outside will not work and it will re-open the menu
         $isSelected ? `pointer-events: none;` : ''}
 
-    ${({ $backgroundColor }) =>
+    ${({ $backgroundColor, $isDarkTheme }) =>
         $backgroundColor
             ? `
                 background-color: ${$backgroundColor} !important;
+                ${
+                    $isDarkTheme
+                        ? 'filter: invert(1) hue-rotate(180deg)!important;'
+                        : ''
+                }
             `
             : `
                 background-color: transparent;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18420

### Description:

Added dark theme support for table cell background colors. This PR introduces a new `isDarkTheme` prop to the `BodyCell` component that is used to apply a color inversion filter when dark theme is active. 

> [!NOTE]
> This is an intermediate solution. Ideally we would have two different palettes for light/dark themes


![CleanShot 2025-12-03 at 16.44.11.png](https://app.graphite.com/user-attachments/assets/345c9f70-6f23-4e40-ab52-013ced634fe3.png)

![CleanShot 2025-12-03 at 16.43.40.png](https://app.graphite.com/user-attachments/assets/58aa36d0-a342-4056-b3c6-daba58a5116f.png)


> [!NOTE]
> This hack doesn't work well when configuring a chart, as colors are inverted

![CleanShot 2025-12-03 at 16.47.47.png](https://app.graphite.com/user-attachments/assets/4782422d-734d-4beb-96d6-0105ac7cc351.png)

