### PR TITLE
fix: do not delete files when making --nested download

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -502,22 +502,6 @@ export const downloadHandler = async (
         },
     });
     try {
-        const projectDir = path.join(
-            getDownloadFolder(options.path),
-            projectName,
-        );
-        const dirExists = () =>
-            fs
-                .access(projectDir, fs.constants.F_OK)
-                .then(() => true)
-                .catch(() => false);
-
-        // We clear the output directory first to get the latest state of content
-        // regarding projects and spaces if nested.
-        if (options.nested && (await dirExists())) {
-            await fs.rm(projectDir, { recursive: true });
-        }
-
         // If any filter is provided, we skip those items without filters
         // eg: if a --charts filter is provided, we skip dashboards if no --dashboards filter is provided
         const hasFilters =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18781

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
Remove deleting the project folder locally when calling `lightdash download` with `--nested`