### PR TITLE
style: dark mode swatch tick

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.tsx
@@ -30,7 +30,7 @@ export const CatalogCategorySwatch: FC<Props> = ({
                 <MantineIcon
                     icon={IconCheck}
                     strokeWidth={2}
-                    color="dark"
+                    color="foreground.0"
                     size={12}
                 />
             )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Fixed the check icon color in `CatalogCategorySwatch` component to adapt to the theme's color scheme. Now the check icon will appear white in dark mode and black in light mode, improving visibility and contrast in both themes.

![image.png](https://app.graphite.com/user-attachments/assets/6cd020ea-1d19-473e-ab73-96c6cdf80a67.png)

