### PR TITLE
chore: create generator for chart metadata

### DIFF
--- a/packages/backend/src/ee/analytics/index.ts
+++ b/packages/backend/src/ee/analytics/index.ts
@@ -69,6 +69,15 @@ export type CustomVizGenerated = BaseTrack & {
         timeOpenAi: number;
     };
 };
+
+export type GenerateChartMetadataGenerated = BaseTrack & {
+    event: 'ai.chart_metadata.generated';
+    properties: {
+        organizationId: string;
+        projectId: string;
+        chartType: string;
+    };
+};
 // SCIM events
 
 export type ScimAccessTokenAuthenticationEvent = BaseTrack & {

--- a/packages/backend/src/ee/controllers/aiController.ts
+++ b/packages/backend/src/ee/controllers/aiController.ts
@@ -1,9 +1,11 @@
 import {
     ApiAiDashboardSummaryResponse,
+    ApiAiGenerateChartMetadataResponse,
     ApiAiGenerateCustomVizResponse,
     ApiAiGetDashboardSummaryResponse,
     ApiErrorPayload,
     DashboardSummary,
+    GenerateChartMetadataRequest,
     ItemsMap,
 } from '@lightdash/common';
 import {
@@ -98,6 +100,26 @@ export class AiController extends BaseController {
                 projectUuid,
                 ...body,
             }),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/chart/generate-metadata')
+    @OperationId('generateChartMetadata')
+    async generateChartMetadata(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: GenerateChartMetadataRequest,
+    ): Promise<ApiAiGenerateChartMetadataResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiService().generateChartMetadata(
+                req.user!,
+                projectUuid,
+                body,
+            ),
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -88,6 +88,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     dashboardModel: models.getDashboardModel(),
                     dashboardSummaryModel: models.getDashboardSummaryModel(),
                     projectService: repository.getProjectService(),
+                    featureFlagService: repository.getFeatureFlagService(),
                     openAi: new OpenAi(), // TODO This should go in client repository as soon as it is available
                 }),
             aiAgentService: ({

--- a/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
@@ -1,0 +1,97 @@
+import { Field } from '@lightdash/common';
+import { generateObject, LanguageModel } from 'ai';
+import { z } from 'zod';
+
+const TITLE_MAX_LENGTH_CHARS = 120;
+const DESCRIPTION_MAX_LENGTH_CHARS = 500;
+
+const ChartMetadataSchema = z.object({
+    title: z
+        .string()
+        .min(1, 'Title must not be empty')
+        .max(
+            TITLE_MAX_LENGTH_CHARS,
+            `Title must be ${TITLE_MAX_LENGTH_CHARS} characters or less`,
+        )
+        .describe('A concise, descriptive title for the chart'),
+    description: z
+        .string()
+        .max(
+            DESCRIPTION_MAX_LENGTH_CHARS,
+            `Description must be ${DESCRIPTION_MAX_LENGTH_CHARS} characters or less`,
+        )
+        .describe(
+            'A brief description explaining what insights this chart provides',
+        ),
+});
+
+export type GeneratedChartMetadata = z.infer<typeof ChartMetadataSchema>;
+
+type FieldInfo = Pick<Field, 'name' | 'label' | 'description' | 'type'>;
+
+export type ChartMetadataContext = {
+    tableName: string;
+    chartType: string;
+    dimensions: string[];
+    metrics: string[];
+    filters?: string;
+    fieldsContext: FieldInfo[];
+    /** Raw chart configuration as JSON string */
+    chartConfigJson?: string;
+};
+
+/**
+ * Build a field ID to label mapping for the prompt
+ */
+function buildFieldLabelMap(fieldsContext: FieldInfo[]): string {
+    if (fieldsContext.length === 0) return 'No field information available.';
+    return fieldsContext
+        .map(
+            (f) =>
+                `${f.name} = "${f.label}"${
+                    f.description ? ` (${f.description})` : ''
+                }`,
+        )
+        .join('\n');
+}
+
+export async function generateChartMetadata(
+    model: LanguageModel,
+    context: ChartMetadataContext,
+): Promise<GeneratedChartMetadata> {
+    const fieldLabelMap = buildFieldLabelMap(context.fieldsContext);
+
+    const result = await generateObject({
+        model,
+        schema: ChartMetadataSchema,
+        messages: [
+            {
+                role: 'system',
+                content: `Generate a concise title (max ${TITLE_MAX_LENGTH_CHARS} chars) and description (max ${DESCRIPTION_MAX_LENGTH_CHARS} chars) for a data chart.
+
+Title: Be specific. Represent the title as a data question that it answers. 
+Description: Explain what insights the chart provides in one sentence.
+
+IMPORTANT: Use the human-readable field labels provided, NOT the technical field IDs.
+ALWAYS look at the chart type and its configuration so you know how to best represent the title and description.
+Be direct - avoid phrases like "This chart shows..." and also avoid mentioning what the chart type is, but what what the chart is about.`,
+            },
+            {
+                role: 'user',
+                content: `Chart type: ${context.chartType}
+Data source: "${context.tableName}"
+${context.filters ? `Filters: ${context.filters}\n` : ''}
+Field labels (use these instead of IDs):
+${fieldLabelMap}
+${
+    context.chartConfigJson
+        ? `\nChart configuration:\n${context.chartConfigJson}`
+        : ''
+}`,
+            },
+        ],
+        temperature: 0.3,
+    });
+
+    return result.object;
+}

--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -46,6 +46,19 @@ export const MODEL_PRESETS: {
                 parallelToolCalls: false,
             },
         },
+        {
+            name: 'gpt-4o-mini',
+            provider: 'openai',
+            modelId: 'gpt-4o-mini',
+            displayName: 'GPT-4o Mini',
+            description: 'Fast and cost-effective model for simple tasks',
+            supportsReasoning: false,
+            callOptions: { temperature: 0.3 },
+            providerOptions: {
+                strictJsonSchema: true,
+                parallelToolCalls: false,
+            },
+        },
     ],
     anthropic: [
         {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5665,6 +5665,82 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GeneratedChartMetadata: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: { dataType: 'string', required: true },
+                title: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiGenerateChartMetadataResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'GeneratedChartMetadata', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Field.name-or-label-or-description-or-type_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                name: { dataType: 'string', required: true },
+                type: { dataType: 'string', required: true },
+                label: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GenerateChartMetadataRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                chartConfigJson: { dataType: 'string' },
+                fieldsContext: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'Pick_Field.name-or-label-or-description-or-type_',
+                    },
+                    required: true,
+                },
+                filters: { dataType: 'string' },
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                chartType: { dataType: 'string', required: true },
+                tableName: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_':
         {
             dataType: 'refAlias',
@@ -6771,11 +6847,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7271,11 +7347,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7290,11 +7366,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7309,11 +7385,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7328,11 +7404,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7347,11 +7423,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -25624,6 +25700,72 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'generateCustomViz',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiController_generateChartMetadata: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'GenerateChartMetadataRequest',
+        },
+    };
+    app.post(
+        '/api/v1/ai/:projectUuid/chart/generate-metadata',
+        ...fetchMiddlewares<RequestHandler>(AiController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiController.prototype.generateChartMetadata,
+        ),
+
+        async function AiController_generateChartMetadata(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiController_generateChartMetadata,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<AiController>(
+                    AiController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'generateChartMetadata',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6440,6 +6440,93 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "GeneratedChartMetadata": {
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "required": ["description", "title"],
+                "type": "object"
+            },
+            "ApiAiGenerateChartMetadataResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/GeneratedChartMetadata"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Pick_Field.name-or-label-or-description-or-type_": {
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "label": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "type", "label"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "GenerateChartMetadataRequest": {
+                "properties": {
+                    "chartConfigJson": {
+                        "type": "string"
+                    },
+                    "fieldsContext": {
+                        "items": {
+                            "$ref": "#/components/schemas/Pick_Field.name-or-label-or-description-or-type_"
+                        },
+                        "type": "array"
+                    },
+                    "filters": {
+                        "type": "string"
+                    },
+                    "metrics": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "chartType": {
+                        "type": "string"
+                    },
+                    "tableName": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "fieldsContext",
+                    "metrics",
+                    "dimensions",
+                    "chartType",
+                    "tableName"
+                ],
+                "type": "object"
+            },
             "Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableReasoning-or-version_": {
                 "properties": {
                     "description": {
@@ -7584,8 +7671,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -69,6 +69,7 @@ import { type EmailStatusExpiring } from './email';
 import { type Explore, type SummaryExplore } from './explore';
 import {
     type DimensionType,
+    type Field,
     type FilterableField,
     type ItemsMap,
 } from './field';
@@ -684,6 +685,28 @@ export type ApiAiGenerateCustomVizResponse = {
     results: string;
 };
 
+export type GenerateChartMetadataRequest = {
+    tableName: string;
+    chartType: string;
+    dimensions: string[];
+    metrics: string[];
+    filters?: string;
+    fieldsContext: Array<
+        Pick<Field, 'name' | 'label' | 'description' | 'type'>
+    >;
+    chartConfigJson?: string;
+};
+
+export type GeneratedChartMetadata = {
+    title: string;
+    description: string;
+};
+
+export type ApiAiGenerateChartMetadataResponse = {
+    status: 'ok';
+    results: GeneratedChartMetadata;
+};
+
 type ApiResults =
     | ApiQueryResults
     | ApiSqlQueryResults
@@ -768,6 +791,7 @@ type ApiResults =
     | ApiCreateProjectResults
     | ApiAiDashboardSummaryResponse['results']
     | ApiAiGetDashboardSummaryResponse['results']
+    | ApiAiGenerateChartMetadataResponse['results']
     | ApiCatalogMetadataResults
     | ApiCatalogAnalyticsResults
     | ApiPromotionChangesResponse['results']


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Added AI-powered chart metadata generation to automatically create titles and descriptions for charts. This feature:

- Implements a new endpoint `/api/v1/ai/:projectUuid/chart/generate-metadata` to generate chart metadata
- Creates a chart metadata generator agent that uses LLMs to analyze chart data and configuration
- Adds support for fast, cost-effective models (GPT-4o Mini, Claude Haiku) for lightweight tasks
- Tracks chart metadata generation events for analytics
- Requires the AI Copilot feature flag to be enabled

The generator creates concise, descriptive titles and descriptions based on the chart's dimensions, metrics, and configuration, helping users create more informative visualizations with less effort.