### PR TITLE
feat: release ai generation of chart metadata to all

### DIFF
--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -16,6 +16,7 @@ import {
     isDashboardChartTileType,
     isField,
 } from '@lightdash/common';
+import { LanguageModel } from 'ai';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
 import { LightdashConfig } from '../../../config/parseConfig';
@@ -33,6 +34,8 @@ import OpenAi from '../../clients/OpenAi';
 import { DashboardSummaryModel } from '../../models/DashboardSummaryModel';
 import { generateChartMetadata as generateChartMetadataFromContext } from '../ai/agents/chartMetadataGenerator';
 import { getModel } from '../ai/models';
+import { getAnthropicModel } from '../ai/models/anthropic-claude';
+import { getModelPreset } from '../ai/models/presets';
 import {
     fieldDesc,
     formatSummaryArray,
@@ -86,6 +89,47 @@ export class AiService {
         this.openAi = dependencies.openAi;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.featureFlagService = dependencies.featureFlagService;
+    }
+
+    /**
+     * Gets a language model for ambient AI tasks.
+     * 1. Checks anthropic shared key
+     * 2. Falls back to AI Copilot if the feature flag is enabled for the user,
+     *    using their configured model.
+     *
+     * @returns The language model
+     */
+    private async getAmbientAiModel(user: SessionUser): Promise<LanguageModel> {
+        const anthropicConfig =
+            this.lightdashConfig.ai.copilot.providers.anthropic;
+
+        if (anthropicConfig?.apiKey) {
+            const preset = getModelPreset('anthropic', 'claude-haiku-4-5');
+            if (!preset) {
+                throw new UnexpectedServerError(
+                    'claude-haiku-4-5 preset not found',
+                );
+            }
+            const aiModel = getAnthropicModel(anthropicConfig, preset, {
+                enableReasoning: false,
+            });
+            return aiModel.model;
+        }
+
+        const aiCopilotFlag = await this.featureFlagService.get({
+            user,
+            featureFlagId: CommercialFeatureFlags.AiCopilot,
+        });
+
+        if (!aiCopilotFlag.enabled) {
+            throw new ForbiddenError('Ambient AI is not available');
+        }
+
+        const aiModel = getModel(this.lightdashConfig.ai.copilot, {
+            enableReasoning: false,
+            useFastModel: true,
+        });
+        return aiModel.model;
     }
 
     private static async throwOnFeatureDisabled(user: SessionUser) {
@@ -394,19 +438,7 @@ export class AiService {
         projectUuid: string,
         payload: GenerateChartMetadataRequest,
     ): Promise<GeneratedChartMetadata> {
-        const aiCopilotFlag = await this.featureFlagService.get({
-            user,
-            featureFlagId: CommercialFeatureFlags.AiCopilot,
-        });
-
-        if (!aiCopilotFlag.enabled) {
-            throw new ForbiddenError('AI Copilot is not enabled!');
-        }
-
-        const { model } = getModel(this.lightdashConfig.ai.copilot, {
-            enableReasoning: false,
-            useFastModel: true,
-        });
+        const model = await this.getAmbientAiModel(user);
 
         const result = await generateChartMetadataFromContext(model, {
             tableName: payload.tableName,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -17252,7 +17252,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17262,7 +17262,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17272,7 +17272,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17285,7 +17285,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -17988,22 +17988,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -23553,7 +23553,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2251.2",
+        "version": "0.2259.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -104,6 +104,7 @@ export const BaseResponse: HealthState = {
     ai: {
         analyticsProjectUuid: undefined,
         analyticsDashboardUuid: undefined,
+        isAmbientAiEnabled: false,
     },
     echarts6: {
         enabled: false,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -203,6 +203,9 @@ export class HealthService extends BaseService {
                     this.lightdashConfig.ai.analyticsProjectUuid,
                 analyticsDashboardUuid:
                     this.lightdashConfig.ai.analyticsDashboardUuid,
+                isAmbientAiEnabled:
+                    !!this.lightdashConfig.ai.copilot.providers.anthropic
+                        ?.apiKey,
             },
             echarts6: {
                 enabled: this.lightdashConfig.echarts6.enabled,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -417,6 +417,7 @@ export type HealthState = {
     ai: {
         analyticsProjectUuid?: string;
         analyticsDashboardUuid?: string;
+        isAmbientAiEnabled: boolean;
     };
     echarts6: {
         enabled: boolean;

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -1,12 +1,12 @@
-import {
-    CommercialFeatureFlags,
-    getItemId,
-    getMetrics,
-} from '@lightdash/common';
+import { getItemId, getMetrics } from '@lightdash/common';
 import { Button, Tooltip } from '@mantine-8/core';
 import { IconDeviceFloppy } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
+import {
+    useAmbientAiEnabled,
+    useGenerateChartMetadata,
+} from '../../../ee/features/ambientAi';
 import {
     selectHasUnsavedChanges,
     selectIsValidQuery,
@@ -16,8 +16,6 @@ import {
 } from '../../../features/explorer/store';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
-import { useGenerateChartMetadata } from '../../../hooks/useGenerateChartMetadata';
 import { useAddVersionMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
 import MantineIcon from '../../common/MantineIcon';
@@ -27,9 +25,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
     isExplorer,
     disabled,
 }) => {
-    const { data: aiCopilotFlag } = useFeatureFlag(
-        CommercialFeatureFlags.AiCopilot,
-    );
+    const isAmbientAiEnabled = useAmbientAiEnabled();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
@@ -141,10 +137,10 @@ const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
                     {...(isDisabled && {
                         'data-disabled': true,
                     })}
-                    // Trigger metadata generation on mouse enter if AI Copilot is enabled
+                    // Trigger metadata generation on mouse enter if available
                     onMouseEnter={() => {
                         if (savedChart) return;
-                        if (!aiCopilotFlag?.enabled) return;
+                        if (!isAmbientAiEnabled) return;
                         triggerMetadataGeneration();
                     }}
                     style={{

--- a/packages/frontend/src/ee/features/ambientAi/hooks/useAmbientAiEnabled.ts
+++ b/packages/frontend/src/ee/features/ambientAi/hooks/useAmbientAiEnabled.ts
@@ -1,0 +1,15 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
+import useHealth from '../../../../hooks/health/useHealth';
+import { useFeatureFlagEnabled } from '../../../../hooks/useFeatureFlagEnabled';
+
+/**
+ * Checks if the ambient ai is enabled.
+ * It checks if the shared anthropic api key is available or if the ai copilot feature flag is enabled
+ */
+export const useAmbientAiEnabled = () => {
+    const { data: health } = useHealth();
+    const isAiCopilotEnabled = useFeatureFlagEnabled(
+        CommercialFeatureFlags.AiCopilot,
+    );
+    return health?.ai.isAmbientAiEnabled || isAiCopilotEnabled;
+};

--- a/packages/frontend/src/ee/features/ambientAi/hooks/useGenerateChartMetadata.ts
+++ b/packages/frontend/src/ee/features/ambientAi/hooks/useGenerateChartMetadata.ts
@@ -9,7 +9,7 @@ import {
 } from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { lightdashApi } from '../api';
+import { lightdashApi } from '../../../../api';
 
 // 5 second timeout for AI metadata generation - anything longer is too disruptive
 const METADATA_GENERATION_TIMEOUT_MS = 5000;
@@ -39,6 +39,9 @@ type UseGenerateChartMetadataOptions = {
     onComplete?: (metadata: ChartMetadata | null) => void;
 };
 
+/**
+ * Generate chart metadata using ambient AI
+ */
 export const useGenerateChartMetadata = ({
     projectUuid,
     unsavedChartVersion,

--- a/packages/frontend/src/ee/features/ambientAi/index.ts
+++ b/packages/frontend/src/ee/features/ambientAi/index.ts
@@ -1,0 +1,3 @@
+// Hooks
+export { useAmbientAiEnabled } from './hooks/useAmbientAiEnabled';
+export { useGenerateChartMetadata } from './hooks/useGenerateChartMetadata';

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -105,6 +105,7 @@ export default function mockHealthResponse(
         ai: {
             analyticsProjectUuid: undefined,
             analyticsDashboardUuid: undefined,
+            isAmbientAiEnabled: false,
         },
         echarts6: {
             enabled: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Adds support for wide-purpose AI tasks using a shared Anthropic API key. This implementation:

1. Creates a new `getWidePurposeModel` method in `AiService` that:
   - First checks for a shared Anthropic API key (claude-haiku-4-5)
   - Falls back to the user's AI Copilot configuration if enabled

2. Refactors the chart metadata generation to use this new method instead of directly checking for AI Copilot access

3. Adds `hasSharedAnthropicApiKey` flag to the health endpoint response

4. Creates a new React hook `useAiWidePurposeFeaturesCheck` that checks if wide-purpose AI features are available (either through shared key or user's AI Copilot)

This change allows certain AI features to work for all users when a shared Anthropic API key is configured, without requiring individual AI Copilot access.