### PR TITLE
feat: use derived pivot configuration in visualization warning

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,6 +1,8 @@
 import { subject } from '@casl/ability';
 import {
+    derivePivotConfigurationFromChart,
     ECHARTS_DEFAULT_COLORS,
+    getFieldsFromMetricQuery,
     getHiddenTableFields,
     getPivotConfig,
     NotFoundError,
@@ -219,6 +221,19 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
         missingRequiredParameters,
     ]);
 
+    const dirtyPivotConfiguration = useMemo(() => {
+        return explore
+            ? derivePivotConfigurationFromChart(
+                  unsavedChartVersion,
+                  unsavedChartVersion.metricQuery,
+                  getFieldsFromMetricQuery(
+                      unsavedChartVersion.metricQuery,
+                      explore,
+                  ),
+              )
+            : undefined;
+    }, [unsavedChartVersion, explore]);
+
     if (!unsavedChartVersion.tableName) {
         return <CollapsableCard title="Charts" disabled />;
     }
@@ -284,8 +299,8 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                     headerElement={
                         isOpen && (
                             <VisualizationWarning
-                                pivotDimensions={
-                                    unsavedChartVersion.pivotConfig?.columns
+                                dirtyPivotConfiguration={
+                                    dirtyPivotConfiguration
                                 }
                                 chartConfig={unsavedChartVersion.chartConfig}
                                 resultsData={resultsData}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -6,6 +6,7 @@ import {
     type ChartConfig,
     type ItemsMap,
     type MetricQuery,
+    type PivotConfiguration,
 } from '@lightdash/common';
 import { Badge, List, Tooltip } from '@mantine-8/core';
 import { IconAlertCircle } from '@tabler/icons-react';
@@ -16,7 +17,7 @@ import { type InfiniteQueryResults } from '../../../hooks/useQueryResults';
 import MantineIcon from '../../common/MantineIcon';
 
 export type PivotMismatchWarningProps = {
-    pivotDimensions: string[] | undefined;
+    dirtyPivotConfiguration: PivotConfiguration | undefined;
     chartConfig: ChartConfig;
     resultsData: Pick<
         InfiniteQueryResults,
@@ -30,7 +31,7 @@ export type PivotMismatchWarningProps = {
 };
 
 const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
-    pivotDimensions,
+    dirtyPivotConfiguration,
     chartConfig,
     resultsData,
     isLoading,
@@ -41,8 +42,11 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
     );
 
     const dirtyPivotDimensions = useMemo(
-        () => pivotDimensions ?? [],
-        [pivotDimensions],
+        () =>
+            (dirtyPivotConfiguration?.groupByColumns ?? []).map(
+                (c: { reference: string }) => c.reference,
+            ),
+        [dirtyPivotConfiguration],
     );
 
     const isQueryFetching = Boolean(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactored the VisualizationCard component to use a derived pivot configuration instead of directly accessing the unsaved chart version's pivot config. This change introduces a new `dirtyPivotConfiguration` that is calculated using the `derivePivotConfigurationFromChart` function, which provides a more complete pivot configuration object to the VisualizationWarning component.

The VisualizationWarning component was updated to accept this new configuration object instead of just the pivot dimensions array, making the component more flexible and providing it with more context about the pivot configuration.