### PR TITLE
feat: update mantine modals on scim/custom roles/service accounts

### DIFF
--- a/packages/frontend/src/components/common/Callout.tsx
+++ b/packages/frontend/src/components/common/Callout.tsx
@@ -33,7 +33,7 @@ const CALLOUT_CONFIG: Record<
 interface CalloutProps extends Omit<AlertProps, 'title' | 'icon'> {
     variant: CalloutVariant;
     title?: ReactNode;
-    children: ReactNode;
+    children?: ReactNode;
 }
 
 /**
@@ -69,7 +69,7 @@ const Callout: FC<CalloutProps> = ({
             title={title}
             {...alertProps}
         >
-            {children}
+            {children ? children : null}
         </Alert>
     );
 };

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesDeleteModal.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesDeleteModal.tsx
@@ -1,7 +1,9 @@
-import { Button, Group, Modal, Stack, Text } from '@mantine/core';
+import { Button, Text } from '@mantine-8/core';
+import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 
 import { type RoleWithScopes } from '@lightdash/common';
+import MantineModal from '../../../components/common/MantineModal';
 
 type DeleteModalProps = {
     isOpen: boolean;
@@ -19,37 +21,29 @@ export const CustomRolesDeleteModal: FC<DeleteModalProps> = ({
     role,
 }) => {
     return (
-        <Modal
+        <MantineModal
             opened={isOpen}
             onClose={onClose}
             title="Delete custom role"
-            size="md"
+            icon={IconTrash}
+            cancelDisabled={isDeleting}
+            actions={
+                <Button color="red" onClick={onDelete} loading={isDeleting}>
+                    Delete role
+                </Button>
+            }
         >
-            <Stack>
-                <Text>
-                    Are you sure you want to delete the role{' '}
-                    <Text component="span" weight="bold">
-                        {role.name}
-                    </Text>
-                    ?
+            <Text fz="sm">
+                Are you sure you want to delete the role{' '}
+                <Text component="span" fw={700}>
+                    {role.name}
                 </Text>
-                <Text size="sm" color="dimmed">
-                    This action cannot be undone. Users and groups will no
-                    longer be able to use this role.
-                </Text>
-                <Group position="right" mt="md">
-                    <Button
-                        variant="outline"
-                        onClick={onClose}
-                        disabled={isDeleting}
-                    >
-                        Cancel
-                    </Button>
-                    <Button color="red" onClick={onDelete} loading={isDeleting}>
-                        Delete role
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+                ?
+            </Text>
+            <Text fz="sm" c="dimmed">
+                This action cannot be undone. Users and groups will no longer be
+                able to use this role.
+            </Text>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/CreateTokenModal.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/CreateTokenModal.tsx
@@ -1,20 +1,19 @@
 import { formatTimestamp } from '@lightdash/common';
 import {
     ActionIcon,
-    Alert,
     Button,
     CopyButton,
-    Modal,
     Select,
     Stack,
     TextInput,
-    Title,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm } from '@mantine/form';
-import { IconAlertCircle, IconCheck, IconCopy } from '@tabler/icons-react';
+import { IconCheck, IconCopy, IconKey } from '@tabler/icons-react';
 import { type FC } from 'react';
+import Callout from '../../../../../components/common/Callout';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
 import { useCreateScimToken } from '../../hooks/useScimAccessToken';
 
 export const CreateTokenModal: FC<{
@@ -82,23 +81,33 @@ export const CreateTokenModal: FC<{
     });
 
     return (
-        <Modal
-            size="lg"
+        <MantineModal
             opened
-            onClose={() => {
-                onBackClick();
-            }}
-            title={
-                <Title order={4}>
-                    {data ? 'Your token has been generated' : 'New token'}
-                </Title>
+            onClose={onBackClick}
+            title={isSuccess ? 'Your token has been generated' : 'New token'}
+            icon={IconKey}
+            size="lg"
+            cancelLabel={isSuccess ? false : 'Cancel'}
+            cancelDisabled={isLoading}
+            actions={
+                !isSuccess ? (
+                    <Button
+                        type="submit"
+                        form="create-scim-token-form"
+                        loading={isLoading}
+                    >
+                        Generate token
+                    </Button>
+                ) : (
+                    <Button onClick={onBackClick}>Done</Button>
+                )
             }
         >
             {!isSuccess ? (
-                <form onSubmit={handleOnSubmit}>
-                    <Stack spacing="md">
+                <form id="create-scim-token-form" onSubmit={handleOnSubmit}>
+                    <Stack gap="md">
                         <TextInput
-                            label="What’s this token for?"
+                            label="What's this token for?"
                             disabled={isLoading}
                             placeholder="Description"
                             required
@@ -106,22 +115,17 @@ export const CreateTokenModal: FC<{
                         />
 
                         <Select
-                            withinPortal
                             defaultValue={expireOptions[0].value}
                             label="Expiration"
                             data={expireOptions}
                             required
                             disabled={isLoading}
                             {...form.getInputProps('expiresAt')}
-                        ></Select>
-
-                        <Button type="submit" ml="auto" loading={isLoading}>
-                            Generate token
-                        </Button>
+                        />
                     </Stack>
                 </form>
             ) : (
-                <Stack spacing="md">
+                <Stack gap="md">
                     <TextInput
                         id="invite-link-input"
                         label="Token"
@@ -153,15 +157,17 @@ export const CreateTokenModal: FC<{
                             </CopyButton>
                         }
                     />
-                    <Alert icon={<MantineIcon icon={IconAlertCircle} />}>
+                    <Callout
+                        variant="info"
+                        title="Make sure to copy your access token now. You won't be able to see it again!"
+                    >
                         {data.expiresAt &&
-                            `This token will expire on
-                        ${formatTimestamp(data.expiresAt)} `}
-                        Make sure to copy your access token now. You won’t be
-                        able to see it again!
-                    </Alert>
+                            `This token will expire on ${formatTimestamp(
+                                data.expiresAt,
+                            )} `}
+                    </Callout>
                 </Stack>
             )}
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsDeleteModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsDeleteModal.tsx
@@ -1,9 +1,9 @@
-import { Button, Flex, Group, Modal, Stack, Text } from '@mantine/core';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { Button, Text } from '@mantine-8/core';
+import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 
 import { type ServiceAccount } from '@lightdash/common';
-import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
 
 type Props = {
     isDeleting: boolean;
@@ -21,51 +21,31 @@ export const ServiceAccountsDeleteModal: FC<Props> = ({
     serviceAccount,
 }) => {
     return (
-        <Modal
+        <MantineModal
             opened={isOpen}
             onClose={onClose}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon icon={IconAlertCircle} color="red" />
-                    <span>Delete service account</span>
-                </Group>
+            title="Delete service account"
+            icon={IconTrash}
+            cancelDisabled={isDeleting}
+            actions={
+                <Button
+                    color="red"
+                    loading={isDeleting}
+                    onClick={() => {
+                        onDelete(serviceAccount?.uuid ?? '');
+                    }}
+                >
+                    Delete
+                </Button>
             }
-            styles={(theme) => ({
-                title: {
-                    fontWeight: 'bold',
-                    fontSize: theme.fontSizes.lg,
-                },
-            })}
         >
-            <Stack spacing="xl">
-                <Text>
-                    Are you sure? This will permanently delete the{' '}
-                    <Text fw={600} component="span">
-                        {serviceAccount?.description}
-                    </Text>{' '}
-                    service account.
-                </Text>
-
-                <Flex gap="sm" justify="flex-end">
-                    <Button
-                        color="dark"
-                        variant="outline"
-                        disabled={isDeleting}
-                        onClick={onClose}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        color="red"
-                        disabled={isDeleting}
-                        onClick={() => {
-                            onDelete(serviceAccount?.uuid ?? '');
-                        }}
-                    >
-                        Delete
-                    </Button>
-                </Flex>
-            </Stack>
-        </Modal>
+            <Text fz="sm">
+                Are you sure? This will permanently delete the{' '}
+                <Text fw={600} component="span">
+                    {serviceAccount?.description}
+                </Text>{' '}
+                service account.
+            </Text>
+        </MantineModal>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Refactored modal components to use the new `MantineModal` component across the application. This includes:

- Updated `CustomRolesDeleteModal` to use the new modal component with improved layout
- Refactored `DuplicateRoleModal` to use the new modal structure and updated the Select component implementation
- Migrated `CreateTokenModal` for SCIM tokens to use the standardized modal pattern
- Updated `ServiceAccountsCreateModal` and `ServiceAccountsDeleteModal` to use the new modal component
- Made `children` optional in `AlertMessage` component to support empty alerts with just titles
- Updated imports to use `@mantine-8/core` instead of `@mantine/core`

These changes provide a more consistent UI experience across all modals in the application.

![Screenshot 2025-12-29 at 16.20.38.png](https://app.graphite.com/user-attachments/assets/86eeea2d-7734-4f36-b4b1-f0dcc50d6112.png)

![Screenshot 2025-12-29 at 16.40.17.png](https://app.graphite.com/user-attachments/assets/d8b8c06e-6f6d-42bb-9360-7bbfe754e7b4.png)

![Screenshot 2025-12-29 at 16.32.33.png](https://app.graphite.com/user-attachments/assets/7638384c-424d-46d5-b53c-7a220028672c.png)

![Screenshot 2025-12-29 at 16.30.22.png](https://app.graphite.com/user-attachments/assets/ee234808-7bbc-40d6-a6fa-6858369e8df8.png)

