### PR TITLE
fix: simplify dashboard search filter configuration

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -296,14 +296,8 @@ export class SearchModel {
         subquery = filterByCreatedByUuid(
             subquery,
             {
-                join: {
-                    isVersioned: true,
-                    joinTableName: 'first_version',
-                    joinTableIdColumnName: 'dashboard_id',
-                    joinTableUserUuidColumnName: 'updated_by_user_uuid',
-                    tableIdColumnName: 'dashboard_id',
-                },
-                tableName: DashboardsTableName,
+                tableName: 'first_version',
+                tableUserUuidColumnName: 'updated_by_user_uuid',
             },
             filters,
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2151

### Description:

Simplified the `filterByCreatedByUuid` parameters in the SearchModel by removing the complex join configuration and replacing it with direct table references. This change streamlines the filtering logic by directly using the 'first_version' table and its 'updated_by_user_uuid' column instead of defining a verbose join structure.

Before:

![CleanShot 2025-12-23 at 10.00.17@2x.png](https://app.graphite.com/user-attachments/assets/b06bcc6b-393b-4397-b0e2-b6b2353462c2.png)



After: 

![CleanShot 2025-12-23 at 10.04.37@2x.png](https://app.graphite.com/user-attachments/assets/399970cc-5da9-48de-8573-a4b4ef229f74.png)

: