### PR TITLE
feat: add heading tile to dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -1,4 +1,8 @@
-import { DashboardTileTypes, type Dashboard } from '@lightdash/common';
+import {
+    DashboardTileTypes,
+    FeatureFlags,
+    type Dashboard,
+} from '@lightdash/common';
 import {
     Button,
     Group,
@@ -9,6 +13,7 @@ import {
 } from '@mantine/core';
 import {
     IconChartBar,
+    IconHeading,
     IconInfoCircle,
     IconMarkdown,
     IconNewSection,
@@ -18,6 +23,7 @@ import {
 import { useCallback, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../common/MantineIcon';
 import AddChartTilesModal from './TileForms/AddChartTilesModal';
@@ -37,6 +43,9 @@ const AddTileButton: FC<Props> = ({
     activeTabUuid,
     dashboardTabs,
 }) => {
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
         useState<boolean>(false);
@@ -129,6 +138,17 @@ const AddTileButton: FC<Props> = ({
                         Loom video
                     </Menu.Item>
 
+                    {isDashboardRedesignEnabled && (
+                        <Menu.Item
+                            onClick={() =>
+                                setAddTileType(DashboardTileTypes.HEADING)
+                            }
+                            icon={<MantineIcon icon={IconHeading} />}
+                        >
+                            Heading
+                        </Menu.Item>
+                    )}
+
                     <Menu.Item
                         onClick={() => setAddingTab(true)}
                         icon={<MantineIcon icon={IconNewSection} />}
@@ -146,7 +166,8 @@ const AddTileButton: FC<Props> = ({
             )}
 
             {addTileType === DashboardTileTypes.MARKDOWN ||
-            addTileType === DashboardTileTypes.LOOM ? (
+            addTileType === DashboardTileTypes.LOOM ||
+            addTileType === DashboardTileTypes.HEADING ? (
                 <TileAddModal
                     opened={!!addTileType}
                     type={addTileType}

--- a/packages/frontend/src/components/DashboardTiles/DashboardHeadingTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardHeadingTile.tsx
@@ -1,0 +1,30 @@
+import { type DashboardHeadingTile as DashboardHeadingTileType } from '@lightdash/common';
+import { Text } from '@mantine-8/core';
+import React, { type FC } from 'react';
+
+import TileBase from './TileBase/index';
+
+export type Props = Pick<
+    React.ComponentProps<typeof TileBase>,
+    'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
+> & {
+    tile: DashboardHeadingTileType;
+};
+
+const DashboardHeadingTile: FC<Props> = (props) => {
+    const {
+        tile: {
+            properties: { text },
+        },
+    } = props;
+
+    return (
+        <TileBase title="" transparent {...props}>
+            <Text size="24px" fw="bold">
+                {text}
+            </Text>
+        </TileBase>
+    );
+};
+
+export default DashboardHeadingTile;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -99,10 +99,11 @@ export const TileTitleLink = styled.a<TileTitleProps>`
         `}
 `;
 
-export const ChartContainer = styled.div`
+export const ChartContainer = styled.div<{ $alignItems?: 'center' }>`
     flex: 1;
     overflow: hidden;
     display: flex;
+    align-items: ${({ $alignItems }) => $alignItems};
 `;
 
 export const TileCardWrapper = styled.div`

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -60,6 +60,7 @@ type Props<T> = {
     minimal?: boolean;
     tabs?: DashboardTab[];
     lockHeaderVisibility?: boolean;
+    transparent?: boolean;
 };
 
 const TileBase = <T extends Dashboard['tiles'][number]>({
@@ -80,6 +81,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     minimal = false,
     tabs,
     lockHeaderVisibility = false,
+    transparent = false,
 }: Props<T>) => {
     const [isEditingTileContent, setIsEditingTileContent] = useState(false);
     const [isMovingTabs, setIsMovingTabs] = useState(false);
@@ -96,9 +98,10 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     const [isMenuOpen, toggleMenu] = useToggle([false, true]);
 
     const hideTitle =
-        tile.type !== DashboardTileTypes.MARKDOWN
+        tile.type === DashboardTileTypes.HEADING ||
+        (tile.type !== DashboardTileTypes.MARKDOWN
             ? tile.properties.hideTitle
-            : false;
+            : false);
     const belongsToDashboard: boolean =
         isDashboardChartTileType(tile) && !!tile.properties.belongsToDashboard;
 
@@ -113,16 +116,21 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 ref={containerRef}
                 h="100%"
                 direction="column"
-                p="md"
+                p={transparent ? 0 : 'md'}
                 radius="sm"
-                bg="background"
+                bg={transparent ? 'transparent' : 'background'}
                 shadow={isEditMode ? 'xs' : undefined}
                 sx={(theme) => {
-                    let border = `1px solid ${
-                        theme.colorScheme === 'dark'
-                            ? theme.fn.lighten(theme.colors.ldDark[1], 0.05)
-                            : theme.colors.ldGray[1]
-                    }`;
+                    let border = transparent
+                        ? 'none'
+                        : `1px solid ${
+                              theme.colorScheme === 'dark'
+                                  ? theme.fn.lighten(
+                                        theme.colors.ldDark[1],
+                                        0.05,
+                                    )
+                                  : theme.colors.ldGray[1]
+                          }`;
                     if (isEditMode) {
                         border = `1px dashed ${theme.colors.blue[5]}`;
                     }
@@ -359,6 +367,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             ? chartHoveredProps.handleMouseLeave
                             : undefined
                     }
+                    $alignItems={transparent ? 'center' : undefined}
                 >
                     {children}
                 </ChartContainer>

--- a/packages/frontend/src/components/DashboardTiles/TileForms/HeadingTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/HeadingTileForm.tsx
@@ -1,0 +1,20 @@
+import { type DashboardHeadingTileProperties } from '@lightdash/common';
+import { Stack, TextInput } from '@mantine-8/core';
+import { type UseFormReturnType } from '@mantine/form';
+
+interface HeadingTileFormProps {
+    form: UseFormReturnType<DashboardHeadingTileProperties['properties']>;
+}
+
+const HeadingTileForm = ({ form }: HeadingTileFormProps) => (
+    <Stack gap="md">
+        <TextInput
+            label="Heading text"
+            placeholder="Enter heading text"
+            required
+            {...form.getInputProps('text')}
+        />
+    </Stack>
+);
+
+export default HeadingTileForm;

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -129,6 +129,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
 
             case DashboardTileTypes.LOOM:
             case DashboardTileTypes.MARKDOWN:
+            case DashboardTileTypes.HEADING:
                 throw new Error(
                     `not implemented for chart tile type: ${dashboardTileType}`,
                 );

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -7,6 +7,7 @@ import { IconUnlink } from '@tabler/icons-react';
 import { useEffect, useMemo, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useLocation, useNavigate } from 'react-router';
+import HeadingTile from '../../../../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../../../../components/DashboardTiles/DashboardLoomTile';
 import SqlChartTile from '../../../../../components/DashboardTiles/DashboardSqlChartTile';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
@@ -103,6 +104,14 @@ const EmbedDashboardGrid: FC<{
                             />
                         ) : tile.type === DashboardTileTypes.SQL_CHART ? (
                             <SqlChartTile
+                                key={tile.uuid}
+                                tile={tile}
+                                isEditMode={false}
+                                onDelete={() => {}}
+                                onEdit={() => {}}
+                            />
+                        ) : tile.type === DashboardTileTypes.HEADING ? (
+                            <HeadingTile
                                 key={tile.uuid}
                                 tile={tile}
                                 isEditMode={false}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedMarkdownTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedMarkdownTile.tsx
@@ -6,6 +6,7 @@ import DashboardMarkdownTile, {
 } from '../../../../../components/DashboardTiles/DashboardMarkdownTile';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 
+// TODO same for HeadingTile
 export const EmbedMarkdownTile: React.FC<
     MarkdownTileProps & { tileIndex: number; dashboardSlug: string }
 > = ({ tileIndex, dashboardSlug, ...props }) => {

--- a/packages/frontend/src/features/dashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.tsx
@@ -7,6 +7,7 @@ import {
 import { Box } from '@mantine/core';
 import { memo, type FC } from 'react';
 import ChartTile from '../../components/DashboardTiles/DashboardChartTile';
+import HeadingTile from '../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../../components/DashboardTiles/DashboardMarkdownTile';
 import SqlChartTile from '../../components/DashboardTiles/DashboardSqlChartTile';
@@ -26,12 +27,15 @@ const GridTile: FC<
     const { tile } = props;
 
     if (props.locked) {
-        // Allow markdown and loom tiles to show even when locked since they are not filterable
+        // Allow markdown, loom, and heading tiles to show even when locked since they are not filterable
         if (tile.type === DashboardTileTypes.MARKDOWN) {
             return <MarkdownTile {...props} tile={tile} />;
         }
         if (tile.type === DashboardTileTypes.LOOM) {
             return <LoomTile {...props} tile={tile} />;
+        }
+        if (tile.type === DashboardTileTypes.HEADING) {
+            return <HeadingTile {...props} tile={tile} />;
         }
 
         return (
@@ -50,6 +54,8 @@ const GridTile: FC<
             return <LoomTile {...props} tile={tile} />;
         case DashboardTileTypes.SQL_CHART:
             return <SqlChartTile {...props} tile={tile} />;
+        case DashboardTileTypes.HEADING:
+            return <HeadingTile {...props} tile={tile} />;
         default: {
             return assertUnreachable(
                 tile,

--- a/packages/frontend/src/features/dashboardTabsV2/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/GridTile.tsx
@@ -7,6 +7,7 @@ import {
 import { Box } from '@mantine/core';
 import { memo, type FC } from 'react';
 import ChartTile from '../../components/DashboardTiles/DashboardChartTile';
+import HeadingTile from '../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../../components/DashboardTiles/DashboardMarkdownTile';
 import SqlChartTile from '../../components/DashboardTiles/DashboardSqlChartTile';
@@ -26,12 +27,15 @@ const GridTile: FC<
     const { tile } = props;
 
     if (props.locked) {
-        // Allow markdown and loom tiles to show even when locked since they are not filterable
+        // Allow markdown, loom, and heading tiles to show even when locked since they are not filterable
         if (tile.type === DashboardTileTypes.MARKDOWN) {
             return <MarkdownTile {...props} tile={tile} />;
         }
         if (tile.type === DashboardTileTypes.LOOM) {
             return <LoomTile {...props} tile={tile} />;
+        }
+        if (tile.type === DashboardTileTypes.HEADING) {
+            return <HeadingTile {...props} tile={tile} />;
         }
 
         return (
@@ -50,6 +54,8 @@ const GridTile: FC<
             return <LoomTile {...props} tile={tile} />;
         case DashboardTileTypes.SQL_CHART:
             return <SqlChartTile {...props} tile={tile} />;
+        case DashboardTileTypes.HEADING:
+            return <HeadingTile {...props} tile={tile} />;
         default: {
             return assertUnreachable(
                 tile,

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -16,6 +16,7 @@ import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useParams } from 'react-router';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ChartTile from '../components/DashboardTiles/DashboardChartTile';
+import HeadingTile from '../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../components/DashboardTiles/DashboardMarkdownTile';
 import SqlChartTile from '../components/DashboardTiles/DashboardSqlChartTile';
@@ -250,6 +251,14 @@ const MinimalDashboard: FC = () => {
                                 />
                             ) : tile.type === DashboardTileTypes.SQL_CHART ? (
                                 <SqlChartTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={false}
+                                    onDelete={() => {}}
+                                    onEdit={() => {}}
+                                />
+                            ) : tile.type === DashboardTileTypes.HEADING ? (
+                                <HeadingTile
                                     key={tile.uuid}
                                     tile={tile}
                                     isEditMode={false}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #6357

### Description:

Added a new Heading tile type to dashboards that allows users to add section headers to organize their dashboard content. The heading tile is displayed as bold text without a tile background, making it visually distinct from other tile types.

The implementation includes:

- New heading tile option in the Add Tile menu
- HeadingTileForm component for creating and editing heading tiles
- DashboardHeadingTile component for displaying the heading
- Support for heading tiles in all dashboard views (standard, minimal, embedded)
- Automatic sizing of heading tiles to span the width of the dashboard with minimal height



![CleanShot 2025-12-15 at 17.53.14@2x.png](https://app.graphite.com/user-attachments/assets/256ad92d-325b-46c9-82c1-dec3ead76a00.png)

![CleanShot 2025-12-15 at 17.53.34@2x.png](https://app.graphite.com/user-attachments/assets/98f075f1-cdd4-4034-bd34-b387bc2cb5a7.png)

