### PR TITLE
fix: update active project when there's no lastProject.uuid because of 404

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -137,22 +137,34 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
         defaultProject?.projectUuid ||
         fallbackProject?.projectUuid;
 
-    // Update localStorage when we find an active project but don't have one stored
+    // Update localStorage when URL param takes precedence or no valid lastProject
     useEffect(() => {
         const newValue =
             paramProject?.projectUuid ||
             defaultProject?.projectUuid ||
             fallbackProject?.projectUuid;
-        if (!isLoading && !lastProjectUuid && newValue) {
+
+        const hasValidLastProject = !!lastProject?.projectUuid;
+        const shouldPersistProject =
+            !!params.projectUuid || !hasValidLastProject;
+
+        if (
+            !isLoading &&
+            shouldPersistProject &&
+            newValue &&
+            newValue !== lastProjectUuid
+        ) {
             mutate(newValue);
         }
     }, [
-        isLoading,
         defaultProject?.projectUuid,
         fallbackProject?.projectUuid,
+        isLoading,
+        lastProject?.projectUuid,
         lastProjectUuid,
         mutate,
         paramProject?.projectUuid,
+        params.projectUuid,
     ]);
 
     return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-1993/infinite-refresh-when-lastproject-is-not-available
Relates to: https://github.com/lightdash/lightdash/pull/18805

### Description:
Fixed a bug in `useActiveProjectUuid` hook where it was checking `lastProjectUuid` directly instead of `lastProject?.projectUuid`. 

This ensures that the active project mutation when stored last project is stale (not available, e.g. org switched)
**Before**

  | Scenario                                   | lastProjectUuid | newValue      | Mutates?    |
  |--------------------------------------------|-----------------|---------------|-------------|
  | No localStorage, using fallback            | undefined       | fallback UUID | ✅ Yes       |
  | Valid localStorage project                 | has value       | undefined     | ❌ No        |
  | Stale project (org switch), using fallback | has value       | fallback UUID | ❌ No |

**After**

  | Scenario                                   | lastProject?.projectUuid | newValue      | Mutates? |
  |--------------------------------------------|--------------------------|---------------|----------|
  | No localStorage, using fallback            | undefined                | fallback UUID | ✅ Yes    |
  | Valid localStorage project                 | valid UUID               | undefined     | ❌ No     |
  | Stale project (org switch), using fallback | undefined                | fallback UUID | ✅ Yes    |