### PR TITLE
feat: new dashboard tile toolbar

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -280,7 +280,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
             {chartData.config.type === ChartKind.TABLE &&
                 isVizTableConfig(chartData.config) && (
                     // So that the Table tile isn't cropped by the overflow
-                    <Box w="100%" h="100%" sx={{ overflow: 'auto' }}>
+                    <Box w="100%" h="100%" style={{ overflow: 'auto' }}>
                         <Table
                             resultsRunner={chartResultsData.resultsRunner}
                             columnsConfig={chartData.config.columns}

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -1,0 +1,29 @@
+.tileWrapper {
+    position: relative;
+    height: 100%;
+}
+
+.tileCard {
+    overflow: unset;
+
+    border: 1px solid
+        light-dark(
+            var(--mantine-color-ldGray-1),
+            lighten(var(--mantine-color-ldDark-1), 0.05)
+        ) !important;
+
+    &[data-with-transparent-border='true'] {
+        border: 1px solid transparent !important;
+    }
+
+    &[data-with-edit-mode='true'] {
+        border: 1px dashed var(--mantine-color-blue-5) !important;
+    }
+}
+
+.dragHandleIcon {
+    cursor: grab;
+    &:active {
+        cursor: grabbing;
+    }
+}

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
@@ -7,15 +7,15 @@ import {
     ActionIcon,
     Box,
     Card,
-    Flex,
     Group,
     LoadingOverlay,
-    Menu,
+    Paper,
     Text,
     Tooltip,
     getDefaultZIndex,
-} from '@mantine/core';
-import { useHover, useToggle } from '@mantine/hooks';
+} from '@mantine-8/core';
+import { useHover, useToggle } from '@mantine-8/hooks';
+import { Menu } from '@mantine/core';
 import {
     IconArrowAutofitContent,
     IconDots,
@@ -30,12 +30,10 @@ import DeleteChartTileThatBelongsToDashboardModal from '../../common/modal/Delet
 import ChartUpdateModal from '../TileForms/ChartUpdateModal';
 import MoveTileToTabModal from '../TileForms/MoveTileToTabModal';
 import TileUpdateModal from '../TileForms/TileUpdateModal';
-
+import styles from './TileBase.module.css';
 import {
     ChartContainer,
-    DragHandle,
     HeaderContainer,
-    TileCardWrapper,
     TileTitleLink,
     TitleWrapper,
 } from './TileBase.styles';
@@ -88,36 +86,158 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
         tile.type === DashboardTileTypes.MARKDOWN && !title;
 
     return (
-        <TileCardWrapper>
+        <div ref={containerRef} className={styles.tileWrapper}>
+            {containerHovered && isEditMode && !minimal && (
+                <Paper
+                    className={styles.dragHandleIcon}
+                    pos="absolute"
+                    shadow="sm"
+                    top={-6}
+                    left={-2}
+                    px={5}
+                    py={8}
+                    style={{ zIndex: 10 }}
+                >
+                    <MantineIcon icon={IconGripVertical} color="ldGray" />
+                </Paper>
+            )}
+
+            {((containerHovered && !titleHovered && !chartHovered) ||
+                isMenuOpen ||
+                lockHeaderVisibility) && (
+                <Paper
+                    p={5}
+                    className="non-draggable"
+                    shadow="sm"
+                    pos="absolute"
+                    top={-6}
+                    right={-2}
+                    style={{ zIndex: 10 }}
+                >
+                    <Group gap={5} wrap="nowrap">
+                        {titleLeftIcon}
+
+                        {visibleHeaderElement && (
+                            <Group gap="xs" className="non-draggable">
+                                {visibleHeaderElement}
+                            </Group>
+                        )}
+
+                        {extraHeaderElement}
+
+                        {(isEditMode || (!isEditMode && extraMenuItems)) && (
+                            <Menu
+                                withArrow
+                                withinPortal
+                                shadow="md"
+                                position="bottom-end"
+                                offset={4}
+                                arrowOffset={10}
+                                opened={isMenuOpen}
+                                onOpen={() => toggleMenu(true)}
+                                onClose={() => toggleMenu(false)}
+                            >
+                                <Menu.Dropdown>
+                                    {extraMenuItems}
+                                    {isEditMode && extraMenuItems && (
+                                        <Menu.Divider />
+                                    )}
+                                    {isEditMode && (
+                                        <>
+                                            <Box>
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconEdit}
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        setIsEditingTileContent(
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    Edit tile content
+                                                </Menu.Item>
+                                            </Box>
+                                            {tabs && tabs.length > 1 && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconArrowAutofitContent
+                                                            }
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        setIsMovingTabs(true)
+                                                    }
+                                                >
+                                                    Move to another tab
+                                                </Menu.Item>
+                                            )}
+                                            <Menu.Divider />
+                                            {belongsToDashboard ? (
+                                                <Menu.Item
+                                                    color="red"
+                                                    onClick={() =>
+                                                        setIsDeletingChartThatBelongsToDashboard(
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    Delete chart
+                                                </Menu.Item>
+                                            ) : (
+                                                <Menu.Item
+                                                    color="red"
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconTrash}
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        onDelete(tile)
+                                                    }
+                                                >
+                                                    Remove tile
+                                                </Menu.Item>
+                                            )}
+                                        </>
+                                    )}
+                                </Menu.Dropdown>
+
+                                <Menu.Target>
+                                    <ActionIcon
+                                        size="sm"
+                                        variant="subtle"
+                                        color="gray"
+                                        style={{
+                                            position: 'relative',
+                                            zIndex: 1,
+                                        }}
+                                    >
+                                        <MantineIcon
+                                            data-testid="tile-icon-more"
+                                            icon={IconDots}
+                                        />
+                                    </ActionIcon>
+                                </Menu.Target>
+                            </Menu>
+                        )}
+                    </Group>
+                </Paper>
+            )}
+
             <Card
