### PR TITLE
feat: reassign schedulers on user delete

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -5,7 +5,9 @@ import { type MostPopularAndRecentlyUpdated } from './resourceViewItem';
 import {
     type ApiJobScheduledResponse,
     type ApiJobStatusResponse,
+    type ApiReassignUserSchedulersResponse,
     type ApiSchedulersResponse,
+    type ApiUserSchedulersSummaryResponse,
     type SchedulerAndTargets,
     type SchedulerJobStatus,
 } from './scheduler';
@@ -793,6 +795,8 @@ type ApiResults =
     | ApiExecuteAsyncDashboardChartQueryResults
     | ApiGetAsyncQueryResults
     | ApiSchedulersResponse['results']
+    | ApiUserSchedulersSummaryResponse['results']
+    | ApiReassignUserSchedulersResponse['results']
     | ApiUserActivityDownloadCsv['results']
     | ApiRenameFieldsResponse['results']
     | ApiDownloadAsyncQueryResults

--- a/packages/frontend/src/components/SchedulersView/ReassignSchedulerOwnerModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/ReassignSchedulerOwnerModal.tsx
@@ -1,18 +1,7 @@
-import {
-    Button,
-    Group,
-    Loader,
-    Modal,
-    Select,
-    Stack,
-    Text,
-} from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
-import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import { Button, Group, Modal, Stack, Text } from '@mantine-8/core';
+import { useCallback, useState, type FC } from 'react';
 import { useSchedulerReassignOwnerMutation } from '../../features/scheduler/hooks/useSchedulerReassignOwnerMutation';
-import { useInfiniteOrganizationUsers } from '../../hooks/useOrganizationUsers';
-import { LightdashUserAvatar } from '../Avatar';
-import { DEFAULT_PAGE_SIZE } from '../common/Table/constants';
+import { UserSelect } from '../common/UserSelect';
 
 type ReassignSchedulerOwnerModalProps = {
     opened: boolean;
@@ -21,17 +10,6 @@ type ReassignSchedulerOwnerModalProps = {
     schedulerUuids: string[];
     excludedUserUuid?: string;
     onSuccess?: () => void;
-};
-
-const getUserDisplayName = (
-    firstName: string | undefined,
-    lastName: string | undefined,
-    email: string,
-): string => {
-    if (firstName && lastName) {
-        return `${firstName} ${lastName}`;
-    }
-    return email;
 };
 
 const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
@@ -45,72 +23,12 @@ const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
     const [selectedUserUuid, setSelectedUserUuid] = useState<string | null>(
         null,
     );
-    const [searchValue, setSearchValue] = useState('');
-    const [debouncedSearchValue] = useDebouncedValue(searchValue, 300);
-    const viewportRef = useRef<HTMLDivElement>(null);
-
-    const {
-        data: infiniteUsers,
-        isLoading: isLoadingUsers,
-        isFetching: isFetchingUsers,
-        hasNextPage,
-        fetchNextPage,
-    } = useInfiniteOrganizationUsers(
-        {
-            searchInput: debouncedSearchValue,
-            pageSize: DEFAULT_PAGE_SIZE,
-        },
-        { keepPreviousData: true },
-    );
-
-    const organizationUsers = useMemo(
-        () => infiniteUsers?.pages.flatMap((page) => page.data) ?? [],
-        [infiniteUsers],
-    );
 
     const { mutate: reassignOwner, isLoading: isReassigning } =
         useSchedulerReassignOwnerMutation(projectUuid);
 
-    // Filter out the excluded user (current owner for single selection)
-    const eligibleUsers = useMemo(() => {
-        if (!organizationUsers) return [];
-        return organizationUsers.filter(
-            (user) => user.userUuid !== excludedUserUuid,
-        );
-    }, [organizationUsers, excludedUserUuid]);
-
-    // Store user data in a map for lookup
-    const usersMap = useMemo(() => {
-        return new Map(
-            eligibleUsers.map((user) => [
-                user.userUuid,
-                {
-                    name: getUserDisplayName(
-                        user.firstName,
-                        user.lastName,
-                        user.email,
-                    ),
-                    email: user.email,
-                },
-            ]),
-        );
-    }, [eligibleUsers]);
-
-    // Convert to Select data format
-    const selectData = useMemo(() => {
-        return eligibleUsers.map((user) => ({
-            value: user.userUuid,
-            label: getUserDisplayName(
-                user.firstName,
-                user.lastName,
-                user.email,
-            ),
-        }));
-    }, [eligibleUsers]);
-
     const handleClose = useCallback(() => {
         setSelectedUserUuid(null);
-        setSearchValue('');
         onClose();
     }, [onClose]);
 
@@ -137,20 +55,6 @@ const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
         onSuccess,
     ]);
 
