### PR TITLE
fix: add error handling for Slack notifications

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -923,19 +923,28 @@ export class SlackClient {
         text: string;
         blocks?: Block[];
     }): Promise<void> {
-        const channelId = await this.getNotificationChannel(organizationUuid);
-        if (!channelId) {
-            Logger.warn(
-                `Unable to send slack notification for organization ${organizationUuid}. No notification channel set.`,
+        try {
+            const channelId = await this.getNotificationChannel(
+                organizationUuid,
             );
-            return;
+            if (!channelId) {
+                Logger.warn(
+                    `Unable to send slack notification for organization ${organizationUuid}. No notification channel set.`,
+                );
+                return;
+            }
+            await this.postMessage({
+                organizationUuid,
+                text,
+                channel: channelId,
+                blocks,
+            });
+        } catch (e) {
+            slackErrorHandler(
+                e,
+                `Unable to send slack notification for organization ${organizationUuid}.`,
+            );
         }
-        await this.postMessage({
-            organizationUuid,
-            text,
-            channel: channelId,
-            blocks,
-        });
     }
 
     async updateMessage({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2170

### Description:

Added error handling to the `sendNotification` method in the SlackClient class. The method now catches any errors that occur during the notification process and passes them to the `slackErrorHandler` function, which provides better error reporting and prevents unhandled exceptions when sending Slack notifications.