### PR TITLE
fix: enable resizing of schedulers table columns

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -678,6 +678,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                 id: 'actions',
                 header: '',
                 enableSorting: false,
+                enableResizing: false,
                 size: 50,
                 Cell: ({ row }) => {
                     const item = row.original;
@@ -711,7 +712,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
     const table = useMantineReactTable({
         columns,
         data: tableData,
-        enableColumnResizing: false,
+        enableColumnResizing: true,
         enableRowNumbers: false,
         enablePagination: false,
         enableFilters: false,
@@ -752,6 +753,13 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
         mantineTableHeadRowProps: {
             sx: {
                 boxShadow: 'none',
+                'th > div > div:last-child': {
+                    top: -10,
+                    right: -5,
+                },
+                'th > div > div:last-child > .mantine-Divider-root': {
+                    border: 'none',
+                },
             },
         },
         mantineTableContainerProps: {
@@ -768,6 +776,11 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
             const isLastColumn =
                 props.table.getAllColumns().indexOf(props.column) ===
                 props.table.getAllColumns().length - 1;
+
+            const isAnyColumnResizing = props.table
+                .getAllColumns()
+                .some((c) => c.getIsResizing());
+            const canResize = props.column.getCanResize();
 
             return {
                 bg: 'ldGray.0',
@@ -787,6 +800,16 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                                   : theme.colors.ldGray[2]
                           }`,
                     borderLeft: 'none',
+                },
+                sx: {
+                    '&:hover': canResize
+                        ? {
+                              borderRight: !isAnyColumnResizing
+                                  ? `2px solid ${theme.colors.blue[3]} !important` // This is needed to override the default inline styles
+                                  : undefined,
+                              transition: `border-right ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                          }
+                        : {},
                 },
             };
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/GLITCH-126/i-would-like-to-be-able-to-resize-column-in-the-scheduled-deliveries

### Description:
Enable column resizing in the Schedulers Table with improved visual feedback. The actions column remains fixed width, while other columns can now be resized. Added hover effects that show a blue border on resizable columns and styled the resize handle for better usability.

Note: this is similar to other tables in our codebase, e.g. `packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx`

[Screen Recording 2025-12-30 at 09.27.56.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0741591d-e06a-4c0e-adff-603c58982745.mov" />](https://app.graphite.com/user-attachments/video/0741591d-e06a-4c0e-adff-603c58982745.mov)