-                component={Flex}
-                className="tile-base"
-                ref={containerRef}
+                className={styles.tileCard}
+                data-with-transparent-border={transparent}
+                data-with-edit-mode={isEditMode}
                 h="100%"
-                direction="column"
                 p={transparent ? 0 : 'md'}
-                radius="sm"
                 bg={transparent ? 'transparent' : 'background'}
-                shadow={isEditMode ? 'xs' : undefined}
-                sx={(theme) => {
-                    let border = transparent
-                        ? 'none'
-                        : `1px solid ${
-                              theme.colorScheme === 'dark'
-                                  ? theme.fn.lighten(
-                                        theme.colors.ldDark[1],
-                                        0.05,
-                                    )
-                                  : theme.colors.ldGray[1]
-                          }`;
-                    if (isEditMode) {
-                        border = `1px dashed ${theme.colors.blue[5]}`;
-                    }
-                    return {
-                        overflow: 'unset',
-                        border: border,
-                    };
-                }}
+                shadow={isEditMode && !transparent ? 'xs' : '0'}
+                radius="sm"
             >
                 <LoadingOverlay
                     // ! Very important to have this class name on the tile loading overlay, otherwise the unfurl service will not be able to find it
@@ -125,13 +245,7 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                     visible={isLoading ?? false}
                     zIndex={getDefaultZIndex('modal') - 10}
                 />
-                {isEditMode && !minimal && (
-                    <DragHandle className="drag-handle-icon">
-                        <ActionIcon size="sm" color="gray" variant="subtle">
-                            <MantineIcon icon={IconGripVertical} />
-                        </ActionIcon>
-                    </DragHandle>
-                )}
+
                 <HeaderContainer
                     $isEditMode={isEditMode}
                     $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
@@ -146,7 +260,10 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                             <Tooltip
                                 disabled={!description}
                                 label={
-                                    <Text style={{ whiteSpace: 'pre-line' }}>
+                                    <Text
+                                        style={{ whiteSpace: 'pre-line' }}
+                                        fz="sm"
+                                    >
                                         {description}
                                     </Text>
                                 }
@@ -164,19 +281,18 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                         )
                     ) : (
                         <Group
-                            spacing="xs"
-                            noWrap
+                            gap="xs"
+                            wrap="nowrap"
                             align="start"
-                            sx={{ overflow: 'hidden' }}
+                            style={{ overflow: 'hidden' }}
                         >
-                            {titleLeftIcon}
-
                             <TitleWrapper $hovered={titleHovered}>
                                 <Tooltip
                                     disabled={!description}
                                     label={
                                         <Text
                                             style={{ whiteSpace: 'pre-line' }}
+                                            fz="sm"
                                         >
                                             {description}
                                         </Text>
@@ -219,134 +335,8 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                             </TitleWrapper>
                         </Group>
                     )}
