### PR TITLE
chore: simplify foreground and background color creation

### DIFF
--- a/packages/frontend/STYLE_GUIDE.md
+++ b/packages/frontend/STYLE_GUIDE.md
@@ -235,9 +235,9 @@ Before moving styles to CSS modules, analyze if they're actually needed:
 <Button bg="ldDark.8" c="ldDark.0">Dark button</Button>  // Dark bg/light text → Light bg/dark text
 <Badge bg="ldDark.9" c="ldDark.1">Dark badge</Badge>    // Inverts for dark mode
 
-// ✅ Good - Foreground/background variables (always use .0 as there is only one option for now)
-<Text c="foreground.0">Primary text</Text>      // Main text color
-<Box bg="background.0">Main background</Box>    // Main background color
+// ✅ Good - Foreground/background variables
+<Text c="foreground">Primary text</Text>      // Main text color
+<Box bg="background">Main background</Box>    // Main background color
 ```
 
 **Available custom color scales:**
@@ -246,14 +246,14 @@ Before moving styles to CSS modules, analyze if they're actually needed:
 |-------|------------|-----------|---------|
 | `ldGray.0-9` | Light grays (#f8f9fa → #212529) | Dark grays (#2e2e32 → #d9d9df) | Borders, text |
 | `ldDark.0-9` | Dark shades (#C9C9C9 → #141414) | Light shades (#f3f5ff → #18181a) | Inverted contrast elements |
-| `background.0` | #FEFEFE (white) | #1A1B1E (dark) | Page/card backgrounds |
-| `foreground.0` | #1A1B1E (dark) | #FEFEFE (white) | Primary text color |
+| `background` | #FEFEFE (white) | #1A1B1E (dark) | Page/card backgrounds |
+| `foreground` | #1A1B1E (dark) | #FEFEFE (white) | Primary text color |
 
 **When to use each:**
 - **`ldGray`**: Borders, subtle text, neutral UI elements
 - **`ldDark`**: Buttons/badges with dark backgrounds in light mode, "inverted" elements
-- **`foreground.0`**: Main text color throughout the app
-- **`background.0`**: Main page/container backgrounds
+- **`foreground`**: Main text color throughout the app
+- **`background`**: Main page/container backgrounds
 - **Standard colors**: Brand colors (blue, red, green) for accents and semantic meanings
 
 #### Advanced Theme Customization

--- a/packages/frontend/src/components/CompilationHistory/SourceFilter.tsx
+++ b/packages/frontend/src/components/CompilationHistory/SourceFilter.tsx
@@ -37,7 +37,7 @@ const CompilationSourceFilter: FC<CompilationSourceFilterProps> = ({
                 >
                     <Button
                         h={32}
-                        c="foreground.0"
+                        c="foreground"
                         fw={500}
                         fz="sm"
                         variant="default"

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -999,7 +999,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                         <Text
                                                             fw={600}
                                                             span
-                                                            color="foreground.0"
+                                                            color="foreground"
                                                         >
                                                             {
                                                                 filterRuleLabels.field
@@ -1008,7 +1008,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                         </Text>{' '}
                                                         {filterRule.disabled ? (
                                                             <Text
-                                                                color="foreground.0"
+                                                                color="foreground"
                                                                 span
                                                             >
                                                                 is any value
@@ -1017,7 +1017,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                             <>
                                                                 <Text
                                                                     span
-                                                                    color="foreground.0"
+                                                                    color="foreground"
                                                                 >
                                                                     {
                                                                         filterRuleLabels.operator
@@ -1026,7 +1026,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                                 <Text
                                                                     fw={600}
                                                                     span
-                                                                    color="foreground.0"
+                                                                    color="foreground"
                                                                 >
                                                                     {
                                                                         filterRuleLabels.value

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -115,7 +115,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 direction="column"
                 p="md"
                 radius="sm"
-                bg="background.0"
+                bg="background"
                 shadow={isEditMode ? 'xs' : undefined}
                 sx={(theme) => {
                     let border = `1px solid ${theme.colors.ldGray[1]}`;
@@ -189,7 +189,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                             fw={600}
                                             fz="md"
                                             hidden={hideTitle}
-                                            c="foreground.0"
+                                            c="foreground"
                                         >
                                             {title}
                                         </Text>

--- a/packages/frontend/src/components/SchedulersView/filters/CreatedByFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/CreatedByFilter.tsx
@@ -39,7 +39,7 @@ const CreatedByFilter: FC<CreatedByFilterProps> = ({
                 >
                     <Button
                         h={32}
-                        c="foreground.0"
+                        c="foreground"
                         fw={500}
                         fz="sm"
                         variant="default"

--- a/packages/frontend/src/components/SchedulersView/filters/DestinationFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/DestinationFilter.tsx
@@ -41,7 +41,7 @@ const DestinationFilter: FC<DestinationFilterProps> = ({
                 >
                     <Button
                         h={32}
-                        c="foreground.0"
+                        c="foreground"
                         fw={500}
                         fz="sm"
                         variant="default"

--- a/packages/frontend/src/components/SchedulersView/filters/FormatFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/FormatFilter.tsx
@@ -42,7 +42,7 @@ const FormatFilter: FC<FormatFilterProps> = ({
                 >
                     <Button
                         h={32}
-                        c="foreground.0"
+                        c="foreground"
                         fw={500}
                         fz="sm"
                         variant="default"

--- a/packages/frontend/src/components/SchedulersView/filters/StatusFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/StatusFilter.tsx
@@ -45,7 +45,7 @@ const StatusFilter: FC<StatusFilterProps> = ({
                 >
                     <Button
                         h={32}
-                        c="foreground.0"
+                        c="foreground"
                         fw={500}
                         fz="sm"
                         variant="default"

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -82,7 +82,7 @@ const BigNumberText: FC<
     return (
         <Text
             ref={ref}
-            c="foreground.0"
+            c="foreground"
             ta="center"
             fw={500}
             {...textProps}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -61,7 +61,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
     }
 
     return (
-        <Box h="100%" pos="relative" bg="background.0">
+        <Box h="100%" pos="relative" bg="background">
             <LoadingOverlay
                 pos="absolute"
                 visible={isLoadingThread}

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategorySwatch.tsx
@@ -30,7 +30,7 @@ export const CatalogCategorySwatch: FC<Props> = ({
                 <MantineIcon
                     icon={IconCheck}
                     strokeWidth={2}
-                    color="foreground.0"
+                    color="foreground"
                     size={12}
                 />
             )}

--- a/packages/frontend/src/features/metricsCatalog/components/SelectItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/SelectItem.tsx
@@ -15,7 +15,7 @@ const SelectItem = forwardRef<
         <Box ref={mergeRefs(ref, hoverRef)} {...others} w={290}>
             <Text
                 fz="sm"
-                c="foreground.1"
+                c="foreground"
                 fw={400}
                 truncate={hovered ? undefined : 'end'}
             >

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -1,3 +1,4 @@
+import { colorsTuple } from '@mantine-8/core';
 import {
     rem,
     type ColorScheme,
@@ -8,30 +9,8 @@ import {
 type ColorTuple = Tuple<string, 10>;
 
 const lightModeColors = {
-    background: [
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-    ] as ColorTuple,
-    foreground: [
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-    ] as ColorTuple,
+    background: colorsTuple('#FEFEFE') as ColorTuple,
+    foreground: colorsTuple('#1A1B1E') as ColorTuple,
 
     ldDark: [
         '#C9C9C9',
@@ -61,30 +40,8 @@ const lightModeColors = {
 };
 
 const darkModeColors = {
-    background: [
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-        '#1A1B1E',
-    ] as ColorTuple,
-    foreground: [
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-        '#FEFEFE',
-    ] as ColorTuple,
+    background: colorsTuple('#1A1B1E') as ColorTuple,
+    foreground: colorsTuple('#FEFEFE') as ColorTuple,
 
     ldDark: [
         '#101113',


### PR DESCRIPTION
### Description:
Simplifies theme color usage by removing the `.0` suffix from `foreground` and `background` color references. This change makes the code more concise while maintaining the same functionality.

The PR:
- Updates the style guide documentation to reflect the new simplified syntax
- Refactors all component references to use `foreground` and `background` without the `.0` index
- Improves theme implementation by using `colorsTuple()` helper instead of manually defining repeated color arrays

This change makes the codebase more maintainable and consistent with modern Mantine theming practices.