### PR TITLE
fix(security): upgrade jsonwebtoken to 9.0.3 (jws vulnerability)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -111,7 +111,7 @@
         "immer": "^10.1.1",
         "jose": "^5.2.3",
         "js-yaml": "^4.1.1",
-        "jsonwebtoken": "^9.0.2",
+        "jsonwebtoken": "^9.0.3",
         "knex": "^2.5.1",
         "langchain": "^0.3.13",
         "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,8 +340,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       jsonwebtoken:
-        specifier: ^9.0.2
-        version: 9.0.2
+        specifier: ^9.0.3
+        version: 9.0.3
       knex:
         specifier: ^2.5.1
         version: 2.5.1(pg@8.13.1)
@@ -12802,8 +12802,8 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
-  jsonwebtoken@9.0.2:
-    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
   jspdf@3.0.2:
@@ -12820,17 +12820,17 @@ packages:
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
-  jwa@1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
-
   jwa@2.0.0:
     resolution: {integrity: sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==}
 
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
   jws@4.0.0:
     resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -19970,7 +19970,7 @@ snapshots:
   '@azure/msal-node@3.6.4':
     dependencies:
       '@azure/msal-common': 15.9.0
-      jsonwebtoken: 9.0.2
+      jsonwebtoken: 9.0.3
       uuid: 8.3.2
 
   '@azure/storage-blob@12.26.0':
@@ -24954,7 +24954,7 @@ snapshots:
       '@slack/web-api': 6.13.0
       '@types/jsonwebtoken': 8.5.9
       '@types/node': 22.13.1
-      jsonwebtoken: 9.0.2
+      jsonwebtoken: 9.0.3
       lodash.isstring: 4.0.1
     transitivePeerDependencies:
       - debug
@@ -24965,7 +24965,7 @@ snapshots:
       '@slack/web-api': 7.10.0
       '@types/jsonwebtoken': 9.0.5
       '@types/node': 22.15.3
-      jsonwebtoken: 9.0.2
+      jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - debug
 
@@ -33098,9 +33098,9 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  jsonwebtoken@9.0.2:
+  jsonwebtoken@9.0.3:
     dependencies:
-      jws: 3.2.2
+      jws: 4.0.1
       lodash.includes: 4.3.0
       lodash.isboolean: 3.0.3
       lodash.isinteger: 4.0.4
@@ -33109,7 +33109,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.6.3
+      semver: 7.7.3
 
   jspdf@3.0.2:
     dependencies:
@@ -33141,26 +33141,26 @@ snapshots:
       readable-stream: 2.3.8
       setimmediate: 1.0.5
 
-  jwa@1.4.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
   jwa@2.0.0:
     dependencies:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
-  jws@3.2.2:
+  jwa@2.0.1:
     dependencies:
-      jwa: 1.4.1
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
   jws@4.0.0:
     dependencies:
       jwa: 2.0.0
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
       safe-buffer: 5.2.1
 
   keyv@4.5.4:
@@ -36982,7 +36982,7 @@ snapshots:
       glob: 10.5.0
       google-auth-library: 10.2.1
       https-proxy-agent: 7.0.6
-      jsonwebtoken: 9.0.2
+      jsonwebtoken: 9.0.3
       mime-types: 2.1.35
       moment: 2.30.1
       moment-timezone: 0.5.48
@@ -38003,7 +38003,7 @@ snapshots:
   universal-github-app-jwt@1.1.2:
     dependencies:
       '@types/jsonwebtoken': 9.0.5
-      jsonwebtoken: 9.0.2
+      jsonwebtoken: 9.0.3
 
   universal-user-agent@6.0.1: {}
 


### PR DESCRIPTION
## Summary
- Addresses Dependabot alerts #392, #393
- Upgrades `jsonwebtoken` from `^9.0.2` to `^9.0.3` in `packages/backend`

## Security Issue
jws HMAC Signature Verification vulnerability (CVE-2025-65945). The jws package is a transitive dependency of jsonwebtoken.

- jsonwebtoken 9.0.3 updates jws from 3.2.2 to 4.0.1 (patched)
- Lightdash uses jsonwebtoken's verify() interface, which is not directly affected

## Test plan
- [ ] Run backend tests: `pnpm -F backend test:dev:nowatch`
- [ ] Verify JWT auth works in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)