### PR TITLE
refactor: remove unused activeTabUuid prop from filter components

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
@@ -49,7 +49,6 @@ type Props = {
     field: FilterableDimension | undefined;
     filterRule: DashboardFilterRule;
     openPopoverId: string | undefined;
-    activeTabUuid: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
     onUpdate: (filter: DashboardFilterRule) => void;
@@ -64,7 +63,6 @@ const Filter: FC<Props> = ({
     field,
     filterRule,
     openPopoverId,
-    activeTabUuid,
     onPopoverOpen,
     onPopoverClose,
     onUpdate,
@@ -339,7 +337,6 @@ const Filter: FC<Props> = ({
                             fields={allFilterableFields || []}
                             tiles={dashboardTiles}
                             tabs={dashboardTabs}
-                            activeTabUuid={activeTabUuid}
                             originalFilterRule={originalFilterRule}
                             availableTileFilters={
                                 filterableFieldsByTileUuid ?? {}

--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/index.tsx
@@ -288,7 +288,6 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                                         )}
                                         field={field}
                                         filterRule={item}
-                                        activeTabUuid={activeTabUuid}
                                         openPopoverId={openPopoverId}
                                         onPopoverOpen={onPopoverOpen}
                                         onPopoverClose={onPopoverClose}
@@ -347,7 +346,6 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                         isEditMode={isEditMode}
                         field={field}
                         filterRule={item}
-                        activeTabUuid={activeTabUuid}
                         openPopoverId={openPopoverId}
                         onPopoverOpen={onPopoverOpen}
                         onPopoverClose={onPopoverClose}

--- a/packages/frontend/src/features/dashboardFiltersV2/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/AddFilterButton.tsx
@@ -8,7 +8,6 @@ import FilterConfiguration from './FilterConfiguration';
 type Props = {
     isEditMode: boolean;
     openPopoverId: string | undefined;
-    activeTabUuid: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
     onSave: (value: DashboardFilterRule) => void;
@@ -17,7 +16,6 @@ type Props = {
 const AddFilterButton: FC<Props> = ({
     isEditMode,
     openPopoverId,
-    activeTabUuid,
     onPopoverOpen,
     onPopoverClose,
     onSave,
@@ -127,7 +125,6 @@ const AddFilterButton: FC<Props> = ({
                             fields={allFilterableFields || []}
                             tiles={dashboardTiles}
                             tabs={dashboardTabs}
-                            activeTabUuid={activeTabUuid}
                             availableTileFilters={
                                 filterableFieldsByTileUuid ?? {}
                             }

--- a/packages/frontend/src/features/dashboardFiltersV2/index.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/index.tsx
@@ -79,7 +79,6 @@ const DashboardFiltersV2: FC<Props> = ({ isEditMode, activeTabUuid }) => {
                 <AddFilterButton
                     isEditMode={isEditMode}
                     openPopoverId={openPopoverId}
-                    activeTabUuid={activeTabUuid}
                     onPopoverOpen={handlePopoverOpen}
                     onPopoverClose={handlePopoverClose}
                     onSave={handleSaveNew}


### PR DESCRIPTION
### Description:
Removed the `activeTabUuid` prop from dashboard filter components as it's no longer needed. This simplifies the filter configuration by allowing filters to be applied across all tabs rather than filtering based on the active tab.

The changes remove the filtering logic that was previously restricting available tile filters and SQL chart columns to only those from the active tab, enabling a more consistent filtering experience throughout the dashboard.