### PR TITLE
feat: optimize suboptimalState for smaller container sizes

### DIFF
--- a/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.module.css
+++ b/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.module.css
@@ -1,0 +1,26 @@
+.container {
+    container-type: size;
+    container-name: suboptimal-state;
+}
+
+.supportIcon {
+    flex-shrink: 0;
+    @container suboptimal-state (max-height: 200px) {
+        display: none;
+    }
+}
+
+.title {
+    @container suboptimal-state (max-height: 200px) {
+        --text-fz: var(--mantine-font-size-sm) !important;
+        /*a bit smaller lh to fit content*/
+        --text-lh: var(--mantine-line-height-xs) !important;
+    }
+}
+
+.description {
+    @container suboptimal-state (max-height: 200px) {
+        /*a bit smaller lh to fit content*/
+        line-height: 1.2 !important;
+    }
+}

--- a/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
+++ b/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
@@ -1,6 +1,7 @@
 import { Box, Loader, Stack, Text, type StackProps } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import MantineIcon, { type MantineIconProps } from '../MantineIcon';
+import classes from './SuboptimalState.module.css';
 
 interface Props extends StackProps {
     icon?: MantineIconProps['icon'];
@@ -26,14 +27,26 @@ const SuboptimalState: FC<Props> = ({
             align="center"
             justify="center"
             ta="center"
+            className={classes.container}
             style={{
                 alignItems: 'center',
                 ...rest?.style,
             }}
         >
-            {loading && <Loader color="ldGray.5" />}
+            {loading && (
+                <Loader
+                    color="ldGray.5"
+                    size={title || description ? 'xs' : 'md'}
+                    className={classes.supportIcon}
+                />
+            )}
             {icon && !loading && (
-                <MantineIcon color="ldGray.5" size="lg" icon={icon} />
+                <MantineIcon
+                    color="ldGray.5"
+                    size="lg"
+                    icon={icon}
+                    className={classes.supportIcon}
+                />
             )}
             {title && (
                 <Text
@@ -41,6 +54,7 @@ const SuboptimalState: FC<Props> = ({
                     size="md"
                     fw={600}
                     style={{ whiteSpace: 'pre-wrap' }}
+                    className={classes.title}
                 >
                     {title}
                 </Text>
@@ -48,7 +62,9 @@ const SuboptimalState: FC<Props> = ({
             {description && (
                 <Box c="dimmed" fz="xs" maw={400} mt={title ? -10 : 0}>
                     {typeof description === 'string' ? (
-                        <Text size="xs">{description}</Text>
+                        <Text size="xs" className={classes.description}>
+                            {description}
+                        </Text>
                     ) : (
                         description
                     )}


### PR DESCRIPTION

### Description:
Added responsive styling to the SuboptimalState component using CSS container queries. When the container height is limited (max-height: 200px), the component now:
- Hides the support icon
- Reduces the title font size and line height
- Decreases the description line height

These changes ensure the component remains usable in space-constrained environments while maintaining readability.

_After_
![CleanShot 2025-12-26 at 12.44.51.png](https://app.graphite.com/user-attachments/assets/8936d4ad-36b5-49a0-bfb4-b67f409572d0.png)

_Before_
![CleanShot 2025-12-26 at 12.46.17.png](https://app.graphite.com/user-attachments/assets/1ed87e22-3aeb-49fc-8ba7-0064bad36a15.png)

_Shrinking icon_

![CleanShot 2025-12-26 at 12.48.06.png](https://app.graphite.com/user-attachments/assets/5a21b4a6-5c08-4a2f-a0b4-4f60ab45c162.png)

