### PR TITLE
feat: adjust chart margins based on legend presence

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Grid/constants.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Grid/constants.ts
@@ -2,8 +2,19 @@ export const defaultGrid = {
     containLabel: true,
     left: '25px', // small padding
     right: '25px', // small padding
+    top: '30px', // base padding from top
+    bottom: '30px', // pixels from bottom (makes room for x-axis)
+} as const;
+
+// Legacy grid config with fixed top spacing (pre-dashboard-redesign)
+export const defaultGridLegacy = {
+    containLabel: true,
+    left: '25px', // small padding
+    right: '25px', // small padding
     top: '70px', // pixels from top (makes room for legend)
     bottom: '30px', // pixels from bottom (makes room for x-axis)
 } as const;
+
+export const legendTopSpacing = 40; // extra spacing added when legend is shown
 
 export const defaultAxisLabelGap = 20;


### PR DESCRIPTION
Closes: #17934

### Description:

Improved chart grid spacing to dynamically adjust when legends are displayed. Previously, charts had a fixed top padding of 70px regardless of whether a legend was shown. Now, charts use a base padding of 30px and only add an additional 40px spacing when a legend is present.

This change makes charts with no legend display more efficiently by reducing unnecessary whitespace, while still providing appropriate spacing for charts with legends.

> [!NOTE]
> Implemented with feature flag `isDashboardRedesignEnabled`