### PR TITLE
ci: remove build-and-test dependency from preview job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,7 +100,6 @@ jobs:
   preview:
     name: Deploy Preview
     runs-on: depot-ubuntu-24.04-4
-    needs: build-and-test
     outputs:
       url: ${{ steps.deploy.outputs.url }}
     steps:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Remove dependency on `build-and-test` job for the `preview` job in PR workflow. This allows the preview deployment to start immediately without waiting for tests to complete, speeding up the feedback loop for visual changes.