### PR TITLE
feat: reorganize dashboard add menu with tiles and elements sections

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -88,6 +88,7 @@ const AddTileButton: FC<Props> = ({
                     </Button>
                 </Menu.Target>
                 <Menu.Dropdown>
+                    <Menu.Label>Tiles</Menu.Label>
                     <Menu.Item
                         onClick={() => setIsAddChartTilesModalOpen(true)}
                         icon={<MantineIcon icon={IconChartBar} />}
@@ -138,6 +139,16 @@ const AddTileButton: FC<Props> = ({
                         Loom video
                     </Menu.Item>
 
+                    <Menu.Divider />
+
+                    <Menu.Label>Elements</Menu.Label>
+                    <Menu.Item
+                        onClick={() => setAddingTab(true)}
+                        icon={<MantineIcon icon={IconNewSection} />}
+                    >
+                        Tab
+                    </Menu.Item>
+
                     {isDashboardRedesignEnabled && (
                         <Menu.Item
                             onClick={() =>
@@ -148,13 +159,6 @@ const AddTileButton: FC<Props> = ({
                             Heading
                         </Menu.Item>
                     )}
-
-                    <Menu.Item
-                        onClick={() => setAddingTab(true)}
-                        icon={<MantineIcon icon={IconNewSection} />}
-                    >
-                        Add tab
-                    </Menu.Item>
                 </Menu.Dropdown>
             </Menu>
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Reorganized the Add Tile dropdown menu by:

- Adding "Tiles" and "Elements" section labels
- Adding a divider between the two sections
- Moving the "Tab" option under the "Elements" section
- Renaming "Add tab" to just "Tab" for consistency
- Keeping the "Heading" option under "Elements" when dashboard redesign is enabled
