### PR TITLE
feat: add actions to map popovers

### DIFF
--- a/packages/frontend/src/components/SimpleMap/SimpleMap.module.css
+++ b/packages/frontend/src/components/SimpleMap/SimpleMap.module.css
@@ -135,3 +135,34 @@
         color: var(--mantine-color-ldGray-5);
     }
 }
+
+/* Match popup border-radius to tooltip (3px) and reduce horizontal padding */
+:global(.leaflet-popup-content-wrapper) {
+    border-radius: 3px !important;
+}
+
+:global(.leaflet-popup-content) {
+    margin: 13px 10px !important;
+}
+
+:global(.leaflet-popup-tip) {
+    /* Slightly reduce the popup tip to match the smaller radius */
+    width: 14px !important;
+    height: 14px !important;
+}
+
+/* Popup action button styles */
+/* Force light mode colors since Leaflet popups are always white background */
+.popupActionButton {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    padding: var(--mantine-spacing-xxs) var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+    width: 100%;
+    color: var(--mantine-color-ldGray-7);
+
+    &:hover {
+        background-color: var(--mantine-color-gray-1);
+    }
+}

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -1,5 +1,7 @@
 import { MapChartType } from '@lightdash/common';
-import { IconMap } from '@tabler/icons-react';
+import { Box, Divider, Text, UnstyledButton } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import { IconCopy, IconMap } from '@tabler/icons-react';
 import { scaleSqrt } from 'd3-scale';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -13,25 +15,156 @@ import {
     type FC,
     type RefObject,
 } from 'react';
+import { renderToString } from 'react-dom/server';
 import {
     CircleMarker,
     GeoJSON,
     MapContainer,
     Popup,
     TileLayer,
+    Tooltip,
     useMap,
 } from 'react-leaflet';
 import * as topojson from 'topojson-client';
 import type { Topology } from 'topojson-specification';
