### PR TITLE
fix: auto-scroll when reasoning parts change in AI chat

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ScrollToBottom.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ScrollToBottom.tsx
@@ -71,7 +71,6 @@ const ThreadScrollToBottom = ({
     const totalReasoningPartsCount = streamingState?.reasoning?.flatMap(
         (r) => r.parts,
     ).length;
-    console.log('totalReasoningPartsCount', totalReasoningPartsCount);
 
     useLayoutEffect(() => {
         return scrollToBottom({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added auto-scrolling functionality for reasoning parts in AI Copilot chat. The component now tracks the total count of reasoning parts and triggers a scroll to bottom when new reasoning content is streamed, ensuring users can see new content as it appears.
