### PR TITLE
feat: add hide frame option for dashboard markdown tiles

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -121,6 +121,7 @@ type DbDashboardTileMarkdowns = {
     dashboard_tile_uuid: string;
     title: string;
     content: string;
+    hide_frame: boolean | null;
 };
 
 export type DashboardTileMarkdownsTable =

--- a/packages/backend/src/database/migrations/20251215141911_add_dashboard_markdown_tile_hide_frame_property.ts
+++ b/packages/backend/src/database/migrations/20251215141911_add_dashboard_markdown_tile_hide_frame_property.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const DASHBOARD_TILE_MARKDOWNS_TABLE = 'dashboard_tile_markdowns';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DASHBOARD_TILE_MARKDOWNS_TABLE, (table) => {
+        table.boolean('hide_frame').defaultTo(false);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DASHBOARD_TILE_MARKDOWNS_TABLE, (table) => {
+        table.dropColumn('hide_frame');
+    });
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -238,6 +238,7 @@ export const markdownTileEntry = {
     type: DashboardTileTypes.MARKDOWN,
     title: 'my markdown title',
     content: 'my markdown content',
+    hide_frame: false,
 };
 
 export const dashboardChartTileEntry: GetChartTileQuery = {
@@ -291,6 +292,7 @@ export const expectedDashboard: DashboardDAO = {
                 title: markdownTileEntry.title,
                 content: markdownTileEntry.content,
                 hideTitle: false,
+                hideFrame: false,
             },
             x: dashboardTileEntry.x_offset,
             y: dashboardTileEntry.y_offset,

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -253,6 +253,7 @@ export class DashboardModel {
                         properties.content,
                         HTML_SANITIZE_MARKDOWN_TILE_RULES,
                     ),
+                    hide_frame: properties.hideFrame ?? false,
                 })),
             );
         }
@@ -785,6 +786,7 @@ export class DashboardModel {
                     content: string | null;
                     text: string | null;
                     hide_title: boolean | null;
+                    hide_frame: boolean | null;
                     title: string | null;
                     views_count: string;
                     first_viewed_at: Date | null;
@@ -837,6 +839,7 @@ export class DashboardModel {
                 ),
                 `${DashboardTileLoomsTableName}.url`,
                 `${DashboardTileMarkdownsTableName}.content`,
+                `${DashboardTileMarkdownsTableName}.hide_frame`,
                 `${DashboardTileHeadingsTableName}.text`,
             )
             .leftJoin(DashboardTileChartTableName, function chartsJoin() {
@@ -960,6 +963,7 @@ export class DashboardModel {
                     hide_title,
                     url,
                     content,
+                    hide_frame,
                     text,
                     belongs_to_dashboard,
                     name,
@@ -1005,6 +1009,7 @@ export class DashboardModel {
                                 properties: {
                                     ...commonProperties,
                                     content: content || '',
+                                    hideFrame: hide_frame ?? false,
                                 },
                             };
                         case DashboardTileTypes.LOOM:

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -35,6 +35,7 @@ export type DashboardMarkdownTileProperties = {
     properties: {
         title: string;
         content: string;
+        hideFrame?: boolean;
     };
 };
 

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -1,4 +1,4 @@
-import { type DashboardMarkdownTile } from '@lightdash/common';
+import { FeatureFlags, type DashboardMarkdownTile } from '@lightdash/common';
 import { Menu, Text, useMantineTheme } from '@mantine/core';
 import { IconCopy } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
@@ -8,6 +8,7 @@ import { v4 as uuid4 } from 'uuid';
 import { DashboardTileComments } from '../../features/comments';
 import { appendNewTilesToBottom } from '../../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../common/MantineIcon';
 import TileBase from './TileBase/index';
@@ -24,11 +25,16 @@ const MarkdownTile: FC<Props> = (props) => {
 
     const {
         tile: {
-            properties: { title, content },
+            properties: { title, content, hideFrame: rawHideFrame },
             uuid,
         },
         isEditMode,
     } = props;
+
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
+    const hideFrame = isDashboardRedesignEnabled ? rawHideFrame : false;
 
     const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
     const showComments = useDashboardContext(
@@ -81,7 +87,8 @@ const MarkdownTile: FC<Props> = (props) => {
 
     return (
         <TileBase
-            title={title}
+            title={hideFrame ? '' : title}
+            transparent={hideFrame}
             lockHeaderVisibility={isCommentsMenuOpen}
             visibleHeaderElement={
                 tileHasComments ? dashboardComments : undefined

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -380,7 +380,11 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             ? chartHoveredProps.handleMouseLeave
                             : undefined
                     }
-                    $alignItems={transparent ? 'center' : undefined}
+                    $alignItems={
+                        tile.type === DashboardTileTypes.HEADING
+                            ? 'center'
+                            : undefined
+                    }
                 >
                     {children}
                 </ChartContainer>

--- a/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
@@ -1,29 +1,60 @@
-import { type DashboardMarkdownTileProperties } from '@lightdash/common';
-import { Stack, TextInput } from '@mantine/core';
+import {
+    FeatureFlags,
+    type DashboardMarkdownTileProperties,
+} from '@lightdash/common';
+import { ActionIcon, Group, Stack, Switch, TextInput } from '@mantine/core';
 import { type UseFormReturnType } from '@mantine/form';
+import { IconInfoCircle } from '@tabler/icons-react';
 import MDEditor from '@uiw/react-md-editor';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 
 interface MarkdownTileFormProps {
     form: UseFormReturnType<DashboardMarkdownTileProperties['properties']>;
 }
 
-const MarkdownTileForm = ({ form }: MarkdownTileFormProps) => (
-    <Stack spacing="md">
-        <TextInput
-            label="Title"
-            placeholder="Tile title"
-            {...form.getInputProps('title')}
-        />
+const MarkdownTileForm = ({ form }: MarkdownTileFormProps) => {
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
 
-        <MDEditor
-            preview="edit"
-            maxHeight={300}
-            minHeight={100}
-            visibleDragbar
-            overflow={false}
-            {...form.getInputProps('content')}
-        />
-    </Stack>
-);
+    return (
+        <Stack spacing="md">
+            <TextInput
+                label="Title"
+                placeholder="Tile title"
+                disabled={form.values.hideFrame}
+                {...form.getInputProps('title')}
+            />
+
+            <MDEditor
+                preview="edit"
+                maxHeight={300}
+                minHeight={100}
+                visibleDragbar
+                overflow={false}
+                {...form.getInputProps('content')}
+            />
+            {isDashboardRedesignEnabled && (
+                <Switch
+                    label={
+                        <Group spacing="xs">
+                            Show tile frame
+                            <ActionIcon size="xs" variant="subtle">
+                                <IconInfoCircle size={14} />
+                            </ActionIcon>
+                        </Group>
+                    }
+                    checked={!form.values.hideFrame}
+                    onChange={(e) =>
+                        form.setFieldValue(
+                            'hideFrame',
+                            !e.currentTarget.checked,
+                        )
+                    }
+                />
+            )}
+        </Stack>
+    );
+};
 
 export default MarkdownTileForm;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #17969

### Description:

Added a new `hide_frame` property to markdown tiles in dashboards. This allows users to toggle the visibility of the tile frame, making the markdown content appear more seamlessly integrated with the dashboard.

The implementation includes:

- Database migration to add the `hide_frame` column to the `dashboard_tile_markdowns` table
- Updated entity types and models to support the new property
- Added a toggle switch in the markdown tile form to control this setting
- Modified the tile rendering to respect the hide frame setting
