### PR TITLE
fix: value labels on horizontal charts stacked

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -915,25 +915,15 @@ const getSimpleSeries = ({
             ...getValueLabelStyle(series.label.position, series.type),
             ...(itemsMap &&
                 itemsMap[yFieldHash] && {
-                    formatter: (value: any) => {
+                    formatter: (param: any) => {
                         const field = itemsMap[yFieldHash];
-                        const v = value?.value;
-                        let rawValue: any;
 
-                        // Handle tuple mode (array) vs dataset mode (object)
-                        if (Array.isArray(v)) {
-                            // Use encode.y to get the right index
-                            const yIdx = Array.isArray(value?.encode?.y)
-                                ? value.encode.y[0]
-                                : value?.encode?.y;
-                            rawValue =
-                                typeof yIdx === 'number' ? v[yIdx] : v[1];
-                        } else if (v && typeof v === 'object') {
-                            // Dataset mode: use yFieldHash as key
-                            rawValue = v[yFieldHash];
-                        } else {
-                            rawValue = v;
-                        }
+                        const rawValue = getMetricFromParam(
+                            param,
+                            series,
+                            yFieldHash,
+                            !!flipAxes,
+                        );
 
                         // For 100% stacked charts on the primary axis, values are already percentages (0-100)
                         // Only apply stack100 formatting if this series is on yAxisIndex 0


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18727

### Description:

Refactored the formatter function in `useEchartsCartesianConfig.ts` to use a dedicated `getMetricFromParam` helper function instead of inline logic for extracting values from chart parameters. This simplifies the code and improves maintainability by centralizing the value extraction logic.


![Screenshot 2025-12-10 at 12.05.26.png](https://app.graphite.com/user-attachments/assets/ef0da668-4a23-4ba0-a9be-7a7466f2c5cc.png)

