### PR TITLE
fix: skip table calculation references in variable pattern replacement

### DIFF
--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -799,6 +799,12 @@ const explorerSlice = createSlice({
             state.unsavedChartVersion.metricQuery.filters = newFilters;
 
             // Update tableCalculations SQL references
+            const tableCalcNames = new Set(
+                state.unsavedChartVersion.metricQuery.tableCalculations.map(
+                    (tc) => tc.name,
+                ),
+            );
+
             state.unsavedChartVersion.metricQuery.tableCalculations =
                 state.unsavedChartVersion.metricQuery.tableCalculations.map(
                     (tableCalculation) => {
@@ -809,6 +815,11 @@ const explorerSlice = createSlice({
                         const newSql = tableCalculation.sql.replace(
                             lightdashVariablePattern,
                             (_, fieldRef) => {
+                                // Skip table calculation references - they're valid without table prefix
+                                if (tableCalcNames.has(fieldRef)) {
+                                    return `\${${fieldRef}}`;
+                                }
+
                                 const fieldId =
                                     convertFieldRefToFieldId(fieldRef);
                                 if (fieldId === previousAdditionalMetricName) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18612

### Description:
Fix table calculation references in SQL expressions by skipping table calculation names when updating SQL references. This prevents table calculation references from being incorrectly modified when they don't need a table prefix.

The change adds a check to identify table calculation names and preserve their references in the format `${name}` without attempting to add table prefixes to them.

Matching the backend behaviour:
https://github.com/lightdash/lightdash/blob/eaf4aa1f7a39f63270c3c66b567f28a0ef232c2b/packages/backend/src/queryCompiler.ts#L102-L111 