### PR TITLE
style: dark mode darkprimary button

### DIFF
--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -186,18 +186,19 @@ export const getMantineThemeOverride = (
                 variants: {
                     darkPrimary: (theme) => ({
                         root: {
-                            background: `var(--mantine-color-ldDark-9)`,
+                            background: `var(--mantine-color-foreground-0)`,
                             borderRadius: theme.radius.md,
-                            color: `var(--mantine-color-ldDark-0)`,
+                            color: `var(--mantine-color-ldGray-0)`,
+                            boxShadow: `inset 0 -2px 0 0 color-mix(in srgb, var(--mantine-color-ldDark-0) 40%, transparent)`, // glossy effect
                             ...theme.fn.hover({
-                                background: `var(--mantine-color-ldDark-8)`,
+                                background: `color-mix(in srgb, var(--mantine-color-foreground-0) 80%, transparent)`,
                             }),
                             '&[data-loading]': {
                                 boxShadow: theme.shadows.subtle,
                             },
                             '&[data-disabled]': {
                                 boxShadow: theme.shadows.subtle,
-                                color: `var(--mantine-color-ldDark-5)`,
+                                color: `color-mix(in srgb, var(--mantine-color-foreground-0) 50%, transparent)`,
                             },
                         },
                     }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Updates the `darkPrimary` button variant styling to use foreground colors instead of ldDark colors. This change enhances the button's appearance with:

- Changed background from ldDark-9 to foreground-0
- Updated text color from ldDark-0 to ldGray-0
- Added a glossy effect with an inset box shadow
- Improved hover state with a semi-transparent background
- Refined disabled state styling with a color mix instead of a fixed color

![Screenshot 2025-12-04 at 17.44.10.png](https://app.graphite.com/user-attachments/assets/3d826337-16e5-47b6-b6d9-d66e1cc05b2d.png)

![image.png](https://app.graphite.com/user-attachments/assets/94792f83-07f3-4548-94c9-349e1de8f250.png)

