### PR TITLE
fix: reference lines not visible in dark mode

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/referenceLineStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/referenceLineStyles.ts
@@ -1,17 +1,27 @@
+import { getReadableColor } from '../../../utils/colors';
 import { GRAY_7, GRAY_8, GRAY_9, WHITE } from './themeColors';
 
 /**
  * Get reference line styling
+ * @param lineColor Optional custom color for the line
+ * @param backgroundColor Background color to ensure contrast against (required for color adjustment)
  */
-export const getReferenceLineStyle = (lineColor?: string) => {
+export const getReferenceLineStyle = (
+    lineColor?: string,
+    backgroundColor?: string,
+) => {
     const defaultLineColor = lineColor || GRAY_9;
+    // Adjust color for visibility if background color is provided
+    const adjustedLineColor = backgroundColor
+        ? getReadableColor(defaultLineColor, backgroundColor)
+        : defaultLineColor;
 
     return {
         emphasis: {
             disabled: true,
         },
         lineStyle: {
-            color: defaultLineColor,
+            color: adjustedLineColor,
             type: [2, 3] as const, // Dotted: 2px dash, 3px gap
             width: 2,
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18900


### Description:
Adjust user-selected reference line colors to meet accessibility standards while keeping them as close to the original as possible

#### Before
![CleanShot 2025-12-19 at 11.40.52.png](https://app.graphite.com/user-attachments/assets/a65eaefa-2e19-4b6e-958d-41185891ae81.png)

![CleanShot 2025-12-19 at 11.41.40.png](https://app.graphite.com/user-attachments/assets/cff55094-1f66-42d8-b57e-940bbafaa146.png)

-----

#### After

![CleanShot 2025-12-19 at 11.43.08.png](https://app.graphite.com/user-attachments/assets/52b5057a-feb2-4d99-bfcb-590e297b89e3.png)

![CleanShot 2025-12-19 at 11.42.17.png](https://app.graphite.com/user-attachments/assets/2827a243-f219-4da0-b47e-a8a021aae0e2.png)

