### PR TITLE
fix: illegible label inside bar charts with dark background

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts
@@ -1,17 +1,18 @@
 import { CartesianSeriesType, type Series } from '../../../types/savedCharts';
+import { getReadableTextColor } from '../../../utils/colors';
 import { BACKGROUND, FOREGROUND } from './themeColors';
 
 /**
  * Get value label styling for any chart series (line, bar, area, scatter, etc.)
- * Inside: White on dark backgrounds, gray.9 on light backgrounds, weight 500
- * Outside: gray.9 text with colored border matching series, weight 600
  * Size: 11px
  * @param position - Label position relative to data point
  * @param type - Series type
+ * @param backgroundColor - Optional series color
  */
 export const getValueLabelStyle = (
     position: 'left' | 'right' | 'top' | 'bottom' | 'inside' | undefined,
     type: Series['type'],
+    backgroundColor?: string,
 ) => {
     const isInside = position === 'inside';
 
@@ -21,8 +22,20 @@ export const getValueLabelStyle = (
         color: FOREGROUND,
     } as const;
 
+    // For bar charts with inside labels, use contrasting color based on bar color
+    if (isInside && type === CartesianSeriesType.BAR && backgroundColor) {
+        return {
+            ...base,
+            fontSize: 10,
+            color: getReadableTextColor(backgroundColor),
+            backgroundColor,
+            borderRadius: 4,
+            padding: [1, 2],
+        };
+    }
+
+    // For line and area charts with inside labels, use border for legibility
     if (
-        // inside labels for line and area series should have a white border - similar way to bar series for legibility
         isInside &&
         (type === CartesianSeriesType.LINE || type === CartesianSeriesType.AREA)
     ) {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -800,7 +800,11 @@ const getPivotSeries = ({
             label: {
                 ...series.label,
                 ...(series.color &&
-                    getValueLabelStyle(series.label.position, series.type)),
+                    getValueLabelStyle(
+                        series.label.position,
+                        series.type,
+                        series.color,
+                    )),
                 ...(itemsMap &&
                     itemsMap[series.encode.yRef.field] && {
                         formatter: (param: any) => {
@@ -912,7 +916,11 @@ const getSimpleSeries = ({
         label: {
             ...series.label,
             // Apply value label styling for all series types
-            ...getValueLabelStyle(series.label.position, series.type),
+            ...getValueLabelStyle(
+                series.label.position,
+                series.type,
+                series.color,
+            ),
             ...(itemsMap &&
                 itemsMap[yFieldHash] && {
                     formatter: (param: any) => {
@@ -2124,6 +2132,7 @@ const useEchartsCartesianConfig = (
                             ...getValueLabelStyle(
                                 serie.label.position,
                                 serie.type,
+                                computedColor,
                             ),
                         },
                     }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18839

### Description:
Enhances value label styling for bar charts by using contrasting text colors based on the bar's background color. This improves readability by ensuring text is always visible against its background.

![image.png](https://app.graphite.com/user-attachments/assets/5c0c7f23-831e-4a5c-818b-8f7ee3438e2a.png)

