### PR TITLE
fix: default to maxQueryLimit if agent provided limit is over it

### DIFF
--- a/packages/common/src/ee/AiAgent/validators.ts
+++ b/packages/common/src/ee/AiAgent/validators.ts
@@ -3,11 +3,5 @@ export function getValidAiQueryLimit(limit: number | null, maxLimit: number) {
         return maxLimit;
     }
 
-    if (limit > maxLimit) {
-        throw new Error(
-            `The limit provided is greater than the maximum allowed limit of ${maxLimit}`,
-        );
-    }
-
-    return limit;
+    return Math.min(limit, maxLimit);
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18776

### Description:

Simplifies the `getValidAiQueryLimit` function by replacing the error-throwing logic with a `Math.min` operation. Instead of throwing an error when the limit exceeds the maximum allowed value, the function now simply returns the smaller of the two values.
