### PR TITLE
chore: change space share modal users dropdown load button

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -301,7 +301,8 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                                 {(hasUsersNextPage || hasGroupsNextPage) && (
                                     <Button
                                         size="xs"
-                                        variant="white"
+                                        variant="default"
+                                        fullWidth
                                         onClick={async () => {
                                             await Promise.all([
                                                 fetchGroupsNextPage(),
@@ -313,8 +314,14 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                                             isUsersFetching ||
                                             isGroupsFetching
                                         }
+                                        mt="xs"
+                                        sx={(theme) => ({
+                                            borderRadius: 0,
+                                            border: 0,
+                                            borderTop: `1px solid ${theme.colors.ldGray[2]}`,
+                                        })}
                                     >
-                                        <Text>Load more</Text>
+                                        Load more
                                     </Button>
                                 )}
                             </>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Improved the styling of the "Load more" button in the ShareSpaceAddUser component by:
- Changed button variant from "white" to "default"
- Made the button full width
- Added top margin
- Removed the Text wrapper component
- Added custom styling with no border radius, no side/bottom borders, and a light gray top border

This creates a cleaner, more integrated look for the load more functionality in the user selection interface.

**Before**
![Screenshot 2025-12-18 at 16.56.02.png](https://app.graphite.com/user-attachments/assets/99111aa7-0219-4e80-b4fd-e51e869ebd12.png)

**After**

![Screenshot 2025-12-18 at 17.07.03.png](https://app.graphite.com/user-attachments/assets/73eafac7-4ea7-4ad3-b157-30439e752844.png)

![Screenshot 2025-12-18 at 17.07.10.png](https://app.graphite.com/user-attachments/assets/7de4af93-63e4-44b7-9f0c-596cf2db5646.png)

