### PR TITLE
fix: fetch fallback projects even when there is a last project

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -89,8 +89,9 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
         isLoggedIn &&
         !params.projectUuid &&
         isLastProjectUuidFetched &&
-        !lastProjectUuid &&
+        !lastProject &&
         !!organization?.defaultProjectUuid;
+
     const { data: defaultProject, isInitialLoading: isLoadingDefaultProject } =
         useProject(
             shouldFetchDefaultProject
@@ -99,12 +100,12 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
         );
 
     // Priority 4: Fallback to any project (when org has no defaultProjectUuid)
-    // Only fetch projects list if we have no other option AND localStorage check is complete
+    // Try to fetch fallback since the last project might have been a preview that was deleted
     const shouldFetchFallbackProjects =
         isLoggedIn &&
         !params.projectUuid &&
         isLastProjectUuidFetched &&
-        !lastProjectUuid &&
+        !lastProject &&
         !isLoadingOrg &&
         !organization?.defaultProjectUuid;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixed a bug in the active project selection logic. Changed the condition to check for the existence of the last project object instead of just the UUID, ensuring that preview projects that have been deleted don't cause issues in the fallback logic.

Relates to: https://github.com/lightdash/lightdash/pull/18626

**Steps to reproduce**
1. Start a preview project
2. Open the preview project in the browser
3. Delete the preview project
4. Try to go to `localhost:3000`

**Before**
![image.png](https://app.graphite.com/user-attachments/assets/75d0dc56-eb6b-4ea5-948f-80aa410b8551.png)

**After**
<img width="2552" height="1389" alt="image" src="https://github.com/user-attachments/assets/370e3c4a-4026-4948-b243-8b8fbc23caaf" />


