### PR TITLE
fix: use immutable updates for dashboard tiles when managing tabs

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -175,9 +175,14 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                     order: 0,
                 };
                 newTabs.push(firstTab);
-                dashboardTiles?.forEach((tile) => {
-                    tile.tabUuid = firstTab.uuid; // move all tiles to default tab
-                });
+                // Move all tiles to the new default tab (immutable update)
+                setDashboardTiles((currentTiles) =>
+                    currentTiles?.map((tile) => ({
+                        ...tile,
+                        tabUuid: firstTab.uuid,
+                    })),
+                );
+                setHaveTilesChanged(true);
             }
             const lastOrd = newTabs.sort((a, b) => b.order - a.order)[0].order;
             const newTab = {
@@ -228,9 +233,14 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
         setDeletingTab(false);
 
         if (dashboardTabs.length === 1) {
-            dashboardTiles?.forEach((tile) => {
-                tile.tabUuid = undefined; // set tab uuid back to null to avoid foreign key constraint error
-            });
+            // Clear tabUuid from all tiles to avoid foreign key constraint error (immutable update)
+            setDashboardTiles((currentTiles) =>
+                currentTiles?.map((tile) => ({
+                    ...tile,
+                    tabUuid: undefined,
+                })),
+            );
+            setHaveTilesChanged(true);
             // If this is the last tab, navigate to the non-tab URL.
             // See `const = sortedTabs` for more context.
             void navigate(

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -270,9 +270,14 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                     order: 0,
                 };
                 newTabs.push(firstTab);
-                dashboardTiles?.forEach((tile) => {
-                    tile.tabUuid = firstTab.uuid; // move all tiles to default tab
-                });
+                // Move all tiles to the new default tab (immutable update)
+                setDashboardTiles((currentTiles) =>
+                    currentTiles?.map((tile) => ({
+                        ...tile,
+                        tabUuid: firstTab.uuid,
+                    })),
+                );
+                setHaveTilesChanged(true);
             }
             const lastOrd = newTabs.sort((a, b) => b.order - a.order)[0].order;
             const newTab = {
@@ -323,9 +328,14 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
         setDeletingTab(false);
 
         if (dashboardTabs.length === 1) {
-            dashboardTiles?.forEach((tile) => {
-                tile.tabUuid = undefined; // set tab uuid back to null to avoid foreign key constraint error
-            });
+            // Clear tabUuid from all tiles to avoid foreign key constraint error (immutable update)
+            setDashboardTiles((currentTiles) =>
+                currentTiles?.map((tile) => ({
+                    ...tile,
+                    tabUuid: undefined,
+                })),
+            );
+            setHaveTilesChanged(true);
             // If this is the last tab, navigate to the non-tab URL.
             // See `const = sortedTabs` for more context.
             void navigate(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1545 / LIGHTDASH-FRONTEND-40V

### Bug repro steps:
1. Enter edit mode on a dashboard without tabs
2. (Create and) edit a markdown tile title or content
3. Without saving those changes, try adding a new tab
4. Fails silently with `Cannot assign to read only property 'tabUuid' of object '#<Object>'`

### Description:
Fixed mutable state updates in dashboard tabs by replacing direct mutations with immutable updates. The PR:

1. Replaces direct mutations of `dashboardTiles` with proper state updates using `setDashboardTiles`
2. Adds `setHaveTilesChanged(true)` calls to trigger proper re-renders when tiles are modified
3. Implements the same fixes in both the original dashboard tabs and V2 implementation

This change ensures that React's state management works correctly and prevents potential bugs from mutable state updates.