### PR TITLE
fix: update anthropic and bedrock providers to resolve empty tool call input issue

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -39,8 +39,8 @@
         "ts-node": "^10.9.2"
     },
     "dependencies": {
-        "@ai-sdk/amazon-bedrock": "^3.0.53",
-        "@ai-sdk/anthropic": "^2.0.43",
+        "@ai-sdk/amazon-bedrock": "^3.0.66",
+        "@ai-sdk/anthropic": "^2.0.53",
         "@ai-sdk/azure": "^2.0.66",
         "@ai-sdk/openai": "^2.0.64",
         "@aws-sdk/client-s3": "^3.529.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,11 +118,11 @@ importers:
   packages/backend:
     dependencies:
       '@ai-sdk/amazon-bedrock':
-        specifier: ^3.0.53
-        version: 3.0.53(zod@3.25.55)
+        specifier: ^3.0.66
+        version: 3.0.66(zod@3.25.55)
       '@ai-sdk/anthropic':
-        specifier: ^2.0.43
-        version: 2.0.43(zod@3.25.55)
+        specifier: ^2.0.53
+        version: 2.0.53(zod@3.25.55)
       '@ai-sdk/azure':
         specifier: ^2.0.66
         version: 2.0.66(zod@3.25.55)
@@ -1486,14 +1486,14 @@ packages:
   '@adobe/css-tools@4.4.2':
     resolution: {integrity: sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==}
 
-  '@ai-sdk/amazon-bedrock@3.0.53':
-    resolution: {integrity: sha512-HyVLZbdGunqJbdCK2v/jofo9Z4lDAbngO2X/T57K+4wPZtCeUnv0f9F941RgU6XVJwdxjxITX1XEhhBP1qqGnw==}
+  '@ai-sdk/amazon-bedrock@3.0.66':
+    resolution: {integrity: sha512-aGy9BtmfSIC83EH1TpMMMQqyMQXNh5KcOyT5MsrGnoDSwOJb61pnQO0ugB4VqoOITh6vYXXa8mK4YchmBMkq9Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/anthropic@2.0.43':
-    resolution: {integrity: sha512-YQWYdoU6X1E16BS/KYCkage18q8sqj3FguCZ/RQs/wxS1551DVeD5DrWiYXxm5T293HzeAVJssQFEx67kc4LmA==}
+  '@ai-sdk/anthropic@2.0.53':
+    resolution: {integrity: sha512-ih7NV+OFSNWZCF+tYYD7ovvvM+gv7TRKQblpVohg2ipIwC9Y0TirzocJVREzZa/v9luxUwFbsPji++DUDWWxsg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1536,6 +1536,12 @@ packages:
 
   '@ai-sdk/provider-utils@3.0.16':
     resolution: {integrity: sha512-lsWQY9aDXHitw7C1QRYIbVGmgwyT98TF3MfM8alNIXKpdJdi+W782Rzd9f1RyOfgRmZ08gJ2EYNDhWNK7RqpEA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.18':
+    resolution: {integrity: sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -8678,6 +8684,7 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
+    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -17581,20 +17588,20 @@ snapshots:
 
   '@adobe/css-tools@4.4.2': {}
 
-  '@ai-sdk/amazon-bedrock@3.0.53(zod@3.25.55)':
+  '@ai-sdk/amazon-bedrock@3.0.66(zod@3.25.55)':
     dependencies:
-      '@ai-sdk/anthropic': 2.0.43(zod@3.25.55)
+      '@ai-sdk/anthropic': 2.0.53(zod@3.25.55)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.16(zod@3.25.55)
+      '@ai-sdk/provider-utils': 3.0.18(zod@3.25.55)
       '@smithy/eventstream-codec': 4.0.2
       '@smithy/util-utf8': 4.2.0
       aws4fetch: 1.0.20
       zod: 3.25.55
 
-  '@ai-sdk/anthropic@2.0.43(zod@3.25.55)':
+  '@ai-sdk/anthropic@2.0.53(zod@3.25.55)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.16(zod@3.25.55)
+      '@ai-sdk/provider-utils': 3.0.18(zod@3.25.55)
       zod: 3.25.55
 
   '@ai-sdk/azure@2.0.66(zod@3.25.55)':
@@ -17637,6 +17644,13 @@ snapshots:
       zod: 3.25.55
 
   '@ai-sdk/provider-utils@3.0.16(zod@3.25.55)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.55
+
+  '@ai-sdk/provider-utils@3.0.18(zod@3.25.55)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
@@ -17714,7 +17728,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.910.0
+      '@aws-sdk/types': 3.922.0
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
@@ -18042,7 +18056,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.1
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -18085,7 +18099,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.1
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -18128,7 +18142,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.1
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -18296,7 +18310,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.2
       '@smithy/signature-v4': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-middleware': 4.2.2
       fast-xml-parser: 4.4.1
       tslib: 2.8.1
@@ -18311,7 +18325,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.2
       '@smithy/signature-v4': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-middleware': 4.2.2
@@ -18329,7 +18343,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.2
       '@smithy/signature-v4': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-base64': 4.3.0
       '@smithy/util-middleware': 4.2.2
       '@smithy/util-utf8': 4.2.0
@@ -18373,7 +18387,7 @@ snapshots:
       '@aws-sdk/core': 3.799.0
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.858.0':
@@ -18381,7 +18395,7 @@ snapshots:
       '@aws-sdk/core': 3.858.0
       '@aws-sdk/types': 3.840.0
       '@smithy/property-provider': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.910.0':
@@ -18389,7 +18403,7 @@ snapshots:
       '@aws-sdk/core': 3.910.0
       '@aws-sdk/types': 3.910.0
       '@smithy/property-provider': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.928.0':
@@ -18421,7 +18435,7 @@ snapshots:
       '@smithy/property-provider': 4.2.2
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-stream': 4.5.2
       tslib: 2.8.1
 
@@ -18434,7 +18448,7 @@ snapshots:
       '@smithy/property-provider': 4.2.2
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-stream': 4.5.2
       tslib: 2.8.1
 
@@ -18447,7 +18461,7 @@ snapshots:
       '@smithy/property-provider': 4.2.2
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-stream': 4.5.2
       tslib: 2.8.1
 
@@ -18495,7 +18509,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.2
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18513,7 +18527,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.2
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18531,7 +18545,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.2
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18585,7 +18599,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.2
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18619,7 +18633,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.2
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18655,7 +18669,7 @@ snapshots:
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.858.0':
@@ -18664,7 +18678,7 @@ snapshots:
       '@aws-sdk/types': 3.840.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.910.0':
@@ -18673,7 +18687,7 @@ snapshots:
       '@aws-sdk/types': 3.910.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.928.0':
@@ -18706,7 +18720,7 @@ snapshots:
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18719,7 +18733,7 @@ snapshots:
       '@aws-sdk/types': 3.840.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18732,7 +18746,7 @@ snapshots:
       '@aws-sdk/types': 3.910.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18764,7 +18778,7 @@ snapshots:
       '@aws-sdk/nested-clients': 3.799.0
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18775,7 +18789,7 @@ snapshots:
       '@aws-sdk/nested-clients': 3.858.0
       '@aws-sdk/types': 3.840.0
       '@smithy/property-provider': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18787,7 +18801,7 @@ snapshots:
       '@aws-sdk/types': 3.910.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -18865,7 +18879,7 @@ snapshots:
       '@aws-sdk/util-arn-parser': 3.723.0
       '@smithy/node-config-provider': 4.3.2
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-config-provider': 4.2.0
       tslib: 2.8.1
 
@@ -18880,7 +18894,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.775.0
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.620.0':
@@ -18904,7 +18918,7 @@ snapshots:
       '@smithy/is-array-buffer': 4.2.0
       '@smithy/node-config-provider': 4.3.2
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-middleware': 4.2.2
       '@smithy/util-stream': 4.5.2
       '@smithy/util-utf8': 4.2.0
@@ -18921,21 +18935,21 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.775.0
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.840.0':
     dependencies:
       '@aws-sdk/types': 3.840.0
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.910.0':
     dependencies:
       '@aws-sdk/types': 3.910.0
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.922.0':
@@ -18954,7 +18968,7 @@ snapshots:
   '@aws-sdk/middleware-location-constraint@3.775.0':
     dependencies:
       '@aws-sdk/types': 3.775.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.609.0':
@@ -18966,19 +18980,19 @@ snapshots:
   '@aws-sdk/middleware-logger@3.775.0':
     dependencies:
       '@aws-sdk/types': 3.775.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.840.0':
     dependencies:
       '@aws-sdk/types': 3.840.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.910.0':
     dependencies:
       '@aws-sdk/types': 3.910.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.922.0':
@@ -18998,14 +19012,14 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.775.0
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.840.0':
     dependencies:
       '@aws-sdk/types': 3.840.0
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.910.0':
@@ -19013,7 +19027,7 @@ snapshots:
       '@aws-sdk/types': 3.910.0
       '@aws/lambda-invoke-store': 0.0.1
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.922.0':
@@ -19048,7 +19062,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.2
       '@smithy/signature-v4': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-middleware': 4.2.2
       '@smithy/util-stream': 4.5.2
@@ -19074,7 +19088,7 @@ snapshots:
   '@aws-sdk/middleware-ssec@3.775.0':
     dependencies:
       '@aws-sdk/types': 3.775.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.620.0':
@@ -19092,7 +19106,7 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.787.0
       '@smithy/core': 3.16.1
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.858.0':
@@ -19102,7 +19116,7 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.848.0
       '@smithy/core': 3.16.1
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.910.0':
@@ -19112,7 +19126,7 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.910.0
       '@smithy/core': 3.16.1
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.928.0':
@@ -19153,7 +19167,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.1
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -19196,7 +19210,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.1
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -19239,7 +19253,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.1
       '@smithy/protocol-http': 5.3.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -19310,7 +19324,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.775.0
       '@smithy/node-config-provider': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-middleware': 4.2.2
       tslib: 2.8.1
@@ -19319,7 +19333,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.840.0
       '@smithy/node-config-provider': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-middleware': 4.2.2
       tslib: 2.8.1
@@ -19328,7 +19342,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.910.0
       '@smithy/node-config-provider': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-middleware': 4.2.2
       tslib: 2.8.1
@@ -19367,7 +19381,7 @@ snapshots:
       '@aws-sdk/types': 3.775.0
       '@smithy/protocol-http': 5.3.2
       '@smithy/signature-v4': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.622.0(@aws-sdk/client-sts@3.622.0))':
@@ -19385,7 +19399,7 @@ snapshots:
       '@aws-sdk/types': 3.775.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -19397,7 +19411,7 @@ snapshots:
       '@aws-sdk/types': 3.840.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -19409,7 +19423,7 @@ snapshots:
       '@aws-sdk/types': 3.910.0
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -19433,17 +19447,17 @@ snapshots:
 
   '@aws-sdk/types@3.775.0':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/types@3.840.0':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/types@3.910.0':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/types@3.922.0':
@@ -19469,14 +19483,14 @@ snapshots:
   '@aws-sdk/util-endpoints@3.787.0':
     dependencies:
       '@aws-sdk/types': 3.775.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-endpoints': 3.2.2
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.848.0':
     dependencies:
       '@aws-sdk/types': 3.840.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-endpoints': 3.2.2
       tslib: 2.8.1
@@ -19484,7 +19498,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.910.0':
     dependencies:
       '@aws-sdk/types': 3.910.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-endpoints': 3.2.2
       tslib: 2.8.1
@@ -19518,21 +19532,21 @@ snapshots:
   '@aws-sdk/util-user-agent-browser@3.775.0':
     dependencies:
       '@aws-sdk/types': 3.775.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       bowser: 2.11.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.840.0':
     dependencies:
       '@aws-sdk/types': 3.840.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       bowser: 2.11.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.910.0':
     dependencies:
       '@aws-sdk/types': 3.910.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       bowser: 2.11.0
       tslib: 2.8.1
 
@@ -19555,7 +19569,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.799.0
       '@aws-sdk/types': 3.775.0
       '@smithy/node-config-provider': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.858.0':
@@ -19563,7 +19577,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.858.0
       '@aws-sdk/types': 3.840.0
       '@smithy/node-config-provider': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.910.0':
@@ -19571,7 +19585,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.910.0
       '@aws-sdk/types': 3.910.0
       '@smithy/node-config-provider': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.928.0':
@@ -19589,17 +19603,17 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.775.0':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.821.0':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.910.0':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       fast-xml-parser: 5.2.5
       tslib: 2.8.1
 
@@ -19767,7 +19781,7 @@ snapshots:
       '@babel/traverse': 7.26.4
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19787,7 +19801,7 @@ snapshots:
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.0
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19887,13 +19901,6 @@ snapshots:
       semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
-
-  '@babel/helper-module-imports@7.24.7':
-    dependencies:
-      '@babel/traverse': 7.25.6
-      '@babel/types': 7.28.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-module-imports@7.24.7(supports-color@5.5.0)':
     dependencies:
@@ -20145,18 +20152,6 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
 
-  '@babel/traverse@7.25.6':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.28.0
-      '@babel/parser': 7.28.0
-      '@babel/template': 7.25.0
-      '@babel/types': 7.28.2
-      debug: 4.4.0(supports-color@8.1.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/traverse@7.25.6(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -20188,7 +20183,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.0
       '@babel/types': 7.28.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -20414,7 +20409,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.10.6':
     dependencies:
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/runtime': 7.27.0
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
@@ -20893,7 +20888,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.2.0
@@ -21270,7 +21265,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -24709,12 +24704,12 @@ snapshots:
 
   '@smithy/abort-controller@4.0.4':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/abort-controller@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/abort-controller@4.2.5':
@@ -24751,7 +24746,7 @@ snapshots:
   '@smithy/config-resolver@4.3.2':
     dependencies:
       '@smithy/node-config-provider': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-middleware': 4.2.2
       tslib: 2.8.1
@@ -24780,7 +24775,7 @@ snapshots:
     dependencies:
       '@smithy/middleware-serde': 4.2.2
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-middleware': 4.2.2
@@ -24814,7 +24809,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.2
       '@smithy/property-provider': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       tslib: 2.8.1
 
@@ -24836,7 +24831,7 @@ snapshots:
   '@smithy/eventstream-codec@4.0.2':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-hex-encoding': 4.2.0
       tslib: 2.8.1
 
@@ -24849,7 +24844,7 @@ snapshots:
   '@smithy/eventstream-serde-browser@4.0.2':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.0.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-config-resolver@3.0.3':
@@ -24859,7 +24854,7 @@ snapshots:
 
   '@smithy/eventstream-serde-config-resolver@4.1.0':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-node@3.0.4':
@@ -24871,7 +24866,7 @@ snapshots:
   '@smithy/eventstream-serde-node@4.0.2':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.0.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-universal@3.0.4':
@@ -24883,7 +24878,7 @@ snapshots:
   '@smithy/eventstream-serde-universal@4.0.2':
     dependencies:
       '@smithy/eventstream-codec': 4.0.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@3.2.4':
@@ -24898,7 +24893,7 @@ snapshots:
     dependencies:
       '@smithy/protocol-http': 5.3.2
       '@smithy/querystring-builder': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-base64': 4.3.0
       tslib: 2.8.1
 
@@ -24921,7 +24916,7 @@ snapshots:
     dependencies:
       '@smithy/chunked-blob-reader': 5.0.0
       '@smithy/chunked-blob-reader-native': 4.0.0
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/hash-node@3.0.3':
@@ -24933,14 +24928,14 @@ snapshots:
 
   '@smithy/hash-node@4.0.4':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-buffer-from': 4.2.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
   '@smithy/hash-node@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-buffer-from': 4.2.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
@@ -24960,7 +24955,7 @@ snapshots:
 
   '@smithy/hash-stream-node@4.0.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
@@ -24971,12 +24966,12 @@ snapshots:
 
   '@smithy/invalid-dependency@4.0.4':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.5':
@@ -25004,7 +24999,7 @@ snapshots:
 
   '@smithy/md5-js@4.0.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
@@ -25017,13 +25012,13 @@ snapshots:
   '@smithy/middleware-content-length@4.0.4':
     dependencies:
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.2':
     dependencies:
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.5':
@@ -25048,7 +25043,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.2
       '@smithy/node-config-provider': 4.3.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-middleware': 4.2.2
       tslib: 2.8.1
@@ -25059,7 +25054,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.2
       '@smithy/node-config-provider': 4.3.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.2
       '@smithy/util-middleware': 4.2.2
       tslib: 2.8.1
@@ -25093,7 +25088,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.2
       '@smithy/service-error-classification': 4.2.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-middleware': 4.2.2
       '@smithy/util-retry': 4.2.2
       tslib: 2.8.1
@@ -25105,7 +25100,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.2
       '@smithy/service-error-classification': 4.2.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-middleware': 4.2.2
       '@smithy/util-retry': 4.2.2
       '@smithy/uuid': 1.1.0
@@ -25131,7 +25126,7 @@ snapshots:
   '@smithy/middleware-serde@4.2.2':
     dependencies:
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.2.5':
@@ -25147,12 +25142,12 @@ snapshots:
 
   '@smithy/middleware-stack@4.0.4':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.5':
@@ -25171,7 +25166,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.2
       '@smithy/shared-ini-file-loader': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.5':
@@ -25202,7 +25197,7 @@ snapshots:
       '@smithy/abort-controller': 4.2.2
       '@smithy/protocol-http': 5.3.2
       '@smithy/querystring-builder': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.5':
@@ -25220,7 +25215,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/property-provider@4.2.5':
@@ -25251,13 +25246,13 @@ snapshots:
 
   '@smithy/querystring-builder@4.0.4':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-uri-escape': 4.2.0
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-uri-escape': 4.2.0
       tslib: 2.8.1
 
@@ -25274,7 +25269,7 @@ snapshots:
 
   '@smithy/querystring-parser@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.5':
@@ -25288,7 +25283,7 @@ snapshots:
 
   '@smithy/service-error-classification@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
 
   '@smithy/service-error-classification@4.2.5':
     dependencies:
@@ -25301,7 +25296,7 @@ snapshots:
 
   '@smithy/shared-ini-file-loader@4.3.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.0':
@@ -25357,7 +25352,7 @@ snapshots:
       '@smithy/middleware-endpoint': 4.3.3
       '@smithy/middleware-stack': 4.2.2
       '@smithy/protocol-http': 5.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-stream': 4.5.2
       tslib: 2.8.1
 
@@ -25396,7 +25391,7 @@ snapshots:
   '@smithy/url-parser@4.2.2':
     dependencies:
       '@smithy/querystring-parser': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/url-parser@4.2.5':
@@ -25472,7 +25467,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       bowser: 2.11.0
       tslib: 2.8.1
 
@@ -25480,7 +25475,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@4.3.6':
@@ -25507,7 +25502,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.2
       '@smithy/property-provider': 4.2.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.3':
@@ -25517,7 +25512,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.2
       '@smithy/property-provider': 4.2.2
       '@smithy/smithy-client': 4.8.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.9':
@@ -25539,7 +25534,7 @@ snapshots:
   '@smithy/util-endpoints@3.2.2':
     dependencies:
       '@smithy/node-config-provider': 4.3.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/util-endpoints@3.2.5':
@@ -25568,7 +25563,7 @@ snapshots:
 
   '@smithy/util-middleware@4.2.2':
     dependencies:
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/util-middleware@4.2.5':
@@ -25585,13 +25580,13 @@ snapshots:
   '@smithy/util-retry@4.0.6':
     dependencies:
       '@smithy/service-error-classification': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/util-retry@4.2.2':
     dependencies:
       '@smithy/service-error-classification': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/util-retry@4.2.5':
@@ -25615,7 +25610,7 @@ snapshots:
     dependencies:
       '@smithy/fetch-http-handler': 5.3.3
       '@smithy/node-http-handler': 4.4.1
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       '@smithy/util-base64': 4.3.0
       '@smithy/util-buffer-from': 4.2.0
       '@smithy/util-hex-encoding': 4.2.0
@@ -25665,7 +25660,7 @@ snapshots:
   '@smithy/util-waiter@4.0.3':
     dependencies:
       '@smithy/abort-controller': 4.2.2
-      '@smithy/types': 4.7.1
+      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.0':
@@ -27106,7 +27101,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.5.4)
     optionalDependencies:
@@ -27138,7 +27133,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -27152,7 +27147,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -27626,7 +27621,7 @@ snapshots:
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -29028,7 +29023,7 @@ snapshots:
       '@actions/core': 1.11.1
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.47.9(@babel/core@7.28.4)
       globby: 11.1.0
@@ -30212,7 +30207,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.5
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -30730,7 +30725,7 @@ snapshots:
       '@actions/core': 1.11.1
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       find-test-names: 1.29.5(@babel/core@7.28.4)
       globby: 11.1.0
       minimatch: 3.1.2
@@ -31622,7 +31617,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -31642,7 +31637,7 @@ snapshots:
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -36665,7 +36660,7 @@ snapshots:
   spec-change@1.11.11:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       deep-equal: 2.2.3
       dependency-tree: 11.0.1
       lazy-ass: 2.0.3


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updates AI SDK dependencies for Amazon Bedrock and Anthropic:

- `@ai-sdk/amazon-bedrock` from 3.0.53 to 3.0.66
- `@ai-sdk/anthropic` from 2.0.43 to 2.0.53

https://github.com/vercel/ai/issues/10295