### PR TITLE
fix: color stability across charts in a dashboard

### DIFF
--- a/packages/frontend/src/hooks/useChartColorConfig/CLAUDE.md
+++ b/packages/frontend/src/hooks/useChartColorConfig/CLAUDE.md
@@ -1,0 +1,77 @@
+<summary>
+Provides consistent color assignment for chart series across dashboards.
+
+When multiple charts display the same data series (e.g., "pending" orders), this module ensures they share the same color. Colors are assigned deterministically using a hash of the series identifier, persisting across page reloads.
+
+</summary>
+
+<howToUse>
+Use `useChartColorConfig` hook to get color assignment functions:
+
+-   `calculateSeriesColorAssignment(series)` - Get color for a single series
+-   `registerSeriesForColorAssignment(series[])` - Pre-register multiple series (populates cache)
+-   `calculateKeyColorAssignment(group, identifier)` - Low-level color lookup
+
+The `ChartColorMappingContextProvider` must wrap your app (already done in App.tsx).
+</howToUse>
+
+<codeExample>
+
+```tsx
+import { useChartColorConfig } from './useChartColorConfig';
+
+const MyChart = ({ series, colorPalette }) => {
+    const { calculateSeriesColorAssignment, registerSeriesForColorAssignment } =
+        useChartColorConfig({ colorPalette });
+
+    // Pre-register all series (populates cache for performance)
+    useEffect(() => {
+        registerSeriesForColorAssignment(series);
+    }, [series, registerSeriesForColorAssignment]);
+
+    // Get color for each series
+    const colors = series.map((s) => calculateSeriesColorAssignment(s));
+};
+```
+
+</codeExample>
+
+<importantToKnow>
+**Color Priority** (in VisualizationProvider):
+
+1. Explicit `series.color` (user-set)
+2. Metadata colors (saved in chart config)
+3. Dimension colors (from dbt model)
+4. Calculated colors (this module, when feature flag ON)
+5. Fallback colors (position-based, when flag OFF)
+
+**Feature Flag**: `CalculateSeriesColor` controls whether calculated colors are used. When OFF, falls back to position-based `fallbackColors`.
+
+**Hash-Based Assignment**: Colors are assigned using djb2 hash of the identifier, ensuring the same identifier always maps to the same color index. This provides determinism across page reloads and regardless of what other series exist.
+
+**Per-Chart Collision Handling**: When two series in the same chart hash to the same color index, linear probing finds the next available color. This ensures no two series within a chart share the same color.
+
+**Collision Resolution Trade-off**:
+-   Non-colliding series: Always get the same color (hash-based, deterministic)
+-   Colliding series: May get different colors on reload (depends on registration order)
+-   Cross-chart consistency: Same identifier always gets the same color once registered in the Map
+
+**Map Structure**: `Map<group, Map<identifier, colorIndex>>` used as a cache. The color index is computed via hash (with collision handling), stored in Map for cross-chart consistency.
+
+**Series Identifier Structure**: `calculateSeriesLikeIdentifier(series)` returns `[groupKey, identifier]`:
+
+-   Ungrouped series: `["$ungrouped", "orders_count"]` - all ungrouped metrics share one group
+-   Grouped series: `["orders_status", "pending"]` (field + pivot value)
+-   Used as `groupKey|identifier` for fallback lookup, or passed to Map for calculated colors
+
+**Flipped Axis Edge Case**: When axis is flipped, ECharts includes pivot value in the field identifier (e.g., `orders_status.pending`). The code strips this to maintain consistent `basefield→pivot_value` mapping.
+
+**Multi-Pivot Grouping**: When multiple pivot values exist, a suffix `_n{count}` is added to the group key. This creates separate color scopes for different pivot configurations.
+</importantToKnow>
+
+<links>
+- @packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx - Main consumer
+- @packages/frontend/src/hooks/useChartColorConfig/utils.ts - Series identifier calculation
+- https://github.com/lightdash/lightdash/issues/13831 - Original color consistency issue
+- https://github.com/lightdash/lightdash/issues/14468 - Cross-chart color matching
+</links>

