### PR TITLE
fix: underlying data on explores using parameters

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1860,6 +1860,10 @@ export const GenericDashboardChartTile: FC<
             tableName={dashboardChartReadyQuery.chart.tableName || ''}
             explore={dashboardChartReadyQuery.explore}
             queryUuid={dashboardChartReadyQuery.executeQueryResponse.queryUuid}
+            parameters={
+                dashboardChartReadyQuery.executeQueryResponse
+                    .usedParametersValues
+            }
         >
             {minimal ? (
                 <DashboardChartTileMinimal


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18768

### Description:
This PR fixes the handling of parameters in underlying data queries. It now properly filters out dimensions and metrics that have missing parameters, preventing errors when users try to view underlying data for charts with parameterized fields.

Key changes:
- Moved parameter combination earlier in the process flow to filter dimensions by parameter availability
- Added new utility functions `getDimensionsWithValidParameters` and `getMetricsWithValidParameters` to filter fields based on parameter availability
- Added parameter validation for custom SQL dimensions
- Passed used parameter values to the underlying data component in the dashboard chart tile

This ensures that when viewing underlying data, only fields with needed are parameters present are included in the query, preventing errors from missing parameter values.

**Steps to test**
1. Create a chart on an explore with dimensions/metrics that use parameters - chart should not use any dimension with parameters
2. Click to view underlying data

**Before**

![Screenshot 2025-12-12 at 16.24.35.png](https://app.graphite.com/user-attachments/assets/dd2645ce-e178-4166-9e29-2202c3b11b25.png)

**After**

![image.png](https://app.graphite.com/user-attachments/assets/8e92d3ab-3778-4dc6-aef8-16ab93ff2373.png)

