### PR TITLE
fix: seq scans on search queries

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -41,6 +41,7 @@ import {
     shouldSearchForType,
 } from './utils/filters';
 import {
+    getFullTextSearchFilterSql,
     getFullTextSearchRankCalcSql,
     getRegexFromUserQuery,
     getTableOrFieldMatchCount,
@@ -76,6 +77,13 @@ export class SearchModel {
             },
         });
 
+        // Use GIN index filter to reduce rows before computing ts_rank_cd
+        const searchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: `${SpaceTableName}.search_vector`,
+            searchQuery: query,
+        });
+
         let subquery = this.database(SpaceTableName)
             .innerJoin(
                 ProjectTableName,
@@ -86,6 +94,7 @@ export class SearchModel {
                 search_rank: searchRankRawSql,
             })
             .where('projects.project_uuid', projectUuid)
+            .whereRaw(searchFilterSql)
             .orderBy('search_rank', 'desc');
 
         subquery = filterByCreatedAt(SpaceTableName, subquery, filters);
@@ -106,7 +115,6 @@ export class SearchModel {
         return this.database(SpaceTableName)
             .select()
             .from(subquery.as('spaces_with_rank'))
-            .where('search_rank', '>', 0)
             .limit(10);
     }
 
@@ -144,6 +152,26 @@ export class SearchModel {
                 searchVectorColumn: 'tile_charts.search_vector',
                 searchQuery: query,
             },
+            fullTextSearchOperator,
+        });
+
+        // GIN index filters - these use indexes instead of computing rank for all rows
+        const dashboardSearchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: `${DashboardsTableName}.search_vector`,
+            searchQuery: query,
+            fullTextSearchOperator,
+        });
+        const directChartSearchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: 'direct_charts.search_vector',
+            searchQuery: query,
+            fullTextSearchOperator,
+        });
+        const tileChartSearchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: 'tile_charts.search_vector',
+            searchQuery: query,
             fullTextSearchOperator,
         });
 
