### PR TITLE
fix: unify dashboard title colors

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -189,6 +189,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                             fw={600}
                                             fz="md"
                                             hidden={hideTitle}
+                                            c="foreground.0"
                                         >
                                             {title}
                                         </Text>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added text color property to the tile title to ensure consistent foreground color rendering.

The noticeable difference was on markdown tiles, as these use a plain Mantine `<Text>` component for their titles, which was inheriting color from the `wmde-markdown` CSS context (`#c9d1d9`), while other tile types use a styled `<TileTitleLink>` component with explicit color `var(--mantine-color-foreground-0)` (`#fefefe` in dark mode)

_new_

![CleanShot 2025-12-04 at 12.30.42.png](https://app.graphite.com/user-attachments/assets/a962cb2e-6149-40a1-af5c-23db81fe56a9.png)

---

_before_

![CleanShot 2025-12-04 at 12.30.59.png](https://app.graphite.com/user-attachments/assets/d1c2e888-945f-4b78-81de-0401b7dcc5df.png)