### PR TITLE
feat: add styles to sticky dashboard elements

### DIFF
--- a/packages/frontend/src/components/common/StickyWithDetection.tsx
+++ b/packages/frontend/src/components/common/StickyWithDetection.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, type FC, type ReactNode } from 'react';
+
+type StickyWithDetectionProps = {
+    /**
+     * React children to render
+     */
+    children: ReactNode;
+    /**
+     * The top offset of the sticky element (should match CSS top value)
+     */
+    offset?: number;
+    /**
+     * Optional scrolling container element. Defaults to document.body
+     */
+    scrollContainer?: HTMLElement | null;
+    /**
+     * Callback that fires when stuck state changes
+     */
+    onStuckChange: (isStuck: boolean) => void;
+};
+
+/**
+ * Wrapper component that detects when a sticky element becomes stuck.
+ * Uses IntersectionObserver to detect when the sentinel element crosses the sticky threshold.
+ *
+ * @example
+ * ```tsx
+ * const [isStuck, setIsStuck] = useState(false);
+ *
+ * <StickyWithDetection offset={50} onStuckChange={setIsStuck}>
+ *   <div data-is-stuck={isStuck}>
+ *     Header content
+ *   </div>
+ * </StickyWithDetection>
+ * ```
+ */
+export const StickyWithDetection: FC<StickyWithDetectionProps> = ({
+    children,
+    offset = 0,
+    scrollContainer,
+    onStuckChange,
+}) => {
+    const sentinelRef = useRef<HTMLDivElement>(null);
+    const onStuckChangeRef = useRef(onStuckChange);
+
+    useEffect(() => {
+        onStuckChangeRef.current = onStuckChange;
+    }, [onStuckChange]);
+
+    useEffect(() => {
+        const sentinel = sentinelRef.current;
+        if (!sentinel) return;
+
+        const container = scrollContainer || document.body;
+
+        const rootMargin = offset > 0 ? `-${offset + 1}px 0px 0px 0px` : '0px';
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                onStuckChangeRef.current(!entry.isIntersecting);
+            },
+            {
+                root: container,
+                threshold: 0,
+                rootMargin,
+            },
+        );
+
+        observer.observe(sentinel);
+
+        return () => {
+            observer.disconnect();
+        };
+    }, [offset, scrollContainer]);
+
+    return (
+        <>
+            <div
+                ref={sentinelRef}
+                style={{
+                    height: '1px',
+                    marginTop: '-1px',
+                    pointerEvents: 'none',
+                }}
+            />
+            {children}
+        </>
+    );
+};

--- a/packages/frontend/src/features/dashboardFiltersV2/DashboardFiltersBarSummary.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/DashboardFiltersBarSummary.tsx
@@ -31,7 +31,7 @@ export const DashboardFiltersBarSummary: FC<Props> = ({
         >
             <Group gap="xs" align="center">
                 {(hasFilters || hasParameters || hasDateZoom) && (
-                    <FilterGroupSeparator icon={IconFilter} size="sm" />
+                    <FilterGroupSeparator icon={IconFilter} />
                 )}
 
                 <Text fz="12" c="dimmed">

--- a/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
+++ b/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
@@ -8,6 +8,10 @@
     &[data-has-header-above='true'] {
         top: var(--dashboard-header-height);
     }
+
+    &[data-is-stuck='true'] {
+        border-bottom: 1px solid var(--mantine-color-ldGray-3);
+    }
 }
 
 .list {


### PR DESCRIPTION
### Description:

Added a new `StickyWithDetection` component that detects when a sticky element becomes stuck to improve the dashboard tabs UI. This component uses the Intersection Observer API to detect when an element becomes sticky and provides this state via a render prop.

Implemented this component in the dashboard tabs to add a bottom border when the tabs are stuck to the top of the viewport, improving visual distinction when scrolling. The component handles different offset values based on whether the dashboard is in edit mode.

#### With tabs

[CleanShot 2025-12-23 at 11.28.52.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/48d6e033-62bb-4fb0-b3be-1ba7ad461f85.mp4" />](https://app.graphite.com/user-attachments/video/48d6e033-62bb-4fb0-b3be-1ba7ad461f85.mp4)

#### No Tabs

[CleanShot 2025-12-23 at 11.30.16.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c054920c-c7d5-4b98-ac4e-b3026793e805.mp4" />](https://app.graphite.com/user-attachments/video/c054920c-c7d5-4b98-ac4e-b3026793e805.mp4)

