### PR TITLE
fix: adjust border color for dark mode in grid items

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -56,7 +56,10 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
                     flexGrow: 1,
                     borderBottomWidth: 1,
                     borderBottomStyle: 'solid',
-                    borderBottomColor: t.colors.ldGray[3],
+                    borderBottomColor:
+                        t.colorScheme === 'dark'
+                            ? t.colors.ldGray[1]
+                            : t.colors.ldGray[3],
                 })}
             >
                 {dragIcon}

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -56,7 +56,10 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
                     flexGrow: 1,
                     borderBottomWidth: 1,
                     borderBottomStyle: 'solid',
-                    borderBottomColor: t.colors.ldGray[3],
+                    borderBottomColor:
+                        t.colorScheme === 'dark'
+                            ? t.colors.ldGray[1]
+                            : t.colors.ldGray[3],
                 })}
             >
                 {dragIcon}


### PR DESCRIPTION
### Description:
Improved dark mode support for ResourceViewGrid components by adjusting the border color based on the color scheme. In dark mode, the border now uses `ldGray[1]` instead of `ldGray[3]` for better contrast and visibility.