### PR TITLE
fix: don't report unrecoverable Slack errors to Sentry

### DIFF
--- a/packages/backend/src/errors.ts
+++ b/packages/backend/src/errors.ts
@@ -1,5 +1,6 @@
 import {
     getErrorMessage,
+    isUnrecoverableSlackError,
     LightdashError,
     ScimError,
     SlackError,
@@ -57,6 +58,11 @@ export const scimErrorHandler = (
 };
 export const slackErrorHandler = (e: unknown, context: string) => {
     Logger.error(`${context}: ${getErrorMessage(e)}`);
+
+    // Don't report unrecoverable errors to Sentry (expected for broken installations)
+    if (isUnrecoverableSlackError(e)) {
+        return;
+    }
 
     if (
         typeof e === 'object' &&

--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -17,6 +17,8 @@ export const UNRECOVERABLE_SLACK_ERRORS = [
     'account_inactive', // Bot/app was deactivated
     'invalid_auth', // Invalid authentication
     'missing_scope', // Missing required OAuth scope
+    'channel_not_found', // Channel doesn't exist
+    'not_in_channel', // Bot/app isn't in the channel
 ] as const;
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1605

### Description:
Prevent reporting unrecoverable Slack errors to Sentry. Added logic to check for unrecoverable errors in the Slack error handler and added two new error types to the unrecoverable errors list: `channel_not_found` and `not_in_channel`. This will reduce noise in Sentry by not reporting expected errors from broken Slack installations.