### PR TITLE
fix: github client creating branch against wrong source branch

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -122,10 +122,12 @@ export const getLastCommit = async ({
     token: string;
 }) => {
     const { octokit, headers } = getOctokitRestForUser(token);
+    // GitHub API uses `sha` param to filter by branch
+    // @see https://docs.github.com/en/rest/commits/commits#list-commits
     const response = await octokit.rest.repos.listCommits({
         owner,
         repo,
-        ref: branch,
+        sha: branch,
         headers,
     });
 
@@ -149,6 +151,8 @@ export const getFileContent = async ({
 }) => {
     const { octokit, headers } = getOctokitRestForUser(token);
     try {
+        // GitHub API uses `ref` param for branch/tag/commit
+        // @see https://docs.github.com/en/rest/repos/contents#get-repository-content
         const response = await octokit.rest.repos.getContent({
             owner,
             repo,
@@ -196,6 +200,8 @@ export const createBranch = async ({
     const { octokit, headers } = getOctokitRestForUser(token);
 
     try {
+        // GitHub API uses `ref` as fully qualified reference (refs/heads/...)
+        // @see https://docs.github.com/en/rest/git/refs#create-a-reference
         const response = await octokit.rest.git.createRef({
             owner,
             repo,
@@ -247,6 +253,8 @@ export const updateFile = async ({
 > => {
     const { octokit, headers } = getOctokitRestForUser(token);
     try {
+        // GitHub API uses `branch` param for target branch
+        // @see https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
         const response = await octokit.rest.repos.createOrUpdateFileContents({
             owner,
             repo,
@@ -295,6 +303,8 @@ export const createFile = async ({
     const { octokit, headers } = getOctokitRestForUser(token);
 
     try {
+        // GitHub API uses `branch` param for target branch
+        // @see https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents
         const response = await octokit.rest.repos.createOrUpdateFileContents({
             owner,
             repo,
@@ -364,11 +374,13 @@ export const checkFileDoesNotExist = async ({
     const { octokit, headers } = getOctokitRestForUser(token);
 
     try {
+        // GitHub API uses `ref` param for branch/tag/commit
+        // @see https://docs.github.com/en/rest/repos/contents#get-repository-content
         await octokit.rest.repos.getContent({
             owner,
             repo,
             path,
-            branch,
+            ref: branch,
             headers,
         });
         throw new AlreadyExistsError(`File "${path}" already exists in Github`);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18710

### Description:
Fixed inconsistent parameter naming in GitHub API calls by using the correct parameter names as per GitHub's documentation:

- Changed `ref` to `sha` in `listCommits` to properly filter by branch
- Kept `ref` in `getContent` for specifying branch/tag/commit
- Added clarification that `ref` in `createRef` should be fully qualified (refs/heads/...)
- Kept `branch` in `createOrUpdateFileContents` as it's the correct parameter
- Changed `branch` to `ref` in `getContent` within `checkFileDoesNotExist`

Added documentation links to GitHub API references for each method to improve code clarity and maintainability.

### Steps to reproduce
1. Create repository with empty `main` branch and dbt project on a separate branch
2. Add github integration to lightdash
3. Use github in project connection
4. Set the branch to be the branch containing the dbt project and the path

![image.png](https://app.graphite.com/user-attachments/assets/f0122477-5e92-48a0-99c0-3449acdfcb4d.png)

5. Try to write back a custom dimension/metric/sql model

**Before**

![image.png](https://app.graphite.com/user-attachments/assets/b17cb06d-7a8f-4e15-af3c-2de4afa8b7df.png)

**After**

![image.png](https://app.graphite.com/user-attachments/assets/4d1b88f9-d8b5-482d-bf04-869750d50997.png)

