### PR TITLE
feat: update mantine modals on all things tabs

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/MoveTileToTabModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MoveTileToTabModal.tsx
@@ -1,31 +1,23 @@
 import { type Dashboard, type DashboardTab } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Select,
-    Stack,
-    Text,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, Select, Stack, Text, type ModalProps } from '@mantine-8/core';
 import { IconArrowAutofitContent } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
-import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
 
 type Tile = Dashboard['tiles'][number];
-type Props = ModalProps & {
+type Props = Pick<ModalProps, 'opened' | 'onClose' | 'className'> & {
     tile: Tile;
     tabs?: DashboardTab[];
     onConfirm: (tile: Tile) => void;
 };
 
 const MoveTileToTabModal: FC<Props> = ({
+    opened,
+    onClose,
     tabs,
     tile,
-    onClose,
     onConfirm,
-    ...modalProps
+    className,
 }) => {
     const [selectedTabId, setSelectedTabId] = useState<string | null>(null);
 
@@ -39,22 +31,21 @@ const MoveTileToTabModal: FC<Props> = ({
             });
         }
     }, [onConfirm, selectedTabId, tile]);
+
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        size="lg"
-                        color="blue.8"
-                        icon={IconArrowAutofitContent}
-                    />
-                    <Title order={4}>Move tile to another tab</Title>
-                </Group>
-            }
-            {...modalProps}
+        <MantineModal
+            opened={opened}
             onClose={onClose}
+            title="Move tile to another tab"
+            icon={IconArrowAutofitContent}
+            actions={
+                <Button onClick={handleConfirm} disabled={!selectedTabId}>
+                    Move
+                </Button>
+            }
+            modalRootProps={{ className }}
         >
-            <Stack spacing="lg" pt="sm">
+            <Stack gap="md">
                 {tabs && tabs.length ? (
                     <Select
                         label="Select tab to move this tile to"
@@ -66,24 +57,13 @@ const MoveTileToTabModal: FC<Props> = ({
                                 value: tab.uuid,
                                 label: tab.name,
                             }))}
-                        withinPortal
                         onChange={(value) => setSelectedTabId(value)}
                     />
                 ) : (
                     <Text>No tabs available</Text>
                 )}
-
-                <Group position="right" mt="sm">
-                    <Button variant="outline" onClick={onClose}>
-                        Cancel
-                    </Button>
-
-                    <Button onClick={handleConfirm} disabled={!selectedTabId}>
-                        Move
-                    </Button>
-                </Group>
             </Stack>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/features/dashboardTabs/AddTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabs/AddTabModal.tsx
@@ -1,67 +1,58 @@
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    TextInput,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, type ModalProps, Stack, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineModal from '../../components/common/MantineModal';
 
