### PR TITLE
feat: wrap getAllByOrganizationUuid calls with Sentry transactions

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -485,10 +485,14 @@ export class McpService extends BaseService {
                     McpToolName.LIST_PROJECTS,
                 );
 
-                const projects =
-                    await this.projectModel.getAllByOrganizationUuid(
-                        organizationUuid,
-                    );
+                const projects = await wrapSentryTransaction(
+                    'McpService.listProjects.getAllByOrganizationUuid',
+                    { organizationUuid },
+                    async () =>
+                        this.projectModel.getAllByOrganizationUuid(
+                            organizationUuid,
+                        ),
+                );
 
                 const projectList = projects.map((project) => ({
                     name: project.name,

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -49,6 +49,7 @@ import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../../models/RolesModel';
 import { UserModel } from '../../../models/UserModel';
 import { BaseService } from '../../../services/BaseService';
+import { wrapSentryTransaction } from '../../../utils';
 import { CommercialFeatureFlagModel } from '../../models/CommercialFeatureFlagModel';
 import { ServiceAccountModel } from '../../models/ServiceAccountModel';
 
@@ -1628,8 +1629,11 @@ export class ScimService extends BaseService {
         );
 
         // Get all projects for the organization, ignoring preview projects
-        const allProjects = await this.projectModel.getAllByOrganizationUuid(
-            organizationUuid,
+        const allProjects = await wrapSentryTransaction(
+            'ScimService.getAllRoles.getAllByOrganizationUuid',
+            { organizationUuid },
+            async () =>
+                this.projectModel.getAllByOrganizationUuid(organizationUuid),
         );
         const nonPreviewProjects = allProjects.filter(
             (project) => project.type !== ProjectType.PREVIEW,

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -22,6 +22,7 @@ import {
 } from '../../models/ContentModel/ContentModelTypes';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SpaceModel } from '../../models/SpaceModel';
+import { wrapSentryTransaction } from '../../utils';
 import { BaseService } from '../BaseService';
 import { DashboardService } from '../DashboardService/DashboardService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
@@ -84,7 +85,14 @@ export class ContentService extends BaseService {
             throw new NotExistsError('Organization not found');
         }
         const projectUuids = (
-            await this.projectModel.getAllByOrganizationUuid(organizationUuid)
+            await wrapSentryTransaction(
+                'ContentService.find.getAllByOrganizationUuid',
+                { organizationUuid },
+                async () =>
+                    this.projectModel.getAllByOrganizationUuid(
+                        organizationUuid,
+                    ),
+            )
         )
             .filter((project) =>
                 user.ability.can(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -42,6 +42,7 @@ import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberP
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { UserModel } from '../../models/UserModel';
+import { wrapSentryTransaction } from '../../utils';
 import { BaseService } from '../BaseService';
 
 type OrganizationServiceArguments = {
@@ -291,8 +292,12 @@ export class OrganizationService extends BaseService {
         if (organizationUuid === undefined) {
             throw new NotExistsError('Organization not found');
         }
-        const projects = await this.projectModel.getAllByOrganizationUuid(
-            organizationUuid,
+
+        const projects = await wrapSentryTransaction(
+            'OrganizationService.getProjects.getAllByOrganizationUuid',
+            { organizationUuid },
+            async () =>
+                this.projectModel.getAllByOrganizationUuid(organizationUuid),
         );
 
         return projects.filter((project) =>

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -25,6 +25,7 @@ import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../models/RolesModel';
 import { UserModel } from '../../models/UserModel';
+import { wrapSentryTransaction } from '../../utils';
 import { BaseService } from '../BaseService';
 
 type RolesServiceArguments = {
@@ -99,8 +100,11 @@ export class RolesService extends BaseService {
         }
 
         // get all projects in organization
-        const projects = await this.projectModel.getAllByOrganizationUuid(
-            organizationUuid,
+        const projects = await wrapSentryTransaction(
+            'RolesService.validateRolesViewAccess.getAllByOrganizationUuid',
+            { organizationUuid },
+            async () =>
+                this.projectModel.getAllByOrganizationUuid(organizationUuid),
         );
 
         const canManageSomeProjects = projects.some((project) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

This should go live before https://github.com/lightdash/lightdash/pull/18624 so we can measure performance changes 

I'm doing this on the `call` rather than the `getAllByOrganizationUuid` implementation for 3 reasons: 

- this will be easier to detect where the underlying issue is, based on the method (I was surprised to see this call on the RolesService) 
- This will avoid conflicts with `https://github.com/lightdash/lightdash/pull/18624`
- easier to read and review than wrapping an entire method . 

### Description:
Added Sentry transaction wrapping to `ProjectModel.getAllByOrganizationUuid()` calls across multiple services to improve observability and performance tracking. This change enables better monitoring of database queries that fetch projects for an organization, helping to identify potential bottlenecks in McpService, ScimService, ContentService, OrganizationService, and RolesService.