### PR TITLE
feat: add bedrock support for reasoning UI parts

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -71,6 +71,11 @@ const getReasoningFromPart = (part: ReasoningUIPart) => {
                 reasoningId: part.providerMetadata.anthropic.signature,
                 text: part.text,
             };
+        case part.providerMetadata?.bedrock !== undefined:
+            return {
+                reasoningId: part.providerMetadata.bedrock.signature,
+                text: part.text,
+            };
         default:
             return null;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added support for Bedrock provider in the AI Copilot reasoning extraction logic. This change enables the system to properly extract reasoning information from Bedrock AI responses by handling its specific metadata structure, similar to how it's already done for other providers like Anthropic.