-                    <Group
-                        spacing="xs"
-                        className="non-draggable"
-                        sx={{ marginLeft: 'auto' }}
-                        noWrap
-                    >
-                        {visibleHeaderElement && (
-                            <Group spacing="xs" className="non-draggable">
-                                {visibleHeaderElement}
-                            </Group>
-                        )}
-                        {(containerHovered && !titleHovered && !chartHovered) ||
-                        isMenuOpen ||
-                        lockHeaderVisibility ? (
-                            <>
-                                {extraHeaderElement}
-
-                                {(isEditMode ||
-                                    (!isEditMode && extraMenuItems)) && (
-                                    <Menu
-                                        withArrow
-                                        withinPortal
-                                        shadow="md"
-                                        position="bottom-end"
-                                        offset={4}
-                                        arrowOffset={10}
-                                        opened={isMenuOpen}
-                                        onOpen={() => toggleMenu(true)}
-                                        onClose={() => toggleMenu(false)}
-                                    >
-                                        <Menu.Dropdown>
-                                            {extraMenuItems}
-                                            {isEditMode && extraMenuItems && (
-                                                <Menu.Divider />
-                                            )}
-                                            {isEditMode && (
-                                                <>
-                                                    <Box>
-                                                        <Menu.Item
-                                                            icon={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconEdit
-                                                                    }
-                                                                />
-                                                            }
-                                                            onClick={() =>
-                                                                setIsEditingTileContent(
-                                                                    true,
-                                                                )
-                                                            }
-                                                        >
-                                                            Edit tile content
-                                                        </Menu.Item>
-                                                    </Box>
-                                                    {tabs &&
-                                                        tabs.length > 1 && (
-                                                            <Menu.Item
-                                                                icon={
-                                                                    <MantineIcon
-                                                                        icon={
-                                                                            IconArrowAutofitContent
-                                                                        }
-                                                                    />
-                                                                }
-                                                                onClick={() =>
-                                                                    setIsMovingTabs(
-                                                                        true,
-                                                                    )
-                                                                }
-                                                            >
-                                                                Move to another
-                                                                tab
-                                                            </Menu.Item>
-                                                        )}
-                                                    <Menu.Divider />
-                                                    {belongsToDashboard ? (
-                                                        <Menu.Item
-                                                            color="red"
-                                                            onClick={() =>
-                                                                setIsDeletingChartThatBelongsToDashboard(
-                                                                    true,
-                                                                )
-                                                            }
-                                                        >
-                                                            Delete chart
-                                                        </Menu.Item>
-                                                    ) : (
-                                                        <Menu.Item
-                                                            color="red"
-                                                            icon={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconTrash
-                                                                    }
-                                                                />
-                                                            }
-                                                            onClick={() =>
-                                                                onDelete(tile)
-                                                            }
-                                                        >
-                                                            Remove tile
-                                                        </Menu.Item>
-                                                    )}
-                                                </>
-                                            )}
-                                        </Menu.Dropdown>
-
-                                        <Menu.Target>
-                                            <ActionIcon
-                                                size="sm"
-                                                style={{
-                                                    position: 'relative',
-                                                    zIndex: 1,
-                                                }}
-                                            >
-                                                <MantineIcon
-                                                    data-testid="tile-icon-more"
-                                                    icon={IconDots}
-                                                />
-                                            </ActionIcon>
-                                        </Menu.Target>
-                                    </Menu>
-                                )}
-                            </>
-                        ) : null}
-                    </Group>
                 </HeaderContainer>
+
                 <ChartContainer
                     className="non-draggable sentry-block ph-no-capture"
                     onMouseEnter={
@@ -368,6 +358,7 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                 >
                     {children}
                 </ChartContainer>
+
                 {isEditingTileContent &&
                     (tile.type === DashboardTileTypes.SAVED_CHART ||
                     tile.type === DashboardTileTypes.SQL_CHART ? (
@@ -401,6 +392,7 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                             }}
                         />
                     ))}
