### PR TITLE
fix: add retries to googleSheetsSync jobs and only track a sentry error on the last retry

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -383,6 +383,7 @@ export class SchedulerClient {
             payload,
             date,
             JobPriority.LOW,
+            3,
         );
 
         this.analytics.track({
@@ -901,6 +902,7 @@ export class SchedulerClient {
             payload,
             now,
             JobPriority.LOW,
+            3,
         );
 
         await this.schedulerModel.logSchedulerJob({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-1635/googlesheetstransienterror-error-internal-error-encountered
Relates to: https://github.com/lightdash/lightdash/pull/13461

### Description:
Added retry capability for Google Sheets transient errors in the scheduler. The PR:

1. Sets a maximum of 3 retry attempts for scheduler jobs that refresh Google Sheets data
2. Implements smarter error handling that only reports to Sentry on the final retry attempt or for non-retryable errors
3. Prevents unnecessary error reporting for transient Google Sheets errors that will be automatically retried

This change will reduce noise in Sentry while allowing temporary Google Sheets connectivity issues to resolve themselves through retries.