### PR TITLE
feat: add concurrency limiting for headless browser sessions

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -254,6 +254,8 @@ export const lightdashConfigMock: LightdashConfig = {
     headlessBrowser: {
         internalLightdashHost: 'https://test.lightdash.cloud',
         browserEndpoint: 'ws://headless-browser:3000',
+        maxConcurrentSessions: 5,
+        concurrencyLimitEnabled: false,
     },
     contentAsCode: {
         maxDownloads: 100,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -999,6 +999,8 @@ export type HeadlessBrowserConfig = {
     port?: string;
     internalLightdashHost: string;
     browserEndpoint: string;
+    maxConcurrentSessions: number;
+    concurrencyLimitEnabled: boolean;
 };
 export type S3Config = {
     region: string;
@@ -1536,6 +1538,13 @@ export const parseConfig = (): LightdashConfig => {
             internalLightdashHost:
                 process.env.INTERNAL_LIGHTDASH_HOST || siteUrl,
             browserEndpoint,
+            maxConcurrentSessions:
+                getIntegerFromEnvironmentVariable(
+                    'HEADLESS_BROWSER_MAX_CONCURRENT_SESSIONS',
+                ) || 5,
+            concurrencyLimitEnabled:
+                process.env.HEADLESS_BROWSER_CONCURRENCY_LIMIT_ENABLED ===
+                'true',
         },
         s3: parseBaseS3Config(),
         results: {

--- a/packages/backend/src/services/UnfurlService/Semaphore.ts
+++ b/packages/backend/src/services/UnfurlService/Semaphore.ts
@@ -1,0 +1,42 @@
+/**
+ * A simple counting semaphore for limiting concurrent operations.
+ * Used to prevent overwhelming the headless browser with too many simultaneous connections.
+ */
+export class Semaphore {
+    private permits: number;
+
+    private waiting: Array<() => void> = [];
+
+    constructor(permits: number) {
+        this.permits = permits;
+    }
+
+    async acquire(): Promise<void> {
+        if (this.permits > 0) {
+            this.permits -= 1;
+            return Promise.resolve();
+        }
+        return new Promise((resolve) => {
+            this.waiting.push(resolve);
+        });
+    }
+
+    release(): void {
+        const next = this.waiting.shift();
+        if (next) {
+            next();
+        } else {
+            this.permits += 1;
+        }
+    }
+
+    /** Returns number of operations currently waiting for a permit */
+    get queueLength(): number {
+        return this.waiting.length;
+    }
+
+    /** Returns number of available permits */
+    get availablePermits(): number {
+        return this.permits;
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #16182 & GLITCH-105

### Description:
Implemented a concurrency limit for headless browser sessions to prevent resource exhaustion. Added a Semaphore class to control the number of concurrent browser connections, with configurable limits through environment variables:

- `HEADLESS_BROWSER_MAX_CONCURRENT_SESSIONS`: Sets maximum concurrent sessions (default: 5)
- `HEADLESS_BROWSER_CONCURRENCY_LIMIT_ENABLED`: Enables/disables the concurrency limit

 A semaphore is a concurrency control mechanism that maintains a count of available "permits". When a job wants to use the browser:

  1. It requests a permit from the semaphore
  2. If permits are available, it proceeds immediately
  3. If no permits are available, it waits in a queue until one is released
  4. After finishing, it releases its permit for the next waiting job

This ensures we never exceed a configurable maximum number of concurrent browser sessions, preventing the browser from being overwhelmed while still processing all deliveries (just queued rather than failing).

Did a bit of stress testing locally.
**Before**
<img width="1061" height="604" alt="Screenshot 2025-12-12 at 17 55 25" src="https://github.com/user-attachments/assets/e581dea5-698b-4bf4-84bd-c9a0257a6815" />

**After**
<img width="1054" height="605" alt="Screenshot 2025-12-12 at 18 46 02" src="https://github.com/user-attachments/assets/de0cf544-f11f-4ca5-999f-c70d8d54488f" />
