### PR TITLE
fix: treemap section name unreadable due to background color

### DIFF
--- a/packages/common/src/utils/colors.ts
+++ b/packages/common/src/utils/colors.ts
@@ -25,14 +25,16 @@ export const cleanColorArray = (colors: string[]): string[] =>
 /**
  * Returns the best contrasting text color (black or white) for a given background color
  * Uses APCA contrast algorithm for accurate perception-based contrast
- * @param backgroundColor Hex color string for the background
+ * @param backgroundColor Any valid color string (hex, rgb, rgba, named colors, etc.)
  * @returns 'white' or 'black' depending on which has better contrast
  */
 export const getReadableTextColor = (backgroundColor: string): string => {
-    if (!isHexCodeColor(backgroundColor)) {
+    try {
+        const onWhite = Math.abs(Color.contrastAPCA('white', backgroundColor));
+        const onBlack = Math.abs(Color.contrastAPCA('black', backgroundColor));
+        return onWhite > onBlack ? 'white' : 'black';
+    } catch (e) {
+        // Not supported color string, default to black
         return 'black';
     }
-    const onWhite = Math.abs(Color.contrastAPCA('white', backgroundColor));
-    const onBlack = Math.abs(Color.contrastAPCA('black', backgroundColor));
-    return onWhite > onBlack ? 'white' : 'black';
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18795

### Description:
Treemap charts are using `getReadableTextColor` that returns most readable color depending on background. This function only supported hex codes, meaning that this didn't work with Color Metric custom selection (returns rgba colors)

This PR updates the `getReadableTextColor` input to support all Color.js color strings.

[CleanShot 2025-12-15 at 13.13.41.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d67e2403-16db-49f2-9408-36fd22d057e3.mp4" />](https://app.graphite.com/user-attachments/video/d67e2403-16db-49f2-9408-36fd22d057e3.mp4)

