### PR TITLE
fix: saved charts header dark theme

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
@@ -15,7 +15,7 @@ type Props = {
 const MAX_WIDTH_TITLE_PX = 160;
 
 const SlashDivider = () => (
-    <Text span c="ldDark.3">
+    <Text span c="ldGray.8">
         /
     </Text>
 );
@@ -54,7 +54,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                                     to={`/projects/${projectUuid}/dashboards/${dashboardUuid}`}
                                 >
                                     <MantineIcon
-                                        color="ldDark.2"
+                                        color="ldGray.4"
                                         icon={IconFolder}
                                     />
                                 </ActionIcon>
@@ -62,7 +62,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                                 <Anchor
                                     fw={500}
                                     fz="md"
-                                    c="ldDark.2"
+                                    c="ldGray.6"
                                     component={Link}
                                     to={`/projects/${projectUuid}/spaces/${spaceUuid}`}
                                     sx={{
@@ -99,7 +99,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                     >
                         <Anchor
                             fw={500}
-                            c="ldDark.2"
+                            c="ldGray.6"
                             fz="md"
                             component={Link}
                             to={`/projects/${projectUuid}/dashboards/${dashboardUuid}`}

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -18,7 +18,6 @@ import {
     Text,
     Title,
     Tooltip,
-    useMantineColorScheme,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
@@ -112,8 +111,6 @@ const SavedChartsHeader: FC = () => {
     const spaceUuid = useSearchParams('fromSpace');
 
     const { data: project } = useProject(projectUuid);
-
-    const { colorScheme } = useMantineColorScheme();
 
     const { mutate: promoteChart } = usePromoteMutation();
     const {
@@ -372,11 +369,7 @@ const SavedChartsHeader: FC = () => {
                                     dashboardName={savedChart.dashboardName}
                                 />
                                 <Title
-                                    c={
-                                        colorScheme === 'dark'
-                                            ? 'ldDark.0'
-                                            : 'ldDark.6'
-                                    }
+                                    c="ldGray.8"
                                     order={5}
                                     fw={600}
                                     truncate


### PR DESCRIPTION
### Description:
Fixed breadcrumbs, dividers, and title colors for saved charts after introducing new dark theme palette

_after_

![CleanShot 2025-12-03 at 17.31.34.png](https://app.graphite.com/user-attachments/assets/2f591f52-81af-48a0-af09-8db428e277f0.png)

_before_

![CleanShot 2025-12-03 at 17.32.01.png](https://app.graphite.com/user-attachments/assets/374b3e5c-d18a-4532-84c0-81c5d1b4cc7f.png)