-type AddProps = ModalProps & {
+type AddTabModalProps = Pick<ModalProps, 'opened' | 'onClose'> & {
     onConfirm: (tabName: string) => void;
 };
 
-export const TabAddModal: FC<AddProps> = ({
+export const AddTabModal: FC<AddTabModalProps> = ({
+    opened,
     onClose,
     onConfirm,
-    ...modalProps
 }) => {
     const form = useForm<{ tabName: string }>();
 
-    const handleConfirm = form.onSubmit(({ ...tabProps }) => {
-        onConfirm(tabProps.tabName);
+    const handleConfirm = form.onSubmit(({ tabName }) => {
+        onConfirm(tabName);
         form.reset();
     });
 
     const handleClose = () => {
         form.reset();
-        onClose?.();
+        onClose();
     };
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <Title order={4}>Add new tab</Title>
-                </Group>
-            }
-            {...modalProps}
-            size="sm"
+        <MantineModal
+            opened={opened}
             onClose={handleClose}
+            title="Add new tab"
+            icon={IconPlus}
+            size="sm"
+            actions={
+                <Button
+                    type="submit"
+                    form="add-tab-form"
+                    disabled={!form.isValid()}
+                >
+                    Add
+                </Button>
+            }
         >
-            <form onSubmit={handleConfirm}>
-                <Stack spacing="lg" pt="sm">
+            <form id="add-tab-form" onSubmit={handleConfirm}>
+                <Stack gap="md">
                     <TextInput
                         label="Tab name"
                         placeholder="Name your tab"
                         data-autofocus
                         required
                         {...form.getInputProps('tabName')}
-                    ></TextInput>
-                    <Group position="right" mt="sm">
-                        <Button variant="outline" onClick={handleClose}>
-                            Cancel
-                        </Button>
-
-                        <Button type="submit" disabled={!form.isValid()}>
-                            Add
-                        </Button>
-                    </Group>
+                    />
                 </Stack>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/dashboardTabs/DuplicateTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabs/DuplicateTabModal.tsx
@@ -1,27 +1,21 @@
 import { type DashboardTab } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    TextInput,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, TextInput, type ModalProps } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
+import { IconCopy } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { z } from 'zod';
+import MantineModal from '../../components/common/MantineModal';
 
-type DuplicateTabModalProps = ModalProps & {
+type DuplicateTabModalProps = Pick<ModalProps, 'opened' | 'onClose'> & {
     tab: DashboardTab;
     onConfirm: (name: string) => void;
 };
 
 const DuplicateTabModal: FC<DuplicateTabModalProps> = ({
+    opened,
+    onClose,
     tab,
     onConfirm,
-    onClose,
-    ...modalProps
 }) => {
     const formSchema = z.object({
         name: z
@@ -45,42 +39,36 @@ const DuplicateTabModal: FC<DuplicateTabModalProps> = ({
 
     const handleClose = () => {
         form.reset();
-        onClose?.();
+        onClose();
     };
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <Title order={4}>Duplicate Tab</Title>
-                </Group>
-            }
-            {...modalProps}
-            size="sm"
+        <MantineModal
+            opened={opened}
             onClose={handleClose}
+            title="Duplicate Tab"
+            icon={IconCopy}
+            size="sm"
+            actions={
+                <Button
+                    type="submit"
+                    form="duplicate-tab-form"
+                    disabled={!form.isValid()}
+                >
+                    Create duplicate
+                </Button>
+            }
         >
-            <form onSubmit={handleConfirm}>
-                <Stack spacing="lg" pt="sm">
-                    <TextInput
-                        label="Tab name"
-                        required
-                        placeholder={`Copy of ${tab.name}`}
-                        data-autofocus
-                        {...form.getInputProps('name')}
-                    />
-
-                    <Group position="right" mt="sm">
-                        <Button variant="outline" onClick={handleClose}>
-                            Cancel
-                        </Button>
-
-                        <Button type="submit" disabled={!form.isValid()}>
-                            Create duplicate
-                        </Button>
-                    </Group>
-                </Stack>
+            <form id="duplicate-tab-form" onSubmit={handleConfirm}>
+                <TextInput
+                    label="Tab name"
+                    required
+                    placeholder={`Copy of ${tab.name}`}
+                    data-autofocus
+                    {...form.getInputProps('name')}
+                />
             </form>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/features/dashboardTabs/EditTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabs/EditTabModal.tsx
@@ -1,26 +1,20 @@
 import { type DashboardTab } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    TextInput,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, type ModalProps, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconPencil } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineModal from '../../components/common/MantineModal';
 
-type AddProps = ModalProps & {
+type EditProps = Pick<ModalProps, 'opened' | 'onClose'> & {
     tab: DashboardTab;
     onConfirm: (tabName: string, tabUuid: string) => void;
 };
 
-export const TabEditModal: FC<AddProps> = ({
-    tab,
+export const TabEditModal: FC<EditProps> = ({
+    opened,
     onClose,
+    tab,
     onConfirm,
-    ...modalProps
 }) => {
     const form = useForm<{ newTabName: string }>({
         initialValues: {
@@ -28,47 +22,42 @@ export const TabEditModal: FC<AddProps> = ({
         },
     });
 
-    const handleConfirm = form.onSubmit(({ ...tabProps }) => {
-        onConfirm(tabProps.newTabName, tab.uuid);
+    const handleConfirm = form.onSubmit(({ newTabName }) => {
+        onConfirm(newTabName, tab.uuid);
         form.reset();
     });
 
     const handleClose = () => {
         form.reset();
-        onClose?.();
+        onClose();
     };
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <Title order={4}>Edit your tab</Title>
-                </Group>
-            }
-            {...modalProps}
-            size="sm"
+        <MantineModal
+            opened={opened}
             onClose={handleClose}
+            title="Edit your tab"
+            icon={IconPencil}
+            size="sm"
+            actions={
+                <Button
+                    type="submit"
+                    form="edit-tab-form"
+                    disabled={!form.isValid()}
+                >
+                    Update
+                </Button>
+            }
         >
-            <form onSubmit={handleConfirm}>
-                <Stack spacing="lg" pt="sm">
-                    <TextInput
-                        label="Tab name"
-                        placeholder="Name your tab"
-                        data-autofocus
-                        required
-                        {...form.getInputProps('newTabName')}
-                    ></TextInput>
-                    <Group position="right" mt="sm">
-                        <Button variant="outline" onClick={handleClose}>
-                            Cancel
-                        </Button>
-
-                        <Button type="submit" disabled={!form.isValid()}>
-                            Update
-                        </Button>
-                    </Group>
-                </Stack>
+            <form id="edit-tab-form" onSubmit={handleConfirm}>
+                <TextInput
+                    label="Tab name"
+                    placeholder="Name your tab"
+                    data-autofocus
+                    required
+                    {...form.getInputProps('newTabName')}
+                />
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -18,7 +18,7 @@ import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import { TrackSection } from '../../providers/Tracking/TrackingProvider';
 import '../../styles/droppable.css';
 import { SectionName } from '../../types/Events';
-import { TabAddModal } from './AddTabModal';
+import { AddTabModal } from './AddTabModal';
 import { TabDeleteModal } from './DeleteTabModal';
 import DuplicateTabModal from './DuplicateTabModal';
 import { TabEditModal } from './EditTabModal';
@@ -531,7 +531,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                         dashboardTabs={dashboardTabs}
                                     />
                                 )}
-                                <TabAddModal
+                                <AddTabModal
                                     onClose={() => setAddingTab(false)}
                                     opened={addingTab}
                                     onConfirm={(name) => {

--- a/packages/frontend/src/features/dashboardTabsV2/AddTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/AddTabModal.tsx
@@ -1,67 +1,54 @@
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    TextInput,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, Stack, TextInput, type ModalProps } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineModal from '../../components/common/MantineModal';
 
-type AddProps = ModalProps & {
+type AddProps = Pick<ModalProps, 'opened' | 'onClose'> & {
     onConfirm: (tabName: string) => void;
 };
 
-export const TabAddModal: FC<AddProps> = ({
-    onClose,
-    onConfirm,
-    ...modalProps
-}) => {
+export const AddTabModal: FC<AddProps> = ({ opened, onClose, onConfirm }) => {
     const form = useForm<{ tabName: string }>();
 
-    const handleConfirm = form.onSubmit(({ ...tabProps }) => {
-        onConfirm(tabProps.tabName);
+    const handleConfirm = form.onSubmit(({ tabName }) => {
+        onConfirm(tabName);
         form.reset();
     });
 
     const handleClose = () => {
         form.reset();
-        onClose?.();
+        onClose();
     };
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <Title order={4}>Add new tab</Title>
-                </Group>
-            }
-            {...modalProps}
-            size="sm"
+        <MantineModal
+            opened={opened}
             onClose={handleClose}
+            title="Add new tab"
+            icon={IconPlus}
+            size="sm"
+            actions={
+                <Button
+                    type="submit"
+                    form="add-tab-form"
+                    disabled={!form.isValid()}
+                >
+                    Add
+                </Button>
+            }
         >
-            <form onSubmit={handleConfirm}>
-                <Stack spacing="lg" pt="sm">
+            <form id="add-tab-form" onSubmit={handleConfirm}>
+                <Stack gap="md">
                     <TextInput
                         label="Tab name"
                         placeholder="Name your tab"
                         data-autofocus
                         required
                         {...form.getInputProps('tabName')}
-                    ></TextInput>
-                    <Group position="right" mt="sm">
-                        <Button variant="outline" onClick={handleClose}>
-                            Cancel
-                        </Button>
-
-                        <Button type="submit" disabled={!form.isValid()}>
-                            Add
-                        </Button>
-                    </Group>
+                    />
                 </Stack>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/dashboardTabsV2/DeleteTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/DeleteTabModal.tsx
@@ -6,25 +6,22 @@ import {
     type DashboardTile,
 } from '@lightdash/common';
 import {
-    Alert,
     Button,
-    Group,
     List,
-    Modal,
     Radio,
     Select,
     Stack,
     Text,
-    Title,
     type ModalProps,
-} from '@mantine/core';
-import { IconAlertCircle, IconTrash } from '@tabler/icons-react';
+} from '@mantine-8/core';
+import { IconTrash } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
-import MantineIcon from '../../components/common/MantineIcon';
+import Callout from '../../components/common/Callout';
+import MantineModal from '../../components/common/MantineModal';
 import { useDashboardSchedulers } from '../../features/scheduler/hooks/useDashboardSchedulers';
 import useToaster from '../../hooks/toaster/useToaster';
 
-type AddProps = ModalProps & {
+type DeleteProps = ModalProps & {
     tab: DashboardTab;
     dashboardTiles: DashboardTile[] | undefined;
     dashboardTabs: DashboardTab[] | undefined;
@@ -38,15 +35,15 @@ enum RemoveActions {
     DELETE = 'delete',
 }
 
-export const TabDeleteModal: FC<AddProps> = ({
+export const TabDeleteModal: FC<DeleteProps> = ({
+    opened,
+    onClose,
     tab,
     dashboardTiles,
     dashboardTabs,
     dashboardUuid,
-    onClose: handleClose,
-    onDeleteTab: handleDeleteTab,
-    onMoveTile: handleMoveTile,
-    ...modalProps
+    onDeleteTab,
+    onMoveTile,
 }) => {
     const [removeAction, setRemoveAction] = useState('move');
     const [destinationTabId, setDestinationTabId] = useState<
@@ -76,7 +73,7 @@ export const TabDeleteModal: FC<AddProps> = ({
     );
 
     useEffect(() => {
-        if (modalProps.opened) {
+        if (opened) {
             setRemoveAction(RemoveActions.MOVE);
             const destinationTab =
                 destinationTabs.length === 1
@@ -84,7 +81,7 @@ export const TabDeleteModal: FC<AddProps> = ({
                     : undefined;
             setDestinationTabId(destinationTab);
         }
-    }, [modalProps.opened, destinationTabs]);
+    }, [opened, destinationTabs]);
 
     const { showToastSuccess } = useToaster();
 
@@ -106,12 +103,12 @@ export const TabDeleteModal: FC<AddProps> = ({
     );
 
     const handleSubmit = useCallback(() => {
-        handleClose();
+        onClose();
         const numTiles = tilesToRemove.length || 0;
         let toastMessage = '';
         if (removeAction === RemoveActions.MOVE) {
             tilesToRemove.forEach((tile) => {
-                handleMoveTile({
+                onMoveTile({
                     ...tile,
                     x: 0,
                     y: 0,
@@ -124,60 +121,72 @@ export const TabDeleteModal: FC<AddProps> = ({
         } else {
             toastMessage = `Tab "${tab.name}" was removed and ${numTiles} tile${pluralTiles} deleted.`;
         }
-        handleDeleteTab(tab.uuid);
+        onDeleteTab(tab.uuid);
         showToastSuccess({ title: toastMessage });
     }, [
-        handleClose,
+        onClose,
         tilesToRemove,
         removeAction,
-        handleDeleteTab,
+        onDeleteTab,
         tab.uuid,
         tab.name,
         showToastSuccess,
         pluralTiles,
-        handleMoveTile,
+        onMoveTile,
         destinationTabId,
     ]);
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <MantineIcon icon={IconTrash} color="red" size="lg" />
-                    <Title order={4}>Remove tab</Title>
-                </Group>
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Remove tab"
+            icon={IconTrash}
+            actions={
+                <Button
+                    color={
+                        removeAction === RemoveActions.DELETE
+                            ? 'red'
+                            : undefined
+                    }
+                    disabled={
+                        removeAction === RemoveActions.MOVE && !destinationTabId
+                    }
+                    onClick={handleSubmit}
+                >
+                    {removeAction === RemoveActions.MOVE
+                        ? 'Transfer'
+                        : 'Delete tiles'}
+                </Button>
             }
-            {...modalProps}
-            onClose={handleClose}
         >
-            <Stack spacing="lg" pt="sm">
+            <Stack gap="md">
                 <Text>
                     What would you like to do with the tiles in this tab before
                     removing it?
                 </Text>
                 <Radio.Group
-                    size="xs"
                     value={removeAction}
-                    onChange={(val: RemoveActions) => setRemoveAction(val)}
+                    onChange={(val: string) => setRemoveAction(val)}
                 >
-                    <Stack spacing="xs" mt={0}>
+                    <Stack gap="xs" mt={0}>
                         <Radio
                             label="Delete all tiles in this tab"
                             value={RemoveActions.DELETE}
-                            styles={(theme) => ({
+                            styles={{
                                 label: {
-                                    paddingLeft: theme.spacing.xs,
+                                    paddingLeft: 'var(--mantine-spacing-xs)',
                                 },
-                            })}
+                            }}
                         />
                         <Radio
                             label="Transfer all tiles to another tab"
                             value={RemoveActions.MOVE}
-                            styles={(theme) => ({
+                            styles={{
                                 label: {
-                                    paddingLeft: theme.spacing.xs,
+                                    paddingLeft: 'var(--mantine-spacing-xs)',
                                 },
-                            })}
+                            }}
                         />
                         {dashboardTabs?.length &&
                             removeAction === RemoveActions.MOVE && (
@@ -191,24 +200,23 @@ export const TabDeleteModal: FC<AddProps> = ({
                                         value: otherTab.uuid,
                                         label: otherTab.name,
                                     }))}
-                                    withinPortal
-                                    styles={(theme) => ({
+                                    styles={{
                                         root: {
-                                            paddingLeft: theme.spacing.xl,
+                                            paddingLeft:
+                                                'var(--mantine-spacing-xl)',
                                         },
-                                    })}
+                                    }}
                                 />
                             )}
                     </Stack>
                 </Radio.Group>
 
                 {affectedSchedulers.length > 0 && (
-                    <Alert
-                        color="orange"
-                        icon={<IconAlertCircle size={16} />}
+                    <Callout
+                        variant="warning"
                         title="Warning: Scheduled deliveries affected"
                     >
-                        <Stack spacing="xs">
+                        <Stack gap="xs">
                             <Text size="sm">
                                 This tab is currently used by{' '}
                                 <Text fw={600} span>
@@ -228,7 +236,7 @@ export const TabDeleteModal: FC<AddProps> = ({
                                 ))}
                             </List>
                         </Stack>
-                    </Alert>
+                    </Callout>
                 )}
 
                 {removeAction === RemoveActions.DELETE && (
@@ -239,7 +247,7 @@ export const TabDeleteModal: FC<AddProps> = ({
                             <b>{tilesToRemove?.length}</b> tile{pluralTiles}?
                         </Text>
                         {newSavedCharts.length > 0 && (
-                            <Group spacing="xs">
+                            <Stack gap="xs">
                                 <Text>
                                     On save, this action will also permanently
                                     delete the following
@@ -257,35 +265,11 @@ export const TabDeleteModal: FC<AddProps> = ({
                                         </List.Item>
                                     ))}
                                 </List>
-                            </Group>
+                            </Stack>
                         )}
                     </>
                 )}
-
-                <Group position="right" mt="sm">
-                    <Button variant="outline" onClick={handleClose}>
-                        Cancel
-                    </Button>
-
-                    <Button
-                        type="submit"
-                        color={
-                            removeAction === RemoveActions.DELETE
-                                ? 'red'
-                                : 'unset'
-                        }
-                        disabled={
-                            removeAction === RemoveActions.MOVE &&
-                            !destinationTabId
-                        }
-                        onClick={handleSubmit}
-                    >
-                        {removeAction === RemoveActions.MOVE
-                            ? 'Transfer'
-                            : 'Delete tiles'}
-                    </Button>
-                </Group>
             </Stack>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/dashboardTabsV2/DuplicateTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/DuplicateTabModal.tsx
@@ -1,16 +1,10 @@
 import { type DashboardTab } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    TextInput,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, TextInput, type ModalProps } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
+import { IconCopy } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { z } from 'zod';
+import MantineModal from '../../components/common/MantineModal';
 
 type DuplicateTabModalProps = ModalProps & {
     tab: DashboardTab;
@@ -18,10 +12,10 @@ type DuplicateTabModalProps = ModalProps & {
 };
 
 const DuplicateTabModal: FC<DuplicateTabModalProps> = ({
+    opened,
+    onClose,
     tab,
     onConfirm,
-    onClose,
-    ...modalProps
 }) => {
     const formSchema = z.object({
         name: z
@@ -45,42 +39,36 @@ const DuplicateTabModal: FC<DuplicateTabModalProps> = ({
 
     const handleClose = () => {
         form.reset();
-        onClose?.();
+        onClose();
     };
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <Title order={4}>Duplicate Tab</Title>
-                </Group>
-            }
-            {...modalProps}
-            size="sm"
+        <MantineModal
+            opened={opened}
             onClose={handleClose}
+            title="Duplicate Tab"
+            icon={IconCopy}
+            size="sm"
+            actions={
+                <Button
+                    type="submit"
+                    form="duplicate-tab-form"
+                    disabled={!form.isValid()}
+                >
+                    Create duplicate
+                </Button>
+            }
         >
-            <form onSubmit={handleConfirm}>
-                <Stack spacing="lg" pt="sm">
-                    <TextInput
-                        label="Tab name"
-                        required
-                        placeholder={`Copy of ${tab.name}`}
-                        data-autofocus
-                        {...form.getInputProps('name')}
-                    />
-
-                    <Group position="right" mt="sm">
-                        <Button variant="outline" onClick={handleClose}>
-                            Cancel
-                        </Button>
-
-                        <Button type="submit" disabled={!form.isValid()}>
-                            Create duplicate
-                        </Button>
-                    </Group>
-                </Stack>
+            <form id="duplicate-tab-form" onSubmit={handleConfirm}>
+                <TextInput
+                    label="Tab name"
+                    required
+                    placeholder={`Copy of ${tab.name}`}
+                    data-autofocus
+                    {...form.getInputProps('name')}
+                />
             </form>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/features/dashboardTabsV2/EditTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/EditTabModal.tsx
@@ -1,26 +1,22 @@
 import { type DashboardTab } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    TextInput,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconPencil } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineModal from '../../components/common/MantineModal';
 
-type AddProps = ModalProps & {
+type EditProps = {
+    opened: boolean;
+    onClose: () => void;
     tab: DashboardTab;
     onConfirm: (tabName: string, tabUuid: string) => void;
 };
 
-export const TabEditModal: FC<AddProps> = ({
-    tab,
+export const TabEditModal: FC<EditProps> = ({
+    opened,
     onClose,
+    tab,
     onConfirm,
-    ...modalProps
 }) => {
     const form = useForm<{ newTabName: string }>({
         initialValues: {
@@ -28,47 +24,42 @@ export const TabEditModal: FC<AddProps> = ({
         },
     });
 
-    const handleConfirm = form.onSubmit(({ ...tabProps }) => {
-        onConfirm(tabProps.newTabName, tab.uuid);
+    const handleConfirm = form.onSubmit(({ newTabName }) => {
+        onConfirm(newTabName, tab.uuid);
         form.reset();
     });
 
     const handleClose = () => {
         form.reset();
-        onClose?.();
+        onClose();
     };
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <Title order={4}>Edit your tab</Title>
-                </Group>
-            }
-            {...modalProps}
-            size="sm"
+        <MantineModal
+            opened={opened}
             onClose={handleClose}
+            title="Edit your tab"
+            icon={IconPencil}
+            size="sm"
+            actions={
+                <Button
+                    type="submit"
+                    form="edit-tab-form"
+                    disabled={!form.isValid()}
+                >
+                    Update
+                </Button>
+            }
         >
-            <form onSubmit={handleConfirm}>
-                <Stack spacing="lg" pt="sm">
-                    <TextInput
-                        label="Tab name"
-                        placeholder="Name your tab"
-                        data-autofocus
-                        required
-                        {...form.getInputProps('newTabName')}
-                    ></TextInput>
-                    <Group position="right" mt="sm">
-                        <Button variant="outline" onClick={handleClose}>
-                            Cancel
-                        </Button>
-
-                        <Button type="submit" disabled={!form.isValid()}>
-                            Update
-                        </Button>
-                    </Group>
-                </Stack>
+            <form id="edit-tab-form" onSubmit={handleConfirm}>
+                <TextInput
+                    label="Tab name"
+                    placeholder="Name your tab"
+                    data-autofocus
+                    required
+                    {...form.getInputProps('newTabName')}
+                />
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -27,7 +27,7 @@ import { SectionName } from '../../types/Events';
 import { DashboardFiltersBar } from '../dashboardFiltersV2/DashboardFiltersBar';
 import { DashboardFiltersBarSummary } from '../dashboardFiltersV2/DashboardFiltersBarSummary';
 import { doesFilterApplyToTile } from '../dashboardFiltersV2/FilterConfiguration/utils';
-import { TabAddModal } from './AddTabModal';
+import { AddTabModal } from './AddTabModal';
 import { TabDeleteModal } from './DeleteTabModal';
 import DuplicateTabModal from './DuplicateTabModal';
 import { TabEditModal } from './EditTabModal';
@@ -703,7 +703,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                         dashboardTabs={dashboardTabs}
                                     />
                                 )}
-                                <TabAddModal
+                                <AddTabModal
                                     onClose={() => setAddingTab(false)}
                                     opened={addingTab}
                                     onConfirm={(name) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Refactored modal components across dashboard tabs to use the new `MantineModal` component, which provides a consistent UI with standardized actions and layout. This update:

- Migrated from `@mantine/core` to `@mantine-8/core` for all tab-related modals
- Replaced custom modal headers with the standardized `MantineModal` title and icon props
- Moved action buttons from the modal body to the dedicated `actions` prop
- Simplified form handling with form IDs and submit buttons
- Standardized prop types to only include necessary modal properties
- Improved spacing with the new Mantine 8 gap system
- Replaced `Alert` components with the `Callout` component

![Screenshot 2025-12-29 at 22.03.12.png](https://app.graphite.com/user-attachments/assets/240d28d2-fe8b-4212-91d2-8d5fd8018093.png)

![Screenshot 2025-12-29 at 22.07.40.png](https://app.graphite.com/user-attachments/assets/3e984bcf-ce02-45a3-9f99-454f48bbf4e7.png)

![Screenshot 2025-12-29 at 22.07.15.png](https://app.graphite.com/user-attachments/assets/391b2943-bbe9-4ab7-b76c-41bc45d255ca.png)

![Screenshot 2025-12-29 at 22.03.32.png](https://app.graphite.com/user-attachments/assets/19c1c9b4-7fcd-4fc5-a4db-fd5a9878b403.png)

