### PR TITLE
fix: improve error message for CLI-created projects without dbt connection

### DIFF
--- a/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtNoneCredentialsProjectAdapter.ts
@@ -4,6 +4,7 @@ import {
     Explore,
     ExploreError,
     LightdashProjectConfig,
+    ParameterError,
     type RunQueryTags,
 } from '@lightdash/common';
 import { WarehouseClient } from '@lightdash/warehouses';
@@ -37,7 +38,9 @@ export class DbtNoneCredentialsProjectAdapter implements ProjectAdapter {
         organizationUuid: string;
         projectUuid: string;
     }): Promise<(Explore | ExploreError)[]> {
-        throw new Error('Cannot compile explores with CLI-created projects');
+        throw new ParameterError(
+            'Cannot compile explores as this project was created via CLI and has no dbt connection configured. Either configure a dbt connection in project settings or use the CLI to deploy explores.',
+        );
     }
 
     // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2155

### Description:

Improved error message when attempting to compile explores in CLI-created projects without dbt connection. The error now clearly explains that users need to either configure a dbt connection in project settings or use the CLI to deploy explores, rather than showing a generic error message.