### PR TITLE
chore: upgrade @modelcontextprotocol/sdk from 1.17.5 to 1.25.1

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -54,7 +54,7 @@
         "@lightdash/common": "workspace:*",
         "@lightdash/warehouses": "workspace:*",
         "@mastra/schema-compat": "^0.11.2",
-        "@modelcontextprotocol/sdk": "^1.17.5",
+        "@modelcontextprotocol/sdk": "^1.25.1",
         "@node-oauth/oauth2-server": "^5.2.0",
         "@octokit/app": "^14.0.2",
         "@octokit/auth-app": "^6.0.3",

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1,9 +1,9 @@
+/* eslint-disable import/extensions */
 import { subject } from '@casl/ability';
 import {
     Account,
     AnyType,
     ApiKeyAccount,
-    CatalogFilter,
     CatalogType,
     CommercialFeatureFlags,
     Explore,
@@ -29,11 +29,14 @@ import {
     toolSearchFieldValuesArgsSchema,
     UserAttributeValueMap,
 } from '@lightdash/common';
-import * as Sentry from '@sentry/node';
-// eslint-disable-next-line import/extensions
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
-// eslint-disable-next-line import/extensions
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import {
+    ServerNotification,
+    ServerRequest,
+} from '@modelcontextprotocol/sdk/types.js';
+import * as Sentry from '@sentry/node';
 import { z, ZodRawShape } from 'zod';
 import {
     LightdashAnalytics,
@@ -228,9 +231,12 @@ export class McpService extends BaseService {
                 description: 'Get the current Lightdash version',
                 inputSchema: {},
             },
-            async (_args, context) => {
+            async (
+                _args: Record<string, never>,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.GET_LIGHTDASH_VERSION,
                 );
                 return {
@@ -238,7 +244,7 @@ export class McpService extends BaseService {
                         {
                             type: 'text',
                             text: this.getLightdashVersion(
-                                context as McpProtocolContext,
+                                extra as McpProtocolContext,
                             ),
                         },
                     ],
@@ -252,31 +258,35 @@ export class McpService extends BaseService {
                 description: mcpToolListExploresArgsSchema.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     mcpToolListExploresArgsSchema,
-                ) as AnyType,
+                ),
             },
-            async (_args, context) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 try {
                     const { user } = this.getAccount(
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
 
                     const projectUuid = await this.resolveProjectUuid(
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
 
                     this.trackToolCall(
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                         McpToolName.LIST_EXPLORES,
                         projectUuid,
                     );
 
                     const tagsFromContext = await this.getTagsFromContext(
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
 
                     const userAttributeOverrides =
                         await this.getUserAttributeOverridesFromContext(
-                            context as McpProtocolContext,
+                            extra as McpProtocolContext,
                         );
 
                     const listExplores = async () =>
@@ -323,18 +333,22 @@ export class McpService extends BaseService {
                 description: toolFindExploresArgsSchemaV3.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     toolFindExploresArgsSchemaV3,
-                ) as AnyType,
+                ),
             },
-            async (_args, context) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 const args = _args as Omit<ToolFindExploresArgsV3, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.FIND_EXPLORES,
                     projectUuid,
                 );
@@ -342,17 +356,16 @@ export class McpService extends BaseService {
                 const findExplores: FindExploresFn =
                     await this.getFindExploresFunction(
                         argsWithProject,
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
 
-                const { user } = (context as McpProtocolContext).authInfo!
-                    .extra;
+                const { user } = (extra as McpProtocolContext).authInfo!.extra;
                 const tagsFromContext = await this.getTagsFromContext(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                 );
                 const userAttributeOverrides =
                     await this.getUserAttributeOverridesFromContext(
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
                 const availableExplores = await this.getAvailableExplores(
                     user,
@@ -395,18 +408,22 @@ export class McpService extends BaseService {
                 description: toolFindFieldsArgsSchema.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     toolFindFieldsArgsSchema,
-                ) as AnyType,
+                ),
             },
-            async (_args, context) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 const args = _args as Omit<ToolFindFieldsArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.FIND_FIELDS,
                     projectUuid,
                 );
@@ -414,7 +431,7 @@ export class McpService extends BaseService {
                 const findFields: FindFieldFn =
                     await this.getFindFieldsFunction(
                         argsWithProject,
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
 
                 const findFieldsTool = getFindFields({
@@ -446,16 +463,20 @@ export class McpService extends BaseService {
                     toolFindContentArgsSchema,
                 ),
             },
-            async (_args, context) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 const args = _args as Omit<ToolFindContentArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.FIND_CONTENT,
                     projectUuid,
                 );
@@ -463,7 +484,7 @@ export class McpService extends BaseService {
                 const findContent: FindContentFn =
                     await this.getFindContentFunction(
                         argsWithProject,
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
 
                 const findContentTool = getFindContent({
@@ -492,13 +513,16 @@ export class McpService extends BaseService {
                 description: 'List all accessible projects in the organization',
                 inputSchema: {},
             },
-            async (_args, context) => {
-                const { user, organizationUuid, account } = this.getAccount(
-                    context as McpProtocolContext,
+            async (
+                _args: Record<string, never>,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
+                const { user, organizationUuid } = this.getAccount(
+                    extra as McpProtocolContext,
                 );
 
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.LIST_PROJECTS,
                 );
 
@@ -533,18 +557,22 @@ export class McpService extends BaseService {
                 description:
                     'Set the active project for subsequent MCP operations',
                 inputSchema: {
-                    projectUuid: z.string() as AnyType,
-                    tags: z.array(z.string()).optional() as AnyType,
+                    projectUuid: z.string(),
+                    tags: z.array(z.string()).optional(),
                 },
             },
-            async (_args, context) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 const args = _args as { projectUuid: string; tags?: string[] };
                 const { user, organizationUuid, account } = this.getAccount(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                 );
 
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.SET_PROJECT,
                     args.projectUuid,
                 );
@@ -619,13 +647,16 @@ export class McpService extends BaseService {
                 description: 'Get the currently active project',
                 inputSchema: {},
             },
-            async (_args, context) => {
+            async (
+                _args: Record<string, never>,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 const { user, organizationUuid } = this.getAccount(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                 );
 
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.GET_CURRENT_PROJECT,
                 );
 
@@ -678,18 +709,22 @@ export class McpService extends BaseService {
                 description: toolRunMetricQueryArgsSchema.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     toolRunMetricQueryArgsSchema,
-                ) as AnyType,
+                ),
             },
-            async (_args, context) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 const args = _args as Omit<ToolRunMetricQueryArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.RUN_METRIC_QUERY,
                     projectUuid,
                 );
@@ -697,7 +732,7 @@ export class McpService extends BaseService {
                 const { agentContext, runMiniMetricQuery } =
                     await this.getRunMetricQueryDependencies(
                         argsWithProject,
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
 
                 const runMetricQueryTool = getRunMetricQuery({
@@ -731,18 +766,22 @@ export class McpService extends BaseService {
                 description: toolSearchFieldValuesArgsSchema.description,
                 inputSchema: this.getMcpCompatibleSchema(
                     toolSearchFieldValuesArgsSchema,
-                ) as AnyType,
+                ),
             },
-            async (_args, context) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
                 const args = _args as Omit<ToolSearchFieldValuesArgs, 'type'>;
 
                 const projectUuid = await this.resolveProjectUuid(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                 );
                 const argsWithProject = { ...args, projectUuid };
 
                 this.trackToolCall(
-                    context as McpProtocolContext,
+                    extra as McpProtocolContext,
                     McpToolName.SEARCH_FIELD_VALUES,
                     projectUuid,
                 );
@@ -750,7 +789,7 @@ export class McpService extends BaseService {
                 const searchFieldValues: SearchFieldValuesFn =
                     await this.getSearchFieldValuesFunction(
                         argsWithProject,
-                        context as McpProtocolContext,
+                        extra as McpProtocolContext,
                     );
 
                 const searchFieldValuesTool = getSearchFieldValues({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^0.11.2
         version: 0.11.2(ai@5.0.90(zod@3.25.55))(zod@3.25.55)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.17.5
-        version: 1.17.5
+        specifier: ^1.25.1
+        version: 1.25.1(hono@4.11.1)(zod@3.25.55)
       '@node-oauth/oauth2-server':
         specifier: ^5.2.0
         version: 5.2.0
@@ -3516,6 +3516,12 @@ packages:
       react: ^16.8.5 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
 
+  '@hono/node-server@1.19.7':
+    resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/error-message@2.0.0':
     resolution: {integrity: sha512-Y90nHzjgL2MP7GFy75kscdvxrCTjtyxGmOLLxX14nd08OXRIh9lMH/y9Kpdo0p1IPowJBiZMHyueg7p+yrqynQ==}
     peerDependencies:
@@ -3968,9 +3974,15 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@modelcontextprotocol/sdk@1.17.5':
-    resolution: {integrity: sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==}
+  '@modelcontextprotocol/sdk@1.25.1':
+    resolution: {integrity: sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@monaco-editor/loader@1.4.0':
     resolution: {integrity: sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==}
@@ -7299,6 +7311,9 @@ packages:
   ajv@8.13.0:
     resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
 
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
   alien-signals@0.4.14:
     resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
@@ -9563,6 +9578,9 @@ packages:
   fast-text-encoding@1.0.3:
     resolution: {integrity: sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
@@ -10228,6 +10246,10 @@ packages:
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
+
+  hono@4.11.1:
+    resolution: {integrity: sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -10999,6 +11021,9 @@ packages:
   jose@5.2.3:
     resolution: {integrity: sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==}
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-cookie@2.2.1:
     resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
@@ -11065,6 +11090,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -15777,6 +15805,11 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
+  zod-to-json-schema@3.25.0:
+    resolution: {integrity: sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
   zod@3.25.55:
     resolution: {integrity: sha512-219huNnkSLQnLsQ3uaRjXsxMrVm5C9W3OOpEVt2k5tvMKuA8nBSu38e0B//a+he9Iq2dvmk2VyYVlHqiHa4YBA==}
 
@@ -19284,6 +19317,10 @@ snapshots:
       - '@types/react-dom'
       - react-native
 
+  '@hono/node-server@1.19.7(hono@4.11.1)':
+    dependencies:
+      hono: 4.11.1
+
   '@hookform/error-message@2.0.0(react-dom@19.2.0(react@19.2.0))(react-hook-form@7.26.1(react@19.2.0))(react@19.2.0)':
     dependencies:
       react: 19.2.0
@@ -19904,9 +19941,11 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@modelcontextprotocol/sdk@1.17.5':
+  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.1)(zod@3.25.55)':
     dependencies:
-      ajv: 6.12.6
+      '@hono/node-server': 1.19.7(hono@4.11.1)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
@@ -19914,11 +19953,14 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
       zod: 3.25.55
-      zod-to-json-schema: 3.24.6(zod@3.25.55)
+      zod-to-json-schema: 3.25.0(zod@3.25.55)
     transitivePeerDependencies:
+      - hono
       - supports-color
 
   '@monaco-editor/loader@1.4.0(monaco-editor@0.44.0)':
@@ -24056,6 +24098,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.13.0
 
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -24083,6 +24129,13 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   alien-signals@0.4.14: {}
 
@@ -26854,6 +26907,8 @@ snapshots:
 
   fast-text-encoding@1.0.3: {}
 
+  fast-uri@3.1.0: {}
+
   fast-xml-parser@4.4.1:
     dependencies:
       strnum: 1.1.2
@@ -27782,6 +27837,8 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
+  hono@4.11.1: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -28001,7 +28058,7 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.7
       has: 1.0.3
-      side-channel: 1.0.6
+      side-channel: 1.1.0
 
   internal-slot@1.1.0:
     dependencies:
@@ -28833,6 +28890,8 @@ snapshots:
 
   jose@5.2.3: {}
 
+  jose@6.1.3: {}
+
   js-cookie@2.2.1: {}
 
   js-levenshtein@1.1.6: {}
@@ -28905,6 +28964,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -32422,7 +32483,7 @@ snapshots:
       call-bind: 1.0.8
       es-errors: 1.3.0
       get-intrinsic: 1.2.7
-      object-inspect: 1.13.1
+      object-inspect: 1.13.3
 
   side-channel@1.1.0:
     dependencies:
@@ -34529,6 +34590,10 @@ snapshots:
       zod: 4.1.5
 
   zod-to-json-schema@3.24.6(zod@3.25.55):
+    dependencies:
+      zod: 3.25.55
+
+  zod-to-json-schema@3.25.0(zod@3.25.55):
     dependencies:
       zod: 3.25.55
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2126

### Description:
Upgrades the Model Context Protocol SDK from version 1.17.5 to 1.25.1. This update brings in new dependencies including Hono and updated JSON schema tools, which will enable improved API functionality and schema validation.