### PR TITLE
fix: cannot read properties of undefined in isFilterableDimension

### DIFF
--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -735,8 +735,9 @@ export interface Metric extends Field {
 }
 
 export const isFilterableDimension = (
-    dimension: Dimension,
+    dimension: Dimension | undefined,
 ): dimension is FilterableDimension =>
+    !!dimension &&
     [
         DimensionType.STRING,
         DimensionType.NUMBER,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-1982/typeerror-cannot-read-properties-of-undefined-reading-type

### Description:
Fix `isFilterableDimension` to handle undefined dimensions by adding a check before evaluating the dimension type. This prevents potential runtime errors when the function is called with an `undefined` value.

**Initial error:**
```
TypeError: Cannot read properties of undefined (reading 'type')
    at isFilterableDimension (/usr/app/packages/common/dist/cjs/types/field.js:424:22)
    at filters (/services/ProjectService/ProjectService.ts:4936:54)
    at Array.filter (<anonymous>)
    at <anonymous> (/services/ProjectService/ProjectService.ts:4934:58)
    at Array.map (<anonymous>)
    at allFilters (/services/ProjectService/ProjectService.ts:4910:36)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at ProjectService.getAvailableFiltersForSavedQueries (/services/ProjectService/ProjectService.ts:4868:22)
    at <anonymous> (/routers/dashboardRouter.ts:155:29)
```