-    const handleScrollPositionChange = useCallback(
-        ({ y }: { x: number; y: number }) => {
-            if (!viewportRef.current || isFetchingUsers || !hasNextPage) return;
-
-            const { scrollHeight, clientHeight } = viewportRef.current;
-            const isNearBottom = y >= scrollHeight - clientHeight - 50;
-
-            if (isNearBottom) {
-                void fetchNextPage();
-            }
-        },
-        [fetchNextPage, hasNextPage, isFetchingUsers],
-    );
-
     const schedulerCount = schedulerUuids.length;
     const schedulerText =
         schedulerCount === 1
@@ -172,47 +76,11 @@ const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
                     {schedulerCount === 1 ? 'it' : 'them'}.
                 </Text>
 
-                <Select
+                <UserSelect
                     label="New owner"
-                    placeholder="Search for a user..."
-                    searchable
-                    searchValue={searchValue}
-                    onSearchChange={setSearchValue}
                     value={selectedUserUuid}
                     onChange={setSelectedUserUuid}
-                    data={selectData}
-                    nothingFoundMessage="No users found"
-                    maxDropdownHeight={250}
-                    rightSection={
-                        isLoadingUsers || isFetchingUsers ? (
-                            <Loader size="xs" />
-                        ) : null
-                    }
-                    scrollAreaProps={{
-                        viewportRef,
-                        onScrollPositionChange: handleScrollPositionChange,
-                    }}
-                    renderOption={({ option }) => {
-                        const userData = usersMap.get(option.value);
-                        if (!userData) return option.label;
-
-                        return (
-                            <Group gap="sm" wrap="nowrap">
-                                <LightdashUserAvatar
-                                    name={userData.name}
-                                    size="sm"
-                                />
-                                <Stack gap={2}>
-                                    <Text size="sm" fw={500}>
-                                        {userData.name}
-                                    </Text>
-                                    <Text size="xs" c="dimmed">
-                                        {userData.email}
-                                    </Text>
-                                </Stack>
-                            </Group>
-                        );
-                    }}
+                    excludedUserUuid={excludedUserUuid}
                 />
 
                 <Group justify="flex-end" gap="sm">

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
@@ -4,29 +4,40 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Alert,
     Button,
     Card,
+    Collapse,
     Group,
     Menu,
     Modal,
     Paper,
+    Radio,
     Stack,
     Text,
     Title,
 } from '@mantine-8/core';
 import {
     IconAlertCircle,
+    IconChevronDown,
+    IconChevronUp,
     IconDots,
     IconMail,
     IconTrash,
 } from '@tabler/icons-react';
