### PR TITLE
fix: Optimize get all projects in frontend

### DIFF
--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -10,7 +10,7 @@ import { memo, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { useActiveProjectUuid } from '../../hooks/useActiveProject';
-import { useProjects } from '../../hooks/useProjects';
+import { useProject } from '../../hooks/useProject';
 import { getMantineThemeOverride } from '../../mantineTheme';
 import useFullscreen from '../../providers/Fullscreen/useFullscreen';
 import { BANNER_HEIGHT, NAVBAR_HEIGHT } from '../common/Page/constants';
@@ -41,9 +41,6 @@ const useNavBarMode = () => {
 
 const NavBar = memo(() => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { data: projects } = useProjects();
-    const { activeProjectUuid, isLoading: isLoadingActiveProject } =
-        useActiveProjectUuid({ refetchOnMount: true });
     const { isFullscreen } = useFullscreen();
 
     const { navBarMode } = useNavBarMode();
@@ -54,12 +51,12 @@ const NavBar = memo(() => {
         const { globalStyles, ...themeWithoutGlobalStyles } = fullDarkTheme;
         return themeWithoutGlobalStyles;
     }, []);
+    const { activeProjectUuid, isLoading: isLoadingActiveProject } =
+        useActiveProjectUuid({ refetchOnMount: true });
 
-    const isCurrentProjectPreview = !!projects?.find(
-        (project) =>
-            project.projectUuid === activeProjectUuid &&
-            project.type === ProjectType.PREVIEW,
-    );
+    const { data: project } = useProject(activeProjectUuid);
+
+    const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
 
     const getHeaderStyles = useCallback(
         (theme: MantineTheme) => ({

--- a/packages/frontend/src/components/ProjectRoute.tsx
+++ b/packages/frontend/src/components/ProjectRoute.tsx
@@ -2,7 +2,8 @@ import { subject } from '@casl/ability';
 import React, { type FC } from 'react';
 import { Navigate, useParams } from 'react-router';
 import ErrorState from '../components/common/ErrorState';
-import { useProjects } from '../hooks/useProjects';
+import { useActiveProjectUuid } from '../hooks/useActiveProject';
+import { useProject } from '../hooks/useProject';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import PageSpinner from './PageSpinner';
@@ -10,8 +11,10 @@ import PageSpinner from './PageSpinner';
 const ProjectRoute: FC<React.PropsWithChildren> = ({ children }) => {
     const { user } = useApp();
     const { projectUuid } = useParams();
-    const { data: projects, isInitialLoading, isError, error } = useProjects();
+    const { activeProjectUuid, isLoading: isInitialLoading } =
+        useActiveProjectUuid({ refetchOnMount: true });
 
+    const { data: project, isError, error } = useProject(activeProjectUuid);
     if (isInitialLoading) {
         return <PageSpinner />;
     }
@@ -20,7 +23,7 @@ const ProjectRoute: FC<React.PropsWithChildren> = ({ children }) => {
         return <ErrorState error={error.error} />;
     }
 
-    if (!projects || projects.length <= 0) {
+    if (!project) {
         return <Navigate to="/no-access" />;
     }
 

--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -4,7 +4,7 @@ import { useDisclosure, useElementSize } from '@mantine/hooks';
 import { type FC } from 'react';
 import ErrorBoundary from '../../../features/errorBoundary/ErrorBoundary';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
-import { useProjects } from '../../../hooks/useProjects';
+import { useProject } from '../../../hooks/useProject';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import AboutFooter from '../../AboutFooter';
@@ -234,16 +234,9 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
         refetchOnMount: true,
         enabled: withNavbar,
     } as AnyType);
-    const { data: projects } = useProjects({
-        enabled: withNavbar,
-    });
-    const isCurrentProjectPreview =
-        withNavbar &&
-        !!projects?.find(
-            (project) =>
-                project.projectUuid === activeProjectUuid &&
-                project.type === ProjectType.PREVIEW,
-        );
+    const { data: project } = useProject(activeProjectUuid);
+
+    const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
 
     const { classes } = usePageStyles(
         {

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRedirect.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRedirect.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Navigate } from 'react-router';
 import PageSpinner from '../../../components/PageSpinner';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { useDefaultProject } from '../../../hooks/useProjects';
+import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 
 /**
@@ -10,11 +10,11 @@ import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentP
  * This page will redirect them to their default project ai-agents welcome page.
  */
 const AgentsRedirect = () => {
-    const { data, isLoading } = useDefaultProject();
+    const { activeProjectUuid, isLoading } = useActiveProjectUuid();
     const { showToastInfo } = useToaster();
     const canViewAiAgents = useAiAgentPermission({
         action: 'view',
-        projectUuid: data?.projectUuid,
+        projectUuid: activeProjectUuid,
     });
 
     useEffect(() => {
@@ -29,9 +29,9 @@ const AgentsRedirect = () => {
         return <PageSpinner />;
     }
 
-    if (canViewAiAgents && data) {
+    if (canViewAiAgents && activeProjectUuid) {
         return (
-            <Navigate to={`/projects/${data.projectUuid}/ai-agents`} replace />
+            <Navigate to={`/projects/${activeProjectUuid}/ai-agents`} replace />
         );
     }
 

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -1,3 +1,4 @@
+import { ProjectType } from '@lightdash/common';
 import {
     useMutation,
     useQuery,
@@ -6,7 +7,9 @@ import {
 } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useParams } from 'react-router';
-import { useDefaultProject, useProjects } from './useProjects';
+import { useOrganization } from './organization/useOrganization';
+import { useProject } from './useProject';
+import { useProjects } from './useProjects';
 
 const LAST_PROJECT_KEY = 'lastProject';
 
@@ -59,51 +62,95 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
     refetchOnMount: boolean;
 }) => {
     const params = useParams<{ projectUuid?: string }>();
-    const { data: projects, isInitialLoading: isLoadingProjects } =
-        useProjects(useQueryFetchOptions);
-    const { data: defaultProject, isLoading: isLoadingDefaultProject } =
-        useDefaultProject(useQueryFetchOptions);
-    const { data: lastProjectUuid, isInitialLoading: isLoadingLastProject } =
+    const { data: lastProjectUuid, isFetched: isLastProjectUuidFetched } =
         useActiveProject();
     const { mutate } = useUpdateActiveProjectMutation();
 
+    // Get organization to access defaultProjectUuid (lightweight call, usually cached)
+    const { data: organization, isInitialLoading: isLoadingOrg } =
+        useOrganization(useQueryFetchOptions);
+
+    // Priority 1: Project UUID from URL params
+    const { data: paramProject, isInitialLoading: isLoadingParamProject } =
+        useProject(params.projectUuid);
+
+    // Priority 2: Last used project from localStorage
+    // Only fetch if no param project and we have a lastProjectUuid
+    const shouldFetchLastProject = !params.projectUuid && !!lastProjectUuid;
+    const { data: lastProject, isInitialLoading: isLoadingLastProject } =
+        useProject(shouldFetchLastProject ? lastProjectUuid : undefined);
+
+    // Priority 3: Organization's default project
+    // Only fetch if no param project, no last project, and org has a default
+    const shouldFetchDefaultProject =
+        !params.projectUuid &&
+        isLastProjectUuidFetched &&
+        !lastProjectUuid &&
+        !!organization?.defaultProjectUuid;
+    const { data: defaultProject, isInitialLoading: isLoadingDefaultProject } =
+        useProject(
+            shouldFetchDefaultProject
+                ? organization?.defaultProjectUuid
+                : undefined,
+        );
+
+    // Priority 4: Fallback to any project (when org has no defaultProjectUuid)
+    // Only fetch projects list if we have no other option AND localStorage check is complete
+    const shouldFetchFallbackProjects =
+        !params.projectUuid &&
+        isLastProjectUuidFetched &&
+        !lastProjectUuid &&
+        !isLoadingOrg &&
+        !organization?.defaultProjectUuid;
+
+    const { data: projects, isInitialLoading: isLoadingProjects } = useProjects(
+        {
+            enabled: shouldFetchFallbackProjects,
+        },
+    );
+
+    // Find fallback project: first try ProjectType.DEFAULT, then first available
+    const fallbackProject = shouldFetchFallbackProjects
+        ? projects?.find(({ type }) => type === ProjectType.DEFAULT) ||
+          projects?.[0]
+        : undefined;
+
     const isLoading =
-        isLoadingProjects || isLoadingDefaultProject || isLoadingLastProject;
+        // Still loading if we haven't checked localStorage yet (unless we have URL param)
+        (!params.projectUuid && !isLastProjectUuidFetched) ||
+        isLoadingParamProject ||
+        (shouldFetchLastProject && isLoadingLastProject) ||
+        (shouldFetchDefaultProject && isLoadingDefaultProject) ||
+        (shouldFetchFallbackProjects && isLoadingProjects) ||
+        (!params.projectUuid && !lastProjectUuid && isLoadingOrg);
 
-    const paramProject = projects?.find(
-        (project) => project.projectUuid === params.projectUuid,
-    );
+    // Determine the active project UUID
+    const activeProjectUuid =
+        paramProject?.projectUuid ||
+        lastProject?.projectUuid ||
+        defaultProject?.projectUuid ||
+        fallbackProject?.projectUuid;
 
-    const lastProject = projects?.find(
-        (project) => project.projectUuid === lastProjectUuid,
-    );
-
+    // Update localStorage when we find an active project but don't have one stored
     useEffect(() => {
         const newValue =
-            paramProject?.projectUuid || defaultProject?.projectUuid;
-        if (!isLoading && !lastProject && newValue) {
+            paramProject?.projectUuid ||
+            defaultProject?.projectUuid ||
+            fallbackProject?.projectUuid;
+        if (!isLoading && !lastProjectUuid && newValue) {
             mutate(newValue);
         }
     }, [
         isLoading,
         defaultProject?.projectUuid,
-        lastProject,
+        fallbackProject?.projectUuid,
+        lastProjectUuid,
         mutate,
         paramProject?.projectUuid,
     ]);
 
-    if (isLoading) {
-        return {
-            isLoading: true,
-            activeProjectUuid: undefined,
-        };
-    }
-
     return {
-        isLoading: false,
-        activeProjectUuid:
-            paramProject?.projectUuid ||
-            lastProject?.projectUuid ||
-            defaultProject?.projectUuid,
+        isLoading,
+        activeProjectUuid: isLoading ? undefined : activeProjectUuid,
     };
 };

--- a/packages/frontend/src/hooks/useProjects.ts
+++ b/packages/frontend/src/hooks/useProjects.ts
@@ -1,8 +1,4 @@
-import {
-    ProjectType,
-    type ApiError,
-    type OrganizationProject,
-} from '@lightdash/common';
+import { type ApiError, type OrganizationProject } from '@lightdash/common';
 import {
     useMutation,
     useQuery,
@@ -10,7 +6,6 @@ import {
     type UseQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
-import { useOrganization } from './organization/useOrganization';
 import useToaster from './toaster/useToaster';
 
 const getProjectsQuery = async () =>
@@ -21,38 +16,12 @@ const getProjectsQuery = async () =>
 
 export const useProjects = (
     useQueryOptions?: UseQueryOptions<OrganizationProject[], ApiError>,
-) => {
-    return useQuery<OrganizationProject[], ApiError>({
+) =>
+    useQuery<OrganizationProject[], ApiError>({
         queryKey: ['projects'],
         queryFn: getProjectsQuery,
         ...useQueryOptions,
     });
-};
-
-export const useDefaultProject = (useQueryOptions?: {
-    refetchOnMount: boolean;
-}): {
-    isLoading: boolean;
-    data: OrganizationProject | undefined;
-} => {
-    const { isInitialLoading: isOrganizationLoading, data: org } =
-        useOrganization(useQueryOptions);
-    const { isInitialLoading: isLoadingProjects, data: projects = [] } =
-        useProjects(useQueryOptions);
-
-    const defaultProject = projects?.find(
-        (project) => project.projectUuid === org?.defaultProjectUuid,
-    );
-
-    const fallbackProject = projects?.find(
-        ({ type }) => type === ProjectType.DEFAULT,
-    );
-
-    return {
-        isLoading: isOrganizationLoading || isLoadingProjects,
-        data: defaultProject || fallbackProject || projects?.[0],
-    };
-};
 
 const deleteProjectQuery = async (id: string) =>
     lightdashApi<null>({

--- a/packages/frontend/src/pages/Projects.tsx
+++ b/packages/frontend/src/pages/Projects.tsx
@@ -1,25 +1,19 @@
 import { type FC } from 'react';
 import { Navigate } from 'react-router';
 import PageSpinner from '../components/PageSpinner';
-import ErrorState from '../components/common/ErrorState';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
-import { useProjects } from '../hooks/useProjects';
 
 const Projects: FC = () => {
-    const { isInitialLoading, data, error } = useProjects();
     const { isLoading: isActiveProjectLoading, activeProjectUuid } =
         useActiveProjectUuid();
 
-    if (!isInitialLoading && data && data.length === 0) {
+    // If loading is done and there's no active project, user has no projects
+    if (!isActiveProjectLoading && !activeProjectUuid) {
         return <Navigate to="/no-access" />;
     }
 
-    if (isInitialLoading || isActiveProjectLoading || !activeProjectUuid) {
+    if (isActiveProjectLoading || !activeProjectUuid) {
         return <PageSpinner />;
-    }
-
-    if (error && error.error) {
-        return <ErrorState error={error.error} />;
     }
 
     return <Navigate to={`/projects/${activeProjectUuid}/home`} />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Removes all unnecesari /projects calls on the endpoint, mainly in the navbar.

### Description:
Optimized project loading by implementing a more efficient data fetching strategy. Instead of loading all projects on every page, we now:

1. Added a dedicated `useProject` hook to fetch a single project by UUID
2. Only fetch all projects when the project switcher menu is opened
3. Show a loading state in the project switcher while projects are being fetched
4. Fetch only the active project for UI elements that need just the current project

This change significantly reduces unnecessary API calls and improves performance, especially for organizations with many projects.