### PR TITLE
refactor: consolidate NotExistsError and NotFoundError

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7183,7 +7183,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7206,7 +7206,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                chartUsage:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7236,12 +7236,6 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -7249,6 +7243,12 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7452,7 +7452,7 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7475,7 +7475,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    chartUsage:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7505,12 +7505,6 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -7518,6 +7512,12 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -16932,7 +16932,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -16942,7 +16942,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -16952,7 +16952,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -16965,7 +16965,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -17388,7 +17388,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17398,7 +17398,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17408,7 +17408,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17421,7 +17421,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7978,12 +7978,12 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -7991,10 +7991,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8003,8 +8003,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8098,12 +8098,12 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "searchRank": {
+                                                                                    "chartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -8111,10 +8111,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8123,8 +8123,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -17764,22 +17764,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiChartAsCodeListResponse": {
@@ -18134,22 +18134,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -23699,7 +23699,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2278.2",
+        "version": "0.2279.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -5,7 +5,6 @@ import {
     GroupMember,
     GroupMembership,
     GroupWithMembers,
-    NotExistsError,
     NotFoundError,
     ParameterError,
     ProjectGroupAccess,
@@ -657,7 +656,7 @@ export class GroupsModel {
             .where('organization_uuid', organizationUuid)
             .first('organization_id');
         if (!organization) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
 
         const existingGroups = await this.database('groups')
@@ -675,7 +674,7 @@ export class GroupsModel {
                 .first('user_id')
         )?.user_id;
         if (!userIdToInsert) {
-            throw new NotExistsError('Cannot find user');
+            throw new NotFoundError('Cannot find user');
         }
 
         const insertData = existingGroups.map((group) => ({

--- a/packages/backend/src/models/InviteLinkModel.ts
+++ b/packages/backend/src/models/InviteLinkModel.ts
@@ -1,4 +1,4 @@
-import { InviteLink, NotExistsError } from '@lightdash/common';
+import { InviteLink, NotFoundError } from '@lightdash/common';
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
 import { URL } from 'url';
@@ -79,7 +79,7 @@ export class InviteLinkModel {
                 '*',
             );
         if (inviteLinks.length === 0) {
-            throw new NotExistsError('No invite link found');
+            throw new NotFoundError('No invite link found');
         }
         return this.mapDbObjectToInviteLink(inviteCode, inviteLinks[0]);
     }
@@ -95,7 +95,7 @@ export class InviteLinkModel {
             .where('organization_uuid', organizationUuid)
             .select('*');
         if (orgs.length === 0) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
         const org = orgs[0];
         await this.database('invite_links')
@@ -115,7 +115,7 @@ export class InviteLinkModel {
             .where('organization_uuid', organizationUuid)
             .select('*');
         if (orgs.length === 0) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
         const org = orgs[0];
         await this.database('invite_links')

--- a/packages/backend/src/models/OnboardingModel/OnboardingModel.ts
+++ b/packages/backend/src/models/OnboardingModel/OnboardingModel.ts
@@ -1,4 +1,4 @@
-import { NotExistsError, OnbordingRecord } from '@lightdash/common';
+import { NotFoundError, OnbordingRecord } from '@lightdash/common';
 import { Knex } from 'knex';
 import { OnboardingTableName } from '../../database/entities/onboarding';
 import { OrganizationTableName } from '../../database/entities/organizations';
@@ -21,7 +21,7 @@ export class OnboardingModel {
             .where('organization_uuid', organizationUuid)
             .select('organization_id');
         if (orgs.length === 0) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
         const onboardings = await this.database(OnboardingTableName)
             .select('shownSuccess_at', 'ranQuery_at')
@@ -52,7 +52,7 @@ export class OnboardingModel {
             .where('organization_uuid', organizationUuid)
             .select('organization_id');
         if (orgs.length === 0) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
 
         await this.database(OnboardingTableName)

--- a/packages/backend/src/models/OpenIdIdentitiesModel.ts
+++ b/packages/backend/src/models/OpenIdIdentitiesModel.ts
@@ -1,6 +1,5 @@
 import {
     CreateOpenIdIdentity,
-    NotExistsError,
     NotFoundError,
     OpenIdIdentity,
     OpenIdIdentityIssuerType,
@@ -69,7 +68,7 @@ export class OpenIdIdentityModel {
             .where('issuer', issuer)
             .andWhere('subject', subject);
         if (identity === undefined) {
-            throw new NotExistsError('Cannot find openid identity');
+            throw new NotFoundError('Cannot find openid identity');
         }
         return OpenIdIdentityModel._parseDbIdentity(identity);
     }

--- a/packages/backend/src/models/PasswordResetLinkModel.ts
+++ b/packages/backend/src/models/PasswordResetLinkModel.ts
@@ -1,4 +1,4 @@
-import { NotExistsError, PasswordResetLink } from '@lightdash/common';
+import { NotFoundError, PasswordResetLink } from '@lightdash/common';
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
 import { URL } from 'url';
@@ -47,7 +47,7 @@ export class PasswordResetLinkModel {
             ])
             .where('code_hash', codeHash);
         if (links.length === 0) {
-            throw new NotExistsError('No password reset link found');
+            throw new NotFoundError('No password reset link found');
         }
         const passwordResetLink = links[0];
         return {
@@ -69,7 +69,7 @@ export class PasswordResetLinkModel {
             .where('email', email)
             .select('*');
         if (emails.length === 0) {
-            throw new NotExistsError('Cannot find email');
+            throw new NotFoundError('Cannot find email');
         }
         const result = emails[0];
         const links = await this.database(PasswordResetTableName)

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -14,7 +14,6 @@ import {
     ExploreError,
     ExploreType,
     IdContentMapping,
-    NotExistsError,
     NotFoundError,
     OrganizationProject,
     ParameterError,
@@ -247,7 +246,7 @@ export class ProjectModel {
     async getSingleProjectUuidInInstance(): Promise<string> {
         const projects = await this.database('projects').select('*');
         if (projects.length === 0) {
-            throw new NotExistsError('Cannot find project');
+            throw new NotFoundError('Cannot find project');
         }
         if (projects.length > 1) {
             throw new ParameterError(
@@ -264,7 +263,7 @@ export class ProjectModel {
             .where('organization_uuid', organizationUuid)
             .select('*');
         if (orgs.length === 0) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
 
         const organizationId = orgs[0].organization_id;
@@ -416,7 +415,7 @@ export class ProjectModel {
             .where('organization_uuid', organizationUuid)
             .select('*');
         if (orgs.length === 0) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
 
         const projects = await this.database('projects')
@@ -446,7 +445,7 @@ export class ProjectModel {
             .where('organization_uuid', organizationUuid)
             .select('*');
         if (orgs.length === 0) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
         return this.database.transaction(async (trx) => {
             let encryptedCredentials: Buffer;
@@ -689,13 +688,13 @@ export class ProjectModel {
                     .select<QueryResult>()
                     .where('projects.project_uuid', projectUuid);
                 if (projects.length === 0) {
-                    throw new NotExistsError(
+                    throw new NotFoundError(
                         `Cannot find project with id: ${projectUuid}`,
                     );
                 }
                 const [project] = projects;
                 if (!project.dbt_connection) {
-                    throw new NotExistsError(
+                    throw new NotFoundError(
                         'Project has no valid dbt credentials',
                     );
                 }
@@ -789,7 +788,7 @@ export class ProjectModel {
             .where('projects.project_uuid', projectUuid)
             .first();
         if (!project) {
-            throw new NotExistsError(
+            throw new NotFoundError(
                 `Cannot find project with id: ${projectUuid}`,
             );
         }
@@ -863,7 +862,7 @@ export class ProjectModel {
             .select('warehouse_connection');
 
         if (!orgCredentials) {
-            throw new NotExistsError(
+            throw new NotFoundError(
                 'Organization warehouse credentials not found',
             );
         }
@@ -933,7 +932,7 @@ export class ProjectModel {
             .select(['table_selection_type', 'table_selection_value'])
             .where('project_uuid', projectUuid);
         if (projects.length === 0) {
-            throw new NotExistsError(
+            throw new NotFoundError(
                 `Cannot find project with id: ${projectUuid}`,
             );
         }
@@ -1173,7 +1172,7 @@ export class ProjectModel {
         );
         const cachedExplore = cachedExplores[exploreName];
         if (cachedExplore === undefined) {
-            throw new NotExistsError(
+            throw new NotFoundError(
                 `Explore "${exploreName}" does not exist.`,
             );
         }
@@ -1467,7 +1466,7 @@ export class ProjectModel {
                     project.organization_id,
                 );
             if (user === undefined) {
-                throw new NotExistsError(
+                throw new NotFoundError(
                     `Can't find user with email ${email} in the organization`,
                 );
             }
@@ -1588,7 +1587,7 @@ export class ProjectModel {
             ])
             .where('project_uuid', projectUuid);
         if (row === undefined) {
-            throw new NotExistsError(
+            throw new NotFoundError(
                 `Cannot find any warehouse credentials for project.`,
             );
         }

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -7,7 +7,7 @@ import {
     ExploreError,
     ExploreType,
     FieldSearchResult,
-    NotExistsError,
+    NotFoundError,
     SavedChartSearchResult,
     SearchFilters,
     SearchItemType,
@@ -1060,7 +1060,7 @@ export class SearchModel {
             .where('project_uuid', projectUuid)
             .limit(1);
         if (projects.length === 0) {
-            throw new NotExistsError(
+            throw new NotFoundError(
                 `Cannot find project with id: ${projectUuid}`,
             );
         }

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -12,7 +12,6 @@ import {
     LightdashUser,
     LightdashUserWithAbilityRules,
     MemberAbility,
-    NotExistsError,
     NotFoundError,
     OpenIdIdentityIssuerType,
     OpenIdUser,
@@ -646,7 +645,7 @@ export class UserModel {
             .where('organization_uuid', organizationUuid)
             .select('organization_id');
         if (!org) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
         const email = isOpenIdUser(createUser)
             ? createUser.openId.email
@@ -854,7 +853,7 @@ export class UserModel {
         const user = await this.findSessionUserByUUID(userUuid);
 
         if (!user?.userId) {
-            throw new NotExistsError('User is missing user_id');
+            throw new NotFoundError('User is missing user_id');
         }
 
         await this.database(PasswordLoginTableName)
@@ -928,7 +927,7 @@ export class UserModel {
             .select('user_id')
             .first();
         if (!user) {
-            throw new NotExistsError('Cannot find user');
+            throw new NotFoundError('Cannot find user');
         }
         return this.database(PasswordLoginTableName)
             .where({
@@ -952,14 +951,14 @@ export class UserModel {
             .where('organization_uuid', organizationUuid)
             .select('organization_id');
         if (!org) {
-            throw new NotExistsError('Cannot find organization');
+            throw new NotFoundError('Cannot find organization');
         }
 
         const [user] = await this.database(UserTableName)
             .where('user_uuid', userUuid)
             .select('user_id');
         if (!user) {
-            throw new NotExistsError('Cannot find user');
+            throw new NotFoundError('Cannot find user');
         }
 
         await this.database.transaction(async (trx) => {
@@ -1019,11 +1018,11 @@ export class UserModel {
             .select('refresh_token');
 
         if (!row) {
-            throw new NotExistsError('Cannot find user with refresh token');
+            throw new NotFoundError('Cannot find user with refresh token');
         }
 
         if (!row.refresh_token) {
-            throw new NotExistsError('Cannot find refresh token');
+            throw new NotFoundError('Cannot find refresh token');
         }
 
         return row.refresh_token;

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -9,7 +9,6 @@ export const IGNORE_ERRORS = [
     'FieldReferenceError',
     'NotEnoughResults',
     'CompileError',
-    'NotExistsError',
     'NotFoundError',
     'ForbiddenError',
     'TokenError',

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -9,7 +9,7 @@ import {
     ForbiddenError,
     KnexPaginateArgs,
     KnexPaginatedData,
-    NotExistsError,
+    NotFoundError,
     SessionUser,
     SummaryContent,
 } from '@lightdash/common';
@@ -82,7 +82,7 @@ export class ContentService extends BaseService {
     ): Promise<KnexPaginatedData<SummaryContent[]>> {
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
         const projectUuids = (
             await wrapSentryTransaction(
@@ -148,7 +148,7 @@ export class ContentService extends BaseService {
         targetSpaceUuid: string | null,
     ) {
         if (user.organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
 
         const { organizationUuid } = await this.projectModel.getSummary(
@@ -239,7 +239,7 @@ export class ContentService extends BaseService {
         targetSpaceUuid: string | null,
     ) {
         if (user.organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
 
         const { organizationUuid } = await this.projectModel.getSummary(

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
@@ -2,7 +2,7 @@
 import {
     AnyType,
     DbtProjectType,
-    NotExistsError,
+    NotFoundError,
     OrganizationMemberRole,
     ParameterError,
     ServiceAccountScope,
@@ -245,7 +245,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
             });
         });
 
-        test('should throw NotExistsError when admin user is not found', async () => {
+        test('should throw NotFoundError when admin user is not found', async () => {
             service = createMockService({
                 organizationModel: {
                     getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
@@ -274,7 +274,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
             });
 
             await expect(service.updateInstanceConfiguration()).rejects.toThrow(
-                NotExistsError,
+                NotFoundError,
             );
             await expect(service.updateInstanceConfiguration()).rejects.toThrow(
                 `User ${mockAdminEmail} not found`,

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -4,7 +4,7 @@ import {
     CreateWarehouseCredentials,
     DbtProjectConfig,
     isGitProjectType,
-    NotExistsError,
+    NotFoundError,
     OrganizationMemberRole,
     ParameterError,
     ProjectType,
@@ -299,7 +299,7 @@ export class InstanceConfigurationService extends BaseService {
             const sessionUser =
                 await this.userModel.findSessionUserByPrimaryEmail(adminEmail);
             if (!sessionUser) {
-                throw new NotExistsError(`User ${adminEmail} not found`);
+                throw new NotFoundError(`User ${adminEmail} not found`);
             }
             // Revoke other existing PATs for the admin.
             await this.personalAccessTokenModel.deleteAllTokensForUser(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -14,7 +14,7 @@ import {
     KnexPaginateArgs,
     KnexPaginatedData,
     LightdashMode,
-    NotExistsError,
+    NotFoundError,
     OnbordingRecord,
     Organization,
     OrganizationColorPalette,
@@ -135,7 +135,7 @@ export class OrganizationService extends BaseService {
             throw new ForbiddenError();
         }
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
         if (data.name) {
             validateOrganizationNameOrThrow(data.name);
@@ -230,7 +230,7 @@ export class OrganizationService extends BaseService {
             throw new ForbiddenError();
         }
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
 
         const { pagination, data: organizationMembers } = includeGroups
@@ -290,7 +290,7 @@ export class OrganizationService extends BaseService {
     async getProjects(account: Account): Promise<OrganizationProject[]> {
         const { organizationUuid } = account.organization;
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
 
         const projects = await wrapSentryTransaction(
@@ -314,7 +314,7 @@ export class OrganizationService extends BaseService {
     async getOnboarding(user: SessionUser): Promise<OnbordingRecord> {
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
         return this.onboardingModel.getByOrganizationUuid(organizationUuid);
     }
@@ -325,7 +325,7 @@ export class OrganizationService extends BaseService {
         }
         const { shownSuccessAt } = await this.getOnboarding(user);
         if (shownSuccessAt) {
-            throw new NotExistsError('Can not override "shown success" date');
+            throw new NotFoundError('Can not override "shown success" date');
         }
         return this.onboardingModel.update(user.organizationUuid, {
             shownSuccessAt: new Date(),
@@ -447,7 +447,7 @@ export class OrganizationService extends BaseService {
     ): Promise<AllowedEmailDomains> {
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
 
         const allowedEmailDomains =
@@ -471,7 +471,7 @@ export class OrganizationService extends BaseService {
     ): Promise<AllowedEmailDomains> {
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
 
         if (
@@ -675,7 +675,7 @@ export class OrganizationService extends BaseService {
         user: SessionUser,
     ): Promise<OrganizationColorPaletteWithIsActive[]> {
         if (!user.organizationUuid) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
 
         return this.organizationModel.getColorPalettes(user.organizationUuid);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -111,7 +111,6 @@ import {
     MissingWarehouseCredentialsError,
     MostPopularAndRecentlyUpdated,
     normalizeIndexColumns,
-    NotExistsError,
     NotFoundError,
     NotSupportedError,
     OpenIdIdentityIssuerType,
@@ -3716,15 +3715,15 @@ export class ProjectService extends BaseService {
         }
 
         if (!explore) {
-            throw new NotExistsError(`Explore ${table} does not exist`);
+            throw new NotFoundError(`Explore ${table} does not exist`);
         } else if (isExploreError(explore)) {
-            throw new NotExistsError(`Explore ${table} has errors`);
+            throw new NotFoundError(`Explore ${table} has errors`);
         }
 
         const field = findFieldByIdInExplore(explore, fieldId);
 
         if (!field) {
-            throw new NotExistsError(`Can't dimension with id: ${fieldId}`);
+            throw new NotFoundError(`Can't dimension with id: ${fieldId}`);
         }
 
         if (!isDimension(field)) {
@@ -4422,12 +4421,12 @@ export class ProjectService extends BaseService {
                 const explore = exploresMap[exploreName];
 
                 if (!explore) {
-                    throw new NotExistsError(
+                    throw new NotFoundError(
                         `Explore "${exploreName}" does not exist.`,
                     );
                 }
                 if (isExploreError(explore)) {
-                    throw new NotExistsError(
+                    throw new NotFoundError(
                         `Explore "${exploreName}" has an error.`,
                     );
                 }

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -12,7 +12,6 @@ import {
     getItemId,
     isExploreError,
     NameChanges,
-    NotExistsError,
     NotFoundError,
     NotImplementedError,
     ParameterError,
@@ -198,7 +197,7 @@ export class RenameService extends BaseService {
                     this.projectModel.getExploreFromCache(projectUuid, from),
                 );
                 if (isError(toExists) && isError(fromExists)) {
-                    throw new NotExistsError(
+                    throw new NotFoundError(
                         `Neither "${from}" nor "${to}" explores exist in the project.`,
                     );
                 }

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -19,7 +19,6 @@ import {
     isValidTimezone,
     KnexPaginateArgs,
     KnexPaginatedData,
-    NotExistsError,
     NotFoundError,
     ParameterError,
     ScheduledJobs,
@@ -655,7 +654,7 @@ export class SchedulerService extends BaseService {
             throw new ForbiddenError();
         }
         if (job.status === 'error') {
-            throw new NotExistsError(
+            throw new NotFoundError(
                 job.details?.error ?? 'Unable to download CSV',
             );
         }

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -29,7 +29,6 @@ import {
     LoginOptions,
     LoginOptionTypes,
     MissingConfigError,
-    NotExistsError,
     NotFoundError,
     NotImplementedError,
     OpenIdIdentityIssuerType,
@@ -376,7 +375,7 @@ export class UserService extends BaseService {
         const { expiresAt, email, role } = createInviteLink;
         const inviteCode = nanoid(30);
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
 
         const existingUserWithEmail = await this.userModel.findUserByEmail(
@@ -473,7 +472,7 @@ export class UserService extends BaseService {
             throw new ForbiddenError();
         }
         if (organizationUuid === undefined) {
-            throw new NotExistsError('Organization not found');
+            throw new NotFoundError('Organization not found');
         }
         await this.inviteLinkModel.deleteByOrganization(organizationUuid);
         this.analytics.track({
@@ -1035,7 +1034,7 @@ export class UserService extends BaseService {
             try {
                 await this.inviteLinkModel.deleteByCode(inviteLink.inviteCode);
             } catch (e) {
-                throw new NotExistsError('Invite link not found');
+                throw new NotFoundError('Invite link not found');
             }
             throw new ExpiredError('Invite link expired');
         }
@@ -1245,9 +1244,9 @@ export class UserService extends BaseService {
             try {
                 await this.passwordResetLinkModel.deleteByCode(link.code);
             } catch (e) {
-                throw new NotExistsError('Password reset link not found');
+                throw new NotFoundError('Password reset link not found');
             }
-            throw new NotExistsError('Password reset link expired');
+            throw new NotFoundError('Password reset link expired');
         }
     }
 
@@ -1272,7 +1271,7 @@ export class UserService extends BaseService {
     async resetPassword(data: PasswordReset): Promise<void> {
         const link = await this.passwordResetLinkModel.getByCode(data.code);
         if (link.isExpired) {
-            throw new NotExistsError('Password reset link expired');
+            throw new NotFoundError('Password reset link expired');
         }
         const user = await this.userModel.findUserByEmail(link.email);
         if (user) {
@@ -1506,7 +1505,7 @@ export class UserService extends BaseService {
             userUuid,
         );
         if (organizations.length === 0) {
-            throw new NotExistsError('User not part of any organization');
+            throw new NotFoundError('User not part of any organization');
         } else if (organizations.length > 1) {
             throw new ForbiddenError('User is part of multiple organizations');
         }

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -73,17 +73,6 @@ export class AuthorizationError extends LightdashError {
     }
 }
 
-export class NotExistsError extends LightdashError {
-    constructor(message: string) {
-        super({
-            message,
-            name: 'NotExistsError',
-            statusCode: 404,
-            data: {},
-        });
-    }
-}
-
 export class ExpiredError extends LightdashError {
     constructor(message: string) {
         super({

--- a/packages/frontend/src/components/common/ErrorState/index.tsx
+++ b/packages/frontend/src/components/common/ErrorState/index.tsx
@@ -50,7 +50,7 @@ const ErrorState: FC<{
                         title: 'Authorization error',
                         description,
                     };
-                case 'NotExistsError':
+                case 'NotFoundError':
                     return {
                         icon: IconAlertCircle,
                         title: 'Not found',


### PR DESCRIPTION
Consolidates two redundant error classes (NotExistsError and NotFoundError) into a single NotFoundError class. Both classes had identical behavior with 404 status codes and were used interchangeably throughout the codebase.

Changes:
- Replaced all ~20 usages of NotExistsError with NotFoundError across backend models, services, and tests
- Updated frontend ErrorState component to handle NotFoundError instead of NotExistsError
- Removed NotExistsError from Sentry ignore list (NotFoundError already present)
- Removed NotExistsError class definition from common/types/errors.ts

This reduces code duplication and establishes clearer error handling patterns.

Fixes #19092

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
