### PR TITLE
ci: add OIDC permissions for Depot authentication

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,6 +15,10 @@ env:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    # Set permissions for depot OIDC authentication
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Set up Docker tags
         id: meta


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added OIDC authentication permissions to the Docker build workflow to enable depot authentication. This includes write permissions for id-token and read permissions for contents.