### PR TITLE
fix: skip channel sync on missing groups:read scope

### DIFF
--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -1,2 +1,9 @@
-// Regex to detect Slack IDs: C (public channel), G (private channel), U/W (user/DM)
+/**
+ * Regex to detect Slack IDs: C (public channel), G (private channel), U/W (user/DM)
+ * @example
+ * const isSlackId = SLACK_ID_REGEX.test('C1234567890');
+ * const isSlackId = SLACK_ID_REGEX.test('G1234567890');
+ * const isSlackId = SLACK_ID_REGEX.test('U1234567890');
+ * const isSlackId = SLACK_ID_REGEX.test('W1234567890');
+ */
 export const SLACK_ID_REGEX = /^[CGUW][A-Z0-9]{8,}$/i;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18815

### Description:

This PR adds scope validation before syncing Slack channels. It checks if the Slack installation has the required scopes and skips the sync if necessary, providing appropriate error messages. Additionally, it improves error handling when fetching Slack channel information by using the `slackErrorHandler` function instead of a generic console error.

![Screenshot 2025-12-15 at 14.10.15.png](https://app.graphite.com/user-attachments/assets/f80a25b2-7c4f-4bbb-ab69-0c84cfa4497f.png)


ℹ️ **how to test**
Create a slack app. 
Mutate db entry in `slack_auth_tokens` table to **not** have the "groups:read" scope
You will see the issue. 

Users have to reinstall the slack app themselves. This is because our slack scopes were added incrementally, so besides us having to update the configuration, users also have to reinstall the app to sync correctly.