### PR TITLE
feat: improve loading states for tiles in dashboards

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -5,6 +5,7 @@ import {
     createDashboardFilterRuleFromField,
     DashboardTileTypes,
     FeatureFlags,
+    getChartKind,
     getCustomLabelsFromTableConfig,
     getDimensions,
     getFields,
@@ -557,6 +558,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
     const projectUuid = useProjectUuid();
 
+    const chartKind = useMemo(
+        () => getChartKind(chart.chartConfig.type, chart.chartConfig.config),
+        [chart.chartConfig.type, chart.chartConfig.config],
+    );
+
     const addDimensionDashboardFilter = useDashboardContext(
         (c) => c.addDimensionDashboardFilter,
     );
@@ -1010,6 +1016,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         <>
             <TileBase
                 lockHeaderVisibility={isCommentsMenuOpen}
+                chartKind={chartKind}
                 visibleHeaderElement={
                     // Dashboard comments button is always visible if they exist
                     tileHasComments ? dashboardComments : undefined
@@ -1682,6 +1689,11 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         [dashboardChartReadyQuery.executeQueryResponse.queryUuid],
     );
 
+    const chartKind = useMemo(
+        () => getChartKind(chart.chartConfig.type, chart.chartConfig.config),
+        [chart.chartConfig.type, chart.chartConfig.config],
+    );
+
     return (
         <>
             <TileBase
@@ -1689,6 +1701,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                 titleHref={`/projects/${projectUuid}/saved/${savedChartUuid}/`}
                 description={chart.description}
                 isLoading={false}
+                chartKind={chartKind}
                 minimal={true}
                 extraMenuItems={
                     canExportCsv ||
@@ -1873,6 +1886,7 @@ export const GenericDashboardChartTile: FC<
                 isEditMode={isEditMode}
                 tile={tile}
                 hasError
+                chartKind={tile.properties.lastVersionChartKind ?? null}
                 extraMenuItems={
                     tile.properties.savedChartUuid && (
                         <Tooltip
@@ -1909,6 +1923,7 @@ export const GenericDashboardChartTile: FC<
                 belongsToDashboard={tile.properties.belongsToDashboard}
                 tile={tile}
                 isLoading
+                chartKind={tile.properties.lastVersionChartKind ?? null}
                 title={tile.properties.title || tile.properties.chartName || ''}
                 extraMenuItems={
                     !minimal &&

--- a/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.module.css
@@ -1,0 +1,18 @@
+.overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--mantine-color-background);
+    border-radius: var(--mantine-radius-sm);
+    padding: var(--mantine-spacing-md);
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.skeleton {
+    &::after {
+        background-color: var(--mantine-color-ldGray-1);
+    }
+}

--- a/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.tsx
@@ -1,0 +1,98 @@
+import { ChartKind } from '@lightdash/common';
+import {
+    Box,
+    Center,
+    Group,
+    Skeleton as MantineSkeleton,
+    Stack,
+    type SkeletonProps,
+} from '@mantine-8/core';
+import { clsx } from '@mantine/core';
+import { type FC, type ReactElement } from 'react';
+import styles from './LoadingSkeletonOverlay.module.css';
+
+interface LoadingSkeletonOverlayProps {
+    visible: boolean;
+    className?: string;
+    hasTitle?: boolean;
+    chartKind?: ChartKind | null;
+}
+
+const Skeleton: FC<SkeletonProps> = (props) => (
+    <MantineSkeleton radius="lg" {...props} className={styles.skeleton} />
+);
+
+const BigNumberSkeleton: FC = () => (
+    <Center h="100%">
+        <Skeleton maw={'80%'} h={'60%'} mah={140} />
+    </Center>
+);
+
+const TableSkeleton: FC = () => (
+    <Stack gap="xs">
+        <Skeleton h={40} radius="sm" />
+        {Array.from({ length: 10 }).map((_, index) => (
+            <Group gap="xs" key={index}>
+                <Skeleton h={30} flex={1} radius="sm" />
+                <Skeleton h={30} flex={1} radius="sm" />
+                <Skeleton h={30} flex={1} radius="sm" />
+                <Skeleton h={30} flex={1} radius="sm" />
+            </Group>
+        ))}
+    </Stack>
+);
+
+const PieSkeleton: FC = () => (
+    <Center h="100%">
+        <Box w="100%" maw={'300px'} style={{ aspectRatio: 1 }}>
+            <Skeleton h="100%" w="100%" circle />
+        </Box>
+    </Center>
+);
+
+const DefaultSkeleton: FC = () => (
+    <Center h="100%">
+        <Skeleton h="80%" radius="lg" />
+    </Center>
+);
+
+const getSkeletonByChartKind = (chartKind: ChartKind): ReactElement => {
+    switch (chartKind) {
+        case ChartKind.BIG_NUMBER:
+            return <BigNumberSkeleton />;
+        case ChartKind.TABLE:
+            return <TableSkeleton />;
+        case ChartKind.PIE:
+            return <PieSkeleton />;
+        default:
+            return <DefaultSkeleton />;
+    }
+};
+
+const LoadingSkeletonOverlay = ({
+    visible,
+    className,
+    hasTitle,
+    chartKind,
+}: LoadingSkeletonOverlayProps) => {
+    if (!visible) return null;
+
+    return (
+        <Stack
+            className={clsx(styles.overlay, className)}
+            gap="sm"
+            style={{ zIndex: 1 }}
+        >
+            {hasTitle && <Box h={28} style={{ flexShrink: 0 }} />}
+            <Box flex={1} mih={0} style={{ overflow: 'hidden' }}>
+                {chartKind ? (
+                    getSkeletonByChartKind(chartKind)
+                ) : (
+                    <DefaultSkeleton />
+                )}
+            </Box>
+        </Stack>
+    );
+};
+
+export default LoadingSkeletonOverlay;

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
@@ -11,7 +11,6 @@ import {
     Flex,
     getDefaultZIndex,
     Group,
-    LoadingOverlay,
     Paper,
     rem,
     Text,
@@ -33,6 +32,7 @@ import DeleteChartTileThatBelongsToDashboardModal from '../../common/modal/Delet
 import ChartUpdateModal from '../TileForms/ChartUpdateModal';
 import MoveTileToTabModal from '../TileForms/MoveTileToTabModal';
 import TileUpdateModal from '../TileForms/TileUpdateModal';
+import LoadingSkeletonOverlay from './LoadingSkeletonOverlay';
 import styles from './TileBase.module.css';
 import { type TileBaseProps } from './types';
 
@@ -45,6 +45,7 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
     tile,
     isLoading = false,
     hasError = false,
+    chartKind,
     extraMenuItems = null,
     onDelete,
     onEdit,
@@ -239,11 +240,12 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                 bg={transparent ? 'transparent' : 'background'}
                 radius={isEditMode ? rem(4) : rem(12)}
             >
-                <LoadingOverlay
+                <LoadingSkeletonOverlay
                     // ! Very important to have this class name on the tile loading overlay, otherwise the unfurl service will not be able to find it
                     className={LOADING_CHART_OVERLAY_CLASS}
+                    hasTitle={!hideTitle}
+                    chartKind={chartKind}
                     visible={isLoading ?? false}
-                    zIndex={getDefaultZIndex('modal') - 10}
                 />
 
                 <Group

--- a/packages/frontend/src/components/DashboardTiles/TileBase/types.ts
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/types.ts
@@ -1,4 +1,4 @@
-import { type DashboardTab } from '@lightdash/common';
+import { type ChartKind, type DashboardTab } from '@lightdash/common';
 import { type ReactNode } from 'react';
 
 export type TileBaseProps<T> = {
@@ -12,6 +12,7 @@ export type TileBaseProps<T> = {
     tile: T;
     isLoading?: boolean;
     hasError?: boolean;
+    chartKind?: ChartKind | null;
     extraMenuItems?: ReactNode;
     onDelete: (tile: T) => void;
     onEdit: (tile: T) => void;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18008, #19015

### Description:

Improved dashboard tile loading states by implementing chart-specific skeleton loaders. This replaces the generic loading overlay with tailored skeleton loaders for different chart types (Big Number, Table, Pie) that better represent the final content.

The implementation:

- Added a new `LoadingSkeletonOverlay` component with specific skeleton designs for different chart kinds
- Added `chartKind` prop to `TileBase` to determine which skeleton to display
    - I originally tried adding different skeletons per chart type, but it was too much, so I only left a couple

> [!NOTE]
> The following video is forcing loading state (hence the markdown element also being triggered) Ignore that, this is just to showcase how it feels like

[CleanShot 2025-12-24 at 15.25.42.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a6e46b9b-5323-4ef8-9adb-a0763caf51d3.mp4" />](https://app.graphite.com/user-attachments/video/a6e46b9b-5323-4ef8-9adb-a0763caf51d3.mp4)

---

[CleanShot 2025-12-24 at 15.30.46.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/1c87713b-92e9-47ed-8313-938af4548b87.mp4" />](https://app.graphite.com/user-attachments/video/1c87713b-92e9-47ed-8313-938af4548b87.mp4)