### PR TITLE
feat: reasoning toggle for the agent threads

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -637,6 +637,7 @@ export class AiAgentService {
                     description: preset.description,
                     provider: preset.provider,
                     default: isDefault,
+                    supportsReasoning: preset.supportsReasoning,
                 };
             },
         );
@@ -2917,7 +2918,8 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 
         const agentSettings = await this.getAgentSettings(user, prompt);
         const modelProperties = getModel(this.lightdashConfig.ai.copilot, {
-            enableReasoning: agentSettings.enableReasoning,
+            enableReasoning:
+                prompt.modelConfig?.reasoning ?? agentSettings.enableReasoning,
             modelId: prompt.modelConfig?.modelId,
             provider: prompt.modelConfig?.modelProvider as AnyType,
         });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -502,39 +502,19 @@ export const streamAgentResponse = async ({
                 }
             },
             onStepFinish: (step) => {
-                const reasoningsToStore = step.reasoning
-                    .map((reasoning) => {
-                        if (
-                            reasoning.text &&
-                            reasoning.text.length > 0 &&
-                            'providerMetadata' in reasoning &&
-                            typeof reasoning.providerMetadata === 'object' &&
-                            reasoning.providerMetadata !== null &&
-                            'openai' in reasoning.providerMetadata &&
-                            typeof reasoning.providerMetadata.openai ===
-                                'object' &&
-                            reasoning.providerMetadata.openai !== null &&
-                            'itemId' in reasoning.providerMetadata.openai &&
-                            typeof reasoning.providerMetadata.openai.itemId ===
-                                'string'
-                        ) {
-                            return {
-                                reasoningId:
-                                    reasoning.providerMetadata.openai.itemId,
-                                text: reasoning.text,
-                            };
-                        }
-                        return null;
-                    })
-                    .filter((r) => r !== null);
-
-                if (reasoningsToStore.length > 0) {
+                if (step.reasoningText && step.reasoningText.length > 0) {
                     logger(
                         'On Step Finish',
-                        `Storing ${reasoningsToStore.length} reasoning parts for Prompt UUID ${args.promptUuid}`,
+                        `Storing reasoning text for Prompt UUID ${args.promptUuid}`,
                     );
                     void dependencies
-                        .storeReasoning(args.promptUuid, reasoningsToStore)
+                        .storeReasoning(args.promptUuid, [
+                            {
+                                // TODO :: this works for now, but we need to find a better way to capture the reasoning id from `providerMetadata`
+                                reasoningId: crypto.randomUUID(),
+                                text: step.reasoningText,
+                            },
+                        ])
                         .catch((error) => {
                             Logger.error(
                                 'On Step Finish',

--- a/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
+++ b/packages/backend/src/ee/services/ai/models/anthropic-claude.ts
@@ -10,6 +10,7 @@ export const getAnthropicModel = (
         LightdashConfig['ai']['copilot']['providers']['anthropic']
     >,
     preset: ModelPreset<'anthropic'>,
+    options?: { enableReasoning?: boolean },
 ): AiModel<typeof PROVIDER> => {
     const anthropic = createAnthropic({
         apiKey: config.apiKey,
@@ -17,20 +18,28 @@ export const getAnthropicModel = (
 
     const model = anthropic(preset.modelId);
 
+    const reasoningEnabled =
+        options?.enableReasoning && preset.supportsReasoning;
+
     return {
         model,
-        callOptions: preset.callOptions,
+        callOptions: {
+            ...preset.callOptions,
+            // temperature is not supported when reasoning is enabled
+            ...(reasoningEnabled
+                ? { temperature: undefined }
+                : { temperature: 0.2 }),
+        },
         providerOptions: {
             [PROVIDER]: {
                 ...(preset.providerOptions || {}),
-                // TODO :: reasoning
-                // ...(preset.supportsReasoning && {
-                //     thinking: {
-                //         type: 'enabled',
-                //         /** @ref https://platform.claude.com/docs/en/build-with-claude/extended-thinking#working-with-thinking-budgets */
-                //         budgetTokens: 1024, // TODO :: low - 1024, medium - 4096, high - 16384
-                //     },
-                // }),
+                ...(reasoningEnabled && {
+                    thinking: {
+                        type: 'enabled',
+                        /** @ref https://platform.claude.com/docs/en/build-with-claude/extended-thinking#working-with-thinking-budgets */
+                        budgetTokens: 2048,
+                    },
+                }),
             },
         },
     };

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -129,7 +129,9 @@ export const getModel = (
                 config,
                 options?.modelId,
             );
-            return getOpenaiGptmodel(openaiConfig, preset);
+            return getOpenaiGptmodel(openaiConfig, preset, {
+                enableReasoning: options?.enableReasoning,
+            });
         }
         case 'azure': {
             const azureConfig = config.providers.azure;
@@ -145,7 +147,9 @@ export const getModel = (
                 config,
                 options?.modelId,
             );
-            return getAnthropicModel(anthropicConfig, preset);
+            return getAnthropicModel(anthropicConfig, preset, {
+                enableReasoning: options?.enableReasoning,
+            });
         }
         case 'openrouter': {
             const openrouterConfig = config.providers.openrouter;
@@ -163,7 +167,9 @@ export const getModel = (
                 config,
                 options?.modelId,
             );
-            return getBedrockModel(bedrockConfig, preset);
+            return getBedrockModel(bedrockConfig, preset, {
+                enableReasoning: options?.enableReasoning,
+            });
         }
         default:
             return assertUnreachable(provider, `Invalid provider: ${provider}`);

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5943,6 +5943,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                supportsReasoning: { dataType: 'boolean', required: true },
                 default: { dataType: 'boolean', required: true },
                 provider: { dataType: 'string', required: true },
                 description: { dataType: 'string', required: true },
@@ -7439,6 +7440,24 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                modelConfig: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                reasoning: { dataType: 'boolean' },
+                                modelProvider: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                modelId: { dataType: 'string', required: true },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 referencedArtifacts: {
                     dataType: 'union',
                     subSchemas: [
@@ -7608,6 +7627,7 @@ const models: TsoaRoute.Models = {
                 modelConfig: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        reasoning: { dataType: 'boolean' },
                         modelProvider: { dataType: 'string', required: true },
                         modelId: { dataType: 'string', required: true },
                     },
@@ -7649,6 +7669,7 @@ const models: TsoaRoute.Models = {
                 modelConfig: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        reasoning: { dataType: 'boolean' },
                         modelProvider: { dataType: 'string', required: true },
                         modelId: { dataType: 'string', required: true },
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6744,6 +6744,9 @@
             },
             "AIModelOption": {
                 "properties": {
+                    "supportsReasoning": {
+                        "type": "boolean"
+                    },
                     "default": {
                         "type": "boolean"
                     },
@@ -6761,6 +6764,7 @@
                     }
                 },
                 "required": [
+                    "supportsReasoning",
                     "default",
                     "provider",
                     "description",
@@ -7872,6 +7876,22 @@
             },
             "AiAgentMessageAssistant": {
                 "properties": {
+                    "modelConfig": {
+                        "properties": {
+                            "reasoning": {
+                                "type": "boolean"
+                            },
+                            "modelProvider": {
+                                "type": "string"
+                            },
+                            "modelId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["modelProvider", "modelId"],
+                        "type": "object",
+                        "nullable": true
+                    },
                     "referencedArtifacts": {
                         "items": {
                             "$ref": "#/components/schemas/AiAgentMessageAssistantArtifact"
@@ -7941,6 +7961,7 @@
                     }
                 },
                 "required": [
+                    "modelConfig",
                     "referencedArtifacts",
                     "artifacts",
                     "savedQueryUuid",
@@ -8021,6 +8042,9 @@
                 "properties": {
                     "modelConfig": {
                         "properties": {
+                            "reasoning": {
+                                "type": "boolean"
+                            },
                             "modelProvider": {
                                 "type": "string"
                             },
@@ -8058,6 +8082,9 @@
                 "properties": {
                     "modelConfig": {
                         "properties": {
+                            "reasoning": {
+                                "type": "boolean"
+                            },
                             "modelProvider": {
                                 "type": "string"
                             },

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -168,7 +168,11 @@ export type AiAgentMessageAssistant = {
 
     artifacts: AiAgentMessageAssistantArtifact[] | null;
     referencedArtifacts: AiAgentMessageAssistantArtifact[] | null;
-    modelConfig: { modelId: string; modelProvider: string } | null;
+    modelConfig: {
+        modelId: string;
+        modelProvider: string;
+        reasoning?: boolean;
+    } | null;
 };
 
 export type AiAgentMessage<TUser extends AiAgentUser = AiAgentUser> =
@@ -261,14 +265,22 @@ export type ApiAiAgentThreadResponse = {
 
 export type ApiAiAgentThreadCreateRequest = {
     prompt?: string;
-    modelConfig?: { modelId: string; modelProvider: string };
+    modelConfig?: {
+        modelId: string;
+        modelProvider: string;
+        reasoning?: boolean;
+    };
 };
 
 export type ApiAiAgentThreadCreateResponse = ApiSuccess<AiAgentThreadSummary>;
 
 export type ApiAiAgentThreadMessageCreateRequest = {
     prompt: string;
-    modelConfig?: { modelId: string; modelProvider: string };
+    modelConfig?: {
+        modelId: string;
+        modelProvider: string;
+        reasoning?: boolean;
+    };
 };
 
 export type ApiAiAgentThreadMessageCreateResponse = ApiSuccess<
@@ -617,6 +629,7 @@ export type AIModelOption = {
     description: string;
     provider: string;
     default: boolean;
+    supportsReasoning: boolean;
 };
 
 export type ApiAiAgentModelOptionsResponse = ApiSuccess<AIModelOption[]>;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -38,7 +38,11 @@ export type AiPrompt = {
     createdAt: Date;
     response: string | null;
     humanScore: number | null;
-    modelConfig: { modelId: string; modelProvider: string } | null;
+    modelConfig: {
+        modelId: string;
+        modelProvider: string;
+        reasoning?: boolean;
+    } | null;
 };
 
 export type SlackPrompt = AiPrompt & {
@@ -69,7 +73,11 @@ export type CreateWebAppPrompt = {
     threadUuid: string;
     createdByUserUuid: string;
     prompt: string;
-    modelConfig?: { modelId: string; modelProvider: string };
+    modelConfig?: {
+        modelId: string;
+        modelProvider: string;
+        reasoning?: boolean;
+    };
 };
 
 export type UpdateSlackResponse = {


### PR DESCRIPTION
# Enable reasoning support for AI models

### Description:

This PR adds support for extended reasoning/thinking capabilities across multiple AI model providers:

- Implements reasoning support for OpenAI, Anthropic Claude, and Bedrock models
- Adds a `supportsReasoning` flag to model options to indicate which models support this feature
- Adds a UI toggle for enabling extended thinking when using supported models
- Updates the model configuration to pass reasoning settings to the appropriate providers
- Simplifies the reasoning storage mechanism to work across different providers
- Adjusts temperature settings when reasoning is enabled for optimal performance
