### PR TITLE
security: update hono override to ^4.10.2 (CVE-2025-62610)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "pnpm": {
         "overrides": {
-            "hono": "^4.9.6",
+            "hono": "^4.10.2",
             "linkifyjs": "^4.3.2",
             "axios": "^1.12.0",
             "form-data@2.5.3": "2.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@types/react': 19.2.2
   '@types/react-dom': 19.2.2
   typescript: 5.5.4
-  hono: ^4.9.6
+  hono: ^4.10.2
   linkifyjs: ^4.3.2
   axios: ^1.12.0
   form-data@2.5.3: 2.5.5
@@ -3793,7 +3793,7 @@ packages:
     resolution: {integrity: sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.9.6
+      hono: ^4.10.2
 
   '@hookform/error-message@2.0.0':
     resolution: {integrity: sha512-Y90nHzjgL2MP7GFy75kscdvxrCTjtyxGmOLLxX14nd08OXRIh9lMH/y9Kpdo0p1IPowJBiZMHyueg7p+yrqynQ==}
@@ -11838,7 +11838,7 @@ packages:
       '@valibot/to-json-schema': ^1.0.0-beta.3
       arktype: ^2.0.0
       effect: ^3.11.3
-      hono: ^4.9.6
+      hono: ^4.10.2
       openapi-types: ^12.1.3
       valibot: ^1.0.0-beta.9
       zod: ^3.23.8
@@ -11871,8 +11871,8 @@ packages:
       zod-openapi:
         optional: true
 
-  hono@4.9.6:
-    resolution: {integrity: sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA==}
+  hono@4.11.1:
+    resolution: {integrity: sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -21492,9 +21492,9 @@ snapshots:
       - '@types/react-dom'
       - react-native
 
-  '@hono/node-server@1.19.6(hono@4.9.6)':
+  '@hono/node-server@1.19.6(hono@4.11.1)':
     dependencies:
-      hono: 4.9.6
+      hono: 4.11.1
 
   '@hookform/error-message@2.0.0(react-dom@19.2.0(react@19.2.0))(react-hook-form@7.26.1(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -22162,8 +22162,8 @@ snapshots:
       ai-v5: ai@5.0.28(zod@3.25.55)
       date-fns: 3.6.0
       dotenv: 16.6.1
-      hono: 4.9.6
-      hono-openapi: 0.4.8(hono@4.9.6)(openapi-types@12.1.3)(zod@3.25.55)
+      hono: 4.11.1
+      hono-openapi: 0.4.8(hono@4.11.1)(openapi-types@12.1.3)(zod@3.25.55)
       js-tiktoken: 1.0.21
       json-schema: 0.4.0
       json-schema-to-zod: 2.6.1
@@ -22212,7 +22212,7 @@ snapshots:
       find-workspaces: 0.3.1
       fs-extra: 11.3.0
       globby: 14.1.0
-      hono: 4.9.6
+      hono: 4.11.1
       resolve-from: 5.0.0
       rollup: 4.44.2
       rollup-plugin-esbuild: 6.2.1(esbuild@0.25.11)(rollup@4.44.2)
@@ -24298,8 +24298,8 @@ snapshots:
   '@react-grab/claude-code@0.0.70(@types/react@19.2.2)(react@19.2.0)(zod@3.25.55)':
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.59(zod@3.25.55)
-      '@hono/node-server': 1.19.6(hono@4.9.6)
-      hono: 4.9.6
+      '@hono/node-server': 1.19.6(hono@4.11.1)
+      hono: 4.11.1
       picocolors: 1.1.1
       react-grab: 0.0.70(@types/react@19.2.2)(react@19.2.0)
     transitivePeerDependencies:
@@ -31883,15 +31883,15 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono-openapi@0.4.8(hono@4.9.6)(openapi-types@12.1.3)(zod@3.25.55):
+  hono-openapi@0.4.8(hono@4.11.1)(openapi-types@12.1.3)(zod@3.25.55):
     dependencies:
       json-schema-walker: 2.0.0
       openapi-types: 12.1.3
     optionalDependencies:
-      hono: 4.9.6
+      hono: 4.11.1
       zod: 3.25.55
 
-  hono@4.9.6: {}
+  hono@4.11.1: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Updates the hono pnpm override from ^4.9.6 to ^4.10.2
- Fixes CVE-2025-62610 (Hono Improper Authorization vulnerability in JWT Audience Validation)
- Resolves Dependabot alert #364

## Context
hono is a transitive dependency of `@mastra/core` which is used by the backend. Since @mastra/core@0.24.8 still depends on hono@^4.9.7 (vulnerable), we need the override to enforce the patched version.

## Test plan
- [x] pnpm install succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)