### PR TITLE
style: update dashboard border tiles on dark mode

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -118,7 +118,11 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 bg="background"
                 shadow={isEditMode ? 'xs' : undefined}
                 sx={(theme) => {
-                    let border = `1px solid ${theme.colors.ldGray[1]}`;
+                    let border = `1px solid ${
+                        theme.colorScheme === 'dark'
+                            ? theme.fn.lighten(theme.colors.ldDark[1], 0.05)
+                            : theme.colors.ldGray[1]
+                    }`;
                     if (isEditMode) {
                         border = `1px dashed ${theme.colors.blue[5]}`;
                     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:

Enhances the TileBase component to support dark mode by dynamically adjusting the border color based on the theme's color scheme. In dark mode, the border now uses a slightly lightened version of the dark theme color instead of always using the light gray color.

![Screenshot 2025-12-10 at 18.27.25.png](https://app.graphite.com/user-attachments/assets/d1fb58a5-4498-42c6-9b33-9809107bf790.png)

