### PR TITLE
feat: allow smaller dashboard tile widths

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/gridUtils.ts
+++ b/packages/frontend/src/components/DashboardTabs/gridUtils.ts
@@ -26,7 +26,7 @@ export const getReactGridLayoutConfig = (
 
     return {
         minH: 1,
-        minW: 6,
+        minW: 4,
         x: tile.x * scaleFactor,
         y: tile.y,
         w: tile.w * scaleFactor,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/18225

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Reduces the minimum Dashboard tile width from 6 to 4 to allow tables of MD tiles. 

### Before
<img width="1507" height="700" alt="Screen Shot 2025-12-05 at 2 32 05 PM" src="https://github.com/user-attachments/assets/98fb60ad-5e11-495e-b55b-6c3b13b0040b" />


### After
<img width="1509" height="623" alt="Screen Shot 2025-12-05 at 2 29 58 PM" src="https://github.com/user-attachments/assets/b6fdfa05-b71f-4555-aa7f-3224bec568a5" />

