### PR TITLE
fix: ignore UserInfoError from Google OAuth2 in Sentry

### DIFF
--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -17,6 +17,7 @@ export const IGNORE_ERRORS = [
     'SshTunnelError',
     'ReadFileError',
     'AiAgentValidatorError',
+    'UserInfoError', // Google oauth2 error when using invalid credentials
 ];
 
 Sentry.init({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2152

### Description:
Added `UserInfoError` to the list of ignored errors in Sentry. This error occurs during Google OAuth2 authentication when invalid credentials are used, and doesn't need to be tracked in Sentry.