### PR TITLE
fix: tiles with error styles should respect edit mode

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -21,7 +21,7 @@
     }
 
     &[data-has-error='true'] {
-        border: 1px dashed var(--mantine-color-ldGray-3) !important;
+        border-style: dashed !important;
         background: transparent !important;
     }
 }


### PR DESCRIPTION
### Description:
Simplified the error state styling for dashboard tiles by changing from a specific border declaration to just setting the border style to dashed. This maintains the visual indication of an error state while allowing the border color to be inherited from other styles.

_After_
![CleanShot 2025-12-26 at 15.14.56.png](https://app.graphite.com/user-attachments/assets/ee417efc-fa4e-4cf2-8586-b9146c0d8295.png)

_Before_
![CleanShot 2025-12-26 at 15.16.44.png](https://app.graphite.com/user-attachments/assets/a8fc39b6-6c32-4f8f-80aa-18aba74d76d7.png)

> [!NOTE]
> New border color is going to be defined by #19099