### PR TITLE
feat: add translation support for heading tiles in embedded dashboards

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -7,7 +7,6 @@ import { IconUnlink } from '@tabler/icons-react';
 import { useEffect, useMemo, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useLocation, useNavigate } from 'react-router';
-import HeadingTile from '../../../../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../../../../components/DashboardTiles/DashboardLoomTile';
 import SqlChartTile from '../../../../../components/DashboardTiles/DashboardSqlChartTile';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
@@ -25,6 +24,7 @@ import EmbedDashboardHeader from './EmbedDashboardHeader';
 
 import { Group, Tabs, Title } from '@mantine/core';
 import '../../../../../styles/react-grid.css';
+import { EmbedHeadingTile } from './EmbedHeadingTile';
 import { EmbedMarkdownTile } from './EmbedMarkdownTile';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
@@ -111,12 +111,14 @@ const EmbedDashboardGrid: FC<{
                                 onEdit={() => {}}
                             />
                         ) : tile.type === DashboardTileTypes.HEADING ? (
-                            <HeadingTile
+                            <EmbedHeadingTile
                                 key={tile.uuid}
                                 tile={tile}
                                 isEditMode={false}
                                 onDelete={() => {}}
                                 onEdit={() => {}}
+                                tileIndex={index}
+                                dashboardSlug={dashboard.slug}
                             />
                         ) : (
                             assertUnreachable(

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedHeadingTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedHeadingTile.tsx
@@ -1,0 +1,16 @@
+import DashboardHeadingTile, {
+    type Props as HeadingTileProps,
+} from '../../../../../components/DashboardTiles/DashboardHeadingTile';
+import { useTranslatedTile } from '../hooks/useTranslatedTile';
+
+export const EmbedHeadingTile: React.FC<
+    HeadingTileProps & { tileIndex: number; dashboardSlug: string }
+> = ({ tileIndex, dashboardSlug, ...props }) => {
+    const translatedTile = useTranslatedTile(
+        props.tile,
+        dashboardSlug,
+        tileIndex,
+    );
+
+    return <DashboardHeadingTile {...props} tile={translatedTile} />;
+};

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedMarkdownTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedMarkdownTile.tsx
@@ -1,28 +1,16 @@
-import { mergeExisting } from '@lightdash/common';
-import { produce } from 'immer';
-import { useMemo } from 'react';
 import DashboardMarkdownTile, {
     type Props as MarkdownTileProps,
 } from '../../../../../components/DashboardTiles/DashboardMarkdownTile';
-import useEmbed from '../../../../providers/Embed/useEmbed';
+import { useTranslatedTile } from '../hooks/useTranslatedTile';
 
-// TODO same for HeadingTile
 export const EmbedMarkdownTile: React.FC<
     MarkdownTileProps & { tileIndex: number; dashboardSlug: string }
 > = ({ tileIndex, dashboardSlug, ...props }) => {
-    const { languageMap } = useEmbed();
-
-    const translatedTile = useMemo(() => {
-        if (!languageMap || !props.tile) return props.tile;
-
-        const properties =
-            languageMap.dashboard?.[dashboardSlug]?.tiles?.[tileIndex]
-                ?.properties || {};
-
-        return produce(props.tile, (draft) => {
-            draft.properties = mergeExisting(draft.properties, properties);
-        });
-    }, [props.tile, languageMap, tileIndex, dashboardSlug]);
+    const translatedTile = useTranslatedTile(
+        props.tile,
+        dashboardSlug,
+        tileIndex,
+    );
 
     return <DashboardMarkdownTile {...props} tile={translatedTile} />;
 };

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks/useTranslatedTile.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks/useTranslatedTile.ts
@@ -1,0 +1,24 @@
+import { mergeExisting, type DashboardTile } from '@lightdash/common';
+import { produce } from 'immer';
+import { useMemo } from 'react';
+import useEmbed from '../../../../providers/Embed/useEmbed';
+
+export const useTranslatedTile = <T extends DashboardTile>(
+    tile: T,
+    dashboardSlug: string,
+    tileIndex: number,
+): T => {
+    const { languageMap } = useEmbed();
+
+    return useMemo(() => {
+        if (!languageMap) return tile;
+
+        const properties =
+            languageMap.dashboard?.[dashboardSlug]?.tiles?.[tileIndex]
+                ?.properties || {};
+
+        return produce(tile, (draft) => {
+            draft.properties = mergeExisting(draft.properties, properties);
+        });
+    }, [tile, languageMap, tileIndex, dashboardSlug]);
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added translation support for heading tiles in embedded dashboards by creating a new `EmbedHeadingTile` component that leverages the existing `DashboardHeadingTile`. Extracted the translation logic into a reusable `useTranslatedTile` hook that is now shared between both markdown and heading tiles, ensuring consistent translation behavior across different tile types in embedded dashboards.
