### PR TITLE
feat: update mantine modals for project access&preview

### DIFF
--- a/packages/frontend/src/components/ProjectAccess/CreateProjectAccessModal.tsx
+++ b/packages/frontend/src/components/ProjectAccess/CreateProjectAccessModal.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { validateEmail, type InviteLink } from '@lightdash/common';
-
-import { Button, Group, Modal, Select, Title } from '@mantine/core';
+import { Button, Group } from '@mantine-8/core';
+import { Select } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconUserPlus } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
@@ -17,7 +17,7 @@ import {
     PageType,
 } from '../../types/Events';
 import InviteSuccess from '../UserSettings/UsersAndGroupsPanel/InviteSuccess';
-import MantineIcon from '../common/MantineIcon';
+import MantineModal from '../common/MantineModal';
 
 interface Props {
     projectUuid: string;
@@ -84,18 +84,25 @@ const CreateProjectAccessModal: FC<Props> = ({
         }),
     );
 
+    const formId = 'add-user-to-project';
+
     return (
-        <Modal
+        <MantineModal
             opened
             onClose={onClose}
-            keepMounted={false}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon size="lg" icon={IconUserPlus} />
-                    <Title order={4}>Add user access</Title>
-                </Group>
-            }
+            title="Add user access"
+            icon={IconUserPlus}
             size="lg"
+            actions={
+                <Button
+                    type="submit"
+                    form={formId}
+                    disabled={isLoading}
+                    loading={isLoading}
+                >
+                    Give access
+                </Button>
+            }
         >
             <TrackPage
                 name={PageName.PROJECT_ADD_USER}
@@ -103,16 +110,17 @@ const CreateProjectAccessModal: FC<Props> = ({
                 category={CategoryName.SETTINGS}
             >
                 <form
-                    name="add_user_to_project"
+                    id={formId}
                     onSubmit={form.onSubmit(
                         (values: { userId: string; roleId: string }) =>
                             handleSubmit(values),
                     )}
                 >
-                    <Group align="flex-end" spacing="xs">
+                    <Group align="flex-end" gap="xs">
                         <Select
-                            name={'email'}
+                            name="email"
                             withinPortal
+                            radius="md"
                             label="Enter user email address"
                             placeholder="example@gmail.com"
                             nothingFound="Nothing found"
@@ -145,18 +153,17 @@ const CreateProjectAccessModal: FC<Props> = ({
                             {...form.getInputProps('userId')}
                             sx={{ flexGrow: 1 }}
                         />
+
                         <Select
                             data={roles}
                             disabled={isLoading}
                             required
+                            radius="md"
                             placeholder="Select role"
                             dropdownPosition="bottom"
                             withinPortal
                             {...form.getInputProps('roleId')}
                         />
-                        <Button disabled={isLoading} type="submit">
-                            Give access
-                        </Button>
                     </Group>
                 </form>
 
@@ -164,7 +171,7 @@ const CreateProjectAccessModal: FC<Props> = ({
                     <InviteSuccess invite={inviteLink} hasMarginTop />
                 )}
             </TrackPage>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccessRowV2.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccessRowV2.tsx
@@ -298,7 +298,11 @@ const ProjectAccessRowV2: FC<Props> = ({
 
             {isDeleteDialogOpen && (
                 <RemoveProjectAccessModal
-                    user={{ email: user.email }}
+                    user={{
+                        firstName: user.firstName,
+                        lastName: user.lastName,
+                        email: user.email,
+                    }}
                     onDelete={handleDelete}
                     onClose={() => setIsDeleteDialogOpen(false)}
                 />

--- a/packages/frontend/src/components/ProjectAccess/RemoveProjectAccessModal.tsx
+++ b/packages/frontend/src/components/ProjectAccess/RemoveProjectAccessModal.tsx
@@ -1,40 +1,33 @@
-import { Button, Group, Modal, Text, Title } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import { IconKey } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { type ProjectUserWithRole } from '../../hooks/useProjectUsersWithRoles';
-import MantineIcon from '../common/MantineIcon';
+import MantineModal from '../common/MantineModal';
 
 type Props = {
-    user: Pick<ProjectUserWithRole, 'email'>;
+    user: Pick<ProjectUserWithRole, 'firstName' | 'lastName' | 'email'>;
     onDelete: () => void;
     onClose: () => void;
 };
 
 const RemoveProjectAccessModal: FC<Props> = ({ user, onDelete, onClose }) => {
     return (
-        <Modal
+        <MantineModal
             opened
             onClose={onClose}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon size="lg" icon={IconKey} color="red" />
-                    <Title order={4}>Revoke project access</Title>
-                </Group>
-            }
-        >
-            <Text pb="md">
-                Are you sure you want to revoke project access for this user{' '}
-                {user.email} ?
-            </Text>
-            <Group spacing="xs" position="right">
-                <Button variant="outline" onClick={onClose} color="dark">
-                    Cancel
-                </Button>
+            title="Revoke project access"
+            icon={IconKey}
+            description={`Are you sure you want to revoke project access for "${
+                user.firstName && user.lastName
+                    ? `${user.firstName} ${user.lastName}`
+                    : user.email
+            }"?`}
+            actions={
                 <Button color="red" onClick={onDelete}>
                     Delete
                 </Button>
-            </Group>
-        </Modal>
+            }
+        />
     );
 };
 

--- a/packages/frontend/src/components/ProjectConnection/FormCollapseButton.tsx
+++ b/packages/frontend/src/components/ProjectConnection/FormCollapseButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
@@ -11,13 +11,13 @@ const FormCollapseButton: FC<
 > = ({ isSectionOpen, onClick, children }) => {
     return (
         <Button
-            color="blue"
             variant="subtle"
-            compact
-            sx={{
+            color="ldGray.6"
+            size="compact-sm"
+            style={{
                 alignSelf: 'end',
             }}
-            leftIcon={
+            leftSection={
                 isSectionOpen ? (
                     <MantineIcon icon={IconChevronUp} />
                 ) : (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Migrated the project access modals and preview project modal to use the new Mantine 8 components and the shared MantineModal component. This includes:

- Updated imports from `@mantine/core` to `@mantine-8/core` for Button, Group, and other components
- Replaced the custom Modal implementation with the shared MantineModal component
- Improved the UI layout with consistent spacing, better action button placement, and clearer titles
- Fixed type issues by using proper null handling for state variables
- Enhanced the RemoveProjectAccessModal to display the user's full name when available
- Updated button styling to match the new design system

The changes maintain all existing functionality while providing a more consistent UI experience across the application.

![Screenshot 2025-12-29 at 15.05.09.png](https://app.graphite.com/user-attachments/assets/7876e022-2d9e-4ec7-aaae-e8c1591e4f03.png)

![Screenshot 2025-12-29 at 15.18.34.png](https://app.graphite.com/user-attachments/assets/8e6d7315-9e6d-44d0-8221-d8e47626f4cc.png)

![Screenshot 2025-12-29 at 15.13.26.png](https://app.graphite.com/user-attachments/assets/d503a6f0-2d33-4761-9095-de755b68738a.png)

![Screenshot 2025-12-29 at 15.20.18.png](https://app.graphite.com/user-attachments/assets/572685e0-8d02-44c3-b602-eb114e9f1e5b.png)

![image.png](https://app.graphite.com/user-attachments/assets/dd3a0a9d-c902-44e7-8ecb-9304b2c5299e.png)

