### PR TITLE
fix: skip channel sync on unrecoverable slack errors

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -2,6 +2,9 @@ import {
     AnyType,
     friendlyName,
     getErrorMessage,
+    getSlackErrorCode,
+    isSlackRateLimitedError,
+    isUnrecoverableSlackError,
     MissingConfigError,
     SLACK_ID_REGEX,
     SlackAppCustomSettings,
@@ -96,13 +99,16 @@ const createThrottledSlackExecutor = () => {
         try {
             return await operation();
         } catch (error: unknown) {
-            const isRateLimited =
-                error instanceof Error &&
-                'code' in error &&
-                error.code === 'slack_webapi_rate_limited_error';
-
-            if (!isRateLimited) {
-                slackErrorHandler(error, `Slack API error during ${context}`);
+            if (!isSlackRateLimitedError(error)) {
+                // Only send unexpected errors to Sentry
+                // Unrecoverable errors (account_inactive, invalid_auth, missing_scope)
+                // are expected for orgs with broken installations - don't spam Sentry
+                if (!isUnrecoverableSlackError(error)) {
+                    slackErrorHandler(
+                        error,
+                        `Slack API error during ${context}`,
+                    );
+                }
                 throw error;
             }
 
@@ -590,6 +596,25 @@ export class SlackClient {
             };
         } catch (error) {
             const errorMessage = getErrorMessage(error);
+
+            // Handle unrecoverable Slack errors gracefully (user needs to re-install)
+            if (isUnrecoverableSlackError(error)) {
+                const slackErrorCode = getSlackErrorCode(error);
+                const reason = `Slack installation is invalid (${slackErrorCode}) - user needs to re-install`;
+                Logger.warn(
+                    `Skipping Slack channel sync for organization ${organizationUuid}: ${reason}`,
+                );
+                await this.slackChannelCacheModel.failSync(
+                    organizationId,
+                    reason,
+                );
+                return {
+                    status: 'skipped',
+                    reason,
+                    totalChannels: 0,
+                };
+            }
+
             Logger.error(
                 `Slack channel sync failed for organization ${organizationUuid}: ${errorMessage}`,
             );

--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -7,3 +7,54 @@
  * const isSlackId = SLACK_ID_REGEX.test('W1234567890');
  */
 export const SLACK_ID_REGEX = /^[CGUW][A-Z0-9]{8,}$/i;
+
+/**
+ * Slack error codes that indicate the installation is broken and won't be fixed by retrying.
+ * These are expected for orgs with invalid/revoked tokens - we handle them gracefully
+ * without spamming Sentry.
+ */
+export const UNRECOVERABLE_SLACK_ERRORS = [
+    'account_inactive', // Bot/app was deactivated
+    'invalid_auth', // Invalid authentication
+    'missing_scope', // Missing required OAuth scope
+] as const;
+
+/**
+ * Extracts the Slack error code from an error object.
+ * Slack API errors have the format: { data: { error: 'error_code' } }
+ */
+export const getSlackErrorCode = (error: unknown): string | undefined => {
+    if (
+        error &&
+        typeof error === 'object' &&
+        'data' in error &&
+        error.data &&
+        typeof error.data === 'object' &&
+        'error' in error.data
+    ) {
+        return (error.data as { error: string }).error;
+    }
+    return undefined;
+};
+
+/**
+ * Checks if a Slack error is unrecoverable (installation is broken).
+ */
+export const isUnrecoverableSlackError = (error: unknown): boolean => {
+    const errorCode = getSlackErrorCode(error);
+    return (
+        errorCode !== undefined &&
+        UNRECOVERABLE_SLACK_ERRORS.includes(
+            errorCode as typeof UNRECOVERABLE_SLACK_ERRORS[number],
+        )
+    );
+};
+
+/**
+ * Checks if a Slack error is a rate limit error.
+ * These errors have a special code from the @slack/web-api package.
+ */
+export const isSlackRateLimitedError = (error: unknown): boolean =>
+    error instanceof Error &&
+    'code' in error &&
+    error.code === 'slack_webapi_rate_limited_error';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18825

### Description:

Improves handling of Slack API errors by gracefully managing unrecoverable errors like invalid tokens, missing permissions, or deactivated apps.

This PR:

- Adds utility functions to identify and handle specific Slack error types
- Prevents sending expected errors to Sentry (reducing noise)
- Gracefully handles broken Slack installations by marking them as "skipped" during channel sync
- Provides more detailed error information to help users understand when they need to reinstall the Slack integration

The changes allow the system to better communicate when a Slack installation needs to be fixed by the user rather than treating all errors as unexpected system failures.

you can override the token with something like "xoxb-000000000000-0000000000000-invalidtoken" to test `invalid_auth`



![Screenshot 2025-12-15 at 16.59.17.png](https://app.graphite.com/user-attachments/assets/4807bc3d-8f0d-402f-9112-2e1770564d27.png)

