### PR TITLE
fix: prevent navigation when table is initially loading

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -529,7 +529,7 @@ const InfiniteResourceTable = ({
                 onClick: () => {
                     if (isTableSelectionActive) {
                         row.toggleSelected();
-                    } else {
+                    } else if (!isInitialLoading) {
                         void navigate(
                             getResourceUrl(filters.projectUuid, row.original),
                         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2196 / LIGHTDASH-FRONTEND-43C

### Description:
Prevents navigation to resource details when clicking on a row during initial loading. This fix ensures that users can only navigate to resource details when the table is fully loaded, avoiding potential issues with incomplete data.