### PR TITLE
chore: ignore warehouse errors in sentry

### DIFF
--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -4,6 +4,7 @@ import { lightdashConfig } from './config/lightdashConfig';
 import { VERSION } from './version';
 
 export const IGNORE_ERRORS = [
+    'WarehouseConnectionError',
     'WarehouseQueryError',
     'FieldReferenceError',
     'NotEnoughResults',


### PR DESCRIPTION
This error is due to warehouse connectivity / credentials issues, not something to alert in sentry