### PR TITLE
feat(wip): add owners column to scheduled deliveries table

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -31,6 +31,7 @@ import {
     IconRadar,
     IconRun,
     IconTextCaption,
+    IconUser,
 } from '@tabler/icons-react';
 import {
     MantineReactTable,
@@ -392,6 +393,26 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                 },
             },
             {
+                accessorKey: 'createdByName',
+                header: 'Owner',
+                enableSorting: false,
+                size: 150,
+                Header: ({ column }) => (
+                    <Group gap="two" wrap="nowrap">
+                        <MantineIcon icon={IconUser} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const item = row.original;
+                    return (
+                        <Text fz="xs" c="ldGray.6">
+                            {item.createdByName || 'Unknown'}
+                        </Text>
+                    );
+                },
+            },
+            {
                 accessorKey: 'lastRunStatus',
                 header: 'Last Run Status',
                 enableSorting: false,
@@ -618,7 +639,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                 Cell: ({ row }) => {
                     const item = row.original;
                     return (
-                        <Text fz="sm" c="ldGray.7">
+                        <Text fz="xs" c="ldGray.6">
                             {new Date(item.createdAt).toLocaleDateString()}
                         </Text>
                     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-111/transfer-scheduled-deliveries-to-new-owner

### Description:
Added an "Owner" column to the Schedulers table to display who created each scheduler.
Also adjusted the font size and color of the creation date to maintain visual consistency.

![image.png](https://app.graphite.com/user-attachments/assets/98a10379-d1fb-49c5-91b4-817a6d59c3c8.png)

