### PR TITLE
fix: add error handling for JSON parsing in paginated query response

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -846,18 +846,26 @@ export class UnfurlService extends BaseService {
                                             responseUrl,
                                         )
                                     ) {
-                                        const json = JSON.parse(
-                                            buffer.toString(),
-                                        ) as Partial<{
-                                            status: 'ok';
-                                            results: ApiGetAsyncQueryResults;
-                                        }>;
-                                        if (
-                                            json.results?.status ===
-                                            QueryHistoryStatus.ERROR
-                                        ) {
-                                            this.logger.error(
-                                                `Headless browser response error while fetching paginated results - url: ${responseUrl}, text: ${json.results.error}`,
+                                        try {
+                                            const json = JSON.parse(
+                                                buffer.toString(),
+                                            ) as Partial<{
+                                                status: 'ok';
+                                                results: ApiGetAsyncQueryResults;
+                                            }>;
+                                            if (
+                                                json.results?.status ===
+                                                QueryHistoryStatus.ERROR
+                                            ) {
+                                                this.logger.error(
+                                                    `Headless browser response error while fetching paginated results - url: ${responseUrl}, text: ${json.results.error}`,
+                                                );
+                                            }
+                                        } catch (parseError) {
+                                            this.logger.warn(
+                                                `Failed to parse paginated query response - url: ${responseUrl}, error: ${getErrorMessage(
+                                                    parseError,
+                                                )}`,
                                             );
                                         }
                                     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1631 / LIGHTDASH-BACKEND-7FT

### Description:
Added error handling for JSON parsing in the UnfurlService when fetching paginated results. Previously, if the response couldn't be parsed as JSON, it would throw an unhandled exception. Now, we catch parsing errors and log them as warnings with the response URL and error message.