### PR TITLE
ci: increase App E2E test parallelization from 3 to 5 containers

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -248,7 +248,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3]
+        containers: [ 1, 2, 3, 4, 5 ]
     name: "E2E: App (${{ matrix.containers }}/${{ strategy.job-total }})"
     env:
       NODE_OPTIONS: '--max-old-space-size=8192'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Increased the number of containers for E2E app tests from 3 to 5 in the GitHub workflow. This change will help distribute the test load more evenly and potentially reduce overall test execution time.

test-frontend
test-backend