### PR TITLE
fix: handle missing root space gracefully in getSpaceRoot method

### DIFF
--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -698,3 +698,14 @@ export class ChangesetConflictError extends LightdashError {
         });
     }
 }
+
+export class InvalidSpaceStateError extends LightdashError {
+    constructor(message: string) {
+        super({
+            message,
+            name: 'InvalidSpaceStateError',
+            statusCode: 500,
+            data: {},
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2194](https://linear.app/lightdash/issue/PROD-2194/spaces-and-content-missing-from-project-due-to-broken-parent-space)

### Description:

Added error handling for invalid space states to prevent failures when retrieving space shares. Created a new `InvalidSpaceStateError` class to better identify and handle cases where a root space cannot be found.

## Before

- When a root space couldn't be found, a `NotFoundError` was thrown, causing the entire request to fail
- No error details were captured for debugging

## After

- Added a new `InvalidSpaceStateError` class to specifically handle invalid space states
- Enhanced error reporting by capturing exceptions in Sentry with detailed context (space UUID, parent space UUID, path)
- Improved resilience in `getSpaceSharesBySpaceUuids` by filtering out spaces with invalid states instead of failing the entire request
- Added `parent_space_uuid` to the selected fields to provide more context in error reporting