### PR TITLE
fix: improve text wrapping in FieldSelect component

### DIFF
--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -55,18 +55,13 @@ const ItemComponent = forwardRef<HTMLDivElement, ItemComponentProps>(
             openDelay={500}
         >
             <Box ref={ref} {...rest}>
-                <Group
-                    noWrap
-                    spacing={size}
-                    maw="100%"
-                    sx={{ overflow: 'hidden' }}
-                >
+                <Group noWrap spacing={size} maw="100%">
                     <FieldIcon
                         style={{ flexShrink: 0 }}
                         item={item}
                         selected={rest.selected}
                     />
-                    <Text truncate size={size}>
+                    <Text span size={size} style={{ wordBreak: 'normal' }}>
                         {label}
                     </Text>
                 </Group>


### PR DESCRIPTION
### Description:
Improves text display in FieldSelect component by removing overflow hidden from the Group component and changing the Text component to use `span` with `wordBreak: 'normal'` instead of `truncate`. This allows field labels to display properly without being cut off.