### PR TITLE
feat: add divider tile to dashboards

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -16,6 +16,7 @@ export const DashboardTileSqlChartTableName = 'dashboard_tile_sql_charts';
 export const DashboardTileMarkdownsTableName = 'dashboard_tile_markdowns';
 export const DashboardTileLoomsTableName = 'dashboard_tile_looms';
 export const DashboardTileHeadingsTableName = 'dashboard_tile_headings';
+export const DashboardTileDividersTableName = 'dashboard_tile_dividers';
 export const DashboardTabsTableName = 'dashboard_tabs';
 
 export type DbDashboard = {
@@ -135,6 +136,15 @@ type DbDashboardTileHeadings = {
 
 export type DashboardTileHeadingsTable =
     Knex.CompositeTableType<DbDashboardTileHeadings>;
+
+type DbDashboardTileDividers = {
+    dashboard_version_id: number;
+    dashboard_tile_uuid: string;
+    orientation: 'horizontal' | 'vertical';
+};
+
+export type DashboardTileDividersTable =
+    Knex.CompositeTableType<DbDashboardTileDividers>;
 
 export type DbDashboardTabs = {
     name: string;

--- a/packages/backend/src/database/migrations/20251216134715_add_dashboard_tile_type_divider.ts
+++ b/packages/backend/src/database/migrations/20251216134715_add_dashboard_tile_type_divider.ts
@@ -1,0 +1,41 @@
+import { Knex } from 'knex';
+
+const TABLE_NAMES = {
+    dashboardTileTypes: 'dashboard_tile_types',
+    dashboardTiles: 'dashboard_tiles',
+    dashboardTileDividers: 'dashboard_tile_dividers',
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex(TABLE_NAMES.dashboardTileTypes).insert([
+        { dashboard_tile_type: 'divider' },
+    ]);
+
+    if (!(await knex.schema.hasTable(TABLE_NAMES.dashboardTileDividers))) {
+        await knex.schema.createTable(
+            TABLE_NAMES.dashboardTileDividers,
+            (table) => {
+                table.integer('dashboard_version_id').notNullable();
+                table
+                    .uuid('dashboard_tile_uuid')
+                    .notNullable()
+                    .defaultTo(knex.raw('uuid_generate_v4()'));
+                table.primary(['dashboard_version_id', 'dashboard_tile_uuid']);
+                table
+                    .foreign(['dashboard_version_id', 'dashboard_tile_uuid'])
+                    .references(['dashboard_version_id', 'dashboard_tile_uuid'])
+                    .inTable(TABLE_NAMES.dashboardTiles)
+                    .onDelete('CASCADE');
+                table.specificType('orientation', 'VARCHAR(10)').notNullable();
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex(TABLE_NAMES.dashboardTiles).delete().where('type', 'divider');
+    await knex(TABLE_NAMES.dashboardTileTypes)
+        .delete()
+        .where('dashboard_tile_type', 'divider');
+    await knex.schema.dropTableIfExists(TABLE_NAMES.dashboardTileDividers);
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1443,7 +1443,14 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardTileTypes: {
         dataType: 'refEnum',
-        enums: ['saved_chart', 'sql_chart', 'markdown', 'loom', 'heading'],
+        enums: [
+            'saved_chart',
+            'sql_chart',
+            'markdown',
+            'loom',
+            'heading',
+            'divider',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Required_CreateDashboardTileBase_: {
@@ -1710,6 +1717,49 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'DashboardTileTypes.DIVIDER': {
+        dataType: 'refEnum',
+        enums: ['divider'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardDividerTileProperties: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                properties: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        orientation: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'enum', enums: ['horizontal'] },
+                                { dataType: 'enum', enums: ['vertical'] },
+                            ],
+                            required: true,
+                        },
+                        title: { dataType: 'undefined', required: true },
+                    },
+                    required: true,
+                },
+                type: { ref: 'DashboardTileTypes.DIVIDER', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardDividerTile: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'DashboardTileBase' },
+                { ref: 'DashboardDividerTileProperties' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardTile: {
         dataType: 'refAlias',
         type: {
@@ -1720,6 +1770,7 @@ const models: TsoaRoute.Models = {
                 { ref: 'DashboardLoomTile' },
                 { ref: 'DashboardSqlChartTile' },
                 { ref: 'DashboardHeadingTile' },
+                { ref: 'DashboardDividerTile' },
             ],
             validators: {},
         },
@@ -16350,6 +16401,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateDashboardDividerTile: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CreateDashboardTileBase' },
+                { ref: 'DashboardDividerTileProperties' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_UpdatedByUser.userUuid_': {
         dataType: 'refAlias',
         type: {
@@ -16390,6 +16453,7 @@ const models: TsoaRoute.Models = {
                             { ref: 'CreateDashboardLoomTile' },
                             { ref: 'CreateDashboardSqlChartTile' },
                             { ref: 'CreateDashboardHeadingTile' },
+                            { ref: 'CreateDashboardDividerTile' },
                         ],
                     },
                     required: true,
@@ -17035,6 +17099,29 @@ const models: TsoaRoute.Models = {
                                         },
                                     },
                                 },
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        orientation: {
+                                            dataType: 'union',
+                                            subSchemas: [
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['horizontal'],
+                                                },
+                                                {
+                                                    dataType: 'enum',
+                                                    enums: ['vertical'],
+                                                },
+                                            ],
+                                            required: true,
+                                        },
+                                        title: {
+                                            dataType: 'undefined',
+                                            required: true,
+                                        },
+                                    },
+                                },
                             ],
                             required: true,
                         },
@@ -17252,7 +17339,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DIVIDER--properties_58__orientation-horizontal-or-vertical___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17262,7 +17349,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DIVIDER--properties_58__orientation-horizontal-or-vertical___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17272,7 +17359,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DIVIDER--properties_58__orientation-horizontal-or-vertical___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17285,7 +17372,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DIVIDER--properties_58__orientation-horizontal-or-vertical___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1574,7 +1574,8 @@
                     "sql_chart",
                     "markdown",
                     "loom",
-                    "heading"
+                    "heading",
+                    "divider"
                 ],
                 "type": "string"
             },
@@ -1840,6 +1841,40 @@
                     }
                 ]
             },
