### PR TITLE
feat: add max height and scroll to filter inputs

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
@@ -118,6 +118,10 @@ const FilterMultiStringInput: FC<Props> = ({
                     </Group>
                 )}
                 styles={{
+                    input: {
+                        maxHeight: '350px',
+                        overflowY: 'auto',
+                    },
                     item: {
                         // makes add new item button sticky to bottom
                         '&:last-child:not([value])': {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -301,6 +301,10 @@ const FilterStringAutoComplete: FC<Props> = ({
                     </Group>
                 )}
                 styles={(theme) => ({
+                    input: {
+                        maxHeight: '350px',
+                        overflowY: 'auto',
+                    },
                     item: {
                         // makes add new item button sticky to bottom
                         '&:last-child:not([value])': {


### PR DESCRIPTION
### Description:
Added a maximum height with scrolling to filter input components to prevent them from growing too large. Both `FilterMultiStringInput` and `FilterStringAutoComplete` components now have a max height of 350px with automatic vertical scrolling when content exceeds this limit.