### PR TITLE
fix: table locked columns in dark mode

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -27,7 +27,11 @@ import {
 } from '../../../../utils/colorUtils';
 import { getConditionalRuleLabelFromItem } from '../../Filters/FilterInputs/utils';
 import MantineIcon from '../../MantineIcon';
-import { ROW_HEIGHT_PX, SMALL_TEXT_LENGTH } from '../constants';
+import {
+    FROZEN_COLUMN_BACKGROUND,
+    ROW_HEIGHT_PX,
+    SMALL_TEXT_LENGTH,
+} from '../constants';
 import { Tr } from '../Table.styles';
 import { type TableContext } from '../types';
 import { useTableContext } from '../useTableContext';
@@ -127,12 +131,12 @@ const TableRow: FC<TableRowProps> = ({
                         },
                     });
 
-                // Frozen/locked rows should have a white background, unless there is a conditional formatting color
+                // Frozen/locked rows should have a fixed background, unless there is a conditional formatting color
                 let backgroundColor: string | undefined;
                 if (conditionalFormattingColor) {
                     backgroundColor = conditionalFormattingColor;
                 } else if (meta?.frozen) {
-                    backgroundColor = 'white';
+                    backgroundColor = FROZEN_COLUMN_BACKGROUND;
                 }
 
                 const tooltipContent = getConditionalFormattingDescription(

--- a/packages/frontend/src/components/common/Table/Table.styles.tsx
+++ b/packages/frontend/src/components/common/Table/Table.styles.tsx
@@ -1,6 +1,11 @@
 import { forwardRef, type ComponentPropsWithRef, type ReactNode } from 'react';
 import styled, { css } from 'styled-components';
-import { ROW_HEIGHT_PX } from './constants';
+import {
+    FROZEN_COLUMN_BACKGROUND,
+    FROZEN_COLUMN_BORDER_COLOR,
+    FROZEN_COLUMN_BORDER_WIDTH,
+    ROW_HEIGHT_PX,
+} from './constants';
 import trStyles from './Tr.module.css';
 
 export const TableScrollableWrapper = styled.div`
@@ -132,15 +137,16 @@ export const Table = styled.table<{
         word-break: break-word;
         :hover {
             white-space: normal;
-            background-color: white;
+            background-color: ${FROZEN_COLUMN_BACKGROUND};
         }
     }
     th.sticky-column {
-        background: white !important;
+        background: ${FROZEN_COLUMN_BACKGROUND} !important;
     }
 
     .last-sticky-column {
-        border-right: 1.4px solid rgb(189, 189, 189);
+        border-right: ${FROZEN_COLUMN_BORDER_WIDTH} solid
+            ${FROZEN_COLUMN_BORDER_COLOR};
     }
 `;
 

--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -6,7 +6,11 @@ import {
     type GroupingState,
 } from '@tanstack/react-table';
 import React, { useEffect, useMemo, useState, type FC } from 'react';
-import { DEFAULT_PAGE_SIZE, ROW_NUMBER_COLUMN_ID } from './constants';
+import {
+    DEFAULT_PAGE_SIZE,
+    FROZEN_COLUMN_BACKGROUND,
+    ROW_NUMBER_COLUMN_ID,
+} from './constants';
 import Context from './context';
 import { getGroupedRowModelLightdash } from './getGroupedRowModelLightdash';
 import { type ProviderProps, type TableColumn } from './types';
@@ -116,7 +120,7 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
                 style: {
                     maxWidth: rowColumnWidth,
                     minWidth: rowColumnWidth,
-                    backgroundColor: 'white',
+                    backgroundColor: FROZEN_COLUMN_BACKGROUND,
                 },
             },
         };

--- a/packages/frontend/src/components/common/Table/constants.ts
+++ b/packages/frontend/src/components/common/Table/constants.ts
@@ -7,3 +7,11 @@ export const SMALL_TEXT_LENGTH = 35;
 
 // Needed for virtualization. Matches value from Pivot table.
 export const ROW_HEIGHT_PX = 34;
+
+// Frozen/locked column styling constants
+export const FROZEN_COLUMN_BACKGROUND =
+    'light-dark(var(--mantine-color-background), var(--mantine-color-ldGray-0))';
+
+export const FROZEN_COLUMN_BORDER_COLOR = 'var(--mantine-color-ldGray-4)';
+
+export const FROZEN_COLUMN_BORDER_WIDTH = '1.4px';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18994

### Description:
Adds dark mode support for frozen/locked columns in tables by replacing hardcoded white backgrounds with theme variables. 


#### Before

![CleanShot 2025-12-19 at 17.32.05.png](https://app.graphite.com/user-attachments/assets/adc89874-7342-433e-ba9a-b51eacec9aca.png)

![CleanShot 2025-12-19 at 17.32.00.png](https://app.graphite.com/user-attachments/assets/1f280026-71a8-4bc2-bdc2-b820d3cd6135.png)


#### After

![CleanShot 2025-12-19 at 17.31.42.png](https://app.graphite.com/user-attachments/assets/4a84ddfa-abb4-483d-a582-aa0881e11ec2.png)

![CleanShot 2025-12-19 at 17.31.54.png](https://app.graphite.com/user-attachments/assets/a1e4c562-e9db-4895-b37e-f8245c85b968.png)

