### PR TITLE
feat: improve dashboard table tile empty state

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,7 +1,7 @@
 import { FeatureFlags } from '@lightdash/common';
 import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
-import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
+import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
 import { type FC, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
     isChunkLoadError,
@@ -170,6 +170,16 @@ const SimpleTable: FC<SimpleTableProps> = ({
         [isDashboard, itemsMap, minimal, tileUuid],
     );
 
+    const DashboardEmptyState = useCallback(() => {
+        return (
+            <SuboptimalState
+                icon={IconTable}
+                title="No results"
+                description="This query ran successfully but returned no results"
+            />
+        );
+    }, []);
+
     useEffect(() => {
         if (shouldPaginateResults) return;
 
@@ -288,6 +298,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 totalRowsCount={resultsData?.totalResults || 0}
                 isFetchingRows={!!resultsData?.isFetchingRows}
                 loadingState={LoadingChart}
+                emptyState={isDashboard ? DashboardEmptyState : undefined}
                 fetchMoreRows={resultsData?.fetchMoreRows || noop}
                 columns={columns}
                 columnOrder={columnOrder}

--- a/packages/frontend/src/components/common/Table/Table.styles.tsx
+++ b/packages/frontend/src/components/common/Table/Table.styles.tsx
@@ -25,6 +25,10 @@ export const TableScrollableWrapper = styled.div<{
             border-left: none;
             border-right: none;
         `}
+
+    &:not(:has(thead tr)):not(:has(tbody tr)) {
+        border: none;
+    }
 `;
 
 interface TableContainerProps {


### PR DESCRIPTION
Closes: PROD-2204

### Description:

Added a custom empty state for tables in dashboards to match other charts. Also fixed table styling to remove borders when there are no rows or headers.

_After_

![CleanShot 2025-12-26 at 15.08.33.png](https://app.graphite.com/user-attachments/assets/f0a5743f-0c9a-4bc3-9207-0fedb7e547c1.png)

_Before_

![CleanShot 2025-12-26 at 15.08.45.png](https://app.graphite.com/user-attachments/assets/316f4952-6dac-4ed9-9874-e84b025aa50a.png)