### PR TITLE
test: accept 304 status code in CSV download polling test

### DIFF
--- a/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
+++ b/packages/e2e/cypress/e2e/app/downloadCsv.cy.ts
@@ -54,7 +54,9 @@ const waitForDownloadToComplete = (
 
         cy.wait(`@${pollAlias}`, { timeout: pollInterval * 2 }).then(
             (interception) => {
-                expect(interception?.response?.statusCode).to.eq(200);
+                expect(interception?.response?.statusCode).to.be.oneOf([
+                    200, 304,
+                ]);
                 const jobStatus = interception?.response?.body.results;
 
                 cy.log(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Update the Cypress test for CSV downloads to accept both 200 and 304 status codes as valid responses. This makes the test more resilient by handling cases where the server returns a "Not Modified" response.

Before: 

<img width="2030" height="1010" alt="CleanShot 2025-12-22 at 12 52 23@2x" src="https://github.com/user-attachments/assets/59d3f48f-3dd7-4fbc-a3ee-43f1d73558fe" />
