### PR TITLE
fix: changeset conflicts causes explore failures

### DIFF
--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -109,6 +109,25 @@ export class ParameterError extends LightdashError {
     }
 }
 
+export class ChangesetConflictError extends LightdashError {
+    constructor(
+        message: string,
+        data: {
+            entityName: string;
+            entityTableName: string;
+            conflictType: 'already_exists';
+            changeUuid?: string;
+        },
+    ) {
+        super({
+            message,
+            name: 'ChangesetConflictError',
+            statusCode: 409,
+            data,
+        });
+    }
+}
+
 export class NonCompiledModelError extends LightdashError {
     constructor(message: string, data: { [key: string]: AnyType } = {}) {
         super({

--- a/packages/common/src/utils/changeset.ts
+++ b/packages/common/src/utils/changeset.ts
@@ -1,7 +1,7 @@
 import * as JsonPatch from 'fast-json-patch';
 import { type ChangeBase } from '../types/changeset';
 import {
-    ForbiddenError,
+    ChangesetConflictError,
     NotImplementedError,
     ParameterError,
 } from '../types/errors';
@@ -47,7 +47,7 @@ export class ChangesetUtils {
         }
     }
 
-    static applyChangeset<C extends ChangeBase>(
+    static applyChangeset<C extends ChangeBase & { changeUuid?: string }>(
         changeset: { changes: C[] },
         explores: Record<string, Explore | ExploreError>,
     ) {
@@ -133,8 +133,14 @@ export class ChangesetUtils {
                                         entityType
                                     ][change.entityName]
                                 ) {
-                                    throw new ForbiddenError(
+                                    throw new ChangesetConflictError(
                                         `Entity "${change.entityName}" already exists in table "${tableName}" of explore`,
+                                        {
+                                            changeUuid: change.changeUuid,
+                                            entityName: change.entityName,
+                                            entityTableName: tableName,
+                                            conflictType: 'already_exists',
+                                        },
                                     );
                                 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18627

### Description:
Implemented automatic conflict resolution for changesets by adding a retry mechanism that handles conflicts gracefully. When a conflict occurs during changeset application, the system now:

1. Identifies the conflicting change using the new `ChangesetConflictError` class
2. Automatically removes the conflicting change
3. Retries applying the remaining changes (up to 3 times)
4. Logs detailed information about the conflict resolution process

This improves system resilience by preventing changeset conflicts from causing failures in the project model.

_logs on conflict resolution_
![CleanShot 2025-12-08 at 13.55.36.png](https://app.graphite.com/user-attachments/assets/e81da6cd-106c-488a-96bd-2635e814eb68.png)

