### PR TITLE
fix: docs link to email env variables

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm.tsx
@@ -1125,7 +1125,7 @@ const SchedulerForm: FC<Props> = ({
                                                     delivery, you need to add
                                                     <Anchor
                                                         target="_blank"
-                                                        href="https://docs.lightdash.com/references/environmentVariables"
+                                                        href="https://docs.lightdash.com/self-host/customize-deployment/configure-smtp-for-lightdash-email-notifications"
                                                     >
                                                         {' '}
                                                         SMTP environment


### PR DESCRIPTION
### Description:

Update link to docs about setting up variables for email delivery. A customer reported the current link hits a 404
