### PR TITLE
feat: make table charts full width in dashboard redesign

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -490,6 +490,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const showExecutionTime = useFeatureFlagEnabled(
         FeatureFlags.ShowExecutionTime,
     );
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
 
     const {
         tile: {
@@ -1323,6 +1326,10 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                         </>
                     )
                 }
+                fullWidth={
+                    chart.chartConfig.type === ChartType.TABLE &&
+                    isDashboardRedesignEnabled
+                }
                 {...props}
             >
                 <>
@@ -1475,6 +1482,9 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         top: number;
     }>();
     const [isDataExportModalOpen, setIsDataExportModalOpen] = useState(false);
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
 
     const {
         tile: {
@@ -1658,6 +1668,10 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                                 )}
                         </>
                     ) : undefined
+                }
+                fullWidth={
+                    isDashboardRedesignEnabled &&
+                    chart.chartConfig.type === ChartType.TABLE
                 }
                 {...props}
             >

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.styles.tsx
@@ -99,11 +99,19 @@ export const TileTitleLink = styled.a<TileTitleProps>`
         `}
 `;
 
-export const ChartContainer = styled.div<{ $alignItems?: 'center' }>`
+export const ChartContainer = styled.div<{
+    $alignItems?: 'center';
+    $fullWidth?: boolean;
+}>`
     flex: 1;
     overflow: hidden;
     display: flex;
     align-items: ${({ $alignItems }) => $alignItems};
+    ${({ $fullWidth }) =>
+        $fullWidth &&
+        css`
+            margin: 0 -16px -16px -16px;
+        `}
 `;
 
 export const TileCardWrapper = styled.div`

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -61,6 +61,7 @@ type Props<T> = {
     tabs?: DashboardTab[];
     lockHeaderVisibility?: boolean;
     transparent?: boolean;
+    fullWidth?: boolean;
 };
 
 const TileBase = <T extends Dashboard['tiles'][number]>({
@@ -82,6 +83,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     tabs,
     lockHeaderVisibility = false,
     transparent = false,
+    fullWidth = false,
 }: Props<T>) => {
     const [isEditingTileContent, setIsEditingTileContent] = useState(false);
     const [isMovingTabs, setIsMovingTabs] = useState(false);
@@ -385,6 +387,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                             ? 'center'
                             : undefined
                     }
+                    $fullWidth={fullWidth}
                 >
                     {children}
                 </ChartContainer>

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
@@ -6,6 +7,7 @@ import {
     isChunkLoadError,
     triggerChunkErrorReload,
 } from '../../features/chunkErrorHandler';
+import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import { isTableVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import { LoadingChart } from '../SimpleChart';
@@ -38,6 +40,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
     minimal = false,
     ...rest
 }) => {
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
     const {
         columnOrder,
         itemsMap,
@@ -188,7 +193,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
     } else if (pivotTableData.loading || pivotTableData.data) {
         return (
             <Box
-                p="xs"
+                p={isDashboard && isDashboardRedesignEnabled ? 0 : 'xs'}
                 pb={showResultsTotal ? 'xxl' : 'xl'}
                 miw="100%"
                 h="100%"
@@ -199,6 +204,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                             className={className}
                             data={pivotTableData.data}
                             isMinimal={minimal}
+                            isDashboard={isDashboard}
                             conditionalFormattings={conditionalFormattings}
                             minMaxMap={minMaxMap}
                             getFieldLabel={getFieldLabel}
@@ -226,8 +232,14 @@ const SimpleTable: FC<SimpleTableProps> = ({
     }
 
     return (
-        <Box p="xs" pb="md" miw="100%" h="100%">
+        <Box
+            p={isDashboard && isDashboardRedesignEnabled ? 0 : 'xs'}
+            pb="md"
+            miw="100%"
+            h="100%"
+        >
             <Table
+                isDashboard={isDashboard}
                 minimal={minimal}
                 $shouldExpand={$shouldExpand}
                 className={className}

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -1,4 +1,4 @@
-import { assertUnreachable } from '@lightdash/common';
+import { assertUnreachable, FeatureFlags } from '@lightdash/common';
 import {
     Box,
     Text,
@@ -26,6 +26,7 @@ import {
 } from 'react';
 import { useScroll } from 'react-use';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { SMALL_TEXT_LENGTH } from './constants';
 import {
     useTableCellStyles,
@@ -39,6 +40,7 @@ type BoxProps = Omit<BoxPropsBase, 'component' | 'children'>;
 
 type TableProps = PolymorphicComponentProps<'table', BoxProps> & {
     containerRef: React.RefObject<HTMLDivElement | null>;
+    isDashboard?: boolean;
 };
 type TableSectionProps = PolymorphicComponentProps<
     'thead' | 'tbody' | 'tfoot',
@@ -151,9 +153,22 @@ const TableProvider: FC<
 };
 
 const TableComponent = forwardRef<HTMLTableElement, TableProps>(
-    ({ children, component = 'table', containerRef, ...rest }, ref) => {
+    (
+        {
+            children,
+            component = 'table',
+            containerRef,
+            isDashboard = false,
+            ...rest
+        },
+        ref,
+    ) => {
         const { cx, classes } = useTableStyles();
         const theme = useMantineTheme();
+        const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+            FeatureFlags.DashboardRedesign,
+        );
+        const shouldRemoveBorders = isDashboard && isDashboardRedesignEnabled;
 
         const [isContainerInitialized, setIsContainerInitialized] =
             useState(false);
@@ -192,7 +207,11 @@ const TableComponent = forwardRef<HTMLTableElement, TableProps>(
                 sx={{
                     overflow: 'auto',
                     border: `1px solid ${theme.colors.ldGray[3]}`,
-                    borderRadius: '4px',
+                    borderRadius: shouldRemoveBorders ? '0' : '4px',
+                    ...(shouldRemoveBorders && {
+                        borderLeft: 'none',
+                        borderRight: 'none',
+                    }),
                 }}
             >
                 <Box

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -105,6 +105,7 @@ type PivotTableProps = BoxProps & // TODO: remove this
         showSubtotals?: boolean;
         columnProperties?: ColumnProperties;
         isMinimal: boolean;
+        isDashboard?: boolean;
     };
 
 const PivotTable: FC<PivotTableProps> = ({
@@ -118,6 +119,7 @@ const PivotTable: FC<PivotTableProps> = ({
     showSubtotals = false,
     columnProperties = {},
     isMinimal = false,
+    isDashboard = false,
     ...tableProps
 }) => {
     const { colorScheme } = useMantineColorScheme();
@@ -421,6 +423,7 @@ const PivotTable: FC<PivotTableProps> = ({
             className={className}
             {...tableProps}
             containerRef={containerRef}
+            isDashboard={isDashboard}
         >
             <Table.Head withSticky>
                 {data.headerValues.map((headerValues, headerRowIndex) => (

--- a/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
@@ -1,4 +1,6 @@
+import { FeatureFlags } from '@lightdash/common';
 import { useRef, type FC } from 'react';
+import { useFeatureFlagEnabled } from '../../../../hooks/useFeatureFlagEnabled';
 import { Table, TableScrollableWrapper } from '../Table.styles';
 import { useTableContext } from '../useTableContext';
 import TableBody from './TableBody';
@@ -8,17 +10,25 @@ import TableHeader from './TableHeader';
 interface ScrollableTableProps {
     minimal?: boolean;
     showSubtotals?: boolean;
+    isDashboard?: boolean;
 }
 
 const ScrollableTable: FC<ScrollableTableProps> = ({
     minimal = true,
     showSubtotals = true,
+    isDashboard = false,
 }) => {
     const { footer } = useTableContext();
     const tableContainerRef = useRef<HTMLDivElement>(null);
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
 
     return (
-        <TableScrollableWrapper ref={tableContainerRef}>
+        <TableScrollableWrapper
+            ref={tableContainerRef}
+            $isDashboard={isDashboard && isDashboardRedesignEnabled}
+        >
             <Table $showFooter={!!footer?.show}>
                 <TableHeader minimal={minimal} showSubtotals={showSubtotals} />
                 <TableBody

--- a/packages/frontend/src/components/common/Table/Table.styles.tsx
+++ b/packages/frontend/src/components/common/Table/Table.styles.tsx
@@ -3,15 +3,23 @@ import styled, { css } from 'styled-components';
 import { ROW_HEIGHT_PX } from './constants';
 import trStyles from './Tr.module.css';
 
-export const TableScrollableWrapper = styled.div`
+export const TableScrollableWrapper = styled.div<{
+    $isDashboard?: boolean;
+}>`
     display: flex;
     flex-direction: column;
 
     position: relative;
     overflow: auto;
     min-width: 100%;
-    border-radius: 4px;
+    border-radius: ${({ $isDashboard }) => ($isDashboard ? '0' : '4px')};
     border: 1px solid var(--mantine-color-ldGray-3);
+    ${({ $isDashboard }) =>
+        $isDashboard &&
+        css`
+            border-left: none;
+            border-right: none;
+        `}
 `;
 
 interface TableContainerProps {

--- a/packages/frontend/src/components/common/Table/index.tsx
+++ b/packages/frontend/src/components/common/Table/index.tsx
@@ -24,9 +24,11 @@ type Props = ComponentProps<typeof TableProvider> & {
     $padding?: number;
     'data-testid'?: string;
     errorDetail?: ApiErrorDetail | null;
+    isDashboard?: boolean;
 };
 
 const Table: FC<React.PropsWithChildren<Props>> = ({
+    isDashboard = false,
     $shouldExpand,
     $padding,
     status,
@@ -63,6 +65,7 @@ const Table: FC<React.PropsWithChildren<Props>> = ({
                 <ScrollableTable
                     minimal={minimal}
                     showSubtotals={showSubtotals}
+                    isDashboard={isDashboard}
                 />
 
                 {status === 'error' && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-164](https://linear.app/lightdash/issue/ZAP-164/remove-the-extra-spacing-from-the-panels-for-table-charts)

### Description:

This PR enhances table visualization in dashboards when the Dashboard Redesign feature flag is enabled. Tables now display with full width, removing padding and extending to the edges of the tile for better data visibility. The changes include:

- Added `fullWidth` prop to `TileBase` component that removes margins when enabled
- Modified `TableScrollableWrapper` styling to remove border radius and side borders for dashboard tables
- Removed padding from tables in dashboard context
- Applied these changes only when both the chart type is TABLE and the Dashboard Redesign feature flag is enabled
