### PR TITLE
fix: skip Slack channel sync when Slack is not configured

### DIFF
--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -942,6 +942,13 @@ export class SchedulerWorker extends SchedulerTask {
                 _payload,
                 helpers,
             ) => {
+                if (!this.slackClient.isEnabled) {
+                    Logger.info(
+                        'Skipping Slack channel sync generation: Slack is not configured',
+                    );
+                    return;
+                }
+
                 Logger.info('Starting daily Slack channel sync job generation');
 
                 // Get all organizations with Slack installations


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1985 / LIGHTDASH-BACKEND-BDE

### Description:
Skip Slack channel sync job when Slack is not configured. This guards the job from execution and logs a message indicating why the sync was skipped. This way we prevent further execution down the codepath that would throw `MissingConfigError: Slack is not configured`.