### PR TITLE
feat(backend): reassign user scheduled delivers on delete

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3744,6 +3744,20 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                axisLabelFontSize: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                axisTitleFontSize: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -7183,7 +7197,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                chartUsage:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7206,7 +7220,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7236,6 +7250,12 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -7243,12 +7263,6 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7452,7 +7466,7 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    chartUsage:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7475,7 +7489,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    searchRank:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7505,6 +7519,12 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -7512,12 +7532,6 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -18787,6 +18801,80 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 role: { ref: 'OrganizationMemberRole', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserSchedulersSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                byProject: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            count: { dataType: 'double', required: true },
+                            projectName: { dataType: 'string', required: true },
+                            projectUuid: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                totalCount: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_UserSchedulersSummary_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'UserSchedulersSummary', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUserSchedulersSummaryResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_UserSchedulersSummary_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess__reassignedCount-number__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        reassignedCount: { dataType: 'double', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiReassignUserSchedulersResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess__reassignedCount-number__', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ReassignUserSchedulersRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                newOwnerUserUuid: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -39573,6 +39661,134 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'deleteUser',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationController_getUserSchedulersSummary: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        userUuid: {
+            in: 'path',
+            name: 'userUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/org/user/:userUuid/schedulers-summary',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.getUserSchedulersSummary,
+        ),
+
+        async function OrganizationController_getUserSchedulersSummary(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationController_getUserSchedulersSummary,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationController>(
+                        OrganizationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getUserSchedulersSummary',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationController_reassignUserSchedulers: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        userUuid: {
+            in: 'path',
+            name: 'userUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ReassignUserSchedulersRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/org/user/:userUuid/reassign-schedulers',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.reassignUserSchedulers,
+        ),
+
+        async function OrganizationController_reassignUserSchedulers(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationController_reassignUserSchedulers,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationController>(
+                        OrganizationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'reassignUserSchedulers',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4115,6 +4115,14 @@
                     },
                     "showAxisTicks": {
                         "type": "boolean"
+                    },
+                    "axisLabelFontSize": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "axisTitleFontSize": {
+                        "type": "number",
+                        "format": "double"
                     }
                 },
                 "type": "object",
@@ -7978,12 +7986,12 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -7991,10 +7999,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8003,8 +8011,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8098,12 +8106,12 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "chartUsage": {
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "searchRank": {
+                                                                                    "chartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -8111,10 +8119,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8123,8 +8131,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -19551,6 +19559,85 @@
                 "required": ["role"],
                 "type": "object"
             },
+            "UserSchedulersSummary": {
+                "properties": {
+                    "byProject": {
+                        "items": {
+                            "properties": {
+                                "count": {
+                                    "type": "number",
+                                    "format": "double"
+                                },
+                                "projectName": {
+                                    "type": "string"
+                                },
+                                "projectUuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["count", "projectName", "projectUuid"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "totalCount": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["byProject", "totalCount"],
+                "type": "object"
+            },
+            "ApiSuccess_UserSchedulersSummary_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/UserSchedulersSummary"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiUserSchedulersSummaryResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_UserSchedulersSummary_"
+            },
+            "ApiSuccess__reassignedCount-number__": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "reassignedCount": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": ["reassignedCount"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiReassignUserSchedulersResponse": {
+                "$ref": "#/components/schemas/ApiSuccess__reassignedCount-number__"
+            },
+            "ReassignUserSchedulersRequest": {
+                "properties": {
+                    "newOwnerUserUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["newOwnerUserUuid"],
+                "type": "object"
+            },
             "OrganizationMemberRole.EDITOR": {
                 "enum": ["editor"],
                 "type": "string"
@@ -23699,7 +23786,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2279.0",
+        "version": "0.2282.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -33399,6 +33486,102 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/org/user/{userUuid}/schedulers-summary": {
+            "get": {
+                "operationId": "GetUserSchedulersSummary",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUserSchedulersSummaryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Gets a summary of scheduled deliveries owned by a user across all projects",
+                "summary": "Get user schedulers",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/org/user/{userUuid}/reassign-schedulers": {
+            "patch": {
+                "operationId": "ReassignUserSchedulers",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiReassignUserSchedulersResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Reassigns all scheduled deliveries from one user to another",
+                "summary": "Reassign schedulers",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the uuid of the user whose schedulers will be reassigned",
+                        "in": "path",
+                        "name": "userUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "the new owner details",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ReassignUserSchedulersRequest",
+                                "description": "the new owner details"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/org/allowedEmailDomains": {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -33,6 +33,7 @@ import {
     SchedulerWithLogs,
     SessionUser,
     UpdateSchedulerAndTargetsWithoutId,
+    UserSchedulersSummary,
     type Account,
 } from '@lightdash/common';
 import cronstrue from 'cronstrue';
@@ -989,5 +990,199 @@ export class SchedulerService extends BaseService {
         });
 
         return runLogs;
+    }
+
+    /**
+     * Get a summary of schedulers owned by a user.
+     * Used to show scheduler count when deleting a user.
+     * Only returns projects where the calling user can view scheduled deliveries.
+     */
+    async getUserSchedulersSummary(
+        user: SessionUser,
+        targetUserUuid: string,
+    ): Promise<UserSchedulersSummary> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+
+        const { organizationUuid } = user;
+
+        // Validate target user exists and is in the same organization
+        try {
+            await this.userModel.findSessionUserAndOrgByUuid(
+                targetUserUuid,
+                organizationUuid,
+            );
+        } catch (error) {
+            if (error instanceof InvalidUser) {
+                throw new NotFoundError(
+                    'User not found or not a member of the organization',
+                );
+            }
+            throw error;
+        }
+
+        const summary = await this.schedulerModel.getSchedulersSummaryByOwner(
+            targetUserUuid,
+        );
+
+        // Check user can view scheduled deliveries in all projects
+        const projectsWithoutPermission = summary.byProject
+            .filter((project) =>
+                user.ability.cannot(
+                    'view',
+                    subject('ScheduledDeliveries', {
+                        organizationUuid,
+                        projectUuid: project.projectUuid,
+                    }),
+                ),
+            )
+            .map((project) => project.projectName);
+
+        if (projectsWithoutPermission.length > 0) {
+            throw new ForbiddenError(
+                `You do not have permission to view scheduled deliveries in: ${projectsWithoutPermission.join(
+                    ', ',
+                )}`,
+            );
+        }
+
+        return summary;
+    }
+
+    /**
+     * Reassign all schedulers from one user to another.
+     * Used when deleting a user to transfer their schedulers.
+     */
+    async reassignUserSchedulers(
+        user: SessionUser,
+        fromUserUuid: string,
+        newOwnerUserUuid: string,
+    ): Promise<{ reassignedCount: number }> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+
+        const { organizationUuid } = user;
+
+        // Validate fromUser exists and is in the same organization
+        try {
+            await this.userModel.findSessionUserAndOrgByUuid(
+                fromUserUuid,
+                organizationUuid,
+            );
+        } catch (error) {
+            if (error instanceof InvalidUser) {
+                throw new NotFoundError(
+                    'User not found or not a member of the organization',
+                );
+            }
+            throw error;
+        }
+
+        // Get scheduler summary to find which projects have schedulers
+        const summary = await this.schedulerModel.getSchedulersSummaryByOwner(
+            fromUserUuid,
+        );
+
+        if (summary.totalCount === 0) {
+            return { reassignedCount: 0 };
+        }
+
+        // Check calling user has manage:ScheduledDeliveries permission on ALL projects
+        const projectsUserCannotManage: string[] = [];
+        for (const project of summary.byProject) {
+            if (
+                user.ability.cannot(
+                    'manage',
+                    subject('ScheduledDeliveries', {
+                        organizationUuid,
+                        projectUuid: project.projectUuid,
+                    }),
+                )
+            ) {
+                projectsUserCannotManage.push(project.projectName);
+            }
+        }
+
+        if (projectsUserCannotManage.length > 0) {
+            throw new ForbiddenError(
+                `You do not have permission to manage scheduled deliveries in: ${projectsUserCannotManage.join(
+                    ', ',
+                )}`,
+            );
+        }
+
+        // Validate new owner exists and is a member of the organization
+        let newOwner: SessionUser | undefined;
+        try {
+            newOwner = await this.userModel.findSessionUserAndOrgByUuid(
+                newOwnerUserUuid,
+                organizationUuid,
+            );
+        } catch (error) {
+            if (error instanceof InvalidUser) {
+                // `findSessionUserAndOrgByUuid` throws invalid user, we convert it here to NotFoundError - related issue: https://github.com/lightdash/lightdash/issues/11603
+                throw new NotFoundError(
+                    'New owner not found or not a member of the organization',
+                );
+            }
+            throw error;
+        }
+
+        if (!newOwner) {
+            throw new NotFoundError(
+                'New owner not found or not a member of the organization',
+            );
+        }
+
+        // Validate new owner has create:ScheduledDeliveries permission in ALL projects
+        const projectsWithoutPermission: string[] = [];
+        for (const project of summary.byProject) {
+            if (
+                newOwner.ability.cannot(
+                    'create',
+                    subject('ScheduledDeliveries', {
+                        organizationUuid,
+                        projectUuid: project.projectUuid,
+                    }),
+                )
+            ) {
+                projectsWithoutPermission.push(project.projectName);
+            }
+        }
+
+        if (projectsWithoutPermission.length > 0) {
+            throw new ForbiddenError(
+                `New owner does not have permission to create scheduled deliveries in: ${projectsWithoutPermission.join(
+                    ', ',
+                )}`,
+            );
+        }
+
+        // Update ownership - only for projects where permissions were validated
+        const validatedProjectUuids = summary.byProject.map(
+            (p) => p.projectUuid,
+        );
+        const reassignedCount = await this.schedulerModel.updateOwnerByUser(
+            fromUserUuid,
+            newOwnerUserUuid,
+            validatedProjectUuids,
+        );
+
+        // Track analytics event
+        this.analytics.track({
+            userId: user.userUuid,
+            event: 'scheduler.user_ownership_reassigned',
+            properties: {
+                organizationId: organizationUuid,
+                fromUserUuid,
+                newOwnerUserUuid,
+                reassignedCount,
+                projectCount: summary.byProject.length,
+            },
+        });
+
+        return { reassignedCount };
     }
 }

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -373,6 +373,26 @@ export type ApiReassignSchedulerOwnerResponse = ApiSuccess<
     SchedulerAndTargets[]
 >;
 
+export type UserSchedulersSummary = {
+    totalCount: number;
+    byProject: Array<{
+        projectUuid: string;
+        projectName: string;
+        count: number;
+    }>;
+};
+
+export type ReassignUserSchedulersRequest = {
+    newOwnerUserUuid: string;
+};
+
+export type ApiUserSchedulersSummaryResponse =
+    ApiSuccess<UserSchedulersSummary>;
+
+export type ApiReassignUserSchedulersResponse = ApiSuccess<{
+    reassignedCount: number;
+}>;
+
 export type TraceTaskBase = {
     organizationUuid: string;
     projectUuid: string;

--- a/packages/e2e/cypress/e2e/api/scheduler.cy.ts
+++ b/packages/e2e/cypress/e2e/api/scheduler.cy.ts
@@ -6,12 +6,15 @@ import {
     SchedulerAndTargets,
     SchedulerFormat,
     SchedulerSlackTarget,
+    SEED_ORG_1_ADMIN,
     SEED_ORG_1_EDITOR,
     SEED_ORG_1_VIEWER,
     SEED_ORG_2_ADMIN,
     SEED_PROJECT,
     UpdateSchedulerAndTargetsWithoutId,
     type ApiReassignSchedulerOwnerResponse,
+    type ApiReassignUserSchedulersResponse,
+    type ApiUserSchedulersSummaryResponse,
     type Dashboard,
     type SavedChart,
 } from '@lightdash/common';
@@ -40,6 +43,73 @@ const getUpdateSchedulerBody = (
     format: SchedulerFormat.IMAGE,
     options: {},
 });
+
+// Helper functions for scheduler creation and cleanup
+const createChartScheduler = (): Cypress.Chainable<string> =>
+    cy
+        .request(`${apiUrl}/projects/${SEED_PROJECT.project_uuid}/charts`)
+        .then((res) => {
+            const chart = res.body.results.find(
+                (s: SavedChart) =>
+                    s.name ===
+                    'How much revenue do we have per payment method?',
+            );
+            return cy.request<{ results: SchedulerAndTargets }>({
+                url: `${apiUrl}/saved/${chart.uuid}/schedulers`,
+                headers: { 'Content-type': 'application/json' },
+                method: 'POST',
+                body: createSchedulerBody,
+            });
+        })
+        .then((res) => res.body.results.schedulerUuid);
+
+const createDashboardScheduler = (): Cypress.Chainable<string> =>
+    cy
+        .request(`${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`)
+        .then((res) => {
+            const dashboard = res.body.results.find(
+                (d: Dashboard) => d.name === 'Jaffle dashboard',
+            );
+            return cy.request<{ results: SchedulerAndTargets }>({
+                url: `${apiUrl}/dashboards/${dashboard.uuid}/schedulers`,
+                headers: { 'Content-type': 'application/json' },
+                method: 'POST',
+                body: createSchedulerBody,
+            });
+        })
+        .then((res) => res.body.results.schedulerUuid);
+
+const createChartInDashboardScheduler = (): Cypress.Chainable<string> =>
+    cy
+        .request(
+            `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/chart-summaries`,
+        )
+        .then((res) => {
+            const chart = res.body.results.find(
+                (s: SavedChart) =>
+                    s.name ===
+                    '[Saved in dashboard] How much revenue do we have per payment method?',
+            );
+            return cy.request<{ results: SchedulerAndTargets }>({
+                url: `${apiUrl}/saved/${chart.uuid}/schedulers`,
+                headers: { 'Content-type': 'application/json' },
+                method: 'POST',
+                body: createSchedulerBody,
+            });
+        })
+        .then((res) => res.body.results.schedulerUuid);
+
+const deleteScheduler = (uuid: string): void => {
+    cy.request({
+        url: `${apiUrl}/schedulers/${uuid}`,
+        method: 'DELETE',
+        failOnStatusCode: false,
+    });
+};
+
+const deleteSchedulers = (uuids: string[]): void => {
+    uuids.filter(Boolean).forEach(deleteScheduler);
+};
 
 describe('Lightdash scheduler endpoints', () => {
     beforeEach(() => {
@@ -249,159 +319,650 @@ describe('Lightdash scheduler endpoints', () => {
         );
     });
 
-    describe('Reassign scheduler owner', () => {
-        let schedulerUuid: string;
+    describe('Scheduler reassignment', () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 
-        beforeEach(() => {
-            cy.login();
-            // Create a scheduler to test with
-            cy.request(`${apiUrl}/projects/${projectUuid}/charts`).then(
-                (projectResponse) => {
-                    const savedChart = projectResponse.body.results.find(
-                        (s: SavedChart) =>
-                            s.name ===
-                            'How much revenue do we have per payment method?',
-                    );
+        describe('Reassign specific schedulers - /reassign-owner', () => {
+            describe('Success cases by scheduler type', () => {
+                let schedulerUuid: string;
 
-                    cy.request<{ results: SchedulerAndTargets }>({
-                        url: `${apiUrl}/saved/${savedChart.uuid}/schedulers`,
-                        headers: { 'Content-type': 'application/json' },
-                        method: 'POST',
-                        body: createSchedulerBody,
-                    }).then((createResponse) => {
-                        schedulerUuid =
-                            createResponse.body.results.schedulerUuid;
-                    });
-                },
-            );
-        });
-
-        afterEach(() => {
-            // Clean up - delete the scheduler
-            cy.login();
-            if (schedulerUuid) {
-                cy.request({
-                    url: `${apiUrl}/schedulers/${schedulerUuid}`,
-                    method: 'DELETE',
-                    failOnStatusCode: false,
+                afterEach(() => {
+                    cy.login();
+                    if (schedulerUuid) {
+                        deleteScheduler(schedulerUuid);
+                    }
                 });
-            }
-        });
 
-        it('Should reassign scheduler ownership as admin', () => {
-            cy.request<ApiReassignSchedulerOwnerResponse>({
-                url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
-                headers: { 'Content-type': 'application/json' },
-                method: 'PATCH',
-                body: {
-                    schedulerUuids: [schedulerUuid],
-                    newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
-                },
-            }).then((response) => {
-                expect(response.status).to.eq(200);
-                expect(response.body.results).to.have.length(1);
-                expect(response.body.results[0].schedulerUuid).to.eq(
-                    schedulerUuid,
-                );
-                expect(response.body.results[0].createdBy).to.eq(
-                    SEED_ORG_1_EDITOR.user_uuid,
-                );
+                it('Should reassign standalone chart scheduler', () => {
+                    createChartScheduler().then((uuid) => {
+                        schedulerUuid = uuid;
+                        cy.request<ApiReassignSchedulerOwnerResponse>({
+                            url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                            headers: { 'Content-type': 'application/json' },
+                            method: 'PATCH',
+                            body: {
+                                schedulerUuids: [schedulerUuid],
+                                newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                            },
+                        }).then((response) => {
+                            expect(response.status).to.eq(200);
+                            expect(response.body.results).to.have.length(1);
+                            expect(
+                                response.body.results[0].schedulerUuid,
+                            ).to.eq(schedulerUuid);
+                            expect(response.body.results[0].createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                            expect(
+                                response.body.results[0].savedChartUuid,
+                            ).to.not.eq(null);
+                            expect(
+                                response.body.results[0].dashboardUuid,
+                            ).to.eq(null);
+                        });
+                    });
+                });
+
+                it('Should reassign dashboard scheduler', () => {
+                    createDashboardScheduler().then((uuid) => {
+                        schedulerUuid = uuid;
+                        cy.request<ApiReassignSchedulerOwnerResponse>({
+                            url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                            headers: { 'Content-type': 'application/json' },
+                            method: 'PATCH',
+                            body: {
+                                schedulerUuids: [schedulerUuid],
+                                newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                            },
+                        }).then((response) => {
+                            expect(response.status).to.eq(200);
+                            expect(response.body.results).to.have.length(1);
+                            expect(
+                                response.body.results[0].schedulerUuid,
+                            ).to.eq(schedulerUuid);
+                            expect(response.body.results[0].createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                            expect(
+                                response.body.results[0].dashboardUuid,
+                            ).to.not.eq(null);
+                            expect(
+                                response.body.results[0].savedChartUuid,
+                            ).to.eq(null);
+                        });
+                    });
+                });
+
+                it('Should reassign chart-in-dashboard scheduler', () => {
+                    createChartInDashboardScheduler().then((uuid) => {
+                        schedulerUuid = uuid;
+                        cy.request<ApiReassignSchedulerOwnerResponse>({
+                            url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                            headers: { 'Content-type': 'application/json' },
+                            method: 'PATCH',
+                            body: {
+                                schedulerUuids: [schedulerUuid],
+                                newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                            },
+                        }).then((response) => {
+                            expect(response.status).to.eq(200);
+                            expect(response.body.results).to.have.length(1);
+                            expect(
+                                response.body.results[0].schedulerUuid,
+                            ).to.eq(schedulerUuid);
+                            expect(response.body.results[0].createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                            expect(
+                                response.body.results[0].savedChartUuid,
+                            ).to.not.eq(null);
+                            expect(
+                                response.body.results[0].dashboardUuid,
+                            ).to.eq(null);
+                        });
+                    });
+                });
+            });
+
+            describe('Permission tests', () => {
+                let schedulerUuid: string;
+
+                beforeEach(() => {
+                    cy.login();
+                    createChartScheduler().then((uuid) => {
+                        schedulerUuid = uuid;
+                    });
+                });
+
+                afterEach(() => {
+                    cy.login();
+                    if (schedulerUuid) {
+                        deleteScheduler(schedulerUuid);
+                    }
+                });
+
+                it('Should succeed as admin', () => {
+                    cy.request<ApiReassignSchedulerOwnerResponse>({
+                        url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            schedulerUuids: [schedulerUuid],
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                    }).then((response) => {
+                        expect(response.status).to.eq(200);
+                        expect(response.body.results).to.have.length(1);
+                        expect(response.body.results[0].createdBy).to.eq(
+                            SEED_ORG_1_EDITOR.user_uuid,
+                        );
+                    });
+                });
+
+                it('Should succeed as editor', () => {
+                    cy.loginAsEditor();
+                    cy.request<ApiReassignSchedulerOwnerResponse>({
+                        url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            schedulerUuids: [schedulerUuid],
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                    }).then((response) => {
+                        expect(response.status).to.eq(200);
+                        expect(response.body.results).to.have.length(1);
+                        expect(response.body.results[0].createdBy).to.eq(
+                            SEED_ORG_1_EDITOR.user_uuid,
+                        );
+                    });
+                });
+
+                it('Should fail as viewer', () => {
+                    cy.loginAsViewer();
+                    cy.request({
+                        url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            schedulerUuids: [schedulerUuid],
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(403);
+                    });
+                });
+            });
+
+            describe('Validation errors', () => {
+                let schedulerUuid: string;
+
+                beforeEach(() => {
+                    cy.login();
+                    createChartScheduler().then((uuid) => {
+                        schedulerUuid = uuid;
+                    });
+                });
+
+                afterEach(() => {
+                    cy.login();
+                    if (schedulerUuid) {
+                        deleteScheduler(schedulerUuid);
+                    }
+                });
+
+                it('Should fail when scheduler not found', () => {
+                    cy.request({
+                        url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            schedulerUuids: [
+                                '00000000-0000-0000-0000-000000000000',
+                            ],
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(404);
+                    });
+                });
+
+                it('Should fail when new owner not in org', () => {
+                    cy.request({
+                        url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            schedulerUuids: [schedulerUuid],
+                            newOwnerUserUuid: SEED_ORG_2_ADMIN.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(404);
+                    });
+                });
+
+                it('Should fail when new owner is viewer', () => {
+                    cy.request({
+                        url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            schedulerUuids: [schedulerUuid],
+                            newOwnerUserUuid: SEED_ORG_1_VIEWER.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(403);
+                    });
+                });
+
+                it('Should fail when schedulerUuids empty', () => {
+                    cy.request({
+                        url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            schedulerUuids: [],
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(400);
+                    });
+                });
             });
         });
 
-        it('Should reassign scheduler ownership as editor', () => {
-            cy.loginAsEditor();
-            cy.request<ApiReassignSchedulerOwnerResponse>({
-                url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
-                headers: { 'Content-type': 'application/json' },
-                method: 'PATCH',
-                body: {
-                    schedulerUuids: [schedulerUuid],
-                    newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
-                },
-            }).then((response) => {
-                expect(response.status).to.eq(200);
-                expect(response.body.results).to.have.length(1);
-                expect(response.body.results[0].createdBy).to.eq(
-                    SEED_ORG_1_EDITOR.user_uuid,
-                );
+        describe('User scheduler summary - /schedulers-summary', () => {
+            describe('Success cases', () => {
+                let schedulerUuid: string;
+
+                beforeEach(() => {
+                    cy.login();
+                    createChartScheduler().then((uuid) => {
+                        schedulerUuid = uuid;
+                    });
+                });
+
+                afterEach(() => {
+                    cy.login();
+                    if (schedulerUuid) {
+                        deleteScheduler(schedulerUuid);
+                    }
+                });
+
+                it('Should get summary as admin', () => {
+                    cy.request<ApiUserSchedulersSummaryResponse>({
+                        url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/schedulers-summary`,
+                        method: 'GET',
+                    }).then((response) => {
+                        expect(response.status).to.eq(200);
+                        expect(response.body.results).to.have.property(
+                            'totalCount',
+                        );
+                        expect(response.body.results).to.have.property(
+                            'byProject',
+                        );
+                        expect(response.body.results.totalCount).to.be.gte(1);
+                        expect(response.body.results.byProject).to.be.an(
+                            'array',
+                        );
+                    });
+                });
+
+                it('Should include all scheduler types in count', () => {
+                    // Create additional schedulers of different types
+                    let dashboardUuid: string;
+                    let chartInDashboardUuid: string;
+
+                    createDashboardScheduler().then((uuid) => {
+                        dashboardUuid = uuid;
+                    });
+                    createChartInDashboardScheduler().then((uuid) => {
+                        chartInDashboardUuid = uuid;
+                    });
+
+                    cy.request<ApiUserSchedulersSummaryResponse>({
+                        url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/schedulers-summary`,
+                        method: 'GET',
+                    }).then((response) => {
+                        expect(response.status).to.eq(200);
+                        expect(response.body.results.totalCount).to.be.gte(3);
+
+                        // Cleanup additional schedulers
+                        deleteSchedulers([dashboardUuid, chartInDashboardUuid]);
+                    });
+                });
+
+                it('Should return empty for user with no schedulers', () => {
+                    cy.request<ApiUserSchedulersSummaryResponse>({
+                        url: `${apiUrl}/org/user/${SEED_ORG_1_VIEWER.user_uuid}/schedulers-summary`,
+                        method: 'GET',
+                    }).then((response) => {
+                        expect(response.status).to.eq(200);
+                        expect(response.body.results.totalCount).to.eq(0);
+                        expect(response.body.results.byProject).to.have.length(
+                            0,
+                        );
+                    });
+                });
+            });
+
+            describe('Error cases', () => {
+                let schedulerUuid: string;
+
+                // Create a scheduler so permission checks run
+                // (the check only triggers if byProject has items)
+                beforeEach(() => {
+                    cy.login();
+                    createChartScheduler().then((uuid) => {
+                        schedulerUuid = uuid;
+                    });
+                });
+
+                afterEach(() => {
+                    cy.login();
+                    if (schedulerUuid) {
+                        deleteScheduler(schedulerUuid);
+                    }
+                });
+
+                it('Should fail when user not found', () => {
+                    cy.request({
+                        url: `${apiUrl}/org/user/00000000-0000-0000-0000-000000000000/schedulers-summary`,
+                        method: 'GET',
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(404);
+                    });
+                });
+
+                it('Should fail for user in different org', () => {
+                    cy.request({
+                        url: `${apiUrl}/org/user/${SEED_ORG_2_ADMIN.user_uuid}/schedulers-summary`,
+                        method: 'GET',
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(404);
+                    });
+                });
+
+                it('Should fail as viewer', () => {
+                    cy.loginAsViewer();
+                    cy.request({
+                        url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/schedulers-summary`,
+                        method: 'GET',
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(403);
+                    });
+                });
             });
         });
 
-        it('Should fail to reassign scheduler ownership as viewer', () => {
-            cy.loginAsViewer();
-            cy.request({
-                url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
-                headers: { 'Content-type': 'application/json' },
-                method: 'PATCH',
-                body: {
-                    schedulerUuids: [schedulerUuid],
-                    newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
-                },
-                failOnStatusCode: false,
-            }).then((response) => {
-                expect(response.status).to.eq(403);
-            });
-        });
+        describe('Reassign all user schedulers - /reassign-schedulers', () => {
+            describe('Success cases by scheduler type', () => {
+                let chartSchedulerUuid: string;
+                let dashboardSchedulerUuid: string;
+                let chartInDashboardSchedulerUuid: string;
 
-        it('Should fail when scheduler does not exist', () => {
-            cy.request({
-                url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
-                headers: { 'Content-type': 'application/json' },
-                method: 'PATCH',
-                body: {
-                    schedulerUuids: ['00000000-0000-0000-0000-000000000000'],
-                    newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
-                },
-                failOnStatusCode: false,
-            }).then((response) => {
-                expect(response.status).to.eq(404);
-            });
-        });
+                afterEach(() => {
+                    cy.login();
+                    deleteSchedulers([
+                        chartSchedulerUuid,
+                        dashboardSchedulerUuid,
+                        chartInDashboardSchedulerUuid,
+                    ]);
+                });
 
-        it('Should fail when new owner is not in organization', () => {
-            cy.request({
-                url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
-                headers: { 'Content-type': 'application/json' },
-                method: 'PATCH',
-                body: {
-                    schedulerUuids: [schedulerUuid],
-                    newOwnerUserUuid: SEED_ORG_2_ADMIN.user_uuid,
-                },
-                failOnStatusCode: false,
-            }).then((response) => {
-                expect(response.status).to.eq(404);
-            });
-        });
+                it('Should reassign all chart schedulers', () => {
+                    createChartScheduler().then((uuid) => {
+                        chartSchedulerUuid = uuid;
 
-        it('Should fail when new owner is a viewer (cannot create scheduled deliveries)', () => {
-            cy.request({
-                url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
-                headers: { 'Content-type': 'application/json' },
-                method: 'PATCH',
-                body: {
-                    schedulerUuids: [schedulerUuid],
-                    newOwnerUserUuid: SEED_ORG_1_VIEWER.user_uuid,
-                },
-                failOnStatusCode: false,
-            }).then((response) => {
-                expect(response.status).to.eq(403);
-            });
-        });
+                        cy.request<ApiReassignUserSchedulersResponse>({
+                            url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/reassign-schedulers`,
+                            headers: { 'Content-type': 'application/json' },
+                            method: 'PATCH',
+                            body: {
+                                newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                            },
+                        }).then((response) => {
+                            expect(response.status).to.eq(200);
+                            expect(
+                                response.body.results.reassignedCount,
+                            ).to.be.gte(1);
+                        });
 
-        it('Should fail when schedulerUuids is empty', () => {
-            cy.request({
-                url: `${apiUrl}/schedulers/${projectUuid}/reassign-owner`,
-                headers: { 'Content-type': 'application/json' },
-                method: 'PATCH',
-                body: {
-                    schedulerUuids: [],
-                    newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
-                },
-                failOnStatusCode: false,
-            }).then((response) => {
-                expect(response.status).to.eq(400);
+                        cy.request<{ results: SchedulerAndTargets }>({
+                            url: `${apiUrl}/schedulers/${chartSchedulerUuid}`,
+                            method: 'GET',
+                        }).then((response) => {
+                            expect(response.body.results.createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                        });
+                    });
+                });
+
+                it('Should reassign all dashboard schedulers', () => {
+                    createDashboardScheduler().then((uuid) => {
+                        dashboardSchedulerUuid = uuid;
+
+                        cy.request<ApiReassignUserSchedulersResponse>({
+                            url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/reassign-schedulers`,
+                            headers: { 'Content-type': 'application/json' },
+                            method: 'PATCH',
+                            body: {
+                                newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                            },
+                        }).then((response) => {
+                            expect(response.status).to.eq(200);
+                            expect(
+                                response.body.results.reassignedCount,
+                            ).to.be.gte(1);
+                        });
+
+                        cy.request<{ results: SchedulerAndTargets }>({
+                            url: `${apiUrl}/schedulers/${dashboardSchedulerUuid}`,
+                            method: 'GET',
+                        }).then((response) => {
+                            expect(response.body.results.createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                        });
+                    });
+                });
+
+                it('Should reassign all chart-in-dashboard schedulers', () => {
+                    createChartInDashboardScheduler().then((uuid) => {
+                        chartInDashboardSchedulerUuid = uuid;
+
+                        cy.request<ApiReassignUserSchedulersResponse>({
+                            url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/reassign-schedulers`,
+                            headers: { 'Content-type': 'application/json' },
+                            method: 'PATCH',
+                            body: {
+                                newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                            },
+                        }).then((response) => {
+                            expect(response.status).to.eq(200);
+                            expect(
+                                response.body.results.reassignedCount,
+                            ).to.be.gte(1);
+                        });
+
+                        cy.request<{ results: SchedulerAndTargets }>({
+                            url: `${apiUrl}/schedulers/${chartInDashboardSchedulerUuid}`,
+                            method: 'GET',
+                        }).then((response) => {
+                            expect(response.body.results.createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                        });
+                    });
+                });
+
+                it('Should reassign mixed scheduler types', () => {
+                    createChartScheduler().then((uuid) => {
+                        chartSchedulerUuid = uuid;
+                    });
+                    createDashboardScheduler().then((uuid) => {
+                        dashboardSchedulerUuid = uuid;
+                    });
+                    createChartInDashboardScheduler().then((uuid) => {
+                        chartInDashboardSchedulerUuid = uuid;
+
+                        cy.request<ApiReassignUserSchedulersResponse>({
+                            url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/reassign-schedulers`,
+                            headers: { 'Content-type': 'application/json' },
+                            method: 'PATCH',
+                            body: {
+                                newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                            },
+                        }).then((response) => {
+                            expect(response.status).to.eq(200);
+                            expect(
+                                response.body.results.reassignedCount,
+                            ).to.be.gte(3);
+                        });
+
+                        // Verify each scheduler was reassigned
+                        cy.request<{ results: SchedulerAndTargets }>({
+                            url: `${apiUrl}/schedulers/${chartSchedulerUuid}`,
+                            method: 'GET',
+                        }).then((response) => {
+                            expect(response.body.results.createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                        });
+
+                        cy.request<{ results: SchedulerAndTargets }>({
+                            url: `${apiUrl}/schedulers/${dashboardSchedulerUuid}`,
+                            method: 'GET',
+                        }).then((response) => {
+                            expect(response.body.results.createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                        });
+
+                        cy.request<{ results: SchedulerAndTargets }>({
+                            url: `${apiUrl}/schedulers/${chartInDashboardSchedulerUuid}`,
+                            method: 'GET',
+                        }).then((response) => {
+                            expect(response.body.results.createdBy).to.eq(
+                                SEED_ORG_1_EDITOR.user_uuid,
+                            );
+                        });
+                    });
+                });
+
+                it('Should return 0 for user with no schedulers', () => {
+                    cy.request<ApiReassignUserSchedulersResponse>({
+                        url: `${apiUrl}/org/user/${SEED_ORG_1_VIEWER.user_uuid}/reassign-schedulers`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                    }).then((response) => {
+                        expect(response.status).to.eq(200);
+                        expect(response.body.results.reassignedCount).to.eq(0);
+                    });
+                });
+            });
+
+            describe('Error cases', () => {
+                let schedulerUuid: string;
+
+                // Create a scheduler so that validation checks run
+                // (the service returns early if there are no schedulers)
+                beforeEach(() => {
+                    cy.login();
+                    createChartScheduler().then((uuid) => {
+                        schedulerUuid = uuid;
+                    });
+                });
+
+                afterEach(() => {
+                    cy.login();
+                    if (schedulerUuid) {
+                        deleteScheduler(schedulerUuid);
+                    }
+                });
+
+                it('Should fail when fromUser not found', () => {
+                    cy.request({
+                        url: `${apiUrl}/org/user/00000000-0000-0000-0000-000000000000/reassign-schedulers`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(404);
+                    });
+                });
+
+                it('Should fail when fromUser in different org', () => {
+                    cy.request({
+                        url: `${apiUrl}/org/user/${SEED_ORG_2_ADMIN.user_uuid}/reassign-schedulers`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(404);
+                    });
+                });
+
+                it('Should fail when new owner in different org', () => {
+                    cy.request({
+                        url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/reassign-schedulers`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            newOwnerUserUuid: SEED_ORG_2_ADMIN.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(404);
+                    });
+                });
+
+                it('Should fail when new owner is viewer', () => {
+                    cy.request({
+                        url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/reassign-schedulers`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            newOwnerUserUuid: SEED_ORG_1_VIEWER.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(403);
+                    });
+                });
+
+                it('Should fail as viewer', () => {
+                    cy.loginAsViewer();
+                    cy.request({
+                        url: `${apiUrl}/org/user/${SEED_ORG_1_ADMIN.user_uuid}/reassign-schedulers`,
+                        headers: { 'Content-type': 'application/json' },
+                        method: 'PATCH',
+                        body: {
+                            newOwnerUserUuid: SEED_ORG_1_EDITOR.user_uuid,
+                        },
+                        failOnStatusCode: false,
+                    }).then((response) => {
+                        expect(response.status).to.eq(403);
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-124/i-would-like-to-transfer-ownership-of-scheduled-deliveries-and-syncs

### Description:

Added endpoints to manage scheduled deliveries when deleting a user:

1. Added `GET /api/v1/org/user/{userUuid}/schedulers-summary` endpoint to get a summary of scheduled deliveries owned by a user across all projects
2. Added `PATCH /api/v1/org/user/{userUuid}/reassign-schedulers` endpoint to reassign all scheduled deliveries from one user to another
3. Implemented backend services and models to support these operations with proper permission checks
4. Added comprehensive e2e tests for both endpoints

These endpoints will be used in the user management UI to handle scheduled deliveries when deleting users.