### PR TITLE
fix: only attempt fetching projects when user is logged in

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -70,19 +70,23 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
     const { data: organization, isInitialLoading: isLoadingOrg } =
         useOrganization(useQueryFetchOptions);
 
+    const isLoggedIn = !!organization;
+
     // Priority 1: Project UUID from URL params
     const { data: paramProject, isInitialLoading: isLoadingParamProject } =
         useProject(params.projectUuid);
 
     // Priority 2: Last used project from localStorage
     // Only fetch if no param project and we have a lastProjectUuid
-    const shouldFetchLastProject = !params.projectUuid && !!lastProjectUuid;
+    const shouldFetchLastProject =
+        isLoggedIn && !params.projectUuid && !!lastProjectUuid;
     const { data: lastProject, isInitialLoading: isLoadingLastProject } =
         useProject(shouldFetchLastProject ? lastProjectUuid : undefined);
 
     // Priority 3: Organization's default project
     // Only fetch if no param project, no last project, and org has a default
     const shouldFetchDefaultProject =
+        isLoggedIn &&
         !params.projectUuid &&
         isLastProjectUuidFetched &&
         !lastProjectUuid &&
@@ -97,6 +101,7 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
     // Priority 4: Fallback to any project (when org has no defaultProjectUuid)
     // Only fetch projects list if we have no other option AND localStorage check is complete
     const shouldFetchFallbackProjects =
+        isLoggedIn &&
         !params.projectUuid &&
         isLastProjectUuidFetched &&
         !lastProjectUuid &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Prevents fetching projects when the user is not logged in by adding an `isLoggedIn` check to the project fetching logic in `useActiveProjectUuid`.

To reproduce the issue:

- Login to Lightdash,
- Logout, refresh the page
- Get "We are currently unable to reach the Lightdash server. Please try again in a few moments." error  
  
  
![CleanShot 2025-12-12 at 11.49.53@2x.png](https://app.graphite.com/user-attachments/assets/bac71704-6715-4783-94fe-cce6fe52336c.png)

    