### PR TITLE
fix: introduce new error boundary for missing chunks

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -2,6 +2,10 @@ import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
 import { type FC, useCallback, useEffect, useMemo } from 'react';
+import {
+    isChunkLoadError,
+    triggerChunkErrorReload,
+} from '../../features/chunkErrorHandler';
 import { isTableVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import { LoadingChart } from '../SimpleChart';
@@ -143,9 +147,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
     } = visualizationConfig.chartConfig;
 
     if (pivotTableData.error) {
-        const isWorkerFetchError = pivotTableData.error.includes(
-            'Failed to fetch dynamically imported module',
-        );
+        const isWorkerFetchError = isChunkLoadError(pivotTableData.error);
         if (isWorkerFetchError) {
             return (
                 <SuboptimalState
@@ -168,7 +170,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                             variant="default"
                             size={'xs'}
                             leftIcon={<IconRefresh size={16} />}
-                            onClick={() => window.location.reload()}
+                            onClick={triggerChunkErrorReload}
                         >
                             Refresh page
                         </Button>

--- a/packages/frontend/src/features/chunkErrorHandler/CLAUDE.md
+++ b/packages/frontend/src/features/chunkErrorHandler/CLAUDE.md
@@ -1,0 +1,59 @@
+# Chunk Error Handler
+
+<summary>
+Handles automatic recovery when users encounter stale JavaScript chunks after a deployment.
+
+When Lightdash deploys a new version:
+
+1. Vite generates new JS chunks with content-hashed filenames (e.g., `ExplorePanel-abc123.js`)
+2. Old chunks are deleted from the server
+3. Users with cached HTML still reference old chunk URLs
+4. When React.lazy() tries to load the old chunk → 404 → error
+
+This module detects these "Failed to fetch dynamically imported module" errors and auto-reloads
+the page to fetch fresh HTML with correct chunk references.
+
+</summary>
+
+<howToUse>
+This module is already integrated into:
+- `@/features/errorBoundary/ErrorBoundary.tsx` - Auto-reload on chunk errors
+- `@/hooks/thirdPartyServices/useSentry.ts` - Filters chunk errors from Sentry until auto-reload fails
+- `@/components/SimpleTable/index.tsx` - Manual refresh UI for pivot table worker errors (no auto-reload)
+
+You typically don't need to use this directly unless handling chunk errors in a new location.
+</howToUse>
+
+<codeExample>
+
+```typescript
+import {
+    isChunkLoadErrorObject,
+    hasRecentChunkReload,
+    triggerChunkErrorReload,
+} from '../chunkErrorHandler';
+
+// In an error boundary fallback:
+if (isChunkLoadErrorObject(error)) {
+    if (!hasRecentChunkReload()) {
+        triggerChunkErrorReload(); // Auto-reload once
+        return null;
+    }
+    // Show manual refresh UI (auto-reload already failed)
+}
+```
+
+</codeExample>
+
+<importantToKnow>
+- Uses sessionStorage to prevent infinite reload loops (60s cooldown)
+- `isChunkLoadError(message: string)` - checks error message strings
+- `isChunkLoadErrorObject(error: unknown)` - checks Error objects
+- Sentry integration: errors are only reported if auto-reload fails
+</importantToKnow>
+
+<links>
+- @/features/errorBoundary/ErrorBoundary.tsx - Primary integration point
+- @/hooks/thirdPartyServices/useSentry.ts - Sentry filtering logic
+- @/components/SimpleTable/index.tsx - Manual refresh UI for pivot table worker errors
+</links>

--- a/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
@@ -1,0 +1,55 @@
+const CHUNK_ERROR_RELOAD_KEY = 'lightdash-chunk-error-reload';
+const RELOAD_COOLDOWN_MS = 60_000; // 60 seconds before allowing another auto-reload
+
+const CHUNK_ERROR_MESSAGE = 'Failed to fetch dynamically imported module';
+
+export const isChunkLoadError = (message: string): boolean => {
+    return message.includes(CHUNK_ERROR_MESSAGE);
+};
+
+export const isChunkLoadErrorObject = (error: unknown): boolean => {
+    if (error instanceof Error) {
+        return isChunkLoadError(error.message);
+    }
+    return false;
+};
+
+/**
+ * Check if we've recently attempted an auto-reload for chunk errors.
+ * Used by ErrorBoundary to decide whether to auto-reload or show manual refresh UI.
+ */
+export const hasRecentChunkReload = (): boolean => {
+    try {
+        const reloadTimestamp = sessionStorage.getItem(CHUNK_ERROR_RELOAD_KEY);
+        if (!reloadTimestamp) {
+            return false;
+        }
+
+        const reloadTime = parseInt(reloadTimestamp, 10);
+
+        if (isNaN(reloadTime) || Date.now() - reloadTime > RELOAD_COOLDOWN_MS) {
+            sessionStorage.removeItem(CHUNK_ERROR_RELOAD_KEY);
+            return false;
+        }
+
+        return true;
+    } catch {
+        // sessionStorage may throw in private browsing or when storage is disabled.
+        // Return true to skip auto-reload and show manual refresh UI (avoids infinite loop).
+        return true;
+    }
+};
+
+/**
+ * Trigger an auto-reload for a chunk error.
+ * Sets sessionStorage flag to prevent infinite loops.
+ */
+export const triggerChunkErrorReload = (): void => {
+    try {
+        sessionStorage.setItem(CHUNK_ERROR_RELOAD_KEY, Date.now().toString());
+    } catch {
+        // sessionStorage may throw in private browsing or when storage is disabled.
+        // Proceed with reload anyway - worst case user sees manual refresh UI.
+    }
+    window.location.reload();
+};

--- a/packages/frontend/src/features/chunkErrorHandler/index.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/index.ts
@@ -1,0 +1,6 @@
+export {
+    hasRecentChunkReload,
+    isChunkLoadError,
+    isChunkLoadErrorObject,
+    triggerChunkErrorReload,
+} from './chunkErrorHandler';

--- a/packages/frontend/src/features/errorBoundary/ErrorBoundary.tsx
+++ b/packages/frontend/src/features/errorBoundary/ErrorBoundary.tsx
@@ -1,9 +1,127 @@
-import { Flex, Stack, Text, type FlexProps } from '@mantine/core';
+import { Box, Button, Flex, Stack, Text, type FlexProps } from '@mantine/core';
 import { Prism } from '@mantine/prism';
 import * as Sentry from '@sentry/react';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
 import { type FC, type PropsWithChildren } from 'react';
 import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
+import {
+    hasRecentChunkReload,
+    isChunkLoadErrorObject,
+    triggerChunkErrorReload,
+} from '../chunkErrorHandler';
+
+/**
+ * Fallback UI shown when a chunk load error occurs after auto-reload has failed.
+ * This happens when the browser cache is aggressive or there are network issues.
+ */
+const ChunkErrorFallback: FC = () => (
+    <SuboptimalState
+        icon={IconAlertCircle}
+        title="Application update required"
+        description={
+            <Box>
+                <Text mb="xs">
+                    A new version of Lightdash is available. Please refresh your
+                    browser to load the latest version.
+                </Text>
+                <Text size="sm" c="dimmed">
+                    If this persists after refreshing, try clearing your browser
+                    cache or opening in an incognito window.
+                </Text>
+            </Box>
+        }
+        action={
+            <Button
+                variant="default"
+                size="xs"
+                leftSection={<IconRefresh size={16} />}
+                onClick={triggerChunkErrorReload}
+            >
+                Refresh page
+            </Button>
+        }
+    />
+);
+
+/**
+ * Fallback UI shown for general application errors.
+ * Displays error details and Sentry event ID for support.
+ */
+const GeneralErrorFallback: FC<{ eventId: string; error: unknown }> = ({
+    eventId,
+    error,
+}) => (
+    <SuboptimalState
+        icon={IconAlertCircle}
+        title="Something went wrong."
+        description={
+            <Stack
+                spacing="xs"
+                sx={(theme) => ({
+                    borderRadius: theme.radius.md,
+                    padding: theme.spacing.xs,
+                    backgroundColor: theme.colors.ldGray[1],
+                })}
+            >
+                <Text>You can contact support with the following error ID</Text>
+                <Prism
+                    language="javascript"
+                    ta="left"
+                    maw="400"
+                    styles={{ copy: { right: 0 } }}
+                >
+                    {`Error ID: ${eventId}\n${
+                        error instanceof Error ? error.toString() : ''
+                    }`}
+                </Prism>
+            </Stack>
+        }
+    />
+);
+
+/**
+ * Renders the appropriate fallback based on error type.
+ * For chunk errors: auto-reload once, then show manual refresh UI.
+ * For other errors: show error details with Sentry event ID.
+ */
+const ErrorFallback: FC<{
+    eventId: string;
+    error: unknown;
+    wrapper?: FlexProps;
+}> = ({ eventId, error, wrapper }) => {
+    // Check if this is a chunk load error
+    if (isChunkLoadErrorObject(error)) {
+        // If we haven't recently reloaded, auto-reload now
+        if (!hasRecentChunkReload()) {
+            triggerChunkErrorReload();
+            // Return null while reloading - page will refresh
+            return null;
+        }
+        // Auto-reload already attempted, show manual refresh UI
+        return (
+            <Flex
+                justify="flex-start"
+                align="center"
+                direction="column"
+                {...wrapper}
+            >
+                <ChunkErrorFallback />
+            </Flex>
+        );
+    }
+
+    // Regular error - show error details
+    return (
+        <Flex
+            justify="flex-start"
+            align="center"
+            direction="column"
+            {...wrapper}
+        >
+            <GeneralErrorFallback eventId={eventId} error={error} />
+        </Flex>
+    );
+};
 
 const ErrorBoundary: FC<PropsWithChildren & { wrapper?: FlexProps }> = ({
     children,
@@ -12,44 +130,11 @@ const ErrorBoundary: FC<PropsWithChildren & { wrapper?: FlexProps }> = ({
     return (
         <Sentry.ErrorBoundary
             fallback={({ eventId, error }) => (
-                <Flex
-                    justify="flex-start"
-                    align="center"
-                    direction="column"
-                    {...wrapper}
-                >
-                    <SuboptimalState
-                        icon={IconAlertCircle}
-                        title="Something went wrong."
-                        description={
-                            <Stack
-                                spacing="xs"
-                                sx={(theme) => ({
-                                    borderRadius: theme.radius.md,
-                                    padding: theme.spacing.xs,
-                                    backgroundColor: theme.colors.ldGray[1],
-                                })}
-                            >
-                                <Text>
-                                    You can contact support with the following
-                                    error ID
-                                </Text>
-                                <Prism
-                                    language="javascript"
-                                    ta="left"
-                                    maw="400"
-                                    styles={{ copy: { right: 0 } }}
-                                >
-                                    {`Error ID: ${eventId}\n${
-                                        error instanceof Error
-                                            ? error.toString()
-                                            : ''
-                                    }`}
-                                </Prism>
-                            </Stack>
-                        }
-                    />
-                </Flex>
+                <ErrorFallback
+                    eventId={eventId}
+                    error={error}
+                    wrapper={wrapper}
+                />
             )}
         >
             {children}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/SPK-266/typeerror-failed-to-fetch-dynamically-imported-module
Closes: https://linear.app/lightdash/issue/PROD-470/failed-to-fetch-dynamically-imported-module

### Description:
Added a chunk error handler to automatically recover from stale JavaScript chunks after deployments. This prevents users from seeing errors when they have cached HTML that references old chunks that no longer exist on the server.

Key improvements:
- Created a dedicated `chunkErrorHandler` module with utilities to detect and handle chunk load errors
- Implemented auto-reload with a 60-second cooldown to prevent infinite reload loops
- Enhanced ErrorBoundary to automatically reload once on chunk errors, then show a user-friendly refresh UI
- Added Sentry integration to filter chunk errors until auto-reload fails
- Refactored SimpleTable to use the new chunk error handler for pivot table worker errors

### Steps to reproduce
1. Run `pnpm -F frontend build`
2. Run `pnpm -F frontend serve`
3. Delete `packages/frontend/build/assets/BasePanel*` chunks
4. Access the URL for frontend serve
5. It should auto reload and then present a error boundary with a reload button (this is because we have no new chunks - no new build - expected in local dev)

**Before**

[Screen Recording 2025-12-17 at 11.37.12.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9ea87659-9647-40d0-9d37-47ee82473c80.mov" />](https://app.graphite.com/user-attachments/video/9ea87659-9647-40d0-9d37-47ee82473c80.mov)

**After**

[Screen Recording 2025-12-17 at 12.51.47.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/722d3ed7-b965-4192-a187-9382e34df6b2.mov" />](https://app.graphite.com/user-attachments/video/722d3ed7-b965-4192-a187-9382e34df6b2.mov)

