### PR TITLE
fix: disable space access in embed mode

### DIFF
--- a/packages/frontend/src/hooks/user/useCreateInAnySpaceAccess.ts
+++ b/packages/frontend/src/hooks/user/useCreateInAnySpaceAccess.ts
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import useEmbed from '../../ee/providers/Embed/useEmbed';
 import useApp from '../../providers/App/useApp';
 import { useSpaceSummaries } from '../useSpaces';
 
@@ -8,11 +9,15 @@ const useCreateInAnySpaceAccess = (
     options?: { enabled?: boolean },
 ): boolean => {
     const { user } = useApp();
+    const { embedToken } = useEmbed();
+
+    const isEmbedMode = !!embedToken;
+
     const spaces = useSpaceSummaries(projectUuid, true, {
-        enabled: options?.enabled && !!projectUuid,
+        enabled: !!projectUuid && !isEmbedMode && (options?.enabled ?? true),
     });
 
-    if (!projectUuid) {
+    if (!projectUuid || isEmbedMode) {
         return false;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: #19083 / PROD-2199 

### Description:
Disable "Create in any space" functionality in embed mode by checking for the presence of an embed token. This prevents the hook from fetching space summaries when in embed mode and ensures the hook returns `false` when an embed token is present.

TLDR; this fired a `/spaces` request that would be 401 and also unneeded, since we don't save from embeds.