### PR TITLE
fix: increase pg warehouse connection timeout

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -235,7 +235,7 @@ export class PostgresClient<
         return new Promise<void>((resolve, reject) => {
             pool = new pg.Pool({
                 ...this.config,
-                connectionTimeoutMillis: 5000,
+                connectionTimeoutMillis: 30000,
                 query_timeout: this.credentials.timeoutSeconds
                     ? this.credentials.timeoutSeconds * 1000
                     : 1000 * 60 * 5, // sets the default query timeout to 5 minutes


### PR DESCRIPTION
### Description:

We have some users seeing connection timeouts connecting to redshift. They have noticed it primarily when scheduling syncs, but in the logs we also see it for looking at dashboards. It seems pretty plausible that the 5s connection timeout isn't enough for redshift to warm up.  This increases the connection timeout to 30s, which should give it sufficient time. 
