### PR TITLE
refactor: filter dashboard tiles by active tab and remove unused prop

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/FilterConfiguration/TileFilterConfiguration.tsx
@@ -61,8 +61,6 @@ type TileWithTargetColumns = {
 type Props = {
     tiles: DashboardTile[];
     tabs: DashboardTab[];
-    // TODO: unused, remove
-    activeTabUuid: string | undefined;
     availableTileFilters: Record<string, Field[] | undefined>;
     field?: Field;
     filterRule: DashboardFilterRule;


### PR DESCRIPTION
### Description:
This PR filters dashboard filter configurations to only include tiles from the active tab. When creating or editing a filter, the available tile filters and columns are now filtered based on the active tab UUID, ensuring that only relevant tiles are considered.

Additionally, I removed an unused `activeTabUuid` prop from the `TileFilterConfiguration` component that was previously marked with a TODO comment.