### PR TITLE
chore: remove metrics_tree_edges triggers

### DIFF
--- a/packages/backend/src/database/migrations/20251219150115_delete_metrics_tree_edges_triggers.ts
+++ b/packages/backend/src/database/migrations/20251219150115_delete_metrics_tree_edges_triggers.ts
@@ -1,0 +1,36 @@
+import { Knex } from 'knex';
+
+const METRICS_TREE_EDGES_TABLE = 'metrics_tree_edges';
+const CATALOG_SEARCH_TABLE = 'catalog_search';
+const TRIGGER_NAME = 'set_metrics_tree_edge_project_uuid';
+const FUNCTION_NAME = 'set_metrics_tree_edge_project_uuid_fn';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(
+        `DROP TRIGGER IF EXISTS ${TRIGGER_NAME} ON ${METRICS_TREE_EDGES_TABLE}`,
+    );
+    await knex.raw(`DROP FUNCTION IF EXISTS ${FUNCTION_NAME}()`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`
+        CREATE OR REPLACE FUNCTION ${FUNCTION_NAME}()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF NEW.project_uuid IS NULL THEN
+                SELECT project_uuid INTO NEW.project_uuid
+                FROM ${CATALOG_SEARCH_TABLE}
+                WHERE catalog_search_uuid = NEW.source_metric_catalog_search_uuid;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    `);
+
+    await knex.raw(`
+        CREATE TRIGGER ${TRIGGER_NAME}
+        BEFORE INSERT ON ${METRICS_TREE_EDGES_TABLE}
+        FOR EACH ROW
+        EXECUTE FUNCTION ${FUNCTION_NAME}();
+    `);
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/PROD-2038/gcp-alert-cloud-sql-database-cpu-utilization

### Description:
This PR removes the database trigger `set_metrics_tree_edge_project_uuid` and its associated function `set_metrics_tree_edge_project_uuid_fn` from the `metrics_tree_edges` table. The trigger was previously used to automatically set the `project_uuid` field when inserting new records by looking up the value from the `catalog_search` table.

The migration provides both the removal logic in the `up` function and restoration logic in the `down` function for rollback purposes.