### PR TITLE
feat: add ability to hide date zoom in dashboard

### DIFF
--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -146,6 +146,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
     const filterableFieldsByTileUuid = useDashboardContext(
         (c) => c.filterableFieldsByTileUuid,
     );
+    const isDateZoomDisabled = useDashboardContext((c) => c.isDateZoomDisabled);
 
     // tabs state
     const [isEditingTab, setEditingTab] = useState<boolean>(false);
@@ -620,40 +621,44 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                             )}
                                         </Group>
 
-                                        {/* DateZoom section will adjust width dynamically */}
-                                        {hasDashboardTiles && (
-                                            <Group
-                                                gap="xs"
-                                                style={{ marginLeft: 'auto' }}
-                                                wrap="nowrap"
-                                            >
-                                                <Divider orientation="vertical" />
+                                        {hasDashboardTiles &&
+                                            (!isDateZoomDisabled ||
+                                                isEditMode) && (
+                                                <Group
+                                                    gap="xs"
+                                                    style={{
+                                                        marginLeft: 'auto',
+                                                    }}
+                                                    wrap="nowrap"
+                                                >
+                                                    <Divider orientation="vertical" />
 
-                                                <FilterGroupSeparator
-                                                    icon={IconCalendar}
-                                                    tooltipLabel={
-                                                        <div>
-                                                            <Text
-                                                                fw={500}
-                                                                fz="xs"
-                                                            >
-                                                                Date Zoom
-                                                            </Text>
+                                                    <FilterGroupSeparator
+                                                        icon={IconCalendar}
+                                                        tooltipLabel={
+                                                            <div>
+                                                                <Text
+                                                                    fw={500}
+                                                                    fz="xs"
+                                                                >
+                                                                    Date Zoom
+                                                                </Text>
 
-                                                            <Text fz="xs">
-                                                                Quickly change
-                                                                the date
-                                                                granularity of
-                                                                charts.
-                                                            </Text>
-                                                        </div>
-                                                    }
-                                                />
-                                                <DateZoomV2
-                                                    isEditMode={isEditMode}
-                                                />
-                                            </Group>
-                                        )}
+                                                                <Text fz="xs">
+                                                                    Quickly
+                                                                    change the
+                                                                    date
+                                                                    granularity
+                                                                    of charts.
+                                                                </Text>
+                                                            </div>
+                                                        }
+                                                    />
+                                                    <DateZoomV2
+                                                        isEditMode={isEditMode}
+                                                    />
+                                                </Group>
+                                            )}
                                     </Group>
                                 </div>
 

--- a/packages/frontend/src/features/dateZoomV2/components/DateZoom.module.css
+++ b/packages/frontend/src/features/dateZoomV2/components/DateZoom.module.css
@@ -1,27 +1,10 @@
-/* Dashed outline button for adding date zoom */
-.addDateZoomButton {
-    border-style: dashed;
-    border-width: 1px;
-    border-color: var(--mantine-color-gray-4);
-}
-
-/* Positioned close button on date zoom */
-.closeButton {
-    position: absolute;
-    top: -6px;
-    left: -6px;
-    z-index: 1;
-}
-
-/* Active date zoom button with blue border */
 .activeDateZoomButton {
     border-color: var(--mantine-color-blue-6);
 }
 
-/* Menu item styling for disabled state */
-.menuItemDisabled {
-    color: white;
-    &:not([data-disabled='false']) {
-        color: var(--mantine-color-gray-6);
-    }
+.closeButton {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    z-index: 1;
 }

--- a/packages/frontend/src/features/dateZoomV2/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoomV2/components/DateZoom.tsx
@@ -1,7 +1,6 @@
 import { DateGranularity } from '@lightdash/common';
-import { ActionIcon, Box, Button, Group, Menu } from '@mantine-8/core';
+import { ActionIcon, Button, Group, Menu, Text } from '@mantine-8/core';
 import {
-    IconCalendarSearch,
     IconCheck,
     IconChevronDown,
     IconChevronUp,
@@ -41,13 +40,11 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
         if (isEditMode)
             return (
                 <Button
-                    variant="outline"
+                    variant="light"
                     size="xs"
-                    leftSection={<MantineIcon icon={IconCalendarSearch} />}
                     onClick={() => setIsDateZoomDisabled(false)}
-                    classNames={{ root: styles.addDateZoomButton }}
                 >
-                    + Add date zoom
+                    Add Date Zoom
                 </Button>
             );
         return null;
@@ -86,29 +83,33 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                                 ? { root: styles.activeDateZoomButton }
                                 : undefined
                         }
-                        leftSection={<MantineIcon icon={IconCalendarSearch} />}
                         rightSection={
-                            <MantineIcon
-                                icon={
-                                    showOpenIcon
-                                        ? IconChevronUp
-                                        : IconChevronDown
-                                }
-                            />
+                            isEditMode ? null : (
+                                <MantineIcon
+                                    icon={
+                                        showOpenIcon
+                                            ? IconChevronUp
+                                            : IconChevronDown
+                                    }
+                                />
+                            )
                         }
                     >
-                        Date Zoom
-                        {dateZoomGranularity ? `:` : null}{' '}
+                        <Text fz="inherit" fw={600}>
+                            Date Zoom
+                        </Text>
                         {dateZoomGranularity ? (
-                            <Box fw={500} ml="xxs">
-                                {dateZoomGranularity}
-                            </Box>
+                            <>
+                                :{' '}
+                                <Text fz="inherit" fw={500} ml="xxs">
+                                    {dateZoomGranularity}
+                                </Text>
+                            </>
                         ) : null}
                     </Button>
                 </Group>
             </Menu.Target>
             <Menu.Dropdown>
-                <Menu.Label fz={10}>Granularity</Menu.Label>
                 <Menu.Item
                     fz="xs"
                     onClick={() => {
@@ -122,11 +123,6 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                         setDateZoomGranularity(undefined);
                     }}
                     disabled={dateZoomGranularity === undefined}
-                    className={
-                        dateZoomGranularity === undefined
-                            ? styles.menuItemDisabled
-                            : ''
-                    }
                     rightSection={
                         dateZoomGranularity === undefined ? (
                             <MantineIcon icon={IconCheck} size={14} />
@@ -135,6 +131,7 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                 >
                     Default
                 </Menu.Item>
+
                 {Object.values(DateGranularity).map((granularity) => (
                     <Menu.Item
                         fz="xs"
@@ -149,11 +146,6 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                             setDateZoomGranularity(granularity);
                         }}
                         disabled={dateZoomGranularity === granularity}
-                        className={
-                            dateZoomGranularity === granularity
-                                ? styles.menuItemDisabled
-                                : ''
-                        }
                         rightSection={
                             dateZoomGranularity === granularity ? (
                                 <MantineIcon icon={IconCheck} size={14} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Improved the Date Zoom UI in dashboards by:

- Adding the ability to hide Date Zoom when not needed via a new `isDateZoomDisabled` context flag
- Simplifying the Date Zoom button UI with cleaner styling
- Improving the button layout and text formatting for better readability
- Updating the edit mode to use a "Add Date Zoom" button instead of the previous dashed outline style
- Repositioning the close button to the right side for better usability
- Removing unnecessary styling and simplifying the CSS