+
                 <DeleteChartTileThatBelongsToDashboardModal
                     className={'non-draggable'}
                     name={chartName ?? ''}
@@ -413,6 +405,7 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                         setIsDeletingChartThatBelongsToDashboard(false);
                     }}
                 />
+
                 <MoveTileToTabModal
                     className="non-draggable"
                     opened={isMovingTabs}
@@ -425,7 +418,7 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                     onClose={() => setIsMovingTabs(false)}
                 />
             </Card>
-        </TileCardWrapper>
+        </div>
     );
 };
 

--- a/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/index.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/index.tsx
@@ -1,6 +1,6 @@
 import { type DashboardSummary } from '@lightdash/common';
-import { Button, Modal, Tooltip } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
+import { Button, Modal, Tooltip } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconWand } from '@tabler/icons-react';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -117,7 +117,7 @@ const AIDashboardSummary: FC<DashboardAIProps> = ({
                 <Button
                     variant="light"
                     onClick={open}
-                    leftIcon={<MantineIcon icon={IconWand} />}
+                    leftSection={<MantineIcon icon={IconWand} />}
                     size="xs"
                     color="violet"
                     loading={

--- a/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
+++ b/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
@@ -2,7 +2,6 @@
 .stickyTabsAndFilters {
     position: sticky;
     top: 0;
-    z-index: var(--dashboard-tabs-zindex);
 
     /* When header is sticky above (edit mode), position below it */
     &[data-has-header-above='true'] {
@@ -10,6 +9,7 @@
     }
 
     &[data-is-stuck='true'] {
+        z-index: var(--dashboard-tabs-zindex);
         border-bottom: 1px solid var(--mantine-color-ldGray-3);
     }
 }

--- a/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTile.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTile.tsx
@@ -1,49 +1,18 @@
-import {
-    type CompiledDimension,
-    type DateGranularity,
-} from '@lightdash/common';
-import { Text, Tooltip } from '@mantine/core';
-import { IconCalendarSearch } from '@tabler/icons-react';
+import { FeatureFlags } from '@lightdash/common';
 import { type FC } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
+import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import { DateZoomInfoOnTileV1 } from './DateZoomInfoOnTileV1';
+import { DateZoomInfoOnTileV2 } from './DateZoomInfoOnTileV2';
+import { type DateZoomInfoOnTileProps } from './types';
 
-type Props = {
-    dateZoomGranularity: DateGranularity;
-    dateDimension: Pick<CompiledDimension, 'label' | 'name'>;
-};
+export const DateZoomInfoOnTile: FC<DateZoomInfoOnTileProps> = (props) => {
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
 
-export const DateZoomInfoOnTile: FC<Props> = ({
-    dateZoomGranularity,
-    dateDimension,
-}) => {
-    return (
-        <Tooltip
-            label={
-                <>
-                    <Text fz="xs">
-                        Date zoom:{' '}
-                        <Text span fw={500}>
-                            {dateZoomGranularity}
-                        </Text>
-                    </Text>
-                    <Text fz="xs">
-                        On:{' '}
-                        <Text span fw={500}>
-                            {dateDimension?.label}
-                        </Text>
-                    </Text>
-                </>
-            }
-            disabled={!dateDimension}
-            multiline
-            withinPortal
-        >
-            <MantineIcon
-                icon={IconCalendarSearch}
-                color="blue"
-                size={20}
-                style={{ flexShrink: 0 }}
-            />
-        </Tooltip>
+    return isDashboardRedesignEnabled ? (
+        <DateZoomInfoOnTileV2 {...props} />
+    ) : (
+        <DateZoomInfoOnTileV1 {...props} />
     );
 };

--- a/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTileV1.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTileV1.tsx
@@ -1,0 +1,41 @@
+import { Text, Tooltip } from '@mantine/core';
+import { IconCalendarSearch } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { type DateZoomInfoOnTileProps } from './types';
+
+export const DateZoomInfoOnTileV1: FC<DateZoomInfoOnTileProps> = ({
+    dateZoomGranularity,
+    dateDimension,
+}) => {
+    return (
+        <Tooltip
+            label={
+                <>
+                    <Text fz="xs">
+                        Date zoom:{' '}
+                        <Text span fw={500}>
+                            {dateZoomGranularity}
+                        </Text>
+                    </Text>
+                    <Text fz="xs">
+                        On:{' '}
+                        <Text span fw={500}>
+                            {dateDimension?.label}
+                        </Text>
+                    </Text>
+                </>
+            }
+            disabled={!dateDimension}
+            multiline
+            withinPortal
+        >
+            <MantineIcon
+                icon={IconCalendarSearch}
+                color="blue"
+                size={20}
+                style={{ flexShrink: 0 }}
+            />
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTileV2.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTileV2.tsx
@@ -1,0 +1,41 @@
+import { Group, Paper, Text, Tooltip } from '@mantine-8/core';
+import { IconCalendar } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { type DateZoomInfoOnTileProps } from './types';
+
+export const DateZoomInfoOnTileV2: FC<DateZoomInfoOnTileProps> = ({
+    dateZoomGranularity,
+    dateDimension,
+}) => {
+    return (
+        <Tooltip
+            label={
+                <>
+                    <Text fz="xs">
+                        Date zoom:{' '}
+                        <Text span fw={500}>
+                            {dateZoomGranularity}
+                        </Text>
+                    </Text>
+                    <Text fz="xs">
+                        On:{' '}
+                        <Text span fw={500}>
+                            {dateDimension?.label}
+                        </Text>
+                    </Text>
+                </>
+            }
+            disabled={!dateDimension}
+            multiline
+            withinPortal
+        >
+            <Paper radius="sm" py="xxs" px="xs" shadow="0">
+                <Group wrap="nowrap" gap="xxs">
+                    <MantineIcon icon={IconCalendar} size="sm" />
+                    <Text fz={11}>{dateZoomGranularity}</Text>
+                </Group>
+            </Paper>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/features/dateZoom/components/types.ts
+++ b/packages/frontend/src/features/dateZoom/components/types.ts
@@ -1,0 +1,6 @@
+import type { CompiledDimension, DateGranularity } from '@lightdash/common';
+
+export type DateZoomInfoOnTileProps = {
+    dateZoomGranularity: DateGranularity;
+    dateDimension: Pick<CompiledDimension, 'label' | 'name'>;
+};

--- a/packages/frontend/src/features/export/components/ExportToGoogleSheet.tsx
+++ b/packages/frontend/src/features/export/components/ExportToGoogleSheet.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import { type ApiScheduledDownloadCsv } from '@lightdash/common';
-import { Button, Loader, Menu } from '@mantine/core';
+import { Button, Loader } from '@mantine-8/core';
+import { Menu } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useEffect, type FC } from 'react';
 import { GSheetsIcon } from '../../../components/common/GSheetsIcon';
@@ -80,7 +81,7 @@ export const ExportToGoogleSheet: FC<ExportToGoogleSheetProps> = memo(
                 size="xs"
                 variant="default"
                 loading={isExporting}
-                leftIcon={<MantineIcon icon={GSheetsIcon} />}
+                leftSection={<MantineIcon icon={GSheetsIcon} />}
                 onClick={() => mutate()}
                 disabled={disabled}
             >

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -346,6 +346,7 @@ export const getMantineThemeOverride = (
                 fontWeight: 600,
             },
 
+            // TODO: remove after we migrate dashboards to v2 (feature flag: DashboardRedesign, dashboard-redesign)
             '.react-draggable.react-draggable-dragging .tile-base': {
                 border: `1px solid ${theme.colors.blue[5]}`,
             },


### PR DESCRIPTION
### Description:

Migrated dashboard tile components to use CSS modules and Mantine v8 components as part of the dashboard redesign.

### What changed?

- Replaced styled components with CSS modules in `TileBase.module.css`
- Updated `TileBaseV2` component to use Mantine v8 components and hooks
- Restructured tile layout with improved positioning of controls and headers
- Created separate V1 and V2 versions of `DateZoomInfoOnTile` component
- Fixed overflow handling in `DashboardSqlChartTile` by replacing `sx` with `style`
- Updated z-index behavior in dashboard tabs to only apply when stuck
- Migrated various components to use Mantine v8 imports (`@mantine-8/core` and `@mantine-8/hooks`)