### PR TITLE
chore: disable flaky e2e tests

### DIFF
--- a/packages/e2e/cypress/e2e/api/embedChart.cy.ts
+++ b/packages/e2e/cypress/e2e/api/embedChart.cy.ts
@@ -305,7 +305,7 @@ describe('Embed Chart JWT API', () => {
         });
 
         describe('GET chart views', () => {
-            it('should get chart views using JWT token (authorized)', () => {
+            it.skip('should get chart views using JWT token (authorized)', () => {
                 // FIXME this doesn't work
                 // > 500: Internal Server Error
                 cy.get<string>('@chartJwtToken').then((token) => {
@@ -350,7 +350,7 @@ describe('Embed Chart JWT API', () => {
         // This method is deprecated, but still supported for backwards compatibility
         // We still need to make sure we can get access using the JWT token if the chart matches
         describe('POST chart results deprecated', () => {
-            it('should get chart results using JWT token (authorized)', () => {
+            it.skip('should get chart results using JWT token (authorized)', () => {
                 // FIXME this doesn't work currently because SavedChartController.postChartResults
                 // is not supporting account, so fails to get userUuid parameter
                 cy.get<string>('@chartJwtToken').then((token) => {

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -181,7 +181,7 @@ describe('Admin access to spaces', () => {
         }
     });
 
-    it('can see all the spaces on Admin content view', () => {
+    it.skip('can see all the spaces on Admin content view', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/spaces`);
 
         cy.contains('Admin Content View').click();
@@ -195,7 +195,7 @@ describe('Admin access to spaces', () => {
         }
     });
 
-    it('can see nested spaces', () => {
+    it.skip('can see nested spaces', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/spaces`);
 
         cy.contains('Admin Content View').click();


### PR DESCRIPTION
Skip the following tests that are currently unreliable:
- Admin content view space tests
- JWT token chart views/results tests
