### PR TITLE
fix: improve warehouse credentials compatibility and add Snowflake token backwards compatibility

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1110,22 +1110,27 @@ export class ProjectService extends BaseService {
 
             if (userWarehouseCredentials) {
                 // User has credentials - use them
+                credentials = {
+                    ...credentials,
+                    ...userWarehouseCredentials.credentials,
+                } as CreateWarehouseCredentials; // force type as typescript doesn't know the types match
+
+                // Backwards compatibility token for snowflake
                 if (
-                    credentials.type ===
-                    userWarehouseCredentials.credentials.type
+                    userWarehouseCredentials.credentials.type ===
+                        WarehouseTypes.SNOWFLAKE &&
+                    credentials.type === WarehouseTypes.SNOWFLAKE
                 ) {
                     credentials = {
                         ...credentials,
-                        ...userWarehouseCredentials.credentials,
-                    } as CreateWarehouseCredentials; // force type as typescript doesn't know the types match
-                } else {
-                    throw new UnexpectedServerError(
-                        'User warehouse credentials are not compatible',
-                    );
+                        refreshToken:
+                            userWarehouseCredentials.credentials.token,
+                    };
                 }
                 this.logger.debug(
                     `Using user warehouse credentials for user ${userId}`,
                 );
+
                 credentials = await this.refreshCredentials(
                     credentials,
                     userId,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

The method `findForProjectWithSecrets` to get user credentials is only used in this code, so this issue should not be happening in any other place

### Description:
Fixes a bug in the ProjectService where user warehouse credentials were not being properly merged with existing credentials. Now, all user credentials are merged first, and then a special case for Snowflake handles backward compatibility by copying the token to refreshToken. This removes the previous error that would occur when credential types didn't match exactly.