### PR TITLE
fix: Optimize get all projects in backend

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -18359,7 +18359,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                requireUserCredentials: { dataType: 'boolean' },
                 warehouseType: { ref: 'WarehouseTypes' },
                 upstreamProjectUuid: {
                     dataType: 'union',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -19072,9 +19072,6 @@
             },
             "OrganizationProject": {
                 "properties": {
-                    "requireUserCredentials": {
-                        "type": "boolean"
-                    },
                     "warehouseType": {
                         "$ref": "#/components/schemas/WarehouseTypes"
                     },
@@ -23401,7 +23398,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2236.2",
+        "version": "0.2242.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -323,7 +323,6 @@ export class ProjectModel {
                 `projects.copied_from_project_uuid`,
                 `projects.created_by_user_uuid`,
                 `${WarehouseCredentialTableName}.warehouse_type`,
-                `${WarehouseCredentialTableName}.encrypted_credentials`,
                 this.database.raw(
                     '(agg_project_group_access_counts.member_count + agg_project_membership_counts.member_count) as member_count',
                 ),
@@ -359,37 +358,18 @@ export class ProjectModel {
                 created_by_user_uuid,
                 copied_from_project_uuid,
                 warehouse_type,
-                encrypted_credentials,
-            }) => {
-                try {
-                    const warehouseCredentials =
-                        encrypted_credentials !== null
-                            ? (JSON.parse(
-                                  this.encryptionUtil.decrypt(
-                                      encrypted_credentials,
-                                  ),
-                              ) as CreateWarehouseCredentials)
-                            : undefined;
-                    return {
-                        name,
-                        projectUuid: project_uuid,
-                        type: project_type,
-                        createdByUserUuid: created_by_user_uuid,
-                        createdAt: created_at,
-                        upstreamProjectUuid: copied_from_project_uuid,
-                        warehouseType:
-                            warehouse_type !== null
-                                ? (warehouse_type as WarehouseTypes)
-                                : undefined,
-                        requireUserCredentials:
-                            !!warehouseCredentials?.requireUserCredentials,
-                    };
-                } catch (e) {
-                    throw new UnexpectedServerError(
-                        'Unexpected error: failed to parse warehouse credentials',
-                    );
-                }
-            },
+            }) => ({
+                name,
+                projectUuid: project_uuid,
+                type: project_type,
+                createdByUserUuid: created_by_user_uuid,
+                createdAt: created_at,
+                upstreamProjectUuid: copied_from_project_uuid,
+                warehouseType:
+                    warehouse_type !== null
+                        ? (warehouse_type as WarehouseTypes)
+                        : undefined,
+            }),
         );
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -335,7 +335,6 @@ export const defaultProject: OrganizationProject = {
     createdAt: new Date('2024-01-01T00:00:00Z'),
     upstreamProjectUuid: null,
     warehouseType: WarehouseTypes.POSTGRES,
-    requireUserCredentials: false,
 };
 
 export const spacesWithSavedCharts: Space[] = [

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -69,7 +69,6 @@ export type OrganizationProject = {
     createdAt: Date;
     upstreamProjectUuid: string | null;
     warehouseType?: WarehouseTypes;
-    requireUserCredentials?: boolean;
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


Removed requireUserCredentials from OrganizationProject to eliminate the need to decrypt
  credentials for all N projects when listing them.

  Changes Made:

  1. packages/common/src/types/organization.ts
    - Removed requireUserCredentials?: boolean from OrganizationProject type
  2. packages/backend/src/models/ProjectModel/ProjectModel.ts
    - Removed encrypted_credentials from the SELECT query
    - Removed the entire decryption loop that was calling this.encryptionUtil.decrypt() for every
  project
    - Simplified the mapping function
  3. packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
    - Changed from useProjects() to useProject(activeProjectUuid)
    - Now gets requireUserCredentials from activeProject?.warehouseConnection?.requireUserCredentials
    - Gets warehouseType from activeProject?.warehouseConnection?.type

  Performance Impact:

  | Before                              | After                            |
  |-------------------------------------|----------------------------------|
  | Decrypt N credentials per request | No decryption needed for listing |
  | O(n) crypto operations              | O(1) - only for active project   |

  The useProject hook fetches project details only for the active project, and that data is likely
  already cached from other parts of the app that need it.


### Description:
This PR fixes the order of enum values in API response schemas, ensuring that 'error' comes before 'success' consistently. It also reorders property definitions in several nested objects, placing 'fieldType' before 'tableName' and 'searchRank' before 'joinedTables'.

Additionally, the PR removes the 'requireUserCredentials' property from the OrganizationProject type and updates the UserCredentialsSwitcher component to use the warehouseConnection data from the active project instead of relying on the deprecated property.

The PR also updates the dashboard schema definitions to correctly order properties in tile configurations, ensuring 'chartName' comes before 'title' in the appropriate contexts.