### PR TITLE
refactor: improve dashboard filter UI with CSS modules and reset button

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.module.css
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.module.css
@@ -1,0 +1,21 @@
+.button {
+    border-radius: 100px !important;
+}
+
+.unsetRequiredFilter {
+    border-style: solid;
+    border-width: '3px';
+}
+
+.inactiveFilter {
+    border-style: dashed;
+    border-width: 1px;
+    background-color: rgba(var(--mantine-color-background-0), 0.7);
+}
+
+.label {
+    max-width: 800px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
@@ -9,12 +9,11 @@ import {
     ActionIcon,
     Box,
     Button,
-    createStyles,
     Indicator,
     Popover,
     Text,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useDisclosure, useId } from '@mantine/hooks';
 import { IconGripVertical, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
@@ -27,19 +26,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import FilterConfiguration from '../FilterConfiguration';
 import { hasFilterValueSet } from '../FilterConfiguration/utils';
-
-const useDashboardFilterStyles = createStyles((theme) => ({
-    unsetRequiredFilter: {
-        borderStyle: 'solid',
-        borderWidth: '3px',
-    },
-    inactiveFilter: {
-        borderStyle: 'dashed',
-        borderWidth: '1px',
-        borderColor: theme.fn.rgba(theme.colors.ldGray[5], 0.7),
-        backgroundColor: theme.fn.rgba(theme.colors.background[0], 0.7),
-    },
-}));
+import classes from './Filter.module.css';
 
 type Props = {
     isEditMode: boolean;
@@ -68,7 +55,6 @@ const Filter: FC<Props> = ({
     onUpdate,
     onRemove,
 }) => {
-    const { classes } = useDashboardFilterStyles();
     const popoverId = useId();
 
     const dashboard = useDashboardContext((c) => c.dashboard);
@@ -184,28 +170,8 @@ const Filter: FC<Props> = ({
                 <Popover.Target>
                     <Indicator
                         inline
-                        position="top-end"
-                        size={16}
+                        processing
                         disabled={!hasUnsetRequiredFilter}
-                        label={
-                            <Tooltip
-                                fz="xs"
-                                label="Set a value to run this dashboard"
-                            >
-                                <Text fz="9px" fw={500}>
-                                    Required
-                                </Text>
-                            </Tooltip>
-                        }
-                        styles={(theme) => ({
-                            common: {
-                                top: -5,
-                                right: 24,
-                                borderRadius: theme.radius.xs,
-                                borderBottomRightRadius: 0,
-                                borderBottomLeftRadius: 0,
-                            },
-                        })}
                     >
                         <Tooltip
                             fz="xs"
@@ -216,18 +182,20 @@ const Filter: FC<Props> = ({
                             <Button
                                 pos="relative"
                                 size="xs"
-                                radius="md"
                                 variant={
                                     isTemporary || hasUnsetRequiredFilter
                                         ? 'outline'
                                         : 'default'
                                 }
-                                className={`${
+                                classNames={{
+                                    label: classes.label,
+                                }}
+                                className={`${classes.button} ${
                                     hasUnsetRequiredFilter
                                         ? classes.unsetRequiredFilter
                                         : ''
                                 } ${isOrphaned ? classes.inactiveFilter : ''}`}
-                                leftIcon={
+                                leftSection={
                                     isDraggable && (
                                         <MantineIcon
                                             icon={IconGripVertical}
@@ -236,11 +204,14 @@ const Filter: FC<Props> = ({
                                         />
                                     )
                                 }
-                                rightIcon={
+                                rightSection={
                                     (isEditMode || isTemporary) && (
                                         <ActionIcon
                                             onClick={onRemove}
                                             size="xs"
+                                            color="dark"
+                                            radius="xl"
+                                            variant="subtle"
                                         >
                                             <MantineIcon
                                                 size="sm"
@@ -249,14 +220,6 @@ const Filter: FC<Props> = ({
                                         </ActionIcon>
                                     )
                                 }
-                                styles={{
-                                    label: {
-                                        maxWidth: '800px',
-                                        whiteSpace: 'nowrap',
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                    },
-                                }}
                                 onClick={() =>
                                     isPopoverOpen
                                         ? handleClose()
@@ -264,7 +227,7 @@ const Filter: FC<Props> = ({
                                 }
                             >
                                 <Box
-                                    sx={{
+                                    style={{
                                         maxWidth: '100%',
                                         overflow: 'hidden',
                                     }}
@@ -280,12 +243,16 @@ const Filter: FC<Props> = ({
                                             openDelay={1000}
                                             offset={8}
                                             label={
-                                                <Text fz="xs">
+                                                <Text fz="inherit">
                                                     {filterRuleTables?.length ===
                                                     1
                                                         ? 'Table: '
                                                         : 'Tables: '}
-                                                    <Text span fw={600}>
+                                                    <Text
+                                                        span
+                                                        fw={600}
+                                                        fz="inherit"
+                                                    >
                                                         {filterRuleTables?.join(
                                                             ', ',
                                                         )}
@@ -293,7 +260,12 @@ const Filter: FC<Props> = ({
                                                 </Text>
                                             }
                                         >
-                                            <Text fw={600} span truncate>
+                                            <Text
+                                                fz="inherit"
+                                                fw={600}
+                                                span
+                                                truncate
+                                            >
                                                 {filterRule?.label ||
                                                     filterRuleLabels?.field}{' '}
                                             </Text>
@@ -301,7 +273,8 @@ const Filter: FC<Props> = ({
                                         {filterRule?.disabled ? (
                                             <Text
                                                 span
-                                                color="ldGray.6"
+                                                fz="inherit"
+                                                c="ldGray.6"
                                                 truncate
                                             >
                                                 is any value
@@ -310,12 +283,18 @@ const Filter: FC<Props> = ({
                                             <>
                                                 <Text
                                                     span
-                                                    color="ldGray.7"
+                                                    fz="inherit"
+                                                    c="dimmed"
                                                     truncate
                                                 >
                                                     {filterRuleLabels?.operator}{' '}
                                                 </Text>
-                                                <Text fw={700} span truncate>
+                                                <Text
+                                                    fw={500}
+                                                    fz="inherit"
+                                                    span
+                                                    truncate
+                                                >
                                                     {filterRuleLabels?.value}
                                                 </Text>
                                             </>

--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/index.tsx
@@ -12,16 +12,8 @@ import {
 } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 import { type DashboardFilterRule } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Skeleton,
-    Tooltip,
-    useMantineTheme,
-} from '@mantine/core';
-import { IconRotate2 } from '@tabler/icons-react';
+import { Group, Skeleton, useMantineTheme } from '@mantine-8/core';
 import { useCallback, useMemo, type FC, type ReactNode } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import {
     doesFilterApplyToAnyTile,
@@ -36,7 +28,6 @@ interface ActiveFiltersProps {
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
-    onResetDashboardFilters: () => void;
 }
 
 const DraggableItem: FC<{
@@ -102,7 +93,6 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
     openPopoverId,
     onPopoverOpen,
     onPopoverClose,
-    onResetDashboardFilters,
 }) => {
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
@@ -133,11 +123,6 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
     );
     const setHaveFiltersChanged = useDashboardContext(
         (c) => c.setHaveFiltersChanged,
-    );
-    const haveFiltersChanged = useDashboardContext(
-        (c) =>
-            c.haveFiltersChanged ||
-            c.dashboardTemporaryFilters.dimensions.length > 0,
     );
 
     const mouseSensor = useSensor(MouseSensor, {
@@ -200,7 +185,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
 
     if (isLoadingDashboardFilters || isFetchingDashboardFilters) {
         return (
-            <Group spacing="xs" ml="xs">
+            <Group gap="xs" ml="xs">
                 <Skeleton h={30} w={100} radius={4} />
                 <Skeleton h={30} w={100} radius={4} />
                 <Skeleton h={30} w={100} radius={4} />
@@ -237,23 +222,6 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
 
     return (
         <>
-            {!isEditMode && haveFiltersChanged && (
-                <Tooltip label="Reset all filters">
-                    <Button
-                        aria-label="Reset all filters"
-                        size="xs"
-                        variant="default"
-                        radius="md"
-                        color="gray"
-                        onClick={() => {
-                            setHaveFiltersChanged(false);
-                            onResetDashboardFilters();
-                        }}
-                    >
-                        <MantineIcon icon={IconRotate2} />
-                    </Button>
-                </Tooltip>
-            )}
             <DndContext
                 sensors={dragSensors}
                 onDragStart={handleDragStart}

--- a/packages/frontend/src/features/dashboardFiltersV2/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/AddFilterButton.tsx
@@ -1,7 +1,16 @@
 import { type DashboardFilterRule } from '@lightdash/common';
-import { Button, Popover, Text, Tooltip } from '@mantine/core';
-import { useDisclosure, useId } from '@mantine/hooks';
+import {
+    Button,
+    Divider,
+    Group,
+    Popover,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { useDisclosure, useId } from '@mantine-8/hooks';
+import { IconRotate2 } from '@tabler/icons-react';
 import { type FC, useCallback, useMemo } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import FilterConfiguration from './FilterConfiguration';
 
@@ -11,6 +20,7 @@ type Props = {
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
     onSave: (value: DashboardFilterRule) => void;
+    onResetDashboardFilters: () => void;
 };
 
 const AddFilterButton: FC<Props> = ({
@@ -19,6 +29,7 @@ const AddFilterButton: FC<Props> = ({
     onPopoverOpen,
     onPopoverClose,
     onSave,
+    onResetDashboardFilters,
 }) => {
     const popoverId = useId();
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
@@ -45,6 +56,16 @@ const AddFilterButton: FC<Props> = ({
         (c) => c.isFetchingDashboardFilters,
     );
 
+    const haveFiltersChanged = useDashboardContext(
+        (c) =>
+            c.haveFiltersChanged ||
+            c.dashboardTemporaryFilters.dimensions.length > 0,
+    );
+
+    const setHaveFiltersChanged = useDashboardContext(
+        (c) => c.setHaveFiltersChanged,
+    );
+
     const isPopoverOpen = openPopoverId === popoverId;
 
     const [isSubPopoverOpen, { close: closeSubPopover, open: openSubPopover }] =
@@ -63,8 +84,10 @@ const AddFilterButton: FC<Props> = ({
         [onSave, handleClose],
     );
 
+    const showResetFiltersButton = !isEditMode && haveFiltersChanged;
+
     return (
-        <>
+        <Group gap={0}>
             <Popover
                 position="bottom-start"
                 trapFocus
@@ -106,6 +129,24 @@ const AddFilterButton: FC<Props> = ({
                                 isLoadingDashboardFilters ||
                                 isFetchingDashboardFilters
                             }
+                            styles={{
+                                root: {
+                                    borderStyle: 'dashed',
+                                    borderRadius: '100px',
+                                    ...(showResetFiltersButton
+                                        ? {
+                                              borderRightWidth: '0px',
+                                              borderTopRightRadius: '0px',
+                                              borderBottomRightRadius: '0px',
+                                          }
+                                        : {
+                                              borderRightStyle: 'dashed',
+                                              borderRightWidth: '1px',
+                                              borderTopRightRadius: '100px',
+                                              borderBottomRightRadius: '100px',
+                                          }),
+                                },
+                            }}
                             onClick={() =>
                                 isPopoverOpen
                                     ? handleClose()
@@ -137,7 +178,39 @@ const AddFilterButton: FC<Props> = ({
                     )}
                 </Popover.Dropdown>
             </Popover>
-        </>
+
+            {showResetFiltersButton && (
+                <>
+                    <Divider orientation="vertical" />
+
+                    <Tooltip label="Reset all filters" withinPortal>
+                        <Button
+                            aria-label="Reset all filters"
+                            size="xs"
+                            variant="default"
+                            radius="md"
+                            color="gray"
+                            onClick={() => {
+                                setHaveFiltersChanged(false);
+                                onResetDashboardFilters();
+                            }}
+                            styles={{
+                                root: {
+                                    borderLeft: '0px',
+                                    borderStartStartRadius: '0px',
+                                    borderEndStartRadius: '0px',
+                                    borderStartEndRadius: '100px',
+                                    borderEndEndRadius: '100px',
+                                    borderStyle: 'dashed',
+                                },
+                            }}
+                        >
+                            <MantineIcon icon={IconRotate2} />
+                        </Button>
+                    </Tooltip>
+                </>
+            )}
+        </Group>
     );
 };
 

--- a/packages/frontend/src/features/dashboardFiltersV2/index.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/index.tsx
@@ -1,10 +1,8 @@
 import {
     type DashboardFieldTarget,
     type DashboardFilterRule,
-    type FilterableDimension,
     type FilterOperator,
 } from '@lightdash/common';
-import { Flex } from '@mantine/core';
 import { useCallback, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import FiltersProvider from '../../components/common/Filters/FiltersProvider';
@@ -67,7 +65,7 @@ const DashboardFiltersV2: FC<Props> = ({ isEditMode, activeTabUuid }) => {
     }, []);
 
     return (
-        <FiltersProvider<Record<string, FilterableDimension>>
+        <FiltersProvider
             projectUuid={projectUuid}
             itemsMap={allFilterableFieldsMap}
             startOfWeek={
@@ -75,24 +73,22 @@ const DashboardFiltersV2: FC<Props> = ({ isEditMode, activeTabUuid }) => {
             }
             dashboardFilters={allFilters}
         >
-            <Flex gap="xs" wrap="wrap" mb="xs">
-                <AddFilterButton
-                    isEditMode={isEditMode}
-                    openPopoverId={openPopoverId}
-                    onPopoverOpen={handlePopoverOpen}
-                    onPopoverClose={handlePopoverClose}
-                    onSave={handleSaveNew}
-                />
+            <AddFilterButton
+                isEditMode={isEditMode}
+                openPopoverId={openPopoverId}
+                onPopoverOpen={handlePopoverOpen}
+                onPopoverClose={handlePopoverClose}
+                onSave={handleSaveNew}
+                onResetDashboardFilters={resetDashboardFilters}
+            />
 
-                <ActiveFilters
-                    isEditMode={isEditMode}
-                    activeTabUuid={activeTabUuid}
-                    openPopoverId={openPopoverId}
-                    onPopoverOpen={handlePopoverOpen}
-                    onPopoverClose={handlePopoverClose}
-                    onResetDashboardFilters={resetDashboardFilters}
-                />
-            </Flex>
+            <ActiveFilters
+                isEditMode={isEditMode}
+                activeTabUuid={activeTabUuid}
+                openPopoverId={openPopoverId}
+                onPopoverOpen={handlePopoverOpen}
+                onPopoverClose={handlePopoverClose}
+            />
         </FiltersProvider>
     );
 };

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -498,7 +498,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                         align="flex-start"
                                         wrap="nowrap"
                                         px="lg"
-                                        pt="sm"
+                                        py="sm"
                                     >
                                         {/* This Group will take up remaining space (and not push DateZoom) */}
                                         <Group
@@ -506,15 +506,12 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                             align="flex-start"
                                             wrap="nowrap"
                                             grow
-                                            style={{
-                                                overflow: 'auto',
-                                            }}
                                         >
                                             {hasTilesThatSupportFilters && (
                                                 <Group
                                                     align="flex-start"
                                                     gap="xs"
-                                                    wrap="nowrap"
+                                                    wrap="wrap"
                                                 >
                                                     <FilterGroupSeparator
                                                         icon={IconFilter}


### PR DESCRIPTION
### Description:

Redesigned dashboard filters UI with improved styling and functionality:

- Moved filter styles from inline to a dedicated CSS module
- Updated filter button styling with rounded corners and cleaner layout
- Improved text overflow handling with ellipsis for filter labels
- Relocated the "Reset all filters" button to be part of the "Add filter" button group
- Enhanced typography with consistent font sizes and weights
- Updated component imports to use Mantine 8
- Fixed filter button border styles for better visual hierarchy
- Improved layout of filter components in dashboard tabs