### PR TITLE
feat: add sankey chart type

### DIFF
--- a/packages/backend/src/database/migrations/20251211171557_add_sankey_to_chart_type.ts
+++ b/packages/backend/src/database/migrations/20251211171557_add_sankey_to_chart_type.ts
@@ -1,0 +1,10 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex('chart_types').insert({ chart_type: 'sankey' });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex('saved_queries_versions').where('chart_type', 'sankey').delete();
+    await knex('chart_types').delete().where('chart_type', 'sankey');
+}

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -329,6 +329,7 @@ export function derivePivotConfigurationFromChart(
         case ChartType.GAUGE:
         case ChartType.CUSTOM:
         case ChartType.BIG_NUMBER:
+        case ChartType.SANKEY:
         case ChartType.MAP:
             newConfig = undefined;
             break;

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -25,6 +25,7 @@ export enum ChartKind {
     CUSTOM = 'custom',
     TREEMAP = 'treemap',
     GAUGE = 'gauge',
+    SANKEY = 'sankey',
     MAP = 'map',
 }
 
@@ -36,6 +37,7 @@ export enum ChartType {
     FUNNEL = 'funnel',
     TREEMAP = 'treemap',
     GAUGE = 'gauge',
+    SANKEY = 'sankey',
     CUSTOM = 'custom',
     MAP = 'map',
 }
@@ -139,6 +141,31 @@ export type GaugeChart = {
     maxFieldId?: string;
     showAxisLabels?: boolean;
     sections?: GaugeSection[];
+    customLabel?: string;
+};
+
+export enum SankeyOrientationType {
+    HORIZONTAL = 'horizontal',
+    VERTICAL = 'vertical',
+}
+
+export enum SankeyNodeAlign {
+    LEFT = 'left',
+    RIGHT = 'right',
+    JUSTIFY = 'justify',
+}
+
+export type SankeyChart = {
+    sourceFieldId: string | null;
+    targetFieldId: string | null;
+    valueFieldId: string | null;
+    orientation?: SankeyOrientationType;
+    nodeAlign?: SankeyNodeAlign;
+    nodeGap?: number;
+    nodeWidth?: number;
+    showLabels?: boolean;
+    labelOverrides?: Record<string, string>;
+    colorOverrides?: Record<string, string>;
     customLabel?: string;
 };
 
@@ -476,6 +503,11 @@ export type GaugeChartConfig = {
     config?: GaugeChart;
 };
 
+export type SankeyChartConfig = {
+    type: ChartType.SANKEY;
+    config?: SankeyChart;
+};
+
 export type MapChartConfig = {
     type: ChartType.MAP;
     config?: MapChart;
@@ -490,6 +522,7 @@ export type ChartConfig =
     | TableChartConfig
     | TreemapChartConfig
     | GaugeChartConfig
+    | SankeyChartConfig
     | MapChartConfig;
 
 export type SavedChartType = ChartType;
@@ -686,6 +719,8 @@ export const getChartType = (chartKind: ChartKind | undefined): ChartType => {
             return ChartType.TREEMAP;
         case ChartKind.GAUGE:
             return ChartType.GAUGE;
+        case ChartKind.SANKEY:
+            return ChartType.SANKEY;
         default:
             return ChartType.CARTESIAN;
     }
@@ -742,6 +777,8 @@ export const getChartKind = (
             return ChartKind.TREEMAP;
         case ChartType.GAUGE:
             return ChartKind.GAUGE;
+        case ChartType.SANKEY:
+            return ChartKind.SANKEY;
         case ChartType.MAP:
             return ChartKind.MAP;
         default:

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -17,6 +17,7 @@ import { ConfigTabs as FunnelChartConfigTabs } from '../../VisualizationConfigs/
 import { ConfigTabs as GaugeConfigTabs } from '../../VisualizationConfigs/GaugeConfig/GaugeConfigTabs';
 import { ConfigTabs as MapConfigTabs } from '../../VisualizationConfigs/MapConfig';
 import { ConfigTabs as PieChartConfigTabs } from '../../VisualizationConfigs/PieChartConfig/PieChartConfigTabs';
+import { ConfigTabs as SankeyConfigTabs } from '../../VisualizationConfigs/SankeyConfig/SankeyConfigTabs';
 import { ConfigTabs as TableConfigTabs } from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
 import { ConfigTabs as TreemapConfigTabs } from '../../VisualizationConfigs/TreemapConfig/TreemapConfigTabs';
 import VisualizationCardOptions from '../VisualizationCardOptions';
@@ -52,6 +53,8 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
                 return GaugeConfigTabs;
             case ChartType.MAP:
                 return MapConfigTabs;
+            case ChartType.SANKEY:
+                return SankeyConfigTabs;
             case ChartType.CUSTOM:
                 // Return a wrapper component that handles lazy loading
                 return () => (

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -13,6 +13,7 @@ import {
     IconChartDots,
     IconChartLine,
     IconChartPie,
+    IconChartSankey,
     IconChartTreemap,
     IconChevronDown,
     IconCode,
@@ -190,6 +191,11 @@ const VisualizationCardOptions: FC = memo(() => {
                 return {
                     text: 'Map',
                     icon: <MantineIcon icon={IconMap} color="gray" />,
+                };
+            case ChartType.SANKEY:
+                return {
+                    text: 'Sankey chart',
+                    icon: <MantineIcon icon={IconChartSankey} color="ldGray" />,
                 };
             case ChartType.CUSTOM:
                 return {
@@ -433,6 +439,23 @@ const VisualizationCardOptions: FC = memo(() => {
                         Map
                     </Menu.Item>
                 )}
+
+                <Menu.Item
+                    disabled={disabled}
+                    color={
+                        isMapVisualizationConfig(visualizationConfig)
+                            ? 'blue'
+                            : undefined
+                    }
+                    icon={<MantineIcon icon={IconChartSankey} />}
+                    onClick={() => {
+                        setStacking(undefined);
+                        setCartesianType(undefined);
+                        setChartType(ChartType.SANKEY);
+                    }}
+                >
+                    Sankey
+                </Menu.Item>
 
                 <Menu.Item
                     disabled={disabled}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigSankey.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigSankey.tsx
@@ -1,0 +1,41 @@
+import { ChartType } from '@lightdash/common';
+import { useEffect, useMemo } from 'react';
+import useSankeyChartConfig from '../../hooks/useSankeyChartConfig';
+import {
+    type VisualizationConfigSankey,
+    type VisualizationConfigSankeyProps,
+} from './types';
+
+const VisualizationSankeyConfig: React.FC<VisualizationConfigSankeyProps> = ({
+    itemsMap,
+    initialChartConfig,
+    onChartConfigChange,
+    children,
+}) => {
+    const sankeyConfig = useSankeyChartConfig(
+        initialChartConfig as any,
+        itemsMap,
+    );
+
+    useEffect(() => {
+        if (!onChartConfigChange || !sankeyConfig.validConfig) return;
+
+        onChartConfigChange({
+            type: ChartType.SANKEY,
+            config: sankeyConfig.validConfig,
+        });
+    }, [sankeyConfig, onChartConfigChange]);
+
+    const visualizationConfig: VisualizationConfigSankey = useMemo(
+        () => ({
+            chartType: sankeyConfig.chartType,
+            chartConfig: sankeyConfig,
+            allFields: itemsMap ?? {},
+        }),
+        [sankeyConfig, itemsMap],
+    );
+
+    return children({ visualizationConfig });
+};
+
+export default VisualizationSankeyConfig;

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -48,6 +48,7 @@ import VisualizationConfigFunnel from './VisualizationConfigFunnel';
 import VisualizationGaugeConfig from './VisualizationConfigGauge';
 import VisualizationMapConfig from './VisualizationConfigMap';
 import VisualizationPieConfig from './VisualizationConfigPie';
+import VisualizationSankeyConfig from './VisualizationConfigSankey';
 import VisualizationTableConfig from './VisualizationConfigTable';
 import VisualizationTreemapConfig from './VisualizationConfigTreemap';
 import VisualizationCustomConfig from './VisualizationCustomConfig';
@@ -468,6 +469,24 @@ const VisualizationProvider: FC<
                         </Context.Provider>
                     )}
                 </VisualizationGaugeConfig>
+            );
+        case ChartType.SANKEY:
+            return (
+                <VisualizationSankeyConfig
+                    itemsMap={itemsMap}
+                    resultsData={lastValidResultsData}
+                    initialChartConfig={chartConfig.config}
+                    onChartConfigChange={handleChartConfigChange}
+                    parameters={parameters}
+                >
+                    {({ visualizationConfig }) => (
+                        <Context.Provider
+                            value={{ ...value, visualizationConfig }}
+                        >
+                            {children}
+                        </Context.Provider>
+                    )}
+                </VisualizationSankeyConfig>
             );
         case ChartType.MAP:
             return (

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -10,6 +10,7 @@ import FunnelChart from '../FunnelChart';
 import SimpleChart from '../SimpleChart';
 import SimpleGauge from '../SimpleGauge';
 import SimplePieChart from '../SimplePieChart';
+import SimpleSankey from '../SimpleSankey';
 import SimpleStatistic from '../SimpleStatistic';
 import SimpleTable from '../SimpleTable';
 import SimpleTreemap from '../SimpleTreemap';
@@ -154,6 +155,16 @@ const LightdashVisualization = memo(
                 case ChartType.GAUGE:
                     return (
                         <SimpleGauge
+                            className={className}
+                            isInDashboard={isDashboard}
+                            $shouldExpand
+                            data-testid={props['data-testid']}
+                            {...props}
+                        />
+                    );
+                case ChartType.SANKEY:
+                    return (
+                        <SimpleSankey
                             className={className}
                             isInDashboard={isDashboard}
                             $shouldExpand

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -23,6 +23,7 @@ import type useFunnelChartConfig from '../../hooks/useFunnelChartConfig';
 import type useGaugeChartConfig from '../../hooks/useGaugeChartConfig';
 import type usePieChartConfig from '../../hooks/usePieChartConfig';
 import type { InfiniteQueryResults } from '../../hooks/useQueryResults';
+import type useSankeyChartConfig from '../../hooks/useSankeyChartConfig';
 import type useTreemapChartConfig from '../../hooks/useTreemapChartConfig';
 
 export type VisualizationConfigCommon<T extends VisualizationConfig> = {
@@ -218,6 +219,25 @@ export type VisualizationConfigGaugeProps =
         itemsMap: ItemsMap | undefined;
     };
 
+// Sankey
+
+export type VisualizationConfigSankey = {
+    chartType: ChartType.SANKEY;
+    chartConfig: ReturnType<typeof useSankeyChartConfig>;
+    allFields: ItemsMap;
+};
+
+export const isSankeyVisualizationConfig = (
+    visualizationConfig: VisualizationConfig | undefined,
+): visualizationConfig is VisualizationConfigSankey => {
+    return visualizationConfig?.chartType === ChartType.SANKEY;
+};
+
+export type VisualizationConfigSankeyProps =
+    VisualizationConfigCommon<VisualizationConfigSankey> & {
+        itemsMap: ItemsMap | undefined;
+    };
+
 // Map
 
 import type useMapChartConfig from '../../hooks/useMapChartConfig';
@@ -253,5 +273,6 @@ export type VisualizationConfig =
     | VisualizationConfigTable
     | VisualizationConfigTreemap
     | VisualizationConfigGauge
+    | VisualizationConfigSankey
     | VisualizationConfigMap
     | VisualizationCustomConfigType;

--- a/packages/frontend/src/components/SimpleSankey/index.tsx
+++ b/packages/frontend/src/components/SimpleSankey/index.tsx
@@ -1,0 +1,90 @@
+import { IconChartSankey } from '@tabler/icons-react';
+import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
+import { memo, useEffect, type FC } from 'react';
+import useEchartsSankeyConfig from '../../hooks/echarts/useEchartsSankeyConfig';
+import EChartsReact from '../EChartsReactWrapper';
+import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
+
+const EmptyChart = () => (
+    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
+        <SuboptimalState
+            title="No data available"
+            description="Select source, target, and value fields to display a Sankey diagram."
+            icon={IconChartSankey}
+        />
+    </div>
+);
+
+const LoadingChart = () => (
+    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
+        <SuboptimalState
+            title="Loading chart"
+            loading
+            className="loading_chart"
+        />
+    </div>
+);
+
+type SimpleSankeyProps = Omit<EChartsReactProps, 'option'> & {
+    isInDashboard: boolean;
+    $shouldExpand?: boolean;
+    className?: string;
+    'data-testid'?: string;
+};
+
+const EchartOptions: Opts = { renderer: 'svg' };
+
+const SimpleSankey: FC<SimpleSankeyProps> = memo((props) => {
+    const { chartRef, isLoading } = useVisualizationContext();
+
+    const sankeyOptions = useEchartsSankeyConfig({
+        isInDashboard: props.isInDashboard,
+    });
+
+    useEffect(() => {
+        const listener = () => chartRef.current?.getEchartsInstance().resize();
+        const observer = new ResizeObserver(() => {
+            listener();
+        });
+
+        if (chartRef.current?.getEchartsInstance().getDom()) {
+            observer.observe(chartRef.current?.getEchartsInstance().getDom());
+        }
+        window.addEventListener('resize', listener);
+        return () => {
+            window.removeEventListener('resize', listener);
+            observer.disconnect();
+        };
+    });
+
+    if (isLoading) return <LoadingChart />;
+    if (!sankeyOptions) return <EmptyChart />;
+
+    return (
+        <EChartsReact
+            ref={chartRef}
+            data-testid={props['data-testid']}
+            className={props.className}
+            style={
+                props.$shouldExpand
+                    ? {
+                          minHeight: 'inherit',
+                          height: '100%',
+                          width: '100%',
+                      }
+                    : {
+                          minHeight: 'inherit',
+                          // height defaults to 300px
+                          width: '100%',
+                      }
+            }
+            opts={EchartOptions}
+            option={sankeyOptions.eChartsOption}
+            notMerge
+            {...props}
+        />
+    );
+});
+
+export default SimpleSankey;

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
@@ -1,0 +1,36 @@
+import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
+import { memo, useMemo, type FC } from 'react';
+import { getVizConfigThemeOverride } from '../mantineTheme';
+import { SankeyDisplayConfig } from './SankeyDisplayConfig';
+import { SankeyFieldsConfig } from './SankeyFieldsConfig';
+
+export const ConfigTabs: FC = memo(() => {
+    const { colorScheme } = useMantineColorScheme();
+    const themeOverride = useMemo(
+        () => getVizConfigThemeOverride(colorScheme),
+        [colorScheme],
+    );
+
+    return (
+        <MantineProvider inherit theme={themeOverride}>
+            <Tabs defaultValue="fields" keepMounted={false}>
+                <Tabs.List mb="sm">
+                    <Tabs.Tab px="sm" value="fields">
+                        Fields
+                    </Tabs.Tab>
+                    <Tabs.Tab px="sm" value="display">
+                        Display
+                    </Tabs.Tab>
+                </Tabs.List>
+
+                <Tabs.Panel value="fields">
+                    <SankeyFieldsConfig />
+                </Tabs.Panel>
+
+                <Tabs.Panel value="display">
+                    <SankeyDisplayConfig />
+                </Tabs.Panel>
+            </Tabs>
+        </MantineProvider>
+    );
+});

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyDisplayConfig.tsx
@@ -1,0 +1,30 @@
+import { Switch } from '@mantine/core';
+import { memo, type FC } from 'react';
+import { isSankeyVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import { Config } from '../common/Config';
+
+export const SankeyDisplayConfig: FC = memo(() => {
+    const { visualizationConfig } = useVisualizationContext();
+
+    if (!isSankeyVisualizationConfig(visualizationConfig)) {
+        return null;
+    }
+
+    const {
+        chartConfig: { showLabels, setShowLabels },
+    } = visualizationConfig;
+
+    return (
+        <Config>
+            <Config.Section>
+                <Config.Heading>Labels</Config.Heading>
+                <Switch
+                    label="Show node labels"
+                    checked={showLabels}
+                    onChange={(e) => setShowLabels(e.currentTarget.checked)}
+                />
+            </Config.Section>
+        </Config>
+    );
+});

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyFieldsConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyFieldsConfig.tsx
@@ -1,0 +1,91 @@
+import { getItemId } from '@lightdash/common';
+import { Stack } from '@mantine/core';
+import { memo, type FC } from 'react';
+import { isSankeyVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import FieldSelect from '../../common/FieldSelect';
+import { Config } from '../common/Config';
+
+export const SankeyFieldsConfig: FC = memo(() => {
+    const { visualizationConfig } = useVisualizationContext();
+
+    if (!isSankeyVisualizationConfig(visualizationConfig)) {
+        return null;
+    }
+
+    const {
+        chartConfig: {
+            sourceFieldId,
+            setSourceFieldId,
+            targetFieldId,
+            setTargetFieldId,
+            valueFieldId,
+            setValueFieldId,
+            getField,
+        },
+        allFields,
+    } = visualizationConfig;
+
+    const sourceField = getField(sourceFieldId);
+    const targetField = getField(targetFieldId);
+    const valueField = getField(valueFieldId);
+    const fieldsList = Object.values(allFields);
+
+    return (
+        <Config>
+            <Config.Section>
+                <Config.Heading>Fields</Config.Heading>
+                <Stack spacing="sm">
+                    <FieldSelect
+                        label="Source field"
+                        description="The field representing the source node"
+                        item={sourceField ?? undefined}
+                        items={fieldsList.filter(
+                            (field) =>
+                                field.name !== targetField?.name &&
+                                field.name !== valueField?.name,
+                        )}
+                        onChange={(newValue) => {
+                            setSourceFieldId(
+                                newValue ? getItemId(newValue) : null,
+                            );
+                        }}
+                        hasGrouping
+                    />
+                    <FieldSelect
+                        label="Target field"
+                        description="The field representing the target node"
+                        item={targetField ?? undefined}
+                        items={fieldsList.filter(
+                            (field) =>
+                                field.name !== sourceField?.name &&
+                                field.name !== valueField?.name,
+                        )}
+                        onChange={(newValue) => {
+                            setTargetFieldId(
+                                newValue ? getItemId(newValue) : null,
+                            );
+                        }}
+                        hasGrouping
+                    />
+                    <FieldSelect
+                        label="Value field"
+                        description="The field representing the flow weight"
+                        item={valueField ?? undefined}
+                        items={fieldsList.filter(
+                            (field) =>
+                                field.name !== sourceField?.name &&
+                                field.name !== targetField?.name,
+                        )}
+                        onChange={(newValue) => {
+                            setValueFieldId(
+                                newValue ? getItemId(newValue) : null,
+                            );
+                        }}
+                        hasGrouping
+                    />
+                </Stack>
+            </Config.Section>
+        </Config>
+    );
+});

--- a/packages/frontend/src/components/common/ResourceIcon/utils.ts
+++ b/packages/frontend/src/components/common/ResourceIcon/utils.ts
@@ -6,6 +6,7 @@ import {
     IconChartDots,
     IconChartLine,
     IconChartPie,
+    IconChartSankey,
     IconChartTreemap,
     IconCode,
     IconFilter,
@@ -38,6 +39,8 @@ export const getChartIcon = (chartKind: ChartKind | undefined) => {
             return IconChartTreemap;
         case ChartKind.GAUGE:
             return IconGauge;
+        case ChartKind.SANKEY:
+            return IconChartSankey;
         case ChartKind.TABLE:
             return IconTable;
         case ChartKind.BIG_NUMBER:

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -45,6 +45,8 @@ export const getResourceTypeName = (item: ResourceViewItem) => {
                     return 'Custom visualization';
                 case ChartKind.MAP:
                     return 'Map';
+                case ChartKind.SANKEY:
+                    return 'Sankey chart';
                 default:
                     return assertUnreachable(
                         item.data.chartKind,

--- a/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
@@ -1,0 +1,165 @@
+import {
+    formatItemValue,
+    getItemLabelWithoutTableName,
+} from '@lightdash/common';
+import { useMantineTheme } from '@mantine/core';
+import { type EChartsOption } from 'echarts';
+import { useMemo } from 'react';
+import { isSankeyVisualizationConfig } from '../../components/LightdashVisualization/types';
+import { useVisualizationContext } from '../../components/LightdashVisualization/useVisualizationContext';
+
+type SankeyNode = {
+    name: string;
+    itemStyle?: { color?: string };
+    label?: { show?: boolean };
+};
+
+type SankeyLink = {
+    source: string;
+    target: string;
+    value: number;
+};
+
+type Args = {
+    isInDashboard: boolean;
+};
+
+const useEchartsSankeyConfig = ({ isInDashboard }: Args) => {
+    const { visualizationConfig, itemsMap, resultsData, parameters } =
+        useVisualizationContext();
+    const theme = useMantineTheme();
+
+    const chartConfig = useMemo(() => {
+        if (!isSankeyVisualizationConfig(visualizationConfig)) return;
+        return visualizationConfig.chartConfig;
+    }, [visualizationConfig]);
+
+    const eChartsOption: EChartsOption | undefined = useMemo(() => {
+        if (!chartConfig || !resultsData || !itemsMap) return;
+
+        const {
+            sourceFieldId,
+            targetFieldId,
+            valueFieldId,
+            orientation,
+            nodeAlign,
+            nodeGap,
+            nodeWidth,
+            showLabels,
+            labelOverrides,
+            colorOverrides,
+        } = chartConfig.validConfig;
+
+        // Validate required fields
+        if (!sourceFieldId || !targetFieldId || !valueFieldId) {
+            return undefined;
+        }
+
+        const rows = resultsData.rows;
+        if (!rows || rows.length === 0) return undefined;
+
+        // Extract unique nodes and build links
+        const nodeSet = new Set<string>();
+        const links: SankeyLink[] = [];
+
+        for (const row of rows) {
+            const sourceValue = row[sourceFieldId];
+            const targetValue = row[targetFieldId];
+            const weightValue = row[valueFieldId];
+
+            if (!sourceValue || !targetValue || !weightValue) continue;
+
+            const source = String(sourceValue.value.raw);
+            const target = String(targetValue.value.raw);
+            const value = Number(weightValue.value.raw);
+
+            // Skip invalid data
+            if (!source || !target || isNaN(value) || value <= 0) continue;
+
+            // Skip self-loops (source === target)
+            if (source === target) continue;
+
+            nodeSet.add(source);
+            nodeSet.add(target);
+
+            // Aggregate duplicate links
+            const existingLink = links.find(
+                (l) => l.source === source && l.target === target,
+            );
+            if (existingLink) {
+                existingLink.value += value;
+            } else {
+                links.push({ source, target, value });
+            }
+        }
+
+        // Build nodes array with styling
+        const nodes: SankeyNode[] = Array.from(nodeSet).map((nodeName) => ({
+            name: labelOverrides?.[nodeName] || nodeName,
+            itemStyle: colorOverrides?.[nodeName]
+                ? { color: colorOverrides[nodeName] }
+                : undefined,
+            label: { show: showLabels },
+        }));
+
+        // Get field items for tooltip formatting
+        const valueField = itemsMap[valueFieldId];
+
+        const valueLabel = valueField
+            ? getItemLabelWithoutTableName(valueField)
+            : 'Value';
+
+        return {
+            textStyle: {
+                fontFamily: theme?.other?.chartFont as string | undefined,
+            },
+            tooltip: {
+                trigger: 'item',
+                formatter: function (params: any) {
+                    if (params.dataType === 'edge') {
+                        const formattedValue = valueField
+                            ? formatItemValue(
+                                  valueField,
+                                  params.value,
+                                  false,
+                                  parameters,
+                              )
+                            : params.value;
+                        return `${params.data.source} → ${params.data.target}<br/>${valueLabel}: ${formattedValue}`;
+                    }
+                    return params.name;
+                },
+            },
+            series: [
+                {
+                    type: 'sankey',
+                    data: nodes,
+                    links: links,
+                    orient: orientation,
+                    nodeAlign: nodeAlign,
+                    nodeGap: nodeGap,
+                    nodeWidth: nodeWidth,
+                    emphasis: {
+                        focus: 'adjacency',
+                    },
+                    lineStyle: {
+                        color: 'gradient',
+                        curveness: 0.5,
+                    },
+                    label: {
+                        show: showLabels,
+                        color: theme.colors.foreground[0],
+                    },
+                },
+            ],
+            animation: !isInDashboard,
+        };
+    }, [chartConfig, resultsData, itemsMap, theme, isInDashboard, parameters]);
+
+    if (!itemsMap) return;
+    if (!eChartsOption) return;
+
+    return { eChartsOption };
+};
+
+export default useEchartsSankeyConfig;

--- a/packages/frontend/src/hooks/useSankeyChartConfig.ts
+++ b/packages/frontend/src/hooks/useSankeyChartConfig.ts
@@ -1,0 +1,148 @@
+import {
+    ChartType,
+    getItemId,
+    isField,
+    type ItemsMap,
+    type SankeyChart,
+    SankeyNodeAlign,
+    SankeyOrientationType,
+} from '@lightdash/common';
+import { useCallback, useMemo, useState } from 'react';
+
+const useSankeyChartConfig = (
+    initialChartConfig: SankeyChart | undefined,
+    itemsMap: ItemsMap | undefined,
+) => {
+    // Field selection state
+    const [sourceFieldId, setSourceFieldId] = useState<string | null>(
+        initialChartConfig?.sourceFieldId ?? null,
+    );
+    const [targetFieldId, setTargetFieldId] = useState<string | null>(
+        initialChartConfig?.targetFieldId ?? null,
+    );
+    const [valueFieldId, setValueFieldId] = useState<string | null>(
+        initialChartConfig?.valueFieldId ?? null,
+    );
+
+    // Layout state
+    const [orientation, setOrientation] = useState<SankeyOrientationType>(
+        initialChartConfig?.orientation ?? SankeyOrientationType.HORIZONTAL,
+    );
+    const [nodeAlign, setNodeAlign] = useState<SankeyNodeAlign>(
+        initialChartConfig?.nodeAlign ?? SankeyNodeAlign.JUSTIFY,
+    );
+    const [nodeGap, setNodeGap] = useState<number>(
+        initialChartConfig?.nodeGap ?? 8,
+    );
+    const [nodeWidth, setNodeWidth] = useState<number>(
+        initialChartConfig?.nodeWidth ?? 20,
+    );
+
+    // Display state
+    const [showLabels, setShowLabels] = useState<boolean>(
+        initialChartConfig?.showLabels ?? true,
+    );
+    const [labelOverrides, setLabelOverrides] = useState<
+        Record<string, string>
+    >(initialChartConfig?.labelOverrides ?? {});
+    const [colorOverrides, setColorOverrides] = useState<
+        Record<string, string>
+    >(initialChartConfig?.colorOverrides ?? {});
+    const [customLabel, setCustomLabel] = useState<string | undefined>(
+        initialChartConfig?.customLabel,
+    );
+
+    // Available fields (all fields can be used for source/target/value)
+    const availableFieldsIds = useMemo(() => {
+        if (!itemsMap) return [];
+        return Object.values(itemsMap).filter(isField).map(getItemId);
+    }, [itemsMap]);
+
+    const getField = useCallback(
+        (fieldId: string | null) => {
+            if (!fieldId || !itemsMap) return null;
+            return itemsMap[fieldId] ?? null;
+        },
+        [itemsMap],
+    );
+
+    const validConfig: SankeyChart = useMemo(() => {
+        return {
+            sourceFieldId,
+            targetFieldId,
+            valueFieldId,
+            orientation,
+            nodeAlign,
+            nodeGap,
+            nodeWidth,
+            showLabels,
+            labelOverrides,
+            colorOverrides,
+            customLabel,
+        };
+    }, [
+        sourceFieldId,
+        targetFieldId,
+        valueFieldId,
+        orientation,
+        nodeAlign,
+        nodeGap,
+        nodeWidth,
+        showLabels,
+        labelOverrides,
+        colorOverrides,
+        customLabel,
+    ]);
+
+    return useMemo(
+        () => ({
+            chartType: ChartType.SANKEY as const,
+            validConfig,
+            // Field getters/setters
+            sourceFieldId,
+            setSourceFieldId,
+            targetFieldId,
+            setTargetFieldId,
+            valueFieldId,
+            setValueFieldId,
+            getField,
+            availableFieldsIds,
+            // Layout getters/setters
+            orientation,
+            setOrientation,
+            nodeAlign,
+            setNodeAlign,
+            nodeGap,
+            setNodeGap,
+            nodeWidth,
+            setNodeWidth,
+            // Display getters/setters
+            showLabels,
+            setShowLabels,
+            labelOverrides,
+            setLabelOverrides,
+            colorOverrides,
+            setColorOverrides,
+            customLabel,
+            setCustomLabel,
+        }),
+        [
+            validConfig,
+            sourceFieldId,
+            targetFieldId,
+            valueFieldId,
+            getField,
+            availableFieldsIds,
+            orientation,
+            nodeAlign,
+            nodeGap,
+            nodeWidth,
+            showLabels,
+            labelOverrides,
+            colorOverrides,
+            customLabel,
+        ],
+    );
+};
+
+export default useSankeyChartConfig;

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -21,6 +21,7 @@ import {
     type ParameterDefinitions,
     type PieChartConfig,
     type ReplaceCustomFields,
+    type SankeyChartConfig,
     type SavedChart,
     type TableCalculation,
     type TableCalculationMetadata,
@@ -83,6 +84,7 @@ export type ConfigCacheMap = {
     [ChartType.TREEMAP]: ChartConfigCache<TreemapChartConfig['config']>;
     [ChartType.GAUGE]: ChartConfigCache<GaugeChartConfig['config']>;
     [ChartType.MAP]: ChartConfigCache<MapChartConfig['config']>;
+    [ChartType.SANKEY]: ChartConfigCache<SankeyChartConfig['config']>;
     [ChartType.CUSTOM]: ChartConfigCache<CustomVisConfig['config']>;
 };
 

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -12,6 +12,7 @@ const DEFAULTS = {
     [ChartType.TREEMAP]: () => ({}),
     [ChartType.GAUGE]: () => ({}),
     [ChartType.MAP]: () => ({}),
+    [ChartType.SANKEY]: () => ({}),
     [ChartType.CUSTOM]: () => ({}),
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #4645

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Adds simple Sankey implementation. We have an easy way to create single level diagrams. Customers will need to model their data in a way that would lend itself to multi-level diagrams with a hierarchy of transitions. 

Future improvements could make this easier to create more advanced Sankey diagrams from arbitrary data. 

We've opted for the simplest implementation to start and will iterate with customer feedback. 

![Screen Shot 2025-12-12 at 3.57.20 PM.png](https://app.graphite.com/user-attachments/assets/82e3410c-bd55-41ea-9745-c52384676817.png)

![Screen Shot 2025-12-12 at 3.57.35 PM.png](https://app.graphite.com/user-attachments/assets/90592da0-4713-4f97-8ef6-ca5b5ba393f3.png)

