### PR TITLE
fix: dark mode for custom viz config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -1,5 +1,12 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Button, Flex, Group, Loader, Text } from '@mantine/core';
+import {
+    Button,
+    Flex,
+    Group,
+    Loader,
+    Text,
+    useMantineTheme,
+} from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';
@@ -60,6 +67,20 @@ const loadMonaco = (monaco: Monaco, schemas: Schema[]) => {
         foldingRanges: true,
         diagnostics: true,
     });
+
+    // Define light and dark themes
+    monaco.editor.defineTheme('lightdash-light', {
+        base: 'vs',
+        inherit: true,
+        rules: [],
+        colors: {},
+    });
+    monaco.editor.defineTheme('lightdash-dark', {
+        base: 'vs-dark',
+        inherit: true,
+        rules: [],
+        colors: {},
+    });
 };
 
 const registerCustomCompletionProvider = (
@@ -97,6 +118,7 @@ const registerCustomCompletionProvider = (
 
 export const ConfigTabs: React.FC = memo(() => {
     const { visualizationConfig } = useVisualizationContext();
+    const theme = useMantineTheme();
 
     const isCustomConfig = isCustomVisualizationConfig(visualizationConfig);
 
@@ -297,6 +319,11 @@ export const ConfigTabs: React.FC = memo(() => {
                     onChange={(config) => {
                         setEditorConfig(config ?? '');
                     }}
+                    theme={
+                        theme.colorScheme === 'dark'
+                            ? 'lightdash-dark'
+                            : 'lightdash-light'
+                    }
                 />
             </Group>
         </>


### PR DESCRIPTION
### Description:

Use dark mode for monaco editor in custom viz config.

**Before**
<img width="400" height="646" alt="Screenshot 2025-12-17 at 15 42 35" src="https://github.com/user-attachments/assets/39808de6-8fa4-4aea-a23a-1ad7d79b3c01" />

**After**
<img width="407" height="770" alt="Screenshot 2025-12-17 at 15 40 11" src="https://github.com/user-attachments/assets/b3c2e717-b8dc-49b5-aa2b-be9176c727bd" />

