### PR TITLE
feat: add reassign user for individual schedulers

### DIFF
--- a/packages/frontend/src/components/SchedulersView/ReassignSchedulerOwnerModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/ReassignSchedulerOwnerModal.tsx
@@ -1,0 +1,235 @@
+import {
+    Button,
+    Group,
+    Loader,
+    Modal,
+    Select,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import { useSchedulerReassignOwnerMutation } from '../../features/scheduler/hooks/useSchedulerReassignOwnerMutation';
+import { useInfiniteOrganizationUsers } from '../../hooks/useOrganizationUsers';
+import { LightdashUserAvatar } from '../Avatar';
+import { DEFAULT_PAGE_SIZE } from '../common/Table/constants';
+
+type ReassignSchedulerOwnerModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    schedulerUuids: string[];
+    excludedUserUuid?: string;
+    onSuccess?: () => void;
+};
+
+const getUserDisplayName = (
+    firstName: string | undefined,
+    lastName: string | undefined,
+    email: string,
+): string => {
+    if (firstName && lastName) {
+        return `${firstName} ${lastName}`;
+    }
+    return email;
+};
+
+const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    schedulerUuids,
+    excludedUserUuid,
+    onSuccess,
+}) => {
+    const [selectedUserUuid, setSelectedUserUuid] = useState<string | null>(
+        null,
+    );
+    const [searchValue, setSearchValue] = useState('');
+    const [debouncedSearchValue] = useDebouncedValue(searchValue, 300);
+    const viewportRef = useRef<HTMLDivElement>(null);
+
+    const {
+        data: infiniteUsers,
+        isLoading: isLoadingUsers,
+        isFetching: isFetchingUsers,
+        hasNextPage,
+        fetchNextPage,
+    } = useInfiniteOrganizationUsers(
+        {
+            searchInput: debouncedSearchValue,
+            pageSize: DEFAULT_PAGE_SIZE,
+        },
+        { keepPreviousData: true },
+    );
+
+    const organizationUsers = useMemo(
+        () => infiniteUsers?.pages.flatMap((page) => page.data) ?? [],
+        [infiniteUsers],
+    );
+
+    const { mutate: reassignOwner, isLoading: isReassigning } =
+        useSchedulerReassignOwnerMutation(projectUuid);
+
+    // Filter out the excluded user (current owner for single selection)
+    const eligibleUsers = useMemo(() => {
+        if (!organizationUsers) return [];
+        return organizationUsers.filter(
+            (user) => user.userUuid !== excludedUserUuid,
+        );
+    }, [organizationUsers, excludedUserUuid]);
+
+    // Store user data in a map for lookup
+    const usersMap = useMemo(() => {
+        return new Map(
+            eligibleUsers.map((user) => [
+                user.userUuid,
+                {
+                    name: getUserDisplayName(
+                        user.firstName,
+                        user.lastName,
+                        user.email,
+                    ),
+                    email: user.email,
+                },
+            ]),
+        );
+    }, [eligibleUsers]);
+
+    // Convert to Select data format
+    const selectData = useMemo(() => {
+        return eligibleUsers.map((user) => ({
+            value: user.userUuid,
+            label: getUserDisplayName(
+                user.firstName,
+                user.lastName,
+                user.email,
+            ),
+        }));
+    }, [eligibleUsers]);
+
+    const handleClose = useCallback(() => {
+        setSelectedUserUuid(null);
+        setSearchValue('');
+        onClose();
+    }, [onClose]);
+
+    const handleConfirm = useCallback(() => {
+        if (!selectedUserUuid) return;
+
+        reassignOwner(
+            {
+                schedulerUuids,
+                newOwnerUserUuid: selectedUserUuid,
+            },
+            {
+                onSuccess: () => {
+                    handleClose();
+                    onSuccess?.();
+                },
+            },
+        );
+    }, [
+        selectedUserUuid,
+        reassignOwner,
+        schedulerUuids,
+        handleClose,
+        onSuccess,
+    ]);
+
+    const handleScrollPositionChange = useCallback(
+        ({ y }: { x: number; y: number }) => {
+            if (!viewportRef.current || isFetchingUsers || !hasNextPage) return;
+
+            const { scrollHeight, clientHeight } = viewportRef.current;
+            const isNearBottom = y >= scrollHeight - clientHeight - 50;
+
+            if (isNearBottom) {
+                void fetchNextPage();
+            }
+        },
+        [fetchNextPage, hasNextPage, isFetchingUsers],
+    );
+
+    const schedulerCount = schedulerUuids.length;
+    const schedulerText =
+        schedulerCount === 1
+            ? '1 scheduled delivery'
+            : `${schedulerCount} scheduled deliveries`;
+
+    return (
+        <Modal
+            opened={opened}
+            onClose={handleClose}
+            title={`Reassign owner for ${schedulerText}`}
+            size="md"
+        >
+            <Stack gap="lg">
+                <Text fz="sm" c="ldGray.7">
+                    Select a new owner for the selected scheduled{' '}
+                    {schedulerCount === 1 ? 'delivery' : 'deliveries'}. The new
+                    owner will be responsible for managing{' '}
+                    {schedulerCount === 1 ? 'it' : 'them'}.
+                </Text>
+
+                <Select
+                    label="New owner"
+                    placeholder="Search for a user..."
+                    searchable
+                    searchValue={searchValue}
+                    onSearchChange={setSearchValue}
+                    value={selectedUserUuid}
+                    onChange={setSelectedUserUuid}
+                    data={selectData}
+                    nothingFoundMessage="No users found"
+                    maxDropdownHeight={250}
+                    rightSection={
+                        isLoadingUsers || isFetchingUsers ? (
+                            <Loader size="xs" />
+                        ) : null
+                    }
+                    scrollAreaProps={{
+                        viewportRef,
+                        onScrollPositionChange: handleScrollPositionChange,
+                    }}
+                    renderOption={({ option }) => {
+                        const userData = usersMap.get(option.value);
+                        if (!userData) return option.label;
+
+                        return (
+                            <Group gap="sm" wrap="nowrap">
+                                <LightdashUserAvatar
+                                    name={userData.name}
+                                    size="sm"
+                                />
+                                <Stack gap={2}>
+                                    <Text size="sm" fw={500}>
+                                        {userData.name}
+                                    </Text>
+                                    <Text size="xs" c="dimmed">
+                                        {userData.email}
+                                    </Text>
+                                </Stack>
+                            </Group>
+                        );
+                    }}
+                />
+
+                <Group justify="flex-end" gap="sm">
+                    <Button variant="default" onClick={handleClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={handleConfirm}
+                        loading={isReassigning}
+                        disabled={!selectedUserUuid}
+                    >
+                        Reassign
+                    </Button>
+                </Group>
+            </Stack>
+        </Modal>
+    );
+};
+
+export default ReassignSchedulerOwnerModal;

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -62,6 +62,7 @@ import { useProject } from '../../hooks/useProject';
 import GSheetsSvg from '../../svgs/google-sheets.svg?react';
 import SlackSvg from '../../svgs/slack.svg?react';
 import MantineIcon from '../common/MantineIcon';
+import ReassignSchedulerOwnerModal from './ReassignSchedulerOwnerModal';
 import { SchedulerTopToolbar } from './SchedulerTopToolbar';
 import SchedulersViewActionMenu from './SchedulersViewActionMenu';
 import {
@@ -167,6 +168,30 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
     useEffect(() => {
         setTableData(flatData);
     }, [flatData]);
+
+    // Reassign owner modal state
+    const [reassignModalOpen, setReassignModalOpen] = useState(false);
+    const [schedulerUuidsToReassign, setSchedulerUuidsToReassign] = useState<
+        string[]
+    >([]);
+    const [excludedUserUuid, setExcludedUserUuid] = useState<
+        string | undefined
+    >(undefined);
+
+    const handleReassignOwner = useCallback(
+        (schedulerUuid: string, ownerUuid: string | undefined) => {
+            setSchedulerUuidsToReassign([schedulerUuid]);
+            setExcludedUserUuid(ownerUuid);
+            setReassignModalOpen(true);
+        },
+        [],
+    );
+
+    const handleReassignModalClose = useCallback(() => {
+        setReassignModalOpen(false);
+        setSchedulerUuidsToReassign([]);
+        setExcludedUserUuid(undefined);
+    }, []);
 
     // Compute available users from loaded schedulers
     const availableUsers = useMemo(() => {
@@ -663,13 +688,20 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                             <SchedulersViewActionMenu
                                 item={item}
                                 projectUuid={projectUuid}
+                                onReassignOwner={handleReassignOwner}
                             />
                         </Box>
                     );
                 },
             },
         ],
