### PR TITLE
fix: handle ParameterError as non-retryable in scheduler

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3089,7 +3089,7 @@ export default class SchedulerTask {
                 e instanceof ParameterError
             ) {
                 // This captures both the error from thresholdAlert and metricQuery
-                // WarehouseConnectionError indicates misconfigured credentials (wrong password, unreachable host, etc.
+                // WarehouseConnectionError indicates misconfigured credentials (wrong password, unreachable host, etc.)
                 // ParameterError indicates invalid configuration (e.g., selected tabs no longer exist)
                 Logger.warn(
                     `Disabling scheduler with non-retryable error: ${e}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1633 / LIGHTDASH-BACKEND-BE4

### Repro:
1. Create a dashboard with tabs
2. Create a scheduled delivery with image format and select a specific tab
3. Delete that tab
4. Run the scheduler
5. Errors out with something like:
```
packages/backend dev: 2025-12-17 16:49:04 [Lightdash] error: Failed task 1306 (handleScheduledDelivery) with error None of the selected tabs exist in the dashboard (423.28ms):
packages/backend dev:   ParameterError: None of the selected tabs exist in the dashboard
packages/backend dev:       at validateSelectedTabs (/usr/app/packages/common/src/utils/dashboard.ts:44:19)
packages/backend dev:       at UnfurlService.getTitleAndDescription (/usr/app/packages/backend/src/services/UnfurlService/UnfurlService.ts:330:17)
packages/backend dev:       at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
packages/backend dev:       at async UnfurlService.unfurlDetails (/usr/app/packages/backend/src/services/UnfurlService/UnfurlService.ts:409:13)
packages/backend dev:       at async UnfurlService.unfurlImage (/usr/app/packages/backend/src/services/UnfurlService/UnfurlService.ts:486:25)
packages/backend dev:       at async CommercialSchedulerWorker.getNotificationPageData (/usr/app/packages/backend/src/scheduler/SchedulerTask.ts:372:41)
packages/backend dev:       at async CommercialSchedulerWorker.handleScheduledDelivery (/usr/app/packages/backend/src/scheduler/SchedulerTask.ts:2956:23)
packages/backend dev:       at async <anonymous> (/usr/app/packages/backend/src/scheduler/SchedulerWorker.ts:212:29)
packages/backend dev:       at async <anonymous> (/usr/app/packages/backend/src/scheduler/SchedulerClient.ts:164:41)
packages/backend dev:       at async <anonymous> (/usr/app/packages/backend/src/scheduler/SchedulerClient.ts:143:29)
packages/backend dev:       at async <anonymous> (/usr/app/packages/backend/src/scheduler/SchedulerClient.ts:137:21)
```

User doesn't get feedback about it.

### Description:
Added `ParameterError` to the list of non-retryable errors in the scheduler task. This ensures that when a parameter error occurs (e.g., when selected tabs no longer exist), the scheduler will be disabled rather than continuously retrying the operation. The change includes appropriate logging to indicate the reason for disabling the scheduler.

### Feedback to the user

![localhost_3000_generalSettings_projectManagement_3675b69e-8324-4110-bdca-059031aa8da3_scheduledDeliveries_tab=run-history&status=failed.png](https://app.graphite.com/user-attachments/assets/ddb7918d-0c43-4dbb-ade5-eb9c2c6cbfc6.png)

