### PR TITLE
style: update TileBase with darker borders and shadow styling

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -5,11 +5,12 @@
 
 .tileCard {
     overflow: unset;
+    box-shadow: unset;
 
     border: 1px solid
         light-dark(
-            var(--mantine-color-ldGray-1),
-            lighten(var(--mantine-color-ldDark-1), 0.05)
+            var(--mantine-color-ldGray-2),
+            lighten(var(--mantine-color-ldDark-2), 0.05)
         ) !important;
 
     &[data-with-transparent-border='true'] {
@@ -23,6 +24,10 @@
     &[data-has-error='true'] {
         border-style: dashed !important;
         background: transparent !important;
+    }
+
+    &[data-with-shadow='true'] {
+        box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.03);
     }
 }
 

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
@@ -12,6 +12,7 @@ import {
     Group,
     LoadingOverlay,
     Paper,
+    rem,
     Text,
     Tooltip,
 } from '@mantine-8/core';
@@ -237,11 +238,11 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                 data-with-transparent-border={transparent}
                 data-with-edit-mode={isEditMode}
                 data-has-error={hasError}
+                data-with-shadow={!isEditMode && !transparent}
                 h="100%"
                 p={transparent ? 0 : 'md'}
                 bg={transparent ? 'transparent' : 'background'}
-                shadow={isEditMode && !transparent ? 'xs' : '0'}
-                radius="sm"
+                radius={isEditMode ? rem(4) : rem(12)}
             >
                 <LoadingOverlay
                     // ! Very important to have this class name on the tile loading overlay, otherwise the unfurl service will not be able to find it


### PR DESCRIPTION
### Description:
Updated the TileBase component styling with the following changes:
- Changed border color from ldGray-1/ldDark-1 to ldGray-2/ldDark-2 for better contrast
- Added box shadow for non-edit mode and non-transparent tiles
- Replaced the shadow prop with a data attribute for more consistent styling
- Changed the border radius to a fixed rem(12) value instead of "sm"