### PR TITLE
fix: prevent filter groups from wrapping in dashboard tabs

### DIFF
--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -514,6 +514,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                                 <Group
                                                     align="flex-start"
                                                     gap="xs"
+                                                    wrap="nowrap"
                                                 >
                                                     <FilterGroupSeparator
                                                         icon={IconFilter}
@@ -549,7 +550,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                         {hasDashboardTiles &&
                                             Object.keys(parameters).length >
                                                 0 && (
-                                                <Group gap="xs">
+                                                <Group gap="xs" wrap="nowrap">
                                                     <Divider orientation="vertical" />
 
                                                     <FilterGroupSeparator
@@ -615,6 +616,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                             <Group
                                                 gap="xs"
                                                 style={{ marginLeft: 'auto' }}
+                                                wrap="nowrap"
                                             >
                                                 <Divider orientation="vertical" />
 


### PR DESCRIPTION
### Description:
Added `wrap="nowrap"` to Group components in the dashboard tabs to prevent filter elements from wrapping to a new line when space is limited. This ensures that all filter elements remain on a single row, improving the UI consistency and preventing layout shifts.