### PR TITLE
feat: add bulk scheduler reassignment

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
@@ -1,12 +1,14 @@
 import {
     ActionIcon,
+    Button,
     Divider,
     Group,
+    Text,
     Tooltip,
     useMantineTheme,
     type GroupProps,
 } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
+import { IconTrash, IconUserEdit } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import {
     type DestinationType,
@@ -44,6 +46,9 @@ type SchedulerTopToolbarProps = GroupProps &
         onClearFilters?: () => void;
         availableUsers: User[];
         availableDestinations: DestinationType[];
+        // Bulk selection props
+        selectedCount?: number;
+        onBulkReassign?: () => void;
     };
 
 export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
@@ -64,9 +69,12 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
         onClearFilters,
         availableUsers,
         availableDestinations,
+        selectedCount = 0,
+        onBulkReassign,
         ...props
     }) => {
         const theme = useMantineTheme();
+        const hasSelection = selectedCount > 0;
 
         return (
             <Group
@@ -121,19 +129,38 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
                     />
                 </Group>
 
-                {hasActiveFilters && onClearFilters && (
-                    <Tooltip label="Clear all filters">
-                        <ActionIcon
-                            variant="subtle"
-                            size="sm"
-                            color="gray"
-                            onClick={onClearFilters}
-                            style={{ flexShrink: 0 }}
-                        >
-                            <MantineIcon icon={IconTrash} />
-                        </ActionIcon>
-                    </Tooltip>
-                )}
+                <Group gap="sm" wrap="nowrap" style={{ flexShrink: 0 }}>
+                    {hasSelection && onBulkReassign && (
+                        <>
+                            <Text size="sm" c="dimmed">
+                                {selectedCount}{' '}
+                                {selectedCount === 1 ? 'selected' : 'selected'}
+                            </Text>
+                            <Button
+                                size="xs"
+                                variant="light"
+                                leftSection={
+                                    <MantineIcon icon={IconUserEdit} />
+                                }
+                                onClick={onBulkReassign}
+                            >
+                                Reassign owner
+                            </Button>
+                        </>
+                    )}
+                    {hasActiveFilters && onClearFilters && !hasSelection && (
+                        <Tooltip label="Clear all filters">
+                            <ActionIcon
+                                variant="subtle"
+                                size="sm"
+                                color="gray"
+                                onClick={onClearFilters}
+                            >
+                                <MantineIcon icon={IconTrash} />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                </Group>
             </Group>
         );
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/GLITCH-111/transfer-scheduled-deliveries-to-new-owner

### Description:
Added bulk reassignment functionality for schedulers. Users can now select multiple schedulers using checkboxes and reassign them to a different owner in one operation.

- Added row selection capability to the schedulers table
- Added a selection counter that shows how many schedulers are selected
- Added a "Reassign owner" button that appears when schedulers are selected
- Implemented bulk reassignment logic that works with the existing reassignment modal
- Automatically clears selection after successful bulk reassignment

[Screen Recording 2025-12-23 at 13.13.36.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c75fde47-5df9-43a8-bf07-2677dd8425a7.mov" />](https://app.graphite.com/user-attachments/video/c75fde47-5df9-43a8-bf07-2677dd8425a7.mov)

