### PR TITLE
feat: update mantine modal on tiles modals

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -1,25 +1,17 @@
 import {
+    assertUnreachable,
     ChartKind,
     ChartSourceType,
     DashboardTileTypes,
-    assertUnreachable,
     defaultTileSize,
     type ChartContent,
     type Dashboard,
 } from '@lightdash/common';
+import { Button, Group, Loader, Stack, Text, Tooltip } from '@mantine-8/core';
 import {
-    Button,
-    Flex,
-    Group,
-    Loader,
-    Modal,
+    getDefaultZIndex,
     MultiSelect,
     ScrollArea,
-    Stack,
-    Text,
-    Title,
-    Tooltip,
-    getDefaultZIndex,
     type ScrollAreaProps,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
@@ -38,7 +30,7 @@ import { useParams } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
 import { useChartSummariesV2 } from '../../../hooks/useChartSummariesV2';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
-import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
 import { ChartIcon } from '../../common/ResourceIcon';
 
 type Props = {
@@ -67,14 +59,14 @@ const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
         ref,
     ) => (
         <div ref={ref} {...others}>
-            <Stack spacing="one">
+            <Stack gap="1">
                 <Tooltip
                     label={tooltipLabel}
                     disabled={!tooltipLabel}
                     position="top-start"
                     withinPortal
                 >
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <ChartIcon
                             chartKind={chartKind ?? ChartKind.VERTICAL_BAR}
                             color={disabled ? 'ldGray.5' : undefined}
@@ -236,127 +228,107 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
     if (!savedQueries || !dashboardTiles || isInitialLoading) return null;
 
     return (
-        <Modal
-            size="lg"
-            opened={true}
+        <MantineModal
+            opened
             onClose={onClose}
-            title={
-                <Flex align="center" gap="xs">
-                    <MantineIcon
-                        icon={IconChartAreaLine}
-                        size="lg"
-                        color="blue.6"
-                    />
-
-                    <Title order={4}>Add saved charts</Title>
-                </Flex>
-            }
-            withCloseButton
-            closeOnClickOutside={false}
-        >
-            <Stack spacing="md">
-                <form
-                    id="add-saved-charts-to-dashboard"
-                    onSubmit={handleSubmit}
+            title="Add saved charts"
+            icon={IconChartAreaLine}
+            size="lg"
+            modalRootProps={{ closeOnClickOutside: false }}
+            actions={
+                <Button
+                    type="submit"
+                    form="add-saved-charts-to-dashboard"
+                    disabled={
+                        isInitialLoading ||
+                        form.values.savedChartsUuids.length === 0
+                    }
                 >
-                    <MultiSelect
-                        styles={(theme) => ({
-                            separator: {
-                                position: 'sticky',
-                                top: 0,
-                                backgroundColor:
-                                    theme.colorScheme === 'dark'
-                                        ? 'var(--mantine-color-dark-6)'
-                                        : 'var(--mantine-color-white)',
-                                zIndex: getDefaultZIndex('modal'),
-                            },
-                            separatorLabel: {
-                                color: theme.colors.ldGray[6],
-                                fontWeight: 500,
-                                backgroundColor:
-                                    theme.colorScheme === 'dark'
-                                        ? 'var(--mantine-color-dark-6)'
-                                        : 'var(--mantine-color-white)',
-                            },
-                            item: {
-                                paddingTop: 4,
-                                paddingBottom: 4,
-                            },
-                        })}
-                        id="saved-charts"
-                        label={`Select the charts you want to add to this dashboard`}
-                        data={allSavedCharts}
-                        disabled={isInitialLoading}
-                        defaultValue={[]}
-                        placeholder="Search..."
-                        required
-                        searchable
-                        withinPortal
-                        itemComponent={SelectItem}
-                        nothingFound="No charts found"
-                        clearable
-                        clearSearchOnChange
-                        clearSearchOnBlur
-                        searchValue={searchQuery}
-                        onSearchChange={setSearchQuery}
-                        maxDropdownHeight={300}
-                        rightSection={
-                            isFetching && <Loader size="xs" color="gray" />
-                        }
-                        dropdownComponent={({
-                            children,
-                            ...rest
-                        }: ScrollAreaProps) => (
-                            <ScrollArea {...rest} viewportRef={selectScrollRef}>
-                                <>
-                                    {children}
-                                    {hasNextPage && (
-                                        <Button
-                                            size="xs"
-                                            variant="white"
-                                            onClick={async () => {
-                                                await fetchNextPage();
-                                            }}
-                                            disabled={isFetching}
-                                        >
-                                            <Text>Load more</Text>
-                                        </Button>
-                                    )}
-                                </>
-                            </ScrollArea>
-                        )}
-                        filter={(searchString, selected, item) => {
-                            return Boolean(
-                                selected ||
-                                    item.label
-                                        ?.toLowerCase()
-                                        .includes(searchString.toLowerCase()),
-                            );
-                        }}
-                        {...form.getInputProps('savedChartsUuids')}
-                    />
-                    <Group spacing="xs" position="right" mt="md">
-                        <Button
-                            onClick={() => {
-                                if (onClose) onClose();
-                            }}
-                            variant="outline"
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            type="submit"
-                            disabled={
-                                isInitialLoading ||
-                                form.values.savedChartsUuids.length === 0
-                            }
-                        >
-                            Add
-                        </Button>
-                    </Group>
-                </form>
-            </Stack>
-        </Modal>
+                    Add
+                </Button>
+            }
+        >
+            <form id="add-saved-charts-to-dashboard" onSubmit={handleSubmit}>
+                <MultiSelect
+                    radius="md"
+                    styles={(theme) => ({
+                        separator: {
+                            position: 'sticky',
+                            top: 0,
+                            backgroundColor:
+                                theme.colorScheme === 'dark'
+                                    ? 'var(--mantine-color-dark-6)'
+                                    : 'var(--mantine-color-white)',
+                            zIndex: getDefaultZIndex('modal'),
+                        },
+                        separatorLabel: {
+                            color: theme.colors.ldGray[6],
+                            fontWeight: 500,
+                            backgroundColor:
+                                theme.colorScheme === 'dark'
+                                    ? 'var(--mantine-color-dark-6)'
+                                    : 'var(--mantine-color-white)',
+                        },
+                        item: {
+                            paddingTop: 4,
+                            paddingBottom: 4,
+                        },
+                    })}
+                    id="saved-charts"
+                    label={`Select the charts you want to add to this dashboard`}
+                    data={allSavedCharts}
+                    disabled={isInitialLoading}
+                    defaultValue={[]}
+                    placeholder="Search..."
+                    required
+                    searchable
+                    withinPortal
+                    itemComponent={SelectItem}
+                    nothingFound="No charts found"
+                    clearable
+                    clearSearchOnChange
+                    clearSearchOnBlur
+                    searchValue={searchQuery}
+                    onSearchChange={setSearchQuery}
+                    maxDropdownHeight={300}
+                    rightSection={
+                        isFetching && <Loader size="xs" color="gray" />
+                    }
+                    dropdownComponent={({
+                        children,
+                        ...rest
+                    }: ScrollAreaProps) => (
+                        <ScrollArea {...rest} viewportRef={selectScrollRef}>
+                            <>
+                                {children}
+                                {hasNextPage && (
+                                    <Button
+                                        size="xs"
+                                        variant="subtle"
+                                        fullWidth
+                                        onClick={async () => {
+                                            await fetchNextPage();
+                                        }}
+                                        disabled={isFetching}
+                                    >
+                                        Load more
+                                    </Button>
+                                )}
+                            </>
+                        </ScrollArea>
+                    )}
+                    filter={(searchString, selected, item) => {
+                        return Boolean(
+                            selected ||
+                                item.label
+                                    ?.toLowerCase()
+                                    .includes(searchString.toLowerCase()),
+                        );
+                    }}
+                    {...form.getInputProps('savedChartsUuids')}
+                />
+            </form>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/components/DashboardTiles/TileForms/MoveTileToTabModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MoveTileToTabModal.tsx
@@ -1,5 +1,5 @@
 import { type Dashboard, type DashboardTab } from '@lightdash/common';
-import { Button, Select, Stack, Text, type ModalProps } from '@mantine-8/core';
+import { Button, Select, Text, type ModalProps } from '@mantine-8/core';
 import { IconArrowAutofitContent } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import MantineModal from '../../common/MantineModal';
@@ -45,24 +45,22 @@ const MoveTileToTabModal: FC<Props> = ({
             }
             modalRootProps={{ className }}
         >
-            <Stack gap="md">
-                {tabs && tabs.length ? (
-                    <Select
-                        label="Select tab to move this tile to"
-                        value={selectedTabId}
-                        placeholder="Pick a tab"
-                        data={tabs
-                            .filter((tab) => tab.uuid !== tile.tabUuid)
-                            .map((tab) => ({
-                                value: tab.uuid,
-                                label: tab.name,
-                            }))}
-                        onChange={(value) => setSelectedTabId(value)}
-                    />
-                ) : (
-                    <Text>No tabs available</Text>
-                )}
-            </Stack>
+            {tabs && tabs.length ? (
+                <Select
+                    label="Select tab to move this tile to"
+                    value={selectedTabId}
+                    placeholder="Pick a tab"
+                    data={tabs
+                        .filter((tab) => tab.uuid !== tile.tabUuid)
+                        .map((tab) => ({
+                            value: tab.uuid,
+                            label: tab.name,
+                        }))}
+                    onChange={(value) => setSelectedTabId(value)}
+                />
+            ) : (
+                <Text>No tabs available</Text>
+            )}
         </MantineModal>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #migration-to-mantine-8

### Description:
This PR migrates the dashboard tile modals to use the new Mantine 8 components and MantineModal. The changes include:

- Replaced Modal with MantineModal across all tile-related modals
- Updated form layouts to use the new Mantine 8 component structure
- Improved button styling and positioning in modals
- Simplified modal actions by using the actions prop in MantineModal
- Standardized form IDs to enable form submission from modal actions
- Improved "Load more" button styling in dropdowns
- Refactored icon handling to use useMemo instead of useCallback
- Removed unnecessary Stack wrappers and simplified component structure

![Screenshot 2025-12-29 at 22.33.37.png](https://app.graphite.com/user-attachments/assets/293a5402-f308-4358-8ee4-cc5adda72271.png)

![Screenshot 2025-12-29 at 22.40.56.png](https://app.graphite.com/user-attachments/assets/0800422f-43ed-4ee2-a729-3c8d68e99693.png)

![Screenshot 2025-12-29 at 22.34.16.png](https://app.graphite.com/user-attachments/assets/9f3005c8-e286-4d49-bff2-93553dc23ddb.png)

![Screenshot 2025-12-29 at 22.34.10.png](https://app.graphite.com/user-attachments/assets/74308f84-4a13-41da-95d6-ab657b8efe52.png)

![Screenshot 2025-12-29 at 22.34.06.png](https://app.graphite.com/user-attachments/assets/7d34f096-61f1-4970-8514-65e8f36ef718.png)

![Screenshot 2025-12-29 at 22.33.53.png](https://app.graphite.com/user-attachments/assets/5a423240-a66d-4a05-97c8-718b5696bc63.png)

