### PR TITLE
fix: show empty state instead of blank custom viz

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -1,5 +1,5 @@
 import { Anchor, Text } from '@mantine/core';
-import { IconChartBarOff } from '@tabler/icons-react';
+import { IconGraphOff } from '@tabler/icons-react';
 import { Suspense, lazy, useEffect, useRef, type FC } from 'react';
 import { type CustomVisualizationConfigAndData } from '../../hooks/useCustomVisualizationConfig';
 import { isCustomVisualizationConfig } from '../LightdashVisualization/types';
@@ -76,7 +76,7 @@ const CustomVisualization: FC<Props> = ({
                             create your chart.
                         </Text>
                     }
-                    icon={IconChartBarOff}
+                    icon={IconGraphOff}
                 />
             </div>
         );
@@ -86,6 +86,19 @@ const CustomVisualization: FC<Props> = ({
     // configuration for the chart. We should consider renaming it generally.
     const visProps =
         visualizationConfig.chartConfig as CustomVisualizationConfigAndData;
+
+    // Show empty state if there's no data
+    if (!visProps.series || visProps.series.length === 0) {
+        return (
+            <div style={{ height: '100%', width: '100%', padding: '50px 0' }}>
+                <SuboptimalState
+                    title="No data available"
+                    description="Query metrics and dimensions with results."
+                    icon={IconGraphOff}
+                />
+            </div>
+        );
+    }
 
     const data = { values: visProps.series };
 


### PR DESCRIPTION
### Description:
Using SuboptimalState when no data is returned for custom visualizations instead of empty chart
Also updated chart icon to emphasize difference with bar charts

_After_

![CleanShot 2025-12-26 at 15.59.25.png](https://app.graphite.com/user-attachments/assets/bac20407-95e6-4c82-a624-35c47729b6a2.png)

![CleanShot 2025-12-26 at 16.01.38.png](https://app.graphite.com/user-attachments/assets/57c4be8c-ee82-4b36-8adb-e9b76a2b43a3.png)


_Before_

![CleanShot 2025-12-26 at 15.59.34.png](https://app.graphite.com/user-attachments/assets/e63962d1-5619-4341-832d-41f9ff194ece.png)

![CleanShot 2025-12-26 at 16.01.25.png](https://app.graphite.com/user-attachments/assets/69679463-2acf-440f-a2f4-72ab2144e7b7.png)

