### PR TITLE
fix: show empty state instead of blank treemap

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
@@ -208,6 +208,8 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
     ]);
     if (!itemsMap) return;
     if (!eChartsOption || !treemapSeriesOption) return;
+    if (!treemapSeriesOption.data || treemapSeriesOption.data.length === 0)
+        return;
 
     return { eChartsOption, treemapSeriesOption };
 };


### PR DESCRIPTION

### Description:
Added a null check for treemapSeriesOption.data in useEchartsTreemapConfig hook to prevent potential errors when the data array is empty or undefined.

_After_

![CleanShot 2025-12-26 at 16.03.56.png](https://app.graphite.com/user-attachments/assets/2f2bb118-3d8c-4fc4-b12e-36eebc96517f.png)


_Before_

![CleanShot 2025-12-26 at 16.03.43.png](https://app.graphite.com/user-attachments/assets/3ba3b750-287b-4dcb-b525-e80705b72d3e.png)

