### PR TITLE
fix: filter on projectUuid at the metrics_tree_edges level

### DIFF
--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -129,6 +129,7 @@ export const CatalogTagsTableName = 'catalog_search_tags';
 export type DbMetricsTreeEdge = {
     source_metric_catalog_search_uuid: string;
     target_metric_catalog_search_uuid: string;
+    project_uuid: string;
     created_at: Date;
     created_by_user_uuid: string | null;
 };
@@ -137,6 +138,7 @@ export type DbMetricsTreeEdgeIn = Pick<
     DbMetricsTreeEdge,
     | 'source_metric_catalog_search_uuid'
     | 'target_metric_catalog_search_uuid'
+    | 'project_uuid'
     | 'created_by_user_uuid'
 >;
 

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -323,7 +323,7 @@ export class CatalogModel {
                                     break;
                                 }
                                 default:
-                                    assertUnreachable(
+                                    return assertUnreachable(
                                         change.entityType,
                                         `Unknown entity type ${change.entityType}`,
                                     );
@@ -486,7 +486,7 @@ export class CatalogModel {
                                             ];
                                         break;
                                     default:
-                                        assertUnreachable(
+                                        return assertUnreachable(
                                             revertedChange.entityType,
                                             `Unknown entity type`,
                                         );
@@ -1471,6 +1471,7 @@ export class CatalogModel {
             >({
                 source_metric_catalog_search_uuid: `${MetricsTreeEdgesTableName}.source_metric_catalog_search_uuid`,
                 target_metric_catalog_search_uuid: `${MetricsTreeEdgesTableName}.target_metric_catalog_search_uuid`,
+                project_uuid: `${MetricsTreeEdgesTableName}.project_uuid`,
                 created_at: `${MetricsTreeEdgesTableName}.created_at`,
                 created_by_user_uuid: `${MetricsTreeEdgesTableName}.created_by_user_uuid`,
                 source_metric_name: `source_metric.name`,
@@ -1478,25 +1479,16 @@ export class CatalogModel {
                 target_metric_name: `target_metric.name`,
                 target_metric_table_name: `target_metric.table_name`,
             })
+            .where(`${MetricsTreeEdgesTableName}.project_uuid`, projectUuid)
             .innerJoin(
                 { source_metric: CatalogTableName },
-                function joinSource() {
-                    void this.on(
-                        `${MetricsTreeEdgesTableName}.source_metric_catalog_search_uuid`,
-                        '=',
-                        `source_metric.catalog_search_uuid`,
-                    ).andOnVal('source_metric.project_uuid', '=', projectUuid);
-                },
+                `${MetricsTreeEdgesTableName}.source_metric_catalog_search_uuid`,
+                `source_metric.catalog_search_uuid`,
             )
             .innerJoin(
                 { target_metric: CatalogTableName },
-                function joinTarget() {
-                    void this.on(
-                        `${MetricsTreeEdgesTableName}.target_metric_catalog_search_uuid`,
-                        '=',
-                        `target_metric.catalog_search_uuid`,
-                    ).andOnVal('target_metric.project_uuid', '=', projectUuid);
-                },
+                `${MetricsTreeEdgesTableName}.target_metric_catalog_search_uuid`,
+                `target_metric.catalog_search_uuid`,
             );
 
         return edges.map((e) => ({
@@ -1512,7 +1504,7 @@ export class CatalogModel {
             },
             createdAt: e.created_at,
             createdByUserUuid: e.created_by_user_uuid,
-            projectUuid,
+            projectUuid: e.project_uuid,
         }));
     }
 

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -598,6 +598,7 @@ export class CatalogService<
                                 sourceCatalogItem.catalogSearchUuid,
                             target_metric_catalog_search_uuid:
                                 targetCatalogItem.catalogSearchUuid,
+                            project_uuid: projectUuid,
                             created_by_user_uuid: edge.createdByUserUuid,
                             created_at: edge.createdAt,
                         },
@@ -1291,6 +1292,7 @@ export class CatalogService<
         return this.catalogModel.createMetricsTreeEdge({
             source_metric_catalog_search_uuid: sourceCatalogSearchUuid,
             target_metric_catalog_search_uuid: targetCatalogSearchUuid,
+            project_uuid: projectUuid,
             created_by_user_uuid: user.userUuid,
         });
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2038/gcp-alert-cloud-sql-database-cpu-utilization

### Description:
Added `project_uuid` field to the metrics tree edge data structure to simplify queries and fix edge cases. This change:

1. Updates the `DbMetricsTreeEdge` type to include an optional `project_uuid` field
2. Modifies the metrics tree edge queries to filter by project UUID directly on the edge table
3. Simplifies the join conditions by removing complex callbacks