### PR TITLE
test: skip and mark e2e tests for removal or migration to unit tests

### DIFF
--- a/packages/e2e/cypress/e2e/app/chartSlugs.cy.ts
+++ b/packages/e2e/cypress/e2e/app/chartSlugs.cy.ts
@@ -1,11 +1,12 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
-describe('Chart Slugs', () => {
+describe.skip('Chart Slugs', () => {
     beforeEach(() => {
         cy.login();
     });
 
-    it('Should access saved chart by slug instead of UUID', () => {
+    // TODO: remove
+    it.skip('Should access saved chart by slug instead of UUID', () => {
         // Navigate to the chart list
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved`);
 
@@ -40,7 +41,8 @@ describe('Chart Slugs', () => {
         });
     });
 
-    it('Should edit chart accessed by slug', () => {
+    // TODO: remove
+    it.skip('Should edit chart accessed by slug', () => {
         const slug = 'how-much-revenue-do-we-have-per-payment-method';
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved/${slug}`);
 
@@ -56,7 +58,8 @@ describe('Chart Slugs', () => {
         cy.url().should('include', '/edit');
     });
 
-    it('Should access chart via API using slug', () => {
+    // todo: move to api tests
+    it.skip('Should access chart via API using slug', () => {
         const slug = 'how-much-revenue-do-we-have-per-payment-method';
 
         // Test API endpoint with slug
@@ -76,7 +79,8 @@ describe('Chart Slugs', () => {
         });
     });
 
-    it('Should handle invalid chart slug gracefully', () => {
+    // todo: remove
+    it.skip('Should handle invalid chart slug gracefully', () => {
         cy.visit(
             `/projects/${SEED_PROJECT.project_uuid}/saved/non-existent-chart-slug`,
             { failOnStatusCode: false },
@@ -86,7 +90,8 @@ describe('Chart Slugs', () => {
         cy.findByText(/not found|does not exist/i).should('exist');
     });
 
-    it('Should run chart query using slug', () => {
+    // todo: remove
+    it.skip('Should run chart query using slug', () => {
         const slug = 'how-much-revenue-do-we-have-per-payment-method';
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved/${slug}`);
 

--- a/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
+++ b/packages/e2e/cypress/e2e/app/customDimensions.cy.ts
@@ -1,6 +1,7 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
-describe('Custom dimensions', () => {
+// todo: move to unit tests
+describe.skip('Custom dimensions', () => {
     beforeEach(() => {
         cy.login();
     });

--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -299,7 +299,7 @@ describe('Dashboard', () => {
         cy.findAllByText('No data available').should('have.length', 0);
     });
 
-    it('Should preview a dashboard image export', () => {
+    it.skip('Should preview a dashboard image export', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
         // create dashboard with title small
         cy.contains('Create dashboard').click();
@@ -336,7 +336,7 @@ describe('Dashboard', () => {
         cy.get('div').contains('Success', { timeout: 20000 }).should('exist');
     });
 
-    it('Should access dashboard by slug instead of UUID', () => {
+    it.skip('Should access dashboard by slug instead of UUID', () => {
         // First, verify we can access via slug
         const slug = 'jaffle-dashboard';
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards/${slug}`);
@@ -356,7 +356,7 @@ describe('Dashboard', () => {
         cy.get('.echarts-for-react').should('have.length', 3);
     });
 
-    it('Should maintain dashboard filters when using slug', () => {
+    it.skip('Should maintain dashboard filters when using slug', () => {
         const slug = 'jaffle-dashboard';
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards/${slug}`);
 
@@ -392,7 +392,7 @@ describe('Dashboard', () => {
         cy.contains('Payment method is credit_card');
     });
 
-    it('Should access dashboard via API using slug', () => {
+    it.skip('Should access dashboard via API using slug', () => {
         const slug = 'jaffle-dashboard';
 
         // Test API endpoint with slug
@@ -412,7 +412,7 @@ describe('Dashboard', () => {
         });
     });
 
-    it('Should handle invalid dashboard slug gracefully', () => {
+    it.skip('Should handle invalid dashboard slug gracefully', () => {
         cy.visit(
             `/projects/${SEED_PROJECT.project_uuid}/dashboards/non-existent-slug`,
             { failOnStatusCode: false },

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -33,7 +33,8 @@ describe('Date tests', () => {
         cy.login();
     });
 
-    it('Check current timezone', () => {
+    // todo: delete
+    it.skip('Check current timezone', () => {
         const now = new Date('1 January, 2000'); // set specific date to avoid daylight savings
         const timezone = Cypress.env('TZ');
         const offset = now.getTimezoneOffset();
@@ -77,7 +78,8 @@ describe('Date tests', () => {
         }
     });
 
-    it('Should get right month on filtered chart', () => {
+    // todo: move to unit test
+    it.skip('Should get right month on filtered chart', () => {
         cy.intercept('**/compileQuery').as('compileQuery');
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved`);
 
@@ -102,7 +104,8 @@ describe('Date tests', () => {
             );
     });
 
-    it('Should use dashboard month filter', () => {
+    // todo: move to unit test
+    it.skip('Should use dashboard month filter', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
         // wiat for the dashboard to load
@@ -194,7 +197,8 @@ describe('Date tests', () => {
         // cy.contains('2020-08-11 22:58:00');
     });
 
-    it('Should filter by date on results table', () => {
+    // todo: move to unit test
+    it.skip('Should filter by date on results table', () => {
         cy.intercept('**/compileQuery').as('compileQuery');
         // This test should not be timezone sensitive
         const exploreStateUrlParams = `?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22dimensions%22%3A%5B%22orders_order_date_day%22%2C%22orders_order_date_week%22%2C%22orders_order_date_month%22%2C%22orders_order_date_year%22%5D%2C%22metrics%22%3A%5B%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_order_date_day%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A1%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_order_date_day%22%2C%22orders_order_date_week%22%2C%22orders_order_date_month%22%2C%22orders_order_date_year%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_order_date_day%22%2C%22yField%22%3A%5B%22orders_order_date_week%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22series%22%3A%5B%7B%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_day%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_order_date_week%22%7D%7D%2C%22type%22%3A%22bar%22%7D%5D%7D%7D%7D%7D`;
@@ -267,7 +271,8 @@ describe('Date tests', () => {
             );
     });
 
-    it('Should filter by datetimes on results table', () => {
+    // todo: move to unit test
+    it.skip('Should filter by datetimes on results table', () => {
         cy.intercept('**/compileQuery').as('compileQuery');
         const exploreStateUrlParams = `?create_saved_chart_version={"tableName"%3A"events"%2C"metricQuery"%3A{"dimensions"%3A["events_timestamp_tz_raw"%2C"events_timestamp_tz_millisecond"%2C"events_timestamp_tz_second"%2C"events_timestamp_tz_minute"%2C"events_timestamp_tz_hour"]%2C"metrics"%3A[]%2C"filters"%3A{}%2C"sorts"%3A[{"fieldId"%3A"events_timestamp_tz_raw"%2C"descending"%3Atrue}]%2C"limit"%3A1%2C"tableCalculations"%3A[]%2C"additionalMetrics"%3A[]}%2C"tableConfig"%3A{"columnOrder"%3A["events_timestamp_tz_raw"%2C"events_timestamp_tz_millisecond"%2C"events_timestamp_tz_second"%2C"events_timestamp_tz_minute"%2C"events_timestamp_tz_hour"]}%2C"chartConfig"%3A{"type"%3A"cartesian"%2C"config"%3A{"layout"%3A{"xField"%3A"events_timestamp_tz_raw"%2C"yField"%3A["events_timestamp_tz_millisecond"]}%2C"eChartsConfig"%3A{"series"%3A[{"encode"%3A{"xRef"%3A{"field"%3A"events_timestamp_tz_raw"}%2C"yRef"%3A{"field"%3A"events_timestamp_tz_millisecond"}}%2C"type"%3A"bar"}]}}}}`;
         cy.visit(
@@ -359,7 +364,8 @@ describe('Date tests', () => {
             );
     });
 
-    it('Should change dates on filters', () => {
+    // todo: move to unit test
+    it.skip('Should change dates on filters', () => {
         cy.intercept('**/compileQuery').as('compileQuery');
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables/orders`);
 
@@ -440,7 +446,8 @@ describe('Date tests', () => {
         cy.findByTestId('delete-filter-rule-button').click();
     });
 
-    it('Should keep value when changing date operator', () => {
+    // todo: move to unit test
+    it.skip('Should keep value when changing date operator', () => {
         cy.intercept('**/compileQuery').as('compileQuery');
         const todayDate = new Date();
 
@@ -507,7 +514,8 @@ describe('Date tests', () => {
         cy.findByTestId('delete-filter-rule-button').click();
     });
 
-    it('Should filter by date on dimension', () => {
+    // todo: move to unit test
+    it.skip('Should filter by date on dimension', () => {
         cy.intercept('**/compileQuery').as('compileQuery');
         const now = dayjs();
         const exploreStateUrlParams = `?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22dimensions%22%3A%5B%22orders_order_date_day%22%2C%22orders_order_date_week%22%2C%22orders_order_date_month%22%2C%22orders_order_date_year%22%5D%2C%22metrics%22%3A%5B%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_order_date_day%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A1%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_order_date_day%22%2C%22orders_order_date_week%22%2C%22orders_order_date_month%22%2C%22orders_order_date_year%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_order_date_day%22%2C%22yField%22%3A%5B%22orders_order_date_week%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22series%22%3A%5B%7B%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_order_date_day%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_order_date_week%22%7D%7D%2C%22type%22%3A%22bar%22%7D%5D%7D%7D%7D%7D`;

--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -100,7 +100,8 @@ const waitForDownloadToComplete = (
     pollForJob();
 };
 
-describe('Download CSV on Dashboards', () => {
+// todo: remove
+describe.skip('Download CSV on Dashboards', () => {
     beforeEach(() => {
         cy.login();
 
@@ -193,7 +194,8 @@ describe('Download CSV on Explore', () => {
         });
     });
 
-    it('Should download CSV from table chart on Explore', () => {
+    // todo: remove
+    it.skip('Should download CSV from table chart on Explore', () => {
         cy.findByTestId('page-spinner').should('not.exist');
 
         // choose table and select fields

--- a/packages/e2e/cypress/e2e/app/embed.cy.ts
+++ b/packages/e2e/cypress/e2e/app/embed.cy.ts
@@ -86,7 +86,8 @@ describe('Embedded dashboard', () => {
         });
     });
 
-    it('I can use "Explore from here" in embedded dashboard and view the correct elements', () => {
+    // todo: move to unit test
+    it.skip('I can use "Explore from here" in embedded dashboard and view the correct elements', () => {
         getJaffleDashboard().then((dashboardsResp) => {
             const dashboardUuid = dashboardsResp.body.results.data[0]?.uuid;
 
@@ -163,7 +164,8 @@ describe('Embedded dashboard', () => {
         });
     });
 
-    it('URL syncs for dashboard filters in direct mode', () => {
+    // todo: move to unit test
+    it.skip('URL syncs for dashboard filters in direct mode', () => {
         getJaffleDashboard().then((dashboardsResp) => {
             const dashboardUuid = dashboardsResp.body.results.data[0]?.uuid;
 
@@ -210,7 +212,8 @@ describe('Embedded dashboard', () => {
         });
     });
 
-    it('URL filter overrides apply for embedded dashboard with all filters allowed', () => {
+    // todo: move to unit test
+    it.skip('URL filter overrides apply for embedded dashboard with all filters allowed', () => {
         getJaffleDashboard().then((dashboardsResp) => {
             const dashboardUuid = dashboardsResp.body.results.data[0]?.uuid;
 
@@ -270,7 +273,8 @@ describe('Embedded dashboard', () => {
         });
     });
 
-    it('URL syncs for date zoom in direct mode', () => {
+    // todo: move to unit test
+    it.skip('URL syncs for date zoom in direct mode', () => {
         getJaffleDashboard().then((dashboardsResp) => {
             const dashboardUuid = dashboardsResp.body.results.data[0]?.uuid;
 

--- a/packages/e2e/cypress/e2e/app/formats.cy.ts
+++ b/packages/e2e/cypress/e2e/app/formats.cy.ts
@@ -1,11 +1,12 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
-describe('Explore', () => {
+describe.skip('Explore', () => {
     beforeEach(() => {
         cy.login();
     });
 
-    it('Should query in explore with formats and rounds', () => {
+    // todo: move to unit test
+    it.skip('Should query in explore with formats and rounds', () => {
         const urlParam = {
             tableName: 'events',
             metricQuery: {

--- a/packages/e2e/cypress/e2e/app/login.cy.ts
+++ b/packages/e2e/cypress/e2e/app/login.cy.ts
@@ -22,7 +22,8 @@ describe('Login', () => {
         cy.url().should('include', '/home');
     });
 
-    it('Should display error message when credentials are invalid or not recognised', () => {
+    // todo: move to unit test
+    it.skip('Should display error message when credentials are invalid or not recognised', () => {
         cy.logout();
         cy.visit('/login');
         cy.findByPlaceholderText('Your email address').type('test-email');

--- a/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
+++ b/packages/e2e/cypress/e2e/app/pivotTables.cy.ts
@@ -47,7 +47,8 @@ describe('Pivot Tables', () => {
         cy.get('@chartArea').contains('Is completed'); // Check that the chart updated successfully with the pivot table(containing 'is completed' column)
     });
 
-    it('I can save a pivot table chart and add it to a dashboard', () => {
+    // todo: remove
+    it.skip('I can save a pivot table chart and add it to a dashboard', () => {
         // Navigate to the explore page
         cy.visit(
             `/projects/${SEED_PROJECT.project_uuid}/tables/orders?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22%22%2C%22dimensions%22%3A%5B%22orders_order_date_week%22%2C%22orders_status%22%2C%22orders_is_completed%22%5D%2C%22metrics%22%3A%5B%22orders_total_order_amount%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_order_date_week%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22orders_status%22%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_order_date_week%22%2C%22orders_status%22%2C%22orders_is_completed%22%2C%22orders_total_order_amount%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22table%22%2C%22config%22%3A%7B%22showColumnCalculation%22%3Afalse%2C%22showRowCalculation%22%3Afalse%2C%22showTableNames%22%3Atrue%2C%22showResultsTotal%22%3Afalse%2C%22showSubtotals%22%3Afalse%2C%22columns%22%3A%7B%7D%2C%22hideRowNumbers%22%3Afalse%2C%22conditionalFormattings%22%3A%5B%5D%2C%22metricsAsRows%22%3Afalse%7D%7D%7D`,
@@ -84,7 +85,8 @@ describe('Pivot Tables', () => {
     });
 });
 
-describe('100% stacked bar chart', () => {
+// todo: move to unit test
+describe.skip('100% stacked bar chart', () => {
     beforeEach(() => {
         cy.login();
     });

--- a/packages/e2e/cypress/e2e/app/projectPermission.cy.ts
+++ b/packages/e2e/cypress/e2e/app/projectPermission.cy.ts
@@ -1,6 +1,7 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
-describe('Project Permissions', () => {
+// todo: move to api tests (or remove if already addressed in api tests)
+describe.skip('Project Permissions', () => {
     it('Organization admin can see projects', () => {
         cy.login();
 

--- a/packages/e2e/cypress/e2e/app/savedDashboards.cy.ts
+++ b/packages/e2e/cypress/e2e/app/savedDashboards.cy.ts
@@ -1,5 +1,6 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
+// todo: combine into 1 test
 describe('Dashboard List', () => {
     beforeEach(() => {
         cy.login();

--- a/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
@@ -83,7 +83,8 @@ describe('SQL Runner (new)', () => {
         //     });
     });
 
-    it('Should verify that the chart is displayed', () => {
+    // todo: remove
+    it.skip('Should verify that the chart is displayed', () => {
         // Verify that the Run query button is disabled by default
         cy.contains('Run query').should('be.disabled');
 
@@ -133,7 +134,9 @@ describe('SQL Runner (new)', () => {
         cy.contains('Incomplete chart configuration').should('be.visible');
         cy.contains("You're missing an X axis").should('be.visible');
     });
-    it('Should verify that the all chart types are displayed', () => {
+
+    // todo: move to unit test
+    it.skip('Should verify that the all chart types are displayed', () => {
         // Verify that the Run query button is disabled by default
         cy.contains('Run query').should('be.disabled');
 
@@ -271,7 +274,8 @@ describe('SQL Runner (new)', () => {
             .should('be.visible');
     });
 
-    it('Should not trigger an extra query to the warehouse when styling a chart', () => {
+    // todo: remove
+    it.skip('Should not trigger an extra query to the warehouse when styling a chart', () => {
         // Verify that the Run query button is disabled by default
         cy.contains('Run query').should('be.disabled');
 

--- a/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
+++ b/packages/e2e/cypress/e2e/app/tableCalculation.cy.ts
@@ -1,11 +1,12 @@
 import { SEED_PROJECT } from '@lightdash/common';
 
-describe('Table calculations', () => {
+describe.skip('Table calculations', () => {
     beforeEach(() => {
         cy.login();
     });
 
-    it('I can create a quick table calculation (rank in column)', () => {
+    // todo: move to unit test
+    it.skip('I can create a quick table calculation (rank in column)', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables/payments`);
 
         // Select metrics and dimensions
@@ -33,7 +34,8 @@ describe('Table calculations', () => {
         });
     });
 
-    it('I can create a quick table calculation (running total)', () => {
+    // todo: move to unit test
+    it.skip('I can create a quick table calculation (running total)', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables/payments`);
 
         // Select metrics and dimensions
@@ -62,7 +64,8 @@ describe('Table calculations', () => {
         });
     });
 
-    it('I can create a string table calculation', () => {
+    // todo: move to unit test
+    it.skip('I can create a string table calculation', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables/orders`);
         // Select metrics and dimensions
         cy.scrollTreeToItem('Order date');
@@ -112,7 +115,8 @@ describe('Table calculations', () => {
         cy.contains('rank_2').should('not.exist');
     });
 
-    it('I can create a number table calculation', () => {
+    // todo: move to unit test
+    it.skip('I can create a number table calculation', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables/orders`);
         // Select metrics and dimensions
         cy.scrollTreeToItem('Order date');

--- a/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
+++ b/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
@@ -2,6 +2,7 @@ import { SEED_PROJECT } from '@lightdash/common';
 
 const apiUrl = '/api/v1';
 
+// todo: combine into 1 test
 describe('User attributes sql_filter', () => {
     beforeEach(() => {
         cy.login();
@@ -82,6 +83,7 @@ describe('User attributes sql_filter', () => {
     });
 });
 
+// todo: combine into 1 test
 describe('User attributes dimension required_attribute', () => {
     beforeEach(() => {
         cy.login();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Skip or remove E2E tests that should be moved to unit tests or API tests. This PR marks numerous tests with `.skip()` and adds TODO comments indicating which tests should be moved to unit tests, API tests, or removed entirely.

The changes primarily affect tests for chart slugs, custom dimensions, dashboard functionality, date handling, CSV downloads, embedding, formats, login, pivot tables, project permissions, and table calculations.


test-frontend