### PR TITLE
style: dark mode sql runner configuration

### DIFF
--- a/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartTypeConfig.tsx
@@ -22,7 +22,7 @@ const ChartTypeIcon: FC<{ type: CartesianSeriesType }> = ({ type }) => {
             ? ChartKind.VERTICAL_BAR
             : ChartKind.LINE;
 
-    return <MantineIcon icon={getChartIcon(chartKind)} color="ldDark.0" />;
+    return <MantineIcon icon={getChartIcon(chartKind)} color="ldDark.8" />;
 };
 
 const ChartTypeItem = forwardRef<

--- a/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
@@ -41,7 +41,7 @@ const ValueLabelIcon: FC<{
     }
 
     return (
-        <MantineIcon color={position ? 'ldDark.0' : 'ldGray.4'} icon={icon} />
+        <MantineIcon color={position ? 'ldDark.8' : 'ldGray.4'} icon={icon} />
     );
 };
 

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -140,7 +140,7 @@ export const SingleSeriesConfiguration = ({
                                     <Group spacing="xs" noWrap>
                                         <MantineIcon
                                             icon={IconAlignLeft}
-                                            color="ldDark.0"
+                                            color="ldDark.8"
                                         />
                                         <Text>Left</Text>
                                     </Group>
@@ -153,7 +153,7 @@ export const SingleSeriesConfiguration = ({
                                         <Text>Right</Text>
                                         <MantineIcon
                                             icon={IconAlignRight}
-                                            color="ldDark.0"
+                                            color="ldDark.8"
                                         />
                                     </Group>
                                 ),

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -357,7 +357,7 @@ export const DashboardExportModal: FC<Props & ModalProps> = ({
                         <Paper p="xs" withBorder radius="sm">
                             <MantineIcon icon={IconLayoutDashboard} size="sm" />
                         </Paper>
-                        <Text color="ldDark.7" fw={700} fz="md">
+                        <Text color="ldDark.9" fw={700} fz="md">
                             Export dashboard
                         </Text>
                     </Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Updated icon colors in the DataViz components and dashboard export modal for better contrast and visual consistency. Changed color values from `ldDark.0` to `ldDark.8` for chart type icons, value label icons, and alignment icons. Also updated the dashboard export modal title color from `ldDark.7` to `ldDark.9` for improved readability

![Screenshot 2025-12-05 at 18.13.22.png](https://app.graphite.com/user-attachments/assets/2792d526-6100-4c86-b04a-6f88b743af92.png)

.

![Screenshot 2025-12-05 at 18.13.27.png](https://app.graphite.com/user-attachments/assets/a6416299-4ad9-489c-b4c1-3f5a66a3ccf7.png)