+            "DashboardTileTypes.DIVIDER": {
+                "enum": ["divider"],
+                "type": "string"
+            },
+            "DashboardDividerTileProperties": {
+                "properties": {
+                    "properties": {
+                        "properties": {
+                            "orientation": {
+                                "type": "string",
+                                "enum": ["horizontal", "vertical"]
+                            },
+                            "title": {}
+                        },
+                        "required": ["orientation"],
+                        "type": "object"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/DashboardTileTypes.DIVIDER"
+                    }
+                },
+                "required": ["properties", "type"],
+                "type": "object"
+            },
+            "DashboardDividerTile": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/DashboardTileBase"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DashboardDividerTileProperties"
+                    }
+                ]
+            },
             "DashboardTile": {
                 "anyOf": [
                     {
@@ -1856,6 +1891,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/DashboardHeadingTile"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DashboardDividerTile"
                     }
                 ]
             },
@@ -17154,6 +17192,16 @@
                     }
                 ]
             },
+            "CreateDashboardDividerTile": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CreateDashboardTileBase"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DashboardDividerTileProperties"
+                    }
+                ]
+            },
             "Pick_UpdatedByUser.userUuid_": {
                 "properties": {
                     "userUuid": {
@@ -17210,6 +17258,9 @@
                                 },
                                 {
                                     "$ref": "#/components/schemas/CreateDashboardHeadingTile"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/CreateDashboardDividerTile"
                                 }
                             ]
                         },
@@ -17811,6 +17862,20 @@
                                         },
                                         "required": ["text"],
                                         "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "orientation": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "horizontal",
+                                                    "vertical"
+                                                ]
+                                            },
+                                            "title": {}
+                                        },
+                                        "required": ["orientation"],
+                                        "type": "object"
                                     }
                                 ]
                             },
@@ -17988,22 +18053,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DIVIDER--properties_58__orientation-horizontal-or-vertical___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DIVIDER--properties_58__orientation-horizontal-or-vertical___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DIVIDER--properties_58__orientation-horizontal-or-vertical___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DIVIDER--properties_58__orientation-horizontal-or-vertical___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -72,7 +72,8 @@
                             "sql_chart",
                             "markdown",
                             "loom",
-                            "heading"
+                            "heading",
+                            "divider"
                         ]
                     },
                     "x": {
@@ -228,6 +229,18 @@
                                     }
                                 },
                                 "required": ["text"]
