### PR TITLE
style: update saved charts header

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -369,7 +369,7 @@ const SavedChartsHeader: FC = () => {
                                     dashboardName={savedChart.dashboardName}
                                 />
                                 <Title
-                                    c="ldGray.8"
+                                    c="ldDark.9"
                                     order={5}
                                     fw={600}
                                     truncate


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Updated the color of the saved chart title from `ldGray.8` to `ldDark.9` to improve contrast and readability in the Explorer's SavedChartsHeader component.

![Screenshot 2025-12-18 at 13.54.23.png](https://app.graphite.com/user-attachments/assets/bfce1d81-1909-49e7-9095-3b67c1b4eb42.png)

http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/dashboards/aaba1848-0ee8-42d8-ae48-65b1cdc7992f/view