### PR TITLE
feat: update other modals like group access to MantineModal

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
@@ -1,20 +1,15 @@
-import {
-    Anchor,
-    Group,
-    List,
-    Modal,
-    Stack,
-    Text,
-    type ModalProps,
-} from '@mantine/core';
+import { Anchor, List, Stack, Text } from '@mantine-8/core';
 import { IconDeviceAnalytics } from '@tabler/icons-react';
 import { type FC } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../../components/common/MantineModal';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useMetricChartAnalytics } from '../hooks/useMetricChartAnalytics';
-type Props = ModalProps;
+
+type Props = Pick<MantineModalProps, 'opened' | 'onClose'>;
 
 export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
     const { track } = useTracking();
@@ -38,83 +33,53 @@ export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
     });
 
     return (
-        <Modal.Root
+        <MantineModal
             opened={opened}
             onClose={onClose}
-            yOffset={200}
-            scrollAreaComponent={undefined}
-            size="lg"
+            title="Metric Usage"
+            icon={IconDeviceAnalytics}
+            cancelLabel={false}
         >
-            <Modal.Overlay />
-            <Modal.Content sx={{ overflow: 'hidden' }} radius="md">
-                <Modal.Header
-                    sx={(theme) => ({
-                        borderBottom: `1px solid ${theme.colors.ldGray[4]}`,
-                    })}
-                >
-                    <Group spacing="xs">
-                        <MantineIcon
-                            icon={IconDeviceAnalytics}
-                            size="lg"
-                            color="ldGray.7"
-                        />
-                        <Text fw={500}>Metric Usage</Text>
-                    </Group>
-                    <Modal.CloseButton />
-                </Modal.Header>
-                <Modal.Body
-                    p={0}
-                    mah={300}
-                    h="100%"
-                    sx={{
-                        overflowY: 'auto',
-                    }}
-                >
-                    <Stack spacing="xs" p="md">
-                        <Text>
-                            This metric is used in the following charts:
-                        </Text>
-                        {isLoading ? (
-                            <Text size="sm" color="dimmed">
-                                Loading...
-                            </Text>
-                        ) : analytics?.charts.length === 0 ? (
-                            <Text size="sm" color="dimmed">
-                                No charts found using this metric
-                            </Text>
-                        ) : (
-                            <List pl="sm">
-                                {analytics?.charts.map((chart) => (
-                                    <List.Item key={chart.uuid} fz="sm">
-                                        <Anchor
-                                            href={`/projects/${projectUuid}/saved/${chart.uuid}`}
-                                            target="_blank"
-                                            onClick={() => {
-                                                track({
-                                                    name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED,
-                                                    properties: {
-                                                        userId: userUuid,
-                                                        organizationId:
-                                                            organizationUuid,
-                                                        projectId: projectUuid,
-                                                        metricName:
-                                                            activeMetric?.name,
-                                                        tableName:
-                                                            activeMetric?.tableName,
-                                                        chartId: chart.uuid,
-                                                    },
-                                                });
-                                            }}
-                                        >
-                                            {chart.name}
-                                        </Anchor>
-                                    </List.Item>
-                                ))}
-                            </List>
-                        )}
-                    </Stack>
-                </Modal.Body>
-            </Modal.Content>
-        </Modal.Root>
+            <Stack gap="xs">
+                <Text>This metric is used in the following charts:</Text>
+                {isLoading ? (
+                    <Text size="sm" c="dimmed">
+                        Loading...
+                    </Text>
+                ) : analytics?.charts.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                        No charts found using this metric
+                    </Text>
+                ) : (
+                    <List pl="sm">
+                        {analytics?.charts.map((chart) => (
+                            <List.Item key={chart.uuid} fz="sm">
+                                <Anchor
+                                    href={`/projects/${projectUuid}/saved/${chart.uuid}`}
+                                    target="_blank"
+                                    onClick={() => {
+                                        track({
+                                            name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED,
+                                            properties: {
+                                                userId: userUuid,
+                                                organizationId:
+                                                    organizationUuid,
+                                                projectId: projectUuid,
+                                                metricName: activeMetric?.name,
+                                                tableName:
+                                                    activeMetric?.tableName,
+                                                chartId: chart.uuid,
+                                            },
+                                        });
+                                    }}
+                                >
+                                    {chart.name}
+                                </Anchor>
+                            </List.Item>
+                        ))}
+                    </List>
+                )}
+            </Stack>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
@@ -83,14 +83,34 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
 
     const rolesData = useMemo(() => {
         if (!organizationRoles) return [];
-        return organizationRoles.map(
-            (role: Pick<Role, 'roleUuid' | 'name' | 'ownerType'>) => ({
-                value: role.roleUuid,
-                label: role.name,
-                group:
-                    role.ownerType === 'system' ? 'System role' : 'Custom role',
-            }),
+
+        const systemRoles: { value: string; label: string }[] = [];
+        const customRoles: { value: string; label: string }[] = [];
+
+        organizationRoles.forEach(
+            (role: Pick<Role, 'roleUuid' | 'name' | 'ownerType'>) => {
+                const item = { value: role.roleUuid, label: role.name };
+                if (role.ownerType === 'system') {
+                    systemRoles.push(item);
+                } else {
+                    customRoles.push(item);
+                }
+            },
         );
+
+        const roleGroups: {
+            group: string;
+            items: { value: string; label: string }[];
+        }[] = [];
+
+        if (systemRoles.length > 0) {
+            roleGroups.push({ group: 'System role', items: systemRoles });
+        }
+        if (customRoles.length > 0) {
+            roleGroups.push({ group: 'Custom role', items: customRoles });
+        }
+
+        return roleGroups;
     }, [organizationRoles]);
 
     const canManageProjectAccess = ability.can(

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccessItemV2.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccessItemV2.tsx
@@ -2,7 +2,7 @@ import {
     type GroupWithMembers,
     type ProjectGroupAccess,
 } from '@lightdash/common';
-import { ActionIcon, Select, Stack, Text, Tooltip } from '@mantine/core';
+import { ActionIcon, Select, Stack, Text, Tooltip } from '@mantine-8/core';
 import { IconTrash } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -12,10 +12,13 @@ import {
 } from '../../../hooks/useProjectGroupRoles';
 import RevokeProjectGroupAccessModal from './RevokeProjectGroupAccessModal';
 
+type RoleItem = { value: string; label: string };
+type GroupedRoles = { group: string; items: RoleItem[] }[];
+
 type ProjectGroupAccessItemV2Props = {
     group: GroupWithMembers;
     access: ProjectGroupAccess;
-    organizationRoles: { value: string; label: string; group: string }[];
+    organizationRoles: GroupedRoles;
     canManageProjectAccess: boolean;
 };
 
@@ -50,30 +53,36 @@ const ProjectGroupAccessItemV2: FC<ProjectGroupAccessItemV2Props> = ({
         setIsDeleteDialogOpen(false);
     };
 
+    // Flatten roles for lookup
+    const allRoles = useMemo(
+        () => organizationRoles.flatMap((g) => g.items),
+        [organizationRoles],
+    );
+
     // Get the current role UUID
     const currentRoleUuid = useMemo(() => {
         // For new role system, role is already a UUID
         // For old role system, role is a string that matches role name
-        const roleData = organizationRoles.find(
+        const roleData = allRoles.find(
             (role) => role.value === access.role || role.label === access.role,
         );
         return roleData?.value || access.role;
-    }, [access.role, organizationRoles]);
+    }, [access.role, allRoles]);
 
     return (
         <>
             <tr key={access.groupUuid}>
                 <td width="30%">
-                    <Stack spacing="xs" align="flex-start">
+                    <Stack gap="xs" align="flex-start">
                         <Text fw={500}>{group.name}</Text>
-                        <Text size="xs" color="dimmed">
+                        <Text size="xs" c="dimmed">
                             {group.members.length} member
                             {group.members.length !== 1 ? 's' : ''}
                         </Text>
                     </Stack>
                 </td>
                 <td width="70%">
-                    <Stack spacing="xs">
+                    <Stack gap="xs">
                         <Select
                             id={`group-role-${access.groupUuid}`}
                             w="300px"

--- a/packages/frontend/src/features/projectGroupAccess/components/RevokeProjectGroupAccessModal.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/RevokeProjectGroupAccessModal.tsx
@@ -1,13 +1,14 @@
 import { type GroupWithMembers } from '@lightdash/common';
-import { Button, Group, Modal, Text, Title } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import { IconKey } from '@tabler/icons-react';
 import { type FC } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../../components/common/MantineModal';
 
-type RevokeProjectGroupAccessModalProps = {
+type RevokeProjectGroupAccessModalProps = Pick<MantineModalProps, 'onClose'> & {
     group: GroupWithMembers;
     onDelete: () => void;
-    onClose: () => void;
 };
 
 const RevokeProjectGroupAccessModal: FC<RevokeProjectGroupAccessModalProps> = ({
@@ -16,31 +17,18 @@ const RevokeProjectGroupAccessModal: FC<RevokeProjectGroupAccessModalProps> = ({
     onClose,
 }) => {
     return (
-        <Modal
+        <MantineModal
             opened
             onClose={onClose}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon size="lg" icon={IconKey} color="red" />
-                    <Title order={4}>Revoke group project access</Title>
-                </Group>
-            }
-        >
-            <Text pb="md">
-                Are you sure you want to revoke project access for this group "
-                {group.name}"?
-            </Text>
-
-            <Group spacing="xs" position="right">
-                <Button variant="outline" onClick={onClose} color="dark">
-                    Cancel
-                </Button>
-
+            title="Revoke group project access"
+            icon={IconKey}
+            description={`Are you sure you want to revoke project access for this group "${group.name}"?`}
+            actions={
                 <Button color="red" onClick={onDelete}>
                     Revoke
                 </Button>
-            </Group>
-        </Modal>
+            }
+        />
     );
 };
 

--- a/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
+++ b/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
@@ -3,27 +3,22 @@ import {
     type PromotedChart,
     type PromotionChanges,
 } from '@lightdash/common';
-import {
-    Accordion,
-    Button,
-    Flex,
-    Group,
-    Loader,
-    Modal,
-    Stack,
-    Text,
-    Title,
-} from '@mantine/core';
+import { Accordion, Button, Flex, Loader, Stack, Text } from '@mantine-8/core';
 import { useMemo, type FC } from 'react';
 
 import {
     IconChartAreaLine,
     IconFolder,
     IconLayoutDashboard,
+    IconRocket,
 } from '@tabler/icons-react';
+import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../../components/common/MantineModal';
 
-type Props = {
+type Props = Pick<MantineModalProps, 'onClose'> & {
     type: 'chart' | 'dashboard';
     resourceName: string;
     promotionChanges: PromotionChanges | undefined;
@@ -35,6 +30,7 @@ type PromotionChange = {
     action: PromotionAction;
     data: Pick<PromotedChart, 'name' | 'uuid'>;
 };
+
 const PromotionChangesAccordion: FC<{
     type: 'spaces' | 'charts' | 'dashboards';
     items: {
@@ -106,6 +102,7 @@ const PromotionChangesAccordion: FC<{
         </Accordion>
     );
 };
+
 export const PromotionConfirmDialog: FC<Props> = ({
     type,
     resourceName,
@@ -183,30 +180,39 @@ export const PromotionConfirmDialog: FC<Props> = ({
     }, [promotionChanges]);
 
     return (
-        <Modal
-            size="lg"
-            title={<Title order={4}>Promoting {type}</Title>}
-            opened={true}
+        <MantineModal
+            opened
             onClose={onClose}
+            title={`Promoting ${type}`}
+            icon={IconRocket}
+            size="lg"
+            actions={
+                <Button
+                    color="green"
+                    disabled={totalChanges === 0}
+                    onClick={() => {
+                        onConfirm();
+                        onClose();
+                    }}
+                >
+                    Promote
+                </Button>
+            }
+            description={`You are about to promote ${type}: "${resourceName}"`}
         >
-            <Stack spacing="lg" pt="sm">
-                <Text>
-                    Are you sure you want to promote this {type}{' '}
-                    <Text span fw={600}>
-                        {resourceName}
-                    </Text>
-                    ?
-                </Text>
-                These changes will be applied:
+            <Stack>
                 {groupedChanges === undefined ? (
                     <Flex gap="sm" align="center">
-                        <Loader color="gray" size={'sm'} speed={1} />
+                        <Loader color="gray" size={'sm'} />
                         <Text>Loading differences...</Text>
                     </Flex>
                 ) : (
                     <Stack>
                         {groupedChanges.spaces.total > 0 && (
                             <>
+                                <Text fz="sm">
+                                    These changes will be applied:
+                                </Text>
                                 <Flex gap="sm">
                                     <MantineIcon
                                         icon={IconFolder}
@@ -223,6 +229,9 @@ export const PromotionConfirmDialog: FC<Props> = ({
 
                         {groupedChanges.dashboards.total > 0 && (
                             <>
+                                <Text fz="sm">
+                                    These changes will be applied:
+                                </Text>
                                 <Flex>
                                     <MantineIcon
                                         icon={IconLayoutDashboard}
@@ -240,6 +249,9 @@ export const PromotionConfirmDialog: FC<Props> = ({
                         )}
                         {groupedChanges.charts.total > 0 && (
                             <>
+                                <Text fz="sm">
+                                    These changes will be applied:
+                                </Text>
                                 <Flex>
                                     <MantineIcon
                                         icon={IconChartAreaLine}
@@ -257,35 +269,20 @@ export const PromotionConfirmDialog: FC<Props> = ({
                         )}
 
                         {totalChanges === 0 && (
-                            <Text color="yellow.9" fw={600}>
-                                No changes to promote
-                            </Text>
+                            <Callout
+                                variant="info"
+                                title="No changes to promote"
+                            />
                         )}
                         {totalChanges !== 0 && withoutChanges > 0 && (
-                            <Text color="yellow.9" fw={600}>
+                            <Callout variant="info">
                                 We only promote content that is more recent in
                                 this project.
-                            </Text>
+                            </Callout>
                         )}
                     </Stack>
                 )}
-                <Group position="right" mt="sm">
-                    <Button color="dark" variant="outline" onClick={onClose}>
-                        Cancel
-                    </Button>
-
-                    <Button
-                        color="green"
-                        disabled={totalChanges === 0}
-                        onClick={() => {
-                            onConfirm();
-                            onClose();
-                        }}
-                    >
-                        Promote
-                    </Button>
-                </Group>
             </Stack>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/DeleteSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/DeleteSqlChartModal.tsx
@@ -1,17 +1,12 @@
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    Text,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, Text } from '@mantine-8/core';
 import { IconChartBar } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../../components/common/MantineModal';
 import { useDeleteSqlChartMutation } from '../hooks/useSavedSqlCharts';
 
-type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
+type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     projectUuid: string;
     savedSqlUuid: string;
     name: string;
@@ -38,47 +33,28 @@ export const DeleteSqlChartModal: FC<Props> = ({
     }, [isSuccess, onClose, onSuccess]);
 
     return (
-        <Modal
+        <MantineModal
             opened={opened}
             onClose={onClose}
-            keepMounted={false}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        icon={IconChartBar}
-                        size="lg"
-                        color="ldGray.7"
-                    />
-                    <Text fw={500}>Delete chart</Text>
-                </Group>
+            title="Delete chart"
+            icon={IconChartBar}
+            actions={
+                <Button
+                    loading={isLoading}
+                    color="red"
+                    onClick={() => mutate()}
+                >
+                    Delete
+                </Button>
             }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.ldGray[4]}` },
-            })}
         >
-            <Stack pt="sm">
-                <Text>
-                    Are you sure you want to delete the chart{' '}
-                    <Text span fw={600}>
-                        "{name}"
-                    </Text>
-                    ?
+            <Text>
+                Are you sure you want to delete the chart{' '}
+                <Text span fw={600}>
+                    "{name}"
                 </Text>
-
-                <Group position="right" mt="sm">
-                    <Button color="dark" variant="outline" onClick={onClose}>
-                        Cancel
-                    </Button>
-
-                    <Button
-                        loading={isLoading}
-                        color="red"
-                        onClick={() => mutate()}
-                    >
-                        Delete
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+                ?
+            </Text>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
@@ -5,22 +5,22 @@ import {
 import {
     Badge,
     Button,
-    Group,
     List,
     Loader,
-    Modal,
     Stack,
     Text,
     TextInput,
     Tooltip,
-    type ModalProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconBrandGithub, IconInfoCircle } from '@tabler/icons-react';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import { z } from 'zod';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../../components/common/MantineModal';
 import useHealth from '../../../hooks/health/useHealth';
 import { useProject } from '../../../hooks/useProject';
 import { useGithubDbtWriteBack } from '../hooks/useGithubDbtWriteBack';
@@ -33,7 +33,7 @@ const validationSchema = z.object({
 
 type FormValues = z.infer<typeof validationSchema>;
 
-type Props = ModalProps;
+type Props = Pick<MantineModalProps, 'opened' | 'onClose'>;
 
 export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
@@ -101,50 +101,50 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
     );
 
     return (
-        <Modal
+        <MantineModal
             opened={opened}
             onClose={onClose}
-            keepMounted={false}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        icon={IconBrandGithub}
-                        size="lg"
-                        color="ldGray.7"
-                    />
-                    <Text fw={500}>Write back to dbt</Text>
-                    <Tooltip
-                        variant="xs"
-                        withinPortal
-                        multiline
-                        maw={300}
-                        label="Create a new model in your dbt project from this SQL query. This will create a new branch and start a pull request."
-                    >
-                        <MantineIcon
-                            color="ldGray.7"
-                            icon={IconInfoCircle}
-                            size={16}
-                        />
-                    </Tooltip>
-                </Group>
+            title="Write back to dbt"
+            icon={IconBrandGithub}
+            cancelDisabled={isLoadingPullRequest}
+            actions={
+                <Button
+                    type="submit"
+                    form="write-back-to-dbt-form"
+                    disabled={
+                        !form.values.name || !sql || !canWriteToDbtProject
+                    }
+                    loading={isLoadingPullRequest}
+                >
+                    Open Pull Request
+                </Button>
             }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.ldGray[4]}` },
-                body: { padding: 0 },
-            })}
+            headerActions={
+                <Tooltip
+                    label="Create a new model in your dbt project from this SQL query. This will create a new branch and start a pull request."
+                    multiline
+                    maw={300}
+                >
+                    <MantineIcon
+                        color="ldGray.7"
+                        icon={IconInfoCircle}
+                        size={16}
+                    />
+                </Tooltip>
+            }
         >
-            <form onSubmit={form.onSubmit(handleSubmit)}>
-                <Stack p="md">
-                    <Stack spacing="xs">
-                        <TextInput
-                            radius="md"
-                            label="Name"
-                            required
-                            {...form.getInputProps('name')}
-                        />
-                    </Stack>
+            <form
+                id="write-back-to-dbt-form"
+                onSubmit={form.onSubmit(handleSubmit)}
+            >
+                <Stack>
+                    <TextInput
+                        label="Name"
+                        required
+                        {...form.getInputProps('name')}
+                    />
 
-                    <Stack spacing="xs" pl="xs">
+                    <Stack gap="xs" pl="xs">
                         <Text fw={500}>
                             Files to be created in{' '}
                             <Badge
@@ -168,15 +168,13 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
                             </Badge>
                             {isPreviewLoading && <Loader size="xs" />}:
                         </Text>
-                        <List spacing="xs" pl="xs">
+                        <List pl="xs">
                             {writePreviewData?.files.map((file) => (
                                 <Tooltip
                                     key={file}
-                                    variant="xs"
                                     position="top-start"
                                     label={file}
                                     multiline
-                                    withinPortal
                                     maw={300}
                                 >
                                     <List.Item fz="xs" ff="monospace">
@@ -187,30 +185,7 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
                         </List>
                     </Stack>
                 </Stack>
-
-                <Group position="right" w="100%" p="md">
-                    <Button
-                        color="ldGray.7"
-                        onClick={onClose}
-                        variant="outline"
-                        disabled={isLoadingPullRequest}
-                        size="xs"
-                    >
-                        Cancel
-                    </Button>
-
-                    <Button
-                        type="submit"
-                        disabled={
-                            !form.values.name || !sql || !canWriteToDbtProject
-                        }
-                        loading={isLoadingPullRequest}
-                        size="xs"
-                    >
-                        Open Pull Request
-                    </Button>
-                </Group>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/tableCalculation/components/DeleteTableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/DeleteTableCalculationModal.tsx
@@ -1,14 +1,8 @@
 import { type TableCalculation } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    Text,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, type ModalProps } from '@mantine-8/core';
+import { IconTrash } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
+import MantineModal from '../../../components/common/MantineModal';
 import {
     explorerActions,
     useExplorerDispatch,
@@ -34,26 +28,19 @@ export const DeleteTableCalculationModal: FC<Props> = ({
         });
         onClose();
     }, [dispatch, tableCalculation.name, track, onClose]);
-    return (
-        <Modal
-            opened
-            title={<Title order={4}>Delete Table Calculation</Title>}
-            onClose={onClose}
-        >
-            <Stack spacing="lg" pt="sm">
-                <Text>
-                    Are you sure you want to delete this table calculation?
-                </Text>
 
-                <Group position="right" mt="sm">
-                    <Button variant="outline" color="dark" onClick={onClose}>
-                        Cancel
-                    </Button>
-                    <Button color="red" onClick={onConfirm}>
-                        Delete
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title="Delete Table Calculation"
+            icon={IconTrash}
+            description="Are you sure you want to delete this table calculation?"
+            actions={
+                <Button color="red" onClick={onConfirm}>
+                    Delete
+                </Button>
+            }
+        />
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Migrated several modal components to use the new `MantineModal` component from Mantine 8:

- `MetricChartUsageModal`
- `AddProjectGroupAccessModal`
- `RevokeProjectGroupAccessModal`
- `PromotionConfirmDialog`
- `DeleteSqlChartModal`
- `WriteBackToDbtModal`
- `DeleteTableCalculationModal`

The new implementation provides a more consistent UI with standardized header, actions, and layout. This reduces code duplication and improves the overall user experience by maintaining consistent modal patterns throughout the application.

![Screenshot 2025-12-30 at 09.20.57.png](https://app.graphite.com/user-attachments/assets/bac5f38c-840a-4f81-b2a4-dd08ea5f3d29.png)

![Screenshot 2025-12-30 at 09.22.08.png](https://app.graphite.com/user-attachments/assets/aa67fcda-c431-4bc3-9f52-4a69170bb75a.png)

![Screenshot 2025-12-30 at 09.24.30.png](https://app.graphite.com/user-attachments/assets/c2d7ee59-8aa0-48fe-a57c-cf63ba7710f3.png)

![Screenshot 2025-12-30 at 09.25.37.png](https://app.graphite.com/user-attachments/assets/256b19cb-0528-4a85-9220-02249af82a09.png)

![Screenshot 2025-12-30 at 09.34.37.png](https://app.graphite.com/user-attachments/assets/7d0cf3b7-dedd-4b23-bc86-8964000b9ff4.png)

![Screenshot 2025-12-30 at 09.36.44.png](https://app.graphite.com/user-attachments/assets/9de58d78-6260-4129-894e-46df77e505de.png)

![Screenshot 2025-12-30 at 09.37.52.png](https://app.graphite.com/user-attachments/assets/f18179fd-7fbc-450b-ba3e-ec3dbd859778.png)

![Screenshot 2025-12-30 at 09.43.21.png](https://app.graphite.com/user-attachments/assets/cab1317e-7364-45d1-9108-98195e19ee6d.png)

![Screenshot 2025-12-30 at 09.45.14.png](https://app.graphite.com/user-attachments/assets/f70f9e25-1ca5-496d-97af-ad78e47b812f.png)

