### PR TITLE
style: update pagebreadcrumbs light/dark

### DIFF
--- a/packages/frontend/src/components/common/PageBreadcrumbs.tsx
+++ b/packages/frontend/src/components/common/PageBreadcrumbs.tsx
@@ -48,7 +48,7 @@ const PageBreadcrumbs: FC<PageBreadcrumbsProps> = ({
                     HTMLAttributes<HTMLAnchorElement> = {
                     size: size,
                     fw: item.active ? 600 : 500,
-                    color: item.active ? 'ldGray.7' : 'ldGray.6',
+                    color: item.active ? 'ldGray.9' : 'ldGray.6',
                     onClick: item.onClick,
                     sx: {
                         whiteSpace: 'normal',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Darkens the active breadcrumb text color from `ldGray.7` to `ldGray.9` to improve contrast and visibility for active items in the navigation path.


![Screenshot 2025-12-18 at 11.48.30.png](https://app.graphite.com/user-attachments/assets/8ed72fad-75a5-4b6a-a036-9a883e6ed7e2.png)

![Screenshot 2025-12-18 at 11.49.16.png](https://app.graphite.com/user-attachments/assets/6af94c7c-2c21-473c-9959-289224b54d89.png)

![Screenshot 2025-12-18 at 11.49.13.png](https://app.graphite.com/user-attachments/assets/6289a63a-0075-42be-82bd-75698edf55c5.png)

![Screenshot 2025-12-18 at 11.48.34.png](https://app.graphite.com/user-attachments/assets/36e44b24-e09e-4c19-be19-016b878a404d.png)

