### PR TITLE
fix: add user session validation in getSpaces endpoint

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -18,6 +18,7 @@ import {
     ApiSqlChartAsCodeUpsertResponse,
     ApiSqlQueryResults,
     ApiSuccessEmpty,
+    AuthorizationError,
     CalculateTotalFromQuery,
     ChartAsCode,
     CreateProjectMember,
@@ -166,12 +167,15 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
     ): Promise<ApiSpaceSummaryListResponse> {
+        if (!req.user) {
+            throw new AuthorizationError('User session not found');
+        }
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.services
                 .getProjectService()
-                .getSpaces(req.user!, projectUuid),
+                .getSpaces(req.user, projectUuid),
         };
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2098 / LIGHTDASH-BACKEND-BFH

### Description:
Added proper error handling for missing user sessions in the ProjectController's getSpaces endpoint. Now, when a user session is not found, the API will throw an AuthorizationError with a clear message instead of potentially causing a runtime error. Also imported the AuthorizationError class to support this change.