### PR TITLE
refactor: simplify AI model naming and configuration

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -1,11 +1,10 @@
 import { z } from 'zod';
 
-export const DEFAULT_OPENAI_MODEL_NAME = 'gpt-4.1-2025-04-14';
-export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-5-20250929';
+export const DEFAULT_OPENAI_MODEL_NAME = 'gpt-4.1';
+export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-5';
 export const DEFAULT_DEFAULT_AI_PROVIDER = 'openai';
 export const DEFAULT_OPENROUTER_MODEL_NAME = 'openai/gpt-4.1-2025-04-14';
-export const DEFAULT_BEDROCK_MODEL_NAME =
-    'anthropic.claude-sonnet-4-5-20250929-v1:0';
+export const DEFAULT_BEDROCK_MODEL_NAME = 'claude-sonnet-4-5';
 
 export const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const DEFAULT_BEDROCK_EMBEDDING_MODEL = 'cohere.embed-english-v3';

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -79,7 +79,7 @@ export type DbAiPrompt = {
     human_feedback: string | null;
     metric_query: object | null;
     saved_query_uuid: string | null;
-    model_config: { modelId: string; modelProvider: string } | null;
+    model_config: { modelName: string; modelProvider: string } | null;
 };
 
 export type AiPromptTable = Knex.CompositeTableType<

