### PR TITLE
fix: add new project_uuid column for metrics_tree_edges

### DIFF
--- a/packages/backend/src/database/migrations/20251219171117_add_project_id_to_metrics_tree_edges.ts
+++ b/packages/backend/src/database/migrations/20251219171117_add_project_id_to_metrics_tree_edges.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+const METRICS_TREE_EDGES_TABLE = 'metrics_tree_edges';
+const CATALOG_SEARCH_TABLE = 'catalog_search';
+const PROJECTS_TABLE = 'projects';
+
+export async function up(knex: Knex): Promise<void> {
+    // 1. Add nullable column first to allow backfill
+    await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+        table.uuid('project_uuid').nullable();
+    });
+
+    // 2. Backfill project_uuid from catalog_search via source_metric
+    // Only update rows where project_uuid IS NULL to handle concurrent inserts
+    await knex.raw(`
+        UPDATE ${METRICS_TREE_EDGES_TABLE} e
+        SET project_uuid = c.project_uuid
+        FROM ${CATALOG_SEARCH_TABLE} c
+        WHERE e.source_metric_catalog_search_uuid = c.catalog_search_uuid
+          AND e.project_uuid IS NULL
+    `);
+
+    // 3. Make column NOT NULL after backfill
+    await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+        table.uuid('project_uuid').notNullable().alter();
+    });
+
+    // 4. Add foreign key constraint with CASCADE delete
+    await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+        table
+            .foreign('project_uuid')
+            .references('project_uuid')
+            .inTable(PROJECTS_TABLE)
+            .onDelete('CASCADE');
+    });
+
+    // 5. Add index for query performance
+    await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+        table.index('project_uuid');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+        table.dropColumn('project_uuid');
+    });
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/PROD-2038/gcp-alert-cloud-sql-database-cpu-utilization

### Description:

- Adds not nullable `project_uuid` column to `metrics_tree_edges`

This keeps the backwards compatible code and only adds the column so that start running the new code before migration finishes (workers) can adapt.

**Note:** Type change is upstack, to be deployed after this