### PR TITLE
fix: add SlackFileUploadError and handle it gracefully

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -10,6 +10,7 @@ import {
     SlackAppCustomSettings,
     SlackChannel,
     SlackError,
+    SlackFileUploadError,
     SlackInstallationNotFoundError,
     SlackSettings,
     sleep,
@@ -1044,7 +1045,7 @@ export class SlackClient {
         const uploadedFile = result.files?.[0].files?.[0];
 
         if (!uploadedFile?.id) {
-            throw new UnexpectedServerError('Slack file was not uploaded');
+            throw new SlackFileUploadError('Slack file was not uploaded');
         }
 
         // We need to wait for the file to be ready, otherwise slack will fail with invalid_blocks error
@@ -1054,7 +1055,7 @@ export class SlackClient {
 
             const checkFile = async (attempt: number): Promise<string> => {
                 if (attempt >= maxRetries) {
-                    throw new UnexpectedServerError(
+                    throw new SlackFileUploadError(
                         'File URL not available after maximum retries.',
                     );
                 }
@@ -1169,7 +1170,11 @@ export class SlackClient {
             });
             return { url: slackFileUrl, expiring: false };
         } catch (e) {
-            slackErrorHandler(e, 'Failed to upload image to slack');
+            if (e instanceof SlackFileUploadError) {
+                Logger.warn(e.message);
+            } else {
+                slackErrorHandler(e, 'Failed to upload image to slack');
+            }
             return { url: imageUrl, expiring: true };
         }
     }

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -397,6 +397,20 @@ export class SlackError extends LightdashError {
     }
 }
 
+export class SlackFileUploadError extends LightdashError {
+    constructor(
+        message: string = 'Slack file upload failed',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'SlackFileUploadError',
+            statusCode: 400,
+            data,
+        });
+    }
+}
+
 export class MsTeamsError extends LightdashError {
     constructor(
         message: string = 'Microsoft Teams API error occurred',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2166

### Description:

Added a new `SlackFileUploadError` class to handle Slack file upload failures more gracefully. Instead of throwing an `UnexpectedServerError` when file uploads fail, we now use the more specific error type and log a warning instead of treating it as a critical error. This allows the system to fall back to using the original image URL when Slack uploads fail.