--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -13,7 +13,7 @@ import {
     AiAgentWithContext,
     AiDuplicateSlackPromptError,
     AiMetricQueryWithFilters,
-    AIModelOption,
+    AiModelOption,
     AiResultType,
     AiVizMetadata,
     AiWebAppPrompt,
@@ -126,6 +126,7 @@ import { generateArtifactQuestion } from './ai/agents/questionGenerator';
 import { evaluateAgentReadiness } from './ai/agents/readinessScorer';
 import { generateThreadTitle as generateTitleFromMessages } from './ai/agents/titleGenerator';
 import { getAvailableModels, getDefaultModel, getModel } from './ai/models';
+import { matchesPreset } from './ai/models/presets';
 import { AiAgentArgs, AiAgentDependencies } from './ai/types/aiAgent';
 import {
     CreateChangeFn,
@@ -595,7 +596,7 @@ export class AiAgentService {
         user: SessionUser,
         projectUuid: string,
         agentUuid: string,
-    ): Promise<AIModelOption[]> {
+    ): Promise<AiModelOption[]> {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -629,10 +630,10 @@ export class AiAgentService {
             (preset) => {
                 const isDefault =
                     preset.provider === defaultModel.provider &&
-                    preset.modelId === defaultModel.modelId;
+                    matchesPreset(preset, defaultModel.name);
 
                 return {
-                    id: preset.modelId,
+                    name: preset.name,
                     displayName: preset.displayName,
                     description: preset.description,
                     provider: preset.provider,
@@ -2920,7 +2921,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         const modelProperties = getModel(this.lightdashConfig.ai.copilot, {
             enableReasoning:
                 prompt.modelConfig?.reasoning ?? agentSettings.enableReasoning,
-            modelId: prompt.modelConfig?.modelId,
+            modelName: prompt.modelConfig?.modelName,
             provider: prompt.modelConfig?.modelProvider as AnyType,
         });
 

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -7,8 +7,9 @@ import {
     getTestContext,
     IntegrationTestContext,
 } from '../../../../../vitest.setup.integration';
-import { getModel } from '../../models';
+import { getModel, MODEL_PRESETS } from '../../models';
 import { getOpenaiGptmodel } from '../../models/openai-gpt';
+import { getModelPreset } from '../../models/presets';
 import {
     calculateRunQueryEfficiencyScore,
     llmAsAJudge,
@@ -43,21 +44,10 @@ describeOrSkip.concurrent('agent integration tests', () => {
     const { model: judge, callOptions } = getOpenaiGptmodel(
         {
             apiKey: process.env.OPENAI_API_KEY!,
-            modelName: 'gpt-4.1-2025-04-14',
+            modelName: 'gpt-4.1',
             embeddingModelName: 'text-embedding-3-small',
         },
-        {
-            provider: 'openai',
-            modelId: 'gpt-4.1-2025-04-14',
-            displayName: 'GPT-4.1',
-            description: 'Reliable OpenAI model',
-            supportsReasoning: false,
-            callOptions: { temperature: 0.2 },
-            providerOptions: {
-                strictJsonSchema: true,
-                parallelToolCalls: false,
-            },
-        },
+        getModelPreset('openai', 'gpt-4.1')!,
     );
 
     beforeAll(async () => {

--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -1,7 +1,10 @@
 import { CallSettings } from 'ai';
 import { ProviderOptionsMap } from './types';
 
-export type ModelPreset<P extends 'openai' | 'anthropic' | 'bedrock'> = {
+export type ModelPresetProvider = 'openai' | 'anthropic' | 'bedrock';
+
+export type ModelPreset<P extends ModelPresetProvider> = {
+    name: string;
     provider: P;
     modelId: string;
     displayName: string;
@@ -11,93 +14,141 @@ export type ModelPreset<P extends 'openai' | 'anthropic' | 'bedrock'> = {
     providerOptions: ProviderOptionsMap[P] | undefined;
 };
 
-export const MODEL_PRESETS: Record<
-    string,
-    ModelPreset<'openai'> | ModelPreset<'anthropic'> | ModelPreset<'bedrock'>
-> = {
-    // OpenAI models
-    'gpt-5.1-2025-11-13': {
-        provider: 'openai',
-        modelId: 'gpt-5.1-2025-11-13',
-        displayName: 'GPT-5.1',
-        description: 'Intelligent reasoning model',
-        supportsReasoning: true,
-        callOptions: { temperature: 0.2 },
-        providerOptions: {
-            strictJsonSchema: true,
-            parallelToolCalls: false,
+export const MODEL_PRESETS: {
+    openai: ModelPreset<'openai'>[];
+    anthropic: ModelPreset<'anthropic'>[];
+    bedrock: ModelPreset<'bedrock'>[];
+} = {
+    openai: [
+        {
+            name: 'gpt-5.1',
+            provider: 'openai',
+            modelId: 'gpt-5.1-2025-11-13',
+            displayName: 'GPT-5.1',
+            description: 'Intelligent reasoning model',
+            supportsReasoning: true,
+            callOptions: { temperature: 0.2 },
+            providerOptions: {
+                strictJsonSchema: true,
+                parallelToolCalls: false,
+            },
         },
-    },
-    'gpt-4.1-2025-04-14': {
-        provider: 'openai',
-        modelId: 'gpt-4.1-2025-04-14',
-        displayName: 'GPT-4.1',
-        description: 'Smartest non-reasoning model',
-        supportsReasoning: false,
-        callOptions: { temperature: 0.2 },
-        providerOptions: {
-            strictJsonSchema: true,
-            parallelToolCalls: false,
+        {
+            name: 'gpt-4.1',
+            provider: 'openai',
+            modelId: 'gpt-4.1-2025-04-14',
+            displayName: 'GPT-4.1',
+            description: 'Smartest non-reasoning model',
+            supportsReasoning: false,
+            callOptions: { temperature: 0.2 },
+            providerOptions: {
+                strictJsonSchema: true,
+                parallelToolCalls: false,
+            },
         },
-    },
-
-    // Anthropic models
-    'claude-sonnet-4-5-20250929': {
-        provider: 'anthropic',
-        modelId: 'claude-sonnet-4-5-20250929',
-        displayName: 'Claude Sonnet 4.5',
-        description: 'Most capable model for daily tasks',
-        supportsReasoning: true,
-        callOptions: { temperature: 0.2 },
-        providerOptions: undefined,
-    },
-    // 'claude-opus-4-5-20251101': {
-    //     provider: 'anthropic',
-    //     modelId: 'claude-opus-4-5-20251101',
-    //     displayName: 'Claude Opus 4.5',
-    //     description: 'Most capable Anthropic model with reasoning',
-    //     supportsReasoning: true,
-    //     callOptions: { temperature: 0.2 },
-    //     providerOptions: undefined,
-    // },
-    'claude-haiku-4-5-20251001': {
-        provider: 'anthropic',
-        modelId: 'claude-haiku-4-5-20251001',
-        displayName: 'Claude Haiku 4.5',
-        description: 'Fastest model with near-frontier AI capabilities',
-        supportsReasoning: true,
-        callOptions: { temperature: 0.2 },
-        providerOptions: undefined,
-    },
-
-    // Bedrock models
-    'anthropic.claude-sonnet-4-5-20250929-v1:0': {
-        provider: 'bedrock',
-        modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
-        displayName: 'Claude Sonnet 4.5 (Bedrock)',
-        description: 'Most capable model for daily tasks',
-        supportsReasoning: true,
-        callOptions: { temperature: 0.2 },
-        providerOptions: undefined,
-    },
-    // 'anthropic.claude-opus-4-5-20251101-v1:0': {
-    //     provider: 'bedrock',
-    //     modelId: 'anthropic.claude-opus-4-5-20251101-v1:0',
-    //     displayName: 'Claude Opus 4.5 (Bedrock)',
-    //     description: 'Most capable model for daily tasks',
-    //     supportsReasoning: true,
-    //     callOptions: { temperature: 0.2 },
-    //     providerOptions: undefined,
-    // },
-    'anthropic.claude-haiku-4-5-20251001-v1:0': {
-        provider: 'bedrock',
-        modelId: 'anthropic.claude-haiku-4-5-20251001-v1:0',
-        displayName: 'Claude Haiku 4.5 (Bedrock)',
-        description: 'Fastest model with near-frontier AI capabilities',
-        supportsReasoning: true,
-        callOptions: { temperature: 0.2 },
-        providerOptions: undefined,
-    },
+    ],
+    anthropic: [
+        {
+            name: 'claude-sonnet-4-5',
+            provider: 'anthropic',
+            modelId: 'claude-sonnet-4-5-20250929',
+            displayName: 'Claude Sonnet 4.5',
+            description: 'Most capable model for daily tasks',
+            supportsReasoning: true,
+            callOptions: { temperature: 0.2 },
+            providerOptions: undefined,
+        },
+        // {
+        //     name: 'claude-opus-4-5',
+        //     provider: 'anthropic',
+        //     modelId: 'claude-opus-4-5-20251101',
+        //     displayName: 'Claude Opus 4.5',
+        //     description: 'Most capable Anthropic model with reasoning',
+        //     supportsReasoning: true,
+        //     callOptions: { temperature: 0.2 },
+        //     providerOptions: undefined,
+        // },
+        {
+            name: 'claude-haiku-4-5',
+            provider: 'anthropic',
+            modelId: 'claude-haiku-4-5-20251001',
+            displayName: 'Claude Haiku 4.5',
+            description: 'Fastest model with near-frontier AI capabilities',
+            supportsReasoning: true,
+            callOptions: { temperature: 0.2 },
+            providerOptions: undefined,
+        },
+        {
+            name: 'claude-sonnet-4',
+            provider: 'anthropic',
+            modelId: 'claude-sonnet-4-20250514',
+            displayName: 'Claude Sonnet 4',
+            description: 'Previous generation model with reasoning',
+            supportsReasoning: true,
+            callOptions: { temperature: 0.2 },
+            providerOptions: undefined,
+        },
+    ],
+    bedrock: [
+        {
+            name: 'claude-sonnet-4-5',
+            provider: 'bedrock',
+            modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+            displayName: 'Claude Sonnet 4.5',
+            description: 'Most capable model for daily tasks',
+            supportsReasoning: true,
+            callOptions: { temperature: 0.2 },
+            providerOptions: undefined,
+        },
+        // {
+        //     name: 'claude-opus-4-5',
+        //     provider: 'bedrock',
+        //     modelId: 'anthropic.claude-opus-4-5-20251101-v1:0',
+        //     displayName: 'Claude Opus 4.5',
+        //     description: 'Most capable model for daily tasks',
+        //     supportsReasoning: true,
+        //     callOptions: { temperature: 0.2 },
+        //     providerOptions: undefined,
+        // },
+        {
+            name: 'claude-haiku-4-5',
+            provider: 'bedrock',
+            modelId: 'anthropic.claude-haiku-4-5-20251001-v1:0',
+            displayName: 'Claude Haiku 4.5',
+            description: 'Fastest model with near-frontier AI capabilities',
+            supportsReasoning: true,
+            callOptions: { temperature: 0.2 },
+            providerOptions: undefined,
+        },
+        {
+            name: 'claude-sonnet-4',
+            provider: 'bedrock',
+            modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+            displayName: 'Claude Sonnet 4',
+            description: 'Previous generation model with reasoning',
+            supportsReasoning: true,
+            callOptions: { temperature: 0.2 },
+            providerOptions: undefined,
+        },
+    ],
 };
 
-export type ModelPresetId = keyof typeof MODEL_PRESETS;
+export function matchesPreset(
+    preset: ModelPreset<ModelPresetProvider>,
+    name: string,
+): boolean {
+    return preset.name === name || preset.modelId === name;
+}
+
+export function getModelPreset<T extends ModelPresetProvider>(
+    provider: T,
+    name: string,
+): ModelPreset<T> | null {
+    return (
+        (MODEL_PRESETS[provider].find((p) => matchesPreset(p, name)) as
+            | ModelPreset<T>
+            | undefined) ?? null
+    );
+}
+
+export type ModelProvider = keyof typeof MODEL_PRESETS;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5938,7 +5938,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AIModelOption: {
+    AiModelOption: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -5948,20 +5948,20 @@ const models: TsoaRoute.Models = {
                 provider: { dataType: 'string', required: true },
                 description: { dataType: 'string', required: true },
                 displayName: { dataType: 'string', required: true },
-                id: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
             },
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess_AIModelOption-Array_': {
+    'ApiSuccess_AiModelOption-Array_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 results: {
                     dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'AIModelOption' },
+                    array: { dataType: 'refAlias', ref: 'AiModelOption' },
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
@@ -5972,7 +5972,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAiAgentModelOptionsResponse: {
         dataType: 'refAlias',
-        type: { ref: 'ApiSuccess_AIModelOption-Array_', validators: {} },
+        type: { ref: 'ApiSuccess_AiModelOption-Array_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ReadinessScoreEvaluation: {
@@ -7451,7 +7451,10 @@ const models: TsoaRoute.Models = {
                                     dataType: 'string',
                                     required: true,
                                 },
-                                modelId: { dataType: 'string', required: true },
+                                modelName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
                             },
                         },
                         { dataType: 'enum', enums: [null] },
@@ -7629,7 +7632,7 @@ const models: TsoaRoute.Models = {
                     nestedProperties: {
                         reasoning: { dataType: 'boolean' },
                         modelProvider: { dataType: 'string', required: true },
-                        modelId: { dataType: 'string', required: true },
+                        modelName: { dataType: 'string', required: true },
                     },
                 },
                 prompt: { dataType: 'string' },
@@ -7671,7 +7674,7 @@ const models: TsoaRoute.Models = {
                     nestedProperties: {
                         reasoning: { dataType: 'boolean' },
                         modelProvider: { dataType: 'string', required: true },
-                        modelId: { dataType: 'string', required: true },
+                        modelName: { dataType: 'string', required: true },
                     },
                 },
                 prompt: { dataType: 'string', required: true },
@@ -16576,7 +16579,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -16586,7 +16589,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -16596,7 +16599,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -16609,7 +16612,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6742,7 +6742,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "AIModelOption": {
+            "AiModelOption": {
                 "properties": {
                     "supportsReasoning": {
                         "type": "boolean"
@@ -6759,7 +6759,7 @@
                     "displayName": {
                         "type": "string"
                     },
-                    "id": {
+                    "name": {
                         "type": "string"
                     }
                 },
@@ -6769,15 +6769,15 @@
                     "provider",
                     "description",
                     "displayName",
-                    "id"
+                    "name"
                 ],
                 "type": "object"
             },
-            "ApiSuccess_AIModelOption-Array_": {
+            "ApiSuccess_AiModelOption-Array_": {
                 "properties": {
                     "results": {
                         "items": {
-                            "$ref": "#/components/schemas/AIModelOption"
+                            "$ref": "#/components/schemas/AiModelOption"
                         },
                         "type": "array"
                     },
@@ -6791,7 +6791,7 @@
                 "type": "object"
             },
             "ApiAiAgentModelOptionsResponse": {
-                "$ref": "#/components/schemas/ApiSuccess_AIModelOption-Array_"
+                "$ref": "#/components/schemas/ApiSuccess_AiModelOption-Array_"
             },
             "ReadinessScoreEvaluation": {
                 "properties": {
@@ -7884,11 +7884,11 @@
                             "modelProvider": {
                                 "type": "string"
                             },
-                            "modelId": {
+                            "modelName": {
                                 "type": "string"
                             }
                         },
-                        "required": ["modelProvider", "modelId"],
+                        "required": ["modelProvider", "modelName"],
                         "type": "object",
                         "nullable": true
                     },
@@ -8048,11 +8048,11 @@
                             "modelProvider": {
                                 "type": "string"
                             },
-                            "modelId": {
+                            "modelName": {
                                 "type": "string"
                             }
                         },
-                        "required": ["modelProvider", "modelId"],
+                        "required": ["modelProvider", "modelName"],
                         "type": "object"
                     },
                     "prompt": {
@@ -8088,11 +8088,11 @@
                             "modelProvider": {
                                 "type": "string"
                             },
-                            "modelId": {
+                            "modelName": {
                                 "type": "string"
                             }
                         },
-                        "required": ["modelProvider", "modelId"],
+                        "required": ["modelProvider", "modelName"],
                         "type": "object"
                     },
                     "prompt": {
@@ -17383,22 +17383,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiChartAsCodeListResponse": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -169,7 +169,7 @@ export type AiAgentMessageAssistant = {
     artifacts: AiAgentMessageAssistantArtifact[] | null;
     referencedArtifacts: AiAgentMessageAssistantArtifact[] | null;
     modelConfig: {
-        modelId: string;
+        modelName: string;
         modelProvider: string;
         reasoning?: boolean;
     } | null;
@@ -266,7 +266,7 @@ export type ApiAiAgentThreadResponse = {
 export type ApiAiAgentThreadCreateRequest = {
     prompt?: string;
     modelConfig?: {
-        modelId: string;
+        modelName: string;
         modelProvider: string;
         reasoning?: boolean;
     };
@@ -277,7 +277,7 @@ export type ApiAiAgentThreadCreateResponse = ApiSuccess<AiAgentThreadSummary>;
 export type ApiAiAgentThreadMessageCreateRequest = {
     prompt: string;
     modelConfig?: {
-        modelId: string;
+        modelName: string;
         modelProvider: string;
         reasoning?: boolean;
     };
@@ -623,8 +623,8 @@ export type AiAgentWithContext = AiAgentSummary & {
     context: AgentSummaryContext;
 };
 
-export type AIModelOption = {
-    id: string;
+export type AiModelOption = {
+    name: string;
     displayName: string;
     description: string;
     provider: string;
@@ -632,4 +632,4 @@ export type AIModelOption = {
     supportsReasoning: boolean;
 };
 
-export type ApiAiAgentModelOptionsResponse = ApiSuccess<AIModelOption[]>;
+export type ApiAiAgentModelOptionsResponse = ApiSuccess<AiModelOption[]>;

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -39,7 +39,7 @@ export type AiPrompt = {
     response: string | null;
     humanScore: number | null;
     modelConfig: {
-        modelId: string;
+        modelName: string;
         modelProvider: string;
         reasoning?: boolean;
     } | null;
@@ -74,7 +74,7 @@ export type CreateWebAppPrompt = {
     createdByUserUuid: string;
     prompt: string;
     modelConfig?: {
-        modelId: string;
+        modelName: string;
         modelProvider: string;
         reasoning?: boolean;
     };

--- a/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
+++ b/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import type { AIModelOption } from '@lightdash/common';
+import type { AiModelOption } from '@lightdash/common';
 import {
     Button,
     Menu,
@@ -12,7 +12,7 @@ import { useMemo, type FC } from 'react';
 import MantineIcon from '../MantineIcon';
 
 interface Props extends Omit<ButtonProps, 'value' | 'onChange'> {
-    models: AIModelOption[];
+    models: AiModelOption[];
     value: string | null;
     onChange: (modelId: string) => void;
 }
@@ -24,12 +24,12 @@ export const ModelSelector: FC<Props> = ({
     ...buttonProps
 }) => {
     const selectedModel = useMemo(
-        () => models.find((m) => m.id === value),
+        () => models.find((m) => m.name === value),
         [models, value],
     );
 
     const groupedModels = useMemo(() => {
-        const groups = new Map<string, AIModelOption[]>();
+        const groups = new Map<string, AiModelOption[]>();
         models.forEach((model) => {
             const existing = groups.get(model.provider) ?? [];
             groups.set(model.provider, [...existing, model]);
@@ -84,11 +84,11 @@ export const ModelSelector: FC<Props> = ({
                             )}
 
                             {providerModels.map((model) => {
-                                const isSelected = model.id === value;
+                                const isSelected = model.name === value;
                                 return (
                                     <Menu.Item
-                                        key={model.id}
-                                        onClick={() => onChange(model.id)}
+                                        key={model.name}
+                                        onClick={() => onChange(model.name)}
                                         rightSection={
                                             isSelected ? (
                                                 <MantineIcon

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -1,4 +1,4 @@
-import type { AIModelOption } from '@lightdash/common';
+import type { AiModelOption } from '@lightdash/common';
 import {
     ActionIcon,
     alpha,
@@ -29,7 +29,7 @@ interface AgentChatInputProps {
     messageCount?: number;
     projectUuid?: string;
     agentUuid?: string;
-    models?: AIModelOption[];
+    models?: AiModelOption[];
     selectedModelId?: string | null;
     onModelChange?: (modelId: string) => void;
     extendedThinking?: boolean;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageModelIndicator.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageModelIndicator.tsx
@@ -5,7 +5,7 @@ import { useModelOptions } from '../../hooks/useModelOptions';
 interface Props {
     projectUuid: string;
     agentUuid: string;
-    modelConfig: { modelId: string; modelProvider: string } | null;
+    modelConfig: { modelName: string; modelProvider: string } | null;
 }
 
 export const MessageModelIndicator: FC<Props> = ({
@@ -21,7 +21,9 @@ export const MessageModelIndicator: FC<Props> = ({
     const modelDisplayName = useMemo(() => {
         if (!modelConfig || !modelOptions) return null;
 
-        const model = modelOptions.find((m) => m.id === modelConfig.modelId);
+        const model = modelOptions.find(
+            (m) => m.name === modelConfig.modelName,
+        );
         return model?.displayName ?? null;
     }, [modelConfig, modelOptions]);
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useModelOptions.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useModelOptions.ts
@@ -1,5 +1,5 @@
 import type {
-    AIModelOption,
+    AiModelOption,
     ApiAiAgentModelOptionsResponse,
     ApiError,
 } from '@lightdash/common';
@@ -22,7 +22,7 @@ const getModelOptions = async (
 type UseModelOptionsProps = {
     projectUuid: string | undefined;
     agentUuid: string | undefined;
-    options?: UseQueryOptions<AIModelOption[], ApiError>;
+    options?: UseQueryOptions<AiModelOption[], ApiError>;
 };
 
 export const useModelOptions = ({
@@ -30,7 +30,7 @@ export const useModelOptions = ({
     agentUuid,
     options,
 }: UseModelOptionsProps) => {
-    return useQuery<AIModelOption[], ApiError>({
+    return useQuery<AiModelOption[], ApiError>({
         queryKey: [MODEL_OPTIONS_KEY, projectUuid, agentUuid],
         queryFn: () => getModelOptions(projectUuid!, agentUuid!),
         ...options,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -485,14 +485,7 @@ export const useCreateAgentThreadMutation = (
     >({
         mutationFn: (data) =>
             agentUuid
-                ? createAgentThread(projectUuid, agentUuid, {
-                      ...data,
-                      //   TODO :: pass model config from the UI
-                      //   modelConfig: {
-                      //       modelId: 'gpt-5.1-2025-11-13',
-                      //       modelProvider: 'openai',
-                      //   },
-                  })
+                ? createAgentThread(projectUuid, agentUuid, data)
                 : Promise.reject(),
         onSuccess: async (thread) => {
             // Invalidate both user-specific and all-users thread queries

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -42,7 +42,7 @@ const AiAgentNewThreadPage: FC = () => {
     const handleSelectedModelIdChange = useCallback(
         (modelId: string) => {
             setSelectedModelId(modelId);
-            const selectedModel = modelOptions?.find((m) => m.id === modelId);
+            const selectedModel = modelOptions?.find((m) => m.name === modelId);
             if (selectedModel && !selectedModel.supportsReasoning) {
                 setExtendedThinking(false);
             }
@@ -55,14 +55,14 @@ const AiAgentNewThreadPage: FC = () => {
         if (modelOptions && !selectedModelId) {
             const defaultModel = modelOptions.find((m) => m.default);
             if (defaultModel) {
-                handleSelectedModelIdChange(defaultModel.id);
+                handleSelectedModelIdChange(defaultModel.name);
             }
         }
     }, [modelOptions, selectedModelId, handleSelectedModelIdChange]);
 
     // Only enable extended thinking toggle when selected model supports reasoning
     const selectedModel = useMemo(
-        () => modelOptions?.find((m) => m.id === selectedModelId),
+        () => modelOptions?.find((m) => m.name === selectedModelId),
         [modelOptions, selectedModelId],
     );
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
@@ -73,7 +73,7 @@ const AiAgentNewThreadPage: FC = () => {
                 prompt,
                 modelConfig: selectedModel
                     ? {
-                          modelId: selectedModel.id,
+                          modelName: selectedModel.name,
                           modelProvider: selectedModel.provider,
                           reasoning: showExtendedThinking
                               ? extendedThinking


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Simplifies AI model naming conventions by removing version dates from model identifiers. This PR:

- Updates default model names to use simpler formats (e.g., `gpt-4.1` instead of `gpt-4.1-2025-04-14`)
- Refactors model configuration to use `modelName` instead of `modelId` for consistency
- Restructures model presets to be organized by provider
- Adds a `matchesPreset` utility function to handle model name matching
- Updates frontend components to work with the new model naming convention
