### PR TITLE
style: apply icon color to sql runner

### DIFF
--- a/packages/frontend/src/components/Explorer/SqlCard/OpenInSqlRunnerButton.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/OpenInSqlRunnerButton.tsx
@@ -22,7 +22,7 @@ const OpenInSqlRunnerButton: FC<OpenInSqlRunnerButtonProps> = memo(
                     pathname: `/projects/${projectUuid}/sql-runner`,
                 }}
                 state={{ sql: data?.query }} // pass SQL as location state
-                leftIcon={<MantineIcon icon={IconTerminal2} color="gray" />}
+                leftIcon={<MantineIcon icon={IconTerminal2} color="ldGray.7" />}
                 disabled={isInitialLoading || !!error}
             >
                 Open in SQL Runner


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Updated the color of the terminal icon in the "Open in SQL Runner" button from "gray" to "ldGray.7" to better match our design system color palette.

The change ensures consistent styling across the application and improves visual harmony with other UI elements.

![Screenshot 2025-12-04 at 13.45.47.png](https://app.graphite.com/user-attachments/assets/56943a15-da86-4e58-b62a-8cfc200d210d.png)

![Screenshot 2025-12-04 at 13.45.44.png](https://app.graphite.com/user-attachments/assets/eff833a3-e660-441c-bac4-d0565a802c45.png)

