### PR TITLE
ci: add Depot project token to build workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -44,6 +44,7 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           project: bgbbt3d0kc # depot project id
+          token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           file: dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added the `token` parameter to the Depot build-push-action in the GitHub workflow, using the `DEPOT_PROJECT_TOKEN` secret for authentication. This ensures the Docker build process has proper authorization to interact with the Depot project.