### PR TITLE
feat: use inter as primary font

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -115,6 +115,7 @@ const MarkdownTile: FC<Props> = (props) => {
                     '.wmde-markdown': {
                         fontSize: '14px',
                         backgroundColor: 'transparent',
+                        fontFamily: theme.fontFamily,
                     },
                 }}
             >

--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
@@ -58,7 +58,6 @@ export const ChartDataTable = ({
             {...flexProps}
             sx={{
                 overflow: 'auto',
-                fontFamily: "'Inter', sans-serif",
                 fontFeatureSettings: "'tnum'",
                 flexGrow: 1,
                 ...flexProps?.sx,

--- a/packages/frontend/src/components/DataViz/visualizations/Table.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/Table.tsx
@@ -61,7 +61,6 @@ export const Table = <T extends IResultsRunner>({
             {...flexProps}
             sx={{
                 overflow: 'auto',
-                fontFamily: "'Inter', sans-serif",
                 fontFeatureSettings: "'tnum'",
                 flexGrow: 1,
                 ...flexProps?.sx,

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -280,13 +280,6 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                 setRef(elem);
             }}
             {...wrapperProps}
-            styles={{
-                root: {
-                    // TODO: remove this once Inter is the default font
-                    fontFamily:
-                        'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-                },
-            }}
         >
             <Flex style={{ flexShrink: 1 }} justify="center" align="center">
                 {shouldHideContextMenu ? (

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -869,8 +869,6 @@ const PivotTable: FC<PivotTableProps> = ({
                                                             paddingRight:
                                                                 theme.spacing
                                                                     .xxs,
-                                                            fontFamily:
-                                                                "'Inter', sans-serif",
                                                             fontFeatureSettings:
                                                                 "'tnum'",
                                                         },

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnDescription.tsx
@@ -35,7 +35,6 @@ export const MetricsCatalogColumnDescription: FC<Props> = ({ row, table }) => {
         style: {
             fontSize: theme.fontSizes.sm,
             color: theme.colors.ldGray[6],
-            fontFamily: 'Inter',
             backgroundColor: 'inherit',
         },
         components: {

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -164,6 +164,7 @@ export const getMantineThemeOverride = (
         },
 
         fontFamily: [
+            'Inter',
             '-apple-system',
             'BlinkMacSystemFont',
             'Segoe UI',
@@ -357,6 +358,9 @@ export const getMantineThemeOverride = (
             '.ace_editor *': {
                 fontFamily:
                     "Menlo, 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace",
+            },
+            '.wmde-markdown, .wmde-markdown-var': {
+                fontFamily: theme.fontFamily,
             },
             '@keyframes fadeIn': {
                 from: { opacity: 0 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18007

### Description:
Removes redundant font-family declarations from various components by setting 'Inter' as the first font in the global Mantine theme. 