### PR TITLE
feat: unify dashboard loading state

### DIFF
--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -1,7 +1,11 @@
 import { type ApiErrorDetail } from '@lightdash/common';
 import { Text } from '@mantine/core';
 import { Prism } from '@mantine/prism';
-import { IconAlertCircle, IconLock } from '@tabler/icons-react';
+import {
+    IconAlertCircle,
+    IconLock,
+    IconMoodPuzzled,
+} from '@tabler/icons-react';
 import React, { useMemo, type ComponentProps, type FC } from 'react';
 import SuboptimalState from '../SuboptimalState/SuboptimalState';
 
@@ -52,7 +56,7 @@ const ErrorState: FC<{
                     };
                 case 'NotFoundError':
                     return {
-                        icon: IconAlertCircle,
+                        icon: IconMoodPuzzled,
                         title: 'Not found',
                         description,
                     };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import {
     type DashboardTile,
     type Dashboard as IDashboard,
 } from '@lightdash/common';
-import { Box, Button, Group, Modal, Stack, Text } from '@mantine/core';
+import { Button, Group, Modal, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { captureException } from '@sentry/react';
 import { IconAlertCircle } from '@tabler/icons-react';
@@ -20,7 +20,7 @@ import DashboardDeleteModal from '../components/common/modal/DashboardDeleteModa
 import DashboardDuplicateModal from '../components/common/modal/DashboardDuplicateModal';
 import { DashboardExportModal } from '../components/common/modal/DashboardExportModal';
 import Page from '../components/common/Page/Page';
-import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
+import PageSpinner from '../components/PageSpinner';
 import { useDashboardCommentsCheck } from '../features/comments';
 import DashboardHeaderV1 from '../features/dashboardHeader/dashboardHeaderV1';
 import DashboardHeaderV2 from '../features/dashboardHeader/dashboardHeaderV2';
@@ -556,14 +556,24 @@ const Dashboard: FC = () => {
         (c) => c.hasTilesThatSupportFilters,
     );
 
+    if (isDashboardLoading) {
+        return <PageSpinner />;
+    }
+
     if (dashboardError) {
         return <ErrorState error={dashboardError.error} />;
     }
-    if (dashboard === undefined) {
+
+    if (!dashboard) {
         return (
-            <Box mt="md">
-                <SuboptimalState title="Loading..." loading />
-            </Box>
+            <ErrorState
+                error={{
+                    name: 'NotExistsError',
+                    statusCode: 404,
+                    message: 'Dashboard not found',
+                    data: {},
+                }}
+            />
         );
     }
 


### PR DESCRIPTION
Closes: #19081

### Description:
Improved the Dashboard loading and error states by:
- Replacing the `SuboptimalState` component with `PageSpinner` for loading state
- Adding a proper error message when dashboard is not found
- Restructuring the conditional rendering logic to show loading state first

This change provides clearer feedback to users when a dashboard is loading or not found.