### PR TITLE
feat: update reference line label bg to match line color

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/referenceLineStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/referenceLineStyles.ts
@@ -1,5 +1,5 @@
-import { getReadableColor } from '../../../utils/colors';
-import { GRAY_7, GRAY_8, GRAY_9, WHITE } from './themeColors';
+import { getReadableColor, getReadableTextColor } from '../../../utils/colors';
+import { GRAY_9 } from './themeColors';
 
 /**
  * Get reference line styling
@@ -37,10 +37,10 @@ export const getReferenceLineStyle = (
                     ? `${text.substring(0, maxChars)}...`
                     : text;
             },
-            backgroundColor: GRAY_7,
-            color: WHITE,
+            backgroundColor: adjustedLineColor,
+            color: getReadableTextColor(adjustedLineColor),
             borderWidth: 1,
-            borderColor: GRAY_8,
+            borderColor: adjustedLineColor,
             padding: [2, 4],
             borderRadius: 4,
             fontSize: 11,


### PR DESCRIPTION
### Description:
Enhances reference line tooltips by using the line's color for tooltip background and border, and calculating readable text color based on the background. 

![CleanShot 2025-12-19 at 11.46.28.png](https://app.graphite.com/user-attachments/assets/4f0f1ee7-9ca9-4591-83fb-883470d1c57b.png)

![CleanShot 2025-12-19 at 11.46.22.png](https://app.graphite.com/user-attachments/assets/052918d1-26a7-49c9-82f1-855b4f272df5.png)

