### PR TITLE
fix: replace useParams with useProjectUuid hook

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/hooks/useDataForFiltersProvider.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/hooks/useDataForFiltersProvider.ts
@@ -1,4 +1,3 @@
-import { useParams } from 'react-router';
 import {
     selectAdditionalMetrics,
     selectCustomDimensions,
@@ -9,10 +8,11 @@ import {
 import { useExplore } from '../../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../../hooks/useExplorerQuery';
 import { useProject } from '../../../../hooks/useProject';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import { useFieldsWithSuggestions } from '../../FiltersCard/useFieldsWithSuggestions';
 
 export const useDataForFiltersProvider = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const project = useProject(projectUuid);
 
     const tableName = useExplorerSelector(selectTableName);

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -17,7 +17,6 @@ import {
     useTransition,
     type FC,
 } from 'react';
-import { useParams } from 'react-router';
 import {
     explorerActions,
     selectAdditionalMetrics,
@@ -33,6 +32,7 @@ import {
 } from '../../../features/virtualView';
 import { useExplore } from '../../../hooks/useExplore';
 import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -59,7 +59,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
     const [isViewSourceOpen, setIsViewSourceOpen] = useState(false);
     const [, startTransition] = useTransition();
 
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const isGitProject = useIsGitProject(projectUuid ?? '');
     const { data: editYamlInUiFlag } = useFeatureFlag(
         FeatureFlags.EditYamlInUi,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -25,7 +25,6 @@ import {
     IconTrash,
 } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 import {
     explorerActions,
@@ -34,6 +33,7 @@ import {
 import useToaster from '../../../../../hooks/toaster/useToaster';
 import { useFeatureFlagEnabled } from '../../../../../hooks/useFeatureFlagEnabled';
 import { useFilteredFields } from '../../../../../hooks/useFilters';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -58,7 +58,7 @@ const TreeSingleNodeActions: FC<Props> = ({
     hasDescription,
     onViewDescription,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { user } = useApp();
     const { showToastSuccess } = useToaster();
     const { addFilter } = useFilteredFields();

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -3,7 +3,6 @@ import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
 import { ActionIcon, Button, Group, Text, Tooltip } from '@mantine/core';
 import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
 import {
     explorerActions,
     selectAdditionalMetrics,
@@ -12,6 +11,7 @@ import {
     useExplorerSelector,
 } from '../../../../../features/explorer/store';
 import { useFeatureFlagEnabled } from '../../../../../hooks/useFeatureFlagEnabled';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -31,7 +31,7 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
 }) => {
     const { label, color, depth, tableName, treeSection, helpButton } =
         item.data;
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { user } = useApp();
     const { track } = useTracking();
     const dispatch = useExplorerDispatch();

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -4,7 +4,6 @@ import { Badge, Box, Button, Group, Tooltip } from '@mantine/core';
 import { IconAlertCircle, IconArrowLeft } from '@tabler/icons-react';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { memo, useEffect, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import {
     explorerActions,
@@ -19,6 +18,7 @@ import {
 import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
 import { Can } from '../../../providers/Ability';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
@@ -32,7 +32,7 @@ import SaveChartButton from '../SaveChartButton';
 import QueryWarnings from './QueryWarnings';
 
 const ExplorerHeader: FC = memo(() => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { user } = useApp();
     const { onBackToDashboard } = useEmbed();
     const ability = useAbilityContext();

--- a/packages/frontend/src/components/Explorer/ParametersCard/ParametersCard.tsx
+++ b/packages/frontend/src/components/Explorer/ParametersCard/ParametersCard.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@mantine-8/core';
 import { memo, useCallback, useMemo } from 'react';
-import { useParams } from 'react-router';
 import {
     explorerActions,
     selectIsEditMode,
@@ -13,12 +12,13 @@ import {
 } from '../../../features/explorer/store';
 import { ParameterSelection } from '../../../features/parameters';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 
 const ParametersCard = memo(
     ({ parameterReferences }: { parameterReferences?: string[] }) => {
-        const { projectUuid } = useParams<{ projectUuid: string }>();
+        const projectUuid = useProjectUuid();
 
         const paramsIsOpen = useExplorerSelector(selectIsParametersExpanded);
         const isEditMode = useExplorerSelector(selectIsEditMode);

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -15,9 +15,9 @@ import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconEye, IconFilter, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useFilters } from '../../../hooks/useFilters';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -43,7 +43,7 @@ const CellContextMenu: FC<
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
     const { user } = useApp();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const value: ResultValue = useMemo(
         () => cell.getValue()?.value || {},

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -2,7 +2,6 @@ import { getItemId, getMetrics } from '@lightdash/common';
 import { Button, Tooltip } from '@mantine-8/core';
 import { IconDeviceFloppy } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import {
     useAmbientAiEnabled,
     useGenerateChartMetadata,
@@ -16,6 +15,7 @@ import {
 } from '../../../features/explorer/store';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useAddVersionMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
 import MantineIcon from '../../common/MantineIcon';
@@ -26,7 +26,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
     disabled,
 }) => {
     const isAmbientAiEnabled = useAmbientAiEnabled();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
     const savedChart = useExplorerSelector(selectSavedChart);

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/SpaceBrowserMenu.tsx
@@ -8,7 +8,7 @@ import {
     IconTrash,
 } from '@tabler/icons-react';
 import React from 'react';
-import { useParams } from 'react-router';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 
@@ -30,7 +30,7 @@ export const SpaceBrowserMenu: React.FC<React.PropsWithChildren<Props>> = ({
 }) => {
     const { user } = useApp();
     const organizationUuid = user.data?.organizationUuid;
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     return (
         <Menu

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -16,8 +16,8 @@ import {
     useState,
     type FC,
 } from 'react';
-import { useParams } from 'react-router';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -51,7 +51,7 @@ export const SeriesContextMenu: FC<{
         top: number;
     }>();
 
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     useEffect(() => {
         if (echartsSeriesClickEvent !== undefined) {

--- a/packages/frontend/src/hooks/useCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useCalculateTotal.ts
@@ -13,12 +13,12 @@ import {
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import {
     convertDateDashboardFilters,
     convertDateFilters,
 } from '../utils/dateFilter';
+import { useProjectUuid } from './useProjectUuid';
 
 const calculateTotalFromQuery = async (
     projectUuid: string,
@@ -132,8 +132,7 @@ export const useCalculateTotal = ({
         if (showColumnCalculation === false) return [];
         return getCalculationColumnFields(fieldIds, itemsMap);
     }, [fieldIds, itemsMap, showColumnCalculation]);
-
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     // only add relevant fields to the key (filters, metrics)
     const queryKey = savedChartUuid

--- a/packages/frontend/src/hooks/useCompiledSql.ts
+++ b/packages/frontend/src/hooks/useCompiledSql.ts
@@ -5,7 +5,6 @@ import {
     type ParametersValuesMap,
 } from '@lightdash/common';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import {
     selectAdditionalMetrics,
@@ -23,6 +22,7 @@ import {
     useExplorerSelector,
 } from '../features/explorer/store';
 import { convertDateFilters } from '../utils/dateFilter';
+import { useProjectUuid } from './useProjectUuid';
 import useQueryError from './useQueryError';
 
 const getCompiledQuery = async (
@@ -47,7 +47,7 @@ const getCompiledQuery = async (
 export const useCompiledSql = (
     queryOptions?: UseQueryOptions<ApiCompiledQueryResults, ApiError>,
 ) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const tableId = useExplorerSelector(selectTableName);
     const dimensions = useExplorerSelector(selectDimensions);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19083 / PROD-2199

### Description:
Replaced direct usage of `useParams` with a custom hook `useProjectUuid` across the embed `<Explorer/>` components. This refactoring centralizes the logic for retrieving the project UUID, making the code more maintainable and consistent.

The change affects multiple components in the Explorer section including the CustomMetricModal, ExplorePanel, TreeSingleNodeActions, VirtualSectionHeader, ExplorerHeader, ParametersCard, CellContextMenu, SaveChartButton, SpaceBrowserMenu, SeriesContextMenu, and several hooks like useCalculateTotal and useCompiledSql.

### Demo
Previously, pressing `Run query` would do nothing. Now it's working:

<img width="1222" height="520" alt="Screenshot 2025-12-24 at 18 55 31" src="https://github.com/user-attachments/assets/d78166fd-f33b-475f-88b1-8b3f9717c92e" />
