### PR TITLE
style: big number dark mode (title)

### DIFF
--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -82,7 +82,7 @@ const BigNumberText: FC<
     return (
         <Text
             ref={ref}
-            c="ldGray.9"
+            c="foreground.0"
             ta="center"
             fw={500}
             {...textProps}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Updated the color of the `BigNumberText` component from `ldGray.9` to `foreground.0` to improve consistency with our design system's color tokens.



![Screenshot 2025-12-04 at 17.04.52.png](https://app.graphite.com/user-attachments/assets/75ebae0e-a73d-4d98-a602-f2d78425cf1f.png)

![Screenshot 2025-12-04 at 17.04.43.png](https://app.graphite.com/user-attachments/assets/62da43a0-7088-4e1a-866d-619a771bee62.png)

