### PR TITLE
feat: include user in query cache key 

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -853,6 +853,7 @@ export class EmbedService extends BaseService {
         const results =
             await this.projectService.getResultsFromCacheOrWarehouse({
                 projectUuid,
+                userUuid: null,
                 context: QueryExecutionContext.EMBED,
                 warehouseClient,
                 metricQuery,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2123/fix-user-cache-in-getresultsfromcacheorwarehouse

When required user credentials

<img width="962" height="93" alt="Screenshot from 2025-12-19 16-08-09" src="https://github.com/user-attachments/assets/516fddbc-c9f9-4858-bb02-6b5abf0bb9ee" />

When non required

<img width="963" height="114" alt="Screenshot from 2025-12-19 16-11-11" src="https://github.com/user-attachments/assets/b4943c76-3bc9-47df-b7de-6f62f7e1cdce" />


The changes:
1. Add `userUuid` parameter to `getResultsFromCacheOrWarehouse` function
2. Include `userUuid` in the query hash key generation
3. Extract warehouse credentials retrieval to a variable for reuse
4. Determine if user-specific credentials are being used by checking `userWarehouseCredentialsUuid`