### PR TITLE
fix: exported image colors don't match the app's

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/themeColors.ts
+++ b/packages/common/src/visualizations/helpers/styles/themeColors.ts
@@ -2,24 +2,34 @@
  * Theme color constants for ECharts styling
  * Centralizes color usage across all chart style utilities
  * Using Mantine default color palette
+ *
+ * IMPORTANT: These use CSS variables WITH fallback values because CSS variables
+ * are not resolved when exporting charts to images via ECharts.getDataURL().
+ * The fallback ensures colors work in both DOM rendering and image exports.
+ *
+ * Light mode colors are used as fallbacks since charts are typically exported
+ * with white backgrounds (MinimalSavedExplorer uses backgroundColor: 'white').
  */
 
-export const GRAY_0 = 'var(--mantine-color-ldGray-0)';
-export const GRAY_1 = 'var(--mantine-color-ldGray-1)';
-export const GRAY_2 = 'var(--mantine-color-ldGray-2)';
-export const GRAY_3 = 'var(--mantine-color-ldGray-3)';
-export const GRAY_4 = 'var(--mantine-color-ldGray-4)';
-export const GRAY_5 = 'var(--mantine-color-ldGray-5)';
-export const GRAY_6 = 'var(--mantine-color-ldGray-6)';
-export const GRAY_7 = 'var(--mantine-color-ldGray-7)';
-export const GRAY_8 = 'var(--mantine-color-ldGray-8)';
-export const GRAY_9 = 'var(--mantine-color-ldGray-9)';
+// Light mode gray scale (from mantineTheme.ts lightModeColors.ldGray)
+export const GRAY_0 = 'var(--mantine-color-ldGray-0, #f8f9fa)';
+export const GRAY_1 = 'var(--mantine-color-ldGray-1, #f1f3f5)';
+export const GRAY_2 = 'var(--mantine-color-ldGray-2, #e9ecef)';
+export const GRAY_3 = 'var(--mantine-color-ldGray-3, #dee2e6)';
+export const GRAY_4 = 'var(--mantine-color-ldGray-4, #ced4da)';
+export const GRAY_5 = 'var(--mantine-color-ldGray-5, #adb5bd)';
+export const GRAY_6 = 'var(--mantine-color-ldGray-6, #868e96)';
+export const GRAY_7 = 'var(--mantine-color-ldGray-7, #495057)';
+export const GRAY_8 = 'var(--mantine-color-ldGray-8, #343a40)';
+export const GRAY_9 = 'var(--mantine-color-ldGray-9, #212529)';
 
 // White
-export const WHITE = 'var(--mantine-color-white)';
+export const WHITE = 'var(--mantine-color-white, #ffffff)';
 
-export const FOREGROUND = 'var(--mantine-color-foreground-0)';
-export const BACKGROUND = 'var(--mantine-color-background-0)';
-export const TOOLTIP_BACKGROUND = 'var(--mantine-color-background-1)';
+// Foreground and background colors with light mode fallbacks
+export const FOREGROUND = 'var(--mantine-color-foreground-0, #1A1B1E)';
+export const BACKGROUND = 'var(--mantine-color-background-0, #FEFEFE)';
+export const TOOLTIP_BACKGROUND = 'var(--mantine-color-background-0, #FEFEFE)';
 
-export const AXIS_TITLE_COLOR = 'var(--mantine-color-gray-6)';
+// Axis title color (Mantine gray.6)
+export const AXIS_TITLE_COLOR = 'var(--mantine-color-gray-6, #868e96)';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  #18779

### Description:
Added fallback color values to CSS variables in theme colors to ensure consistent rendering when exporting charts to images. 

The ECharts `getDataURL()` method doesn't resolve CSS variables during image export, causing colors to be missing. This change provides explicit fallback values based on light mode colors, ensuring charts look correct both in the DOM and when exported as images.