### PR TITLE
feat: add customizable font sizes for chart axis labels and titles

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -359,6 +359,8 @@ export type CompleteEChartsConfig = {
     yAxis: Axis[];
     tooltip?: string;
     showAxisTicks?: boolean;
+    axisLabelFontSize?: number;
+    axisTitleFontSize?: number;
 };
 
 export type EChartsConfig = Partial<CompleteEChartsConfig>;

--- a/packages/common/src/visualizations/helpers/styles/axisStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/axisStyles.ts
@@ -1,21 +1,24 @@
 import { AXIS_TITLE_COLOR, GRAY_4, GRAY_5, GRAY_7, WHITE } from './themeColors';
 
+export const DEFAULT_AXIS_LABEL_FONT_SIZE = 11.5;
+export const DEFAULT_AXIS_TITLE_FONT_SIZE = 12;
+
 /**
  * Get axis label styling (for values like "Jan", "Feb", "Mar")
  */
-export const getAxisLabelStyle = () => ({
+export const getAxisLabelStyle = (fontSize?: number) => ({
     color: GRAY_7,
     fontWeight: '500',
-    fontSize: 11.5,
+    fontSize: fontSize ?? DEFAULT_AXIS_LABEL_FONT_SIZE,
 });
 
 /**
  * Get axis title styling (for titles like "Month", "Amount")
  */
-export const getAxisTitleStyle = () => ({
+export const getAxisTitleStyle = (fontSize?: number) => ({
     color: AXIS_TITLE_COLOR,
     fontWeight: '500',
-    fontSize: 12,
+    fontSize: fontSize ?? DEFAULT_AXIS_TITLE_FONT_SIZE,
 });
 
 /**

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -9,6 +9,7 @@ import {
     type ItemsMap,
 } from '@lightdash/common';
 import {
+    Button,
     Checkbox,
     Group,
     NumberInput,
@@ -74,6 +75,8 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setShowXAxis,
         setShowYAxis,
         setShowAxisTicks,
+        setAxisLabelFontSize,
+        setAxisTitleFontSize,
         setXAxisSort,
         setXAxisLabelRotation,
         setScrollableChart,
@@ -408,6 +411,72 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             setShowAxisTicks(e.currentTarget.checked);
                         }}
                     />
+                </Config.Section>
+            </Config>
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Tick label size (px)</Config.Heading>
+                    <Group spacing="xs">
+                        <NumberInput
+                            value={
+                                dirtyEchartsConfig?.axisLabelFontSize ?? 11.5
+                            }
+                            min={8}
+                            max={24}
+                            step={0.5}
+                            precision={1}
+                            maw={60}
+                            onChange={(value) => {
+                                setAxisLabelFontSize(
+                                    typeof value === 'number'
+                                        ? value
+                                        : undefined,
+                                );
+                            }}
+                        />
+                        {dirtyEchartsConfig?.axisLabelFontSize !==
+                            undefined && (
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                onClick={() => setAxisLabelFontSize(undefined)}
+                            >
+                                Reset
+                            </Button>
+                        )}
+                    </Group>
+                </Config.Section>
+            </Config>
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Axis title size (px)</Config.Heading>
+                    <Group spacing="xs">
+                        <NumberInput
+                            value={dirtyEchartsConfig?.axisTitleFontSize ?? 12}
+                            min={8}
+                            max={24}
+                            step={0.5}
+                            precision={1}
+                            maw={60}
+                            onChange={(value) => {
+                                setAxisTitleFontSize(
+                                    typeof value === 'number'
+                                        ? value
+                                        : undefined,
+                                );
+                            }}
+                        />
+                        {dirtyEchartsConfig?.axisTitleFontSize !==
+                            undefined && (
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                onClick={() => setAxisTitleFontSize(undefined)}
+                            >
+                                Reset
+                            </Button>
+                        )}
+                    </Group>
                 </Config.Section>
             </Config>
         </Stack>

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -398,6 +398,20 @@ const useCartesianChartConfig = ({
         }));
     }, []);
 
+    const setAxisLabelFontSize = useCallback((fontSize: number | undefined) => {
+        setDirtyEchartsConfig((prev) => ({
+            ...prev,
+            axisLabelFontSize: fontSize,
+        }));
+    }, []);
+
+    const setAxisTitleFontSize = useCallback((fontSize: number | undefined) => {
+        setDirtyEchartsConfig((prev) => ({
+            ...prev,
+            axisTitleFontSize: fontSize,
+        }));
+    }, []);
+
     const setXAxisSort = useCallback((sort: XAxisSort) => {
         setDirtyEchartsConfig((prevState) => {
             const [firstAxis, ...axes] = prevState?.xAxis || [];
@@ -1084,6 +1098,8 @@ const useCartesianChartConfig = ({
         setShowXAxis,
         setShowYAxis,
         setShowAxisTicks,
+        setAxisLabelFontSize,
+        setAxisTitleFontSize,
         setXAxisSort,
         setXAxisLabelRotation,
         setScrollableChart,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1432,6 +1432,11 @@ const getEchartAxes = ({
         leftAxisType,
     );
 
+    const axisLabelFontSize =
+        validCartesianConfig?.eChartsConfig?.axisLabelFontSize;
+    const axisTitleFontSize =
+        validCartesianConfig?.eChartsConfig?.axisTitleFontSize;
+
     const bottomAxisFormatterConfig = getAxisFormatterConfig({
         axisItem: bottomAxisXField,
         longestLabelWidth: calculateWidthText(longestValueXAxisBottom),
@@ -1446,7 +1451,7 @@ const getEchartAxes = ({
         showXAxis && bottomAxisFormatterConfig.axisLabel
             ? {
                   axisLabel: {
-                      ...getAxisLabelStyle(),
+                      ...getAxisLabelStyle(axisLabelFontSize),
                       ...bottomAxisFormatterConfig.axisLabel,
                   },
               }
@@ -1466,7 +1471,7 @@ const getEchartAxes = ({
         showXAxis && topAxisFormatterConfig.axisLabel
             ? {
                   axisLabel: {
-                      ...getAxisLabelStyle(),
+                      ...getAxisLabelStyle(axisLabelFontSize),
                       ...topAxisFormatterConfig.axisLabel,
                   },
               }
@@ -1485,7 +1490,7 @@ const getEchartAxes = ({
         showYAxis && leftAxisFormatterConfig.axisLabel
             ? {
                   axisLabel: {
-                      ...getAxisLabelStyle(),
+                      ...getAxisLabelStyle(axisLabelFontSize),
                       ...leftAxisFormatterConfig.axisLabel,
                   },
               }
@@ -1504,7 +1509,7 @@ const getEchartAxes = ({
         showYAxis && rightAxisFormatterConfig.axisLabel
             ? {
                   axisLabel: {
-                      ...getAxisLabelStyle(),
+                      ...getAxisLabelStyle(axisLabelFontSize),
                       ...rightAxisFormatterConfig.axisLabel,
                   },
               }
@@ -1668,7 +1673,7 @@ const getEchartAxes = ({
                                       getItemLabelWithoutTableName(xAxisItem)
                                     : undefined),
                           nameLocation: 'center',
-                          nameTextStyle: getAxisTitleStyle(),
+                          nameTextStyle: getAxisTitleStyle(axisTitleFontSize),
                       }
                     : {}),
                 ...bottomAxisConfigWithStyle,
@@ -1728,7 +1733,7 @@ const getEchartAxes = ({
                                 })
                               : undefined,
                           nameLocation: 'center',
-                          nameTextStyle: getAxisTitleStyle(),
+                          nameTextStyle: getAxisTitleStyle(axisTitleFontSize),
                       }
                     : {}),
                 min:
@@ -1780,7 +1785,7 @@ const getEchartAxes = ({
                                 }),
                           nameLocation: 'center',
                           nameTextStyle: {
-                              ...getAxisTitleStyle(),
+                              ...getAxisTitleStyle(axisTitleFontSize),
                               align: 'center',
                           },
                       }
@@ -1844,7 +1849,7 @@ const getEchartAxes = ({
                           nameLocation: 'center',
                           nameRotate: -90,
                           nameTextStyle: {
-                              ...getAxisTitleStyle(),
+                              ...getAxisTitleStyle(axisTitleFontSize),
                               align: 'center',
                           },
                       }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-750](https://linear.app/lightdash/issue/PROD-750/i-want-to-be-able-to-change-the-font-size-of-my-axis-tick-labels)

### Description:

Added customizable font sizes for axis labels and titles in charts. Users can now adjust the font size of tick labels and axis titles through the chart configuration panel, with options to reset to default values. This enhances chart readability and customization options for different visualization needs.

The implementation includes:

- New configuration options in the EChartsConfig type
- Default font size constants for consistent styling
- UI controls in the Axes configuration panel with reset buttons
- Integration with the existing axis styling system