@@ -238,8 +266,12 @@ export class SearchModel {
                 { lastUpdatedByUserUuid: 'updated_by_user.user_uuid' },
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            // Use GIN index filters to reduce rows before computing ts_rank_cd.
+            // COALESCE is needed for chart filters because they come from LEFT JOINed tables -
+            // if a dashboard has no charts, search_vector is NULL and `NULL @@ tsquery` returns NULL.
+            // The dashboard filter doesn't need COALESCE since it's on the main table (always has a value).
             .whereRaw(
-                `(${dashboardSearchRankRawSql} > 0 OR ${directChartSearchRankRawSql} > 0 OR ${tileChartSearchRankRawSql} > 0)`,
+                `(${dashboardSearchFilterSql} OR COALESCE(${directChartSearchFilterSql}, false) OR COALESCE(${tileChartSearchFilterSql}, false))`,
             )
             .groupBy(
                 `${DashboardsTableName}.dashboard_id`,
@@ -279,7 +311,6 @@ export class SearchModel {
         const dashboards = await this.database(DashboardsTableName)
             .select()
             .from(subquery.as('dashboards_with_rank'))
-            .where('search_rank', '>', 0)
             .limit(10);
 
         const dashboardUuids = dashboards.map((dashboard) => dashboard.uuid);
@@ -327,7 +358,7 @@ export class SearchModel {
                 'dashboard_versions.dashboard_version_id',
                 'dashboard_tiles.dashboard_version_id',
             )
-            .join('dashboard_tile_charts', function () {
+            .join('dashboard_tile_charts', function joinTileCharts() {
                 this.on(
                     'dashboard_tile_charts.dashboard_version_id',
                     '=',
@@ -485,6 +516,14 @@ export class SearchModel {
             fullTextSearchOperator,
         });
 
+        // Use GIN index filter to reduce rows before computing ts_rank_cd
+        const searchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: `${tableName}.search_vector`,
+            searchQuery: query,
+            fullTextSearchOperator,
+        });
+
         // Needs to be a subquery to be able to use the search rank column to filter out 0 rank results
         let subquery = this.database(tableName)
             .leftJoin(
@@ -492,22 +531,22 @@ export class SearchModel {
                 `${tableName}.dashboard_uuid`,
                 `${DashboardsTableName}.dashboard_uuid`,
             )
-            .leftJoin(SpaceTableName, function joinSpaces() {
-                this.on(
-                    `${tableName}.space_uuid`,
-                    '=',
-                    `${SpaceTableName}.space_uuid`,
-                );
-                this.orOn(
-                    `${DashboardsTableName}.space_id`,
-                    '=',
-                    `${SpaceTableName}.space_id`,
-                );
-            })
+            // Two separate joins to avoid OR condition (which causes Cartesian product)
+            .leftJoin(
+                `${SpaceTableName} as direct_space`,
+                `${tableName}.space_uuid`,
+                `direct_space.space_uuid`,
+            )
+            .leftJoin(
+                `${SpaceTableName} as dashboard_space`,
+                `${DashboardsTableName}.space_id`,
+                `dashboard_space.space_id`,
+            )
             .innerJoin(
                 ProjectTableName,
-                `${ProjectTableName}.project_id`,
-                `${SpaceTableName}.project_id`,
+                this.database.raw(
+                    `${ProjectTableName}.project_id = COALESCE(direct_space.project_id, dashboard_space.project_id)`,
+                ),
             )
             .leftJoin(
                 `${UserTableName} as created_by_user`,
@@ -541,6 +580,7 @@ export class SearchModel {
                 { search_rank: searchRankRawSql },
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereRaw(searchFilterSql)
             .orderBy('search_rank', 'desc');
 
         subquery = filterByCreatedAt(tableName, subquery, filters);
@@ -556,7 +596,6 @@ export class SearchModel {
         const charts = await this.database(tableName)
             .select()
             .from(subquery.as('saved_charts_with_rank'))
-            .where('search_rank', '>', 0)
             .limit(10);
 
         return charts.map((chart) => ({
@@ -623,6 +662,14 @@ export class SearchModel {
             fullTextSearchOperator,
         });
 
+        // Use GIN index filter to reduce rows before computing ts_rank_cd
+        const searchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: `${SavedChartsTableName}.search_vector`,
+            searchQuery: query,
+            fullTextSearchOperator,
+        });
+
         // Needs to be a subquery to be able to use the search rank column to filter out 0 rank results
         let subquery = this.database(SavedChartsTableName)
             .leftJoin(
@@ -630,18 +677,12 @@ export class SearchModel {
                 `${SavedChartsTableName}.dashboard_uuid`,
                 `${DashboardsTableName}.dashboard_uuid`,
             )
-            .leftJoin(SpaceTableName, function joinSpaces() {
-                this.on(
-                    `${SavedChartsTableName}.space_id`,
-                    '=',
-                    `${SpaceTableName}.space_id`,
-                );
-                this.orOn(
-                    `${DashboardsTableName}.space_id`,
-                    '=',
-                    `${SpaceTableName}.space_id`,
-                );
-            })
+            .leftJoin(
+                SpaceTableName,
+                this.database.raw(
+                    `${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+                ),
+            )
             .innerJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,
@@ -686,6 +727,7 @@ export class SearchModel {
                 { lastUpdatedByUserUuid: 'updated_by_user.user_uuid' },
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereRaw(searchFilterSql)
             .orderBy('search_rank', 'desc');
 
         subquery = filterByCreatedAt(SavedChartsTableName, subquery, filters);
@@ -701,7 +743,6 @@ export class SearchModel {
         const savedCharts = await this.database(SavedChartsTableName)
             .select()
             .from(subquery.as('saved_charts_with_rank'))
-            .where('search_rank', '>', 0)
             .limit(10);
 
         const chartUuids = savedCharts.map((chart) => chart.uuid);
@@ -764,24 +805,26 @@ export class SearchModel {
             fullTextSearchOperator,
         });
 
+        // GIN index filter for saved charts
+        const savedChartsSearchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: `${SavedChartsTableName}.search_vector`,
+            searchQuery: query,
+            fullTextSearchOperator,
+        });
+
         const savedChartsSubquery = this.database(SavedChartsTableName)
             .leftJoin(
                 DashboardsTableName,
                 `${SavedChartsTableName}.dashboard_uuid`,
                 `${DashboardsTableName}.dashboard_uuid`,
             )
-            .leftJoin(SpaceTableName, function joinSpaces() {
-                this.on(
-                    `${SavedChartsTableName}.space_id`,
-                    '=',
-                    `${SpaceTableName}.space_id`,
-                );
-                this.orOn(
-                    `${DashboardsTableName}.space_id`,
-                    '=',
-                    `${SpaceTableName}.space_id`,
-                );
-            })
+            .leftJoin(
+                SpaceTableName,
+                this.database.raw(
+                    `${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+                ),
+            )
             .innerJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,
@@ -841,7 +884,8 @@ export class SearchModel {
                 },
                 this.database.raw('? as chart_source', ['saved']),
             )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid);
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereRaw(savedChartsSearchFilterSql);
 
         const savedSqlSearchRankRawSql = getFullTextSearchRankCalcSql({
             database: this.database,
@@ -852,28 +896,36 @@ export class SearchModel {
             fullTextSearchOperator,
         });
 
+        // GIN index filter for SQL charts
+        const savedSqlSearchFilterSql = getFullTextSearchFilterSql({
+            database: this.database,
+            searchVectorColumn: `${SavedSqlTableName}.search_vector`,
+            searchQuery: query,
+            fullTextSearchOperator,
+        });
+
         const savedSqlSubquery = this.database(SavedSqlTableName)
             .leftJoin(
                 DashboardsTableName,
                 `${SavedSqlTableName}.dashboard_uuid`,
                 `${DashboardsTableName}.dashboard_uuid`,
             )
-            .leftJoin(SpaceTableName, function joinSpaces() {
-                this.on(
-                    `${SavedSqlTableName}.space_uuid`,
-                    '=',
-                    `${SpaceTableName}.space_uuid`,
-                );
-                this.orOn(
-                    `${DashboardsTableName}.space_id`,
-                    '=',
-                    `${SpaceTableName}.space_id`,
-                );
-            })
+            // Two separate joins to avoid OR condition (which causes Cartesian product)
+            .leftJoin(
+                `${SpaceTableName} as direct_space`,
+                `${SavedSqlTableName}.space_uuid`,
+                `direct_space.space_uuid`,
+            )
+            .leftJoin(
+                `${SpaceTableName} as dashboard_space`,
+                `${DashboardsTableName}.space_id`,
+                `dashboard_space.space_id`,
+            )
             .innerJoin(
                 ProjectTableName,
-                `${ProjectTableName}.project_id`,
-                `${SpaceTableName}.project_id`,
+                this.database.raw(
+                    `${ProjectTableName}.project_id = COALESCE(direct_space.project_id, dashboard_space.project_id)`,
+                ),
             )
             .leftJoin(
                 `${UserTableName} as sql_chart_created_by_user`,
@@ -921,7 +973,8 @@ export class SearchModel {
                 ),
                 this.database.raw('? as chart_source', ['sql']),
             )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid);
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereRaw(savedSqlSearchFilterSql);
 
         // Type-safe union by ensuring both subqueries have identical column structure
         const unionQuery = this.database
@@ -974,7 +1027,6 @@ export class SearchModel {
                 }>
             >('*')
             .from(unionQuery.as('all_charts_with_rank'))
-            .where('search_rank', '>', 0)
             .orderBy('search_rank', 'desc')
             .limit(20);
 

--- a/packages/backend/src/models/SearchModel/utils/search.ts
+++ b/packages/backend/src/models/SearchModel/utils/search.ts
@@ -48,6 +48,37 @@ export function getFullTextSearchRankCalcSql({
 }
 
 /**
+ * Returns a raw SQL condition that uses the GIN index on search_vector.
+ * This should be used in a WHERE clause BEFORE computing ts_rank_cd to
+ * filter rows using the index, dramatically reducing the number of rows
+ * that need rank computation.
+ */
+export function getFullTextSearchFilterSql({
+    database,
+    searchVectorColumn,
+    searchQuery,
+    fullTextSearchOperator = 'AND',
+}: {
+    database: Knex;
+    searchVectorColumn: string;
+    searchQuery: string;
+    fullTextSearchOperator?: 'OR' | 'AND';
+}) {
+    const formattedQuery = getFullTextSearchQuery(
+        searchQuery,
+        fullTextSearchOperator,
+    );
+
+    return database.raw(
+        `:searchVectorColumn: @@ to_tsquery('lightdash_english_config', :searchQuery)`,
+        {
+            searchVectorColumn,
+            searchQuery: formattedQuery,
+        },
+    );
+}
+
+/**
  * Converts a natural language query to OR-based websearch query.
  * For example: "average cost" becomes "average OR cost"
  * This makes searches more permissive for better recall.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/PROD-1997/gcp-alert-cloud-sql-database-cpu-utilization

  ### Summary

  Optimizes search queries in `SearchModel` to avoid sequential scans

  ### Changes

  1. Added GIN index filter before rank computation - Uses `search_vector @@ to_tsquery()` to filter rows via the GIN index BEFORE computing `ts_rank_cd`, avoiding full table scans
  2. Replaced `OR` joins with `COALESCE` - Changed `space_id = chart.space_id OR space_id = dashboard.space_id` to `COALESCE(chart.space_id, dashboard.space_id)` to prevent Cartesian products

 ### Test plan

  Tested locally with 100k charts. 
`EXPLAIN ANALYZE` results for search with few matches:

  #### Before:
  Parallel Seq Scan on saved_queries
    Filter: ts_rank_cd(...) > 0
    Rows Removed by Filter: 33,337
  Execution Time: 46.65 ms

  #### After:
  Bitmap Index Scan on charts_search_vector_idx
    Index Cond: (search_vector @@ '''which'':*'::tsquery)
    rows=1
  Execution Time: 10.05 ms

  | Metric         | Before            | After             |
  |----------------|-------------------|-------------------|
  | Scan Type      | Parallel Seq Scan | Bitmap Index Scan |
  | Rows Scanned   | 33,337/worker     | 1                 |
  | Execution Time | 46.65 ms          | 10.05 ms          |
  | Speedup        | -                 | 4.6x              |

  The improvement is most significant for queries with few/no matches, meaning that it would have to scan through the whole table to find the matching rows, e.g.

![image.png](https://app.graphite.com/user-attachments/assets/254f88db-5574-450a-8616-08d33d84933a.png)

