### PR TITLE
fix: remove redundant parent selector in dashboard e2e test

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -268,7 +268,6 @@ describe('Dashboard', () => {
         )
             .eq(4)
             .parent()
-            .parent()
             .siblings()
             .first()
             .within(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixed a DOM traversal issue in the dashboard test by removing an unnecessary `.parent()` call. This ensures the test correctly navigates the DOM structure to find the target element.