### PR TITLE
style: improve color settings for tables

### DIFF
--- a/packages/frontend/src/components/common/Table/Table.styles.tsx
+++ b/packages/frontend/src/components/common/Table/Table.styles.tsx
@@ -43,7 +43,9 @@ export const TableContainer = styled.div<
             `}
 `;
 
-export const Table = styled.table<{ $showFooter?: boolean }>`
+export const Table = styled.table<{
+    $showFooter?: boolean;
+}>`
     border-spacing: 0;
     font-size: 14px;
     width: 100%;
@@ -70,21 +72,25 @@ export const Table = styled.table<{ $showFooter?: boolean }>`
     tbody tr:first-child td,
     tfoot tr:first-child th,
     tfoot tr:first-child td {
-        box-shadow: inset 0 1px 0 0 rgba(17, 20, 24, 0.15);
+        box-shadow: inset 0 1px 0 0
+            color-mix(in srgb, var(--mantine-color-ldGray-3) 80%, transparent);
     }
 
     tbody tr td,
     tfoot tr td {
-        box-shadow: inset 0 1px 0 0 rgba(17, 20, 24, 0.15);
+        box-shadow: inset 0 1px 0 0
+            color-mix(in srgb, var(--mantine-color-ldGray-3) 80%, transparent);
     }
 
     tbody tr td:not(:first-child),
     tfoot tr td:not(:first-child) {
-        box-shadow: inset 1px 1px 0 0 rgba(17, 20, 24, 0.15);
+        box-shadow: inset 1px 1px 0 0
+            color-mix(in srgb, var(--mantine-color-ldGray-3) 80%, transparent);
     }
 
     th:not(:first-child) {
-        box-shadow: inset 1px 0 0 0 rgba(17, 20, 24, 0.15);
+        box-shadow: inset 1px 0 0 0
+            color-mix(in srgb, var(--mantine-color-ldGray-3) 80%, transparent);
     }
 
     /* FIXME: everything above this line is copied from blueprint's table css */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:

Replace hardcoded rgba colors with Mantine theme variables in table styles. This change uses `color-mix` with `var(--mantine-color-ldGray-3)` instead of the previous rgba values for table borders and shadows, improving theme consistency.

![Screenshot 2025-12-04 at 16.59.54.png](https://app.graphite.com/user-attachments/assets/190c2f61-9e88-4445-8435-69d357080471.png)

![Screenshot 2025-12-04 at 17.00.06.png](https://app.graphite.com/user-attachments/assets/6b36a59f-15e4-4027-a3bd-9c2572a4817b.png)

![Screenshot 2025-12-04 at 17.00.00.png](https://app.graphite.com/user-attachments/assets/2da4ddad-81d0-47ed-8bbd-acb3a97b08ce.png)

