### PR TITLE
fix: verify email after update is not sent

### DIFF
--- a/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
@@ -25,7 +25,7 @@ const VerifyEmailForm: FC<{
     emailStatusData?: EmailStatusExpiring;
     statusLoading?: boolean;
 }> = ({ isLoading, emailStatusData, statusLoading }) => {
-    const { health, user } = useApp();
+    const { health } = useApp();
     const { mutate: verifyCode, isLoading: verificationLoading } =
         useVerifyEmail();
     const data = emailStatusData;
@@ -71,7 +71,7 @@ const VerifyEmailForm: FC<{
             <Title order={3}>Check your inbox!</Title>
             <Text color="ldGray.6" ta="center">
                 Verify your email address by entering the code we've just sent
-                to <b>{user?.data?.email || 'your email'}</b>
+                to <b>{data?.email || 'your email'}</b>
             </Text>
             <form
                 name="verifyEmail"
@@ -100,7 +100,7 @@ const VerifyEmailForm: FC<{
                     key={expirationTime?.toString()}
                     date={expirationTime}
                     renderer={({ minutes, seconds, completed }) => {
-                        if (completed) {
+                        if (completed && !emailStatusData?.isVerified) {
                             return (
                                 <Alert
                                     icon={


### PR DESCRIPTION
Closes: #18791

### Description:

This PR adds email verification when a user updates their email address. When a user changes their email, the system now automatically sends a one-time passcode to the new email address for verification.

Additionally, the verification email UI has been updated to display the actual email address being verified rather than relying on the user's current email from the app state.



[CleanShot 2025-12-16 at 18.02.20.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/1db2290d-6ea3-4844-8ca4-117756972d2d.mp4" />](https://app.graphite.com/user-attachments/video/1db2290d-6ea3-4844-8ca4-117756972d2d.mp4)



<details><summary>Other issues</summary>

#### Form shows old email + invalid expired callout

_updated from `tatiana@lightdash.com` to `tatiana+test1@lightdash.com`_
<img width="514" height="496" alt="CleanShot 2025-12-16 at 18 15 56" src="https://github.com/user-attachments/assets/e22d0dde-cfc4-4263-9729-dda4c072a6ce" />

</details> 

