### PR TITLE
security: add pnpm override for glob >= 10.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
             "form-data@4.0.0": "4.0.4",
             "form-data@4.0.2": "4.0.4",
             "validator": "^13.15.22",
-            "node-forge": "^1.3.2"
+            "node-forge": "^1.3.2",
+            "glob@>=10.2.0 <10.5.0": "^10.5.0"
         }
     },
     "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   form-data@4.0.2: 4.0.4
   validator: ^13.15.22
   node-forge: ^1.3.2
+  glob@>=10.2.0 <10.5.0: ^10.5.0
 
 pnpmfileChecksum: ljbuipupldntgfel5vaej2gdgy
 
@@ -11569,8 +11570,8 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     hasBin: true
 
   glob@7.2.3:
@@ -21915,7 +21916,7 @@ snapshots:
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.7.2)(vite@7.1.10(@types/node@24.3.1)(lightningcss@1.22.0)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.19.4)(yaml@2.7.0))':
     dependencies:
-      glob: 10.4.5
+      glob: 10.5.0
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.7.2)
       vite: 7.1.10(@types/node@24.3.1)(lightningcss@1.22.0)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.19.4)(yaml@2.7.0)
@@ -26669,7 +26670,7 @@ snapshots:
       '@tsoa/runtime': 6.6.0
       '@types/multer': 1.4.12
       fs-extra: 11.2.0
-      glob: 10.4.5
+      glob: 10.5.0
       handlebars: 4.7.8
       merge-anything: 5.1.7
       minimatch: 9.0.5
@@ -28145,7 +28146,7 @@ snapshots:
 
   archiver-utils@5.0.2:
     dependencies:
-      glob: 10.4.5
+      glob: 10.5.0
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
@@ -30743,7 +30744,7 @@ snapshots:
 
   express-handlebars@7.1.2:
     dependencies:
-      glob: 10.4.5
+      glob: 10.5.0
       graceful-fs: 4.2.11
       handlebars: 4.7.8
 
@@ -31467,7 +31468,7 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.4.5:
+  glob@10.5.0:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 3.4.3
@@ -36978,7 +36979,7 @@ snapshots:
       fast-xml-parser: 4.5.3
       fastest-levenshtein: 1.0.16
       generic-pool: 3.9.0
-      glob: 10.4.5
+      glob: 10.5.0
       google-auth-library: 10.2.1
       https-proxy-agent: 7.0.6
       jsonwebtoken: 9.0.2


### PR DESCRIPTION
## Summary
- Addresses Dependabot alert #378 for command injection in glob CLI
- Adds pnpm override to force glob versions 10.2.0-10.4.x to 10.5.0

## Test plan
- [ ] Verify application starts correctly
- [ ] Confirm file globbing operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)