### PR TITLE
fix: simplify token refresh logic in ProjectService

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -680,35 +680,19 @@ export class ProjectService extends BaseService {
             args.authenticationType === 'sso'
         ) {
             try {
-                let { refreshToken } = args;
+                const { refreshToken } = args;
 
-                // If no refresh token provided, try to get it from user's OpenID table
-                if (refreshToken === undefined) {
-                    refreshToken = await this.userModel.getRefreshToken(
-                        userUuid,
-                        OpenIdIdentityIssuerType.SNOWFLAKE,
-                    );
-                }
-                // If we still don't have a token, we can't refresh
+                // If we don't have a token, we can't refresh
                 if (!refreshToken) {
                     throw new Error(
                         'No refresh token available for Snowflake SSO authentication',
                     );
                 }
-                // Token format validation
-                if (refreshToken.startsWith('ver:1-hint')) {
-                    // This is an invalid refresh token format,
-                    // we are using `access token` as refresh token (refresh token starts with ver:2-hint)
-                    // This might affect older projects that were not storing correctly refresh token
-                    // They should be recompiled to store the refresh token correctly
-                    throw new UnexpectedServerError(
-                        'Invalid snowflake refresh token format, please recompile your project',
-                    );
-                }
                 this.logger.debug(
                     `Refreshing snowflake token for user ${userUuid}`,
                 );
-
+                // If we try to generate access token from token instead of refreshToken
+                // it will throw an error: The request was invalid.
                 const accessToken =
                     await UserService.generateSnowflakeAccessToken(
                         refreshToken,
@@ -769,17 +753,9 @@ export class ProjectService extends BaseService {
                     };
                 }
 
-                let { refreshToken } = args;
+                const { refreshToken } = args;
 
-                // If no refresh token provided, try to get it from user's OpenID table
-                if (refreshToken === undefined) {
-                    refreshToken = await this.userModel.getRefreshToken(
-                        userUuid,
-                        OpenIdIdentityIssuerType.DATABRICKS,
-                    );
-                }
-
-                // If we still don't have a refresh token, we can't refresh
+                // If we don't have a refresh token, we can't refresh
                 if (!refreshToken) {
                     throw new Error(
                         'No refresh token or OAuth credentials available for Databricks OAuth authentication',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/SPK-304/review-usage-of-get-credentials-from-openid-on-snowflake-refresh

  Given all call sites already pass refreshToken:                               
                                                                                
  1. Line 1003-1006: { ...args.warehouseConnection, refreshToken } - explicitly fetched and passed
  2. Line 928-931: orgCredentials includes it (stored by OrganizationWarehouseCredentialsService)
  3. Line 1123-1126: Loaded from org credentials which has it                   
  4. Line 1159-1162: User warehouse credentials should have it                  
  5. Line 1172-1175: Project credentials should have it (stored at line 1012)   
                                                                                
  The fallback at lines 686-691 should never be triggered anymore. We can safely remove it it:

This because new methods like createSnowflakeWarehouseCredentials and UserWarehouseCredentialsWithSecrets only use refreshtoken now instead of the old token,

### Description:
Simplifies token refresh logic for Snowflake and Databricks authentication by removing unnecessary token retrieval from the OpenID table and validation checks. The code now relies solely on the refresh token provided in the arguments, with clear error messages when tokens are missing.

The PR also adds a helpful comment about potential errors when using an access token instead of a refresh token for Snowflake authentication.