### PR TITLE
feat: replace funnel charts text shadows w background

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -6,6 +6,7 @@ import {
     FunnelChartLabelPosition,
     FunnelChartLegendPosition,
     getLegendStyle,
+    getReadableTextColor,
     getTooltipStyle,
     type Metric,
     type ResultRow,
@@ -101,6 +102,18 @@ const useEchartsFunnelConfig = (
                         color: colorOverrides?.[id] ?? colorDefaults[id],
                         borderWidth: 0,
                     },
+                    label:
+                        labels?.position === FunnelChartLabelPosition.INSIDE
+                            ? {
+                                  backgroundColor:
+                                      colorOverrides?.[id] ?? colorDefaults[id],
+                                  color: getReadableTextColor(
+                                      colorOverrides?.[id] ?? colorDefaults[id],
+                                  ),
+                                  borderRadius: 4,
+                                  padding: [4, 8],
+                              }
+                            : undefined,
                 };
             }),
             color: colorPalette,
@@ -139,7 +152,7 @@ const useEchartsFunnelConfig = (
                         : FunnelChartLabelPosition.INSIDE,
                 color:
                     labels?.position !== FunnelChartLabelPosition.INSIDE
-                        ? 'black'
+                        ? theme.colors.foreground[0]
                         : undefined,
                 formatter: ({ name, value }) => {
                     const { formattedValue, percentOfMax } =
@@ -167,7 +180,13 @@ const useEchartsFunnelConfig = (
                 disabled: true,
             },
         };
-    }, [chartConfig, colorPalette, seriesData, parameters]);
+    }, [
+        chartConfig,
+        colorPalette,
+        seriesData,
+        parameters,
+        theme.colors.foreground,
+    ]);
 
     const { tooltip: legendDoubleClickTooltip } = useLegendDoubleClickTooltip();
 


### PR DESCRIPTION
Closes: #10722

### Description:
This PR replaces text shadows with background color in funnel chart labels when they are positioned inside the funnel segments. The background color matches the segment color, and the text color is automatically adjusted to ensure readability against the background using the `getReadableTextColor` function. 


![CleanShot 2025-12-04 at 16.47.27.png](https://app.graphite.com/user-attachments/assets/8089fe26-1468-49f8-9e5a-39e9cb8bf3a1.png)

![CleanShot 2025-12-04 at 16.47.42.png](https://app.graphite.com/user-attachments/assets/14bcdff6-348c-4c99-89bc-a9046c315ef0.png)

