### PR TITLE
fix: add error handling for response body retrieval in UnfurlService

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -236,7 +236,15 @@ export class UnfurlService extends BaseService {
                         return;
                     }
 
-                    const body = await response.body();
+                    let body: Buffer;
+                    try {
+                        body = await response.body();
+                    } catch (error) {
+                        this.logger.debug(
+                            `Failed to get response body for ${response.url()}, skipping`,
+                        );
+                        return;
+                    }
                     let json: Partial<{
                         status: 'ok';
                         results: ApiGetAsyncQueryResults;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-117 / LIGHTDASH-BACKEND-65F

### Description:
Added error handling for response body retrieval in UnfurlService. If getting the response body fails, the service now logs a debug message and skips processing that response instead of crashing.