### PR TITLE
fix: string casting in dashboard filters

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/ActiveFilters/Filter.tsx
@@ -149,7 +149,7 @@ const Filter: FC<Props> = ({
         }
 
         const formattedValues = values.map((v) =>
-            formatDisplayValue(v as string),
+            formatDisplayValue(String(v)),
         );
         const displayedValues = formattedValues.slice(0, MAX_DISPLAYED_VALUES);
         const additionalValues = formattedValues.slice(MAX_DISPLAYED_VALUES);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2136/typeerror-iereplace-is-not-a-function

### Description:
Fixed a type issue in the ActiveFilters component by explicitly converting filter values to strings before formatting them for display. This ensures that all values, regardless of their original type, are properly formatted.

**Before**

[cut.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/90f58766-e0ab-44fd-8dcb-3f0f368013c4.mov" />](https://app.graphite.com/user-attachments/video/90f58766-e0ab-44fd-8dcb-3f0f368013c4.mov)

**After**

[Screen Recording 2025-12-19 at 18.07.52.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ef6ecd7c-f551-4982-888b-c37422027319.mov" />](https://app.graphite.com/user-attachments/video/ef6ecd7c-f551-4982-888b-c37422027319.mov)

