### PR TITLE
chore: skip Sentry for AI API timeouts

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -63,6 +63,7 @@ import { AllMiddlewareArgs, App, SlackEventMiddlewareArgs } from '@slack/bolt';
 import { Block, KnownBlock, WebClient } from '@slack/web-api';
 import { MessageElement } from '@slack/web-api/dist/response/ConversationsHistoryResponse';
 import {
+    APICallError,
     AssistantModelMessage,
     ModelMessage,
     ToolCallPart,
@@ -1981,7 +1982,10 @@ export class AiAgentService {
             Logger.error(
                 `Failed to generate question for artifact version ${payload.artifactVersionUuid}`,
             );
-            Sentry.captureException(error);
+            // Skip Sentry for AI API timeouts - these are expected transient failures
+            if (!APICallError.isInstance(error)) {
+                Sentry.captureException(error);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-176](https://linear.app/lightdash/issue/ZAP-176/ai-apicallerror-failed-to-process-successful-response)

### Description:

Skip Sentry error reporting for AI API timeouts in the AiAgentService. These are expected transient failures that don't need to be tracked in Sentry. The PR adds a check using `APICallError.isInstance()` to identify these specific errors before sending them to Sentry.