-        [project, projectUuid, getSlackChannelName, setSearchParams],
+        [
+            project,
+            projectUuid,
+            getSlackChannelName,
+            setSearchParams,
+            handleReassignOwner,
+        ],
     );
 
     const table = useMantineReactTable({
@@ -795,7 +827,18 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
         },
     });
 
-    return <MantineReactTable table={table} />;
+    return (
+        <>
+            <MantineReactTable table={table} />
+            <ReassignSchedulerOwnerModal
+                opened={reassignModalOpen}
+                onClose={handleReassignModalClose}
+                projectUuid={projectUuid}
+                schedulerUuids={schedulerUuidsToReassign}
+                excludedUserUuid={excludedUserUuid}
+            />
+        </>
+    );
 };
 
 export default SchedulersTable;

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
@@ -5,6 +5,7 @@ import {
     IconSend,
     IconSquarePlus,
     IconTrash,
+    IconUserEdit,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { type FC } from 'react';
@@ -25,11 +26,16 @@ interface SchedulersViewActionMenuProps {
     onClose?: () => void;
     item: SchedulerItem;
     projectUuid: string;
+    onReassignOwner?: (
+        schedulerUuid: string,
+        ownerUuid: string | undefined,
+    ) => void;
 }
 
 const SchedulersViewActionMenu: FC<SchedulersViewActionMenuProps> = ({
     item,
     projectUuid,
+    onReassignOwner,
 }) => {
     const [isDeleting, setIsDeleting] = React.useState(false);
     const [isConfirmOpen, setIsConfirmOpen] = React.useState(false);
@@ -84,6 +90,19 @@ const SchedulersViewActionMenu: FC<SchedulersViewActionMenuProps> = ({
                         onClick={() => setIsConfirmOpen(true)}
                     >
                         Send now
+                    </Menu.Item>
+                    <Menu.Item
+                        component="button"
+                        role="menuitem"
+                        leftSection={<MantineIcon icon={IconUserEdit} />}
+                        onClick={() =>
+                            onReassignOwner?.(
+                                item.schedulerUuid,
+                                item.createdBy,
+                            )
+                        }
+                    >
+                        Reassign owner
                     </Menu.Item>
                     <Menu.Divider />
                     <Menu.Item

--- a/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
@@ -7,20 +7,20 @@ import {
     Stack,
     Text,
     type ModalProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconTrash } from '@tabler/icons-react';
-import React, { useCallback, useEffect, type FC } from 'react';
+import { useCallback, useEffect, type FC } from 'react';
 import ErrorState from '../../../components/common/ErrorState';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useScheduler } from '../hooks/useScheduler';
 import { useSchedulersDeleteMutation } from '../hooks/useSchedulersDeleteMutation';
 
-interface DashboardDeleteModalProps extends ModalProps {
+interface SchedulerDeleteModalProps extends ModalProps {
     schedulerUuid: string;
     onConfirm: () => void;
 }
 
-export const SchedulerDeleteModal: FC<DashboardDeleteModalProps> = ({
+export const SchedulerDeleteModal: FC<SchedulerDeleteModalProps> = ({
     schedulerUuid,
     onConfirm,
     onClose,
@@ -28,6 +28,7 @@ export const SchedulerDeleteModal: FC<DashboardDeleteModalProps> = ({
 }) => {
     const scheduler = useScheduler(schedulerUuid);
     const mutation = useSchedulersDeleteMutation();
+
     useEffect(() => {
         if (mutation.isSuccess) {
             onConfirm();
@@ -42,55 +43,47 @@ export const SchedulerDeleteModal: FC<DashboardDeleteModalProps> = ({
         <Modal
             opened={opened}
             title={
-                <Group spacing="xs">
+                <Group gap="xs">
                     <MantineIcon icon={IconTrash} size="lg" color="red" />
                     <Text fw={600}>Delete scheduled delivery</Text>
                 </Group>
             }
             onClose={onClose}
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.ldGray[4]}` },
-                body: { padding: 0 },
-            })}
         >
-            <Box px="md" py="xl">
-                {scheduler.isInitialLoading ? (
-                    <Stack h={300} w="100%" align="center">
-                        <Text fw={600}>Loading schedulers</Text>
-                        <Loader />
-                    </Stack>
-                ) : scheduler.isError ? (
-                    <ErrorState error={scheduler.error.error} />
-                ) : (
-                    <Text span>
-                        Are you sure you want to delete{' '}
-                        <Text fw={700} span>
-                            "{scheduler.data?.name}"
+            <Stack gap="lg">
+                <Box>
+                    {scheduler.isInitialLoading ? (
+                        <Stack h={300} w="100%" align="center">
+                            <Text fw={600}>Loading scheduler</Text>
+                            <Loader />
+                        </Stack>
+                    ) : scheduler.isError ? (
+                        <ErrorState error={scheduler.error.error} />
+                    ) : (
+                        <Text>
+                            Are you sure you want to delete{' '}
+                            <Text fw={700} span>
+                                "{scheduler.data?.name}"
+                            </Text>
+                            ?
                         </Text>
-                        ?
-                    </Text>
-                )}
-            </Box>
-            <Group
-                position="right"
-                p="md"
-                sx={(theme) => ({
-                    borderTop: `1px solid ${theme.colors.ldGray[4]}`,
-                })}
-            >
-                <Button onClick={onClose} color="dark" variant="outline">
-                    Cancel
-                </Button>
-                {scheduler.isSuccess && (
-                    <Button
-                        loading={mutation.isLoading}
-                        onClick={handleConfirm}
-                        color="red"
-                    >
-                        Delete
+                    )}
+                </Box>
+                <Group justify="flex-end" gap="sm">
+                    <Button onClick={onClose} variant="default">
+                        Cancel
                     </Button>
-                )}
-            </Group>
+                    {scheduler.isSuccess && (
+                        <Button
+                            loading={mutation.isLoading}
+                            onClick={handleConfirm}
+                            color="red"
+                        >
+                            Delete
+                        </Button>
+                    )}
+                </Group>
+            </Stack>
         </Modal>
     );
 };

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerReassignOwnerMutation.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerReassignOwnerMutation.ts
@@ -1,0 +1,49 @@
+import {
+    type ApiError,
+    type ReassignSchedulerOwnerRequest,
+    type SchedulerAndTargets,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+const reassignSchedulerOwner = async (
+    projectUuid: string,
+    data: ReassignSchedulerOwnerRequest,
+) =>
+    lightdashApi<SchedulerAndTargets[]>({
+        url: `/schedulers/${projectUuid}/reassign-owner`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useSchedulerReassignOwnerMutation = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        SchedulerAndTargets[],
+        ApiError,
+        ReassignSchedulerOwnerRequest
+    >((data) => reassignSchedulerOwner(projectUuid, data), {
+        mutationKey: ['reassign_scheduler_owner'],
+        onSuccess: async (_, variables) => {
+            await queryClient.invalidateQueries(['paginatedSchedulers']);
+            await queryClient.invalidateQueries(['chart_schedulers']);
+            await queryClient.invalidateQueries(['dashboard_schedulers']);
+
+            const count = variables.schedulerUuids.length;
+            showToastSuccess({
+                title: `Successfully reassigned ${count} scheduled ${
+                    count === 1 ? 'delivery' : 'deliveries'
+                }`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to reassign scheduled delivery owner',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulersDeleteMutation.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulersDeleteMutation.ts
@@ -18,6 +18,7 @@ export const useSchedulersDeleteMutation = () => {
         onSuccess: async () => {
             await queryClient.invalidateQueries(['chart_schedulers']);
             await queryClient.invalidateQueries(['dashboard_schedulers']);
+            await queryClient.invalidateQueries(['paginatedSchedulers']);
             showToastSuccess({
                 title: `Success! Scheduled delivery was deleted`,
             });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-111/transfer-scheduled-deliveries-to-new-owner

### Description:
Added the ability to reassign owners for scheduled deliveries. This feature allows users to transfer ownership of one or more scheduled deliveries to another user in the organization.

Key changes:
- Created a new `ReassignSchedulerOwnerModal` component that displays a searchable user selection dropdown
- Added a "Reassign owner" option to the scheduler action menu
- Implemented the API mutation hook `useSchedulerReassignOwnerMutation` to handle the backend request
- Updated the SchedulersTable to support the reassign owner functionality
- Improved the SchedulerDeleteModal UI to match the new design system



https://github.com/user-attachments/assets/c5ee30e3-7fcd-4cbe-b9eb-1633eb385d33







