### PR TITLE
feat: gracefully handle screenshot errors - support drawer

### DIFF
--- a/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
+++ b/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
@@ -1,18 +1,20 @@
 import { type AnyType } from '@lightdash/common';
 import {
     Button,
-    Center,
     Checkbox,
     Image,
     Loader,
+    Paper,
     Stack,
     Text,
     Textarea,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
+import { IconIdOff } from '@tabler/icons-react';
 import html2canvas from 'html2canvas';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import { lightdashApi, networkHistory } from '../../api';
+import MantineIcon from '../../components/common/MantineIcon';
 import useToaster from '../../hooks/toaster/useToaster';
 
 type SupportDrawerContentProps = {
@@ -63,14 +65,25 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
     const [allowAccess, setAllowAccess] = useState(true);
 
     const [screenshot, setScreenshot] = useState<string | null>(null);
+    const [screenshotError, setScreenshotError] = useState(false);
     const { showToastSuccess } = useToaster();
     useEffect(() => {
         const element = document.querySelector('body');
-        if (element)
-            void html2canvas(element as HTMLElement).then((canvas) => {
-                const base64 = canvas.toDataURL('image/png');
-                setScreenshot(base64);
-            });
+        if (element) {
+            void html2canvas(element as HTMLElement)
+                .then((canvas) => {
+                    const base64 = canvas.toDataURL('image/png');
+                    setScreenshot(base64);
+                })
+                .catch((error) => {
+                    console.error(
+                        'Failed to capture screenshot:',
+                        error.message,
+                    );
+                    setScreenshotError(true);
+                    setScreenshot(null);
+                });
+        }
     }, []);
 
     const handleShare = useCallback(async () => {
@@ -98,10 +111,12 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
         <Stack spacing="xs">
             <Checkbox
                 label="Include this image"
-                checked={includeImage}
+                checked={screenshotError ? false : includeImage}
                 onChange={(event) => setIncludeImage(event.target.checked)}
                 mt="xs"
+                disabled={screenshotError}
             />
+
             {screenshot ? (
                 <Image
                     height={200}
@@ -110,9 +125,27 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
                     fit="contain"
                 />
             ) : (
-                <Center>
-                    <Loader height={200} w="100%" variant="dots" />
-                </Center>
+                <Paper p="lg" withBorder h={200}>
+                    <Stack
+                        h="100%"
+                        align="center"
+                        justify="center"
+                        spacing="xs"
+                    >
+                        {screenshotError ? (
+                            <>
+                                <MantineIcon icon={IconIdOff} color="ldGray" />
+                                <Text color="dimmed" ta="center">
+                                    Screenshot could not be captured. You can
+                                    still submit your report with the details
+                                    below
+                                </Text>
+                            </>
+                        ) : (
+                            <Loader height={200} w="100%" variant="dots" />
+                        )}
+                    </Stack>
+                </Paper>
             )}
             <Text mt="sm">
                 Do you have and other details you'd like to share?


### PR DESCRIPTION
Related: PROD-1632

### Description:
Improved error handling for screenshot capture in the Support Drawer. When screenshot capture fails, the UI now displays a helpful error message instead of an infinite loading state, and disables the "Include this image" checkbox. Users can still submit their support request with text details even when the screenshot fails.


![CleanShot 2025-12-15 at 18.09.58.png](https://app.graphite.com/user-attachments/assets/2df66904-7ead-4226-9906-c3056422a422.png)


