### PR TITLE
feat: dashboard scrolling updates

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/Dashboard.module.css
+++ b/packages/frontend/src/components/common/Dashboard/Dashboard.module.css
@@ -1,0 +1,6 @@
+.stickyHeader {
+    position: sticky;
+    top: 0;
+    z-index: var(--dashboard-header-zindex);
+    background-color: var(--mantine-color-body);
+}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeaderV1.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeaderV1.tsx
@@ -83,6 +83,7 @@ export type DashboardHeaderProps = {
     onToggleFullscreen: () => void;
     setAddingTab: (value: React.SetStateAction<boolean>) => void;
     onEditClicked: () => void;
+    className?: string;
 };
 
 const DashboardHeaderV1 = ({

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeaderV2.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeaderV2.tsx
@@ -60,6 +60,10 @@ import DashboardUpdateModal from '../modal/DashboardUpdateModal';
 import { type DashboardHeaderProps } from './DashboardHeaderV1';
 import { DashboardRefreshButtonV2 } from './DashboardRefreshButtonV2';
 import { ShareLinkButtonV2 } from './ShareLinkButtonV2';
+import {
+    DASHBOARD_HEADER_HEIGHT,
+    DASHBOARD_HEADER_ZINDEX,
+} from './dashboard.constants';
 
 const DashboardHeaderV2 = ({
     dashboard,
@@ -83,6 +87,7 @@ const DashboardHeaderV2 = ({
     onToggleFullscreen,
     setAddingTab,
     onEditClicked,
+    className,
 }: DashboardHeaderProps) => {
     const isDashboardSummariesEnabled = useFeatureFlagEnabled(
         'ai-dashboard-summary' as FeatureFlags,
@@ -191,7 +196,16 @@ const DashboardHeaderV2 = ({
     );
 
     return (
-        <PageHeader cardProps={{ px: 'xl', py: 0, h: 50, bg: 'background' }}>
+        <PageHeader
+            cardProps={{
+                px: 'xl',
+                py: 0,
+                h: DASHBOARD_HEADER_HEIGHT,
+                bg: 'background',
+                sx: { zIndex: DASHBOARD_HEADER_ZINDEX },
+                className,
+            }}
+        >
             <Group gap="xs" flex={1}>
                 <Title order={6}>{dashboard.name}</Title>
 

--- a/packages/frontend/src/components/common/Dashboard/dashboard.constants.ts
+++ b/packages/frontend/src/components/common/Dashboard/dashboard.constants.ts
@@ -1,0 +1,11 @@
+export const DASHBOARD_HEADER_HEIGHT = 50;
+export const DASHBOARD_HEADER_ZINDEX = 100;
+const DASHBOARD_TAB_HEIGHT = 50;
+const DASHBOARD_TABS_ZINDEX = 99;
+
+export const dashboardCSSVars = {
+    '--dashboard-header-height': `${DASHBOARD_HEADER_HEIGHT}px`,
+    '--dashboard-header-zindex': `${DASHBOARD_HEADER_ZINDEX}`,
+    '--dashboard-tab-height': `${DASHBOARD_TAB_HEIGHT}px`,
+    '--dashboard-tabs-zindex': `${DASHBOARD_TABS_ZINDEX}`,
+} as const;

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -412,7 +412,6 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
         setDuplicatingTab(false);
         setTabToDuplicate(null);
     };
-    const MAGIC_SCROLL_AREA_HEIGHT = 100;
 
     return (
         <DragDropContext
@@ -451,97 +450,121 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                     list: styles.list,
                                     tab: styles.tab,
                                 }}
-                                h={MAGIC_SCROLL_AREA_HEIGHT}
                                 mt={tabsEnabled ? undefined : 'xs'}
                             >
-                                {sortedTabs && sortedTabs?.length > 0 && (
-                                    <Tabs.List px="lg" mb="xs">
-                                        {sortedTabs.map((tab, idx) => (
-                                            <DraggableTab
-                                                key={tab.uuid}
-                                                idx={idx}
-                                                tab={tab}
-                                                isEditMode={isEditMode}
-                                                sortedTabs={sortedTabs}
-                                                currentTabHasTiles={
-                                                    currentTabHasTiles
+                                <div
+                                    className={styles.stickyTabsAndFilters}
+                                    data-has-header-above={isEditMode}
+                                >
+                                    {sortedTabs && sortedTabs?.length > 0 && (
+                                        <Tabs.List px="lg">
+                                            {sortedTabs.map((tab, idx) => (
+                                                <DraggableTab
+                                                    key={tab.uuid}
+                                                    idx={idx}
+                                                    tab={tab}
+                                                    isEditMode={isEditMode}
+                                                    sortedTabs={sortedTabs}
+                                                    currentTabHasTiles={
+                                                        currentTabHasTiles
+                                                    }
+                                                    setEditingTab={
+                                                        setEditingTab
+                                                    }
+                                                    handleDeleteTab={
+                                                        handleDeleteTab
+                                                    }
+                                                    handleDuplicateTab={
+                                                        handleDuplicateTab
+                                                    }
+                                                    setDeletingTab={
+                                                        setDeletingTab
+                                                    }
+                                                />
+                                            ))}
+
+                                            {provided.placeholder}
+
+                                            {isEditMode && (
+                                                <Button
+                                                    ml="sm"
+                                                    size="sm"
+                                                    fz={13}
+                                                    variant="subtle"
+                                                    flex="0 0 auto"
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconPlus}
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        setAddingTab(true)
+                                                    }
+                                                >
+                                                    New tab
+                                                </Button>
+                                            )}
+                                        </Tabs.List>
+                                    )}
+
+                                    {/* Filters bar - collapsed or expanded view */}
+                                    <div className={styles.filtersBar}>
+                                        {isFiltersCollapsed && !isEditMode ? (
+                                            <DashboardFiltersBarSummary
+                                                filtersCount={totalFiltersCount}
+                                                parametersCount={
+                                                    totalParametersCount
                                                 }
-                                                setEditingTab={setEditingTab}
-                                                handleDeleteTab={
-                                                    handleDeleteTab
+                                                dateZoomLabel={
+                                                    isDateZoomDisabled
+                                                        ? null
+                                                        : dateZoomGranularity ||
+                                                          'Default'
                                                 }
-                                                handleDuplicateTab={
-                                                    handleDuplicateTab
+                                                onExpand={() =>
+                                                    setIsFiltersCollapsed(false)
                                                 }
-                                                setDeletingTab={setDeletingTab}
                                             />
-                                        ))}
-
-                                        {provided.placeholder}
-
-                                        {isEditMode && (
-                                            <Button
-                                                ml="sm"
-                                                size="sm"
-                                                fz={13}
-                                                variant="subtle"
-                                                flex="0 0 auto"
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconPlus}
-                                                    />
+                                        ) : (
+                                            <DashboardFiltersBar
+                                                isEditMode={isEditMode}
+                                                activeTabUuid={activeTab?.uuid}
+                                                hasTilesThatSupportFilters={
+                                                    hasTilesThatSupportFilters
                                                 }
-                                                onClick={() =>
-                                                    setAddingTab(true)
+                                                hasDashboardTiles={
+                                                    !!hasDashboardTiles
                                                 }
-                                            >
-                                                New tab
-                                            </Button>
+                                                parameters={parameters}
+                                                parameterValues={
+                                                    parameterValues
+                                                }
+                                                onParameterChange={
+                                                    onParameterChange
+                                                }
+                                                onParameterClearAll={
+                                                    onParameterClearAll
+                                                }
+                                                isParameterLoading={
+                                                    isParameterLoading
+                                                }
+                                                missingRequiredParameters={
+                                                    missingRequiredParameters
+                                                }
+                                                pinnedParameters={
+                                                    pinnedParameters
+                                                }
+                                                onParameterPin={onParameterPin}
+                                                isDateZoomDisabled={
+                                                    isDateZoomDisabled
+                                                }
+                                                onCollapse={() =>
+                                                    setIsFiltersCollapsed(true)
+                                                }
+                                            />
                                         )}
-                                    </Tabs.List>
-                                )}
-
-                                {/* Filters bar - collapsed or expanded view */}
-                                {isFiltersCollapsed && !isEditMode ? (
-                                    <DashboardFiltersBarSummary
-                                        filtersCount={totalFiltersCount}
-                                        parametersCount={totalParametersCount}
-                                        dateZoomLabel={
-                                            isDateZoomDisabled
-                                                ? null
-                                                : dateZoomGranularity ||
-                                                  'Default'
-                                        }
-                                        onExpand={() =>
-                                            setIsFiltersCollapsed(false)
-                                        }
-                                    />
-                                ) : (
-                                    <DashboardFiltersBar
-                                        isEditMode={isEditMode}
-                                        activeTabUuid={activeTab?.uuid}
-                                        hasTilesThatSupportFilters={
-                                            hasTilesThatSupportFilters
-                                        }
-                                        hasDashboardTiles={!!hasDashboardTiles}
-                                        parameters={parameters}
-                                        parameterValues={parameterValues}
-                                        onParameterChange={onParameterChange}
-                                        onParameterClearAll={
-                                            onParameterClearAll
-                                        }
-                                        isParameterLoading={isParameterLoading}
-                                        missingRequiredParameters={
-                                            missingRequiredParameters
-                                        }
-                                        pinnedParameters={pinnedParameters}
-                                        onParameterPin={onParameterPin}
-                                        isDateZoomDisabled={isDateZoomDisabled}
-                                        onCollapse={() =>
-                                            setIsFiltersCollapsed(true)
-                                        }
-                                    />
-                                )}
+                                    </div>
+                                </div>
 
                                 <Group grow pb="lg" px="xs">
                                     <ResponsiveGridLayout

--- a/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
+++ b/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
@@ -1,3 +1,15 @@
+/* Wrapper for tabs and filters - always sticky together */
+.stickyTabsAndFilters {
+    position: sticky;
+    top: 0;
+    z-index: var(--dashboard-tabs-zindex);
+
+    /* When header is sticky above (edit mode), position below it */
+    &[data-has-header-above='true'] {
+        top: var(--dashboard-header-height);
+    }
+}
+
 .list {
     &::before {
         border-bottom: 0;
@@ -28,7 +40,7 @@
     font-size: 13px;
     font-weight: 500;
 
-    height: 50px;
+    height: var(--dashboard-tab-height);
     border-radius: 0;
 
     font-size: 13px;
@@ -56,5 +68,15 @@
     &[data-active='true'] {
         color: var(--mantine-color-ldGray-9);
         border-bottom: 2px solid var(--mantine-color-ldGray-9);
+    }
+}
+
+.filtersBar {
+    padding: var(--mantine-spacing-xs) 0;
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-0);
+    }
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
     }
 }


### PR DESCRIPTION
Closes: #18006

### Description:
Implemented sticky header and tabs for dashboards to improve navigation when scrolling through large dashboards. The implementation:

- Added CSS variables to define sticky element heights
- Created a sticky header component with proper z-index values
- Made tabs and filters stick to the top of the viewport when scrolling
- Ensured proper stacking order between header, tabs, and content
- Added proper positioning when in edit mode (header sticks first, then tabs below it)
- Improved styling for the filters bar with appropriate background colors

This enhancement provides a better user experience by keeping navigation controls accessible at all times, especially for dashboards with many visualizations.