### PR TITLE
fix: log instead of throwing error for missing Slack scopes during channel sync

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -539,10 +539,7 @@ export class SlackClient {
         if (!this.hasRequiredScopes(installation.scopes)) {
             const currentScopes = installation.scopes.join(', ');
             const requiredScopes = this.getRequiredScopes().join(', ');
-            slackErrorHandler(
-                new SlackError(
-                    `Missing required Slack scopes. Has: [${currentScopes}], needs: [${requiredScopes}]`,
-                ),
+            Logger.debug(
                 `Skipping Slack channel sync for organization ${organizationUuid}: missing required scopes. Has: [${currentScopes}], needs: [${requiredScopes}]`,
             );
             return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2146

### Description:

Changed the error handling in SlackClient when required scopes are missing during channel sync. Instead of throwing a SlackError, it now logs a debug message, allowing the process to continue without interruption.