### PR TITLE
style: revert headwayapp widget style

### DIFF
--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -366,15 +366,6 @@ export const getMantineThemeOverride = (
                       '[class*="mantine-"][data-with-border]': {
                           borderColor: theme.colors.ldDark[4],
                       },
-                      '.HW_frame_cont': {
-                          background: `${theme.colors.ldDark[2]} !important`,
-                          boxShadow: `var(--mantine-shadow-md) !important`,
-                          border: `1px solid ${theme.colors.ldDark[3]}!important`,
-                      },
-                      '.HW_frame': {
-                          background: `${theme.colors.ldDark[2]} !important`,
-                          filter: `invert(0.9) hue-rotate(180deg)`,
-                      },
                   }
                 : undefined),
         }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Removes Headway notification widget CSS styling from the Mantine theme. This change eliminates the custom styling for `.HW_frame_cont` and `.HW_frame` classes that were previously used for the notification widget.

ℹ️ headwayapp has dark-mode CSS class in its assets but does not allow changing (at least it's not documented)

![Screenshot 2025-12-12 at 17.05.41.png](https://app.graphite.com/user-attachments/assets/0777135a-d314-4be2-8d06-2d0cdfd02513.png)

