### PR TITLE
fix: pinned parameters do not switch in dark mode

### DIFF
--- a/packages/frontend/src/components/PinnedParameters.tsx
+++ b/packages/frontend/src/components/PinnedParameters.tsx
@@ -69,7 +69,7 @@ const PinnedParameter: FC<PinnedParameterProps> = ({
                     variant="default"
                     styles={{
                         inner: {
-                            color: 'black',
+                            color: 'foreground',
                         },
                         label: {
                             maxWidth: '300px',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #18800

### Description:

Changed the color of pinned parameter text from 'black' to 'foreground' to improve compatibility with dark mode themes.