### PR TITLE
feat: add option to show overlapping labels in stacked bar charts

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -310,6 +310,7 @@ export type Series = {
     label?: {
         show?: boolean;
         position?: 'left' | 'top' | 'right' | 'bottom' | 'inside';
+        showOverlappingLabels?: boolean;
     };
     hidden?: boolean;
     areaStyle?: Record<string, unknown>;

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -340,9 +340,26 @@ export type EChartsSeries = {
         position?: 'left' | 'top' | 'right' | 'bottom' | 'inside';
         formatter?: (param: { data: Record<string, unknown> }) => string;
     };
-    labelLayout?: {
-        hideOverlap?: boolean;
-    };
+    labelLayout?:
+        | {
+              hideOverlap?: boolean;
+          }
+        | ((params: {
+              rect: { x: number; y: number; width: number; height: number };
+              labelRect: {
+                  x: number;
+                  y: number;
+                  width: number;
+                  height: number;
+              };
+          }) =>
+              | {
+                    x?: number;
+                    y?: number;
+                    fontSize?: number;
+                    labelLinePoints?: number[][];
+                }
+              | undefined);
     tooltip?: {
         show?: boolean;
         valueFormatter?: (value: unknown) => string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19126

### Description:
Added support for showing overlapping labels in stacked bar charts. This feature allows users to display labels even when they would normally be hidden due to space constraints.

The implementation:
- Adds a new `showOverlappingLabels` property to series label configuration
- Creates a dynamic label layout function that reduces font size for labels that don't fit in their segments
- Adds a checkbox in the Series configuration panel to toggle this feature for stacked bar charts
- Only shows the checkbox when stacked bar series are present in the chart

This improves data visibility in stacked bar charts by ensuring all labels can be seen, even in smaller segments.

<details>
<summary>Quick demo</summary>

### Acceptable
This is also the customer's case, with only 1 isolated bar segment.
| Off | On  |
|--------------------|---|
| ![localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_saved_6c5f9ce4-9cd7-40b8-814e-8161e9768e5a_edit (2).png](https://app.graphite.com/user-attachments/assets/1a510fac-567c-4c7a-828e-99a440d1bdef.png) | ![localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_saved_6c5f9ce4-9cd7-40b8-814e-8161e9768e5a_edit (3).png](https://app.graphite.com/user-attachments/assets/1891036d-1b03-47cc-a57d-14ee381f7304.png) |

### Not so good
Many stacked ones. Needs either horizontal spacing/shifting or cascading, in case there are many labels. But really, there are so many cases where this will not work - if the label is very long for example. We always are limited by the dimensions of the chart and can only do so much about it. Leading lines could be a solution, but if the space is limited, where do we render those? 🤔 
| Off | On  |
|--------------------|---|
| ![localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_saved_f57a1dad-3ccb-44fd-83b1-4a62e1993adb_edit.png](https://app.graphite.com/user-attachments/assets/3cc2203a-dea6-40b3-a51b-9c3c603c14e5.png) | ![localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_saved_f57a1dad-3ccb-44fd-83b1-4a62e1993adb_edit (1).png](https://app.graphite.com/user-attachments/assets/c7a74bda-e910-4db5-8964-34e3dfc8c887.png) |
</details>