### PR TITLE
refactor: reuse slack regex

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -3,6 +3,7 @@ import {
     friendlyName,
     getErrorMessage,
     MissingConfigError,
+    SLACK_ID_REGEX,
     SlackAppCustomSettings,
     SlackChannel,
     SlackError,
@@ -594,7 +595,7 @@ export class SlackClient {
             throw new Error(`Organization ${organizationUuid} not found`);
         }
         // Check if input looks like a Slack ID (C, G, U, W followed by alphanumerics)
-        const isSlackId = /^[CGUW][A-Z0-9]{8,}$/i.test(input);
+        const isSlackId = SLACK_ID_REGEX.test(input);
 
         if (isSlackId) {
             return this.lookupChannelByIdInternal(

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -198,6 +198,7 @@ export * from './utils/promises';
 export * from './utils/sanitizeHtml';
 export * from './utils/scheduler';
 export * from './utils/searchParams';
+export * from './utils/slack';
 export * from './utils/sleep';
 export * from './utils/slugs';
 export * from './utils/subtotals';

--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -1,0 +1,2 @@
+// Regex to detect Slack IDs: C (public channel), G (private channel), U/W (user/DM)
+export const SLACK_ID_REGEX = /^[CGUW][A-Z0-9]{8,}$/i;

--- a/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
+++ b/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
@@ -1,3 +1,4 @@
+import { SLACK_ID_REGEX } from '@lightdash/common';
 import {
     ActionIcon,
     Loader,
@@ -15,9 +16,6 @@ import {
     useSlackChannels,
 } from '../../../hooks/slack/useSlack';
 import MantineIcon from '../MantineIcon';
-
-// Regex to detect Slack IDs: C (public channel), G (private channel), U/W (user/DM)
-const SLACK_ID_REGEX = /^[CGUW][A-Z0-9]{8,}$/i;
 
 type CommonProps = {
     disabled?: SelectProps['disabled'];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Extracted the Slack ID regex pattern to a common utility to ensure consistent validation across the application. The regex pattern is now imported from `@lightdash/common` in both the backend `SlackClient` and frontend `SlackChannelSelect` components, eliminating duplicate code and ensuring consistent Slack ID validation throughout the application.
