### PR TITLE
feat: add tooltip with description to minimal tile titles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -156,9 +156,22 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 >
                     {minimal ? (
                         !hideTitle ? (
-                            <Text fw={600} size="md">
-                                {title}
-                            </Text>
+                            <Tooltip
+                                disabled={!description}
+                                label={
+                                    <Text style={{ whiteSpace: 'pre-line' }}>
+                                        {description}
+                                    </Text>
+                                }
+                                multiline
+                                position="top-start"
+                                withinPortal
+                                maw={400}
+                            >
+                                <Text fw={600} size="md">
+                                    {title}
+                                </Text>
+                            </Tooltip>
                         ) : (
                             <Box />
                         )


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1214

### Description:
Added a tooltip to display the tile description when hovering over the title in minimal mode. The tooltip shows the description text with preserved line breaks and is positioned at the top-start of the title element. The tooltip is only enabled when a description exists.

Adding tooltips to minimal mode doesn't seem to hurt:
  - PDF/image generation: Tooltip won't appear in static captures
  - Mobile view: Could actually be useful (tap to see description)

### Ta-da
![Screenshot 2025-12-16 at 12.16.38.png](https://app.graphite.com/user-attachments/assets/891f4ee6-06d1-43f7-8791-254841d7b840.png)

