### PR TITLE
fix: conditional formatting not updating correctly when toggling metrics as row

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -573,7 +573,10 @@ const PivotTable: FC<PivotTableProps> = ({
                     const toggleExpander = row.getToggleExpandedHandler();
 
                     return (
-                        <Table.Row key={`row-${rowIndex}`} index={rowIndex}>
+                        <Table.Row
+                            key={`row-${rowIndex}-${data.pivotConfig.metricsAsRows}`}
+                            index={rowIndex}
+                        >
                             {row.getVisibleCells().map((cell, colIndex) => {
                                 const meta = cell.column.columnDef.meta;
                                 const isRowTotal = meta?.type === 'rowTotal';
@@ -677,7 +680,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                     : Table.Cell;
                                 return (
                                     <TableCellComponent
-                                        key={`value-${rowIndex}-${colIndex}`}
+                                        key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
                                         isMinimal={isMinimal}
                                         withAlignRight={isNumericItem(item)}
                                         withColor={conditionalFormatting?.color}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18801

### Description:
Fixed a key generation issue in the PivotTable component by including `metricsAsRows` in the key for both Table.Row and TableCellComponent. This ensures proper re-rendering when the pivot configuration changes.

[CleanShot 2025-12-15 at 12.09.50.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/3cdc292b-1a8e-4075-af07-39cc02314843.mp4" />](https://app.graphite.com/user-attachments/video/3cdc292b-1a8e-4075-af07-39cc02314843.mp4)

