### PR TITLE
fix: replace fragment elements with span tags for proper rendering

### DIFF
--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -91,7 +91,7 @@ const ApiErrorDisplay = ({
             </Group>
         </Stack>
     ) : (
-        <>{apiError.message}</>
+        <span>{apiError.message}</span>
     );
 };
 

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -320,20 +320,20 @@ const MinimalDashboard: FC = () => {
     }, [dashboard?.tiles, schedulerTabsSelected, activeTab, sortedTabs]);
 
     if (isDashboardError || isSchedulerError) {
-        if (dashboardError) return <>{dashboardError.error.message}</>;
-        if (schedulerError) return <>{schedulerError.error.message}</>;
+        if (dashboardError) return <span>{dashboardError.error.message}</span>;
+        if (schedulerError) return <span>{schedulerError.error.message}</span>;
     }
 
     if (!dashboard) {
-        return <>Loading...</>;
+        return <span>Loading...</span>;
     }
 
     if (schedulerUuid && !scheduler) {
-        return <>Loading...</>;
+        return <span>Loading...</span>;
     }
 
     if (dashboard.tiles.length === 0) {
-        return <>No tiles</>;
+        return <span>No tiles</span>;
     }
 
     const isTabEmpty =

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -157,7 +157,7 @@ const MinimalSavedExplorer: FC<Props> = ({
     }
 
     if (isError) {
-        return <>{error.error.message}</>;
+        return <span>{error.error.message}</span>;
     }
 
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2147 / LIGHTDASH-FRONTEND-43G / LIGHTDASH-FRONTEND-433

### Description:
Replaced empty React fragments with `<span>` elements for text content in error and loading states. This change improves accessibility and ensures proper rendering of text messages in the ApiErrorDisplay component and various loading/error states in MinimalDashboard and MinimalSavedExplorer pages.

**Particularly**, when users are translating the page using Google Translate - it breaks the UI if the text is not wrapped into any element.

<details>
<summary>Demo</summary>

### Before
https://github.com/user-attachments/assets/8f992ed1-673a-477c-83ba-776b0f981a2e

### After
https://github.com/user-attachments/assets/deb509b6-a3be-49f0-8e0f-3b7363c3a466
</details>