### PR TITLE
feat: add GPT-5.2 model preset

### DIFF
--- a/packages/backend/src/ee/services/ai/models/presets.ts
+++ b/packages/backend/src/ee/services/ai/models/presets.ts
@@ -21,6 +21,19 @@ export const MODEL_PRESETS: {
 } = {
     openai: [
         {
+            name: 'gpt-5.2',
+            provider: 'openai',
+            modelId: 'gpt-5.2-2025-12-11',
+            displayName: 'GPT-5.2',
+            description: 'Flagship reasoning model for agentic tasks',
+            supportsReasoning: true,
+            callOptions: { temperature: 0.2 },
+            providerOptions: {
+                strictJsonSchema: true,
+                parallelToolCalls: false,
+            },
+        },
+        {
             name: 'gpt-5.1',
             provider: 'openai',
             modelId: 'gpt-5.1-2025-11-13',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Add GPT-5.2 model preset to OpenAI provider options. The preset includes configuration for the new `gpt-5.2-2025-12-11` model, setting it up as a flagship reasoning model for agentic tasks with appropriate temperature and provider options.
