### PR TITLE
fix: show tabs only when multiple exist and hide parameters when empty

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/FilterConfiguration/TileFilterConfiguration.tsx
@@ -505,7 +505,7 @@ const TileFilterConfiguration: FC<Props> = ({
     );
 
     const tileList =
-        tabs.length > 0 ? (
+        tabs.length > 1 ? (
             tabs.map((tab, index) => {
                 const tabTiles = filteredTileTargetList(tab.uuid);
                 return (

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -430,6 +430,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                         align="flex-start"
                                         wrap="nowrap"
                                         px="lg"
+                                        pt="sm"
                                     >
                                         {/* This Group will take up remaining space (and not push DateZoom) */}
                                         <Group
@@ -477,65 +478,69 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                             )}
                                         </Group>
 
-                                        {hasDashboardTiles && (
-                                            <Group gap="xs">
-                                                <Divider orientation="vertical" />
+                                        {hasDashboardTiles &&
+                                            Object.keys(parameters).length >
+                                                0 && (
+                                                <Group gap="xs">
+                                                    <Divider orientation="vertical" />
 
-                                                <FilterGroupSeparator
-                                                    icon={
-                                                        IconAdjustmentsHorizontal
-                                                    }
-                                                    tooltipLabel={
-                                                        <div>
-                                                            <Text
-                                                                fw={500}
-                                                                fz="xs"
-                                                            >
-                                                                Parameters
-                                                            </Text>
+                                                    <FilterGroupSeparator
+                                                        icon={
+                                                            IconAdjustmentsHorizontal
+                                                        }
+                                                        tooltipLabel={
+                                                            <div>
+                                                                <Text
+                                                                    fw={500}
+                                                                    fz="xs"
+                                                                >
+                                                                    Parameters
+                                                                </Text>
 
-                                                            <Text fz="xs">
-                                                                Adjust preset
-                                                                inputs that
-                                                                change how the
-                                                                dashboard's
-                                                                numbers are
-                                                                calculated.
-                                                            </Text>
-                                                        </div>
-                                                    }
-                                                />
+                                                                <Text fz="xs">
+                                                                    Adjust
+                                                                    preset
+                                                                    inputs that
+                                                                    change how
+                                                                    the
+                                                                    dashboard's
+                                                                    numbers are
+                                                                    calculated.
+                                                                </Text>
+                                                            </div>
+                                                        }
+                                                    />
 
-                                                <Parameters
-                                                    isEditMode={isEditMode}
-                                                    parameterValues={
-                                                        parameterValues
-                                                    }
-                                                    onParameterChange={
-                                                        onParameterChange
-                                                    }
-                                                    onClearAll={
-                                                        onParameterClearAll
-                                                    }
-                                                    parameters={parameters}
-                                                    isLoading={
-                                                        isParameterLoading
-                                                    }
-                                                    missingRequiredParameters={
-                                                        missingRequiredParameters
-                                                    }
-                                                    pinnedParameters={
-                                                        pinnedParameters
-                                                    }
-                                                    onParameterPin={
-                                                        onParameterPin
-                                                    }
-                                                />
-                                                <PinnedParameters
-                                                    isEditMode={isEditMode}
-                                                />
-                                            </Group>
-                                        )}
+                                                    <Parameters
+                                                        isEditMode={isEditMode}
+                                                        parameterValues={
+                                                            parameterValues
+                                                        }
+                                                        onParameterChange={
+                                                            onParameterChange
+                                                        }
+                                                        onClearAll={
+                                                            onParameterClearAll
+                                                        }
+                                                        parameters={parameters}
+                                                        isLoading={
+                                                            isParameterLoading
+                                                        }
+                                                        missingRequiredParameters={
+                                                            missingRequiredParameters
+                                                        }
+                                                        pinnedParameters={
+                                                            pinnedParameters
+                                                        }
+                                                        onParameterPin={
+                                                            onParameterPin
+                                                        }
+                                                    />
+                                                    <PinnedParameters
+                                                        isEditMode={isEditMode}
+                                                    />
+                                                </Group>
+                                            )}
 
                                         {/* DateZoom section will adjust width dynamically */}
                                         {hasDashboardTiles && (


### PR DESCRIPTION
### Description:
This PR makes three UI improvements to the dashboard:

1. Only shows tab list in filter configuration when there are more than one tab
2. Adds padding to the top of the dashboard header for better spacing
3. Hides the parameters section when there are no parameters available

These changes improve the UI by reducing clutter and ensuring elements are only displayed when needed.