### PR TITLE
ci: rollback turbo commands for backend sourcemaps and postbuild

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -219,7 +219,7 @@ RUN --mount=type=secret,id=TURBO_TOKEN \
     export TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN 2>/dev/null || echo "") && \
     if [ -n "${SENTRY_AUTH_TOKEN}" ] && [ -n "${SENTRY_ORG}" ] && [ -n "${SENTRY_RELEASE_VERSION}" ] && [ -n "${SENTRY_FRONTEND_PROJECT}" ] && [ -n "${SENTRY_BACKEND_PROJECT}" ] && [ -n "${SENTRY_ENVIRONMENT}" ]; then \
     echo "Building backend with sourcemaps for Sentry"; \
-    turbo build-sourcemaps --filter=backend && turbo postbuild --filter=backend; \
+    pnpm -F backend build-sourcemaps && pnpm -F backend postbuild; \
     else \
     echo "Building backend without sourcemaps"; \
     turbo build --filter=backend; \


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Rollback turbo commands with original pnpm commands.

Fix error during post-release because these commands are not configured in turbo.