### PR TITLE
style: dark mode metrics explorer vis modal

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -375,7 +375,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             h={20}
                             sx={{
                                 alignSelf: 'center',
-                                borderColor: '#DEE2E6',
+                                borderColor: 'ldGray.3',
                             }}
                         />
                     )}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilter.tsx
@@ -223,6 +223,7 @@ export const MetricExploreFilter: FC<Props> = ({
                         placeholder="Filter by"
                         icon={<MantineIcon icon={IconFilter} />}
                         searchable
+                        withinPortal
                         radius="md"
                         size="xs"
                         data={
@@ -237,20 +238,23 @@ export const MetricExploreFilter: FC<Props> = ({
                         itemComponent={SelectItem}
                         onChange={handleDimensionChange}
                         data-selected={!!filterState.fieldId}
-                        data-no-values={!showValuesSection}
+                        data-no-values={!showValuesSection ? 'true' : 'false'}
                         classNames={filterSelectClasses}
                     />
 
                     {filterState.fieldId && (
                         <Select
                             placeholder="Condition"
+                            withinPortal
                             data={operatorOptions}
                             value={filterState.operator}
                             onChange={handleOperatorChange}
                             size="xs"
                             radius="md"
                             classNames={operatorSelectClasses}
-                            data-no-values={!showValuesSection}
+                            data-no-values={
+                                !showValuesSection ? 'true' : 'false'
+                            }
                             data-full-width={
                                 !showValuesSection ? 'true' : 'false'
                             }
@@ -272,7 +276,7 @@ export const MetricExploreFilter: FC<Props> = ({
             </Stack>
             {filterState.fieldId && dimensionMetadata?.requiresValues && (
                 <Button
-                    color="dark"
+                    color={theme.colorScheme === 'dark' ? 'ldGray.2' : 'dark'}
                     compact
                     size="xs"
                     disabled={!canApplyFilter}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreLegend.tsx
@@ -184,7 +184,7 @@ export const MetricExploreLegend: FC<MetricExploreLegendProps> = ({
                         >
                             <Text
                                 span
-                                c="ldDark.4"
+                                c="ldGray.9"
                                 fz={14}
                                 fw={500}
                                 maw={200}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreTooltip.tsx
@@ -88,12 +88,12 @@ const TooltipBadge: FC<{
 }> = ({ value, color = 'indigo', variant = 'default' }) => (
     <Badge
         variant="light"
-        color={variant === 'comparison' ? 'ldGray.7' : color}
+        color={variant === 'comparison' ? 'ldGray.9' : color}
         radius="md"
         h={24}
         sx={(theme) => ({
             border: `1px solid ${
-                theme.colors[variant === 'comparison' ? 'gray' : color][1]
+                theme.colors[variant === 'comparison' ? 'ldGray' : color][2]
             }`,
             fontFeatureSettings: '"tnum"',
         })}
@@ -315,8 +315,8 @@ const PercentageChangeFooter: FC<{
         percentChange > 0
             ? 'green.7'
             : percentChange < 0
-            ? 'red.7'
-            : 'ldDark.4';
+              ? 'red.7'
+              : 'ldDark.4';
 
     return (
         <Group position="right" spacing={4}>

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricsVisualization.tsx
@@ -71,18 +71,18 @@ const tickFormatter = (date: Date) => {
         timeSecond(date) < date
             ? DATE_FORMATS.millisecond
             : timeMinute(date) < date
-            ? DATE_FORMATS.second
-            : timeHour(date) < date
-            ? DATE_FORMATS.minute
-            : timeDay(date) < date
-            ? DATE_FORMATS.hour
-            : timeMonth(date) < date
-            ? timeWeek(date) < date
-                ? DATE_FORMATS.day
-                : DATE_FORMATS.week
-            : timeYear(date) < date
-            ? DATE_FORMATS.month
-            : DATE_FORMATS.year
+              ? DATE_FORMATS.second
+              : timeHour(date) < date
+                ? DATE_FORMATS.minute
+                : timeDay(date) < date
+                  ? DATE_FORMATS.hour
+                  : timeMonth(date) < date
+                    ? timeWeek(date) < date
+                        ? DATE_FORMATS.day
+                        : DATE_FORMATS.week
+                    : timeYear(date) < date
+                      ? DATE_FORMATS.month
+                      : DATE_FORMATS.year
     )(date);
 };
 
@@ -667,7 +667,7 @@ const MetricsVisualization: FC<Props> = ({
                             <CartesianGrid
                                 horizontal
                                 vertical={false}
-                                stroke={colors.gray[2]}
+                                stroke={colors.ldGray[2]}
                                 strokeDasharray="4 3"
                             />
 
@@ -688,7 +688,7 @@ const MetricsVisualization: FC<Props> = ({
                                               style: {
                                                   textAnchor: 'middle',
                                                   fontSize: 14,
-                                                  fill: colors.gray[7],
+                                                  fill: colors.ldGray[8],
                                                   fontWeight: 500,
                                                   userSelect: 'none',
                                               },
@@ -701,16 +701,22 @@ const MetricsVisualization: FC<Props> = ({
                                         value,
                                     );
                                 }}
-                                style={{ userSelect: 'none' }}
+                                style={{
+                                    userSelect: 'none',
+                                    fill: colors.ldGray[8],
+                                }}
                             />
 
                             <XAxis
                                 dataKey="dateValue"
                                 {...xAxisConfig}
-                                axisLine={{ stroke: colors.gray[2] }}
+                                axisLine={{ stroke: colors.ldGray[2] }}
                                 tickLine={false}
                                 fontSize={11}
-                                style={{ userSelect: 'none' }}
+                                style={{
+                                    userSelect: 'none',
+                                    fill: colors.ldGray[8],
+                                }}
                                 allowDuplicatedCategory={false}
                             />
 

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionIntervalPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/TimeDimensionIntervalPicker.tsx
@@ -56,7 +56,7 @@ export const TimeDimensionIntervalPicker: FC<Props> = ({
             withinPortal
             rightSection={
                 <MantineIcon
-                    color="ldDark.2"
+                    color="ldGray.7"
                     icon={IconChevronDown}
                     size={12}
                 />

--- a/packages/frontend/src/features/metricsCatalog/styles/useFilterStyles.ts
+++ b/packages/frontend/src/features/metricsCatalog/styles/useFilterStyles.ts
@@ -7,7 +7,7 @@ const baseStyles = (theme: MantineTheme) => ({
         fontSize: 14,
         height: 32,
         borderColor: theme.colors.ldGray[2],
-        color: theme.colors.ldDark[7],
+        color: theme.colors.ldDark[9],
         '&:hover': {
             backgroundColor: theme.colors.ldGray[0],
             transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
@@ -95,11 +95,14 @@ export const useOperatorSelectStyles = createStyles((theme: MantineTheme) => {
             maxWidth: 100,
             marginLeft: -1,
             borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
-            borderBottomRightRadius: 0,
-            borderTop: 0,
+            borderBottomLeftRadius: 0,
             paddingRight: 8,
             paddingLeft: 8,
+            // When filter accepts values, remove bottom-right radius (connects to autocomplete below)
+            '&[data-no-values="false"]': {
+                borderBottomRightRadius: 0,
+            },
+
             '&[data-full-width="true"]': {
                 width: '100%',
                 maxWidth: '100%',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXX

### Description:
This PR updates the color scheme in the metrics visualization components to use the design system colors consistently. Changes include:

- Updated border colors in `MetricsTableTopToolbar` to use the design system's `ldGray.3` color
- Added `withinPortal` prop to Select components in `MetricExploreFilter` to improve dropdown positioning
- Fixed data attribute values to be proper strings in filter components
- Updated button color in `MetricExploreFilter` to respect dark/light theme
- Changed text color in `MetricExploreLegend` from `ldDark.4` to `ldGray.9`
- Updated badge colors in `MetricExploreTooltip` to use consistent color scheme
- Improved grid and axis colors in `MetricsVisualization` to use `ldGray` colors
- Fixed border radius styling in the operator select component
- Updated icon color in `TimeDimensionIntervalPicker` to use `ldGray.7`

These changes ensure a more consistent visual appearance across the metrics visualization components.

![Screenshot 2025-12-05 at 18.02.57.png](https://app.graphite.com/user-attachments/assets/cb5cc135-8f7a-40a2-a768-91689555c323.png)

![Screenshot 2025-12-05 at 18.02.33.png](https://app.graphite.com/user-attachments/assets/d1f20baf-b196-48db-9005-356c6f0512ea.png)

