### PR TITLE
feat: invalidate user warehouse credentials after OAuth flow

### DIFF
--- a/packages/frontend/src/hooks/useDatabricks.ts
+++ b/packages/frontend/src/hooks/useDatabricks.ts
@@ -1,5 +1,5 @@
 import { type ApiError, type ApiSuccessEmpty } from '@lightdash/common';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { lightdashApi } from '../api';
 import useHealth from './health/useHealth';
@@ -47,9 +47,15 @@ export function useDatabricksLoginPopup({
 }) {
     const { showToastError } = useToaster();
     const health = useHealth();
+    const queryClient = useQueryClient();
     const ssoMutation = useMutation({
         mutationFn: () => triggerDatabricksLogin(health.data?.siteUrl || ''),
-        onSuccess: () => _onLogin?.(),
+        onSuccess: async () => {
+            // Invalidate user warehouse credentials since the backend creates
+            // credentials during the OAuth flow
+            await queryClient.invalidateQueries(['user_warehouse_credentials']);
+            await _onLogin?.();
+        },
         onError: (error: Error) => {
             showToastError({
                 title: 'Authentication failed',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2039/repeated-snowflake-login-prompts-when-changing-tables-in-explore

This was not a regresion, but an issue when invalidating `user_warehouse_credentials` after logging in (so popup doesn't show up again when switching explores) . I think the issue has been there for a while. 

This issue doesn't happen after refreshing the page. 

I also fixed bigquery and databricks oauth popup.


Out of scope: 

- Refactor these popups to reuse a single component. 

### Description:
Invalidate user warehouse credentials after OAuth flow completion for BigQuery, Databricks, and Snowflake. This ensures that the frontend fetches the latest credentials that were created during the OAuth authentication process.

The changes add `useQueryClient` to each authentication hook and invalidate the `user_warehouse_credentials` query after successful login, ensuring the UI reflects the updated credential state.