### PR TITLE
feat: show multiple values on map points

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -163,6 +163,11 @@ export enum MapTileBackground {
     SATELLITE = 'satellite',
 }
 
+export type MapFieldConfig = {
+    visible?: boolean;
+    label?: string;
+};
+
 export type MapChart = {
     mapType?: MapChartLocation;
     customGeoJsonUrl?: string;
@@ -193,6 +198,8 @@ export type MapChart = {
     };
     tileBackground?: MapTileBackground;
     backgroundColor?: string;
+    // Field configuration (controls tooltip visibility and custom labels)
+    fieldConfig?: Record<string, MapFieldConfig>;
 };
 
 export enum FunnelChartDataInput {

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -1,5 +1,5 @@
 import { MapChartType } from '@lightdash/common';
-import { Box, Divider, Text, UnstyledButton } from '@mantine/core';
+import { Box, Divider, Stack, Text, UnstyledButton } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconMap } from '@tabler/icons-react';
 import { scaleSqrt } from 'd3-scale';
@@ -29,6 +29,7 @@ import * as topojson from 'topojson-client';
 import type { Topology } from 'topojson-specification';
 import useLeafletMapConfig, {
     type ScatterPoint,
+    type TooltipFieldInfo,
 } from '../../hooks/leaflet/useLeafletMapConfig';
 import useToaster from '../../hooks/toaster/useToaster';
 import { isMapVisualizationConfig } from '../LightdashVisualization/types';
@@ -41,92 +42,156 @@ import MapLegend from './MapLegend';
 // eslint-disable-next-line css-modules/no-unused-class
 import classes from './SimpleMap.module.css';
 
