### PR TITLE
chore: use fast model on generateThreadTitle

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -1331,15 +1331,10 @@ export class AiAgentService {
                     retrieveRelevantArtifacts: false,
                 });
 
-            // Get agent settings to use reasoning preference
-            const agent = await this.aiAgentModel.getAgent({
-                organizationUuid: user.organizationUuid!,
-                agentUuid,
-            });
-
-            // Get model configuration with agent's reasoning setting
+            // Use fast model for title generation (lightweight task)
             const { model } = getModel(this.lightdashConfig.ai.copilot, {
-                enableReasoning: agent.enableReasoning,
+                enableReasoning: false,
+                useFastModel: true,
             });
 
             // Generate title using the dedicated title generator


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:

### Description:

Use a fast model for title generation in AI agent service instead of fetching agent settings. This optimization makes title generation more efficient by explicitly setting `enableReasoning: false` and `useFastModel: true` rather than retrieving the agent's reasoning preference from the database.



![Screenshot 2025-12-17 at 11.02.00.png](https://app.graphite.com/user-attachments/assets/4a56a3eb-c679-434a-8f93-dea2a21d4fbf.png)

