### PR TITLE
fix: validate query has at least one field before execution

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -1,4 +1,5 @@
 import {
+    AiAgentValidatorError,
     AiResultType,
     convertAiTableCalcsSchemaToTableCalcs,
     getSlackAiEchartsConfig,
@@ -56,6 +57,24 @@ export const validateRunQueryTool = (
     explore: Explore,
 ) => {
     const filterRules = getTotalFilterRules(queryTool.filters);
+
+    const {
+        queryConfig: { dimensions, metrics },
+        customMetrics,
+        tableCalculations,
+    } = queryTool;
+
+    const hasFields =
+        dimensions.length > 0 ||
+        metrics.length > 0 ||
+        (customMetrics && customMetrics.length > 0) ||
+        (tableCalculations && tableCalculations.length > 0);
+
+    if (!hasFields) {
+        throw new AiAgentValidatorError(
+            'Query must have at least one dimension, metric, or table calculation',
+        );
+    }
 
     // Validate dimensions
     validateFieldEntityType(

--- a/packages/backend/src/utils/csvLimitUtils.ts
+++ b/packages/backend/src/utils/csvLimitUtils.ts
@@ -35,7 +35,7 @@ export function metricQueryWithLimit(
         metricQuery.tableCalculations.length;
     if (numberColumns === 0)
         throw new ParameterError(
-            'Query must have at least one dimension or metric',
+            'Query must have at least one dimension, metric, or table calculation',
         );
     const maxRows = Math.floor(csvCellsLimit / Math.max(numberColumns, 1));
     const csvRowLimit =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-167](https://linear.app/lightdash/issue/ZAP-167/parametererror-query-must-have-at-least-one-dimension-or-metric)

### Description:

Enhances query validation to ensure that queries must have at least one dimension, metric, or table calculation. This validation is now consistently applied in both the AI agent validator and the CSV limit utility, with appropriate error messages for each context.
