### PR TITLE
feat: allow non-numeric values field in maps

### DIFF
--- a/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
+++ b/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
@@ -15,7 +15,8 @@ type Args = {
 export type ScatterPoint = {
     lat: number;
     lon: number;
-    value: number;
+    value: number | null;
+    displayValue: string | number;
     sizeValue: number;
     rowData: Record<string, any>;
 };
@@ -196,13 +197,24 @@ const useLeafletMapConfig = ({
 
                         const lat = Number(row[latitudeFieldId]?.value.raw);
                         const lon = Number(row[longitudeFieldId]?.value.raw);
-                        const value = valueFieldId
-                            ? Number(row[valueFieldId]?.value.raw)
+
+                        // Handle value field - support both numeric and non-numeric values
+                        const rawValue = valueFieldId
+                            ? row[valueFieldId]?.value.raw
                             : 1;
-                        // Use sizeFieldId if set, otherwise fall back to value
+                        const numericValue = Number(rawValue);
+                        const isNumeric = !isNaN(numericValue);
+                        const value = isNumeric ? numericValue : null;
+                        const displayValue = valueFieldId
+                            ? row[valueFieldId]?.value.formatted ??
+                              row[valueFieldId]?.value.raw ??
+                              rawValue
+                            : 1;
+
+                        // Use sizeFieldId if set, otherwise fall back to numeric value or 1
                         const sizeValue = sizeFieldId
                             ? Number(row[sizeFieldId]?.value.raw)
-                            : value;
+                            : value ?? 1;
 
                         if (isNaN(lat) || isNaN(lon)) return null;
 
@@ -210,6 +222,7 @@ const useLeafletMapConfig = ({
                             lat,
                             lon,
                             value,
+                            displayValue,
                             sizeValue: isNaN(sizeValue) ? 1 : sizeValue,
                             rowData: row as Record<string, any>,
                         };
@@ -253,11 +266,16 @@ const useLeafletMapConfig = ({
         let valueRange: { min: number; max: number } | null = null;
         let sizeRange: { min: number; max: number } | null = null;
         if (scatterData && scatterData.length > 0) {
-            const values = scatterData.map((d) => d.value);
-            valueRange = {
-                min: Math.min(...values, 0),
-                max: Math.max(...values, 1),
-            };
+            // Filter out non-numeric values for range calculation
+            const numericValues = scatterData
+                .map((d) => d.value)
+                .filter((v): v is number => v !== null);
+            if (numericValues.length > 0) {
+                valueRange = {
+                    min: Math.min(...numericValues, 0),
+                    max: Math.max(...numericValues, 1),
+                };
+            }
             // Calculate size range for bubble sizing
             const sizeValues = scatterData.map((d) => d.sizeValue);
             sizeRange = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18816, PROD-1638

### Description:

Make it possible to use a non-numeric value field in maps. This will display the field instead of NaN and show the correct color for the points instead of nothing. 

There are more enhancements we could add here (more customisable tooltips), but this is a good start. 

**Before**
<img width="831" height="579" alt="Screenshot 2025-12-16 at 17 48 51" src="https://github.com/user-attachments/assets/c6598477-e241-42ca-9d0e-eeb10e2cff8f" />

**After**
<img width="953" height="598" alt="Screenshot 2025-12-16 at 17 38 12" src="https://github.com/user-attachments/assets/7c9945a6-51ee-4043-bbef-ce60712bac49" />

