### PR TITLE
fix: remove transparency from bg LD_FIELD_COLORS

### DIFF
--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -92,21 +92,21 @@ export interface LightdashFieldColors {
 
 export const LD_FIELD_COLORS = {
     dimension: {
-        bg: 'light-dark(#4b69ef18, #4b69ef21)',
+        bg: 'light-dark(#EDF0FD, #202539)',
         bgHover: 'light-dark(#4b69ef28, #4b69ef35)',
         color: 'light-dark(#3b5bdb, #95aaf0)',
         columnHeaderColor: 'light-dark(#1c2b67, #93acff)',
         mantineColor: 'dimension',
     },
     metric: {
-        bg: 'light-dark(#e8590c20, #7b50135e)',
+        bg: 'light-dark(#FBE9E0, #3E2F1A)',
         bgHover: 'light-dark(#e8590c30, #81510d75)',
         color: 'light-dark(#de7f0b, #e08a20)',
         columnHeaderColor: 'light-dark(#502e06, #de7f0b)',
         mantineColor: 'metric',
     },
     calculation: {
-        bg: 'light-dark(#2f9e4418, #2375354b)',
+        bg: 'light-dark(#EBF5ED, #1D3525)',
         bgHover: 'light-dark(#2f9e4428, #23753565)',
         color: 'light-dark(#2b8a3e, #38af4d)',
         columnHeaderColor: 'light-dark(#1b5326, #48b95d)',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18840

### Description:

Updated the background colors for field types in the Mantine theme to improve contrast and readability. Changed the background colors for dimensions, metrics, and calculations to more distinct color values while maintaining the light/dark mode compatibility.

![Screenshot 2025-12-16 at 10.32.42.png](https://app.graphite.com/user-attachments/assets/05e50bfa-736b-40fb-955d-35c24c866421.png)



![image.png](https://app.graphite.com/user-attachments/assets/9a6b821e-e4e4-485a-9a13-4fdeeadfa8e6.png)

