### PR TITLE
fix: limit query results to maximum of 500 rows

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2688,7 +2688,7 @@ export class AsyncQueryService extends ProjectService {
             filters,
             metrics: availableMetrics.map(getItemId),
             sorts: [],
-            limit: limit ?? 500,
+            limit: Math.min(limit ?? 500, 500),
             tableCalculations: [],
             additionalMetrics: [],
         };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

  Problem: The "view underlying data" feature was causing OOM (out of memory) errors because when
  exporting CSV with "all results", the frontend was passing MAX_SAFE_INTEGER (2,147,483,647) as the
   limit value. The backend was using this value directly without capping it.

  Solution: Modified packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts at line
  2691 to cap the underlying data query limit at 500 results maximum:

  // Before:
  limit: limit ?? 500,

  // After: 
  limit: Math.min(limit ?? 500, 500),

  This ensures that even if a client passes a very large limit value (like when exporting "all
  results"), the underlying data query will never exceed 500 rows, preventing OOM errors.


### Description:
Enforces a maximum limit of 500 rows for async queries by applying `Math.min()` to the user-provided limit value. This prevents users from requesting an excessive number of rows that could impact performance.