### PR TITLE
fix: CLI throws "dbt not found error" when working with lightdash yaml

### DIFF
--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -157,7 +157,7 @@ type CliCompileStarted = BaseTrack & {
     event: 'compile.started';
     properties: {
         executionId: string;
-        dbtVersion: string;
+        dbtVersion?: string;
         skipDbtCompile: boolean;
         skipWarehouseCatalog: boolean;
         useDbtList: boolean;
@@ -170,14 +170,14 @@ type CliCompileCompleted = BaseTrack & {
         explores: number;
         errors: number;
         dbtMetrics: number;
-        dbtVersion: string;
+        dbtVersion?: string;
     };
 };
 type CliCompileError = BaseTrack & {
     event: 'compile.error';
     properties: {
         executionId: string;
-        dbtVersion: string;
+        dbtVersion?: string;
         error: string;
     };
 };

--- a/packages/cli/src/handlers/compile.test.ts
+++ b/packages/cli/src/handlers/compile.test.ts
@@ -1,0 +1,114 @@
+import fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { compile } from './compile';
+
+jest.mock('execa');
+jest.mock('../analytics/analytics');
+jest.mock('../config', () => ({
+    getConfig: jest.fn().mockResolvedValue({ user: null, context: null }),
+}));
+
+describe('compile', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'lightdash-compile-test-'),
+        );
+
+        // Create minimal lightdash.config.yml
+        await fs.writeFile(
+            path.join(tempDir, 'lightdash.config.yml'),
+            `
+warehouse:
+  type: postgres
+            `,
+        );
+
+        // Create lightdash/models directory and a test model
+        const modelsDir = path.join(tempDir, 'lightdash', 'models');
+        await fs.mkdir(modelsDir, { recursive: true });
+        await fs.writeFile(
+            path.join(modelsDir, 'test_model.yml'),
+            `
+version: 1
+type: model
+name: test_model
+description: Test model
+sql_from: "SELECT * FROM test_table"
+dimensions:
+  - name: id
+    description: ID column
+    type: number
+    sql: id
+            `,
+        );
+    });
+
+    afterEach(async () => {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    test('should compile Lightdash YAML project without dbt installed', async () => {
+        // Mock analytics to prevent actual tracking
+        const { LightdashAnalytics } = await import('../analytics/analytics');
+        (LightdashAnalytics.track as jest.Mock).mockResolvedValue(undefined);
+
+        const result = await compile({
+            projectDir: tempDir,
+            profilesDir: '',
+            target: undefined,
+            profile: undefined,
+            vars: undefined,
+            verbose: false,
+            startOfWeek: 0,
+            skipWarehouseCatalog: true,
+            skipDbtCompile: true,
+            useDbtList: false,
+            select: undefined,
+            models: undefined,
+            threads: undefined,
+            noVersionCheck: false,
+            exclude: undefined,
+            selector: undefined,
+            state: undefined,
+            fullRefresh: false,
+            defer: false,
+            targetPath: undefined,
+            favorState: false,
+            warehouseCredentials: false,
+            disableTimestampConversion: false,
+        });
+
+        // Should succeed even though dbt is not installed
+        expect(result).toBeDefined();
+        expect(result.length).toBeGreaterThan(0);
+
+        // Analytics should be called even though dbt is not found
+        const trackCalls = (LightdashAnalytics.track as jest.Mock).mock.calls;
+
+        expect(LightdashAnalytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'compile.started',
+                properties: expect.objectContaining({
+                    dbtVersion: undefined,
+                }),
+            }),
+        );
+
+        expect(LightdashAnalytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'compile.completed',
+            }),
+        );
+
+        // Verify compile.started was called with undefined dbtVersion
+        const startedCall = trackCalls.find(
+            (call) => call[0].event === 'compile.started',
+        );
+        expect(startedCall).toBeDefined();
+        expect(startedCall[0].properties.dbtVersion).toBeUndefined();
+    });
+});

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -69,7 +69,7 @@ const getFallbackDbtVersionOption = (version: string): DbtVersionOption => {
     return getLatestSupportDbtVersion();
 };
 
-type DbtVersion = {
+export type DbtVersion = {
     verboseVersion: string; // Verbose version returned by dbt --version
     versionOption: DbtVersionOption; // The supported version by Lightdash
     isDbtCloudCLI: boolean; // Whether the version is dbt Cloud CLI
@@ -153,4 +153,21 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
         isDbtCloudCLI: isDbtCloudCLI(verboseVersion),
         versionOption: supportedVersionOption ?? fallbackVersionOption,
     };
+};
+
+export const tryGetDbtVersion = async (): Promise<
+    { success: true; version: DbtVersion } | { success: false; error: unknown }
+> => {
+    try {
+        const version = await getDbtVersion();
+        GlobalState.debug(`> dbt version ${version.verboseVersion}`);
+        return { success: true, version };
+    } catch (e) {
+        GlobalState.debug(
+            `> dbt installation not found: ${getErrorMessage(
+                e,
+            )} (might be using Lightdash YAML only)`,
+        );
+        return { success: false, error: e };
+    }
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [Prod-2010](https://linear.app/lightdash/issue/PROD-2010/cli-throws-dbt-not-found-error-when-working-with-lightdash-yaml)

### Description:

Makes dbtVersion optional in analytics tracking and delays loading dbt version until it's actually needed. This optimization avoids unnecessary dbt version checks when using Lightdash YAML projects, which don't require dbt to be installed.

The PR:

1. Makes dbtVersion optional in analytics tracking types
2. Moves dbt version detection inside the conditional block where it's needed
3. Only tracks dbtVersion in analytics when it's available
