### PR TITLE
chore: update ai-instructions for modal usage

### DIFF
--- a/.cursor/rules/frontend.mdc
+++ b/.cursor/rules/frontend.mdc
@@ -57,6 +57,12 @@ The user asks questions about the following coding languages:
 - Prefer mantine Box component, instead of semantic <div>s
 - If you are adding an icon, then use MantineIcon and pass the react-tabler icon as the "icon" prop
 
+### Modals
+- **Always use `MantineModal`** from `components/common/MantineModal` - never use Mantine's Modal directly
+- See `stories/Modal.stories.tsx` for usage examples
+- For forms: use `id` on the form and `form="form-id"` on submit button
+- For alerts inside modals: use `Callout` with variants `danger`, `warning`, `info`
+
 ### Hooks
 - Create custom hooks for reusable logic
 - Follow the pattern in [useOrganization.ts](mdc:packages/frontend/src/hooks/organization/useOrganization.ts) if you're calling the API

--- a/packages/frontend/CLAUDE.md
+++ b/packages/frontend/CLAUDE.md
@@ -12,3 +12,8 @@ the [Frontend Style Guide](STYLE_GUIDE.md). Key points:
 -   **Colors**: Prefer default component colors (auto-theme switching). For custom colors, use `ldGray.X` and `ldDark.X`, not standard `gray.X`
 -   **Prop changes** - `spacing` → `gap`, `noWrap` → `wrap="nowrap"`, `sx` → `style` (v6)
 -   **Component docs** - Props/APIs at `https://mantine.dev/core/[component-name]/` (e.g. select, segmented-control)
+
+## 🧩 Reusable Components
+
+-   **Modals**: Always use `MantineModal` from `components/common/MantineModal`. See `stories/Modal.stories.tsx` for examples.
+-   **Callouts**: Use `Callout` from `components/common/Callout` with variants: `danger`, `warning`, `info`


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Added documentation for modal usage in the frontend codebase:

- Added a new "Modals" section to the frontend rules document with best practices:
  - Always use `MantineModal` from `components/common/MantineModal`
  - Reference to usage examples in `stories/Modal.stories.tsx`
  - Guidelines for forms and alerts inside modals

- Updated the CLAUDE.md file with information about reusable components:
  - Added a new "Reusable Components" section
  - Documented the use of `MantineModal` and `AlertMessage` components