### PR TITLE
fix: explicitly pass pivotConfiguration in getDownloadQueryUuid

### DIFF
--- a/packages/frontend/src/hooks/useExplorerQuery.ts
+++ b/packages/frontend/src/hooks/useExplorerQuery.ts
@@ -71,15 +71,18 @@ export const useExplorerQuery = () => {
                     : queryResults.queryUuid;
 
             if (limit === null || limit !== queryResults.totalResults) {
+                const shouldPivot =
+                    exportPivotedResults && !!useSqlPivotResults?.enabled;
                 const queryArgsWithLimit: QueryResultsProps | null =
                     validQueryArgs
                         ? {
                               ...validQueryArgs,
                               csvLimit: limit,
                               invalidateCache: minimal,
-                              pivotResults:
-                                  exportPivotedResults &&
-                                  useSqlPivotResults?.enabled,
+                              pivotResults: shouldPivot,
+                              pivotConfiguration: shouldPivot
+                                  ? validQueryArgs.pivotConfiguration
+                                  : undefined,
                           }
                         : null;
                 const downloadQuery = await executeQueryAndWaitForResults(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19117

### Description:
When downloading CSV from results table, `getDownloadQueryUuid` creates a new query with different limits. It was spreading `validQueryArgs` which includes `pivotConfiguration`, even when `exportPivotedResults = false`. The backend was seeing the pivot config and returning pivoted row structure, causing the same column mismatch.

Before: [ordersss_2025-12-26 (6).csv](https://github.com/user-attachments/files/24349240/ordersss_2025-12-26.6.csv)

After: [ordersss_2025-12-26 (7).csv](https://github.com/user-attachments/files/24349244/ordersss_2025-12-26.7.csv)
