### PR TITLE
fix: add DOM detachment error as retryable in UnfurlService

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1203,6 +1203,7 @@ export class UnfurlService extends BaseService {
                         errorMessage.includes(
                             'Target page, context or browser has been closed',
                         ) ||
+                        errorMessage.includes('not attached to the DOM') ||
                         isQueueFullError;
 
                     if (isRetryableError && retries) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-119 / LIGHTDASH-BACKEND-BG0

### Description:
Added 'not attached to the DOM' to the list of retryable error messages in the UnfurlService. This ensures that when this specific DOM-related error occurs, the service will attempt to retry the operation rather than failing immediately.