--- a/packages/frontend/src/hooks/useChartColorConfig/ChartColorMappingContextProvider.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig/ChartColorMappingContextProvider.tsx
@@ -3,31 +3,17 @@ import { useLocation } from 'react-router';
 import { ChartColorMappingContext } from './context';
 
 /**
- * Exposes a map of identifier->color values, which can be shared across
- * a context, for shared color assignment.
+ * Provides a shared Map for color assignment across all charts on the same page.
  */
 const ChartColorMappingContextProvider: FC<React.PropsWithChildren<{}>> = ({
     children,
 }) => {
     const location = useLocation();
 
-    /**
-     * Changes to colorMappings are intentionally kept outside the React render loop,
-     * we don't want to trigger re-renders for every mapping assignment, and we're
-     * creating assignments during the render process anyway.
-     */
+    // Using useRef to avoid re-renders on color assignments
     const colorMappings = useRef(new Map<string, Map<string, number>>());
 
-    /**
-     * Any time the path changes, if we have any color mappings in the context,
-     * we reset them completely. This prevents things like playing around with
-     * filters, or editing a chart, from 'polluting' the mappings table in
-     * unpredictable ways.
-     *
-     * This could alternatively be implemented as contexts further down the tree,
-     * but this approach ensures mappings are always shared at the highest possible
-     * level regardless of how/where a chart is being rendered.
-     */
+    // Reset on route changes to prevent color pollution
     useEffect(() => {
         if (colorMappings.current.size > 0) {
             colorMappings.current = new Map<string, Map<string, number>>();

--- a/packages/frontend/src/hooks/useChartColorConfig/constants.ts
+++ b/packages/frontend/src/hooks/useChartColorConfig/constants.ts
@@ -1,5 +1,0 @@
-/**
- * A unique key used to track the latest index assigned within a group,
- * within the color mappings Map.
- */
-export const ASSIGNMENT_IDX_KEY = '$___idx';

--- a/packages/frontend/src/hooks/useChartColorConfig/useChartColorConfig.tsx
+++ b/packages/frontend/src/hooks/useChartColorConfig/useChartColorConfig.tsx
@@ -1,9 +1,8 @@
 import { useMantineTheme } from '@mantine/core';
 import { useCallback, useContext } from 'react';
-import { ASSIGNMENT_IDX_KEY } from './constants';
 import { ChartColorMappingContext } from './context';
 import { type ChartColorMappingContextProps, type SeriesLike } from './types';
-import { calculateSeriesLikeIdentifier } from './utils';
+import { calculateSeriesLikeIdentifier, hashStringToIndex } from './utils';
 
 const useChartColorMappingContext = (): ChartColorMappingContextProps => {
     const ctx = useContext(ChartColorMappingContext);
@@ -25,59 +24,31 @@ export const useChartColorConfig = ({
     const theme = useMantineTheme();
     const { colorMappings } = useChartColorMappingContext();
 
-    /**
-     * Given the org's color palette, and an identifier, return the color palette value
-     * for said identifier.
-     *
-     * This works by taking a group and identifier, and cycling through the color palette
-     * colors on a first-come first-serve basis, scoped to a particular group of identifiers.
-     *
-     * 'Group' will generally be something like a table or model name, e.g 'customer',
-     * 'Identifier' will generally be something like a field name, or a group value.
-     *
-     * Because this color cycling is done per group, it allows unrelated charts/series
-     * to cycle through colors in the palette in parallel.
-     */
+    // Returns a color for a group/identifier pair.
     const calculateKeyColorAssignment = useCallback(
         (group: string, identifier: string) => {
-            // Ensure we always color null the same:
+            // Null values always get gray
             if (!identifier || identifier === 'null') {
                 return theme.colors.ldGray[6];
             }
 
             let groupMappings = colorMappings.get(group);
 
-            /**
-             * If we already picked a color for this group/identifier pair, return it:
-             */
+            // Return existing color if already assigned
             if (groupMappings && groupMappings.has(identifier)) {
                 return colorPalette[groupMappings.get(identifier)!];
             }
 
-            /**
-             * If this is the first time we're seeing this group, create a sub-map for it:
-             */
+            // Create group if first time seeing it
             if (!groupMappings) {
                 groupMappings = new Map<string, number>();
                 colorMappings.set(group, groupMappings);
             }
 
-            /**
-             * Figure out the last color assigned in this group, and either pick the
-             * next color in the palette, or start over from 0.
-             */
-            const currentIdx = groupMappings.get(ASSIGNMENT_IDX_KEY) ?? -1;
-            const nextIdx =
-                currentIdx === colorPalette.length - 1 ? 0 : currentIdx + 1;
-            const colorHex = colorPalette[nextIdx];
-
-            // Keep track of the current value of the color idx for this group:
-            groupMappings.set(ASSIGNMENT_IDX_KEY, nextIdx);
-
-            // Keep track of the color idx used for this identifier, within this group:
-            groupMappings.set(identifier, nextIdx);
-
-            return colorHex;
+            // Use hash for deterministic color assignment
+            const colorIdx = hashStringToIndex(identifier, colorPalette.length);
+            groupMappings.set(identifier, colorIdx);
+            return colorPalette[colorIdx];
         },
         [colorPalette, colorMappings, theme],
     );
@@ -92,8 +63,59 @@ export const useChartColorConfig = ({
         [calculateKeyColorAssignment],
     );
 
+    // Pre-registers series for color assignment with per-chart collision handling.
+    // - Hash determines base color (deterministic across reloads)
+    // - Collisions within a chart are resolved by probing
+    // - Probed results are stored in Map so same series gets same color across charts
+    const registerSeriesForColorAssignment = useCallback(
+        (series: SeriesLike[]) => {
+            const usedIndicesInChart = new Set<number>();
+
+            series.forEach((s) => {
+                const [group, identifier] = calculateSeriesLikeIdentifier(s);
+
+                if (!identifier || identifier === 'null') return;
+
+                let groupMappings = colorMappings.get(group);
+
+                // If already in Map, use that color (cross-chart consistency)
+                if (groupMappings && groupMappings.has(identifier)) {
+                    usedIndicesInChart.add(groupMappings.get(identifier)!);
+                    return;
+                }
+
+                // Create group if needed
+                if (!groupMappings) {
+                    groupMappings = new Map<string, number>();
+                    colorMappings.set(group, groupMappings);
+                }
+
+                // Hash-based assignment with per-chart collision handling
+                let colorIdx = hashStringToIndex(
+                    identifier,
+                    colorPalette.length,
+                );
+
+                // Probe for next available if collision within THIS chart
+                let probeCount = 0;
+                while (
+                    usedIndicesInChart.has(colorIdx) &&
+                    probeCount < colorPalette.length
+                ) {
+                    colorIdx = (colorIdx + 1) % colorPalette.length;
+                    probeCount++;
+                }
+
+                groupMappings.set(identifier, colorIdx);
+                usedIndicesInChart.add(colorIdx);
+            });
+        },
+        [colorMappings, colorPalette.length],
+    );
+
     return {
         calculateKeyColorAssignment,
         calculateSeriesColorAssignment,
+        registerSeriesForColorAssignment,
     };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: #18467

  ### Description

  Makes chart series colors stable and deterministic using hash-based color assignment with per-chart collision handling.

  ### Key changes:
  - Use djb2 hash algorithm to assign colors based on series identifier, providing deterministic colors across page reloads
  - Group all ungrouped metrics under $ungrouped so they get different colors within the same chart
  - Add per-chart collision handling via linear probing to ensure no two series in the same chart share colors
  - Store resolved colors in shared Map for cross-chart consistency

  ### Behavior guarantees:
  - Within same chart: Different series always have different colors
  - Across charts: Same series always has the same color
  - Across charts: Different series can reuse colors
  - Reload stability: Non-colliding series get stable colors; colliding series may vary

  ### Related issues

  - https://github.com/lightdash/lightdash/issues/13831 - Original color consistency issue
  - https://github.com/lightdash/lightdash/issues/14468 - Cross-chart color matching

  ### Reproduction steps

1. Create chart with dimension using parameter in group by
2. add chart to dashboard
3. change the parameter value