### PR TITLE
fix: add ErrorBoundary to AiChartToolCalls and handle null searchQueries

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiChartToolCalls.tsx
@@ -6,6 +6,7 @@ import {
 import { Paper, Stack, Text, Timeline } from '@mantine-8/core';
 import { type FC } from 'react';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
+import ErrorBoundary from '../../../../../../features/errorBoundary/ErrorBoundary';
 import { ToolCallDescription } from './descriptions/ToolCallDescription';
 import { ImproveContextToolCall } from './ImproveContextToolCall';
 import { ToolCallContainer } from './ToolCallContainer';
@@ -46,7 +47,7 @@ export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({
     const { title, icon } = getContainerMetadata(calculationToolCalls, type);
 
     return (
-        <>
+        <ErrorBoundary>
             {projectUuid && agentUuid && threadUuid && (
                 <ImproveContextToolCall
                     projectUuid={projectUuid}
@@ -122,6 +123,6 @@ export const AiChartToolCalls: FC<AiChartToolCallsProps> = ({
                     </Stack>
                 </ToolCallContainer>
             )}
-        </>
+        </ErrorBoundary>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/FieldSearchToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/FieldSearchToolCallDescription.tsx
@@ -12,7 +12,7 @@ export const FieldSearchToolCallDescription: FC<
     return (
         <Text c="dimmed" size="xs">
             Searched for fields{' '}
-            {searchQueries.map((query) => (
+            {searchQueries?.map((query) => (
                 <Badge
                     key={query.label}
                     color="gray"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18615

### Description:

Added error boundary to AiChartToolCalls component to prevent the entire application from crashing if there's an error in the chart rendering. Also fixed a potential null reference error in FieldSearchToolCallDescription by adding a null check before mapping over searchQueries.
