### PR TITLE
feat: add Snowflake external browser authentication support

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -41,6 +41,11 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     startOfWeek?: number;
     warehouseCredentials?: boolean;
     disableTimestampConversion?: boolean;
+    /**
+     * Skip creating a new Snowflake PAT when using externalbrowser auth.
+     * Use this when updating a preview where credentials are already stored.
+     */
+    skipPatCreation?: boolean;
 };
 
 const getExploresFromLightdashYmlProject = async (
@@ -188,6 +193,7 @@ export const compile = async (options: CompileHandlerOptions) => {
                 profile: options.profile || context.profileName,
                 target: options.target,
                 startOfWeek: options.startOfWeek,
+                skipPatCreation: options.skipPatCreation,
             });
             GlobalState.debug('> Fetching warehouse catalog');
             catalog = await warehouseClient.getCatalog(

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -316,10 +316,14 @@ export const previewHandler = async (
                 watcher.unwatch(manifestFilePath);
                 // Deploying will change manifest.json too, so we need to stop watching the file until it is deployed
                 if (project) {
-                    await deploy(await compile(options), {
-                        ...options,
-                        projectUuid: project.projectUuid,
-                    });
+                    // Skip PAT creation on updates - credentials are already stored from initial preview
+                    await deploy(
+                        await compile({ ...options, skipPatCreation: true }),
+                        {
+                            ...options,
+                            projectUuid: project.projectUuid,
+                        },
+                    );
                 }
 
                 console.error(`${styles.success('✔')}   Preview updated \n`);
@@ -382,9 +386,9 @@ export const startPreviewHandler = async (
             },
         });
 
-        // Update
+        // Update - skip PAT creation since credentials are already stored from initial preview
         console.error(`Updating project preview ${projectName}`);
-        const explores = await compile(options);
+        const explores = await compile({ ...options, skipPatCreation: true });
         await deploy(explores, {
             ...options,
             projectUuid: previewProject.projectUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/18546

### Description:
Added support for Snowflake External Browser authentication in the CLI. This enhancement allows users to authenticate via browser, automatically creates a Programmatic Access Token (PAT), and uses that token for subsequent operations. 

The implementation:
- Adds a new `createProgrammaticAccessToken` method to the SnowflakeWarehouseClient
- Updates the CLI's `getWarehouseClient` to handle the external browser authentication flow
- Sets a 1-day expiry for the generated PAT
- Provides clear user feedback during the authentication process

This makes it easier for users to authenticate with Snowflake when using the Lightdash CLI without having to manually create and manage access tokens.