### PR TITLE
fix: show empty state instead of blank pie chart

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -280,6 +280,7 @@ const useEchartsPieConfig = (
 
     if (!itemsMap) return;
     if (!eChartsOption || !pieSeriesOption) return;
+    if (!seriesData || seriesData.length === 0) return;
 
     return { eChartsOption, pieSeriesOption };
 };


### PR DESCRIPTION
### Description:
Added a guard clause in `useEchartsPieConfig` to prevent rendering when series data is empty. This prevents potential errors when trying to render a pie chart with no data.

_After_

![CleanShot 2025-12-26 at 16.02.26.png](https://app.graphite.com/user-attachments/assets/e2971e3a-47e7-4502-a4e8-2dffe032f871.png)


_Before_

![CleanShot 2025-12-26 at 16.03.07.png](https://app.graphite.com/user-attachments/assets/b8bfa23f-6d10-4917-a831-f4d5d305bf84.png)

