### PR TITLE
fix: improve tooltip data lookup for stacked charts

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2633,6 +2633,7 @@ const useEchartsCartesianConfig = (
                 tooltipHtmlTemplate: tooltipConfig,
                 pivotValuesColumnsMap,
                 parameters,
+                rows: dataToRender,
             }),
         };
     }, [
@@ -2645,6 +2646,7 @@ const useEchartsCartesianConfig = (
         originalValues,
         parameters,
         series,
+        dataToRender,
     ]);
 
     const currentGrid = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18944 / PROD-2088

### Description:
Improved tooltip data display for stacked charts by adding a fallback mechanism to find field values that aren't directly available in the tooltip data. When a field isn't included in the current series' tuple data, the code now searches through the original data rows to find matching values based on the x-axis value.

This enhancement ensures that tooltips in stacked charts can display all relevant field values, even those not directly part of the current series, providing users with more complete information when hovering over chart elements.

[Chart to test with](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/orders?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_status%22%5D%2C%22metrics%22%3A%5B%22orders_total_shipping_revenue%22%2C%22orders_total_order_amount%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_total_shipping_revenue%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%7B%22name%22%3A%22cost%22%2C%22displayName%22%3A%22cost%22%2C%22format%22%3A%7B%22type%22%3A%22default%22%2C%22separator%22%3A%22default%22%7D%2C%22type%22%3A%22number%22%2C%22sql%22%3A%22%24%7Borders.total_order_amount%7D+%2B+%24%7Borders.total_shipping_revenue%7D%22%7D%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_status%22%2C%22orders_total_shipping_revenue%22%2C%22orders_total_order_amount%22%2C%22cost%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_status%22%2C%22yField%22%3A%5B%22orders_total_order_amount%22%2C%22orders_total_shipping_revenue%22%2C%22cost%22%5D%2C%22flipAxes%22%3Afalse%2C%22stack%22%3A%22stack%22%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_status%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_total_order_amount%22%7D%7D%2C%22isFilteredOut%22%3Afalse%2C%22stack%22%3A%22stack-all-series%22%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_status%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22orders_total_shipping_revenue%22%7D%7D%2C%22isFilteredOut%22%3Afalse%2C%22stack%22%3A%22stack-all-series%22%7D%2C%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22orders_status%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22cost%22%7D%7D%2C%22stack%22%3A%22stack-all-series%22%2C%22isFilteredOut%22%3Afalse%7D%5D%2C%22xAxis%22%3A%5B%7B%22rotate%22%3A45%7D%5D%2C%22tooltip%22%3A%22%3Cul%3E%5Cn++%3Cli%3E+Total+order+amount+overnight%3A+%24%7Borders_total_order_amount%7D%5Cn++%3Cli%3E+Total+shipping+rev%3A+%24%7Borders_total_shipping_revenue%7D%5Cn++%3Cli%3E+Sum%3A+%24%7Bcost%7D%5Cn%3Cul%3E%22%7D%7D%7D%7D&isExploreFromHere=true)

<details>
<summary>Before/After</summary>

### Before
<img width="810" height="359" alt="Screenshot 2025-12-25 at 18 01 41" src="https://github.com/user-attachments/assets/f69312e2-f0e9-4fd8-a2a0-749fa745d34d" />

### After
<img width="811" height="362" alt="Screenshot 2025-12-25 at 18 01 20" src="https://github.com/user-attachments/assets/0afaac4b-9619-4914-8f08-77a957a74e52" />

</details>