### PR TITLE
fix: prevent same field selection for x-axis and group-by

### DIFF
--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -292,16 +292,23 @@ export const CartesianChartFieldConfiguration = ({
         cartesianChartSelectors.getErrors(state, selectedChartType),
     );
 
+    const filteredXLayoutOptions = xLayoutOptions?.filter(
+        (option) => option.reference !== groupByField?.reference,
+    );
+    const filteredGroupByOptions = groupByLayoutOptions?.filter(
+        (option) => option.reference !== xAxisField?.reference,
+    );
+
     return (
         <Stack spacing="xl" mt="sm">
             <Config>
                 <Config.Section>
                     <Config.Heading>{`X-axis`}</Config.Heading>
-                    {xLayoutOptions && (
+                    {filteredXLayoutOptions && (
                         <XFieldAxisConfig
                             columns={columns}
                             field={xAxisField}
-                            xLayoutOptions={xLayoutOptions}
+                            xLayoutOptions={filteredXLayoutOptions}
                             actions={actions}
                             error={errors?.indexFieldError}
                         />
@@ -352,7 +359,7 @@ export const CartesianChartFieldConfiguration = ({
                     <GroupByFieldAxisConfig
                         columns={columns}
                         field={groupByField}
-                        groupByOptions={groupByLayoutOptions}
+                        groupByOptions={filteredGroupByOptions}
                         actions={actions}
                         error={errors?.groupByFieldError}
                     />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-109 / LIGHTDASH-BACKEND-B3V

### Description:
Prevents the same field from being selected for both X-axis and Group By in CartesianChartFieldConfiguration by filtering out options that are already selected in the other field. This ensures users can't select the same field for both configurations, avoiding potential conflicts in chart visualization.

### Before

![Screenshot 2025-12-18 at 15.23.22.png](https://app.graphite.com/user-attachments/assets/a40d658c-c8d6-43b9-8106-0382c8b8a574.png)

Failing with error:
```
packages/backend dev: 2025-12-18 14:23:16 [Lightdash] error: Handled error of type ParameterError on [POST] /api/v2/projects/3675b69e-8324-4110-bdca-059031aa8da3/query/sql Group column(s) cannot also be part of the index column(s): orders_status
packages/backend dev: 2025-12-18 14:23:16 [Lightdash] error: ParameterError: Group column(s) cannot also be part of the index column(s): orders_status
packages/backend dev:     at PivotQueryBuilder.toSql (/usr/app/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts:693:23)
packages/backend dev:     at <anonymous> (/usr/app/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts:1784:58)
packages/backend dev:     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
packages/backend dev:     at async <anonymous> (/usr/app/packages/backend/src/utils.ts:48:24)
packages/backend dev:     at async AsyncQueryService.executeAsyncSqlQuery (/usr/app/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts:2862:46)
packages/backend dev:     at async QueryController.executeAsyncSqlQuery (/usr/app/packages/backend/src/controllers/v2/QueryController.ts:327:25)
packages/backend dev:     at async ExpressTemplateService.apiHandler (/usr/app/node_modules/.pnpm/@tsoa+runtime@6.6.0/node_modules/@tsoa/runtime/src/routeGeneration/templates/express/expressTemplateService.ts:37:20)
packages/backend dev:     at async QueryController_executeAsyncSqlQuery (/usr/app/packages/backend/src/generated/routes.ts:45347:17)
```

### After
No `order_status` in group by:
<img width="1328" height="876" alt="Screenshot 2025-12-18 at 15 28 18" src="https://github.com/user-attachments/assets/ef68c881-455d-483c-9771-b90dbf183acd" />


No `orders_shipping_method` in X-axis:
![Screenshot 2025-12-18 at 15.23.51.png](https://app.graphite.com/user-attachments/assets/e4693130-d07b-45fd-8efd-00b51976901a.png)

