### PR TITLE
fix: change userUuid type from optional to nullable in query history

### DIFF
--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.test.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.test.ts
@@ -7,7 +7,10 @@ describe('QueryHistoryModel', () => {
         const timezone = 'UTC';
 
         test('should generate correct hash with SQL only', () => {
-            const result = QueryHistoryModel.getCacheKey(projectUuid, { sql });
+            const result = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                userUuid: null,
+            });
             expect(result).toBeDefined();
             expect(typeof result).toBe('string');
             expect(result.length).toBe(64); // SHA-256 produces 64 character hex string
@@ -17,6 +20,7 @@ describe('QueryHistoryModel', () => {
             const result = QueryHistoryModel.getCacheKey(projectUuid, {
                 sql,
                 timezone,
+                userUuid: null,
             });
             expect(result).toBeDefined();
             expect(typeof result).toBe('string');
@@ -25,16 +29,26 @@ describe('QueryHistoryModel', () => {
 
         test('should generate different hashes for different projects with same SQL', () => {
             const projectUuid2 = 'different-project-uuid';
-            const hash1 = QueryHistoryModel.getCacheKey(projectUuid, { sql });
-            const hash2 = QueryHistoryModel.getCacheKey(projectUuid2, { sql });
+            const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                userUuid: null,
+            });
+            const hash2 = QueryHistoryModel.getCacheKey(projectUuid2, {
+                sql,
+                userUuid: null,
+            });
             expect(hash1).not.toBe(hash2);
         });
 
         test('should generate different hashes for same project with different SQL', () => {
             const sql2 = 'SELECT * FROM different_table';
-            const hash1 = QueryHistoryModel.getCacheKey(projectUuid, { sql });
+            const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                userUuid: null,
+            });
             const hash2 = QueryHistoryModel.getCacheKey(projectUuid, {
                 sql: sql2,
+                userUuid: null,
             });
             expect(hash1).not.toBe(hash2);
         });
@@ -44,23 +58,26 @@ describe('QueryHistoryModel', () => {
             const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
                 sql,
                 timezone,
+                userUuid: null,
             });
             const hash2 = QueryHistoryModel.getCacheKey(projectUuid, {
                 sql,
                 timezone: timezone2,
+                userUuid: null,
             });
             expect(hash1).not.toBe(hash2);
         });
 
-        test('should generate same hash when userUuid is undefined (backward compatibility)', () => {
+        test('should generate same hash when userUuid is null (backward compatibility)', () => {
             const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
                 sql,
                 timezone,
+                userUuid: null,
             });
             const hash2 = QueryHistoryModel.getCacheKey(projectUuid, {
                 sql,
                 timezone,
-                userUuid: undefined,
+                userUuid: null,
             });
             expect(hash1).toBe(hash2);
         });
@@ -101,6 +118,7 @@ describe('QueryHistoryModel', () => {
             const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {
                 sql,
                 timezone,
+                userUuid: null,
             });
             const hash2 = QueryHistoryModel.getCacheKey(projectUuid, {
                 sql,

--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -64,7 +64,7 @@ export class QueryHistoryModel {
         resultsIdentifiers: {
             sql: string;
             timezone?: string;
-            userUuid?: string;
+            userUuid: string | null;
         },
     ) {
         const CACHE_VERSION = 'v3'; // change when we want to force invalidation

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1814,7 +1814,7 @@ export class AsyncQueryService extends ProjectService {
                             userUuid:
                                 warehouseCredentials.userWarehouseCredentialsUuid
                                     ? account.user.id
-                                    : undefined,
+                                    : null,
                         },
                     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Fix type mismatch in query history caching by changing `userUuid` from `string | undefined` to `string | null`. This ensures consistent typing between the QueryHistoryModel and AsyncQueryService, where we now explicitly pass `null` instead of `undefined` when warehouse credentials UUID is not present.