### PR TITLE
fix: Column totals for metrics-as-rows

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -806,93 +806,99 @@ const PivotTable: FC<PivotTableProps> = ({
 
             {hasColumnTotals ? (
                 <Table.Footer withSticky>
-                    {data.columnTotals?.map((row, totalRowIndex) => (
-                        <Table.Row
-                            key={`column-total-${totalRowIndex}`}
-                            index={totalRowIndex}
-                        >
-                            {/* shows empty cell if row numbers are visible */}
-                            {hideRowNumbers ? null : <Table.Cell />}
+                    {data.columnTotals?.map((row, totalRowIndex) => {
+                        const totalRowCount = data.columnTotals?.length ?? 1;
+                        const stickyIndex = totalRowCount - 1 - totalRowIndex;
+                        return (
+                            <Table.Row
+                                key={`column-total-${totalRowIndex}`}
+                                index={stickyIndex}
+                            >
+                                {/* shows empty cell if row numbers are visible */}
+                                {hideRowNumbers ? null : <Table.Cell />}
 
-                            {/* render the total label */}
-                            {data.columnTotalFields?.[totalRowIndex].map(
-                                (totalLabel, totalColIndex) =>
-                                    totalLabel ? (
+                                {/* render the total label */}
+                                {data.columnTotalFields?.[totalRowIndex].map(
+                                    (totalLabel, totalColIndex) =>
+                                        totalLabel ? (
+                                            <Table.CellHead
+                                                key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                                isMinimal={isMinimal}
+                                                withAlignRight
+                                                withBoldFont
+                                            >
+                                                {totalLabel.fieldId
+                                                    ? `Total ${getFieldLabel(
+                                                          totalLabel.fieldId,
+                                                      )}`
+                                                    : `Total`}
+                                            </Table.CellHead>
+                                        ) : (
+                                            <Table.Cell
+                                                key={`footer-total-${totalRowIndex}-${totalColIndex}`}
+                                                isMinimal={isMinimal}
+                                            />
+                                        ),
+                                )}
+
+                                {row.map((total, totalColIndex) => {
+                                    const value = data.pivotConfig.metricsAsRows
+                                        ? getMetricAsRowColumnTotalValueFromAxis(
+                                              total,
+                                              totalRowIndex,
+                                          )
+                                        : getColumnTotalValueFromAxis(
+                                              total,
+                                              totalColIndex,
+                                          );
+                                    return value ? (
                                         <Table.CellHead
-                                            key={`footer-total-${totalRowIndex}-${totalColIndex}`}
-                                            isMinimal={isMinimal}
+                                            key={`column-total-${totalRowIndex}-${totalColIndex}`}
                                             withAlignRight
+                                            isMinimal={isMinimal}
                                             withBoldFont
+                                            withInteractions
+                                            withValue={value.formatted}
+                                            withMenu={(
+                                                {
+                                                    isOpen,
+                                                    onClose,
+                                                    onCopy,
+                                                }: MenuCallbackProps,
+                                                render: RenderCallback,
+                                            ) => (
+                                                <TotalCellMenu
+                                                    opened={isOpen}
+                                                    onClose={onClose}
+                                                    onCopy={onCopy}
+                                                >
+                                                    {render()}
+                                                </TotalCellMenu>
+                                            )}
                                         >
-                                            {totalLabel.fieldId
-                                                ? `Total ${getFieldLabel(
-                                                      totalLabel.fieldId,
-                                                  )}`
-                                                : `Total`}
+                                            {value.formatted}
                                         </Table.CellHead>
                                     ) : (
                                         <Table.Cell
                                             key={`footer-total-${totalRowIndex}-${totalColIndex}`}
                                             isMinimal={isMinimal}
                                         />
-                                    ),
-                            )}
+                                    );
+                                })}
 
-                            {row.map((total, totalColIndex) => {
-                                const value = data.pivotConfig.metricsAsRows
-                                    ? getMetricAsRowColumnTotalValueFromAxis(
-                                          total,
-                                          totalRowIndex,
+                                {hasRowTotals
+                                    ? data.rowTotalFields?.[0].map(
+                                          (_, index) => (
+                                              <Table.Cell
+                                                  key={`footer-empty-${totalRowIndex}-${index}`}
+                                                  isMinimal={isMinimal}
+                                              />
+                                          ),
                                       )
-                                    : getColumnTotalValueFromAxis(
-                                          total,
-                                          totalColIndex,
-                                      );
-                                return value ? (
-                                    <Table.CellHead
-                                        key={`column-total-${totalRowIndex}-${totalColIndex}`}
-                                        withAlignRight
-                                        isMinimal={isMinimal}
-                                        withBoldFont
-                                        withInteractions
-                                        withValue={value.formatted}
-                                        withMenu={(
-                                            {
-                                                isOpen,
-                                                onClose,
-                                                onCopy,
-                                            }: MenuCallbackProps,
-                                            render: RenderCallback,
-                                        ) => (
-                                            <TotalCellMenu
-                                                opened={isOpen}
-                                                onClose={onClose}
-                                                onCopy={onCopy}
-                                            >
-                                                {render()}
-                                            </TotalCellMenu>
-                                        )}
-                                    >
-                                        {value.formatted}
-                                    </Table.CellHead>
-                                ) : (
-                                    <Table.Cell
-                                        key={`footer-total-${totalRowIndex}-${totalColIndex}`}
-                                        isMinimal={isMinimal}
-                                    />
-                                );
-                            })}
-
-                            {hasRowTotals
-                                ? data.rowTotalFields?.[0].map((_, index) => (
-                                      <Table.Cell
-                                          key={`footer-empty-${totalRowIndex}-${index}`}
-                                          isMinimal={isMinimal}
-                                      />
-                                  ))
-                                : null}
-                        </Table.Row>
-                    ))}
+                                    : null}
+                            </Table.Row>
+                        );
+                    })}
                 </Table.Footer>
             ) : null}
         </Table>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2154](https://linear.app/lightdash/issue/PROD-2154/column-totals-only-display-a-single-metric-when-show-metrics-as-rows)

### Description:

Root cause: Footer rows use bottom: index * CELL_HEIGHT for sticky positioning:

- Row 0: bottom: 0px (positioned at very bottom)
- Row 1: bottom: 32px (positioned 32px up)

But in DOM order, Row 0 renders first (higher in the tfoot). This mismatch caused rows to overlap - both trying to occupy the same visual space.

Fix: Invert the index for footer rows so DOM order matches sticky positioning:
const stickyIndex = totalRowCount - 1 - totalRowIndex;

Now:

- Row 0 (first in DOM): bottom: 32px (higher position)
- Row 1 (second in DOM): bottom: 0px (at very bottom)

<details>
<summary>Before</summary>

![CleanShot 2025-12-24 at 18.11.55@2x.png](https://app.graphite.com/user-attachments/assets/96c0ee9f-8e72-443a-b801-b131b71633e6.png)

</details>

<details>
<summary>After</summary>

![CleanShot 2025-12-24 at 18.11.29@2x.png](https://app.graphite.com/user-attachments/assets/7ff6b2fd-6055-47d4-8efb-2fceb7ed537e.png)

</details>



