### PR TITLE
fix: adjust padding in dashboard filters bar and tabs layout

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/DashboardFiltersBar.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/DashboardFiltersBar.tsx
@@ -77,7 +77,7 @@ export const DashboardFiltersBar: FC<Props> = ({
                 align="flex-start"
                 wrap="nowrap"
                 px="lg"
-                py="sm"
+                py="xxs"
             >
                 {/* Left section - filters and parameters */}
                 <Group justify="apart" align="flex-start" wrap="nowrap" grow>

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -543,12 +543,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                     />
                                 )}
 
-                                <Group
-                                    grow
-                                    pt={tabsEnabled ? 'sm' : undefined}
-                                    pb="lg"
-                                    px="xs"
-                                >
+                                <Group grow pb="lg" px="xs">
                                     <ResponsiveGridLayout
                                         {...gridProps}
                                         className={`${


### PR DESCRIPTION
### Description:
Adjusted padding in dashboard UI components to improve spacing:
- Reduced vertical padding in the filters bar from "sm" to "xxs"
- Removed the top padding in the dashboard tabs grid layout
- Simplified the Group component's padding properties in the tabs layout

These changes create a more compact and visually balanced dashboard interface.