### PR TITLE
fix: add filter option hides filter search results in dashboard

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -300,15 +300,24 @@ const FilterStringAutoComplete: FC<Props> = ({
                         <Text c="blue.6">Add "{query}"</Text>
                     </Group>
                 )}
-                styles={{
+                styles={(theme) => ({
                     item: {
                         // makes add new item button sticky to bottom
                         '&:last-child:not([value])': {
                             position: 'sticky',
                             bottom: 4,
+                            zIndex: 10,
+                            backgroundColor:
+                                theme.colorScheme === 'dark'
+                                    ? theme.colors.dark[6]
+                                    : theme.white,
+                            boxShadow: `0 -1px 0 0 ${theme.colors.ldGray[2]}`,
+                            paddingTop: theme.spacing.xs,
+                            borderRadius: 0,
+                            marginTop: theme.spacing.xs,
                         },
                     },
-                }}
+                })}
                 disableSelectedItemFiltering
                 searchable
                 clearable={singleValue}


### PR DESCRIPTION
Closes: #19008

### Description:
Enhances the styling of the "Add new item" button in the FilterStringAutoComplete component to make it more visually distinct. The button now has:

![CleanShot 2025-12-23 at 12.01.12.png](https://app.graphite.com/user-attachments/assets/5d015bef-310a-4752-be97-63b3b89a87c6.png)

![CleanShot 2025-12-23 at 12.01.03.png](https://app.graphite.com/user-attachments/assets/1f737b90-4055-47bd-b033-6a995f01f88a.png)

