### PR TITLE
feat: add screenshot ready indicator for dashboard tiles

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -933,7 +933,11 @@ export class UnfurlService extends BaseService {
                             let exploreChartResultsPromise:
                                 | Promise<unknown>
                                 | undefined;
-                            if (chartTileUuids) {
+                            if (
+                                chartTileUuids &&
+                                !this.lightdashConfig.scheduler
+                                    .useScreenshotReadyIndicator
+                            ) {
                                 this.logger.info(
                                     `Dashboard screenshot: Found ${
                                         chartTileUuids.length
@@ -993,7 +997,12 @@ export class UnfurlService extends BaseService {
                             const hasSqlCharts =
                                 filteredSqlChartTileUuids &&
                                 filteredSqlChartTileUuids.length > 0;
-                            if (hasSqlCharts && page) {
+                            if (
+                                hasSqlCharts &&
+                                page &&
+                                !this.lightdashConfig.scheduler
+                                    .useScreenshotReadyIndicator
+                            ) {
                                 sqlInitialLoadPromises =
                                     filteredSqlChartTileUuids.map((id) => {
                                         const responsePattern = new RegExp(
@@ -1046,16 +1055,25 @@ export class UnfurlService extends BaseService {
                             lightdashPage === LightdashPage.CHART ||
                             lightdashPage === LightdashPage.EXPLORE
                         ) {
-                            chartResultsPromises = [
-                                this.waitForPaginatedResultsResponse(page),
-                            ]; // NOTE: No await here
+                            if (
+                                !this.lightdashConfig.scheduler
+                                    .useScreenshotReadyIndicator
+                            ) {
+                                chartResultsPromises = [
+                                    this.waitForPaginatedResultsResponse(page),
+                                ]; // NOTE: No await here
+                            }
                         }
 
                         await page.goto(url, {
                             timeout: 150000,
                         });
 
-                        if (chartResultsPromises) {
+                        if (
+                            chartResultsPromises &&
+                            !this.lightdashConfig.scheduler
+                                .useScreenshotReadyIndicator
+                        ) {
                             // We wait after navigating to the page
                             await Promise.allSettled(chartResultsPromises);
                         }

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -90,6 +90,12 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
         (c) => c.updateSqlChartTilesMetadata,
     );
     const parameters = useDashboardContext((c) => c.parameterValues);
+    const markTileScreenshotReady = useDashboardContext(
+        (c) => c.markTileScreenshotReady,
+    );
+    const markTileScreenshotErrored = useDashboardContext(
+        (c) => c.markTileScreenshotErrored,
+    );
     const dashboardFilters = useDashboardFiltersForTile(tile.uuid);
 
     const closeDataExportModal = useCallback(
@@ -141,6 +147,25 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
         chartResultsData?.originalColumns,
         tile.uuid,
         updateSqlChartTilesMetadata,
+    ]);
+
+    useEffect(() => {
+        if (chartError || chartResultsError) {
+            markTileScreenshotErrored(tile.uuid);
+            return;
+        }
+        if (!isChartLoading && !isChartResultsLoading && chartResultsData) {
+            markTileScreenshotReady(tile.uuid);
+        }
+    }, [
+        isChartLoading,
+        isChartResultsLoading,
+        chartResultsData,
+        chartError,
+        chartResultsError,
+        tile.uuid,
+        markTileScreenshotReady,
+        markTileScreenshotErrored,
     ]);
 
     const userCanExportData = user.data?.ability.can(

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -8,6 +8,7 @@ import {
     getFilterInteractivityValue,
     getItemId,
     isDashboardChartTileType,
+    isDashboardSqlChartTile,
     type CacheMetadata,
     type Dashboard,
     type DashboardFilterRule,
@@ -419,7 +420,11 @@ const DashboardProvider: React.FC<
         if (dashboardTabs && dashboardTabs.length > 0 && !activeTab) return [];
 
         return dashboardTiles
-            .filter(isDashboardChartTileType)
+            .filter(
+                (tile) =>
+                    isDashboardChartTileType(tile) ||
+                    isDashboardSqlChartTile(tile),
+            )
             .filter((tile) => {
                 if (!activeTab) return true;
                 return !tile.tabUuid || tile.tabUuid === activeTab.uuid;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: GLITCH-95

### Description:
Added support for a screenshot ready indicator in the scheduler. This allows the UnfurlService to wait for charts to fully load before taking screenshots by checking if the `useScreenshotReadyIndicator` flag is enabled in the scheduler configuration.

The implementation adds conditional checks in the UnfurlService to skip premature chart loading when the indicator is enabled, and updates the DashboardSqlChartTile component to mark tiles as ready for screenshots once their data has loaded. The DashboardProvider was also updated to include SQL chart tiles in the list of tiles that can be marked as ready for screenshots.

<details>
<summary>Before/After</summary>

### Before
<img width="1240" height="780" alt="localhost_3000_generalSettings_projectManagement_3675b69e-8324-4110-bdca-059031aa8da3_scheduledDeliveries_tab=run-history (2)" src="https://github.com/user-attachments/assets/6baa39ca-2cd1-41cd-9eec-834d337c7da6" />

### After
<img width="1240" height="850" alt="localhost_3000_generalSettings_projectManagement_3675b69e-8324-4110-bdca-059031aa8da3_scheduledDeliveries_tab=run-history (3)" src="https://github.com/user-attachments/assets/ae6e9cf9-6428-4035-85de-d95ba29e843c" />

</details>