### PR TITLE
fix: changeset conflicts on created field causes explore failures

### DIFF
--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -643,3 +643,20 @@ export class CorruptedExploreError extends LightdashError {
         });
     }
 }
+
+export class ChangesetConflictError extends LightdashError {
+    constructor(
+        message: string,
+        data: {
+            entityName: string;
+            entityTableName: string;
+        },
+    ) {
+        super({
+            message,
+            name: 'ChangesetConflictError',
+            statusCode: 409,
+            data,
+        });
+    }
+}

--- a/packages/common/src/utils/changeset.ts
+++ b/packages/common/src/utils/changeset.ts
@@ -1,7 +1,7 @@
 import * as JsonPatch from 'fast-json-patch';
 import { type ChangeBase } from '../types/changeset';
 import {
-    ForbiddenError,
+    ChangesetConflictError,
     NotImplementedError,
     ParameterError,
 } from '../types/errors';
@@ -133,9 +133,16 @@ export class ChangesetUtils {
                                         entityType
                                     ][change.entityName]
                                 ) {
-                                    throw new ForbiddenError(
+                                    const error = new ChangesetConflictError(
                                         `Entity "${change.entityName}" already exists in table "${tableName}" of explore`,
+                                        {
+                                            entityName: change.entityName,
+                                            entityTableName: tableName,
+                                        },
                                     );
+                                    // eslint-disable-next-line no-console
+                                    console.warn(error);
+                                    break;
                                 }
 
                                 const createPatch = JsonPatch.applyPatch(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: #18627

### Description:
Silently ignore `create` field changes from a changeset if they already exist in explore.


