### PR TITLE
feat: conditional formatting gradients for dark mode

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -18,7 +18,13 @@ import {
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
-import { Button, Group, Text, type BoxProps } from '@mantine/core';
+import {
+    Button,
+    Group,
+    Text,
+    useMantineColorScheme,
+    type BoxProps,
+} from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import {
     flexRender,
@@ -40,7 +46,10 @@ import {
     formatCellContent,
     getFormattedValueCell,
 } from '../../../hooks/useColumns';
-import { getColorFromRange } from '../../../utils/colorUtils';
+import {
+    getColorFromRange,
+    transformColorsForDarkMode,
+} from '../../../utils/colorUtils';
 import { getConditionalRuleLabelFromItem } from '../Filters/FilterInputs/utils';
 import Table from '../LightTable';
 import { CELL_HEIGHT } from '../LightTable/constants';
@@ -111,6 +120,7 @@ const PivotTable: FC<PivotTableProps> = ({
     isMinimal = false,
     ...tableProps
 }) => {
+    const { colorScheme } = useMantineColorScheme();
     const containerRef = useRef<HTMLDivElement>(null);
     const [grouping, setGrouping] = React.useState<GroupingState>([]);
 
@@ -600,7 +610,23 @@ const PivotTable: FC<PivotTableProps> = ({
                                         value: value?.raw,
                                         config: conditionalFormattingConfig,
                                         minMaxMap,
-                                        getColorFromRange,
+                                        getColorFromRange: (
+                                            val,
+                                            colorRange,
+                                            minMaxRange,
+                                        ) => {
+                                            const effectiveColorRange =
+                                                colorScheme === 'dark'
+                                                    ? transformColorsForDarkMode(
+                                                          colorRange,
+                                                      )
+                                                    : colorRange;
+                                            return getColorFromRange(
+                                                val,
+                                                effectiveColorRange,
+                                                minMaxRange,
+                                            );
+                                        },
                                     });
 
                                 const conditionalFormatting = (() => {

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,12 +14,17 @@ import {
     Loader,
     Skeleton,
     Tooltip,
+    useMantineColorScheme,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { flexRender, type Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { useEffect, useMemo, type FC } from 'react';
-import { getColorFromRange, readableColor } from '../../../../utils/colorUtils';
+import {
+    getColorFromRange,
+    readableColor,
+    transformColorsForDarkMode,
+} from '../../../../utils/colorUtils';
 import { getConditionalRuleLabelFromItem } from '../../Filters/FilterInputs/utils';
 import MantineIcon from '../../MantineIcon';
 import { ROW_HEIGHT_PX, SMALL_TEXT_LENGTH } from '../constants';
@@ -65,6 +70,7 @@ const TableRow: FC<TableRowProps> = ({
     minMaxMap,
     minimal = false,
 }) => {
+    const { colorScheme } = useMantineColorScheme();
     const rowFields = useMemo(
         () =>
             row
@@ -108,7 +114,17 @@ const TableRow: FC<TableRowProps> = ({
                         value: cellValue?.value?.raw,
                         minMaxMap,
                         config: conditionalFormattingConfig,
-                        getColorFromRange,
+                        getColorFromRange: (val, colorRange, minMaxRange) => {
+                            const effectiveColorRange =
+                                colorScheme === 'dark'
+                                    ? transformColorsForDarkMode(colorRange)
+                                    : colorRange;
+                            return getColorFromRange(
+                                val,
+                                effectiveColorRange,
+                                minMaxRange,
+                            );
+                        },
                     });
 
                 // Frozen/locked rows should have a white background, unless there is a conditional formatting color

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -112,6 +112,12 @@ const darkModeColors = {
     ] as ColorTuple,
 };
 
+// Colors used for conditional formatting in dark mode
+export const DARK_MODE_COLORS = {
+    SUBTLE_GRAY: darkModeColors.ldDark[4],
+    CONTRAST_GRAY: darkModeColors.ldDark[6],
+} as const;
+
 export const getMantineThemeOverride = (
     colorScheme: ColorScheme,
     overrides?: {

--- a/packages/frontend/src/utils/colorUtils.ts
+++ b/packages/frontend/src/utils/colorUtils.ts
@@ -4,6 +4,7 @@ import {
     type ConditionalFormattingMinMax,
 } from '@lightdash/common';
 import Color from 'colorjs.io';
+import { DARK_MODE_COLORS } from '../mantineTheme';
 
 export const readableColor = (backgroundColor: string) => {
     if (!isHexCodeColor(backgroundColor)) {
@@ -12,6 +13,58 @@ export const readableColor = (backgroundColor: string) => {
     const onWhite = Math.abs(Color.contrastAPCA('white', backgroundColor));
     const onBlack = Math.abs(Color.contrastAPCA('black', backgroundColor));
     return onWhite > onBlack ? 'white' : 'black';
+};
+
+/**
+ * Replaces 'problematic' colors in dark mode for better visibility
+ */
+export const transformColorsForDarkMode = (
+    colorRange: ConditionalFormattingColorRange,
+): ConditionalFormattingColorRange => {
+    let startColor = colorRange.start;
+    let endColor = colorRange.end;
+
+    const startColorLuminance = new Color(startColor).get('lch.l');
+    const endColorLuminance = new Color(endColor).get('lch.l');
+
+    // color luminance > 85 indicates light colors
+    const isStartLight = startColorLuminance > 85;
+    const isEndLight = endColorLuminance > 85;
+    // color luminance < 15 indicates dark colors
+    const isStartDark = startColorLuminance < 15;
+    const isEndDark = endColorLuminance < 15;
+
+    if (isStartLight && isEndDark) {
+        // Light-to-dark gradient (e.g., white to black)
+        // White (background-like) → closer to background, Black (contrasting) → more visible
+        startColor = DARK_MODE_COLORS.SUBTLE_GRAY;
+        endColor = DARK_MODE_COLORS.CONTRAST_GRAY;
+    } else if (isStartDark && isEndLight) {
+        // Dark-to-light gradient (e.g., black to white)
+        // Black (contrasting) → more visible, White (background-like) → closer to background
+        startColor = DARK_MODE_COLORS.CONTRAST_GRAY;
+        endColor = DARK_MODE_COLORS.SUBTLE_GRAY;
+    } else {
+        // Single-end problematic colors
+        if (isStartLight) {
+            // Very light start color -> visible dark gray (not background)
+            startColor = DARK_MODE_COLORS.SUBTLE_GRAY;
+        }
+        if (isStartDark) {
+            // Very dark start color -> slightly lighter
+            startColor = DARK_MODE_COLORS.SUBTLE_GRAY;
+        }
+        if (isEndLight) {
+            // Very light end color -> visible dark gray (not background)
+            endColor = DARK_MODE_COLORS.SUBTLE_GRAY;
+        }
+        if (isEndDark) {
+            // Very dark end color -> slightly lighter
+            endColor = DARK_MODE_COLORS.SUBTLE_GRAY;
+        }
+    }
+
+    return { start: startColor, end: endColor };
 };
 
 const getColorRange = (colorConfig: ConditionalFormattingColorRange) => {


### PR DESCRIPTION
Closes: #18420

### Description:
Improved conditional formatting in dark mode by adjusting color ranges for better visibility. Added a new `transformColorsForDarkMode` utility function that intelligently modifies problematic colors (very light or very dark) to ensure they remain visible against the dark background.

The implementation:
- Detects light and dark colors based on luminance values
- Replaces problematic colors with appropriate alternatives from the dark theme
- Applies these transformations in both the PivotTable and ScrollableTable components
- Maintains the original colors in light mode

This ensures conditional formatting remains effective and readable regardless of the user's chosen color scheme.

_From light to dark_
![CleanShot 2025-12-04 at 15.33.03.png](https://app.graphite.com/user-attachments/assets/5ad14ac1-3c21-4202-b3f4-66975a0ee6ab.png)

![CleanShot 2025-12-04 at 15.33.12.png](https://app.graphite.com/user-attachments/assets/e99ae817-214d-4955-9657-3410d4b71f2d.png)

---

_From dark to color_
![CleanShot 2025-12-04 at 15.32.56.png](https://app.graphite.com/user-attachments/assets/90035f33-c948-462e-8804-f956a6ea46ff.png)

![CleanShot 2025-12-04 at 15.33.19.png](https://app.graphite.com/user-attachments/assets/1147a5b6-810d-47b4-a9ef-a66c36d6ee9b.png)

---

_from light to color_
![CleanShot 2025-12-04 at 15.32.36.png](https://app.graphite.com/user-attachments/assets/110f9098-910b-4e13-b0f5-ff7de09ec78d.png)

![CleanShot 2025-12-04 at 15.33.27.png](https://app.graphite.com/user-attachments/assets/6c25f3d9-9efe-4741-a813-e95014e726fd.png)





