### PR TITLE
fix: remove border-radius styling from parameter button

### DIFF
--- a/packages/frontend/src/features/parametersV2/components/Parameter.module.css
+++ b/packages/frontend/src/features/parametersV2/components/Parameter.module.css
@@ -1,7 +1,3 @@
-.button {
-    border-radius: 100px !important;
-}
-
 .unsetRequired {
     border-style: solid;
     border-width: 1px;

--- a/packages/frontend/src/features/parametersV2/components/Parameter.tsx
+++ b/packages/frontend/src/features/parametersV2/components/Parameter.tsx
@@ -136,11 +136,11 @@ const Parameter: FC<Props> = ({
                         classNames={{
                             label: styles.label,
                         }}
-                        className={`${styles.button} ${
+                        className={
                             hasUnsetRequiredParameter
                                 ? styles.unsetRequired
                                 : ''
-                        }`}
+                        }
                         rightSection={
                             hasValue && (
                                 <ActionIcon


### PR DESCRIPTION
### Description:
Removed the `.button` class and its border-radius styling from the Parameter component. Also simplified the className assignment by removing the unnecessary template literal when there's only a conditional class.