### PR TITLE
fix: prevent race conditions in validation updates with transaction locks

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -797,11 +797,19 @@ export class ValidationService extends BaseService {
         validationErrors: CreateValidation[],
         jobId?: string,
     ) {
-        // If not storing for an specific CLI validation, delete previous validations
-        if (jobId === undefined) await this.validationModel.delete(projectUuid);
-
-        if (validationErrors.length > 0)
-            await this.validationModel.create(validationErrors, jobId);
+        // If not storing for an specific CLI validation, replace previous validations
+        if (jobId === undefined) {
+            await this.validationModel.replaceProjectValidations(
+                projectUuid,
+                validationErrors,
+            );
+        } else if (validationErrors.length > 0) {
+            await this.validationModel.create({
+                projectUuid,
+                validations: validationErrors,
+                jobId,
+            });
+        }
     }
 
     async hidePrivateContent(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2179](https://linear.app/lightdash/issue/PROD-2179)

### Description:

Improves validation handling by implementing transaction locks to prevent race conditions during validation updates. The PR refactors the ValidationModel to use database transactions when creating or replacing validations, ensuring that the project is locked for update before making changes. This prevents concurrent validation updates that could lead to inconsistent states.

The implementation adds a new method `replaceProjectValidations` that handles both deletion of existing validations and creation of new ones within a single transaction, and modifies the `create` method to accept structured parameters and use transaction locking.