### PR TITLE
style: update metrics catalog dark&light mode

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -105,7 +105,7 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
                     variant="subtle"
                     leftIcon={<TableFilled />}
                     fz="sm"
-                    c="ldDark.4"
+                    c="ldDark.7"
                     fw={500}
                     sx={{
                         '&[data-disabled]': {
@@ -116,6 +116,14 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
                     styles={(theme) => ({
                         leftIcon: {
                             marginRight: theme.spacing.xxs,
+                            color:
+                                theme.colorScheme === 'dark'
+                                    ? theme.colors.ldDark[7]
+                                    : theme.colors.ldGray[4],
+                            '--table-icon-stroke':
+                                theme.colorScheme === 'dark'
+                                    ? theme.colors.ldDark[4]
+                                    : 'white',
                         },
                     })}
                 >

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -384,7 +384,10 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
         padding: `${theme.spacing.xxs} 10px ${theme.spacing.xxs} ${theme.spacing.xs}`,
         fontSize: theme.fontSizes.sm,
         fontWeight: 500,
-        color: theme.colors.ldGray[7],
+        color:
+            theme.colorScheme === 'dark'
+                ? theme.colors.ldDark[9]
+                : theme.colors.ldGray[7],
     };
 
     return (

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -125,7 +125,7 @@ const SortableColumn: FC<{
                     fz={13}
                     radius="md"
                     fw={500}
-                    color="ldDark.5"
+                    color="ldDark.9"
                 >
                     {column.name}
                 </Text>

--- a/packages/frontend/src/svgs/metricsCatalog/table-filled.svg
+++ b/packages/frontend/src/svgs/metricsCatalog/table-filled.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="2.5" y="2.5" width="11" height="11" rx="1" fill="#ced4da"/>
-  <path d="M2.5 6.5H13.5" stroke="white" stroke-width="1.5"/>
-  <path d="M6.5 2.5V13.5" stroke="white" stroke-width="1.5"/>
+  <rect x="2.5" y="2.5" width="11" height="11" rx="1" fill="currentColor"/>
+  <path d="M2.5 6.5H13.5" stroke="var(--table-icon-stroke, white)" stroke-width="1.5"/>
+  <path d="M6.5 2.5V13.5" stroke="var(--table-icon-stroke, white)" stroke-width="1.5"/>
 </svg>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2074](https://linear.app/lightdash/issue/PROD-2074/dark-mode-reduces-readability-of-table-names-in-metrics-catalog)

### Description:
Improved dark mode support for the Metrics Catalog UI by:

- Updated color values in MetricsCatalogColumns to use `ldDark.7` instead of `ldDark.4` for better contrast
- Enhanced table icon styling with dynamic color based on theme
- Added theme-aware color handling in MetricsCatalogPanel text
- Updated column header text in MetricsTableTopToolbar to use `ldDark.9` for better visibility
- Modified the table-filled SVG to use CSS variables and currentColor for proper theme integration

These changes ensure consistent appearance and improved readability across both light and dark themes.

![Screenshot 2025-12-17 at 18.56.14.png](https://app.graphite.com/user-attachments/assets/a8ba27f9-c1b5-4ff1-b917-ab0126b1dff7.png)

![Screenshot 2025-12-17 at 18.56.41.png](https://app.graphite.com/user-attachments/assets/af59cb0d-41bc-4d32-a840-8effd00c4de5.png)

![Screenshot 2025-12-17 at 18.56.24.png](https://app.graphite.com/user-attachments/assets/c7c8e071-5800-497e-a277-8a94aa7e02ba.png)

![Screenshot 2025-12-17 at 18.56.20.png](https://app.graphite.com/user-attachments/assets/e090bbb1-6bb4-4c9e-9ca1-94bb6e5892a6.png)

