### PR TITLE
fix: only show "not applied to any tabs" warning when tabs are enabled

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
@@ -43,7 +43,8 @@ const useDashboardFilterStyles = createStyles((theme) => ({
 
 type Props = {
     isEditMode: boolean;
-    notAppliedToAnyTab: boolean;
+    isOrphaned: boolean;
+    orphanedTooltip?: string;
     isTemporary?: boolean;
     field: FilterableDimension | undefined;
     filterRule: DashboardFilterRule;
@@ -57,7 +58,8 @@ type Props = {
 
 const Filter: FC<Props> = ({
     isEditMode,
-    notAppliedToAnyTab,
+    isOrphaned,
+    orphanedTooltip = 'This filter is not applied to any tiles',
     isTemporary,
     field,
     filterRule,
@@ -209,10 +211,8 @@ const Filter: FC<Props> = ({
                     >
                         <Tooltip
                             fz="xs"
-                            label={
-                                'This filter is not currently applied to any tabs'
-                            }
-                            disabled={!notAppliedToAnyTab}
+                            label={orphanedTooltip}
+                            disabled={!isOrphaned}
                             withinPortal
                         >
                             <Button
@@ -228,11 +228,7 @@ const Filter: FC<Props> = ({
                                     hasUnsetRequiredFilter
                                         ? classes.unsetRequiredFilter
                                         : ''
-                                } ${
-                                    notAppliedToAnyTab
-                                        ? classes.inactiveFilter
-                                        : ''
-                                }`}
+                                } ${isOrphaned ? classes.inactiveFilter : ''}`}
                                 leftIcon={
                                     isDraggable && (
                                         <MantineIcon

--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/index.tsx
@@ -23,7 +23,10 @@ import { IconRotate2 } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
-import { getTabsForFilterRule } from '../FilterConfiguration/utils';
+import {
+    doesFilterApplyToAnyTile,
+    getTabsForFilterRule,
+} from '../FilterConfiguration/utils';
 import InvalidFilter from '../InvalidFilter';
 import Filter from './Filter';
 
@@ -167,6 +170,34 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
         [dashboardTiles, sortedTabUuids, filterableFieldsByTileUuid],
     );
 
+    // Compute orphaned state for a filter
+    // - With multiple tabs: orphaned if filter applies to no tabs
+    // - With single/no tabs: orphaned if filter applies to no tiles
+    const getOrphanedState = useCallback(
+        (
+            filterRule: DashboardFilterRule,
+            appliesToTabs: string[],
+        ): { isOrphaned: boolean; orphanedTooltip: string } => {
+            if (tabsEnabled) {
+                return {
+                    isOrphaned: appliesToTabs.length === 0,
+                    orphanedTooltip: 'This filter is not applied to any tabs',
+                };
+            }
+            // Single tab or no tabs - check if filter applies to any tile
+            const appliesToAnyTile = doesFilterApplyToAnyTile(
+                filterRule,
+                dashboardTiles,
+                filterableFieldsByTileUuid,
+            );
+            return {
+                isOrphaned: !appliesToAnyTile,
+                orphanedTooltip: 'This filter is not applied to any tiles',
+            };
+        },
+        [tabsEnabled, dashboardTiles, filterableFieldsByTileUuid],
+    );
+
     if (isLoadingDashboardFilters || isFetchingDashboardFilters) {
         return (
             <Group spacing="xs" ml="xs">
@@ -251,11 +282,10 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                                     <Filter
                                         key={item.id}
                                         isEditMode={isEditMode}
-                                        notAppliedToAnyTab={
-                                            // Only show "not applied to any tabs" when tabs are enabled
-                                            tabsEnabled &&
-                                            appliesToTabs.length === 0
-                                        }
+                                        {...getOrphanedState(
+                                            item,
+                                            appliesToTabs,
+                                        )}
                                         field={field}
                                         filterRule={item}
                                         activeTabUuid={activeTabUuid}
@@ -312,10 +342,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                 return field || item.target.isSqlColumn ? (
                     <Filter
                         key={item.id}
-                        notAppliedToAnyTab={
-                            // Only show "not applied to any tabs" when tabs are enabled
-                            tabsEnabled && appliesToTabs.length === 0
-                        }
+                        {...getOrphanedState(item, appliesToTabs)}
                         isTemporary
                         isEditMode={isEditMode}
                         field={field}

--- a/packages/frontend/src/features/dashboardFiltersV2/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/features/dashboardFiltersV2/FilterConfiguration/utils/index.ts
@@ -111,6 +111,28 @@ export const doesFilterApplyToTile = (
 };
 
 /**
+ * Checks if a filter applies to any tile in the dashboard.
+ *
+ * @param filterRule - The filter rule to check
+ * @param dashboardTiles - All tiles in the dashboard
+ * @param filterableFieldsByTileUuid - Map of tile UUID to available filterable fields
+ * @returns true if the filter applies to at least one tile
+ */
+export const doesFilterApplyToAnyTile = (
+    filterRule: DashboardFilterRule,
+    dashboardTiles: DashboardTile[] | undefined,
+    filterableFieldsByTileUuid:
+        | Record<string, FilterableDimension[]>
+        | undefined,
+): boolean => {
+    return (
+        dashboardTiles?.some((tile) =>
+            doesFilterApplyToTile(filterRule, tile, filterableFieldsByTileUuid),
+        ) ?? false
+    );
+};
+
+/**
  * Computes which tab UUIDs a filter applies to based on its tileTargets configuration.
  *
  * A filter applies to a tab if:


### PR DESCRIPTION
### Description:
Only show "not applied to any tab" warning for filters when tabs are actually enabled (when there's more than one tab). This prevents showing unnecessary warnings in single-tab dashboards.