### PR TITLE
fix: skip embedding generator if text is empty

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/embeddingGenerator.ts
@@ -62,6 +62,11 @@ export async function generateEmbedding(
     provider: string;
     modelName: string;
 } | null> {
+    const trimmedText = text.trim();
+    if (!trimmedText) {
+        return null;
+    }
+
     const embeddingModelConfig = getEmbeddingModelConfig(config);
     if (!embeddingModelConfig) {
         return null;
@@ -70,7 +75,7 @@ export async function generateEmbedding(
 
     let { embedding } = await embed({
         model,
-        value: text.trim(),
+        value: trimmedText,
         experimental_telemetry: {
             functionId: 'generateEmbedding',
             isEnabled: true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-169](https://linear.app/lightdash/issue/ZAP-169/ai-apicallerror-dollarinput-is-invalid-please-check-the-api-reference)

### Description:



Ref: https://community.openai.com/t/embedding-api-change-input-is-invalid/707490

Problem: The OpenAI embedding API throws '$.input' is invalid when it receives an empty string.

Root cause: When a Slack prompt has empty or whitespace-only text, the generateEmbedding function was calling text.trim() which produced an empty string, then passed this directly to OpenAI's API.

Fix: Added an early validation check in generateEmbedding that returns null for empty/whitespace strings before making the API call. This is consistent with the existing pattern (the function already returns null when no embedding model is configured).