### PR TITLE
style: update admin content view filter light/dark

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/AdminContentViewFilter.tsx
+++ b/packages/frontend/src/components/common/ResourceView/AdminContentViewFilter.tsx
@@ -48,7 +48,7 @@ const AdminContentViewFilter: React.FC<AdminContentViewFilterProps> = ({
                         value: 'shared',
                         label: (
                             <Center px={'xxs'}>
-                                <Text size="sm" color="ldGray.7">
+                                <Text size="sm" color="ldDark.9">
                                     Shared with me
                                 </Text>
                             </Center>
@@ -71,7 +71,7 @@ const AdminContentViewFilter: React.FC<AdminContentViewFilterProps> = ({
                                         color="ldGray.6"
                                     />
                                 </Tooltip>
-                                <Text size="sm" color="ldGray.7" ml={'xxs'}>
+                                <Text size="sm" color="ldDark.9" ml={'xxs'}>
                                     Admin Content View
                                 </Text>
                             </Center>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:

Updated text color from `ldGray.7` to `ldDark.9` for "Shared with me" and "Admin Content View" labels in the AdminContentViewFilter component to improve readability and maintain consistent styling.

![Screenshot 2025-12-18 at 11.51.33.png](https://app.graphite.com/user-attachments/assets/e641c2b9-8a89-426e-b098-4bb29db9ebae.png)

![Screenshot 2025-12-18 at 11.51.30.png](https://app.graphite.com/user-attachments/assets/7ee6890c-2a6c-49e9-9a8f-8106fcf754ff.png)

