### PR TITLE
refactor: replace styled components with CSS modules in TileBase

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -37,3 +37,74 @@
         cursor: grabbing;
     }
 }
+
+.tileTitle {
+    font-weight: 600;
+    font-size: 16px;
+
+    color: var(--mantine-color-foreground-0);
+    text-decoration: none;
+
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &[data-hidden='true'] {
+        display: none;
+    }
+
+    &:hover,
+    &[data-hovered='true'] {
+        white-space: normal;
+        overflow: visible;
+        z-index: 10;
+        outline: 4px solid var(--mantine-color-background-0);
+        background-color: var(--mantine-color-background-0);
+        color: var(--mantine-color-foreground-0);
+
+        &:is(a) {
+            color: var(--mantine-color-foreground-0) !important;
+            text-decoration: underline;
+        }
+    }
+
+    &:is(a) {
+        &:not([href]) {
+            cursor: default;
+            text-decoration: none;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
+    }
+}
+
+.headerContainer {
+    border-radius: var(--mantine-radius-sm);
+
+    &[data-is-edit-mode='true'] {
+        &:hover {
+            cursor: grab;
+        }
+        &:active,
+        &:focus {
+            cursor: grabbing;
+        }
+    }
+
+    &[data-is-empty='true'] {
+        position: absolute;
+        right: 16px;
+    }
+}
+
+.chartContainer {
+    overflow: hidden;
+
+    &[data-full-width='true'] {
+        margin: 0 -16px -16px -16px;
+    }
+}

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
@@ -8,6 +8,7 @@ import {
     ActionIcon,
     Box,
     Card,
+    Flex,
     getDefaultZIndex,
     Group,
     LoadingOverlay,
@@ -17,7 +18,7 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { useHover, useToggle } from '@mantine-8/hooks';
-import { Menu } from '@mantine/core';
+import { clsx, Menu } from '@mantine/core';
 import {
     IconArrowAutofitContent,
     IconDots,
@@ -33,12 +34,6 @@ import ChartUpdateModal from '../TileForms/ChartUpdateModal';
 import MoveTileToTabModal from '../TileForms/MoveTileToTabModal';
 import TileUpdateModal from '../TileForms/TileUpdateModal';
 import styles from './TileBase.module.css';
-import {
-    ChartContainer,
-    HeaderContainer,
-    TileTitleLink,
-    TitleWrapper,
-} from './TileBase.styles';
 import { type TileBaseProps } from './types';
 
 const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
@@ -251,13 +246,16 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                     zIndex={getDefaultZIndex('modal') - 10}
                 />
 
-                <HeaderContainer
-                    $isEditMode={isEditMode}
-                    $isEmpty={isMarkdownTileTitleEmpty || hideTitle}
+                <Group
+                    className={styles.headerContainer}
+                    justify="flex-start"
+                    align="center"
+                    gap="8px"
+                    mb="12px"
+                    data-is-edit-mode={isEditMode}
+                    data-is-empty={isMarkdownTileTitleEmpty || hideTitle}
                     style={{
-                        alignItems: 'flex-start',
                         zIndex: isLoading ? getDefaultZIndex('modal') - 10 : 3,
-                        borderRadius: '5px',
                     }}
                 >
                     {minimal ? (
@@ -285,65 +283,64 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                             <Box />
                         )
                     ) : (
-                        <Group
-                            gap="xs"
-                            wrap="nowrap"
-                            align="start"
-                            style={{ overflow: 'hidden' }}
-                        >
-                            <TitleWrapper $hovered={titleHovered}>
-                                <Tooltip
-                                    disabled={!description}
-                                    label={
-                                        <Text
-                                            style={{ whiteSpace: 'pre-line' }}
-                                            fz="sm"
-                                        >
-                                            {description}
-                                        </Text>
-                                    }
-                                    multiline
-                                    position="top-start"
-                                    withinPortal
-                                    maw={400}
+                        <Tooltip
+                            disabled={!description}
+                            label={
+                                <Text
+                                    style={{ whiteSpace: 'pre-line' }}
+                                    fz="sm"
                                 >
-                                    {isEditMode ||
-                                    tile.type ===
-                                        DashboardTileTypes.MARKDOWN ? (
-                                        <Text
-                                            fw={600}
-                                            fz="md"
-                                            hidden={hideTitle}
-                                            c="foreground"
-                                        >
-                                            {title}
-                                        </Text>
-                                    ) : (
-                                        <Text
-                                            component={TileTitleLink}
-                                            href={titleHref}
-                                            onMouseEnter={() =>
-                                                setTitleHovered(true)
-                                            }
-                                            onMouseLeave={() =>
-                                                setTitleHovered(false)
-                                            }
-                                            $hovered={titleHovered}
-                                            target="_blank"
-                                            className="non-draggable"
-                                            hidden={hideTitle}
-                                        >
-                                            {title}
-                                        </Text>
-                                    )}
-                                </Tooltip>
-                            </TitleWrapper>
-                        </Group>
+                                    {description}
+                                </Text>
+                            }
+                            multiline
+                            position="top-start"
+                            withinPortal
+                            maw={400}
+                        >
+                            {isEditMode ||
+                            tile.type === DashboardTileTypes.MARKDOWN ? (
+                                <Text
+                                    className={styles.tileTitle}
+                                    data-hidden={hideTitle}
+                                    fw={600}
+                                    fz="md"
+                                    c="foreground"
+                                >
+                                    {title}
+                                </Text>
+                            ) : (
+                                <Text
+                                    component="a"
+                                    className={styles.tileTitle}
+                                    data-hidden={hideTitle}
+                                    data-hovered={titleHovered}
+                                    href={titleHref}
+                                    onMouseEnter={() => setTitleHovered(true)}
+                                    onMouseLeave={() => setTitleHovered(false)}
+                                    target="_blank"
+                                >
+                                    {title}
+                                </Text>
+                            )}
+                        </Tooltip>
                     )}
-                </HeaderContainer>
+                </Group>
 
-                <ChartContainer
-                    className="non-draggable sentry-block ph-no-capture"
+                <Flex
+                    className={clsx(
+                        'non-draggable',
+                        'sentry-block',
+                        'ph-no-capture',
+                        styles.chartContainer,
+                    )}
+                    data-full-width={fullWidth}
+                    flex="1"
+                    align={
+                        tile.type === DashboardTileTypes.HEADING
+                            ? 'center'
+                            : undefined
+                    }
                     onMouseEnter={
                         hideTitle
                             ? chartHoveredProps.handleMouseEnter
@@ -354,15 +351,9 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                             ? chartHoveredProps.handleMouseLeave
                             : undefined
                     }
-                    $alignItems={
-                        tile.type === DashboardTileTypes.HEADING
-                            ? 'center'
-                            : undefined
-                    }
-                    $fullWidth={fullWidth}
                 >
                     {children}
-                </ChartContainer>
+                </Flex>
 
                 {isEditingTileContent &&
                     (tile.type === DashboardTileTypes.SAVED_CHART ||


### PR DESCRIPTION
### Description:
Refactored the TileBase component by replacing styled components with CSS modules. Moved styles from TileBase.styles.tsx to TileBase.module.css for HeaderContainer, ChartContainer, and TileTitleLink components. Updated the component structure to use Mantine's Flex and Group components with appropriate class names and data attributes for styling.

The changes improve consistency in the styling approach and maintain the same visual appearance and functionality while simplifying the component structure.