### PR TITLE
feat: add screenshot ready indicator for minimal saved explorer

### DIFF
--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -66,10 +66,21 @@ const MinimalExplorerContent = memo(() => {
 
     useEffect(() => {
         if (hasSignaledReady.current) return;
-        if (!savedChart || isLoadingQueryResults) return;
+        if (
+            !savedChart ||
+            isLoadingQueryResults ||
+            health.isInitialLoading ||
+            !health.data
+        )
+            return;
         setIsScreenshotReady(true);
         hasSignaledReady.current = true;
-    }, [savedChart, isLoadingQueryResults]);
+    }, [
+        savedChart,
+        isLoadingQueryResults,
+        health.isInitialLoading,
+        health.data,
+    ]);
 
     if (!savedChart || health.isInitialLoading || !health.data) {
         return null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: GLITCH-95

### Description:
Added a screenshot ready indicator to the MinimalSavedExplorer component. The component now tracks when the saved chart and query results are loaded, and displays a ScreenshotReadyIndicator when the visualization is ready to be captured. This improves the reliability of screenshot generation by ensuring the content is fully rendered before capture.