### PR TITLE
chore: free up memory after dashboard load 

### DIFF
--- a/packages/frontend/src/components/DashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/components/DashboardTabs/GridTile.tsx
@@ -5,7 +5,6 @@ import {
     type Dashboard as IDashboard,
 } from '@lightdash/common';
 import { Box } from '@mantine/core';
-import { useProfiler } from '@sentry/react';
 import { memo, type FC } from 'react';
 import ChartTile from '../DashboardTiles/DashboardChartTile';
 import LoomTile from '../DashboardTiles/DashboardLoomTile';
@@ -25,7 +24,6 @@ const GridTile: FC<
     }
 > = memo((props) => {
     const { tile } = props;
-    useProfiler(`Dashboard-${tile.type}`);
 
     if (props.locked) {
         // Allow markdown and loom tiles to show even when locked since they are not filterable

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -78,7 +78,7 @@ export type VisualizationProviderProps = {
     invalidateCache?: boolean;
     colorPalette: string[];
     tableCalculationsMetadata?: TableCalculationMetadata[];
-    setEchartsRef?: (ref: RefObject<EChartsReact | null>) => void;
+    setEchartsRef?: (ref: RefObject<EChartsReact | null> | undefined) => void;
     computedSeries?: Series[];
     apiErrorDetail?: ApiErrorDetail | null;
     containerWidth?: number;
@@ -121,10 +121,23 @@ const VisualizationProvider: FC<
 
     const chartRef = useRef<EChartsReact | null>(null);
     const leafletMapRef = useRef<LeafletMap | null>(null);
+
     useEffect(() => {
         if (setEchartsRef)
             setEchartsRef(chartRef as RefObject<EChartsReact | null>);
-    }, [chartRef, setEchartsRef]);
+
+        // Cleanup: dispose ECharts instance and clear parent reference on unmount
+        return () => {
+            // Dispose the ECharts instance to free up canvas memory
+            if (chartRef.current) {
+                const echartsInstance = chartRef.current.getEchartsInstance();
+                if (echartsInstance && !echartsInstance.isDisposed()) {
+                    echartsInstance.dispose();
+                }
+                chartRef.current = null;
+            }
+        };
+    }, [setEchartsRef]);
     const [lastValidResultsData, setLastValidResultsData] = useState<
         InfiniteQueryResults & { metricQuery?: MetricQuery; fields?: ItemsMap }
     >();

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { Box, Button, Flex, Group, Modal, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { captureException, useProfiler } from '@sentry/react';
+import { captureException } from '@sentry/react';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { type Layout } from 'react-grid-layout';
@@ -786,8 +786,6 @@ const DashboardPage: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { user } = useApp();
     const dashboardCommentsCheck = useDashboardCommentsCheck(user?.data);
-
-    useProfiler('Dashboard');
 
     return (
         <DashboardProvider

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     publicDir: 'public',
     define: {
         __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
-        REACT_SCAN_ENABLED: process.env.REACT_SCAN_ENABLED ?? true,
+        REACT_SCAN_ENABLED: process.env.REACT_SCAN_ENABLED ?? false,
         REACT_GRAB_ENABLED: process.env.REACT_GRAB_ENABLED ?? false,
         REACT_QUERY_DEVTOOLS_ENABLED:
             process.env.REACT_QUERY_DEVTOOLS_ENABLED ?? true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

This PR improves memory management and performance by:

1. Removing Sentry profiling from Dashboard components
2. Adding proper cleanup for ECharts instances to prevent memory leaks
3. Disabling React Scan by default in the Vite configuration
4. Fixing the type definition for `setEchartsRef` to properly handle undefined values

These changes should help reduce memory usage and improve overall application performance, especially for dashboards with multiple visualizations.



This was run with https://facebook.github.io/memlab/docs/intro

> [!NOTE]  
> I can provide the memlab set up if you want, but these changes are quite simple



![Screenshot 2025-12-09 at 09.47.44.png](https://app.graphite.com/user-attachments/assets/a283bce7-dd3c-42b5-9c81-1579b26fae3d.png)

