### PR TITLE
fix: missing borders on pivot tables

### DIFF
--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -81,14 +81,6 @@ export const useTableStyles = createStyles((theme) => {
                 },
             },
 
-            /* Body last row, first cell: no left or bottom border */
-            '> tbody:last-child > *:last-child > *:first-child': {
-                boxShadow: 'none',
-                '&:hover': {
-                    boxShadow: 'none !important',
-                },
-            },
-
             /* Footer last row cells: no bottom border (container provides it) */
             '> tfoot:last-child > *:last-child > *': {
                 boxShadow: `inset -1px 0 0 0 ${borderColor}`,
@@ -99,14 +91,6 @@ export const useTableStyles = createStyles((theme) => {
 
             /* Footer last row, last cell: no right or bottom border */
             '> tfoot:last-child > *:last-child > *:last-child': {
-                boxShadow: 'none',
-                '&:hover': {
-                    boxShadow: 'none !important',
-                },
-            },
-
-            /* Footer last row, first cell: no left or bottom border */
-            '> tfoot:last-child > *:last-child > *:first-child': {
                 boxShadow: 'none',
                 '&:hover': {
                     boxShadow: 'none !important',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18644

### Description:
Removed unnecessary CSS rules for the first cell in the last row of both the table body and footer. This eliminates the special styling that was preventing borders from appearing correctly in these cells.

![CleanShot 2025-12-15 at 11.30.36.png](https://app.graphite.com/user-attachments/assets/5ab9fa04-6736-4c8b-b3d0-8300168ee39e.png)

![CleanShot 2025-12-15 at 11.31.01.png](https://app.graphite.com/user-attachments/assets/94c5135d-3d43-483a-8068-6ba91c41c803.png)

