### PR TITLE
fix: remove AllMSTeamsDeliveriesFailedError and AllSlackDeliveriesFailedError

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1,7 +1,5 @@
 import {
     type Account as AccountType,
-    AllMSTeamsDeliveriesFailedError,
-    AllSlackDeliveriesFailedError,
     AnyType,
     type BatchDeliveryResult,
     CompileProjectPayload,
@@ -3088,9 +3086,7 @@ export default class SchedulerTask {
             if (
                 e instanceof FieldReferenceError ||
                 e instanceof WarehouseConnectionError ||
-                e instanceof ParameterError ||
-                e instanceof AllMSTeamsDeliveriesFailedError ||
-                e instanceof AllSlackDeliveriesFailedError
+                e instanceof ParameterError
             ) {
                 // This captures both the error from thresholdAlert and metricQuery
                 // WarehouseConnectionError indicates misconfigured credentials (wrong password, unreachable host, etc.)
@@ -3499,11 +3495,6 @@ export default class SchedulerTask {
                 batchResult,
                 notification.projectUuid,
             );
-            throw new AllSlackDeliveriesFailedError(
-                `All Slack deliveries failed: ${results
-                    .map((r) => r.error)
-                    .join(', ')}`,
-            );
         } else {
             // Partial failure - some succeeded, some failed
             this.analytics.track({
@@ -3897,11 +3888,6 @@ export default class SchedulerTask {
                 scheduler,
                 batchResult,
                 notification.projectUuid,
-            );
-            throw new AllMSTeamsDeliveriesFailedError(
-                `All MS Teams deliveries failed: ${results
-                    .map((r) => r.error)
-                    .join(', ')}`,
             );
         } else {
             // Partial failure - some succeeded, some failed

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -397,20 +397,6 @@ export class SlackError extends LightdashError {
     }
 }
 
-export class AllSlackDeliveriesFailedError extends LightdashError {
-    constructor(
-        message: string = 'All Slack deliveries failed',
-        data: { [key: string]: AnyType } = {},
-    ) {
-        super({
-            message,
-            name: 'AllSlackDeliveriesFailedError',
-            statusCode: 400,
-            data,
-        });
-    }
-}
-
 export class MsTeamsError extends LightdashError {
     constructor(
         message: string = 'Microsoft Teams API error occurred',
@@ -419,20 +405,6 @@ export class MsTeamsError extends LightdashError {
         super({
             message,
             name: 'MsTeamsError',
-            statusCode: 400,
-            data,
-        });
-    }
-}
-
-export class AllMSTeamsDeliveriesFailedError extends LightdashError {
-    constructor(
-        message: string = 'All MS Teams deliveries failed',
-        data: { [key: string]: AnyType } = {},
-    ) {
-        super({
-            message,
-            name: 'AllMSTeamsDeliveriesFailed',
             statusCode: 400,
             data,
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Removed the `AllMSTeamsDeliveriesFailedError` and `AllSlackDeliveriesFailedError` error classes and their usage in the scheduler task. We already warn the user and mark the job as failed, so we don't need to throw an error.