### PR TITLE
security: update hono override to ^4.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "pnpm": {
         "overrides": {
-            "hono": "^4.9.6",
+            "hono": "^4.10.2",
             "linkifyjs": "^4.3.2",
             "axios": "^1.12.0",
             "form-data@2.5.3": "2.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@types/react': 19.2.2
   '@types/react-dom': 19.2.2
   typescript: 5.5.4
-  hono: ^4.9.6
+  hono: ^4.10.2
   linkifyjs: ^4.3.2
   axios: ^1.12.0
   form-data@2.5.3: 2.5.5
@@ -3793,7 +3793,7 @@ packages:
     resolution: {integrity: sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.9.6
+      hono: ^4.10.2
 
   '@hookform/error-message@2.0.0':
     resolution: {integrity: sha512-Y90nHzjgL2MP7GFy75kscdvxrCTjtyxGmOLLxX14nd08OXRIh9lMH/y9Kpdo0p1IPowJBiZMHyueg7p+yrqynQ==}
@@ -11838,7 +11838,7 @@ packages:
       '@valibot/to-json-schema': ^1.0.0-beta.3
       arktype: ^2.0.0
       effect: ^3.11.3
-      hono: ^4.9.6
+      hono: ^4.10.2
       openapi-types: ^12.1.3
       valibot: ^1.0.0-beta.9
       zod: ^3.23.8
@@ -11871,8 +11871,8 @@ packages:
       zod-openapi:
         optional: true
 
-  hono@4.9.6:
-    resolution: {integrity: sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA==}
+  hono@4.11.1:
+    resolution: {integrity: sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -20025,7 +20025,7 @@ snapshots:
       '@babel/traverse': 7.26.4
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -20045,7 +20045,7 @@ snapshots:
       '@babel/traverse': 7.27.0
       '@babel/types': 7.27.0
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -20145,13 +20145,6 @@ snapshots:
       semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
-
-  '@babel/helper-module-imports@7.24.7':
-    dependencies:
-      '@babel/traverse': 7.25.6
-      '@babel/types': 7.28.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-module-imports@7.24.7(supports-color@5.5.0)':
     dependencies:
@@ -20403,18 +20396,6 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
 
-  '@babel/traverse@7.25.6':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.28.0
-      '@babel/parser': 7.28.0
-      '@babel/template': 7.25.0
-      '@babel/types': 7.28.2
-      debug: 4.4.0(supports-color@8.1.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/traverse@7.25.6(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -20446,7 +20427,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.0
       '@babel/types': 7.28.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -20672,7 +20653,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.10.6':
     dependencies:
-      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/runtime': 7.27.0
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
@@ -21151,7 +21132,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.2.0
@@ -21512,9 +21493,9 @@ snapshots:
       - '@types/react-dom'
       - react-native
 
-  '@hono/node-server@1.19.6(hono@4.9.6)':
+  '@hono/node-server@1.19.6(hono@4.11.1)':
     dependencies:
-      hono: 4.9.6
+      hono: 4.11.1
 
   '@hookform/error-message@2.0.0(react-dom@19.2.0(react@19.2.0))(react-hook-form@7.26.1(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -21532,7 +21513,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -22182,8 +22163,8 @@ snapshots:
       ai-v5: ai@5.0.28(zod@3.25.55)
       date-fns: 3.6.0
       dotenv: 16.6.1
-      hono: 4.9.6
-      hono-openapi: 0.4.8(hono@4.9.6)(openapi-types@12.1.3)(zod@3.25.55)
+      hono: 4.11.1
+      hono-openapi: 0.4.8(hono@4.11.1)(openapi-types@12.1.3)(zod@3.25.55)
       js-tiktoken: 1.0.21
       json-schema: 0.4.0
       json-schema-to-zod: 2.6.1
@@ -22232,7 +22213,7 @@ snapshots:
       find-workspaces: 0.3.1
       fs-extra: 11.3.0
       globby: 14.1.0
-      hono: 4.9.6
+      hono: 4.11.1
       resolve-from: 5.0.0
       rollup: 4.44.2
       rollup-plugin-esbuild: 6.2.1(esbuild@0.25.11)(rollup@4.44.2)
@@ -24318,8 +24299,8 @@ snapshots:
   '@react-grab/claude-code@0.0.70(@types/react@19.2.2)(react@19.2.0)(zod@3.25.55)':
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.59(zod@3.25.55)
-      '@hono/node-server': 1.19.6(hono@4.9.6)
-      hono: 4.9.6
+      '@hono/node-server': 1.19.6(hono@4.11.1)
+      hono: 4.11.1
       picocolors: 1.1.1
       react-grab: 0.0.70(@types/react@19.2.2)(react@19.2.0)
     transitivePeerDependencies:
@@ -27444,7 +27425,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.5.4)
     optionalDependencies:
@@ -27476,7 +27457,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -27490,7 +27471,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -27964,7 +27945,7 @@ snapshots:
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -29371,7 +29352,7 @@ snapshots:
       '@actions/core': 1.11.1
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.47.9(@babel/core@7.28.4)
       globby: 11.1.0
@@ -30554,7 +30535,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.5
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -31072,7 +31053,7 @@ snapshots:
       '@actions/core': 1.11.1
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       find-test-names: 1.29.5(@babel/core@7.28.4)
       globby: 11.1.0
       minimatch: 3.1.2
@@ -31903,15 +31884,15 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono-openapi@0.4.8(hono@4.9.6)(openapi-types@12.1.3)(zod@3.25.55):
+  hono-openapi@0.4.8(hono@4.11.1)(openapi-types@12.1.3)(zod@3.25.55):
     dependencies:
       json-schema-walker: 2.0.0
       openapi-types: 12.1.3
     optionalDependencies:
-      hono: 4.9.6
+      hono: 4.11.1
       zod: 3.25.55
 
-  hono@4.9.6: {}
+  hono@4.11.1: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -31970,7 +31951,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -31990,7 +31971,7 @@ snapshots:
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -37064,7 +37045,7 @@ snapshots:
   spec-change@1.11.11:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@5.5.0)
       deep-equal: 2.2.3
       dependency-tree: 11.0.1
       lazy-ass: 2.0.3


### PR DESCRIPTION
## Summary
- Addresses Dependabot alert #364 for improper authorization vulnerability in hono
- Updates pnpm override from ^4.9.6 to ^4.10.2 (resolves to 4.11.1)

## Test plan
- [ ] Verify application starts correctly
- [ ] Confirm hono-based APIs function properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)