### PR TITLE
fix: handle foreign key violations when inserting validations

### DIFF
--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -81,7 +81,7 @@ export class ValidationModel {
                     error.constraint === 'validations_project_uuid_foreign'
                 ) {
                     Logger.warn(
-                        'Failed to insert validations: Project UUID does not exist. This may happen if the project was deleted during validation.',
+                        `Failed to insert validations: Project UUID (${validations[0].projectUuid}) does not exist. This may happen if the project was deleted during validation.`,
                     );
                     return;
                 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2156

### Description:

Added error handling for validation insertions when a project is deleted during validation. Now, if a foreign key violation occurs because the project UUID no longer exists, the error is caught and logged as a warning instead of causing the validation process to fail.