### PR TITLE
fix: handle undefined filter items in getFilterRulesFromGroup

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -58,10 +58,12 @@ export const getFilterRulesFromGroup = (
     filterGroup: FilterGroup | undefined,
 ): FilterRule[] => {
     if (filterGroup) {
-        const items = isAndFilterGroup(filterGroup)
+        const items: FilterGroupItem[] | undefined = isAndFilterGroup(
+            filterGroup,
+        )
             ? filterGroup.and
             : filterGroup.or;
-        return items.reduce<FilterRule[]>(
+        return (items ?? []).reduce<FilterRule[]>(
             (sum, item) =>
                 isFilterGroup(item)
                     ? [...sum, ...getFilterRulesFromGroup(item)]


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1547 / LIGHTDASH-FRONTEND-40H
Related/similar to: #15502

### Description:
Fixed a potential undefined error in `getFilterRulesFromGroup` by explicitly typing `items` as `FilterGroupItem[] | undefined` and adding a null coalescing operator to handle cases where `items` might be undefined.