### PR TITLE
fix: exclude sensitive fields when merging warehouse credentials

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -296,9 +296,21 @@ export const mergeWarehouseCredentials = <T extends CreateWarehouseCredentials>(
         return newCredentials;
     }
 
+    // Only add non sensitive fields from base credentials to avoid conflicts with authentication methods
+    const keysToExclude = [
+        ...sensitiveCredentialsFieldNames,
+        'authenticationType',
+    ];
+    const filteredBaseCredentials = Object.fromEntries(
+        Object.entries(baseCredentials).filter(
+            ([key]) =>
+                !keysToExclude.includes(key as SensitiveCredentialsFieldNames),
+        ),
+    );
     // We will use new credentials for connection, this might contain new authentication method
     // do not include all baseCredentials here, to avoid conflicts on authentication (that will cause a mix of serviceaccounts/sso/passwords)
     const merged = {
+        ...filteredBaseCredentials, // We copy most of the base config from the parent project, including advanced settings
         ...newCredentials,
         // Keep requireUserCredentials from base credentials, since this is a security setting and should not be overridden
         requireUserCredentials: baseCredentials.requireUserCredentials,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-1106/previews-project-configuration-not-pulled-across

After:

<img width="889" height="697" alt="Screenshot from 2025-12-04 17-16-55" src="https://github.com/user-attachments/assets/5c8ce0f5-d4a6-4fca-a343-f77d2b153897" />



### Description:
Improved warehouse credentials merging by filtering out sensitive fields and authentication types from base credentials before merging. This prevents conflicts between different authentication methods while preserving important configuration settings from the parent project, including advanced settings.