### PR TITLE
feat: display SQL even with compilation errors for debugging

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2249,6 +2249,7 @@ export class ProjectService extends BaseService {
         parameters,
         availableParameterDefinitions,
         pivotConfiguration,
+        continueOnError,
     }: {
         metricQuery: MetricQuery;
         explore: Explore;
@@ -2260,6 +2261,7 @@ export class ProjectService extends BaseService {
         parameters?: ParametersValuesMap;
         availableParameterDefinitions: ParameterDefinitions;
         pivotConfiguration?: PivotConfiguration;
+        continueOnError?: boolean;
     }): Promise<CompiledQuery> {
         const availableParameters = Object.keys(availableParameterDefinitions);
 
@@ -2288,6 +2290,7 @@ export class ProjectService extends BaseService {
             parameters,
             parameterDefinitions: availableParameterDefinitions,
             pivotConfiguration,
+            continueOnError,
         });
 
         return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>
@@ -2383,6 +2386,7 @@ export class ProjectService extends BaseService {
             timezone: this.lightdashConfig.query.timezone || 'UTC',
             parameters,
             availableParameterDefinitions,
+            continueOnError: true, // Return SQL even with compilation errors for debugging
         });
 
         await sshTunnel.disconnect();
@@ -2391,6 +2395,10 @@ export class ProjectService extends BaseService {
             ...compiledQuery,
             // Convert to array so TSOA can serialize it when using in controllers
             parameterReferences: Array.from(compiledQuery.parameterReferences),
+            // Only include compilationErrors if there are any
+            ...(compiledQuery.compilationErrors.length > 0 && {
+                compilationErrors: compiledQuery.compilationErrors,
+            }),
         };
     }
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -214,6 +214,7 @@ export type UpdateMetadata = {
 export type ApiCompiledQueryResults = {
     query: string;
     parameterReferences: string[];
+    compilationErrors?: string[];
 };
 
 export type ApiExploresResults = SummaryExplore[];

--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -111,17 +111,35 @@ export const RenderedSql = () => {
     }
 
     return (
-        <Editor
-            loading={<Loader color="gray" size="xs" />}
-            language={language}
-            beforeMount={beforeMount}
-            value={formattedSql}
-            options={MONACO_READ_ONLY}
-            theme={
-                theme.colorScheme === 'dark'
-                    ? 'lightdash-dark'
-                    : 'lightdash-light'
-            }
-        />
+        <>
+            {data?.compilationErrors && data.compilationErrors.length > 0 && (
+                <div style={{ margin: 10 }}>
+                    <Alert
+                        icon={<IconAlertCircle size="1rem" />}
+                        title="Compilation error"
+                        color="red"
+                        variant="filled"
+                    >
+                        {data.compilationErrors.map(
+                            (errorMsg: string, index: number) => (
+                                <p key={index}>{errorMsg}</p>
+                            ),
+                        )}
+                    </Alert>
+                </div>
+            )}
+            <Editor
+                loading={<Loader color="gray" size="xs" />}
+                language={language}
+                beforeMount={beforeMount}
+                value={formattedSql}
+                options={MONACO_READ_ONLY}
+                theme={
+                    theme.colorScheme === 'dark'
+                        ? 'lightdash-dark'
+                        : 'lightdash-light'
+                }
+            />
+        </>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/SPK-299/sql-card-should-display-sql-with-incorrect-references

Before

<img width="1796" height="361" alt="Screenshot from 2025-12-23 09-18-29" src="https://github.com/user-attachments/assets/4b5c74e2-15ae-47c3-a6ba-f1b747d91fb4" />


After

<img width="1139" height="364" alt="Screenshot from 2025-12-23 09-30-42" src="https://github.com/user-attachments/assets/e581f5b7-8958-41c3-b522-03630ae86e79" />


### Description:
Added error handling to SQL compilation to display SQL even when there are errors. This improves the debugging experience by:

1. Adding a `continueOnError` flag to the query builder that collects errors instead of throwing them
2. Displaying compilation errors in the SQL viewer with an alert banner
3. Showing placeholder SQL for invalid filters with error comments
4. Preserving the SQL output even when parts of the query have errors

This change helps users debug their queries by showing both the error messages and the SQL that would have been generated, rather than failing completely when a single filter or dimension is invalid.

![SQL Error Handling](https://example.com/screenshot.png)