### PR TITLE
fix: update Mantine import path and add onDismiss handler to popovers

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
@@ -14,7 +14,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { useDisclosure, useId } from '@mantine/hooks';
+import { useDisclosure, useId } from '@mantine-8/hooks';
 import { IconGripVertical, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import {
@@ -159,6 +159,7 @@ const Filter: FC<Props> = ({
                 closeOnEscape={!isSubPopoverOpen}
                 closeOnClickOutside={!isSubPopoverOpen}
                 onClose={handleClose}
+                onDismiss={!isSubPopoverOpen ? handleClose : undefined}
                 disabled={disabled}
                 transitionProps={{ transition: 'pop-top-left' }}
                 withArrow

--- a/packages/frontend/src/features/dashboardFiltersV2/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/AddFilterButton.tsx
@@ -95,6 +95,7 @@ const AddFilterButton: FC<Props> = ({
                 closeOnEscape={!isSubPopoverOpen}
                 closeOnClickOutside={!isSubPopoverOpen}
                 onClose={handleClose}
+                onDismiss={!isSubPopoverOpen ? handleClose : undefined}
                 disabled={disabled}
                 transitionProps={{ transition: 'pop-top-left' }}
                 withArrow


### PR DESCRIPTION
### Description:
This PR updates the import path for Mantine hooks from `@mantine/hooks` to `@mantine-8/hooks` to maintain consistency with other Mantine imports. Additionally, it adds the `onDismiss` prop to Popovers in the Filter and AddFilterButton components to properly handle closing when the user clicks outside or presses escape, but only when no sub-popover is open.