### PR TITLE
feat: add support for Azure OpenAI reasoning capabilities

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -36,6 +36,7 @@ export const aiCopilotConfigSchema = z
                     apiKey: z.string(),
                     apiVersion: z.string(),
                     deploymentName: z.string(),
+                    deploymentSupportsReasoning: z.boolean().default(false),
                     embeddingDeploymentName: z
                         .string()
                         .default(DEFAULT_AZURE_EMBEDDING_MODEL),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -689,6 +689,9 @@ export const getAiConfig = () => ({
                   apiKey: process.env.AZURE_AI_API_KEY,
                   apiVersion: process.env.AZURE_AI_API_VERSION,
                   deploymentName: process.env.AZURE_AI_DEPLOYMENT_NAME,
+                  deploymentSupportsReasoning:
+                      process.env.AZURE_AI_DEPLOYMENT_SUPPORTS_REASONING ===
+                      'true',
                   embeddingDeploymentName:
                       process.env.AZURE_EMBEDDING_DEPLOYMENT_NAME,
                   useDeploymentBasedUrls:

--- a/packages/backend/src/ee/services/ai/models/azure-openai-gpt-4.1.ts
+++ b/packages/backend/src/ee/services/ai/models/azure-openai-gpt-4.1.ts
@@ -21,14 +21,24 @@ export const getAzureGpt41Model = (
 
     const model = azure(config.deploymentName);
 
+    const reasoningEnabled = config.deploymentSupportsReasoning;
+    const reasoningEffort = 'medium';
+
     return {
         model,
         callOptions: {
-            temperature: 0.2,
+            ...(reasoningEnabled
+                ? { temperature: undefined }
+                : { temperature: 0.2 }),
         },
         providerOptions: {
-            [PROVIDER]: {
+            // @ts-expect-error - provider should be set to openai for azure
+            openai: {
                 strictJsonSchema: true,
+                ...(reasoningEnabled && {
+                    reasoningSummary: 'auto',
+                    reasoningEffort,
+                }),
             },
         },
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added support for Azure OpenAI reasoning capabilities by introducing a new configuration option `deploymentSupportsReasoning`. When enabled, this configures the Azure GPT-4.1 model to use reasoning features with appropriate parameters (reasoning summary set to 'auto' and reasoning effort set to 'medium'). The feature can be toggled via the `AZURE_AI_DEPLOYMENT_SUPPORTS_REASONING` environment variable.