+                            },
+                            {
+                                "description": "Properties for a divider tile",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "orientation": {
+                                        "type": "string",
+                                        "enum": ["horizontal", "vertical"],
+                                        "description": "Orientation of the divider line"
+                                    }
+                                },
+                                "required": ["orientation"]
                             }
                         ]
                     }

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -4,6 +4,7 @@ import type {
     Dashboard,
     DashboardAsCodeLanguageMap,
     DashboardChartTileProperties,
+    DashboardDividerTileProperties,
     DashboardFilterRule,
     DashboardFilters,
     DashboardHeadingTileProperties,
@@ -98,7 +99,8 @@ export type DashboardTileAsCode = Omit<DashboardTile, 'properties' | 'uuid'> & {
           >
         | DashboardMarkdownTileProperties['properties']
         | DashboardLoomTileProperties['properties']
-        | DashboardHeadingTileProperties['properties'];
+        | DashboardHeadingTileProperties['properties']
+        | DashboardDividerTileProperties['properties'];
 };
 
 export type DashboardTileWithSlug = DashboardTile & {

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -16,6 +16,7 @@ export enum DashboardTileTypes {
     MARKDOWN = 'markdown',
     LOOM = 'loom',
     HEADING = 'heading',
+    DIVIDER = 'divider',
 }
 
 type CreateDashboardTileBase = {
@@ -80,6 +81,14 @@ export type DashboardHeadingTileProperties = {
     };
 };
 
+export type DashboardDividerTileProperties = {
+    type: DashboardTileTypes.DIVIDER;
+    properties: {
+        title: undefined;
+        orientation: 'horizontal' | 'vertical';
+    };
+};
+
 export type CreateDashboardMarkdownTile = CreateDashboardTileBase &
     DashboardMarkdownTileProperties;
 export type DashboardMarkdownTile = DashboardTileBase &
@@ -104,6 +113,11 @@ export type CreateDashboardHeadingTile = CreateDashboardTileBase &
 export type DashboardHeadingTile = DashboardTileBase &
     DashboardHeadingTileProperties;
 
+export type CreateDashboardDividerTile = CreateDashboardTileBase &
+    DashboardDividerTileProperties;
+export type DashboardDividerTile = DashboardTileBase &
+    DashboardDividerTileProperties;
+
 export type CreateDashboard = {
     name: string;
     description?: string;
@@ -113,6 +127,7 @@ export type CreateDashboard = {
         | CreateDashboardLoomTile
         | CreateDashboardSqlChartTile
         | CreateDashboardHeadingTile
+        | CreateDashboardDividerTile
     >;
     filters?: DashboardFilters;
     parameters?: DashboardParameters;
@@ -128,7 +143,8 @@ export type DashboardTile =
     | DashboardMarkdownTile
     | DashboardLoomTile
     | DashboardSqlChartTile
-    | DashboardHeadingTile;
+    | DashboardHeadingTile
+    | DashboardDividerTile;
 
 export const isDashboardChartTileType = (
     tile: DashboardTile,
@@ -149,6 +165,10 @@ export const isDashboardSqlChartTile = (
 export const isDashboardHeadingTileType = (
     tile: DashboardTile,
 ): tile is DashboardHeadingTile => tile.type === DashboardTileTypes.HEADING;
+
+export const isDashboardDividerTileType = (
+    tile: DashboardTile,
+): tile is DashboardDividerTile => tile.type === DashboardTileTypes.DIVIDER;
 
 export type DashboardTab = {
     uuid: string;

--- a/packages/common/src/utils/i18n/dashboardAsCode.ts
+++ b/packages/common/src/utils/i18n/dashboardAsCode.ts
@@ -42,6 +42,12 @@ const dashboardAsCodeSchema = z.object({
                     text: z.string(),
                 }),
             }),
+            z.object({
+                type: z.literal(DashboardTileTypes.DIVIDER),
+                properties: z.object({
+                    orientation: z.enum(['horizontal', 'vertical']),
+                }),
+            }),
         ]),
     ),
 });

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -16,6 +16,7 @@ import {
     IconHeading,
     IconInfoCircle,
     IconMarkdown,
+    IconMinus,
     IconNewSection,
     IconPlus,
     IconVideo,
@@ -150,14 +151,24 @@ const AddTileButton: FC<Props> = ({
                     </Menu.Item>
 
                     {isDashboardRedesignEnabled && (
-                        <Menu.Item
-                            onClick={() =>
-                                setAddTileType(DashboardTileTypes.HEADING)
-                            }
-                            icon={<MantineIcon icon={IconHeading} />}
-                        >
-                            Heading
-                        </Menu.Item>
+                        <>
+                            <Menu.Item
+                                onClick={() =>
+                                    setAddTileType(DashboardTileTypes.HEADING)
+                                }
+                                icon={<MantineIcon icon={IconHeading} />}
+                            >
+                                Heading
+                            </Menu.Item>
+                            <Menu.Item
+                                onClick={() =>
+                                    setAddTileType(DashboardTileTypes.DIVIDER)
+                                }
+                                icon={<MantineIcon icon={IconMinus} />}
+                            >
+                                Divider
+                            </Menu.Item>
+                        </>
                     )}
                 </Menu.Dropdown>
             </Menu>
@@ -171,7 +182,8 @@ const AddTileButton: FC<Props> = ({
 
             {addTileType === DashboardTileTypes.MARKDOWN ||
             addTileType === DashboardTileTypes.LOOM ||
-            addTileType === DashboardTileTypes.HEADING ? (
+            addTileType === DashboardTileTypes.HEADING ||
+            addTileType === DashboardTileTypes.DIVIDER ? (
                 <TileAddModal
                     opened={!!addTileType}
                     type={addTileType}

--- a/packages/frontend/src/components/DashboardTiles/DashboardDividerTile.module.css
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDividerTile.module.css
@@ -1,0 +1,12 @@
+.divider {
+    width: 100%;
+    height: 1px;
+    border-top: 1px solid var(--mantine-color-gray-3);
+}
+
+.dividerVertical {
+    width: 1px;
+    height: 100%;
+    border-top: none;
+    border-left: 1px solid var(--mantine-color-gray-3);
+}

--- a/packages/frontend/src/components/DashboardTiles/DashboardDividerTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDividerTile.tsx
@@ -1,0 +1,34 @@
+import { type DashboardDividerTile as DashboardDividerTileType } from '@lightdash/common';
+import { Box } from '@mantine-8/core';
+import { clsx } from '@mantine/core';
+import React, { type FC } from 'react';
+
+import styles from './DashboardDividerTile.module.css';
+import TileBase from './TileBase/index';
+
+export type Props = Pick<
+    React.ComponentProps<typeof TileBase>,
+    'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
+> & {
+    tile: DashboardDividerTileType;
+};
+
+const DashboardDividerTile: FC<Props> = (props) => {
+    const {
+        tile: {
+            properties: { orientation },
+        },
+    } = props;
+
+    return (
+        <TileBase title="" transparent {...props}>
+            <Box
+                className={clsx(styles.divider, {
+                    [styles.dividerVertical]: orientation === 'vertical',
+                })}
+            />
+        </TileBase>
+    );
+};
+
+export default DashboardDividerTile;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -99,6 +99,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 
     const hideTitle =
         tile.type === DashboardTileTypes.HEADING ||
+        tile.type === DashboardTileTypes.DIVIDER ||
         (tile.type !== DashboardTileTypes.MARKDOWN
             ? tile.properties.hideTitle
             : false);

--- a/packages/frontend/src/components/DashboardTiles/TileForms/DividerTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/DividerTileForm.tsx
@@ -1,0 +1,21 @@
+import { type DashboardDividerTileProperties } from '@lightdash/common';
+import { SegmentedControl, Stack } from '@mantine-8/core';
+import { type UseFormReturnType } from '@mantine/form';
+
+interface DividerTileFormProps {
+    form: UseFormReturnType<DashboardDividerTileProperties['properties']>;
+}
+
+const DividerTileForm = ({ form }: DividerTileFormProps) => (
+    <Stack gap="md">
+        <SegmentedControl
+            data={[
+                { label: 'Horizontal', value: 'horizontal' },
+                { label: 'Vertical', value: 'vertical' },
+            ]}
+            {...form.getInputProps('orientation')}
+        />
+    </Stack>
+);
+
+export default DividerTileForm;

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileAddModal.tsx
@@ -3,6 +3,7 @@ import {
     assertUnreachable,
     defaultTileSize,
     type Dashboard,
+    type DashboardDividerTileProperties,
     type DashboardHeadingTileProperties,
     type DashboardLoomTileProperties,
     type DashboardMarkdownTile,
@@ -17,10 +18,16 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { useForm, type UseFormReturnType } from '@mantine/form';
-import { IconHeading, IconMarkdown, IconVideo } from '@tabler/icons-react';
+import {
+    IconHeading,
+    IconMarkdown,
+    IconMinus,
+    IconVideo,
+} from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import { v4 as uuid4 } from 'uuid';
 import MantineIcon from '../../common/MantineIcon';
+import DividerTileForm from './DividerTileForm';
 import HeadingTileForm from './HeadingTileForm';
 import LoomTileForm from './LoomTileForm';
 import MarkdownTileForm from './MarkdownTileForm';
@@ -33,7 +40,8 @@ type AddProps = ModalProps & {
     type:
         | DashboardTileTypes.LOOM
         | DashboardTileTypes.MARKDOWN
-        | DashboardTileTypes.HEADING;
+        | DashboardTileTypes.HEADING
+        | DashboardTileTypes.DIVIDER;
     onConfirm: (tile: Tile) => void;
 };
 
@@ -58,14 +66,27 @@ export const TileAddModal: FC<AddProps> = ({
             text: (value: string | undefined) =>
                 !value || !value.length ? 'Required field' : null,
         };
+        const orientationValidator = {
+            orientation: (value: string | undefined) =>
+                value === 'horizontal' || value === 'vertical'
+                    ? null
+                    : 'Required field',
+        };
         if (type === DashboardTileTypes.LOOM)
             return { ...urlValidator, ...titleValidator };
         if (type === DashboardTileTypes.HEADING) return textValidator;
+        if (type === DashboardTileTypes.DIVIDER) return orientationValidator;
     };
 
     const form = useForm<TileProperties>({
         validate: getValidators(),
-        validateInputOnChange: ['title', 'url', 'content', 'text'],
+        validateInputOnChange: [
+            'title',
+            'url',
+            'content',
+            'text',
+            'orientation',
+        ],
         transformValues(values) {
             if (type === DashboardTileTypes.MARKDOWN) {
                 return markdownTileContentTransform(
@@ -85,6 +106,8 @@ export const TileAddModal: FC<AddProps> = ({
                 return IconVideo;
             case DashboardTileTypes.HEADING:
                 return IconHeading;
+            case DashboardTileTypes.DIVIDER:
+                return IconMinus;
             default:
                 return assertUnreachable(type, 'Tile type not supported');
         }
@@ -108,6 +131,16 @@ export const TileAddModal: FC<AddProps> = ({
                 ...defaultTileSize,
                 h: 1,
                 w: 36,
+            };
+        }
+
+        if (type === DashboardTileTypes.DIVIDER) {
+            const dividerProps =
+                properties as DashboardDividerTileProperties['properties'];
+            size = {
+                ...defaultTileSize,
+                h: dividerProps.orientation === 'horizontal' ? 1 : 9,
+                w: dividerProps.orientation === 'horizontal' ? 36 : 1,
             };
         }
         onConfirm({
@@ -168,6 +201,14 @@ export const TileAddModal: FC<AddProps> = ({
                             form={
                                 form as UseFormReturnType<
                                     DashboardHeadingTileProperties['properties']
+                                >
+                            }
+                        />
+                    ) : type === DashboardTileTypes.DIVIDER ? (
+                        <DividerTileForm
+                            form={
+                                form as UseFormReturnType<
+                                    DashboardDividerTileProperties['properties']
                                 >
                             }
                         />

--- a/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/TileUpdateModal.tsx
@@ -2,6 +2,7 @@ import {
     DashboardTileTypes,
     assertUnreachable,
     type Dashboard,
+    type DashboardDividerTileProperties,
     type DashboardHeadingTileProperties,
     type DashboardLoomTileProperties,
     type DashboardMarkdownTile,
@@ -16,10 +17,16 @@ import {
     type ModalProps,
 } from '@mantine/core';
 import { useForm, type UseFormReturnType } from '@mantine/form';
-import { IconHeading, IconMarkdown, IconVideo } from '@tabler/icons-react';
+import {
+    IconHeading,
+    IconMarkdown,
+    IconMinus,
+    IconVideo,
+} from '@tabler/icons-react';
 import { produce } from 'immer';
 import { useCallback } from 'react';
 import MantineIcon from '../../common/MantineIcon';
+import DividerTileForm from './DividerTileForm';
 import HeadingTileForm from './HeadingTileForm';
 import LoomTileForm from './LoomTileForm';
 import MarkdownTileForm from './MarkdownTileForm';
@@ -53,16 +60,24 @@ const TileUpdateModal = <T extends Tile>({
             text: (value: string | undefined) =>
                 !value || !value.length ? 'Required field' : null,
         };
+        const orientationValidator = {
+            orientation: (value: string | undefined) =>
+                value === 'horizontal' || value === 'vertical'
+                    ? null
+                    : 'Required field',
+        };
 
         if (tile.type === DashboardTileTypes.LOOM)
             return { ...urlValidator, ...titleValidator };
         if (tile.type === DashboardTileTypes.HEADING) return textValidator;
+        if (tile.type === DashboardTileTypes.DIVIDER)
+            return orientationValidator;
     };
 
     const form = useForm<TileProperties>({
         initialValues: { ...tile.properties },
         validate: getValidators(),
-        validateInputOnChange: ['title', 'url', 'text'],
+        validateInputOnChange: ['title', 'url', 'text', 'orientation'],
         transformValues(values) {
             if (tile.type === DashboardTileTypes.MARKDOWN) {
                 return markdownTileContentTransform(
@@ -91,6 +106,8 @@ const TileUpdateModal = <T extends Tile>({
                 return <IconVideo />;
             case DashboardTileTypes.HEADING:
                 return <IconHeading />;
+            case DashboardTileTypes.DIVIDER:
+                return <IconMinus />;
             case DashboardTileTypes.SAVED_CHART:
                 return null;
             case DashboardTileTypes.SQL_CHART:
@@ -139,6 +156,14 @@ const TileUpdateModal = <T extends Tile>({
                             form={
                                 form as UseFormReturnType<
                                     DashboardHeadingTileProperties['properties']
+                                >
+                            }
+                        />
+                    ) : tile.type === DashboardTileTypes.DIVIDER ? (
+                        <DividerTileForm
+                            form={
+                                form as UseFormReturnType<
+                                    DashboardDividerTileProperties['properties']
                                 >
                             }
                         />

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -7,6 +7,7 @@ import { IconUnlink } from '@tabler/icons-react';
 import { useEffect, useMemo, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useLocation, useNavigate } from 'react-router';
+import DividerTile from '../../../../../components/DashboardTiles/DashboardDividerTile';
 import HeadingTile from '../../../../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../../../../components/DashboardTiles/DashboardLoomTile';
 import SqlChartTile from '../../../../../components/DashboardTiles/DashboardSqlChartTile';
@@ -112,6 +113,14 @@ const EmbedDashboardGrid: FC<{
                             />
                         ) : tile.type === DashboardTileTypes.HEADING ? (
                             <HeadingTile
+                                key={tile.uuid}
+                                tile={tile}
+                                isEditMode={false}
+                                onDelete={() => {}}
+                                onEdit={() => {}}
+                            />
+                        ) : tile.type === DashboardTileTypes.DIVIDER ? (
+                            <DividerTile
                                 key={tile.uuid}
                                 tile={tile}
                                 isEditMode={false}

--- a/packages/frontend/src/features/dashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.tsx
@@ -7,6 +7,7 @@ import {
 import { Box } from '@mantine/core';
 import { memo, type FC } from 'react';
 import ChartTile from '../../components/DashboardTiles/DashboardChartTile';
+import DividerTile from '../../components/DashboardTiles/DashboardDividerTile';
 import HeadingTile from '../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../../components/DashboardTiles/DashboardMarkdownTile';
@@ -27,7 +28,7 @@ const GridTile: FC<
     const { tile } = props;
 
     if (props.locked) {
-        // Allow markdown, loom, and heading tiles to show even when locked since they are not filterable
+        // Allow markdown, loom, heading, and divider tiles to show even when locked since they are not filterable
         if (tile.type === DashboardTileTypes.MARKDOWN) {
             return <MarkdownTile {...props} tile={tile} />;
         }
@@ -36,6 +37,9 @@ const GridTile: FC<
         }
         if (tile.type === DashboardTileTypes.HEADING) {
             return <HeadingTile {...props} tile={tile} />;
+        }
+        if (tile.type === DashboardTileTypes.DIVIDER) {
+            return <DividerTile {...props} tile={tile} />;
         }
 
         return (
@@ -56,6 +60,8 @@ const GridTile: FC<
             return <SqlChartTile {...props} tile={tile} />;
         case DashboardTileTypes.HEADING:
             return <HeadingTile {...props} tile={tile} />;
+        case DashboardTileTypes.DIVIDER:
+            return <DividerTile {...props} tile={tile} />;
         default: {
             return assertUnreachable(
                 tile,

--- a/packages/frontend/src/features/dashboardTabsV2/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/GridTile.tsx
@@ -7,6 +7,7 @@ import {
 import { Box } from '@mantine/core';
 import { memo, type FC } from 'react';
 import ChartTile from '../../components/DashboardTiles/DashboardChartTile';
+import DividerTile from '../../components/DashboardTiles/DashboardDividerTile';
 import HeadingTile from '../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../../components/DashboardTiles/DashboardMarkdownTile';
@@ -27,7 +28,7 @@ const GridTile: FC<
     const { tile } = props;
 
     if (props.locked) {
-        // Allow markdown, loom, and heading tiles to show even when locked since they are not filterable
+        // Allow markdown, loom, heading, and divider tiles to show even when locked since they are not filterable
         if (tile.type === DashboardTileTypes.MARKDOWN) {
             return <MarkdownTile {...props} tile={tile} />;
         }
@@ -36,6 +37,9 @@ const GridTile: FC<
         }
         if (tile.type === DashboardTileTypes.HEADING) {
             return <HeadingTile {...props} tile={tile} />;
+        }
+        if (tile.type === DashboardTileTypes.DIVIDER) {
+            return <DividerTile {...props} tile={tile} />;
         }
 
         return (
@@ -56,6 +60,8 @@ const GridTile: FC<
             return <SqlChartTile {...props} tile={tile} />;
         case DashboardTileTypes.HEADING:
             return <HeadingTile {...props} tile={tile} />;
+        case DashboardTileTypes.DIVIDER:
+            return <DividerTile {...props} tile={tile} />;
         default: {
             return assertUnreachable(
                 tile,

--- a/packages/frontend/src/features/dashboardTabsV2/gridUtils.ts
+++ b/packages/frontend/src/features/dashboardTabsV2/gridUtils.ts
@@ -1,4 +1,4 @@
-import { type DashboardTile } from '@lightdash/common';
+import { type DashboardTile, DashboardTileTypes } from '@lightdash/common';
 import { type Layout } from 'react-grid-layout';
 import { DEFAULT_ROW_HEIGHT } from '../dashboardTabs/gridUtils';
 
@@ -12,6 +12,11 @@ export type ResponsiveGridLayoutProps = {
 };
 
 const DEFAULT_COLS = 36;
+
+const nonResizeableTileTypes = [
+    DashboardTileTypes.DIVIDER,
+    DashboardTileTypes.HEADING,
+];
 
 export const getReactGridLayoutConfig = (
     tile: DashboardTile,
@@ -30,7 +35,9 @@ export const getReactGridLayoutConfig = (
         h: tile.h,
         i: tile.uuid,
         isDraggable: isEditMode,
-        isResizable: isEditMode,
+        isResizable: nonResizeableTileTypes.includes(tile.type)
+            ? false
+            : isEditMode,
     };
 };
 

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -16,6 +16,7 @@ import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useParams } from 'react-router';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ChartTile from '../components/DashboardTiles/DashboardChartTile';
+import DividerTile from '../components/DashboardTiles/DashboardDividerTile';
 import HeadingTile from '../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../components/DashboardTiles/DashboardMarkdownTile';
@@ -259,6 +260,14 @@ const MinimalDashboard: FC = () => {
                                 />
                             ) : tile.type === DashboardTileTypes.HEADING ? (
                                 <HeadingTile
+                                    key={tile.uuid}
+                                    tile={tile}
+                                    isEditMode={false}
+                                    onDelete={() => {}}
+                                    onEdit={() => {}}
+                                />
+                            ) : tile.type === DashboardTileTypes.DIVIDER ? (
+                                <DividerTile
                                     key={tile.uuid}
                                     tile={tile}
                                     isEditMode={false}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-149](https://linear.app/lightdash/issue/ZAP-149/new-dashboard-element-type-divider-poc)

### Description:

Added a new divider tile type for dashboards that allows users to add horizontal or vertical dividers to visually separate content.

The implementation includes:

- New database table and migration for storing divider tile data
- Backend support for creating and retrieving divider tiles
- Frontend components for adding, editing, and displaying dividers
- Support for both horizontal and vertical orientations
- Non-resizable behavior for divider tiles in the dashboard grid