-import useLeafletMapConfig from '../../hooks/leaflet/useLeafletMapConfig';
+import useLeafletMapConfig, {
+    type ScatterPoint,
+} from '../../hooks/leaflet/useLeafletMapConfig';
+import useToaster from '../../hooks/toaster/useToaster';
 import { isMapVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import LoadingChart from '../common/LoadingChart';
+import MantineIcon from '../common/MantineIcon';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import HeatmapLayer from './HeatmapLayer';
 import MapLegend from './MapLegend';
 // eslint-disable-next-line css-modules/no-unused-class
 import classes from './SimpleMap.module.css';
+
+// Shared tooltip content component
+type MapTooltipContentProps = {
+    label: string;
+    value: string | number;
+    lat?: number;
+    lon?: number;
+};
+
+const MapTooltipContent: FC<MapTooltipContentProps> = ({
+    label,
+    value,
+    lat,
+    lon,
+}) => (
+    <Box>
+        <Text size="sm">
+            <strong>{label}:</strong> {value}
+        </Text>
+        {lat !== undefined && lon !== undefined && (
+            <Text size="xs" c="dimmed" mt="sm">
+                Lat: {lat.toFixed(4)}, Lon: {lon.toFixed(4)}
+            </Text>
+        )}
+    </Box>
+);
+
+// Shared popup content component
+type MapPopupContentProps = {
+    label: string;
+    value: string | number;
+    lat?: number;
+    lon?: number;
+    onCopy?: () => void;
+};
+
+const MapPopupContent: FC<MapPopupContentProps> = ({
+    label,
+    value,
+    lat,
+    lon,
+    onCopy,
+}) => (
+    // Force light mode colors since Leaflet popups always have white background
+    <Box mt="xl" c="dark.7">
+        <Text size="sm">
+            <strong>{label}:</strong> {value}
+        </Text>
+        {lat !== undefined && lon !== undefined && (
+            <Text size="xs" c="gray.6" mt="sm" mb="md">
+                Lat: {lat.toFixed(4)}, Lon: {lon.toFixed(4)}
+            </Text>
+        )}
+        <Divider my="xs" c="gray.3" />
+        <UnstyledButton
+            onClick={onCopy}
+            data-copy-value={value}
+            className={classes.popupActionButton}
+        >
+            <MantineIcon icon={IconCopy} />
+            <Text size="sm">Copy value</Text>
+        </UnstyledButton>
+    </Box>
+);
+
+// MapMarker component for scatter points with tooltip/popup behavior
+type MapMarkerProps = {
+    point: ScatterPoint;
+    radius: number;
+    color: string;
+    valueFieldLabel: string;
+};
+
+const MapMarker: FC<MapMarkerProps> = ({
+    point,
+    radius,
+    color,
+    valueFieldLabel,
+}) => {
+    const [isPopupOpen, setIsPopupOpen] = useState(false);
+    const clipboard = useClipboard({ timeout: 200 });
+    const { showToastSuccess } = useToaster();
+
+    const handleCopy = useCallback(() => {
+        clipboard.copy(String(point.displayValue));
+        showToastSuccess({ title: 'Copied to clipboard!' });
+    }, [clipboard, point.displayValue, showToastSuccess]);
+
+    return (
+        <CircleMarker
+            center={[point.lat, point.lon]}
+            radius={radius}
+            pathOptions={{
+                fillColor: color,
+                color: '#fff',
+                fillOpacity: 0.7,
+                weight: 1,
+            }}
+            eventHandlers={{
+                popupopen: () => setIsPopupOpen(true),
+                popupclose: () => setIsPopupOpen(false),
+            }}
+        >
+            {!isPopupOpen && (
+                <Tooltip>
+                    <MapTooltipContent
+                        label={valueFieldLabel}
+                        value={point.displayValue}
+                        lat={point.lat}
+                        lon={point.lon}
+                    />
+                </Tooltip>
+            )}
+            <Popup>
+                <MapPopupContent
+                    label={valueFieldLabel}
+                    value={point.displayValue}
+                    lat={point.lat}
+                    lon={point.lon}
+                    onCopy={handleCopy}
+                />
+            </Popup>
+        </CircleMarker>
+    );
+};
 
 // Component to capture the Leaflet map instance and store it in the ref
 const MapRefUpdater: FC<{ mapRef: RefObject<L.Map | null> }> = ({ mapRef }) => {
@@ -324,6 +457,27 @@ const SimpleMap: FC<SimpleMapProps> = memo(
 
         const isHeatmap = mapConfig?.locationType === MapChartType.HEATMAP;
 
+        // Shared copy handler for popup buttons
+        const clipboard = useClipboard({ timeout: 200 });
+        const { showToastSuccess } = useToaster();
+
+        const handlePopupCopyClick = useCallback(
+            (e: MouseEvent) => {
+                const target = e.target as HTMLElement;
+                const button = target.closest(
+                    '[data-copy-value]',
+                ) as HTMLElement | null;
+                if (button) {
+                    const value = button.dataset.copyValue;
+                    if (value) {
+                        clipboard.copy(value);
+                        showToastSuccess({ title: 'Copied to clipboard!' });
+                    }
+                }
+            },
+            [clipboard, showToastSuccess],
+        );
+
         // Memoize choropleth/area mode calculations
         const regionData = useMemo(
             () => mapConfig?.regionData || [],
@@ -399,7 +553,25 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     'Unknown';
                 const value = regionDataMap.get(name.toLowerCase());
 
+                const valueLabel = mapConfig?.valueFieldLabel || 'Value';
+                const displayValue = value !== undefined ? value : 'No data';
+                // eslint-disable-next-line testing-library/render-result-naming-convention
+                const tooltipHtml = renderToString(
+                    <MapTooltipContent
+                        label={valueLabel}
+                        value={displayValue}
+                    />,
+                );
+                // eslint-disable-next-line testing-library/render-result-naming-convention
+                const popupHtml = renderToString(
+                    <MapPopupContent label={valueLabel} value={displayValue} />,
+                );
+
                 if (layer instanceof L.Path) {
+                    // Bind both tooltip (hover) and popup (click)
+                    layer.bindTooltip(tooltipHtml);
+                    layer.bindPopup(popupHtml);
+
                     layer.on({
                         mouseover: () => {
                             layer.setStyle({
@@ -413,20 +585,31 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                                 fillOpacity: 0.7,
                             });
                         },
+                        popupopen: (e) => {
+                            // Hide tooltip when popup is open
+                            layer.closeTooltip();
+                            layer.unbindTooltip();
+                            // Add click handler for copy button
+                            const popupElement = e.popup.getElement();
+                            popupElement?.addEventListener(
+                                'click',
+                                handlePopupCopyClick,
+                            );
+                        },
+                        popupclose: (e) => {
+                            // Remove click handler to prevent memory leak
+                            const popupElement = e.popup.getElement();
+                            popupElement?.removeEventListener(
+                                'click',
+                                handlePopupCopyClick,
+                            );
+                            // Re-bind tooltip when popup is closed
+                            layer.bindTooltip(tooltipHtml);
+                        },
                     });
                 }
-
-                const valueLabel = mapConfig?.valueFieldLabel || 'Value';
-                const popupContent = `
-                <div>
-                    <strong>${name}</strong><br/>
-                    ${valueLabel}: ${value !== undefined ? value : 'No data'}
-                </div>
-            `;
-
-                (layer as L.Path).bindPopup(popupContent);
             },
-            [regionDataMap, mapConfig?.valueFieldLabel],
+            [regionDataMap, mapConfig?.valueFieldLabel, handlePopupCopyClick],
         );
 
         if (isLoading) {
@@ -506,39 +689,17 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                                                       .length / 2,
                                               )
                                           ];
+
                                 return (
-                                    <CircleMarker
+                                    <MapMarker
                                         key={idx}
-                                        center={[point.lat, point.lon]}
+                                        point={point}
                                         radius={radius}
-                                        pathOptions={{
-                                            fillColor: color,
-                                            fillOpacity: 0.7,
-                                            color: '#fff',
-                                            weight: 1,
-                                        }}
-                                    >
-                                        <Popup>
-                                            <div>
-                                                <strong>
-                                                    {mapConfig.valueFieldLabel ||
-                                                        'Value'}
-                                                    :
-                                                </strong>{' '}
-                                                {point.displayValue}
-                                                <br />
-                                                <span
-                                                    style={{
-                                                        fontSize: '0.85em',
-                                                        opacity: 0.7,
-                                                    }}
-                                                >
-                                                    Lat: {point.lat.toFixed(4)},
-                                                    Lon: {point.lon.toFixed(4)}
-                                                </span>
-                                            </div>
-                                        </Popup>
-                                    </CircleMarker>
+                                        color={color}
+                                        valueFieldLabel={
+                                            mapConfig.valueFieldLabel || 'Value'
+                                        }
+                                    />
                                 );
                             })
                         )}


