### PR TITLE
fix: dashboard tabs always stuck when edit mode

### DIFF
--- a/packages/frontend/src/components/common/StickyWithDetection.tsx
+++ b/packages/frontend/src/components/common/StickyWithDetection.tsx
@@ -53,7 +53,7 @@ export const StickyWithDetection: FC<StickyWithDetectionProps> = ({
 
         const container = scrollContainer || document.body;
 
-        const rootMargin = offset > 0 ? `-${offset + 1}px 0px 0px 0px` : '0px';
+        const rootMargin = offset > 0 ? `-${offset}px 0px 0px 0px` : '0px';
 
         const observer = new IntersectionObserver(
             ([entry]) => {


### PR DESCRIPTION
### Description:
Fixed the `rootMargin` calculation in `StickyWithDetection` component by removing the extra 1px offset that was being added. This ensures the sticky behavior triggers at exactly the specified offset value rather than offset+1px.

_After_
![CleanShot 2025-12-30 at 12.09.10.png](https://app.graphite.com/user-attachments/assets/ac3069ae-bef0-4a1e-9f87-ed228164c3df.png)

_Before_
![CleanShot 2025-12-30 at 12.09.56.png](https://app.graphite.com/user-attachments/assets/72b314a2-68f0-4555-835e-2250a1d4a66a.png)

