### PR TITLE
chore: unify usage readable color utility

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -3,6 +3,7 @@ import {
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
     getItemId,
+    getReadableTextColor,
     isNumericItem,
     type ConditionalFormattingRowFields,
     type ResultRow,
@@ -22,7 +23,6 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { useEffect, useMemo, type FC } from 'react';
 import {
     getColorFromRange,
-    readableColor,
     transformColorsForDarkMode,
 } from '../../../../utils/colorUtils';
 import { getConditionalRuleLabelFromItem } from '../../Filters/FilterInputs/utils';
@@ -146,7 +146,7 @@ const TableRow: FC<TableRowProps> = ({
                 // When conditional formatting is applied, always use calculated contrast color
                 // to ensure text remains readable regardless of light/dark mode
                 const fontColor = conditionalFormattingColor
-                    ? readableColor(conditionalFormattingColor)
+                    ? getReadableTextColor(conditionalFormattingColor)
                     : undefined;
 
                 const suppressContextMenu =

--- a/packages/frontend/src/utils/colorUtils.ts
+++ b/packages/frontend/src/utils/colorUtils.ts
@@ -6,15 +6,6 @@ import {
 import Color from 'colorjs.io';
 import { DARK_MODE_COLORS } from '../mantineTheme';
 
-export const readableColor = (backgroundColor: string) => {
-    if (!isHexCodeColor(backgroundColor)) {
-        return 'black';
-    }
-    const onWhite = Math.abs(Color.contrastAPCA('white', backgroundColor));
-    const onBlack = Math.abs(Color.contrastAPCA('black', backgroundColor));
-    return onWhite > onBlack ? 'white' : 'black';
-};
-
 /**
  * Replaces 'problematic' colors in dark mode for better visibility
  */


### PR DESCRIPTION
### Description:
Removed the `readableColor` function from `colorUtils.ts` and replaced its usage in `TableBody.tsx` with the existing `getReadableTextColor` function. This consolidates duplicate functionality for determining readable text colors based on background colors.