### PR TITLE
fix: ensure changeset doesn't introduce undefined dimensions/metrics into the explore

### DIFF
--- a/packages/common/src/utils/changeset.test.ts
+++ b/packages/common/src/utils/changeset.test.ts
@@ -227,6 +227,99 @@ describe('ChangesetUtils', () => {
                     expect(patchedExplores).toStrictEqual(mockExplores);
                 });
 
+                it('should skip dimension update if dimension does not exist and not introduce undefined values', () => {
+                    // This test ensures that when a changeset tries to update a dimension
+                    // that doesn't exist in the explore, the update is skipped entirely
+                    // and no undefined value is set in the dimensions object.
+                    // This prevents errors like "Cannot read properties of undefined (reading 'table')"
+                    // when iterating over dimensions with Object.values().
+                    const change: Change = {
+                        changeUuid: 'c5b',
+                        changesetUuid: 'cs1',
+                        createdAt: new Date(),
+                        createdByUserUuid: 'u1',
+                        sourcePromptUuid: 'sp1',
+                        type: 'update',
+                        entityType: 'dimension',
+                        entityTableName: 'orders',
+                        entityName: 'non_existent_dimension',
+                        payload: {
+                            patches: [
+                                {
+                                    op: 'replace',
+                                    path: '/description',
+                                    value: 'This should not be applied',
+                                },
+                            ],
+                        },
+                    };
+
+                    const patchedExplores = ChangesetUtils.applyChangeset(
+                        { ...changeset, changes: [change] },
+                        mockExplores,
+                    );
+
+                    // The explores should remain unchanged
+                    expect(patchedExplores).toStrictEqual(mockExplores);
+
+                    // Explicitly verify no undefined values exist in dimensions
+                    const dimensionValues = Object.values(
+                        patchedExplores.orders.tables!.orders.dimensions,
+                    );
+                    expect(dimensionValues.every((d) => d !== undefined)).toBe(
+                        true,
+                    );
+
+                    // Verify the non-existent dimension was not added
+                    expect(
+                        patchedExplores.orders.tables!.orders.dimensions,
+                    ).not.toHaveProperty('non_existent_dimension');
+                });
+
+                it('should skip metric update if metric does not exist and not introduce undefined values', () => {
+                    const change: Change = {
+                        changeUuid: 'c5c',
+                        changesetUuid: 'cs1',
+                        createdAt: new Date(),
+                        createdByUserUuid: 'u1',
+                        sourcePromptUuid: 'sp1',
+                        type: 'update',
+                        entityType: 'metric',
+                        entityTableName: 'orders',
+                        entityName: 'non_existent_metric',
+                        payload: {
+                            patches: [
+                                {
+                                    op: 'replace',
+                                    path: '/description',
+                                    value: 'This should not be applied',
+                                },
+                            ],
+                        },
+                    };
+
+                    const patchedExplores = ChangesetUtils.applyChangeset(
+                        { ...changeset, changes: [change] },
+                        mockExplores,
+                    );
+
+                    // The explores should remain unchanged
+                    expect(patchedExplores).toStrictEqual(mockExplores);
+
+                    // Explicitly verify no undefined values exist in metrics
+                    const metricValues = Object.values(
+                        patchedExplores.orders.tables!.orders.metrics,
+                    );
+                    expect(metricValues.every((m) => m !== undefined)).toBe(
+                        true,
+                    );
+
+                    // Verify the non-existent metric was not added
+                    expect(
+                        patchedExplores.orders.tables!.orders.metrics,
+                    ).not.toHaveProperty('non_existent_metric');
+                });
+
                 it('should skip the patch if the table is not found in the explore', () => {
                     const change: Change = {
                         changeUuid: 'c6',

--- a/packages/common/src/utils/changeset.ts
+++ b/packages/common/src/utils/changeset.ts
@@ -163,6 +163,16 @@ export class ChangesetUtils {
                                     break;
                                 }
 
+                                const existingEntity =
+                                    patchedExplore.tables[tableName][
+                                        entityType
+                                    ][change.entityName];
+
+                                // Skip update if entity doesn't exist to avoid setting undefined values
+                                if (!existingEntity) {
+                                    break;
+                                }
+
                                 const updatePatch = JsonPatch.applyPatch(
                                     patchedExplore,
                                     [
@@ -170,11 +180,7 @@ export class ChangesetUtils {
                                             op: 'replace',
                                             path: `/tables/${tableName}/${entityType}/${change.entityName}`,
                                             value: this.applyChange(
-                                                patchedExplore.tables[
-                                                    tableName
-                                                ][entityType][
-                                                    change.entityName
-                                                ],
+                                                existingEntity,
                                                 change,
                                             ),
                                         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-1984/typeerror-cannot-read-properties-of-undefined-reading-table

### Description:
Fix bug where updating non-existent dimensions or metrics could introduce undefined values

This PR adds a check to skip updates for dimensions and metrics that don't exist in the explore, preventing the introduction of undefined values in the dimensions/metrics objects. This fixes potential errors like "Cannot read properties of undefined (reading 'table')" when iterating over dimensions with Object.values().

The implementation:
1. Checks if the entity exists before applying updates
2. Skips the update entirely if the entity doesn't exist
3. Adds comprehensive tests to verify this behavior for both dimensions and metrics


**Original error**

```
TypeError: Cannot read properties of undefined (reading 'table')
    at getItemId (/usr/app/packages/common/dist/cjs/utils/item.js:36:20)
    at hasADateDimension (/services/AsyncQueryService/AsyncQueryService.ts:2442:63)
    at Array.find (<anonymous>)
    at AsyncQueryService.executeAsyncDashboardChartQuery (/services/AsyncQueryService/AsyncQueryService.ts:2440:33)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at {QueryController#2}.executeAsyncDashboardChartQuery (/controllers/v2/QueryController.ts:246:25)
    at ExpressTemplateService.apiHandler (/usr/app/node_modules/.pnpm/@tsoa+runtime@6.6.0/node_modules/@tsoa/runtime/dist/routeGeneration/templates/express/expressTemplateService.js:10:26)
    at QueryController_executeAsyncDashboardChartQuery (/generated/routes.ts:44822:17)
```