### PR TITLE
fix: handle errors when collecting queue size metrics

### DIFF
--- a/packages/backend/src/prometheus.ts
+++ b/packages/backend/src/prometheus.ts
@@ -391,8 +391,21 @@ export default class PrometheusMetrics {
                 help: 'Number of jobs in the queue',
                 ...rest,
                 async collect() {
-                    const queueSize = await schedulerClient.getQueueSize();
-                    this.set(queueSize);
+                    try {
+                        const queueSize = await schedulerClient.getQueueSize();
+                        this.set(queueSize);
+                    } catch (error) {
+                        Logger.error(
+                            'Failed to collect queue size metric, setting to 0',
+                            {
+                                error:
+                                    error instanceof Error
+                                        ? error.message
+                                        : error,
+                            },
+                        );
+                        this.set(0);
+                    }
                 },
             });
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2171

### Description:

Add error handling to the queue size metric collection in Prometheus. When the scheduler client fails to retrieve the queue size, the metric will be set to 0 and an error will be logged with the appropriate error message.