### PR TITLE
chore: simplify Docker build workflow to single architecture

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -13,40 +13,9 @@ env:
   REGISTRY_IMAGE: lightdash/lightdash
 
 jobs:
-  # This job builds Docker images for various architectures in parallel
-  # See https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
   docker-build:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
     steps:
-      # Free up disk space on GitHub runner
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: true
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
-
-      # Write the PLATFORM_PAIR varible to env and replace `/` with `-`
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV     
-      
       - name: Set up Docker tags
         id: meta
         uses: docker/metadata-action@v5
@@ -55,10 +24,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
 
-      # We need this to perform cross-platform Docker builds
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
       # Improved Docker builds
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -70,67 +35,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push by digest
+      - name: Build and push
         id: build
         uses: docker/build-push-action@v5
         with:
           file: dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          platforms: linux/amd64
           cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,mode=min,ref={0}', env.REGISTRY_IMAGE) || '' }}
+          cache-to: type=registry,mode=min,ref=${{ env.REGISTRY_IMAGE }}
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # This step "merges" multiple images for various architectures into a single image
-  docker-merge:
-    runs-on: ubuntu-latest
-    # Should be kept in sync with the jobs.docker-build.steps.build.with.push condition
-    if: ${{ github.event_name != 'pull_request' }}
-    needs:
-      - docker-build
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: digests-*
-          path: /tmp/digests
-          merge-multiple: true
-
-      - name: Set up Docker tags
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Simplifies the Docker build workflow by removing multi-architecture build process in favor of a single linux/amd64 build. This change eliminates the separate build and merge jobs, removes the digest-based approach, and streamlines the overall workflow by directly building and pushing the Docker image in a single step.