### PR TITLE
fix: ai search box dark mode compat

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -169,7 +169,7 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                                         />
                                         <Text
                                             size="sm"
-                                            c="ldDark.7"
+                                            c="foreground"
                                             flex="1"
                                             mt={2}
                                         >
@@ -181,7 +181,7 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                                             <Text
                                                 component="span"
                                                 fw={600}
-                                                c="ldDark.7"
+                                                c="ldDark.9"
                                             >
                                                 "{form.values.prompt.trim()}"
                                             </Text>
@@ -193,7 +193,7 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                                             <MantineIcon
                                                 icon={IconCornerDownLeft}
                                                 size={16}
-                                                color="ldGray.5"
+                                                color="violet.4"
                                             />
                                         </Box>
                                     </PolymorphicGroupButton>

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.module.css
@@ -27,6 +27,10 @@
 .comboboxOption[data-combobox-selected] > div {
     background-color: var(--mantine-color-ldGray-0);
     color: inherit;
+
+    @mixin dark {
+        background-color: var(--mantine-color-dark-7);
+    }
 }
 
 .comboboxHeader {

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
@@ -1,30 +1,37 @@
 .askAiSection {
     --saturation-mix: 0%;
+    --gradient-from: color-mix(
+        in oklch,
+        var(--mantine-color-violet-0),
+        var(--mantine-color-violet-1) var(--saturation-mix)
+    );
+    --gradient-to: color-mix(
+        in oklch,
+        var(--mantine-color-indigo-0),
+        var(--mantine-color-indigo-1) var(--saturation-mix)
+    );
 
     background: linear-gradient(
         90deg,
-        color-mix(
-                in oklch,
-                var(--mantine-color-grape-0),
-                var(--mantine-color-grape-1) var(--saturation-mix)
-            )
-            0%,
-        color-mix(
-                in oklch,
-                var(--mantine-color-violet-0),
-                var(--mantine-color-violet-1) var(--saturation-mix)
-            )
-            40%,
-        color-mix(
-                in oklch,
-                var(--mantine-color-indigo-0),
-                var(--mantine-color-indigo-1) var(--saturation-mix)
-            )
-            100%
+        var(--gradient-from) 0%,
+        var(--gradient-to) 100%
     );
 
     width: 100%;
     cursor: pointer;
+
+    @mixin dark {
+        --gradient-from: color-mix(
+            in oklch,
+            var(--mantine-color-violet-light),
+            var(--mantine-color-violet-light-hover)
+        );
+        --gradient-to: color-mix(
+            in oklch,
+            var(--mantine-color-indigo-light),
+            var(--mantine-color-indigo-light-hover)
+        );
+    }
 }
 
 [data-combobox-selected='true'] .askAiSection {
@@ -37,6 +44,11 @@
     border-radius: var(--mantine-radius-sm);
     border: 1px solid var(--mantine-color-ldGray-2);
     flex-shrink: 0;
+
+    @mixin dark {
+        background-color: var(--mantine-color-violet-light);
+        border-color: var(--mantine-color-violet-light);
+    }
 }
 
 [data-combobox-selected='true'] .askAiSectionArrow {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18620

### Description:
Enhances the AI Search Box UI with improved color contrast and dark mode support. Updates text colors for better readability, changes the arrow icon color to violet for better visibility, and adds dark mode styling for the search dropdown and AI section background gradient.

![CleanShot 2025-12-05 at 15.51.54.png](https://app.graphite.com/user-attachments/assets/88589dc5-e2fd-4995-8263-cc0aa69b8334.png)

![CleanShot 2025-12-05 at 15.52.12.png](https://app.graphite.com/user-attachments/assets/d7cfab11-6b79-40dc-8c85-6b658bf6b235.png)

![CleanShot 2025-12-05 at 15.52.33.png](https://app.graphite.com/user-attachments/assets/7cfca36e-8618-48d0-b81a-f2fe83f4eabe.png)

