### PR TITLE
feat: add controls for heatmap

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3580,6 +3580,7 @@ const models: TsoaRoute.Models = {
                 label: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        showOverlappingLabels: { dataType: 'boolean' },
                         position: {
                             dataType: 'union',
                             subSchemas: [
@@ -4397,6 +4398,14 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 backgroundColor: { dataType: 'string' },
                 tileBackground: { ref: 'MapTileBackground' },
+                heatmapConfig: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        opacity: { dataType: 'double' },
+                        blur: { dataType: 'double' },
+                        radius: { dataType: 'double' },
+                    },
+                },
                 sizeFieldId: { dataType: 'string' },
                 maxBubbleSize: { dataType: 'double' },
                 minBubbleSize: { dataType: 'double' },
@@ -7105,11 +7114,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7197,7 +7206,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7220,7 +7229,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                chartUsage:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7250,12 +7259,6 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -7263,6 +7266,12 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7466,7 +7475,7 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7489,7 +7498,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    chartUsage:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7519,12 +7528,6 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -7532,6 +7535,12 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -7605,11 +7614,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7624,11 +7633,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7643,11 +7652,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7662,11 +7671,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7681,11 +7690,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3973,6 +3973,9 @@
                     },
                     "label": {
                         "properties": {
+                            "showOverlappingLabels": {
+                                "type": "boolean"
+                            },
                             "position": {
                                 "type": "string",
                                 "enum": [
@@ -4795,6 +4798,23 @@
                     },
                     "tileBackground": {
                         "$ref": "#/components/schemas/MapTileBackground"
+                    },
+                    "heatmapConfig": {
+                        "properties": {
+                            "opacity": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "blur": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "radius": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "type": "object"
                     },
                     "sizeFieldId": {
                         "type": "string"
@@ -7971,6 +7991,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -7986,12 +8019,12 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -7999,10 +8032,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8011,8 +8044,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8106,12 +8139,12 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "searchRank": {
+                                                                                    "chartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -8119,10 +8152,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8131,8 +8164,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -23786,7 +23819,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2282.3",
+        "version": "0.2287.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -185,7 +185,12 @@ export type MapChart = {
     minBubbleSize?: number;
     maxBubbleSize?: number;
     sizeFieldId?: string;
-    // Tile background
+    // Heatmap settings
+    heatmapConfig?: {
+        radius?: number;
+        blur?: number;
+        opacity?: number;
+    };
     tileBackground?: MapTileBackground;
     backgroundColor?: string;
 };

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -666,9 +666,9 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                                 points={heatmapPoints}
                                 options={{
                                     gradient: heatmapGradient,
-                                    radius: 25,
-                                    blur: 15,
-                                    minOpacity: 0.6,
+                                    radius: mapConfig.heatmapConfig.radius,
+                                    blur: mapConfig.heatmapConfig.blur,
+                                    minOpacity: mapConfig.heatmapConfig.opacity,
                                 }}
                             />
                         ) : (

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
@@ -109,6 +109,7 @@ export const Display: FC = memo(() => {
             setMinBubbleSize,
             setMaxBubbleSize,
             setSizeFieldId,
+            setHeatmapConfig,
             setTileBackground,
             setBackgroundColor,
         },
@@ -321,6 +322,68 @@ export const Display: FC = memo(() => {
                                 mb="md"
                             />
                         )}
+                    </Config.Section>
+                </Config>
+            )}
+
+            {isHeatmap && (
+                <Config>
+                    <Config.Section>
+                        <Config.Heading>Heatmap</Config.Heading>
+                        <Text size="xs" mt="sm">
+                            Radius
+                        </Text>
+                        <Slider
+                            min={1}
+                            max={50}
+                            step={1}
+                            value={validConfig.heatmapConfig?.radius ?? 25}
+                            onChange={(value) =>
+                                setHeatmapConfig({ radius: value })
+                            }
+                            marks={[
+                                { value: 1, label: '1' },
+                                { value: 25, label: '25' },
+                                { value: 50, label: '50' },
+                            ]}
+                            mb="md"
+                        />
+                        <Text size="xs" mt="sm">
+                            Blur
+                        </Text>
+                        <Slider
+                            min={0}
+                            max={30}
+                            step={1}
+                            value={validConfig.heatmapConfig?.blur ?? 15}
+                            onChange={(value) =>
+                                setHeatmapConfig({ blur: value })
+                            }
+                            marks={[
+                                { value: 0, label: '0' },
+                                { value: 15, label: '15' },
+                                { value: 30, label: '30' },
+                            ]}
+                            mb="md"
+                        />
+                        <Text size="xs" mt="sm">
+                            Opacity
+                        </Text>
+                        <Slider
+                            min={0.1}
+                            max={1}
+                            step={0.1}
+                            value={validConfig.heatmapConfig?.opacity ?? 0.6}
+                            onChange={(value) =>
+                                setHeatmapConfig({ opacity: value })
+                            }
+                            marks={[
+                                { value: 0.1, label: '0.1' },
+                                { value: 0.5, label: '0.5' },
+                                { value: 1, label: '1' },
+                            ]}
+                            mb="md"
+                        />
                     </Config.Section>
                 </Config>
             )}

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapLayoutConfig.tsx
@@ -61,12 +61,9 @@ export const Layout: FC = memo(() => {
     ];
 
     const locationTypeOptions = [
-        {
-            value: MapChartType.SCATTER,
-            label: 'Scatter',
-        },
-        { value: MapChartType.HEATMAP, label: 'Heatmap' },
+        { value: MapChartType.SCATTER, label: 'Scatter' },
         { value: MapChartType.AREA, label: 'Area' },
+        { value: MapChartType.HEATMAP, label: 'Heatmap' },
     ];
 
     const locationType = validConfig.locationType || MapChartType.SCATTER;

--- a/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
+++ b/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
@@ -47,6 +47,11 @@ export type LeafletMapConfig = {
     minBubbleSize: number;
     maxBubbleSize: number;
     sizeRange: { min: number; max: number } | null;
+    heatmapConfig: {
+        radius: number;
+        blur: number;
+        opacity: number;
+    };
     tile: TileConfig;
     backgroundColor: string | null;
     showLegend: boolean;
@@ -174,6 +179,7 @@ const useLeafletMapConfig = ({
             minBubbleSize,
             maxBubbleSize,
             sizeFieldId,
+            heatmapConfig,
             tileBackground,
             backgroundColor,
             showLegend,
@@ -323,6 +329,11 @@ const useLeafletMapConfig = ({
             minBubbleSize: minBubbleSize ?? 2,
             maxBubbleSize: maxBubbleSize ?? 8,
             sizeRange,
+            heatmapConfig: {
+                radius: heatmapConfig?.radius ?? 25,
+                blur: heatmapConfig?.blur ?? 15,
+                opacity: heatmapConfig?.opacity ?? 0.6,
+            },
             tile: getTileConfig(tileBackground),
             backgroundColor: backgroundColor ?? null,
             showLegend: showLegend ?? false,


### PR DESCRIPTION

### Description:

Adds control over heatmap layer
- Radius 
- Blur 
- Opacity

Without these it's hard to tweak a heatmap to look good with specific data. 

And a better default color ramp.

[Localhost repro](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/airports?create_saved_chart_version=%7B%22tableName%22%3A%22airports%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22airports%22%2C%22dimensions%22%3A%5B%22airports_lon%22%2C%22airports_lat%22%2C%22airports_volume%22%5D%2C%22metrics%22%3A%5B%22airports_total_passenger_volume%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22airports_lon%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A5000%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22airports_lon%22%2C%22airports_lat%22%2C%22airports_volume%22%2C%22airports_total_passenger_volume%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22map%22%2C%22config%22%3A%7B%22mapType%22%3A%22world%22%2C%22locationType%22%3A%22heatmap%22%2C%22latitudeFieldId%22%3A%22airports_lat%22%2C%22longitudeFieldId%22%3A%22airports_lon%22%2C%22colorRange%22%3A%5B%22%233b4cc0%22%2C%22%237092e5%22%2C%22%23aac7fd%22%2C%22%23f7b89c%22%2C%22%23e7553c%22%5D%2C%22showLegend%22%3Afalse%2C%22saveMapExtent%22%3Atrue%2C%22defaultZoom%22%3A5%2C%22defaultCenterLat%22%3A40.72549827698%2C%22defaultCenterLon%22%3A1.2963867187500002%2C%22tileBackground%22%3A%22light%22%7D%7D%7D&isExploreFromHere=true)

<img width="378" height="622" alt="Screenshot 2025-12-22 at 19 52 18" src="https://github.com/user-attachments/assets/9d1eaf63-9a03-4331-9ee8-a8b56aab7978" />

