### PR TITLE
fix: add error handling for paginated response parsing

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -228,11 +228,29 @@ export class UnfurlService extends BaseService {
                     this.logger.debug(
                         `Received paginated response: ${response.url()}`,
                     );
+
+                    if (!response.ok()) {
+                        this.logger.warn(
+                            `Paginated response returned non-OK status ${response.status()} for ${response.url()}`,
+                        );
+                        return;
+                    }
+
                     const body = await response.body();
-                    const json = JSON.parse(body.toString()) as Partial<{
+                    let json: Partial<{
                         status: 'ok';
                         results: ApiGetAsyncQueryResults;
                     }>;
+                    try {
+                        json = JSON.parse(body.toString());
+                    } catch (parseError) {
+                        this.logger.warn(
+                            `Failed to parse paginated response as JSON from ${response.url()}: ${body
+                                .toString()
+                                .slice(0, 100)}`,
+                        );
+                        return;
+                    }
 
                     // Check if is last page (aka has no next page)
                     if (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-118 / LIGHTDASH-BACKEND-BED / LIGHTDASH-BACKEND-AZC

### Description:
Improves error handling in the UnfurlService when processing paginated responses. The changes add checks for non-OK HTTP status codes and handle JSON parsing errors gracefully, with appropriate warning logs. This prevents the service from crashing when encountering malformed responses or server errors.