### PR TITLE
fix: normalize warehouse name comparison in mergeWarehouseCredentials

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -283,6 +283,10 @@ export const mergeWarehouseCredentials = <T extends CreateWarehouseCredentials>(
 ): T => {
     // If types don't match, return newCredentials as-is (can't merge different warehouse types)
     if (baseCredentials.type !== newCredentials.type) {
+        // eslint-disable-next-line no-console
+        console.info(
+            `Skipping merge of warehouse credentials due to differing types: ${baseCredentials.type} and ${newCredentials.type}`,
+        );
         return newCredentials;
     }
 
@@ -291,8 +295,13 @@ export const mergeWarehouseCredentials = <T extends CreateWarehouseCredentials>(
     if (
         baseCredentials.type === WarehouseTypes.SNOWFLAKE &&
         newCredentials.type === WarehouseTypes.SNOWFLAKE &&
-        baseCredentials.warehouse !== newCredentials.warehouse
+        baseCredentials.warehouse.toLowerCase().trim() !==
+            newCredentials.warehouse.toLowerCase().trim()
     ) {
+        // eslint-disable-next-line no-console
+        console.info(
+            `Skipping merge of Snowflake credentials due to differing warehouse names: ${baseCredentials.warehouse} and ${newCredentials.warehouse}`,
+        );
         return newCredentials;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Fix Snowflake warehouse comparison in mergeWarehouseCredentials function by adding case-insensitive and whitespace-trimming logic. This ensures that warehouses with the same name but different casing or whitespace are properly recognized as identical.