### PR TITLE
feat: softer contrast in tooltips for dark mode

### DIFF
--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -10,6 +10,7 @@ import {
     TagsInput,
     Textarea,
     TextInput,
+    Tooltip,
     type ButtonVariant,
     type DefaultMantineColor,
     type MantineColorsTuple,
@@ -19,6 +20,8 @@ import {
 import { type ColorScheme } from '@mantine/styles';
 import { DotsLoader } from './ee/features/aiCopilot/components/ChatElements/DotsLoader/DotsLoader';
 import { getMantineThemeOverride as getMantine6ThemeOverride } from './mantineTheme';
+// eslint-disable-next-line css-modules/no-unused-class
+import styles from './styles/mantine-overrides/tooltip.module.css';
 
 declare module '@mantine-8/core' {
     export interface ButtonProps {
@@ -160,7 +163,10 @@ export const getMantine8ThemeOverride = (
                     },
                 }),
             }),
-            Tooltip: {
+            Tooltip: Tooltip.extend({
+                classNames: {
+                    tooltip: styles.tooltip,
+                },
                 defaultProps: {
                     openDelay: 200,
                     withinPortal: true,
@@ -169,7 +175,7 @@ export const getMantine8ThemeOverride = (
                     maw: 250,
                     fz: 'xs',
                 },
-            },
+            }),
             Popover: {
                 defaultProps: {
                     withinPortal: true,

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -5,6 +5,8 @@ import {
     type MantineThemeOverride,
     type Tuple,
 } from '@mantine/core';
+// eslint-disable-next-line css-modules/no-unused-class
+import styles from './styles/mantine-overrides/tooltip.module.css';
 
 type ColorTuple = Tuple<string, 10>;
 
@@ -170,6 +172,9 @@ export const getMantineThemeOverride = (
             },
 
             Tooltip: {
+                classNames: {
+                    tooltip: styles.tooltipMantine6,
+                },
                 defaultProps: {
                     withArrow: true,
                 },

--- a/packages/frontend/src/styles/mantine-overrides/tooltip.module.css
+++ b/packages/frontend/src/styles/mantine-overrides/tooltip.module.css
@@ -1,0 +1,17 @@
+/* NOTE: Using Mantine's colors here for compatibility with their components */
+
+/* Mantine 6 doesn't use css variables, so we need to override colors directly */
+.tooltipMantine6 {
+    @mixin dark {
+        background-color: var(--mantine-color-dark-4);
+        color: var(--mantine-color-text);
+    }
+}
+
+/* Keep variables here as we want to mantine handle all other modifications needed */
+.tooltip {
+    @mixin dark {
+        --tooltip-bg: var(--mantine-color-dark-4);
+        --tooltip-color: var(--mantine-color-text);
+    }
+}


### PR DESCRIPTION
### Description:
Making tooltip backgrounds a bit darker in dark theme. 
Mantine's default Tooltip colors were confusing, as it looked like they were in light mode:

_After_
![CleanShot 2025-12-09 at 13.36.42.png](https://app.graphite.com/user-attachments/assets/773e5acb-6c25-4f51-8e72-5bf5f51890c6.png)

![CleanShot 2025-12-09 at 13.36.19.png](https://app.graphite.com/user-attachments/assets/5968f41a-b803-4937-959c-ffea46f35b6f.png)

---

_Before_

![CleanShot 2025-12-09 at 13.38.06.png](https://app.graphite.com/user-attachments/assets/30f35052-9f17-4f7b-a6e8-19dbd3d21ca8.png)

