### PR TITLE
fix: centralize monaco editor configuration in vite

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreYamlModal/editor.worker.ts
+++ b/packages/frontend/src/components/Explorer/ExploreYamlModal/editor.worker.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/extensions
-import 'monaco-editor/esm/vs/editor/editor.worker.js';

--- a/packages/frontend/src/components/Explorer/ExploreYamlModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreYamlModal/index.tsx
@@ -45,23 +45,9 @@ import {
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import styles from './ExploreYamlModal.module.css';
-// eslint-disable-next-line import/no-unresolved, import/extensions
-import EditorWorker from './editor.worker.ts?worker';
-// eslint-disable-next-line import/no-unresolved, import/extensions
-import YamlWorker from './yaml.worker.ts?worker';
 
-// Configure Monaco environment to use the YAML worker
-// This must be done before Monaco loads
-// eslint-disable-next-line no-restricted-globals
-self.MonacoEnvironment = {
-    getWorker(_moduleId, label) {
-        if (label === 'yaml') {
-            return new YamlWorker();
-        }
-        // For other languages (like editorWorkerService), use the default editor worker
-        return new EditorWorker();
-    },
-};
+// Note: Monaco worker configuration is handled by vite-plugin-monaco-editor
+// in vite.config.ts with customWorkers for YAML support.
 
 // Configure monaco-yaml with schema once at module level
 let yamlConfigured = false;

--- a/packages/frontend/src/components/Explorer/ExploreYamlModal/yaml.worker.ts
+++ b/packages/frontend/src/components/Explorer/ExploreYamlModal/yaml.worker.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/extensions
-import 'monaco-yaml/yaml.worker.js';

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -26,7 +26,10 @@ export default defineConfig({
         }),
         monacoEditorPlugin({
             forceBuildCDN: true,
-            languageWorkers: ['json'],
+            languageWorkers: ['editorWorkerService', 'json', 'html'],
+            customWorkers: [
+                { label: 'yaml', entry: 'monaco-yaml/yaml.worker.js' },
+            ],
         }),
         sentryVitePlugin({
             telemetry: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: https://linear.app/lightdash/issue/PROD-1976/error-unexpected-usage
Closes: https://linear.app/lightdash/issue/PROD-1971/error-unexpected-usage
Closes: https://linear.app/lightdash/issue/PROD-2157/uncaught-syntaxerror-unexpected-token

### Description:
Refactored Monaco Editor worker configuration for YAML support by moving it from manual setup in component files to the Vite configuration.

This eliminates the need for separate worker files (`editor.worker.ts` and `yaml.worker.ts`) and instead uses the `vite-plugin-monaco-editor` to properly configure the workers. The plugin now handles both the editor worker service and YAML language support through the `customWorkers` configuration.

This fixes:
- Error when trying to `loadForeignModule` - monaco initialization
- Error when trying o render the html editor for custom tooltips - `Unexpected token '<'`

### Before

[Screen Recording 2025-12-22 at 15.38.22.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/00e9a5c7-3d38-42d0-9942-f0c5132e2b2e.mov" />](https://app.graphite.com/user-attachments/video/00e9a5c7-3d38-42d0-9942-f0c5132e2b2e.mov)

### After

[Screen Recording 2025-12-22 at 16.16.56.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/324af897-8050-4861-9906-0106aa05cceb.mov" />](https://app.graphite.com/user-attachments/video/324af897-8050-4861-9906-0106aa05cceb.mov)