-import React, { type FC } from 'react';
+import React, { useCallback, useEffect, type FC } from 'react';
 import useHealth from '../../../hooks/health/useHealth';
 import type { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
-import { useDeleteOrganizationUserMutation } from '../../../hooks/useOrganizationUsers';
+import {
+    useDeleteOrganizationUserMutation,
+    useReassignUserSchedulersMutation,
+    useUserSchedulersSummary,
+} from '../../../hooks/useOrganizationUsers';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
+import { PolymorphicGroupButton } from '../../common/PolymorphicGroupButton';
+import { UserSelect } from '../../common/UserSelect';
 
 interface UsersActionMenuProps {
     user: OrganizationMemberProfile | OrganizationMemberProfileWithGroups;
@@ -55,6 +66,11 @@ const UserNameDisplay: FC<{
     );
 };
 
+enum SchedulerAction {
+    DELETE = 'delete',
+    REASSIGN = 'reassign',
+}
+
 const UsersActionMenu: FC<UsersActionMenuProps> = ({
     user,
     disabled,
@@ -63,15 +79,59 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
     onInviteSent,
 }) => {
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
-    const { mutateAsync, isLoading: isDeleting } =
+    const [schedulerAction, setSchedulerAction] =
+        React.useState<SchedulerAction>(SchedulerAction.REASSIGN);
+    const [selectedNewOwner, setSelectedNewOwner] = React.useState<
+        string | null
+    >(null);
+    const [isProjectBreakdownOpen, setIsProjectBreakdownOpen] =
+        React.useState(false);
+
+    const { mutateAsync: deleteUser, isLoading: isDeleting } =
         useDeleteOrganizationUserMutation();
+    const { mutateAsync: reassignSchedulers, isLoading: isReassigning } =
+        useReassignUserSchedulersMutation();
+    const { data: schedulersSummary, isLoading: isLoadingSchedulers } =
+        useUserSchedulersSummary(user.userUuid, isDeleteDialogOpen);
     const { track } = useTracking();
     const health = useHealth();
 
-    const handleDelete = async () => {
-        await mutateAsync(user.userUuid);
+    const hasSchedulers = schedulersSummary && schedulersSummary.totalCount > 0;
+    const isProcessing = isDeleting || isReassigning;
+
+    // Reset state when modal opens/closes
+    useEffect(() => {
+        if (isDeleteDialogOpen) {
+            setSchedulerAction(SchedulerAction.REASSIGN);
+            setSelectedNewOwner(null);
+            setIsProjectBreakdownOpen(false);
+        }
+    }, [isDeleteDialogOpen]);
+
+    const handleClose = useCallback(() => {
+        if (!isProcessing) {
+            setIsDeleteDialogOpen(false);
+        }
+    }, [isProcessing]);
+
+    const handleDelete = useCallback(async () => {
+        if (hasSchedulers && schedulerAction === SchedulerAction.REASSIGN) {
+            if (!selectedNewOwner) return;
+            await reassignSchedulers({
+                userUuid: user.userUuid,
+                newOwnerUserUuid: selectedNewOwner,
+            });
+        }
+        await deleteUser(user.userUuid);
         setIsDeleteDialogOpen(false);
-    };
+    }, [
+        hasSchedulers,
+        schedulerAction,
+        selectedNewOwner,
+        reassignSchedulers,
+        deleteUser,
+        user.userUuid,
+    ]);
 
     const getNewLink = () => {
         track({
@@ -88,6 +148,29 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
     };
 
     const showResendInvite = canInvite && user.isPending;
+
+    const canConfirmDelete =
+        !hasSchedulers ||
+        schedulerAction === SchedulerAction.DELETE ||
+        (schedulerAction === SchedulerAction.REASSIGN && selectedNewOwner);
+
+    const schedulerText =
+        schedulersSummary?.totalCount === 1
+            ? '1 scheduled delivery'
+            : `${schedulersSummary?.totalCount} scheduled deliveries`;
+
+    const projectCount = schedulersSummary?.byProject.length ?? 0;
+    const projectText =
+        projectCount === 1 ? '1 project' : `${projectCount} projects`;
+
+    const handleSchedulerActionChange = useCallback((value: string) => {
+        if (
+            value !== SchedulerAction.DELETE &&
+            value !== SchedulerAction.REASSIGN
+        )
+            return;
+        setSchedulerAction(value);
+    }, []);
 
     return (
         <>
@@ -138,9 +221,7 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
 
             <Modal
                 opened={isDeleteDialogOpen}
-                onClose={() =>
-                    !isDeleting ? setIsDeleteDialogOpen(false) : undefined
-                }
+                onClose={handleClose}
                 title={
                     <Group gap="xs">
                         <Paper>
@@ -150,22 +231,115 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                     </Group>
                 }
             >
-                <Stack gap="xs">
+                <Stack gap="md">
                     <Text>Are you sure you want to delete this user?</Text>
-                    <Group gap="xs">
-                        <MantineIcon icon={IconAlertCircle} color="gray" />
-                        <Text fz="xs" c="ldGray.6" span>
-                            Scheduled deliveries created by this user will also
-                            be deleted.
-                        </Text>
-                    </Group>
+
                     <Card withBorder>
                         <UserNameDisplay user={user} />
                     </Card>
-                    <Group gap="xs" justify="right" mt="md">
+
+                    {isLoadingSchedulers ? (
+                        <Text fz="sm" c="dimmed">
+                            Checking scheduled deliveries...
+                        </Text>
+                    ) : hasSchedulers ? (
+                        <>
+                            <Alert
+                                color="orange"
+                                icon={<MantineIcon icon={IconAlertCircle} />}
+                            >
+                                <Stack gap="xs">
+                                    <Text fz="sm">
+                                        This user owns {schedulerText} across{' '}
+                                        {projectText}.
+                                    </Text>
+                                    <PolymorphicGroupButton
+                                        gap="xxs"
+                                        onClick={() =>
+                                            setIsProjectBreakdownOpen(
+                                                (prev) => !prev,
+                                            )
+                                        }
+                                    >
+                                        <Text fz="xs" c="orange.7" fw={500}>
+                                            {isProjectBreakdownOpen
+                                                ? 'Hide details'
+                                                : 'Show details'}
+                                        </Text>
+                                        <MantineIcon
+                                            icon={
+                                                isProjectBreakdownOpen
+                                                    ? IconChevronUp
+                                                    : IconChevronDown
+                                            }
+                                            color="orange.7"
+                                            size={14}
+                                        />
+                                    </PolymorphicGroupButton>
+                                    <Collapse in={isProjectBreakdownOpen}>
+                                        <Stack gap="xxs">
+                                            {schedulersSummary?.byProject.map(
+                                                (project) => (
+                                                    <Text
+                                                        key={
+                                                            project.projectUuid
+                                                        }
+                                                        fz="xs"
+                                                    >
+                                                        • {project.projectName}:{' '}
+                                                        {project.count}{' '}
+                                                        {project.count === 1
+                                                            ? 'delivery'
+                                                            : 'deliveries'}
+                                                    </Text>
+                                                ),
+                                            )}
+                                        </Stack>
+                                    </Collapse>
+                                </Stack>
+                            </Alert>
+
+                            {/* this radio group doesn't re-render when the action changes, so we need to use a key to force a re-render */}
+                            <Radio.Group
+                                key={schedulerAction}
+                                name="schedulerAction"
+                                value={schedulerAction}
+                                onChange={handleSchedulerActionChange}
+                            >
+                                <Stack gap="sm">
+                                    <Radio
+                                        value={SchedulerAction.DELETE}
+                                        label="Delete all scheduled deliveries"
+                                    />
+                                    <Radio
+                                        value={SchedulerAction.REASSIGN}
+                                        label="Reassign to another user"
+                                    />
+                                </Stack>
+                            </Radio.Group>
+
+                            {schedulerAction === SchedulerAction.REASSIGN && (
+                                <UserSelect
+                                    label="New owner"
+                                    value={selectedNewOwner}
+                                    onChange={setSelectedNewOwner}
+                                    excludedUserUuid={user.userUuid}
+                                />
+                            )}
+                        </>
+                    ) : (
+                        <Group gap="xs">
+                            <MantineIcon icon={IconAlertCircle} color="gray" />
+                            <Text fz="xs" c="ldGray.6" span>
+                                This user has no scheduled deliveries.
+                            </Text>
+                        </Group>
+                    )}
+
+                    <Group gap="xs" justify="flex-end" mt="md">
                         <Button
-                            disabled={isDeleting}
-                            onClick={() => setIsDeleteDialogOpen(false)}
+                            disabled={isProcessing}
+                            onClick={handleClose}
                             variant="outline"
                             color="dark"
                         >
@@ -173,7 +347,8 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                         </Button>
                         <Button
                             onClick={handleDelete}
-                            disabled={isDeleting}
+                            loading={isProcessing}
+                            disabled={!canConfirmDelete}
                             color="red"
                         >
                             Delete

--- a/packages/frontend/src/components/common/UserSelect/index.tsx
+++ b/packages/frontend/src/components/common/UserSelect/index.tsx
@@ -1,0 +1,156 @@
+import { Group, Loader, Select, Stack, Text } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import { useInfiniteOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+import { LightdashUserAvatar } from '../../Avatar';
+import { DEFAULT_PAGE_SIZE } from '../Table/constants';
+
+const getUserDisplayName = (
+    firstName: string | undefined,
+    lastName: string | undefined,
+    email: string,
+): string => {
+    if (firstName && lastName) {
+        return `${firstName} ${lastName}`;
+    }
+    return email;
+};
+
+type UserSelectProps = {
+    value: string | null;
+    onChange: (value: string | null) => void;
+    excludedUserUuid?: string;
+    label?: string;
+    placeholder?: string;
+    disabled?: boolean;
+};
+
+export const UserSelect: FC<UserSelectProps> = ({
+    value,
+    onChange,
+    excludedUserUuid,
+    label,
+    placeholder = 'Search for a user...',
+    disabled = false,
+}) => {
+    const [searchValue, setSearchValue] = useState('');
+    const [debouncedSearchValue] = useDebouncedValue(searchValue, 300);
+    const viewportRef = useRef<HTMLDivElement>(null);
+
+    const {
+        data: infiniteUsers,
+        isLoading: isLoadingUsers,
+        isFetching: isFetchingUsers,
+        hasNextPage,
+        fetchNextPage,
+    } = useInfiniteOrganizationUsers(
+        {
+            searchInput: debouncedSearchValue,
+            pageSize: DEFAULT_PAGE_SIZE,
+        },
+        { keepPreviousData: true },
+    );
+
+    const organizationUsers = useMemo(
+        () => infiniteUsers?.pages.flatMap((page) => page.data) ?? [],
+        [infiniteUsers],
+    );
+
+    const eligibleUsers = useMemo(() => {
+        if (!organizationUsers) return [];
+        if (!excludedUserUuid) return organizationUsers;
+        return organizationUsers.filter(
+            (user) => user.userUuid !== excludedUserUuid,
+        );
+    }, [organizationUsers, excludedUserUuid]);
+
+    const usersMap = useMemo(() => {
+        return new Map(
+            eligibleUsers.map((user) => [
+                user.userUuid,
+                {
+                    name: getUserDisplayName(
+                        user.firstName,
+                        user.lastName,
+                        user.email,
+                    ),
+                    email: user.email,
+                },
+            ]),
+        );
+    }, [eligibleUsers]);
+
+    const selectData = useMemo(() => {
+        return eligibleUsers.map((user) => ({
+            value: user.userUuid,
+            label: getUserDisplayName(
+                user.firstName,
+                user.lastName,
+                user.email,
+            ),
+        }));
+    }, [eligibleUsers]);
+
+    const handleScrollPositionChange = useCallback(
+        ({ y }: { x: number; y: number }) => {
+            if (!viewportRef.current || isFetchingUsers || !hasNextPage) return;
+
+            const { scrollHeight, clientHeight } = viewportRef.current;
+            const isNearBottom = y >= scrollHeight - clientHeight - 50;
+
+            if (isNearBottom) {
+                void fetchNextPage();
+            }
+        },
+        [fetchNextPage, hasNextPage, isFetchingUsers],
+    );
+
+    const handleChange = useCallback(
+        (newValue: string | null) => {
+            onChange(newValue);
+            setSearchValue('');
+        },
+        [onChange],
+    );
+
+    return (
+        <Select
+            label={label}
+            placeholder={placeholder}
+            searchable
+            searchValue={searchValue}
+            onSearchChange={setSearchValue}
+            value={value}
+            onChange={handleChange}
+            data={selectData}
+            nothingFoundMessage="No users found"
+            maxDropdownHeight={250}
+            disabled={disabled}
+            rightSection={
+                isLoadingUsers || isFetchingUsers ? <Loader size="xs" /> : null
+            }
+            scrollAreaProps={{
+                viewportRef,
+                onScrollPositionChange: handleScrollPositionChange,
+            }}
+            renderOption={({ option }) => {
+                const userData = usersMap.get(option.value);
+                if (!userData) return option.label;
+
+                return (
+                    <Group gap="sm" wrap="nowrap">
+                        <LightdashUserAvatar name={userData.name} size="sm" />
+                        <Stack gap={2}>
+                            <Text size="sm" fw={500}>
+                                {userData.name}
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                                {userData.email}
+                            </Text>
+                        </Stack>
+                    </Group>
+                );
+            }}
+        />
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/GLITCH-124/i-would-like-to-transfer-ownership-of-scheduled-deliveries-and-syncs

### Description:

This PR adds the ability to reassign scheduled deliveries when deleting a user. When a user owns scheduled deliveries, admins now have the option to either delete those deliveries or reassign them to another user.

Key changes:

- Added a new UserSelect component to standardize user selection across the app
- Enhanced the user deletion modal to show scheduled delivery details and reassignment options
- Implemented backend API integration for user scheduler summary and reassignment
- Refactored the ReassignSchedulerOwnerModal to use the new UserSelect component

[Screen Recording 2025-12-29 at 16.34.37.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/01fbabce-b6fc-4e37-bc6e-0a1bb426dbc0.mov" />](https://app.graphite.com/user-attachments/video/01fbabce-b6fc-4e37-bc6e-0a1bb426dbc0.mov)