### PR TITLE
fix: validate BigQuery keyfileContents exists for private key/SSO authentication

### DIFF
--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -3,6 +3,7 @@ import {
     assertUnreachable,
     BigqueryAuthenticationType,
     CreateWarehouseCredentials,
+    ParameterError,
     SnowflakeAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -48,6 +49,15 @@ const credentialsTarget = (
                 case BigqueryAuthenticationType.SSO:
                 case undefined:
                     bqResult.target.method = 'service-account-json';
+                    // Ensure keyfileContents exists and is not null/undefined
+                    if (
+                        !credentials.keyfileContents ||
+                        typeof credentials.keyfileContents !== 'object'
+                    ) {
+                        throw new ParameterError(
+                            'BigQuery private key/SSO authentication requires keyfileContents to be provided',
+                        );
+                    }
                     bqResult.target.keyfile_json = Object.fromEntries(
                         Object.keys(credentials.keyfileContents).map((key) => [
                             key,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2159

### Description:

Added validation for BigQuery keyfileContents when using private key or SSO authentication. This ensures that keyfileContents exists and is a valid object before attempting to use it, throwing a clear ParameterError when the required credentials are missing.