### PR TITLE
ci: simplify dbt CLI tests to only use version 1.10

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -524,7 +524,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dbt: ['1.4', '1.9', '1.10']
+        dbt: [ '1.10' ]
     name: "CLI: dbt ${{ matrix.dbt }}"
     env:
       NODE_OPTIONS: '--max-old-space-size=8192'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Simplifies the PR workflow by limiting dbt CLI tests to only run on version 1.10, removing tests for versions 1.4 and 1.9. This change will reduce CI time while still ensuring compatibility with the latest dbt version.