### PR TITLE
security: add pnpm override for node-forge >= 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
             "form-data@3.0.1": "3.0.4",
             "form-data@4.0.0": "4.0.4",
             "form-data@4.0.2": "4.0.4",
-            "validator": "^13.15.22"
+            "validator": "^13.15.22",
+            "node-forge": "^1.3.2"
         }
     },
     "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   form-data@4.0.0: 4.0.4
   form-data@4.0.2: 4.0.4
   validator: ^13.15.22
+  node-forge: ^1.3.2
 
 pnpmfileChecksum: ljbuipupldntgfel5vaej2gdgy
 
@@ -13903,8 +13904,8 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+  node-forge@1.3.3:
+    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
 
   node-gyp-build-optional-packages@5.0.7:
@@ -31597,7 +31598,7 @@ snapshots:
 
   google-p12-pem@4.0.1:
     dependencies:
-      node-forge: 1.3.1
+      node-forge: 1.3.3
 
   googleapis-common@6.0.4(encoding@0.1.13):
     dependencies:
@@ -34479,7 +34480,7 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-forge@1.3.1: {}
+  node-forge@1.3.3: {}
 
   node-gyp-build-optional-packages@5.0.7:
     optional: true


### PR DESCRIPTION
## Summary
- Addresses Dependabot alert #382 for ASN.1 unbounded recursion in node-forge
- Adds pnpm override to force node-forge to ^1.3.2 (resolves to 1.3.3)

## Test plan
- [ ] Verify application starts correctly
- [ ] Confirm cryptographic operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)