### PR TITLE
fix: prevent tile positions from scaling incorrectly across breakpoints

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/gridUtils.ts
+++ b/packages/frontend/src/features/dashboardTabs/gridUtils.ts
@@ -10,7 +10,7 @@ export type ResponsiveGridLayoutProps = {
     rowHeight: number;
 };
 
-const DEFAULT_COLS = 36;
+export const DEFAULT_COLS = 36;
 /**
  * Row height: fontSize * lineHeight + padding + borders
  */
@@ -35,6 +35,31 @@ export const getReactGridLayoutConfig = (
         isDraggable: isEditMode,
         isResizable: isEditMode,
     };
+};
+
+/**
+ * Converts layout positions from the current breakpoint's coordinate system
+ * back to the base coordinate system (DEFAULT_COLS).
+ *
+ * This is needed when saving tile positions after drag/resize operations,
+ * because react-grid-layout returns positions in the current breakpoint's
+ * column count, but we store positions in the base 36-column system.
+ *
+ * @param layout - The layout array from react-grid-layout
+ * @param currentCols - The current breakpoint's column count
+ * @returns Layout array with positions converted to base coordinates
+ */
+export const convertLayoutToBaseCoordinates = (
+    layout: Layout[],
+    currentCols: number,
+): Layout[] => {
+    const scaleFactor = currentCols / DEFAULT_COLS;
+
+    return layout.map((item) => ({
+        ...item,
+        x: Math.round(item.x / scaleFactor),
+        w: Math.round(item.w / scaleFactor),
+    }));
 };
 
 export const getResponsiveGridLayoutProps = ({

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -25,6 +25,7 @@ import { TabEditModal } from './EditTabModal';
 import GridTile from './GridTile';
 import DraggableTab from './Tab';
 import {
+    convertLayoutToBaseCoordinates,
     getReactGridLayoutConfig,
     getResponsiveGridLayoutProps,
 } from './gridUtils';
@@ -61,6 +62,16 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     setAddingTab,
 }) => {
     const gridProps = getResponsiveGridLayoutProps();
+
+    const [currentCols, setCurrentCols] = useState(gridProps.cols.lg);
+    const handleUpdateTilesWithScaling = async (layout: Layout[]) => {
+        const unscaledLayout = convertLayoutToBaseCoordinates(
+            layout,
+            currentCols,
+        );
+        await handleUpdateTiles(unscaledLayout);
+    };
+
     const layouts = useMemo(
         () => ({
             lg:
@@ -443,8 +454,15 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                 ? 'locked'
                                                 : ''
                                         }`}
-                                        onDragStop={handleUpdateTiles}
-                                        onResizeStop={handleUpdateTiles}
+                                        onDragStop={
+                                            handleUpdateTilesWithScaling
+                                        }
+                                        onResizeStop={
+                                            handleUpdateTilesWithScaling
+                                        }
+                                        onBreakpointChange={(_, cols) => {
+                                            setCurrentCols(cols);
+                                        }}
                                         onWidthChange={(cw) => setGridWidth(cw)}
                                         layouts={layouts}
                                         key={

--- a/packages/frontend/src/features/dashboardTabsV2/gridUtils.ts
+++ b/packages/frontend/src/features/dashboardTabsV2/gridUtils.ts
@@ -1,6 +1,13 @@
 import { type DashboardTile } from '@lightdash/common';
 import { type Layout } from 'react-grid-layout';
-import { DEFAULT_ROW_HEIGHT } from '../dashboardTabs/gridUtils';
+import {
+    convertLayoutToBaseCoordinates,
+    DEFAULT_COLS,
+    DEFAULT_ROW_HEIGHT,
+} from '../dashboardTabs/gridUtils';
+
+// Re-export constants and utilities for use in this module until v2 migration completes
+export { convertLayoutToBaseCoordinates };
 
 export type ResponsiveGridLayoutProps = {
     draggableCancel: string;
@@ -10,8 +17,6 @@ export type ResponsiveGridLayoutProps = {
     cols: { lg: number; md: number; sm: number };
     rowHeight: number;
 };
-
-const DEFAULT_COLS = 36;
 
 export const getReactGridLayoutConfig = (
     tile: DashboardTile,

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -34,6 +34,7 @@ import { TabEditModal } from './EditTabModal';
 import GridTile from './GridTile';
 import DraggableTab from './Tab';
 import {
+    convertLayoutToBaseCoordinates,
     getReactGridLayoutConfig,
     getResponsiveGridLayoutProps,
 } from './gridUtils';
@@ -92,6 +93,15 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
     onParameterPin,
 }) => {
     const gridProps = getResponsiveGridLayoutProps();
+    const [currentCols, setCurrentCols] = useState(gridProps.cols.lg);
+    const handleUpdateTilesWithScaling = async (layout: Layout[]) => {
+        const unscaledLayout = convertLayoutToBaseCoordinates(
+            layout,
+            currentCols,
+        );
+        await handleUpdateTiles(unscaledLayout);
+    };
+
     const layouts = useMemo(
         () => ({
             lg:
@@ -615,8 +625,15 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                                 : ''
                                         }`}
                                         containerPadding={[10, 0]}
-                                        onDragStop={handleUpdateTiles}
-                                        onResizeStop={handleUpdateTiles}
+                                        onDragStop={
+                                            handleUpdateTilesWithScaling
+                                        }
+                                        onResizeStop={
+                                            handleUpdateTilesWithScaling
+                                        }
+                                        onBreakpointChange={(_, cols) => {
+                                            setCurrentCols(cols);
+                                        }}
                                         onWidthChange={(cw) => setGridWidth(cw)}
                                         layouts={layouts}
                                         key={


### PR DESCRIPTION
### Description:

#### Issue

Dashboard tiles would shrink and move to incorrect positions when rearranged on smaller screens. This happened because tile positions were being saved in the current breakpoint's coordinate instead of the base system (36 cols). Each time you dragged a tile at a smaller breakpoint, the position would be saved  with the scale factor applied, causing cumulative scaling errors:

[CleanShot 2025-12-23 at 17.13.12.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/685f6d4c-8480-4f57-b9e4-c42b545e9a3b.mp4" />](https://app.graphite.com/user-attachments/video/685f6d4c-8480-4f57-b9e4-c42b545e9a3b.mp4)

#### Fix

Added `convertLayoutToBaseCoordinates` that converts tile positions from current breakpoint to the base before saving.

[CleanShot 2025-12-23 at 17.16.13.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ecc952bf-fa19-4730-a5db-89e1ef43ba52.mp4" />](https://app.graphite.com/user-attachments/video/ecc952bf-fa19-4730-a5db-89e1ef43ba52.mp4)

---

> [!NOTE]
> Updated both DashboardTabs and DashboardTabsV2, keeping repetition until migration is completed

