### PR TITLE
feat: add write-back buttons for custom metrics and dimensions

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -1,13 +1,20 @@
 import { subject } from '@casl/ability';
-import { Button, Group, Text, Tooltip } from '@mantine/core';
-import { IconPlus } from '@tabler/icons-react';
+import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
+import { ActionIcon, Button, Group, Text, Tooltip } from '@mantine/core';
+import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import {
     explorerActions,
+    selectAdditionalMetrics,
+    selectCustomDimensions,
     useExplorerDispatch,
+    useExplorerSelector,
 } from '../../../../../features/explorer/store';
+import { useFeatureFlagEnabled } from '../../../../../hooks/useFeatureFlagEnabled';
 import useApp from '../../../../../providers/App/useApp';
+import useTracking from '../../../../../providers/Tracking/useTracking';
+import { EventName } from '../../../../../types/Events';
 import DocumentationHelpButton from '../../../../DocumentationHelpButton';
 import MantineIcon from '../../../../common/MantineIcon';
 import { TreeSection, type SectionHeaderItem } from './types';
@@ -26,7 +33,25 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
         item.data;
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { user } = useApp();
+    const { track } = useTracking();
     const dispatch = useExplorerDispatch();
+
+    // Get all custom metrics and dimensions for write-back
+    const allAdditionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+    const allCustomDimensions = useExplorerSelector(selectCustomDimensions);
+
+    // Feature flag for bin dimensions write-back
+    const isWriteBackCustomBinDimensionsEnabled = useFeatureFlagEnabled(
+        FeatureFlags.WriteBackCustomBinDimensions,
+    );
+
+    // Filter custom dimensions based on feature flag
+    const customDimensionsToWriteBack = useMemo(() => {
+        if (!allCustomDimensions) return [];
+        return isWriteBackCustomBinDimensionsEnabled
+            ? allCustomDimensions
+            : allCustomDimensions.filter(isCustomSqlDimension);
+    }, [allCustomDimensions, isWriteBackCustomBinDimensionsEnabled]);
 
     const canManageCustomSql = user.data?.ability?.can(
         'manage',
@@ -46,6 +71,47 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
         );
     }, [dispatch, tableName]);
 
+    const handleWriteBackCustomMetrics = useCallback(() => {
+        if (projectUuid && user.data?.organizationUuid) {
+            track({
+                name: EventName.WRITE_BACK_FROM_CUSTOM_METRIC_HEADER_CLICKED,
+                properties: {
+                    userId: user.data.userUuid,
+                    projectId: projectUuid,
+                    organizationId: user.data.organizationUuid,
+                    customMetricsCount: allAdditionalMetrics?.length || 0,
+                    customDimensionsCount: 0,
+                },
+            });
+        }
+        dispatch(
+            explorerActions.toggleWriteBackModal({
+                items: allAdditionalMetrics,
+            }),
+        );
+    }, [projectUuid, user.data, allAdditionalMetrics, dispatch, track]);
+
+    const handleWriteBackCustomDimensions = useCallback(() => {
+        if (projectUuid && user.data?.organizationUuid) {
+            track({
+                name: EventName.WRITE_BACK_FROM_CUSTOM_DIMENSION_HEADER_CLICKED,
+                properties: {
+                    userId: user.data.userUuid,
+                    projectId: projectUuid,
+                    organizationId: user.data.organizationUuid,
+                    customMetricsCount: 0,
+                    customDimensionsCount:
+                        customDimensionsToWriteBack?.length || 0,
+                },
+            });
+        }
+        dispatch(
+            explorerActions.toggleWriteBackModal({
+                items: customDimensionsToWriteBack || [],
+            }),
+        );
+    }, [projectUuid, user.data, customDimensionsToWriteBack, dispatch, track]);
+
     // Section headers use simplified padding: depth * 20
     // (no base 12px like tree nodes)
     const pl = useMemo(() => {
@@ -55,40 +121,74 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     const showAddButton =
         treeSection === TreeSection.Dimensions && canManageCustomSql;
 
+    const showWriteBackCustomMetrics =
+        treeSection === TreeSection.CustomMetrics &&
+        allAdditionalMetrics &&
+        allAdditionalMetrics.length > 0;
+
+    const showWriteBackCustomDimensions =
+        treeSection === TreeSection.CustomDimensions &&
+        customDimensionsToWriteBack.length > 0;
+
     return (
         <Group mt="sm" mb="xs" pl={pl} pr="sm" position="apart">
-            <Text fw={600} c={color}>
-                {label}
-            </Text>
+            <Group spacing="xs">
+                <Text fw={600} c={color}>
+                    {label}
+                </Text>
+                {helpButton && (
+                    <DocumentationHelpButton
+                        href={helpButton.href}
+                        tooltipProps={{
+                            label: helpButton.tooltipText,
+                            multiline: true,
+                        }}
+                    />
+                )}
+            </Group>
 
-            {showAddButton && (
-                <Tooltip
-                    label="Add a custom dimension with SQL"
-                    variant="xs"
-                    position="left"
-                >
-                    <Button
-                        size="xs"
-                        variant="subtle"
-                        compact
-                        leftIcon={<MantineIcon icon={IconPlus} />}
-                        onClick={handleAddCustomDimension}
-                        data-testid="VirtualSectionHeader/AddCustomDimensionButton"
+            <Group spacing="xs">
+                {showAddButton && (
+                    <Tooltip
+                        label="Add a custom dimension with SQL"
+                        variant="xs"
+                        position="left"
                     >
-                        Add
-                    </Button>
-                </Tooltip>
-            )}
+                        <Button
+                            size="xs"
+                            variant="subtle"
+                            compact
+                            leftIcon={<MantineIcon icon={IconPlus} />}
+                            onClick={handleAddCustomDimension}
+                            data-testid="VirtualSectionHeader/AddCustomDimensionButton"
+                        >
+                            Add
+                        </Button>
+                    </Tooltip>
+                )}
 
-            {helpButton && (
-                <DocumentationHelpButton
-                    href={helpButton.href}
-                    tooltipProps={{
-                        label: helpButton.tooltipText,
-                        multiline: true,
-                    }}
-                />
-            )}
+                {showWriteBackCustomMetrics && (
+                    <Tooltip label="Write back custom metrics">
+                        <ActionIcon
+                            onClick={handleWriteBackCustomMetrics}
+                            data-testid="VirtualSectionHeader/WriteBackCustomMetricsButton"
+                        >
+                            <MantineIcon icon={IconCode} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+
+                {showWriteBackCustomDimensions && (
+                    <Tooltip label="Write back custom dimensions">
+                        <ActionIcon
+                            onClick={handleWriteBackCustomDimensions}
+                            data-testid="VirtualSectionHeader/WriteBackCustomDimensionsButton"
+                        >
+                            <MantineIcon icon={IconCode} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+            </Group>
         </Group>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18597

### Description:
Added "Write back" buttons to the custom metrics and custom dimensions section headers in the Explorer. These buttons allow users to persist their custom metrics and dimensions to the dbt project.

The implementation includes:
- New action icons with tooltips in the section headers
- Tracking events for when users click the write back buttons
- Support for a feature flag to control write-back of custom bin dimensions
- Proper filtering of custom dimensions based on the feature flag status

![Screenshot 2025-12-04 at 20.28.06.png](https://app.graphite.com/user-attachments/assets/c637d8ef-7f5a-4c3e-9bef-d66c7c115f28.png)

That opens pre-existing modal:


![Screenshot 2025-12-04 at 20.28.16.png](https://app.graphite.com/user-attachments/assets/79ecdd94-1bf3-4a12-8658-4bc7a64537c5.png)

