### PR TITLE
fix: allow nullish externalId and email from embed user

### DIFF
--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -86,8 +86,8 @@ export const EmbedJwtSchema = z
         userAttributes: z.record(z.unknown()).optional(),
         user: z
             .object({
-                externalId: z.string().optional(),
-                email: z.string().optional(),
+                externalId: z.string().nullish(),
+                email: z.string().nullish(),
             })
             .optional(),
         content: z.union([


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-1174/error-when-loading-jwt-on-embed

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Fixes Sentry errors by allowing for null values in the JWT schema validation. [Zod.optional](https://github.com/lightdash/lightdash/blob/777ee271766d5724443faa2940a441b236799fe3/packages/backend/src/auth/account/account.ts#L35) only allows `undefined` as the empty value whereas [Zod.nullish](https://github.com/lightdash/lightdash/blob/777ee271766d5724443faa2940a441b236799fe3/packages/backend/src/auth/account/account.ts#L35) allows both `undefined` and `null`. 

This is a safe change because we make [nullish checks](https://github.com/lightdash/lightdash/blob/777ee271766d5724443faa2940a441b236799fe3/packages/backend/src/auth/account/account.ts#L35) for externalId when parsing the JWT. The change is simply to prevent remove alert noise. 

I'm leaving the remaining fields optional for now, since we're only seeing the `user` validation errors right now.