### PR TITLE
fix: remove error toast when lastProject errors fetch

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -81,7 +81,13 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
     const shouldFetchLastProject =
         isLoggedIn && !params.projectUuid && !!lastProjectUuid;
     const { data: lastProject, isInitialLoading: isLoadingLastProject } =
-        useProject(shouldFetchLastProject ? lastProjectUuid : undefined);
+        useProject(shouldFetchLastProject ? lastProjectUuid : undefined, {
+            onError: () => {
+                console.warn(
+                    `Couldn't find last project ${lastProjectUuid}. Will default to organization default or fallback project.`,
+                );
+            },
+        });
 
     // Priority 3: Organization's default project
     // Only fetch if no param project, no last project, and org has a default

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -7,7 +7,12 @@ import {
     type UpdateProject,
     type UpdateSchedulerSettings,
 } from '@lightdash/common';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    type UseQueryOptions,
+} from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import useActiveJob from '../providers/ActiveJob/useActiveJob';
 import useToaster from './toaster/useToaster';
@@ -44,7 +49,10 @@ const updateProjectSchedulerSettings = async (
         body: JSON.stringify(data),
     });
 
-export const useProject = (id: string | undefined) => {
+export const useProject = (
+    id: string | undefined,
+    options?: UseQueryOptions<Project, ApiError>,
+) => {
     const setErrorResponse = useQueryError();
     return useQuery<Project, ApiError>({
         queryKey: ['project', id],
@@ -52,6 +60,7 @@ export const useProject = (id: string | undefined) => {
         enabled: !!id,
         retry: false,
         onError: (result) => setErrorResponse(result),
+        ...options,
     });
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [https://linear.app/lightdash/issue/PROD-2037/error-toast-shows-when-lastproject-is-not-found-and-we-fallback](https://linear.app/lightdash/issue/PROD-2037/error-toast-shows-when-lastproject-is-not-found-and-we-fallback)

### Description:

Added error handling for when a user's last project cannot be found. Now, when a user's last project is not accessible, the system will log a warning and gracefully fall back to the organization's default project or a fallback project.

### Steps to test:

1. In chrome console run `localStorage.setItem('lastProject', 'ac939521-96eb-4781-a736-5598c3d25999')` - you can use any project that doesn't exist
2. Open a route that has no project uuid, e.g. `http://localhost:3000/generalSettings`
3. No error toast should show