### PR TITLE
feat: use db cache for slack channel fetching

### DIFF
--- a/packages/backend/src/clients/ClientRepository.ts
+++ b/packages/backend/src/clients/ClientRepository.ts
@@ -176,6 +176,7 @@ export class ClientRepository
                         this.models.getSlackAuthenticationModel(),
                     slackChannelCacheModel:
                         this.models.getSlackChannelCacheModel(),
+                    schedulerClient: this.getSchedulerClient(),
                 }),
         );
     }

--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    ApiSlackChannelResponse,
     ApiSlackChannelsResponse,
     ApiSlackCustomSettingsResponse,
     ApiSlackGetInstallationResponse,
@@ -15,6 +16,7 @@ import {
     Get,
     Middlewares,
     OperationId,
+    Path,
     Put,
     Query,
     Request,
@@ -70,6 +72,30 @@ export class SlackController extends BaseController {
                         ? includeChannelIds.split(',').filter(Boolean)
                         : undefined,
                 }),
+        };
+    }
+
+    /**
+     * Look up a single Slack channel by ID. Used for on-demand fetching when
+     * user pastes a channel ID not in the cache.
+     * @summary Lookup channel
+     * @param req express request
+     * @param channelId Slack channel ID (e.g., C01234567)
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/channels/{channelId}')
+    @OperationId('getSlackChannelById')
+    async getChannelById(
+        @Request() req: express.Request,
+        @Path() channelId: string,
+    ): Promise<ApiSlackChannelResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getSlackIntegrationService()
+                .lookupChannelById(req.user!, channelId),
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -384,13 +384,14 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     schedulerModel: models.getSchedulerModel(),
                 }),
-            slackClient: ({ context, models }) =>
+            slackClient: ({ context, models, repository }) =>
                 new CommercialSlackClient({
                     analytics: context.lightdashAnalytics,
                     lightdashConfig: context.lightdashConfig,
                     slackAuthenticationModel:
                         models.getSlackAuthenticationModel() as CommercialSlackAuthenticationModel,
                     slackChannelCacheModel: models.getSlackChannelCacheModel(),
+                    schedulerClient: repository.getSchedulerClient(),
                 }),
         },
     };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6790,11 +6790,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6809,11 +6809,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6828,11 +6828,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -6909,25 +6909,6 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
-                                                                                                tableName:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
-                                                                                                name: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
                                                                                                 fieldType:
                                                                                                     {
                                                                                                         dataType:
@@ -6935,6 +6916,25 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
+                                                                                                tableName:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
+                                                                                                name: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
                                                                                             },
                                                                                     },
                                                                                 },
@@ -6958,7 +6958,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -6966,11 +6966,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -6985,7 +6981,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -6993,7 +6989,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7048,11 +7048,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7178,25 +7178,6 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
-                                                                                                    tableName:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required:
-                                                                                                                true,
-                                                                                                        },
-                                                                                                    name: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                     fieldType:
                                                                                                         {
                                                                                                             dataType:
@@ -7204,6 +7185,25 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
+                                                                                                    tableName:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required:
+                                                                                                                true,
+                                                                                                        },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
+                                                                                                    name: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                 },
                                                                                         },
                                                                                         required:
@@ -7233,11 +7233,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7252,11 +7252,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13631,6 +13631,30 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_SlackChannel-or-null_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'SlackChannel' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSlackChannelResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_SlackChannel-or-null_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiSlackCustomSettingsResponse: {
         dataType: 'refAlias',
         type: { ref: 'ApiSuccessEmpty', validators: {} },
@@ -14240,6 +14264,8 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['renameResources'] },
                 { dataType: 'enum', enums: ['cleanQueryHistory'] },
                 { dataType: 'enum', enums: ['downloadAsyncQueryResults'] },
+                { dataType: 'enum', enums: ['syncSlackChannels'] },
+                { dataType: 'enum', enums: ['generateSlackChannelSyncJobs'] },
             ],
             validators: {},
         },
@@ -17087,7 +17113,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17097,7 +17123,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17107,7 +17133,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17120,7 +17146,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -33168,6 +33194,66 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'get',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsSlackController_getChannelById: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        channelId: {
+            in: 'path',
+            name: 'channelId',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/slack/channels/:channelId',
+        ...fetchMiddlewares<RequestHandler>(SlackController),
+        ...fetchMiddlewares<RequestHandler>(
+            SlackController.prototype.getChannelById,
+        ),
+
+        async function SlackController_getChannelById(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsSlackController_getChannelById,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<SlackController>(
+                    SlackController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getChannelById',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7594,6 +7594,19 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "error",
+                                                            "success"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
@@ -7609,24 +7622,24 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "label": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "label",
+                                                                        "fieldType",
                                                                         "tableName",
-                                                                        "name",
-                                                                        "fieldType"
+                                                                        "label",
+                                                                        "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -7635,16 +7648,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -7674,8 +7687,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -7729,24 +7742,24 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "label": {
+                                                                                    "fieldType": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "name": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldType": {
+                                                                                    "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "label",
+                                                                                    "fieldType",
                                                                                     "tableName",
-                                                                                    "name",
-                                                                                    "fieldType"
+                                                                                    "label",
+                                                                                    "name"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -7773,8 +7786,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -13976,6 +13989,28 @@
             "ApiSlackChannelsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_SlackChannel-Array-or-undefined_"
             },
+            "ApiSuccess_SlackChannel-or-null_": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SlackChannel"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiSlackChannelResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_SlackChannel-or-null_"
+            },
             "ApiSlackCustomSettingsResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"
             },
@@ -14718,7 +14753,9 @@
                     "exportCsvDashboard",
                     "renameResources",
                     "cleanQueryHistory",
-                    "downloadAsyncQueryResults"
+                    "downloadAsyncQueryResults",
+                    "syncSlackChannels",
+                    "generateSlackChannelSyncJobs"
                 ]
             },
             "BaseSchedulerLog": {
@@ -17812,22 +17849,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -23364,7 +23401,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2236.1",
+        "version": "0.2236.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -28387,6 +28424,48 @@
                         "in": "query",
                         "name": "includeChannelIds",
                         "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/slack/channels/{channelId}": {
+            "get": {
+                "operationId": "getSlackChannelById",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSlackChannelResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Look up a single Slack channel by ID. Used for on-demand fetching when\nuser pastes a channel ID not in the cache.",
+                "summary": "Lookup channel",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "Slack channel ID (e.g., C01234567)",
+                        "in": "path",
+                        "name": "channelId",
+                        "required": true,
                         "schema": {
                             "type": "string"
                         }

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -144,6 +144,22 @@ export class SlackIntegrationService<
         );
     }
 
+    /**
+     * Look up a single channel by ID or name. Used for on-demand fetching when
+     * user types a channel ID or name not in the cache.
+     * - If input looks like a Slack ID (C/G/U/W + alphanumerics), looks up by ID
+     * - Otherwise, searches by name (e.g., "#my-channel" or "my-channel")
+     */
+    async lookupChannelById(
+        user: SessionUser,
+        input: string,
+    ): Promise<SlackChannel | null> {
+        const organizationUuid = user?.organizationUuid;
+        if (!organizationUuid) throw new ForbiddenError();
+
+        return this.slackClient.lookupChannelById(organizationUuid, input);
+    }
+
     async updateAppCustomSettings(
         user: SessionUser,
         body: SlackAppCustomSettings,

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -578,9 +578,10 @@ export type DownloadAsyncQueryResultsPayload = TraceTaskBase & {
     encodedJwt?: string;
 };
 
-export type SyncSlackChannelsPayload = {
-    organizationUuid: string;
-    userUuid: undefined;
+export type SyncSlackChannelsPayload = Pick<
+    TraceTaskBase,
+    'organizationUuid' | 'schedulerUuid'
+> & {
     projectUuid: undefined;
-    schedulerUuid: undefined;
+    userUuid: undefined;
 };

--- a/packages/common/src/types/slack.ts
+++ b/packages/common/src/types/slack.ts
@@ -8,6 +8,8 @@ export type SlackChannel = {
 
 export type ApiSlackChannelsResponse = ApiSuccess<SlackChannel[] | undefined>;
 
+export type ApiSlackChannelResponse = ApiSuccess<SlackChannel | null>;
+
 export type ApiSlackCustomSettingsResponse = ApiSuccessEmpty;
 
 export type SlackChannelProjectMapping = {

--- a/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
+++ b/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
@@ -7,10 +7,17 @@ import {
     type MultiSelectProps,
     type SelectProps,
 } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
 import { IconRefresh } from '@tabler/icons-react';
-import { useEffect, useMemo, useRef, useState, type FC } from 'react';
-import { useSlackChannels } from '../../../hooks/slack/useSlack';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import {
+    useSlackChannelLookup,
+    useSlackChannels,
+} from '../../../hooks/slack/useSlack';
 import MantineIcon from '../MantineIcon';
+
+// Regex to detect Slack IDs: C (public channel), G (private channel), U/W (user/DM)
+const SLACK_ID_REGEX = /^[CGUW][A-Z0-9]{8,}$/i;
 
 type CommonProps = {
     disabled?: SelectProps['disabled'];
@@ -19,6 +26,8 @@ type CommonProps = {
     size?: SelectProps['size'];
     /** Show refresh button to force re-fetch channels from Slack */
     withRefresh?: boolean;
+    /** Include direct messages in the channel list */
+    includeDms?: boolean;
 };
 
 type SingleSelectProps = CommonProps & {
@@ -42,12 +51,20 @@ export const SlackChannelSelect: FC<
         label,
         size = 'xs',
         withRefresh = false,
+        includeDms = false,
     } = props;
 
     const [search, setSearch] = useState<string | undefined>(undefined);
+    const [debouncedSearch] = useDebouncedValue(search, 300);
 
-    // Accumulate channels across searches so selected channels remain in options
-    const channelCacheRef = useRef<Map<string, string>>(new Map());
+    // Track looked-up channels (ID -> name) that aren't in the cached list yet
+    const [lookedUpChannels, setLookedUpChannels] = useState<
+        Map<string, string>
+    >(new Map());
+
+    // On-demand lookup for pasted channel IDs not in DB cache
+    const { mutate: lookupChannel, isLoading: isLookingUp } =
+        useSlackChannelLookup();
 
     const includeChannelIds = useMemo(() => {
         if (props.multiple) {
@@ -65,29 +82,36 @@ export const SlackChannelSelect: FC<
         search || '',
         {
             excludeArchived: true,
-            excludeDms: true,
+            excludeDms: !includeDms,
             excludeGroups: true,
             includeChannelIds,
         },
         { enabled: !disabled },
     );
 
-    // Add fetched channels to cache
+    // On-demand lookup when user pastes a Slack channel ID
     useEffect(() => {
-        slackChannels?.forEach((channel) => {
-            channelCacheRef.current.set(channel.id, channel.name);
-        });
-    }, [slackChannels]);
+        if (!debouncedSearch || !SLACK_ID_REGEX.test(debouncedSearch)) return;
+
+        // Check if already in fetched channels
+        const alreadyHaveChannel = slackChannels?.some(
+            (c) => c.id === debouncedSearch,
+        );
+        if (alreadyHaveChannel) return;
+
+        // Lookup the channel by ID
+        lookupChannel(debouncedSearch);
+    }, [debouncedSearch, slackChannels, lookupChannel]);
 
     const options = useMemo(() => {
         const optionsMap = new Map<string, string>();
 
-        // Add all cached channels first
-        channelCacheRef.current.forEach((name, id) => {
+        // Add looked-up channels first
+        lookedUpChannels.forEach((name, id) => {
             optionsMap.set(id, name);
         });
 
-        // Add/update with current search results
+        // Add channels from API (will override looked-up if same ID)
         slackChannels?.forEach((channel) => {
             optionsMap.set(channel.id, channel.name);
         });
@@ -96,9 +120,9 @@ export const SlackChannelSelect: FC<
             value: id,
             label: name,
         }));
-    }, [slackChannels]);
+    }, [slackChannels, lookedUpChannels]);
 
-    const isBusy = isLoading || isRefreshing;
+    const isBusy = isLoading || isRefreshing || isLookingUp;
 
     const rightSection = withRefresh ? (
         isBusy ? (
@@ -127,15 +151,40 @@ export const SlackChannelSelect: FC<
         onSearchChange: setSearch,
     };
 
+    // Only allow creating items that look like Slack channel IDs
+    const shouldAllowCreate = (query: string) => SLACK_ID_REGEX.test(query);
+
     return props.multiple ? (
         <MultiSelect
             {...(commonProps as MultiSelectProps)}
             creatable
-            getCreateLabel={(query) => `Send to private channel #${query}`}
+            shouldCreate={shouldAllowCreate}
+            getCreateLabel={(query) =>
+                SLACK_ID_REGEX.test(query)
+                    ? `Look up channel ID: ${query}`
+                    : 'Paste a Slack channel ID (e.g., C01234567)'
+            }
             onCreate={(newItem) => {
-                // Add private channel to cache with # prefix for display
-                channelCacheRef.current.set(newItem, `#${newItem}`);
-                return newItem;
+                if (SLACK_ID_REGEX.test(newItem)) {
+                    // Trigger lookup to get channel info
+                    lookupChannel(newItem, {
+                        onSuccess: (channel) => {
+                            if (channel) {
+                                // Add to looked-up channels so it appears in options
+                                setLookedUpChannels((prev) => {
+                                    const next = new Map(prev);
+                                    next.set(channel.id, channel.name);
+                                    return next;
+                                });
+                                // Add the channel ID to the selection
+                                props.onChange([...props.value, channel.id]);
+                            }
+                        },
+                    });
+                    // Don't add anything yet - wait for lookup to complete
+                    return undefined;
+                }
+                return undefined;
             }}
             value={props.value}
             onChange={(newValue) => {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -1172,6 +1172,7 @@ const SchedulerForm: FC<Props> = ({
                                                         disabled={
                                                             isAddSlackDisabled
                                                         }
+                                                        includeDms
                                                         onChange={(val) => {
                                                             form.setFieldValue(
                                                                 'slackTargets',

--- a/packages/frontend/src/hooks/slack/useSlack.ts
+++ b/packages/frontend/src/hooks/slack/useSlack.ts
@@ -164,6 +164,33 @@ export const useSlackChannels = (
     };
 };
 
+const getSlackChannelById = async (channelId: string) =>
+    lightdashApi<SlackChannel | null>({
+        url: `/slack/channels/${encodeURIComponent(channelId)}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+/**
+ * Hook for on-demand channel lookup when user pastes a channel ID
+ */
+export const useSlackChannelLookup = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<SlackChannel | null, ApiError, string>({
+        mutationFn: getSlackChannelById,
+        onSuccess: async (channel) => {
+            if (channel) {
+                // Invalidate channels queries to include the new channel
+                await queryClient.invalidateQueries({
+                    queryKey: ['slack_channels'],
+                    refetchType: 'none', // Don't refetch, just mark as stale
+                });
+            }
+        },
+    });
+};
+
 const updateSlackCustomSettings = async (opts: SlackAppCustomSettings) =>
     lightdashApi<null>({
         url: `/slack/custom-settings`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #8839
 ## Description

### Problem

Users with large Slack workspaces (4000+ channels) experienced stuck loading states when fetching channels because:

- **In-memory cache was per-process** - In clustered deployments, each pod fetched independently
- **No rate limiting/retry logic** - Relied entirely on Slack SDK, broke on first error
- **Blocking responses** - Full fetch must complete before returning any data
- **No persistence** - Cache lost on server restart

### Solution

Replace in-memory cache with PostgreSQL-backed storage, use Graphile Worker for background sync jobs, and return stale data while refreshing.

---

## Architecture

```mermaid
flowchart TB
    subgraph Frontend
        UI[SlackChannelSelect Component]
        Hook[useSlackChannels / useSlackChannelLookup]
    end

    subgraph Backend
        API[SlackClient.getChannels]
        Lookup[SlackClient.lookupChannelById]
        Service[SlackIntegrationService]
    end

    subgraph Database
        SC[(slack_channels)]
        SAT[(slack_auth_tokens<br/>+ sync status columns)]
    end

    subgraph Scheduler["Graphile Worker"]
        Cron[Daily Cron 6am UTC]
        GenJob[GENERATE_SLACK_CHANNEL_SYNC_JOBS]
        SyncJob[SYNC_SLACK_CHANNELS]
    end

    subgraph Slack["Slack API"]
        Conv[conversations.list]
        Users[users.list]
        Info[conversations.info]
    end

    UI --> Hook
    Hook -->|1. Request channels| Service
    Service --> API
    API -->|2. Check cache| SC
    API -->|3. Return cached data| Hook
    API -.->|4. If stale, queue job| SyncJob

    Cron -->|Daily trigger| GenJob
    GenJob -->|Queue per-org jobs| SyncJob
    SyncJob -->|Paginate with throttling| Conv
    SyncJob -->|Paginate with throttling| Users
    SyncJob -->|Upsert channels| SC
    SyncJob -->|Update status| SAT

    UI -->|Paste channel ID| Hook
    Hook -->|On-demand lookup| Service
    Service --> Lookup
    Lookup -->|Check cache| SC
    Lookup -->|If not found| Info
    Lookup -->|Cache result| SC
```

---

## Request Flow

```mermaid
sequenceDiagram
    participant UI as Frontend
    participant API as SlackClient
    participant DB as PostgreSQL
    participant Worker as Graphile Worker
    participant Slack as Slack API

    UI->>API: getChannels(orgUuid)
    API->>DB: Check slack_channels cache

    alt Cache is empty (first request)
        API->>Worker: Queue SYNC_SLACK_CHANNELS job
        API->>API: Poll for completion (60s timeout)
        Worker->>Slack: Fetch all channels (throttled)
        Worker->>DB: Upsert channels + soft delete missing
        Worker->>DB: Update sync status = completed
        API->>DB: Read cached channels
        API->>UI: Return channels
    else Cache exists but stale
        API->>UI: Return stale data immediately
        API->>Worker: Queue background sync (fire & forget)
        Worker->>Slack: Fetch all channels
        Worker->>DB: Update cache
    else Cache is fresh
        API->>UI: Return cached data
    end
```

---

## Rate Limiting

### Per-Organization Token Isolation

Slack rate limits are applied per OAuth token, not per server. Each organization has its own token:

```
┌─────────────────────────────────────────────────────────────┐
│                    Lightdash Server                          │
├─────────────────────────────────────────────────────────────┤
│                                                              │
│  Org A Sync Job ──► Token A ──► Slack API (Tier 2 limit)   │
│                                                              │
│  Org B Sync Job ──► Token B ──► Slack API (Tier 2 limit)   │
│                                                              │
│  Org C Sync Job ──► Token C ──► Slack API (Tier 2 limit)   │
│                                                              │
│  (Each org has independent rate limit quota)                 │
│                                                              │
└─────────────────────────────────────────────────────────────┘
```

### Throttling Strategy

The implementation uses **proactive throttling** rather than reactive retries:

```mermaid
flowchart TD
    A[API Call Request] --> B{Time since last call?}
    B -->|< 15s| C[Wait remaining time]
    B -->|≥ 15s| D[Track call timing]
    C --> D
    D --> E[Execute Slack API call]
    E --> F{Success?}
    F -->|Yes| G[Return result]
    F -->|Rate limited| H[Wait retry_after]
    F -->|Other error| I[Throw error]
    H --> J[Reset timing]
    J --> K[Retry once]
    K --> L{Success?}
    L -->|Yes| G
    L -->|No| I

    style C fill:#ffeb3b,color:#000
    style H fill:#ffeb3b,color:#000
    style G fill:#4caf50,color:#fff
    style I fill:#f44336,color:#fff
```

### Rate Limit Configuration

| Setting | Value | Reason |
|---------|-------|--------|
| Batch size | 1000 items/request | Slack API maximum |
| Delay between requests | 15 seconds | 20% of Tier 2 (~4 req/min) |
| Retry on rate limit | 1 retry | Safety net using Slack's `retry_after` |

### Multi-Tenant Considerations

For instances with many Slack installations:

- Each org's sync runs independently with its own rate limit
- Jobs are queued via Graphile Worker (handles concurrency)
- Worker concurrency is configurable via `scheduler.concurrency`
- Jobs don't block each other - they run in parallel up to concurrency limit

---

## Database Schema

```sql
-- Cached Slack channels
CREATE TABLE slack_channels (
    slack_channel_uuid UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
    organization_id INTEGER NOT NULL 
        REFERENCES slack_auth_tokens(organization_id) ON DELETE CASCADE,
    channel_id VARCHAR NOT NULL,           -- Slack ID (C01234567)
    channel_name VARCHAR NOT NULL,         -- Display name (#channel or @user)
    channel_type VARCHAR NOT NULL,         -- channel | private_channel | dm
    is_archived BOOLEAN NOT NULL DEFAULT FALSE,
    deleted_at TIMESTAMP,                  -- Soft delete when not in Slack
    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
    UNIQUE(organization_id, channel_id)
);

-- Indexes for efficient queries
CREATE INDEX idx_slack_channels_org ON slack_channels(organization_id);
CREATE INDEX idx_slack_channels_org_name ON slack_channels(organization_id, channel_name);
CREATE INDEX idx_slack_channels_org_deleted ON slack_channels(organization_id, deleted_at);
CREATE INDEX idx_slack_channels_org_archived ON slack_channels(organization_id, is_archived);

-- Sync status columns added to existing slack_auth_tokens table
ALTER TABLE slack_auth_tokens ADD COLUMN channels_last_sync_at TIMESTAMP;
ALTER TABLE slack_auth_tokens ADD COLUMN channels_sync_status VARCHAR;  -- scheduled | started | completed | error
ALTER TABLE slack_auth_tokens ADD COLUMN channels_sync_error TEXT;
ALTER TABLE slack_auth_tokens ADD COLUMN channels_count INTEGER;
```

---

## Cache Behavior

| Scenario | Response | Background Action |
|----------|----------|-------------------|
| Cache valid (< TTL) | Return cached channels | None |
| Cache stale (> TTL) | Return stale channels | Trigger background sync |
| Cache empty (first request) | Block and wait (60s timeout) | Sync runs, then returns |
| `forceRefresh=true` | Return stale if available | Trigger background sync |
| Sync in progress + has data | Return stale channels | None (wait for current) |
| Sync in progress + no data | Block and wait | None (wait for current) |

**TTL:** 10 minutes (configurable via `SLACK_CHANNELS_CACHED_TIME`)

---

## On-Demand Channel Lookup

Users can paste a Slack channel ID to look up channels not yet in the cache. This is useful for newly created channels or private channels the bot has been invited to.

> **Important:** Slack API does not support looking up channels by name - only by ID. Users must paste the channel ID (e.g., `C01234567`).

### How to get a channel ID from Slack:

1. Right-click on the channel in Slack
2. Select "View channel details"
3. Scroll to the bottom of the "About" tab
4. Copy the channel ID

### Lookup Flow

```mermaid
flowchart LR
    A[User pastes channel ID] --> B{Valid Slack ID?}
    B -->|No| Z[Show guidance message]
    B -->|Yes| C{In cache?}
    C -->|Yes| D[Return cached]
    C -->|No| E[Fetch from Slack API]
    E --> F{Found?}
    F -->|Yes| G[Cache result]
    G --> H[Return channel]
    F -->|No| I[Return null]
```

### Backend Implementation

The `lookupChannelById` method in `SlackClient.ts` handles the lookup:

```typescript
// Input validation: must match Slack ID pattern (C/G/U/W + 8+ alphanumerics)
const isSlackId = /^[CGUW][A-Z0-9]{8,}$/i.test(input);

if (isSlackId) {
    // 1. Check cache first
    // 2. If not found, fetch via Slack API conversations.info
    // 3. Cache and return result
}
```

### Frontend Implementation

The `SlackChannelSelect` component:

- Only allows creating items that match the Slack ID regex
- Shows "Paste a Slack channel ID (e.g., C01234567)" as guidance
- On valid ID entry, triggers lookup via `useSlackChannelLookup` mutation
- Adds the channel to selection only after successful lookup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace in-memory Slack channel fetching with DB cache + background sync, add channel lookup endpoint, and update UI to support ID-based lookup and DM selection.
> 
> - **Backend**:
>   - **Slack client/cache**: Replace in-memory cache with DB-backed `SlackChannelCacheModel`; inject `schedulerClient` to queue `syncSlackChannels` jobs; initial empty-cache waits with timeout, otherwise returns cached data and refreshes in background; throttled Slack API pagination for channels/users; soft-delete handling; added `lookupChannelById`/name (uses cache, falls back to `conversations.info`, upserts result).
>   - **API**: New endpoint `GET /api/v1/slack/channels/{channelId}` returning `ApiSlackChannelResponse` for on-demand lookup; expose `getWebClient`; wire in EE `CommercialSlackClient` with `schedulerClient`.
>   - **Models/Types**: `SlackChannelCacheModel` adds `getChannelByName`, improved `hasAnyChannels`, `startSync` now returns boolean; `SyncSlackChannelsPayload` includes `schedulerUuid`; various generated route/swagger updates and API version bump.
> - **Frontend**:
>   - **SlackChannelSelect**: Debounced search, supports DM inclusion, creatable with Slack ID regex; triggers on-demand lookup via new `useSlackChannelLookup`; merges looked-up + cached options; busy state includes lookup.
>   - **Scheduler form**: Enables DM channels in Slack destinations.
>   - **Hooks**: Add `useSlackChannelLookup` and API call for `GET /slack/channels/{channelId}`; invalidate cached channel queries on success.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d81177e6ecb3dfb001d3337553c64b7301a566d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->