### PR TITLE
style: dark mode spotlight categories

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -76,6 +76,7 @@ const EditPopover: FC<EditPopoverProps> = ({
 
     return (
         <Popover
+            withinPortal
             position="top"
             opened={opened}
             closeOnClickOutside

--- a/packages/frontend/src/features/metricsCatalog/styles/useCategoryStyles.ts
+++ b/packages/frontend/src/features/metricsCatalog/styles/useCategoryStyles.ts
@@ -3,23 +3,52 @@ import { type TAG_COLOR_SWATCHES } from '../utils/getRandomTagColor';
 
 export const useCategoryStyles = createStyles(
     (theme, color: typeof TAG_COLOR_SWATCHES[number] | string) => {
+        const isDarkMode = theme.colorScheme === 'dark';
         // Some colors might be custom colors, not in the mantine color palette
         const isMantineColorKey = color in theme.colors;
+
+        // Dark mode: richer, more saturated colors
+        // Light mode: soft, pastel backgrounds
         const textColor = isMantineColorKey
-            ? theme.colors[color][9]
+            ? isDarkMode
+                ? theme.colors[color][2]
+                : theme.colors[color][9]
+            : isDarkMode
+            ? theme.fn.lighten(color, 0.6)
             : theme.fn.darken(color, 0.2);
+
         const backgroundColor = isMantineColorKey
-            ? theme.fn.lighten(theme.colors[color][0], 0.1)
+            ? isDarkMode
+                ? theme.fn.darken(theme.colors[color][8], 0.5)
+                : theme.fn.lighten(theme.colors[color][0], 0.1)
+            : isDarkMode
+            ? theme.fn.darken(color, 0.7)
             : theme.fn.lighten(color, 0.92);
+
         const hoverBackgroundColor = isMantineColorKey
-            ? theme.fn.lighten(theme.colors[color][4], 0.7)
+            ? isDarkMode
+                ? theme.fn.darken(theme.colors[color][7], 0.3)
+                : theme.fn.lighten(theme.colors[color][4], 0.7)
+            : isDarkMode
+            ? theme.fn.darken(color, 0.5)
             : theme.fn.lighten(color, 0.8);
+
         const borderColor = isMantineColorKey
-            ? theme.colors[color][2]
+            ? isDarkMode
+                ? theme.colors[color][6]
+                : theme.colors[color][2]
+            : isDarkMode
+            ? theme.fn.darken(color, 0.3)
             : theme.fn.lighten(color, 0.45);
+
         const removeIconColor = isMantineColorKey
-            ? theme.fn.darken(theme.colors[color][6], 0.4)
+            ? isDarkMode
+                ? theme.fn.lighten(theme.colors[color][4], 0.2)
+                : theme.fn.darken(theme.colors[color][6], 0.4)
+            : isDarkMode
+            ? theme.fn.lighten(color, 0.3)
             : theme.fn.darken(color, 0.4);
+
         const focusOutlineColor = isMantineColorKey
             ? theme.colors[color][5]
             : theme.fn.darken(color, 0.3);
@@ -32,10 +61,6 @@ export const useCategoryStyles = createStyles(
                 cursor: 'pointer',
                 boxShadow: '0px -1px 0px 0px rgba(4, 4, 4, 0.04) inset',
                 outline: 'none',
-                filter:
-                    theme.colorScheme === 'dark'
-                        ? 'brightness(0.8) saturate(0.7)'
-                        : 'none',
                 '&:focus': {
                     outline: `2px solid ${focusOutlineColor}`,
                     outlineOffset: '2px',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #[issue number]

### Description:
Added dark mode support for category tags in the metrics catalog. The PR improves the visual appearance of category tags by:

1. Adding the `withinPortal` prop to the edit popover to ensure proper rendering
2. Implementing distinct color handling for dark and light modes:
   - Dark mode now uses richer, more saturated colors
   - Light mode maintains soft, pastel backgrounds
3. Removing the generic filter brightness that was previously applied to dark mode
4. Creating specific color calculations for text, background, hover states, borders, and icons in both themes

This change ensures better contrast and readability across both light and dark themes while maintaining the visual identity of category tags.

![Screenshot 2025-12-04 at 17.29.23.png](https://app.graphite.com/user-attachments/assets/17c9ab66-bf4c-46fb-8bea-776e7a7d6b34.png)

![Screenshot 2025-12-04 at 17.31.02.png](https://app.graphite.com/user-attachments/assets/f55df895-51d0-4b2c-badf-4b4ea65a7d10.png)

