### PR TITLE
fix: use refreshToken consistently in ProjectService

### DIFF
--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1770,7 +1770,7 @@ export class UserService extends BaseService {
                 user: user.userUuid,
                 type: WarehouseTypes.SNOWFLAKE,
                 authenticationType: SnowflakeAuthenticationType.SSO,
-                token: refreshToken,
+                refreshToken,
             },
         };
         await this.createWarehouseCredentials(user, snowflakeCredentials);

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -1,4 +1,7 @@
+import { z } from 'zod';
 import {
+    SnowflakeAuthenticationType,
+    WarehouseTypes,
     type CreateBigqueryCredentials,
     type CreateClickhouseCredentials,
     type CreateDatabricksCredentials,
@@ -36,7 +39,11 @@ export type UserWarehouseCredentialsWithSecrets = Pick<
         | Pick<CreatePostgresCredentials, 'type' | 'user' | 'password'>
         | Pick<
               CreateSnowflakeCredentials,
-              'type' | 'user' | 'password' | 'authenticationType' | 'token'
+              | 'type'
+              | 'user'
+              | 'password'
+              | 'authenticationType'
+              | 'refreshToken'
           >
         | Pick<CreateTrinoCredentials, 'type' | 'user' | 'password'>
         | Pick<CreateClickhouseCredentials, 'type' | 'user' | 'password'>
@@ -50,7 +57,6 @@ export type UserWarehouseCredentialsWithSecrets = Pick<
               | 'personalAccessToken'
               | 'authenticationType'
               | 'refreshToken'
-              | 'token'
           > &
               Partial<
                   Pick<
@@ -64,3 +70,15 @@ export type UpsertUserWarehouseCredentials = {
     name: string;
     credentials: UserWarehouseCredentialsWithSecrets['credentials'];
 };
+
+// Zod schema for validating Snowflake SSO user warehouse credentials
+// Requires refreshToken and disallows token field
+export const snowflakeSsoUserCredentialsSchema = z
+    .object({
+        type: z.literal(WarehouseTypes.SNOWFLAKE),
+        user: z.string().optional(),
+        password: z.string().optional(),
+        authenticationType: z.literal(SnowflakeAuthenticationType.SSO),
+        refreshToken: z.string(),
+    })
+    .strict();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

List of changes: 

- `improvement`: UserService: new snowflake user warehouse credentials will be using `refreshToken` instead of `token`
- `improvement`: Added extra `clearSecretsFromCredentials` security method that removes all secrets from the project/org credentials before overriding the details with the user (in case there is a missmatch, the authentication will fail) 
- `bugfix`: Remove bug: args.refreshToken || args.token on `refreshToken` method.  We are only expecting `refreshToken` now 
- `bugfix`: UserWarehouseCredentialsModel: We throw errors when snowflake user oauth does not have refresh token , and force users to reauthenticate

<img width="1964" height="467" alt="Screenshot from 2025-12-18 11-23-51" src="https://github.com/user-attachments/assets/c9178c6a-d5f5-4443-ac56-66c66356c775" />

Added tests:

  1. User has refreshToken → works correctly, uses user token instead of project token
  2. User has token (old bug) → throws 'Error refreshing snowflake token'
  3. requireUserCredentials is false → uses project credentials


### Description:
Fixes a bug in the ProjectService where the refreshToken was incorrectly being set from either args.refreshToken or args.token. This PR removes the fallback to args.token and ensures we consistently use the refreshToken property when refreshing warehouse credentials.