### PR TITLE
feat: add scroll to top button in dashboards

### DIFF
--- a/packages/frontend/src/components/common/ScrollToTop.tsx
+++ b/packages/frontend/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,53 @@
+import { ActionIcon, Affix, Transition } from '@mantine/core';
+import { IconArrowUp } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from './MantineIcon';
+
+type ScrollToTopProps = {
+    /**
+     * Whether to show the button
+     */
+    show: boolean;
+    /**
+     * Optional scroll container. Defaults to document.body
+     */
+    scrollContainer?: HTMLElement | null;
+};
+
+/**
+ * Floating Action Button that appears at the bottom-right
+ * and scrolls to the top of the page when clicked
+ */
+export const ScrollToTop: FC<ScrollToTopProps> = ({
+    show,
+    scrollContainer,
+}) => {
+    const handleScrollToTop = () => {
+        const container = scrollContainer || document.body;
+
+        container.scrollTo({
+            top: 0,
+            behavior: 'smooth',
+        });
+    };
+
+    return (
+        <Affix position={{ bottom: 24, right: 34 }}>
+            <Transition transition="slide-up" mounted={show}>
+                {(transitionStyles) => (
+                    <ActionIcon
+                        size={40}
+                        radius="xl"
+                        variant="default"
+                        color="gray"
+                        style={transitionStyles}
+                        onClick={handleScrollToTop}
+                        aria-label="Scroll to top"
+                    >
+                        <MantineIcon icon={IconArrowUp} />
+                    </ActionIcon>
+                )}
+            </Transition>
+        </Affix>
+    );
+};

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -17,6 +17,7 @@ import { v4 as uuid4 } from 'uuid';
 import EmptyStateNoTiles from '../../components/DashboardTiles/EmptyStateNoTiles';
 import { DASHBOARD_HEADER_HEIGHT } from '../../components/common/Dashboard/dashboard.constants';
 import MantineIcon from '../../components/common/MantineIcon';
+import { ScrollToTop } from '../../components/common/ScrollToTop';
 import { StickyWithDetection } from '../../components/common/StickyWithDetection';
 import { LockedDashboardModal } from '../../components/common/modal/LockedDashboardModal';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
@@ -605,7 +606,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                     </div>
                                 </StickyWithDetection>
 
-                                <Group grow pb="lg" px="xs">
+                                <Group grow pb={60} px="xs">
                                     <ResponsiveGridLayout
                                         {...gridProps}
                                         className={`${
@@ -737,6 +738,11 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                     </>
                 )}
             </Droppable>
+
+            <ScrollToTop
+                show={isHeaderStuck}
+                scrollContainer={scrollContainer}
+            />
         </DragDropContext>
     );
 };


### PR DESCRIPTION
### Description:
Added a ScrollToTop component that appears as a floating action button at the bottom-right of the screen when the dashboard header is stuck. 