### PR TITLE
feat: update various modals to MantineModal

### DIFF
--- a/packages/frontend/src/components/JsonViewerModal.tsx
+++ b/packages/frontend/src/components/JsonViewerModal.tsx
@@ -1,19 +1,19 @@
 import {
-    ActionIcon,
-    Box,
+    Button,
     CopyButton,
-    Modal,
+    Group,
+    ScrollArea,
     Stack,
-    Title,
     Tooltip,
-} from '@mantine/core';
-import { type ModalRootProps } from '@mantine/core/lib/Modal/ModalRoot/ModalRoot';
-import { IconCheck, IconCopy } from '@tabler/icons-react';
+    type ModalProps,
+} from '@mantine-8/core';
+import { IconCheck, IconCode, IconCopy } from '@tabler/icons-react';
 import ReactJson from 'react-json-view';
 import { useRjvTheme } from '../hooks/useRjvTheme';
 import MantineIcon from './common/MantineIcon';
+import MantineModal from './common/MantineModal';
 
-type Props = ModalRootProps & {
+type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
     heading: string;
     jsonObject: Record<string, unknown>;
 };
@@ -26,44 +26,49 @@ export const JsonViewerModal = ({
 }: Props) => {
     const theme = useRjvTheme();
     return (
-        <Modal
+        <MantineModal
             opened={opened}
             onClose={onClose}
-            title={<Title order={4}>{heading}</Title>}
+            title={heading}
+            icon={IconCode}
+            cancelLabel={false}
         >
             <Stack>
-                <Box
-                    sx={{
-                        overflow: 'auto',
-                    }}
-                >
+                <ScrollArea.Autosize mah={500}>
                     <ReactJson
                         theme={theme}
                         enableClipboard={false}
                         src={jsonObject}
                     />
-                </Box>
+                </ScrollArea.Autosize>
 
-                <CopyButton value={JSON.stringify(jsonObject)} timeout={2000}>
-                    {({ copied, copy }) => (
-                        <Tooltip
-                            label={copied ? 'Copied' : 'Copy'}
-                            withArrow
-                            position="right"
-                        >
-                            <ActionIcon
-                                sx={{ alignSelf: 'end' }}
-                                color={copied ? 'teal' : 'gray'}
-                                onClick={copy}
+                <Group justify="end">
+                    <CopyButton
+                        value={JSON.stringify(jsonObject)}
+                        timeout={2000}
+                    >
+                        {({ copied, copy }) => (
+                            <Tooltip
+                                label={copied ? 'Copied' : 'Copy'}
+                                withArrow
+                                position="right"
                             >
-                                <MantineIcon
-                                    icon={copied ? IconCheck : IconCopy}
-                                />
-                            </ActionIcon>
-                        </Tooltip>
-                    )}
-                </CopyButton>
+                                <Button
+                                    color={copied ? 'teal' : 'gray'}
+                                    onClick={copy}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={copied ? IconCheck : IconCopy}
+                                        />
+                                    }
+                                >
+                                    Copy
+                                </Button>
+                            </Tooltip>
+                        )}
+                    </CopyButton>
+                </Group>
             </Stack>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
@@ -1,20 +1,19 @@
 import { type SavedChart } from '@lightdash/common';
 import {
     Button,
-    Group,
-    Modal,
     Stack,
     TextInput,
     Textarea,
-    Title,
     type ModalProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconPencil } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import { useSavedQuery, useUpdateMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
+import MantineModal from '../MantineModal';
 
-interface ChartUpdateModalProps extends ModalProps {
+interface ChartUpdateModalProps extends Pick<ModalProps, 'opened' | 'onClose'> {
     uuid: string;
     onConfirm?: () => void;
 }
@@ -22,9 +21,10 @@ interface ChartUpdateModalProps extends ModalProps {
 type FormState = Pick<SavedChart, 'name' | 'description'>;
 
 const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
+    opened,
+    onClose,
     uuid,
     onConfirm,
-    ...modalProps
 }) => {
     const dashboardUuid = useSearchParams('fromDashboard');
     const { data: chart, isInitialLoading } = useSavedQuery({ id: uuid });
@@ -63,9 +63,28 @@ const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
     });
 
     return (
-        <Modal title={<Title order={4}>Update Chart</Title>} {...modalProps}>
-            <form title="Update Chart" onSubmit={handleConfirm}>
-                <Stack spacing="lg" pt="sm">
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Update Chart"
+            icon={IconPencil}
+            actions={
+                <Button
+                    disabled={!form.isValid()}
+                    loading={isUpdating}
+                    type="submit"
+                    form="update-chart-form"
+                >
+                    Save
+                </Button>
+            }
+        >
+            <form
+                id="update-chart-form"
+                title="Update Chart"
+                onSubmit={handleConfirm}
+            >
+                <Stack>
                     <TextInput
                         label="Chart name"
                         required
@@ -82,23 +101,9 @@ const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
                         maxRows={3}
                         {...form.getInputProps('description')}
                     />
-
-                    <Group position="right" mt="sm">
-                        <Button variant="outline" onClick={modalProps.onClose}>
-                            Cancel
-                        </Button>
-
-                        <Button
-                            disabled={!form.isValid()}
-                            loading={isUpdating}
-                            type="submit"
-                        >
-                            Save
-                        </Button>
-                    </Group>
                 </Stack>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
@@ -4,31 +4,32 @@ import {
 } from '@lightdash/common';
 import {
     Button,
-    Group,
     List,
-    Modal,
+    ScrollArea,
     Stack,
     Text,
-    Title,
     type ModalProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
     useDashboardDeleteMutation,
     useDashboardQuery,
 } from '../../../hooks/dashboard/useDashboard';
-import MantineIcon from '../MantineIcon';
+import Callout from '../Callout';
+import MantineModal from '../MantineModal';
 
-interface DashboardDeleteModalProps extends ModalProps {
+interface DashboardDeleteModalProps
+    extends Pick<ModalProps, 'opened' | 'onClose'> {
     uuid: string;
     onConfirm?: () => void;
 }
 
 const DashboardDeleteModal: FC<DashboardDeleteModalProps> = ({
+    opened,
+    onClose,
     uuid,
     onConfirm,
-    ...modalProps
 }) => {
     const { data: dashboard, isInitialLoading } = useDashboardQuery(uuid);
     const { mutateAsync: deleteDashboard, isLoading: isDeleting } =
@@ -50,66 +51,61 @@ const DashboardDeleteModal: FC<DashboardDeleteModalProps> = ({
     );
 
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <MantineIcon icon={IconTrash} color="red" size="lg" />
-                    <Title order={4}>Delete dashboard</Title>
-                </Group>
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Delete dashboard"
+            icon={IconTrash}
+            actions={
+                <Button
+                    color="red"
+                    loading={isDeleting}
+                    onClick={handleConfirm}
+                >
+                    Delete
+                </Button>
             }
-            {...modalProps}
         >
             <Stack>
                 {hasChartsInDashboard(dashboard) ? (
-                    <Stack>
-                        <Text>
+                    <>
+                        <Text fz="sm">
                             Are you sure you want to delete the dashboard{' '}
                             <b>"{dashboard.name}"</b>?
                         </Text>
-                        <Text>
+                        <Text fz="sm">
                             This action will also permanently delete the
                             following charts that were created from within it:
                         </Text>
-                        <List size="sm">
-                            {chartsInDashboardTiles.map(
-                                (tile) =>
-                                    isDashboardChartTileType(tile) && (
-                                        <List.Item key={tile.uuid}>
-                                            <Text>
-                                                {tile.properties.chartName}
-                                            </Text>
-                                        </List.Item>
-                                    ),
-                            )}
-                        </List>
-                    </Stack>
+                        <Callout
+                            variant="danger"
+                            title="This action will also permanently delete the following charts that were created from within it:"
+                        >
+                            <ScrollArea.Autosize mah="300px" scrollbars="y">
+                                <List pr={'md'}>
+                                    {chartsInDashboardTiles.map(
+                                        (tile) =>
+                                            isDashboardChartTileType(tile) && (
+                                                <List.Item
+                                                    key={tile.uuid}
+                                                    fz="xs"
+                                                >
+                                                    {tile.properties.chartName}
+                                                </List.Item>
+                                            ),
+                                    )}
+                                </List>
+                            </ScrollArea.Autosize>
+                        </Callout>
+                    </>
                 ) : (
                     <Text>
                         Are you sure you want to delete the dashboard{' '}
                         <b>"{dashboard.name}"</b>?
                     </Text>
                 )}
-
-                <Group position="right" spacing="xs">
-                    <Button
-                        color="dark"
-                        variant="outline"
-                        onClick={modalProps.onClose}
-                    >
-                        Cancel
-                    </Button>
-
-                    <Button
-                        color="red"
-                        loading={isDeleting}
-                        onClick={handleConfirm}
-                        type="submit"
-                    >
-                        Delete
-                    </Button>
-                </Group>
             </Stack>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDuplicateModal.tsx
@@ -1,20 +1,19 @@
 import { type Dashboard } from '@lightdash/common';
 import {
     Button,
-    Group,
-    Modal,
     Stack,
     TextInput,
     Textarea,
-    Title,
     type ModalProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconCopy } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import {
     useDashboardQuery,
     useDuplicateDashboardMutation,
 } from '../../../hooks/dashboard/useDashboard';
+import MantineModal from '../MantineModal';
 
 interface DashboardDuplicateModalProps extends ModalProps {
     uuid: string;
@@ -24,9 +23,10 @@ interface DashboardDuplicateModalProps extends ModalProps {
 type FormState = Pick<Dashboard, 'name' | 'description'>;
 
 const DashboardDuplicateModal: FC<DashboardDuplicateModalProps> = ({
+    opened,
+    onClose,
     uuid,
     onConfirm,
-    ...modalProps
 }) => {
     const { mutateAsync: duplicateDashboard, isLoading: isUpdating } =
         useDuplicateDashboardMutation({
@@ -68,12 +68,28 @@ const DashboardDuplicateModal: FC<DashboardDuplicateModalProps> = ({
         isInitialLoading || !dashboard || !form.initialized || isUpdating;
 
     return (
-        <Modal
-            title={<Title order={4}>Duplicate Dashboard</Title>}
-            {...modalProps}
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Duplicate Dashboard"
+            icon={IconCopy}
+            actions={
+                <Button
+                    disabled={!form.isValid()}
+                    loading={isLoading}
+                    type="submit"
+                    form="duplicate-dashboard-form"
+                >
+                    Create duplicate
+                </Button>
+            }
         >
-            <form title="Duplicate Dashboard" onSubmit={handleConfirm}>
-                <Stack spacing="lg" pt="sm">
+            <form
+                id="duplicate-dashboard-form"
+                title="Duplicate Dashboard"
+                onSubmit={handleConfirm}
+            >
+                <Stack>
                     <TextInput
                         label="Enter a memorable name for your dashboard"
                         required
@@ -92,23 +108,9 @@ const DashboardDuplicateModal: FC<DashboardDuplicateModalProps> = ({
                         {...form.getInputProps('description')}
                         value={form.values.description ?? ''}
                     />
-
-                    <Group position="right" mt="sm">
-                        <Button variant="outline" onClick={modalProps.onClose}>
-                            Cancel
-                        </Button>
-
-                        <Button
-                            disabled={!form.isValid()}
-                            loading={isLoading}
-                            type="submit"
-                        >
-                            Create duplicate
-                        </Button>
-                    </Group>
                 </Stack>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/components/common/modal/DeleteChartTileThatBelongsToDashboardModal.tsx
+++ b/packages/frontend/src/components/common/modal/DeleteChartTileThatBelongsToDashboardModal.tsx
@@ -1,61 +1,40 @@
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    Text,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, type ModalProps } from '@mantine-8/core';
 import { IconAlertCircle } from '@tabler/icons-react';
-import React, { type FC } from 'react';
-import MantineIcon from '../MantineIcon';
+import { type FC } from 'react';
+import Callout from '../Callout';
+import MantineModal from '../MantineModal';
 
 interface Props extends ModalProps {
     name: string;
     onConfirm: () => void;
+    className?: string;
 }
 
 const DeleteChartTileThatBelongsToDashboardModal: FC<Props> = ({
+    opened,
+    onClose,
     name,
     onConfirm,
-    ...modalProps
+    className,
 }) => (
-    <Modal
-        size="md"
-        title={
-            <Group spacing="xs">
-                <MantineIcon size="lg" icon={IconAlertCircle} color="red" />
-                <Title order={4}>Delete chart</Title>
-            </Group>
+    <MantineModal
+        opened={opened}
+        onClose={onClose}
+        title="Delete chart"
+        icon={IconAlertCircle}
+        modalRootProps={{ className }}
+        description={`Are you sure you want to delete the chart "${name}"?`}
+        actions={
+            <Button color="red" onClick={onConfirm}>
+                Delete
+            </Button>
         }
-        {...modalProps}
     >
-        <Stack>
-            <Text>
-                Are you sure you want to delete the chart <b>{name}</b>?
-            </Text>
-            <Text>
-                This chart was created from within the dashboard, so removing
-                the tile will also result in the permanent deletion of the
-                chart.
-            </Text>
-
-            <Group position="right" spacing="xs">
-                <Button
-                    variant="outline"
-                    color="dark"
-                    onClick={modalProps.onClose}
-                >
-                    Cancel
-                </Button>
-
-                <Button color="red" onClick={onConfirm} type="submit">
-                    Delete
-                </Button>
-            </Group>
-        </Stack>
-    </Modal>
+        <Callout variant="warning" title="This change cannot be undone.">
+            This chart was created from within the dashboard, so removing the
+            tile will also result in the permanent deletion of the chart.
+        </Callout>
+    </MantineModal>
 );
 
 export default DeleteChartTileThatBelongsToDashboardModal;

--- a/packages/frontend/src/components/common/modal/LockedDashboardModal.module.css
+++ b/packages/frontend/src/components/common/modal/LockedDashboardModal.module.css
@@ -1,0 +1,4 @@
+.content {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    box-shadow: none;
+}

--- a/packages/frontend/src/components/common/modal/LockedDashboardModal.tsx
+++ b/packages/frontend/src/components/common/modal/LockedDashboardModal.tsx
@@ -1,7 +1,12 @@
-import { Modal, Stack, Text, type ModalProps } from '@mantine/core';
+import { Modal, Stack, Text } from '@mantine-8/core';
 import { type FC } from 'react';
+import classes from './LockedDashboardModal.module.css';
 
-export const LockedDashboardModal: FC<Pick<ModalProps, 'opened'>> = ({
+interface LockedDashboardModalProps {
+    opened: boolean;
+}
+
+export const LockedDashboardModal: FC<LockedDashboardModalProps> = ({
     opened,
 }) => (
     <Modal
@@ -12,17 +17,14 @@ export const LockedDashboardModal: FC<Pick<ModalProps, 'opened'>> = ({
         withinPortal
         withOverlay={false}
         onClose={() => {}}
-        styles={(theme) => ({
-            content: {
-                border: `1px solid ${theme.colors.ldGray[2]}`,
-                boxShadow: 'none',
-            },
-        })}
+        classNames={{
+            content: classes.content,
+        }}
     >
         <Text fw={600} fz="lg" ta="center" mb="lg">
             Set filter values to get started
         </Text>
-        <Stack spacing="xs">
+        <Stack gap="xs">
             <Text>
                 This dashboard cannot be run without setting the filter values
                 that are required

--- a/packages/frontend/src/components/common/modal/MoveChartThatBelongsToDashboardModal.tsx
+++ b/packages/frontend/src/components/common/modal/MoveChartThatBelongsToDashboardModal.tsx
@@ -1,18 +1,10 @@
 import { ChartSourceType, ContentType } from '@lightdash/common';
-import {
-    Button,
-    Flex,
-    Group,
-    Modal,
-    Stack,
-    Text,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, type ModalProps } from '@mantine-8/core';
 import { IconFolders } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useContentAction } from '../../../hooks/useContent';
-import MantineIcon from '../MantineIcon';
+import Callout from '../Callout';
+import MantineModal from '../MantineModal';
 
 interface Props extends ModalProps {
     uuid: string;
@@ -24,82 +16,56 @@ interface Props extends ModalProps {
 }
 
 const MoveChartThatBelongsToDashboardModal: FC<Props> = ({
+    opened,
+    onClose,
     uuid,
     name,
     spaceUuid,
     spaceName,
     onConfirm,
     projectUuid,
-    ...modalProps
 }) => {
     const { mutate: contentAction } = useContentAction(projectUuid, {
         onSuccess: async () => {
             onConfirm();
-            modalProps.onClose();
+            onClose();
         },
     });
 
     return (
-        <Modal
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title={`Move "${name}"`}
+            icon={IconFolders}
             size="lg"
-            title={
-                <Flex align="center" gap="xs">
-                    <MantineIcon icon={IconFolders} size="lg" />
-                    <Title order={5}>
-                        <Text span fw={400}>
-                            Move{' '}
-                        </Text>
-                        {name}
-                    </Title>
-                </Flex>
+            actions={
+                <Button
+                    onClick={() => {
+                        contentAction({
+                            action: {
+                                type: 'move',
+                                targetSpaceUuid: spaceUuid,
+                            },
+                            item: {
+                                uuid,
+                                contentType: ContentType.CHART,
+                                source: ChartSourceType.DBT_EXPLORE,
+                            },
+                        });
+                    }}
+                >
+                    Move
+                </Button>
             }
-            {...modalProps}
+            description={`Are you sure you want to move the chart "${name}" to the space "${spaceName}"?`}
         >
-            <Stack mt="sm">
-                <Text>
-                    Are you sure you want to move the chart{' '}
-                    <Text fw={600} span>
-                        {name}
-                    </Text>{' '}
-                    to the space{' '}
-                    <Text fw={600} span>
-                        {spaceName}
-                    </Text>
-                    ?
-                </Text>
-                <Text>
-                    This chart was created from within the dashboard, moving the
-                    chart to the space will make it available in chart lists
-                    across the app.
-                </Text>
-                <Text fw={600}>This change cannot be undone.</Text>
-
-                <Group position="right" spacing="xs">
-                    <Button variant="outline" onClick={modalProps.onClose}>
-                        Cancel
-                    </Button>
-
-                    <Button
-                        onClick={() => {
-                            contentAction({
-                                action: {
-                                    type: 'move',
-                                    targetSpaceUuid: spaceUuid,
-                                },
-                                item: {
-                                    uuid,
-                                    contentType: ContentType.CHART,
-                                    source: ChartSourceType.DBT_EXPLORE,
-                                },
-                            });
-                        }}
-                        type="submit"
-                    >
-                        Move
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+            <Callout variant="warning" title="This change cannot be undone.">
+                This chart was created from within the dashboard, moving the
+                chart to the space will make it available in chart lists across
+                the app.
+            </Callout>
+        </MantineModal>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Migrated modal components to Mantine 8 and standardized the modal interface across the application. Updated the `ChartCreateModal`, `ChartUpdateModal`, `DashboardDeleteModal`, `DashboardDuplicateModal`, `DeleteChartTileThatBelongsToDashboardModal`, `LockedDashboardModal`, `MoveChartThatBelongsToDashboardModal`, and `JsonViewerModal` components to use the new `MantineModal` component.

Key changes include:
- Replaced `isOpen` prop with `opened` for consistency
- Improved modal layouts with better spacing and organization
- Enhanced the JSON viewer modal with scrollable content and better copy button
- Standardized action buttons placement and styling
- Added icons to modal headers for better visual cues

![Screenshot 2025-12-30 at 00.08.12.png](https://app.graphite.com/user-attachments/assets/66489a46-3ac3-4ddd-b431-055d7eb38afa.png)



![Screenshot 2025-12-30 at 00.01.37.png](https://app.graphite.com/user-attachments/assets/24e87674-3253-4636-be49-0487d5129c0f.png)

![Screenshot 2025-12-30 at 00.04.18.png](https://app.graphite.com/user-attachments/assets/5115942d-7865-406f-b90c-457465c3d46f.png)

![Screenshot 2025-12-30 at 00.04.24.png](https://app.graphite.com/user-attachments/assets/9045edee-dce6-4b79-838c-5fbe45d2c262.png)

![Screenshot 2025-12-30 at 00.06.05.png](https://app.graphite.com/user-attachments/assets/9543b6f6-8ef5-4ed2-90f9-896fb79a0b3f.png)

