### PR TITLE
feat: add chart loading skeletons for dashboard redesign

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -2,10 +2,10 @@ import { Anchor, Text } from '@mantine/core';
 import { IconChartBarOff } from '@tabler/icons-react';
 import { Suspense, lazy, useEffect, type FC } from 'react';
 import { type CustomVisualizationConfigAndData } from '../../hooks/useCustomVisualizationConfig';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import { isCustomVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
-import { LoadingChart } from '../SimpleChart';
-import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 
 const VegaLite = lazy(() =>
     import('react-vega').then((module) => ({ default: module.VegaLite })),
@@ -34,7 +34,7 @@ const CustomVisualization: FC<Props> = (props) => {
     const spec = visualizationConfig.chartConfig.validConfig.spec;
 
     if (isLoading) {
-        return <LoadingChart />;
+        return <ChartLoadingSkeleton />;
     }
 
     if (
@@ -83,7 +83,7 @@ const CustomVisualization: FC<Props> = (props) => {
                 overflow: 'hidden',
             }}
         >
-            <Suspense fallback={<LoadingChart />}>
+            <Suspense fallback={<ChartLoadingSkeleton />}>
                 <VegaLite
                     style={{
                         width: containerWidth,

--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -9,9 +9,10 @@ import useEchartsFunnelConfig, {
 } from '../../hooks/echarts/useEchartsFunnelConfig';
 import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
 import useApp from '../../providers/App/useApp';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import EChartsReact from '../EChartsReactWrapper';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
-import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import FunnelChartContextMenu, {
     type FunnelChartContextMenuProps,
 } from './FunnelChartContextMenu';
@@ -22,16 +23,6 @@ const EmptyChart = () => (
             title="No data available"
             description="Query metrics and dimensions with results."
             icon={IconFilterOff}
-        />
-    </Box>
-);
-
-const LoadingChart = () => (
-    <Box h="100%" w="100%" py="xl">
-        <SuboptimalState
-            title="Loading chart"
-            loading
-            className="loading_chart"
         />
     </Box>
 );
@@ -99,7 +90,7 @@ const FunnelChart: FC<FunnelChartProps> = memo((props) => {
         close();
     }, [close]);
 
-    if (isLoading) return <LoadingChart />;
+    if (isLoading) return <ChartLoadingSkeleton />;
     if (!funnelChartOptions) return <EmptyChart />;
 
     return (

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -8,6 +8,7 @@ import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
 import { memo, useCallback, useEffect, useMemo, type FC } from 'react';
 import useEchartsCartesianConfig from '../../hooks/echarts/useEchartsCartesianConfig';
 import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import EChartsReact from '../EChartsReactWrapper';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -61,16 +62,6 @@ export const EmptyChart = () => (
             title="No data available"
             description="Query metrics and dimensions with results."
             icon={IconChartBarOff}
-        />
-    </div>
-);
-
-export const LoadingChart = () => (
-    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
-        <SuboptimalState
-            title="Loading chart"
-            loading
-            className="loading_chart"
         />
     </div>
 );
@@ -272,7 +263,7 @@ const SimpleChart: FC<SimpleChartProps> = memo((props) => {
     }, [chartRef, eChartsOptions?.tooltip]);
 
     if (resultsData?.error) return <EmptyChart />;
-    if (isLoading) return <LoadingChart />;
+    if (isLoading) return <ChartLoadingSkeleton />;
     if (!eChartsOptions) return <EmptyChart />;
 
     return (

--- a/packages/frontend/src/components/SimpleGauge/index.tsx
+++ b/packages/frontend/src/components/SimpleGauge/index.tsx
@@ -4,9 +4,10 @@ import clamp from 'lodash/clamp';
 import { memo, useEffect, useMemo, useState, type FC } from 'react';
 import { DEFAULT_ROW_HEIGHT } from '../../features/dashboardTabs/gridUtils';
 import useEchartsGaugeConfig from '../../hooks/echarts/useEchartsGaugeConfig';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import EChartsReact from '../EChartsReactWrapper';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
-import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 
 const EmptyChart = () => (
     <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
@@ -14,16 +15,6 @@ const EmptyChart = () => (
             title="No data available"
             description="Query metrics and dimensions with results."
             icon={IconGauge}
-        />
-    </div>
-);
-
-const LoadingChart = () => (
-    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
-        <SuboptimalState
-            title="Loading chart"
-            loading
-            className="loading_chart"
         />
     </div>
 );
@@ -148,7 +139,7 @@ const SimpleGauge: FC<SimpleGaugeProps> = memo((props) => {
         };
     });
 
-    if (isLoading) return <LoadingChart />;
+    if (isLoading) return <ChartLoadingSkeleton />;
     if (!gaugeOptions) return <EmptyChart />;
 
     return (

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -23,9 +23,10 @@ import {
 import * as topojson from 'topojson-client';
 import type { Topology } from 'topojson-specification';
 import useLeafletMapConfig from '../../hooks/leaflet/useLeafletMapConfig';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import { isMapVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
-import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import HeatmapLayer from './HeatmapLayer';
 import MapLegend from './MapLegend';
 // eslint-disable-next-line css-modules/no-unused-class
@@ -91,16 +92,6 @@ const EmptyChart: FC<{ locationType?: MapChartType }> = ({ locationType }) => {
         </div>
     );
 };
-
-const LoadingChart = () => (
-    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
-        <SuboptimalState
-            title="Loading chart"
-            loading
-            className="loading_chart"
-        />
-    </div>
-);
 
 type SimpleMapProps = {
     isInDashboard: boolean;
@@ -419,7 +410,7 @@ const SimpleMap: FC<SimpleMapProps> = memo((props) => {
     );
 
     if (isLoading) {
-        return <LoadingChart />;
+        return <ChartLoadingSkeleton />;
     }
 
     if (!mapConfig) {

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -8,9 +8,10 @@ import useEchartsPieConfig, {
 } from '../../hooks/echarts/useEchartsPieConfig';
 import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
 import useApp from '../../providers/App/useApp';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import EChartsReact from '../EChartsReactWrapper';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
-import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import PieChartContextMenu, {
     type PieChartContextMenuProps,
 } from './PieChartContextMenu';
@@ -21,16 +22,6 @@ const EmptyChart = () => (
             title="No data available"
             description="Query metrics and dimensions with results."
             icon={IconChartPieOff}
-        />
-    </div>
-);
-
-const LoadingChart = () => (
-    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
-        <SuboptimalState
-            title="Loading chart"
-            loading
-            className="loading_chart"
         />
     </div>
 );
@@ -96,7 +87,7 @@ const SimplePieChart: FC<SimplePieChartProps> = memo((props) => {
         close();
     }, [close]);
 
-    if (isLoading) return <LoadingChart />;
+    if (isLoading) return <ChartLoadingSkeleton />;
     if (!pieChartOptions) return <EmptyChart />;
 
     return (

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -21,10 +21,11 @@ import useEmbed from '../../ee/providers/Embed/useEmbed';
 import { DEFAULT_ROW_HEIGHT } from '../../features/dashboardTabs/gridUtils';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
+import MantineIcon from '../common/MantineIcon';
 import { isBigNumberVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
-import { EmptyChart, LoadingChart } from '../SimpleChart';
-import MantineIcon from '../common/MantineIcon';
+import { EmptyChart } from '../SimpleChart';
 import BigNumberContextMenu from './BigNumberContextMenu';
 import styles from './SimpleStatistic.module.css';
 
@@ -234,7 +235,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
             : _spacingMultiplier;
     const validData = bigNumber && resultsData?.rows.length;
 
-    if (isLoading) return <LoadingChart />;
+    if (isLoading) return <ChartLoadingSkeleton />;
 
     const shouldHideContextMenu =
         (minimal && !embedToken) ||

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import { isTableVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
-import { LoadingChart } from '../SimpleChart';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
 import PivotTable from '../common/PivotTable';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import Table from '../common/Table';
@@ -225,7 +225,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                         )}
                     </>
                 ) : (
-                    <LoadingChart />
+                    <ChartLoadingSkeleton />
                 )}
             </Box>
         );
@@ -247,7 +247,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 data={resultsData?.rows || []}
                 totalRowsCount={resultsData?.totalResults || 0}
                 isFetchingRows={!!resultsData?.isFetchingRows}
-                loadingState={LoadingChart}
+                loadingState={() => <ChartLoadingSkeleton />}
                 fetchMoreRows={resultsData?.fetchMoreRows || noop}
                 columns={columns}
                 columnOrder={columnOrder}

--- a/packages/frontend/src/components/SimpleTreemap/index.tsx
+++ b/packages/frontend/src/components/SimpleTreemap/index.tsx
@@ -2,9 +2,10 @@ import { IconChartTreemap } from '@tabler/icons-react';
 import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
 import { memo, useEffect, type FC } from 'react';
 import useEchartsTreemapConfig from '../../hooks/echarts/useEchartsTreemapConfig';
+import { ChartLoadingSkeleton } from '../common/ChartSkeletons';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import EChartsReact from '../EChartsReactWrapper';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
-import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 
 const EmptyChart = () => (
     <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
@@ -12,16 +13,6 @@ const EmptyChart = () => (
             title="No data available"
             description="Query metrics and dimensions with results."
             icon={IconChartTreemap}
-        />
-    </div>
-);
-
-const LoadingChart = () => (
-    <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
-        <SuboptimalState
-            title="Loading chart"
-            loading
-            className="loading_chart"
         />
     </div>
 );
@@ -51,7 +42,7 @@ const SimpleTreemap: FC<SimpleTreemapProps> = memo((props) => {
         return () => window.removeEventListener('resize', listener);
     });
 
-    if (isLoading) return <LoadingChart />;
+    if (isLoading) return <ChartLoadingSkeleton />;
     if (!treemapOptions) return <EmptyChart />;
 
     return (

--- a/packages/frontend/src/components/common/ChartSkeletons.tsx
+++ b/packages/frontend/src/components/common/ChartSkeletons.tsx
@@ -1,0 +1,36 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Skeleton, Stack } from '@mantine-8/core';
+import type { FC } from 'react';
+import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
+import SuboptimalState from './SuboptimalState/SuboptimalState';
+
+const LegacyLoadingChart: FC<{ className?: string }> = ({ className }) => (
+    <div
+        className={className}
+        style={{ height: '100%', width: '100%', padding: '50px 0' }}
+    >
+        <SuboptimalState title="Loading chart" loading />
+    </div>
+);
+
+const ChartSkeleton: FC<{ className?: string }> = ({ className }) => (
+    <Stack gap="xs" h="100%" className={className}>
+        <Skeleton h={16} w="90%" radius="xl" />
+        <Skeleton h={14} w="80%" radius="xl" />
+        <Skeleton h="100%" w="100%" radius="md" mt="md" />
+    </Stack>
+);
+
+export const ChartLoadingSkeleton: FC<{ className?: string }> = ({
+    className = 'loading_chart',
+}) => {
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
+
+    if (!isDashboardRedesignEnabled) {
+        return <LegacyLoadingChart className={className} />;
+    }
+
+    return <ChartSkeleton className={className} />;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR introduces chart-specific loading skeletons to replace the generic loading spinner. Different chart types (big number, table, cartesian, etc.) now display tailored skeleton UI while loading, providing a more polished user experience.

The implementation respects the `DashboardRedesign` feature flag - when enabled, users will see the new skeleton loaders; when disabled, they'll continue to see the legacy spinner.

The PR includes:

- A new `ChartLoadingSkeleton` component that renders appropriate skeletons based on chart type
- Type-specific skeleton designs for big numbers, tables, and other chart types
- Integration with all chart components to use the new loading states
