### PR TITLE
feat: add event loop blocking test to livez endpoint

### DIFF
--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -24,6 +24,16 @@ import { userRouter } from './userRouter';
 export const apiV1Router: Router = express.Router();
 
 apiV1Router.get('/livez', async (req, res, next) => {
+    // For testing event loop blocking - pass ?blockSeconds=X to block for X seconds
+    const blockSeconds = parseInt(req.query.blockSeconds as string, 10);
+    if (!Number.isNaN(blockSeconds) && blockSeconds > 0 && blockSeconds <= 60) {
+        const startTime = Date.now();
+        const blockUntil = startTime + blockSeconds * 1000;
+        // Synchronous busy-wait to block the event loop
+        while (Date.now() < blockUntil) {
+            // Busy loop - this blocks the event loop
+        }
+    }
     res.json({
         status: 'ok',
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

Also in alpha https://github.com/lightdash/lightdash/pull/18549

<img width="961" height="310" alt="image" src="https://github.com/user-attachments/assets/a9e47b25-6bb4-4552-99cc-ab1e00f9f273" />

I tried to enforce event loop on analytics, adding extra user attributes/groups, loading multiple dashboards, running refresh... But I can't replicate, I can't also find any code that is particuarlly expensive to cause an event loop. 

If we want to at least fix the platform, we need a consistent way to reproduce this issue. This new option argument in livez does exactly that. 

### Description:
Added a testing feature to the `/livez` endpoint that allows simulating event loop blocking. By passing a `blockSeconds` query parameter, the endpoint will block the event loop for the specified number of seconds (up to 60) using a synchronous busy-wait loop. This is useful for testing how the application behaves under event loop blocking conditions.