### PR TITLE
fix: apply right filters to stacked bar underlying data

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -780,12 +780,23 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 e.dimensionNames.includes(getItemId(dimension)),
             );
 
+            // Helper to extract value from click event data
+            // For stacked bars: e.value is an array, e.dimensionNames maps indices to field names
+            // For other charts: e.data is an object with field names as keys
+            const getValueFromClickData = (fieldId: string) => {
+                if (Array.isArray(e.value) && e.dimensionNames) {
+                    const index = e.dimensionNames.indexOf(fieldId);
+                    return index >= 0 ? e.value[index] : undefined;
+                }
+                return (e.data as Record<string, unknown>)[fieldId];
+            };
+
             const dimensionOptions = dimensions.map((dimension) =>
                 createDashboardFilterRuleFromField({
                     field: dimension,
                     availableTileFilters: {},
                     isTemporary: true,
-                    value: e.data[getItemId(dimension)],
+                    value: getValueFromClickData(getItemId(dimension)),
                 }),
             );
             const serie = series[e.seriesIndex];

--- a/packages/frontend/src/components/MetricQueryData/utils.ts
+++ b/packages/frontend/src/components/MetricQueryData/utils.ts
@@ -10,6 +10,38 @@ import {
 import { type EchartsSeriesClickEvent } from '../SimpleChart';
 import { type UnderlyingDataConfig } from './types';
 
+/**
+ * Extracts field values from ECharts click event data.
+ *
+ * For stacked bar charts, e.value is an array and e.dimensionNames maps indices to field names.
+ * For other charts, e.data is an object with field names as keys.
+ */
+const extractFieldValuesFromClickEvent = (
+    e: EchartsSeriesClickEvent,
+): Record<string, ResultValue> => {
+    // Stacked bar charts: e.value is an array, use e.dimensionNames to map indices to field names
+    if (Array.isArray(e.value) && e.dimensionNames) {
+        const valueArray = e.value as unknown[];
+        const fieldValues: Record<string, ResultValue> = {};
+        e.dimensionNames.forEach((dimName, index) => {
+            if (dimName && index < valueArray.length) {
+                const val = valueArray[index];
+                const raw = val === '∅' ? null : val; // convert ∅ values back to null. Echarts doesn't support null formatting https://github.com/apache/echarts/issues/15821
+                fieldValues[dimName] = { raw, formatted: String(val ?? '') };
+            }
+        });
+        return fieldValues;
+    }
+
+    return Object.entries(e.data).reduce<Record<string, ResultValue>>(
+        (acc, [key, val]) => {
+            const raw = val === '∅' ? null : val; // convert ∅ values back to null. Echarts doesn't support null formatting https://github.com/apache/echarts/issues/15821
+            return { ...acc, [key]: { raw, formatted: val } };
+        },
+        {},
+    );
+};
+
 export const getDataFromChartClick = (
     e: EchartsSeriesClickEvent,
     itemsMap: ItemsMap,
@@ -38,16 +70,12 @@ export const getDataFromChartClick = (
     } else if (selectedFields.length > 0) {
         selectedField = selectedFields[0];
     }
+
+    const fieldValues = extractFieldValuesFromClickEvent(e);
+
     const selectedValue = selectedField
-        ? e.data[getItemId(selectedField)]
+        ? fieldValues[getItemId(selectedField)]?.raw
         : undefined;
-    const fieldValues: Record<string, ResultValue> = Object.entries(
-        e.data,
-    ).reduce((acc, entry) => {
-        const [key, val] = entry;
-        const raw = val === '∅' ? null : val; // convert ∅ values back to null. Echarts doesn't support null formatting https://github.com/apache/echarts/issues/15821
-        return { ...acc, [key]: { raw, formatted: val } };
-    }, {});
 
     return {
         item: selectedField,

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -42,9 +42,14 @@ type EchartsBaseClickEvent = {
 
 export type EchartsSeriesClickEvent = EchartsBaseClickEvent & {
     componentType: 'series';
-    data: Record<string, any>;
+    // data can be either:
+    // - Object format: { fieldName: value, ... } - for most dataset mode charts
+    // - Tuple format: { value: [...] } - for stacked bar charts
+    data: Record<string, any> | any[];
     seriesIndex: number;
     dimensionNames: string[];
+    // encode maps x/y axes to indices in dimensionNames (e.g., {x: [0], y: [1]})
+    encode?: { x?: number[]; y?: number[] };
     pivotReference?: PivotReference;
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18730

### Description:

Fixed chart click handling for stacked bar charts by improving value extraction from click events. Previously, the code only handled standard chart formats where data is available as an object with field names as keys. Now it properly handles stacked bar charts where values are provided as arrays with dimension names mapping to indices.

The PR adds a helper function `extractFieldValuesFromClickEvent` that intelligently determines the data format and extracts values accordingly, ensuring consistent behavior across different chart types when users click on chart elements.

**You can test with order date week + payment method + order amount > stacked bar chart > view underlying data; With these changes and what is on main. See "null" value passed to the `underlying-data` payload filter for date
Test also with horizontal bar chart.**