### PR DESCRIPTION
### Description:

- Splits map interactions into tooltips on hover, and popovers with actions on click (before we only had popovers)
- Popover shows the tooltip info + actions. This makes the map interaction more similar to other charts where there is a hover tooltip and an action menu
- Adds a copy value action. This is kind of preparation for adding other actions as well.

[Here is a localhost repro](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/airports?create_saved_chart_version=%7B%22tableName%22%3A%22airports%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22airports%22%2C%22dimensions%22%3A%5B%22airports_lon%22%2C%22airports_lat%22%2C%22airports_volume%22%5D%2C%22metrics%22%3A%5B%22airports_total_passenger_volume%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22airports_lon%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A5000%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22airports_lon%22%2C%22airports_lat%22%2C%22airports_volume%22%2C%22airports_total_passenger_volume%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22map%22%2C%22config%22%3A%7B%22mapType%22%3A%22world%22%2C%22locationType%22%3A%22scatter%22%2C%22latitudeFieldId%22%3A%22airports_lat%22%2C%22longitudeFieldId%22%3A%22airports_lon%22%2C%22colorRange%22%3A%5B%22%23228be6%22%2C%22%23fa5252%22%5D%2C%22showLegend%22%3Afalse%2C%22saveMapExtent%22%3Atrue%2C%22defaultZoom%22%3A4%2C%22defaultCenterLat%22%3A53.51418452077113%2C%22defaultCenterLon%22%3A-23.598632812500004%2C%22tileBackground%22%3A%22light%22%7D%7D%7D&isExploreFromHere=true)

![Kapture 2025-12-18 at 16 49 19](https://github.com/user-attachments/assets/6b61b890-d0a3-4daf-933e-d5e207ddcbda)
