### PR TITLE
chore: limit map extent

### DIFF
--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -440,6 +440,12 @@ const SimpleMap: FC<SimpleMapProps> = memo((props) => {
                     zoom={mapConfig.zoom}
                     style={{ height: '100%', width: '100%' }}
                     scrollWheelZoom
+                    minZoom={2}
+                    maxBounds={[
+                        [-90, -180],
+                        [90, 180],
+                    ]}
+                    maxBoundsViscosity={1.0}
                 >
                     <MapRefUpdater mapRef={leafletMapRef} />
                     <MapExtentTracker
@@ -541,6 +547,12 @@ const SimpleMap: FC<SimpleMapProps> = memo((props) => {
                     zoom={mapConfig.zoom}
                     style={{ height: '100%', width: '100%' }}
                     scrollWheelZoom
+                    minZoom={2}
+                    maxBounds={[
+                        [-90, -180],
+                        [90, 180],
+                    ]}
+                    maxBoundsViscosity={1.0}
                 >
                     <MapRefUpdater mapRef={leafletMapRef} />
                     <MapExtentTracker


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1084

### Description:

Limits the extent of maps so that you can't zoom out infinitely. This is a bit of a tricky problem since we don't have set container sizes. We need to allow zooming out and try not to show weirdness at the edges. This uses some suggested settings from leaflet to:
- Limit the amount a user can zoom out
- Only repeat the map at the edges once

So fully zoomed out it looks like
<img width="1987" height="1266" alt="Screenshot 2025-12-16 at 16 25 02" src="https://github.com/user-attachments/assets/ee79cb8a-c713-4ddd-8814-9821b651857d" />

I tested a version where we only show one map, but it looks a little...bad. 
<img width="1921" height="1172" alt="Screenshot 2025-12-16 at 16 37 59" src="https://github.com/user-attachments/assets/e9574660-817b-45ee-b025-8689b6c3aaac" />

I suppose we could make a user setting, but this seems like a reasonable start. 
