### PR TITLE
fix: default AI_DEFAULT_EMBEDDING_PROVIDER to openai and return undefined on empty strings for float and integer parsing

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -72,7 +72,7 @@ export const getIntegerFromEnvironmentVariable = (
     name: string,
 ): number | undefined => {
     const raw = process.env[name];
-    if (raw === undefined) {
+    if (!raw) {
         return undefined;
     }
     const parsed = Number.parseInt(raw, 10);
@@ -88,7 +88,7 @@ export const getFloatFromEnvironmentVariable = (
     name: string,
 ): number | undefined => {
     const raw = process.env[name];
-    if (raw === undefined) {
+    if (!raw) {
         return undefined;
     }
     const parsed = Number.parseFloat(raw);
@@ -679,7 +679,9 @@ export const getAiConfig = () => ({
     embeddingEnabled: process.env.AI_EMBEDDING_ENABLED === 'true',
     defaultProvider:
         process.env.AI_DEFAULT_PROVIDER || DEFAULT_DEFAULT_AI_PROVIDER,
-    defaultEmbeddingModelProvider: process.env.AI_DEFAULT_EMBEDDING_PROVIDER,
+    defaultEmbeddingModelProvider:
+        process.env.AI_DEFAULT_EMBEDDING_PROVIDER ||
+        DEFAULT_DEFAULT_AI_PROVIDER,
     providers: {
         azure: process.env.AZURE_AI_API_KEY
             ? {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR improves environment variable handling in the config parser:

1. Changed the condition for checking environment variables from `=== undefined` to `!raw` to handle both undefined and empty string cases.

2. Added a fallback to `DEFAULT_DEFAULT_AI_PROVIDER` for the `defaultEmbeddingModelProvider` configuration, ensuring it always has a value even when the environment variable is not set.

**Before**
When `DEFAULT_DEFAULT_AI_PROVIDER` was unset, server would fail with

```
Invalid AI copilot configuration: [
  {
    "received": "",
    "code": "invalid_enum_value",
    "options": [
      "openai",
      "bedrock"
    ],
    "path": [
      "defaultEmbeddingModelProvider"
    ],
    "message": "Invalid enum value. Expected 'openai' | 'bedrock', received ''"
  }
]
```

When `AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD` was set to `''` it would fail with (this happened in docker compose when no variable was set in `.env`

```
Cannot parse environment variable "AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD". Value must be a float but AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD=
ParseError: Cannot parse environment variable "AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD". Value must be a float but AI_VERIFIED_ANSWER_SIMILARITY_THRESHOLD=
    at getFloatFromEnvironmentVariable (/usr/app/packages/backend/src/config/parseConfig.ts:96:15)
    at getAiConfig (/usr/app/packages/backend/src/config/parseConfig.ts:736:40)
    at parseConfig (/usr/app/packages/backend/src/config/parseConfig.ts:1218:41)
    at Object.<anonymous> (/usr/app/packages/backend/src/config/lightdashConfig.ts:3:43)
    at Module._compile (node:internal/modules/cjs/loader:1521:14)
    at Module.m._compile (/usr/app/node_modules/.pnpm/ts-node@10.9.2_@swc+core@1.13.5_@types+node@24.3.1_typescript@5.7.2/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
    at Object.require.extensions.<computed> [as .ts] (/usr/app/node_modules/.pnpm/ts-node@10.9.2_@swc+core@1.13.5_@types+node@24.3.1_typescript@5.7.2/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1266:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1091:12)
```