### PR TITLE
feat: add runSavedChartQuery function to AI agent for chart data retrieval

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -88,6 +88,7 @@ const getAgentTools = (
 
     const findContent = getFindContent({
         findContent: dependencies.findContent,
+        runSavedChartQuery: dependencies.runSavedChartQuery,
         siteUrl: args.siteUrl,
     });
 

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -11,6 +11,7 @@ import {
     GetPromptFn,
     ListExploresFn,
     RunMiniMetricQueryFn,
+    RunSavedChartQueryFn,
     SearchFieldValuesFn,
     SendFileFn,
     StoreReasoningFn,
@@ -62,6 +63,7 @@ export type AiAgentDependencies = {
     findFields: FindFieldFn;
     getExploreCompiler: GetExploreCompilerFn;
     runMiniMetricQuery: RunMiniMetricQueryFn;
+    runSavedChartQuery: RunSavedChartQueryFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
     updatePrompt: UpdatePromptFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -153,3 +153,11 @@ export type CreateChangeFn = (
 ) => Promise<string>;
 
 export type GetExploreCompilerFn = () => Promise<ExploreCompiler>;
+
+export type RunSavedChartQueryFn = (args: {
+    chartUuid: string;
+    limit?: number | null;
+}) => Promise<{
+    rows: Record<string, unknown>[];
+    fields: ItemsMap;
+}>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added the ability for AI agents to run saved chart queries and include the results in the `findContent` tool response. This enhancement allows the AI to access actual chart data when searching for content, providing more context for answering user questions.

The implementation includes:

- A new `runSavedChartQuery` function that executes queries for saved charts
- Integration with the `findContent` tool to automatically run queries for the top 5 charts in search results
- A utility to convert query results to CSV format for inclusion in the AI response
- A static `pollAsyncQueryResults` method to handle async query polling with exponential backoff
