### PR TITLE
fix: prevent pivot mismatch warning when groupByColumns is undefined

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -34,6 +34,7 @@ import {
     selectSavedChart,
     selectTableCalculationsMetadata,
     selectUnsavedChartVersion,
+    selectValidQueryArgs,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
@@ -133,6 +134,15 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
     );
 
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
+
+    const validQueryArgs = useExplorerSelector(selectValidQueryArgs);
+    const pivotDimensions = useMemo(
+        () =>
+            validQueryArgs?.pivotConfiguration?.groupByColumns?.map(
+                (c) => c.reference,
+            ),
+        [validQueryArgs?.pivotConfiguration?.groupByColumns],
+    );
 
     const tableCalculationsMetadata = useExplorerSelector(
         selectTableCalculationsMetadata,
@@ -284,9 +294,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                     headerElement={
                         isOpen && (
                             <VisualizationWarning
-                                pivotDimensions={
-                                    unsavedChartVersion.pivotConfig?.columns
-                                }
+                                pivotDimensions={pivotDimensions}
                                 chartConfig={unsavedChartVersion.chartConfig}
                                 resultsData={resultsData}
                                 isLoading={isLoadingQueryResults}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -62,16 +62,17 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
 
     // Determine if configured pivot dimensions are different from the ones used to compute the results
     const shouldShowPivotMismatch = useMemo(() => {
-        if (!resultsData.pivotDetails?.groupByColumns) return false;
-
-        // Determine pivot used to compute current results
-        const resultsPivotDimensions =
-            resultsData.pivotDetails.groupByColumns.map(
-                (c: { reference: string }) => c.reference,
-            );
-
         // Only show when using SQL pivot results
         if (!useSqlPivotResults?.enabled) return false;
+
+        // Only show when results have been fetched (metricQuery exists)
+        if (!resultsData?.metricQuery) return false;
+
+        // Determine pivot used to compute current results (treat missing as empty)
+        const resultsPivotDimensions = (
+            resultsData?.pivotDetails?.groupByColumns ?? []
+        ).map((c: { reference: string }) => c.reference);
+
         // If both sides empty/undefined, no warning
         if (
             resultsPivotDimensions.length === 0 &&
@@ -81,6 +82,7 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
         // Show when arrays differ
         return !isEqual(dirtyPivotDimensions, resultsPivotDimensions);
     }, [
+        resultsData?.metricQuery,
         resultsData?.pivotDetails?.groupByColumns,
         useSqlPivotResults,
         dirtyPivotDimensions,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixed a potential null reference error in the VisualizationWarning component by adding a null check for `resultsData.pivotDetails?.groupByColumns` before attempting to map over it. Also improved code readability by removing unnecessary optional chaining and array fallback.
