### PR TITLE
fix: disable scheduled delivery if all MS teams deliveries fail

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1,6 +1,7 @@
 import {
     type Account as AccountType,
-    AllMSTeamsDeliveriesFailed,
+    AllMSTeamsDeliveriesFailedError,
+    AllSlackDeliveriesFailedError,
     AnyType,
     type BatchDeliveryResult,
     CompileProjectPayload,
@@ -3088,7 +3089,8 @@ export default class SchedulerTask {
                 e instanceof FieldReferenceError ||
                 e instanceof WarehouseConnectionError ||
                 e instanceof ParameterError ||
-                e instanceof AllMSTeamsDeliveriesFailed
+                e instanceof AllMSTeamsDeliveriesFailedError ||
+                e instanceof AllSlackDeliveriesFailedError
             ) {
                 // This captures both the error from thresholdAlert and metricQuery
                 // WarehouseConnectionError indicates misconfigured credentials (wrong password, unreachable host, etc.)
@@ -3497,7 +3499,7 @@ export default class SchedulerTask {
                 batchResult,
                 notification.projectUuid,
             );
-            throw new Error(
+            throw new AllSlackDeliveriesFailedError(
                 `All Slack deliveries failed: ${results
                     .map((r) => r.error)
                     .join(', ')}`,
@@ -3896,7 +3898,7 @@ export default class SchedulerTask {
                 batchResult,
                 notification.projectUuid,
             );
-            throw new AllMSTeamsDeliveriesFailed(
+            throw new AllMSTeamsDeliveriesFailedError(
                 `All MS Teams deliveries failed: ${results
                     .map((r) => r.error)
                     .join(', ')}`,

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -397,6 +397,20 @@ export class SlackError extends LightdashError {
     }
 }
 
+export class AllSlackDeliveriesFailedError extends LightdashError {
+    constructor(
+        message: string = 'All Slack deliveries failed',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'AllSlackDeliveriesFailedError',
+            statusCode: 400,
+            data,
+        });
+    }
+}
+
 export class MsTeamsError extends LightdashError {
     constructor(
         message: string = 'Microsoft Teams API error occurred',
@@ -411,7 +425,7 @@ export class MsTeamsError extends LightdashError {
     }
 }
 
-export class AllMSTeamsDeliveriesFailed extends LightdashError {
+export class AllMSTeamsDeliveriesFailedError extends LightdashError {
     constructor(
         message: string = 'All MS Teams deliveries failed',
         data: { [key: string]: AnyType } = {},


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1608
Closes: PROD-1606

### Description:
This PR adds a new `AllMSTeamsDeliveriesFailed` error class to better handle cases where all MS Teams deliveries fail. Instead of throwing a generic Error, we now throw this specific error type which allows for better error handling and user feedback. The error is also properly caught in the scheduler task to ensure consistent error handling alongside other error types like `FieldReferenceError`, `WarehouseConnectionError`, and `ParameterError`.