### PR TITLE
fix: handle embeds with deleted users

### DIFF
--- a/packages/backend/src/ee/models/EmbedModel.ts
+++ b/packages/backend/src/ee/models/EmbedModel.ts
@@ -47,13 +47,6 @@ export class EmbedModel {
             );
         }
 
-        // embed table does not cascade when the user gets deleted
-        // so we need to check if the user still exists and throw an error if not
-        // in the frontend this prompts the user to create a new embed
-        if (!embed.user_uuid) {
-            throw new NotFoundError(`User not found for embed`);
-        }
-
         const dashboards = await this.database('dashboards')
             .select()
             .whereIn('dashboard_uuid', embed.dashboard_uuids);
@@ -81,11 +74,13 @@ export class EmbedModel {
             chartUuids: validChartUuids,
             allowAllCharts: embed.allow_all_charts,
             createdAt: embed.created_at,
-            user: {
-                userUuid: embed.user_uuid,
-                firstName: embed.first_name,
-                lastName: embed.last_name,
-            },
+            user: embed.user_uuid
+                ? {
+                      userUuid: embed.user_uuid,
+                      firstName: embed.first_name,
+                      lastName: embed.last_name,
+                  }
+                : null,
         };
     }
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -487,7 +487,7 @@ export class EmbedService extends BaseService {
         );
 
         await this.isFeatureEnabled({
-            userUuid: user.userUuid,
+            userUuid: user?.userUuid ?? account.user.id,
             organizationUuid: dashboard.organizationUuid,
         });
 
@@ -962,7 +962,7 @@ export class EmbedService extends BaseService {
 
         const { organizationUuid } = chart;
         await this.isFeatureEnabled({
-            userUuid: user.userUuid,
+            userUuid: user?.userUuid ?? account.user.id,
             organizationUuid,
         });
 
@@ -1064,7 +1064,7 @@ export class EmbedService extends BaseService {
 
         const { organizationUuid } = chart;
         await this.isFeatureEnabled({
-            userUuid: user.userUuid,
+            userUuid: user?.userUuid ?? account.user.id,
             organizationUuid,
         });
 

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -67,7 +67,7 @@ export type OssEmbed = {
     chartUuids: string[];
     allowAllCharts: boolean;
     createdAt: string;
-    user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'>;
+    user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'> | null;
 };
 
 export type Authentication =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18503

### Description:
This PR fixes an issue with embedded dashboards and charts when the user who created the embed has been deleted. Previously, the system would throw a "User not found" error, but now it properly handles embeds with missing users by making the user field nullable and using the account's user ID as a fallback when checking feature enablement.

The changes:
1. Remove the check that throws an error when a user is not found for an embed
2. Make the user field in the OssEmbed type nullable
3. Add fallback to account.user.id when checking feature enablement if the embed's user is null (this is used solely as a synthetic identifier for PostHog's `distinct_id`)

This allows embeds to continue working even after the original creator's account has been deleted.