### PR TITLE
fix: add filter value not respecting dark mode

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -296,8 +296,8 @@ const FilterStringAutoComplete: FC<Props> = ({
                 }
                 getCreateLabel={(query) => (
                     <Group spacing="xxs">
-                        <MantineIcon icon={IconPlus} color="blue" size="sm" />
-                        <Text color="blue">Add "{query}"</Text>
+                        <MantineIcon icon={IconPlus} color="blue.6" size="sm" />
+                        <Text c="blue.6">Add "{query}"</Text>
                     </Group>
                 )}
                 styles={{
@@ -306,11 +306,6 @@ const FilterStringAutoComplete: FC<Props> = ({
                         '&:last-child:not([value])': {
                             position: 'sticky',
                             bottom: 4,
-                            // casts shadow on the bottom of the list to avoid transparency
-                            boxShadow: '0 4px 0 0 white',
-                        },
-                        '&:last-child:not([value]):not(:hover)': {
-                            background: 'white',
                         },
                     },
                 }}


### PR DESCRIPTION
### Description:

The button to add a filter value wasn't respecting dark mode. 

To repro: 
- Use dark mode
- Add a string filter
- Type a value that doesnt exist yet
- The add button is white

Before:
<img width="1358" height="768" alt="Screenshot 2025-12-15 at 18 47 56" src="https://github.com/user-attachments/assets/9b62e43c-1de6-4527-9407-2ae0559059db" />

After:
<img width="1335" height="689" alt="Screenshot 2025-12-15 at 18 47 06" src="https://github.com/user-attachments/assets/c0eccbd3-de84-4342-8b12-181787cda51b" />

