### PR TITLE
chore: add slack channels cache tables

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -111,6 +111,10 @@ import {
     SlackAuthTokensTableName,
 } from '../database/entities/slackAuthentication';
 import {
+    SlackChannelsTable,
+    SlackChannelsTableName,
+} from '../database/entities/slackChannels';
+import {
     SpaceTable,
     SpaceTableName,
     SpaceUserAccessTable,
@@ -360,6 +364,7 @@ declare module 'knex/types/tables' {
         [ShareTableName]: ShareTable;
         [SpaceUserAccessTableName]: SpaceUserAccessTable;
         [SlackAuthTokensTableName]: SlackAuthTokensTable;
+        [SlackChannelsTableName]: SlackChannelsTable;
         [AnalyticsChartViewsTableName]: AnalyticsChartViews;
         [AnalyticsDashboardViewsTableName]: AnalyticsDashboardViews;
         [PinnedListTableName]: PinnedListTable;

--- a/packages/backend/src/database/entities/slackAuthentication.ts
+++ b/packages/backend/src/database/entities/slackAuthentication.ts
@@ -1,3 +1,4 @@
+import { SchedulerJobStatus } from '@lightdash/common';
 import { Installation } from '@slack/bolt';
 import { Knex } from 'knex';
 
@@ -14,6 +15,12 @@ export type DbSlackAuthTokens = {
     ai_thread_access_consent: boolean;
     ai_require_oauth: boolean;
     ai_multi_agent_channel_id: string | null;
+    // Channel sync status
+    channels_last_sync_at: Date | null;
+    channels_sync_started_at: Date | null;
+    channels_sync_status: SchedulerJobStatus | null;
+    channels_sync_error: string | null;
+    channels_count: number | null;
 };
 
 export type CreateDbSlackAuthTokens = Pick<
@@ -31,6 +38,11 @@ export type UpdateDbSlackAuthTokens = Pick<
             | 'ai_thread_access_consent'
             | 'ai_require_oauth'
             | 'ai_multi_agent_channel_id'
+            | 'channels_last_sync_at'
+            | 'channels_sync_started_at'
+            | 'channels_sync_status'
+            | 'channels_sync_error'
+            | 'channels_count'
         >
     >;
 

--- a/packages/backend/src/database/entities/slackChannels.ts
+++ b/packages/backend/src/database/entities/slackChannels.ts
@@ -1,0 +1,36 @@
+import { Knex } from 'knex';
+
+export const SlackChannelsTableName = 'slack_channels';
+
+export type SlackChannelType = 'channel' | 'private_channel' | 'dm';
+
+export type DbSlackChannel = {
+    slack_channel_uuid: string;
+    organization_id: number;
+    channel_id: string;
+    channel_name: string;
+    channel_type: SlackChannelType;
+    is_archived: boolean;
+    deleted_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type CreateDbSlackChannel = Pick<
+    DbSlackChannel,
+    'organization_id' | 'channel_id' | 'channel_name' | 'channel_type'
+> &
+    Partial<Pick<DbSlackChannel, 'is_archived' | 'deleted_at'>>;
+
+export type UpdateDbSlackChannel = Partial<
+    Pick<
+        DbSlackChannel,
+        'channel_name' | 'is_archived' | 'deleted_at' | 'updated_at'
+    >
+>;
+
+export type SlackChannelsTable = Knex.CompositeTableType<
+    DbSlackChannel,
+    CreateDbSlackChannel,
+    UpdateDbSlackChannel
+>;

--- a/packages/backend/src/database/migrations/20251208120000_add_slack_channels_cache.ts
+++ b/packages/backend/src/database/migrations/20251208120000_add_slack_channels_cache.ts
@@ -1,0 +1,84 @@
+import { Knex } from 'knex';
+
+const SlackChannelsTableName = 'slack_channels';
+const SlackAuthTokensTableName = 'slack_auth_tokens';
+
+export async function up(knex: Knex): Promise<void> {
+    // Cache table for storing channel data (avoids rate limiting from Slack API on-demand requests)
+    await knex.schema.createTable(SlackChannelsTableName, (table) => {
+        table
+            .uuid('slack_channel_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .integer('organization_id')
+            .notNullable()
+            .references('organization_id')
+            .inTable(SlackAuthTokensTableName)
+            .onDelete('CASCADE');
+        table
+            .string('channel_id')
+            .notNullable()
+            .comment('Slack channel ID (e.g., C01234567)');
+        table
+            .string('channel_name')
+            .notNullable()
+            .comment('Display name with prefix (#channel or @user)');
+        table
+            .string('channel_type')
+            .notNullable()
+            .comment('channel | private_channel | dm');
+        table.boolean('is_archived').notNullable().defaultTo(false);
+        table
+            .timestamp('deleted_at', { useTz: false })
+            .nullable()
+            .comment(
+                'Soft delete timestamp - set when channel not found in Slack sync',
+            );
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.unique(['organization_id', 'channel_id']);
+        table.index('organization_id');
+        table.index(['organization_id', 'channel_name']);
+        table.index(['organization_id', 'deleted_at']); // For filtering active channels
+        table.index(['organization_id', 'is_archived']); // For filtering archived channels
+    });
+
+    // Add channel sync status columns to slack_auth_tokens
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table
+            .timestamp('channels_last_sync_at', { useTz: false })
+            .nullable()
+            .comment('Last time channels were successfully synced from Slack');
+        table
+            .timestamp('channels_sync_started_at', { useTz: false })
+            .nullable()
+            .comment(
+                'When the current sync started - used for stale lock detection',
+            );
+        table
+            .string('channels_sync_status')
+            .nullable()
+            .comment('scheduled | started | completed | error');
+        table.text('channels_sync_error').nullable();
+        table.integer('channels_count').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table.dropColumn('channels_last_sync_at');
+        table.dropColumn('channels_sync_started_at');
+        table.dropColumn('channels_sync_status');
+        table.dropColumn('channels_sync_error');
+        table.dropColumn('channels_count');
+    });
+    await knex.schema.dropTableIfExists(SlackChannelsTableName);
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Added a Slack channels cache system to improve performance and avoid rate limiting from the Slack API. This includes:

1. Created a new `slack_channels` table to store channel data (ID, name, type, archived status)
2. Added channel sync status tracking fields to the `slack_auth_tokens` table:
    - `channels_last_sync_at`
    - `channels_sync_status`
    - `channels_sync_error`
    - `channels_count`
3. Updated TypeScript types to support the new database schema

This cache will allow us to efficiently retrieve channel information without making API calls to Slack for each request.

```mermaid
erDiagram
    organizations {
        integer organization_id PK
    }
    
    users {
        integer user_id PK
    }
    
    slack_auth_tokens {
        varchar slack_team_id PK
        integer organization_id FK,UK "unique"
        jsonb installation
        integer created_by_user_id FK
        varchar notification_channel
        varchar app_profile_photo_url
        boolean ai_thread_access_consent "default false"
        boolean ai_require_oauth "default false"
        text ai_multi_agent_channel_id
        timestamp channels_last_sync_at "NEW - last successful sync"
        timestamp channels_sync_started_at "NEW - for stale lock detection"
        varchar channels_sync_status "NEW"
        text channels_sync_error "NEW"
        integer channels_count "NEW"
    }
    
    slack_channels {
        uuid slack_channel_uuid PK
        integer organization_id FK
        varchar channel_id "e.g. C01234567"
        varchar channel_name "#channel or @user"
        varchar channel_type "channel|private_channel|dm"
        boolean is_archived "default false"
        timestamp deleted_at "soft delete"
        timestamp created_at
        timestamp updated_at
    }
    
    organizations ||--o| slack_auth_tokens : "has"
    users ||--o{ slack_auth_tokens : "created_by"
    slack_auth_tokens ||--o{ slack_channels : "caches"
```