+// Helper to get formatted value from row data
+const getFormattedValue = (
+    rowData: Record<string, any>,
+    fieldId: string,
+): string => {
+    const field = rowData[fieldId];
+    if (!field) return '';
+    return field.value?.formatted ?? field.value?.raw ?? '';
+};
+
 // Shared tooltip content component
 type MapTooltipContentProps = {
-    label: string;
-    value: string | number;
+    tooltipFields: TooltipFieldInfo[];
+    rowData: Record<string, any>;
     lat?: number;
     lon?: number;
 };
 
 const MapTooltipContent: FC<MapTooltipContentProps> = ({
-    label,
-    value,
+    tooltipFields,
+    rowData,
     lat,
     lon,
-}) => (
-    <Box>
-        <Text size="sm">
-            <strong>{label}:</strong> {value}
-        </Text>
-        {lat !== undefined && lon !== undefined && (
-            <Text size="xs" c="dimmed" mt="sm">
-                Lat: {lat.toFixed(4)}, Lon: {lon.toFixed(4)}
-            </Text>
-        )}
-    </Box>
-);
+}) => {
+    const visibleFields = tooltipFields.filter((f) => f.visible);
+
+    // Using inline styles because this is rendered via renderToString
+    // and Mantine styles won't be applied
+    return (
+        <div style={{ padding: '4px 6px' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {visibleFields.map((field) => (
+                    <div key={field.fieldId} style={{ fontSize: 14 }}>
+                        <strong>{field.label}:</strong>{' '}
+                        {getFormattedValue(rowData, field.fieldId)}
+                    </div>
+                ))}
+            </div>
+            {lat !== undefined && lon !== undefined && (
+                <div
+                    style={{
+                        fontSize: 12,
+                        color: '#868e96',
+                        marginTop: 8,
+                    }}
+                >
+                    Lat: {lat.toFixed(4)}, Lon: {lon.toFixed(4)}
+                </div>
+            )}
+        </div>
+    );
+};
 
 // Shared popup content component
 type MapPopupContentProps = {
-    label: string;
-    value: string | number;
+    tooltipFields: TooltipFieldInfo[];
+    rowData: Record<string, any>;
     lat?: number;
     lon?: number;
     onCopy?: () => void;
 };
 
 const MapPopupContent: FC<MapPopupContentProps> = ({
-    label,
-    value,
+    tooltipFields,
+    rowData,
     lat,
     lon,
     onCopy,
-}) => (
-    // Force light mode colors since Leaflet popups always have white background
-    <Box mt="xl" c="dark.7">
-        <Text size="sm">
-            <strong>{label}:</strong> {value}
-        </Text>
-        {lat !== undefined && lon !== undefined && (
-            <Text size="xs" c="gray.6" mt="sm" mb="md">
-                Lat: {lat.toFixed(4)}, Lon: {lon.toFixed(4)}
-            </Text>
-        )}
-        <Divider my="xs" c="gray.3" />
-        <UnstyledButton
-            onClick={onCopy}
-            data-copy-value={value}
-            className={classes.popupActionButton}
-        >
-            <MantineIcon icon={IconCopy} />
-            <Text size="sm">Copy value</Text>
-        </UnstyledButton>
-    </Box>
-);
+}) => {
+    const visibleFields = tooltipFields.filter((f) => f.visible);
+    const hasMultipleFields = visibleFields.length > 1;
+
+    // Build copy value - CSV format for multiple fields, single value otherwise
+    const copyValue =
+        visibleFields.length > 0
+            ? hasMultipleFields
+                ? visibleFields
+                      .map((field) => getFormattedValue(rowData, field.fieldId))
+                      .join(', ')
+                : getFormattedValue(rowData, visibleFields[0].fieldId)
+            : '';
+
+    return (
+        // Force light mode colors since Leaflet popups always have white background
+        <Box mt="xl" c="dark.9">
+            <Stack spacing={2}>
+                {visibleFields.map((field) => (
+                    <Text key={field.fieldId} size="sm">
+                        <strong>{field.label}:</strong>{' '}
+                        {getFormattedValue(rowData, field.fieldId)}
+                    </Text>
+                ))}
+            </Stack>
+            {lat !== undefined && lon !== undefined && (
+                <Text size="xs" c="gray.6" mt="sm" mb="md">
+                    Lat: {lat.toFixed(4)}, Lon: {lon.toFixed(4)}
+                </Text>
+            )}
+            {copyValue && (
+                <>
+                    <Divider my="xs" c="gray.3" />
+                    <UnstyledButton
+                        onClick={onCopy}
+                        data-copy-value={copyValue}
+                        className={classes.popupActionButton}
+                    >
+                        <MantineIcon icon={IconCopy} />
+                        <Text size="sm">
+                            {hasMultipleFields ? 'Copy values' : 'Copy value'}
+                        </Text>
+                    </UnstyledButton>
+                </>
+            )}
+        </Box>
+    );
+};
 
 // MapMarker component for scatter points with tooltip/popup behavior
 type MapMarkerProps = {
     point: ScatterPoint;
     radius: number;
     color: string;
-    valueFieldLabel: string;
+    tooltipFields: TooltipFieldInfo[];
 };
 
 const MapMarker: FC<MapMarkerProps> = ({
     point,
     radius,
     color,
-    valueFieldLabel,
+    tooltipFields,
 }) => {
     const [isPopupOpen, setIsPopupOpen] = useState(false);
     const clipboard = useClipboard({ timeout: 200 });
     const { showToastSuccess } = useToaster();
 
     const handleCopy = useCallback(() => {
-        clipboard.copy(String(point.displayValue));
+        const visibleFields = tooltipFields.filter((f) => f.visible);
+        const copyValue =
+            visibleFields.length > 0
+                ? visibleFields.length > 1
+                    ? visibleFields
+                          .map((field) =>
+                              getFormattedValue(point.rowData, field.fieldId),
+                          )
+                          .join(', ')
+                    : getFormattedValue(point.rowData, visibleFields[0].fieldId)
+                : '';
+        clipboard.copy(copyValue);
         showToastSuccess({ title: 'Copied to clipboard!' });
-    }, [clipboard, point.displayValue, showToastSuccess]);
+    }, [clipboard, tooltipFields, point.rowData, showToastSuccess]);
 
     return (
         <CircleMarker
@@ -146,8 +211,8 @@ const MapMarker: FC<MapMarkerProps> = ({
             {!isPopupOpen && (
                 <Tooltip>
                     <MapTooltipContent
-                        label={valueFieldLabel}
-                        value={point.displayValue}
+                        tooltipFields={tooltipFields}
+                        rowData={point.rowData}
                         lat={point.lat}
                         lon={point.lon}
                     />
@@ -155,8 +220,8 @@ const MapMarker: FC<MapMarkerProps> = ({
             )}
             <Popup>
                 <MapPopupContent
-                    label={valueFieldLabel}
-                    value={point.displayValue}
+                    tooltipFields={tooltipFields}
+                    rowData={point.rowData}
                     lat={point.lat}
                     lon={point.lon}
                     onCopy={handleCopy}
@@ -485,9 +550,15 @@ const SimpleMap: FC<SimpleMapProps> = memo(
         );
 
         const regionDataMap = useMemo(() => {
-            const dataMap = new Map<string, number>();
+            const dataMap = new Map<
+                string,
+                { value: number; rowData?: Record<string, any> }
+            >();
             regionData.forEach((d) => {
-                dataMap.set(d.name.toLowerCase(), d.value);
+                dataMap.set(d.name.toLowerCase(), {
+                    value: d.value,
+                    rowData: d.rowData,
+                });
             });
             return dataMap;
         }, [regionData]);
@@ -516,11 +587,11 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     feature.properties.name?.toLowerCase() ||
                     feature.properties.NAME?.toLowerCase() ||
                     '';
-                const value = regionDataMap.get(name);
+                const regionEntry = regionDataMap.get(name);
 
-                if (value !== undefined) {
+                if (regionEntry !== undefined) {
                     const color = getColorForValue(
-                        value,
+                        regionEntry.value,
                         regionValueRange.min,
                         regionValueRange.max,
                         mapConfig.colors.scale,
@@ -551,20 +622,22 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     feature.properties?.name ||
                     feature.properties?.NAME ||
                     'Unknown';
-                const value = regionDataMap.get(name.toLowerCase());
+                const regionEntry = regionDataMap.get(name.toLowerCase());
+                const rowData = regionEntry?.rowData || {};
 
-                const valueLabel = mapConfig?.valueFieldLabel || 'Value';
-                const displayValue = value !== undefined ? value : 'No data';
                 // eslint-disable-next-line testing-library/render-result-naming-convention
                 const tooltipHtml = renderToString(
                     <MapTooltipContent
-                        label={valueLabel}
-                        value={displayValue}
+                        tooltipFields={mapConfig?.tooltipFields || []}
+                        rowData={rowData}
                     />,
                 );
                 // eslint-disable-next-line testing-library/render-result-naming-convention
                 const popupHtml = renderToString(
-                    <MapPopupContent label={valueLabel} value={displayValue} />,
+                    <MapPopupContent
+                        tooltipFields={mapConfig?.tooltipFields || []}
+                        rowData={rowData}
+                    />,
                 );
 
                 if (layer instanceof L.Path) {
@@ -609,7 +682,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     });
                 }
             },
-            [regionDataMap, mapConfig?.valueFieldLabel, handlePopupCopyClick],
+            [regionDataMap, mapConfig?.tooltipFields, handlePopupCopyClick],
         );
 
         if (isLoading) {
@@ -696,9 +769,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                                         point={point}
                                         radius={radius}
                                         color={color}
-                                        valueFieldLabel={
-                                            mapConfig.valueFieldLabel || 'Value'
-                                        }
+                                        tooltipFields={mapConfig.tooltipFields}
                                     />
                                 );
                             })

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapConfigTabs.tsx
@@ -12,17 +12,17 @@ export const ConfigTabs: FC = memo(() => {
     );
     return (
         <MantineProvider inherit theme={themeOverride}>
-            <Tabs defaultValue="layout" keepMounted={false}>
+            <Tabs defaultValue="general" keepMounted={false}>
                 <Tabs.List mb="sm">
-                    <Tabs.Tab px="sm" value="layout">
-                        Layout
+                    <Tabs.Tab px="sm" value="general">
+                        General
                     </Tabs.Tab>
                     <Tabs.Tab px="sm" value="display">
-                        Display
+                        Map display
                     </Tabs.Tab>
                 </Tabs.List>
 
-                <Tabs.Panel value="layout">
+                <Tabs.Panel value="general">
                     <Layout />
                 </Tabs.Panel>
 

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
@@ -109,6 +109,7 @@ export const Display: FC = memo(() => {
             setMinBubbleSize,
             setMaxBubbleSize,
             setSizeFieldId,
+            setValueFieldId,
             setHeatmapConfig,
             setTileBackground,
             setBackgroundColor,
@@ -146,9 +147,30 @@ export const Display: FC = memo(() => {
         <Stack>
             <Config>
                 <Config.Section>
-                    <Config.Heading>
+                    <Config.Heading>Colors</Config.Heading>
+                    {!isHeatmap && (
+                        <Config.Section>
+                            <FieldSelect
+                                label="Color based on"
+                                placeholder="Select field (optional)"
+                                item={valueField}
+                                items={availableFields}
+                                onChange={(newField) =>
+                                    setValueFieldId(
+                                        newField
+                                            ? getItemId(newField)
+                                            : undefined,
+                                    )
+                                }
+                                hasGrouping
+                                clearable
+                                mb="sm"
+                            />
+                        </Config.Section>
+                    )}
+                    <Config.Label>
                         {showColorRange ? 'Color range' : 'Color'}
-                    </Config.Heading>
+                    </Config.Label>
                     {showColorRange ? (
                         <Group spacing="xs" align="flex-start">
                             {colors.map((color, index) => {
@@ -203,62 +225,6 @@ export const Display: FC = memo(() => {
                                 );
                             }}
                         />
-                    )}
-                </Config.Section>
-            </Config>
-
-            <Config>
-                <Config.Section>
-                    <Config.Heading>Legend</Config.Heading>
-                    <Config.Group>
-                        <Config.Label>Show legend</Config.Label>
-                        <Switch
-                            checked={validConfig.showLegend ?? false}
-                            onChange={(e) =>
-                                setShowLegend(e.currentTarget.checked)
-                            }
-                        />
-                    </Config.Group>
-                </Config.Section>
-            </Config>
-
-            <Config>
-                <Config.Section>
-                    <Config.Heading>Background map</Config.Heading>
-                    <Select
-                        data={[
-                            { value: MapTileBackground.NONE, label: 'None' },
-
-                            { value: MapTileBackground.LIGHT, label: 'Light' },
-                            {
-                                value: MapTileBackground.OPENSTREETMAP,
-                                label: 'OpenStreetMap',
-                            },
-                            { value: MapTileBackground.DARK, label: 'Dark' },
-                            {
-                                value: MapTileBackground.SATELLITE,
-                                label: 'Satellite',
-                            },
-                        ]}
-                        value={
-                            validConfig.tileBackground ??
-                            MapTileBackground.LIGHT
-                        }
-                        onChange={(value) =>
-                            setTileBackground(
-                                (value as MapTileBackground) || undefined,
-                            )
-                        }
-                    />
-                    {isBackgroundNone && (
-                        <Config.Group>
-                            <Config.Label>Background color</Config.Label>
-                            <ColorSelector
-                                color={validConfig.backgroundColor ?? '#f3f3f3'}
-                                swatches={ECHARTS_DEFAULT_COLORS}
-                                onColorChange={setBackgroundColor}
-                            />
-                        </Config.Group>
                     )}
                 </Config.Section>
             </Config>
@@ -400,6 +366,61 @@ export const Display: FC = memo(() => {
                             }
                         />
                     </Config.Group>
+                </Config.Section>
+            </Config>
+
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Legend</Config.Heading>
+                    <Config.Group>
+                        <Config.Label>Show legend</Config.Label>
+                        <Switch
+                            checked={validConfig.showLegend ?? false}
+                            onChange={(e) =>
+                                setShowLegend(e.currentTarget.checked)
+                            }
+                        />
+                    </Config.Group>
+                </Config.Section>
+            </Config>
+
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Background map</Config.Heading>
+                    <Select
+                        data={[
+                            { value: MapTileBackground.NONE, label: 'None' },
+                            { value: MapTileBackground.LIGHT, label: 'Light' },
+                            {
+                                value: MapTileBackground.OPENSTREETMAP,
+                                label: 'OpenStreetMap',
+                            },
+                            { value: MapTileBackground.DARK, label: 'Dark' },
+                            {
+                                value: MapTileBackground.SATELLITE,
+                                label: 'Satellite',
+                            },
+                        ]}
+                        value={
+                            validConfig.tileBackground ??
+                            MapTileBackground.LIGHT
+                        }
+                        onChange={(value) =>
+                            setTileBackground(
+                                (value as MapTileBackground) || undefined,
+                            )
+                        }
+                    />
+                    {isBackgroundNone && (
+                        <Config.Group>
+                            <Config.Label>Background color</Config.Label>
+                            <ColorSelector
+                                color={validConfig.backgroundColor ?? '#f3f3f3'}
+                                swatches={ECHARTS_DEFAULT_COLORS}
+                                onColorChange={setBackgroundColor}
+                            />
+                        </Config.Group>
+                    )}
                 </Config.Section>
             </Config>
         </Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
@@ -1,0 +1,118 @@
+import { getItemLabelWithoutTableName } from '@lightdash/common';
+import { ActionIcon, Box, Group, TextInput, Tooltip } from '@mantine/core';
+import { useDebouncedState } from '@mantine/hooks';
+import { IconEye, IconEyeOff } from '@tabler/icons-react';
+import { useEffect, useState, type FC } from 'react';
+import { isMapVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import MantineIcon from '../../common/MantineIcon';
+
+type MapFieldConfigurationInputProps = {
+    fieldId: string;
+    defaultLabel: string;
+    labelOverride: string | undefined;
+    isVisible: boolean;
+    updateFieldConfig: (
+        fieldId: string,
+        config: { visible?: boolean; label?: string },
+    ) => void;
+};
+
+const MapFieldConfigurationInput: FC<MapFieldConfigurationInputProps> = ({
+    fieldId,
+    defaultLabel,
+    labelOverride,
+    isVisible,
+    updateFieldConfig,
+}) => {
+    const initialValue = labelOverride ?? defaultLabel;
+    const [debouncedValue, setValue] = useDebouncedState(initialValue, 300);
+
+    useEffect(() => {
+        // Only update if the debounced value differs from the current override
+        // This prevents unnecessary updates on initial render
+        const newLabel =
+            debouncedValue === defaultLabel ? undefined : debouncedValue;
+        if (newLabel !== labelOverride) {
+            updateFieldConfig(fieldId, { label: newLabel || undefined });
+        }
+    }, [
+        debouncedValue,
+        defaultLabel,
+        fieldId,
+        labelOverride,
+        updateFieldConfig,
+    ]);
+
+    return (
+        <TextInput
+            disabled={!isVisible}
+            placeholder={defaultLabel}
+            defaultValue={initialValue}
+            onChange={(e) => setValue(e.currentTarget.value)}
+        />
+    );
+};
+
+type MapFieldConfigurationProps = {
+    fieldId: string;
+};
+
+const MapFieldConfiguration: FC<MapFieldConfigurationProps> = ({ fieldId }) => {
+    const { visualizationConfig, itemsMap } = useVisualizationContext();
+    const [isTooltipVisible, setTooltipVisible] = useState(false);
+
+    if (!isMapVisualizationConfig(visualizationConfig) || !itemsMap) {
+        return null;
+    }
+
+    const { updateFieldConfig, isFieldVisible, getFieldLabel } =
+        visualizationConfig.chartConfig;
+
+    const item = itemsMap[fieldId];
+    if (!item) return null;
+
+    const defaultLabel = getItemLabelWithoutTableName(item);
+    const labelOverride = getFieldLabel(fieldId);
+    const isVisible = isFieldVisible(fieldId);
+
+    return (
+        <Group spacing="xs" noWrap style={{ flexGrow: 1 }}>
+            <Box style={{ flexGrow: 1 }}>
+                <MapFieldConfigurationInput
+                    fieldId={fieldId}
+                    defaultLabel={defaultLabel}
+                    labelOverride={labelOverride}
+                    isVisible={isVisible}
+                    updateFieldConfig={updateFieldConfig}
+                />
+            </Box>
+
+            <Tooltip
+                position="top"
+                opened={isTooltipVisible}
+                withinPortal
+                label={isVisible ? 'Hide in tooltip' : 'Show in tooltip'}
+            >
+                <Box
+                    onMouseEnter={() => setTooltipVisible(true)}
+                    onMouseLeave={() => setTooltipVisible(false)}
+                >
+                    <ActionIcon
+                        variant="light"
+                        onClick={() => {
+                            setTooltipVisible(false);
+                            updateFieldConfig(fieldId, {
+                                visible: !isVisible,
+                            });
+                        }}
+                    >
+                        <MantineIcon icon={isVisible ? IconEye : IconEyeOff} />
+                    </ActionIcon>
+                </Box>
+            </Tooltip>
+        </Group>
+    );
+};
+
+export default MapFieldConfiguration;

--- a/packages/frontend/src/hooks/useMapChartConfig.ts
+++ b/packages/frontend/src/hooks/useMapChartConfig.ts
@@ -5,6 +5,7 @@ import {
     MapTileBackground,
     type ItemsMap,
     type MapChart,
+    type MapFieldConfig,
 } from '@lightdash/common';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -50,6 +51,13 @@ type MapChartConfig = {
     ) => void;
     setTileBackground: (background: MapTileBackground | undefined) => void;
     setBackgroundColor: (color: string | undefined) => void;
+    // Field configuration methods
+    updateFieldConfig: (
+        fieldId: string,
+        config: Partial<MapFieldConfig>,
+    ) => void;
+    isFieldVisible: (fieldId: string) => boolean;
+    getFieldLabel: (fieldId: string) => string | undefined;
 };
 
 const useMapChartConfig = (
@@ -114,6 +122,9 @@ const useMapChartConfig = (
     const [backgroundColor, setBackgroundColorState] = useState<
         string | undefined
     >(initialConfig?.backgroundColor);
+    const [fieldConfig, setFieldConfigState] = useState<
+        Record<string, MapFieldConfig>
+    >(initialConfig?.fieldConfig ?? {});
 
     // Auto-fill latitude/longitude fields when switching to scatter mode
     useEffect(() => {
@@ -190,6 +201,7 @@ const useMapChartConfig = (
             heatmapConfig,
             tileBackground,
             backgroundColor,
+            fieldConfig,
         };
     }, [
         mapType,
@@ -211,6 +223,7 @@ const useMapChartConfig = (
         heatmapConfig,
         tileBackground,
         backgroundColor,
+        fieldConfig,
     ]);
 
     const defaultConfig: MapChart = useMemo(() => {
@@ -360,6 +373,33 @@ const useMapChartConfig = (
         setBackgroundColorState(color);
     }, []);
 
+    const updateFieldConfig = useCallback(
+        (fieldId: string, config: Partial<MapFieldConfig>) => {
+            setFieldConfigState((prev) => ({
+                ...prev,
+                [fieldId]: {
+                    ...prev[fieldId],
+                    ...config,
+                },
+            }));
+        },
+        [],
+    );
+
+    const isFieldVisible = useCallback(
+        (fieldId: string) => {
+            return fieldConfig[fieldId]?.visible !== false;
+        },
+        [fieldConfig],
+    );
+
+    const getFieldLabel = useCallback(
+        (fieldId: string) => {
+            return fieldConfig[fieldId]?.label;
+        },
+        [fieldConfig],
+    );
+
     return {
         chartType: ChartType.MAP,
         validConfig,
@@ -386,6 +426,9 @@ const useMapChartConfig = (
         setHeatmapConfig,
         setTileBackground,
         setBackgroundColor,
+        updateFieldConfig,
+        isFieldVisible,
+        getFieldLabel,
     };
 };
 


### PR DESCRIPTION
### Description:

This implements a customer request to show more fields in map popups and implements a few other things to make that more useful. 

Specifically:

- Shows all values on the query in tooltips and popovers
- Lets users rename and hide values
- Separates the field to color based on from the field to size bubbles based on
- Moves things around a bit in the config tabs

<img width="1020" height="671" alt="Screenshot 2025-12-29 at 19 17 19" src="https://github.com/user-attachments/assets/53241ce6-e81c-4838-bd36-8a4f583e6f90" />


