### PR TITLE
fix: allow single project name format in Git repository validator

### DIFF
--- a/packages/frontend/src/utils/fieldValidators.ts
+++ b/packages/frontend/src/utils/fieldValidators.ts
@@ -30,9 +30,9 @@ export const hasNoWhiteSpaces: FieldValidator<string> =
             : `${fieldName} should not have white spaces`;
 
 export const isGitRepository: FieldValidator<string> = (fieldName) => (value) =>
-    !value || value.match(/.+\/.+/)
+    !value || value.match(/.+\/.+/) || value.match(/^[a-zA-Z0-9.%_-]+$/)
         ? undefined
-        : `${fieldName} should match the pattern "org/project"`;
+        : `${fieldName} should match the pattern "org/project" or "project"`;
 
 export const startWithSlash: FieldValidator<string> = (fieldName) => (value) =>
     !value || value.match(/^\/.*/)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/18554

lt;dr azure devops don't require org on the project name, otherwise it will build an invalid URL 

Before:

<img width="527" height="313" alt="Screenshot from 2025-12-04 10-34-12" src="https://github.com/user-attachments/assets/dcd725bc-3242-4be8-abd1-1dbd511d7353" />

After:

<img width="476" height="301" alt="image" src="https://github.com/user-attachments/assets/7986704e-87a0-431c-b643-de604f526de0" />


### Description:
Updated the Git repository validator to accept both "org/project" and "project" formats. This allows users to specify repositories without requiring an organization prefix.

The error message has also been updated to reflect the new accepted patterns.