### PR TITLE
style: update pop button light/dark

### DIFF
--- a/packages/frontend/src/components/PeriodOverPeriodButton.tsx
+++ b/packages/frontend/src/components/PeriodOverPeriodButton.tsx
@@ -235,13 +235,13 @@ const PeriodOverPeriodButton: FC<Props> = memo(({ itemsMap, disabled }) => {
                             setOpened(!opened);
                         }}
                         variant={periodOverPeriod ? 'light' : 'subtle'}
-                        color={periodOverPeriod ? 'blue' : 'gray'}
+                        color={periodOverPeriod ? 'blue' : 'ldDark.9'}
                         rightIcon={<BetaBadge />}
                         styles={(theme) => ({
                             root: periodOverPeriod
                                 ? {}
                                 : {
-                                      border: `1px dashed ${theme.colors.gray[4]}`,
+                                      border: `1px dashed ${theme.colors.ldGray[4]}`,
                                   },
                         })}
                     >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Updated the color scheme in the PeriodOverPeriodButton component to use the design system colors. Changed the inactive button color from 'gray' to 'ldDark.9' and updated the border color from 'theme.colors.gray[4]' to 'theme.colors.ldGray[4]' for better consistency with our design system.

![Screenshot 2025-12-18 at 11.46.32.png](https://app.graphite.com/user-attachments/assets/0803d22d-e6d6-4a53-941c-65c71f440473.png)

![Screenshot 2025-12-18 at 11.46.28.png](https://app.graphite.com/user-attachments/assets/3bf5f662-f5b7-476e-b535-74978918c05d.png)

