### PR TITLE
feat: improve z-index config in dashboard v2 tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -59,7 +59,6 @@
     &[data-hovered='true'] {
         white-space: normal;
         overflow: visible;
-        z-index: 10;
         outline: 4px solid var(--mantine-color-background-0);
         background-color: var(--mantine-color-background-0);
         color: var(--mantine-color-foreground-0);
@@ -107,4 +106,12 @@
     &[data-full-width='true'] {
         margin: 0 -16px -16px -16px;
     }
+}
+
+.tileTooltip {
+    /* When tabs are not stuck: show tooltip above tabs (zindex + 1)
+       When tabs are stuck: show tooltip below tabs (zindex - 1) */
+    z-index: calc(
+        var(--dashboard-tabs-zindex) + 1 - (var(--tabs-stuck, 0) * 2)
+    );
 }

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
@@ -9,7 +9,6 @@ import {
     Box,
     Card,
     Flex,
-    getDefaultZIndex,
     Group,
     Paper,
     rem,
@@ -107,12 +106,11 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                 lockHeaderVisibility) && (
                 <Paper
                     p={5}
-                    className="non-draggable"
+                    className={clsx('non-draggable', styles.tileTooltip)}
                     shadow="sm"
                     pos="absolute"
                     top={-6}
                     right={-2}
-                    style={{ zIndex: 10 }}
                 >
                     <Group gap={5} wrap="nowrap">
                         {titleLeftIcon}
@@ -256,9 +254,6 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                     mb="12px"
                     data-is-edit-mode={isEditMode}
                     data-is-empty={isMarkdownTileTitleEmpty || hideTitle}
-                    style={{
-                        zIndex: isLoading ? getDefaultZIndex('modal') - 10 : 3,
-                    }}
                 >
                     {minimal ? (
                         !hideTitle ? (

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -466,6 +466,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                     }
                                 }}
                                 classNames={{
+                                    root: styles.tabsRoot,
                                     list: styles.list,
                                     tab: styles.tab,
                                 }}

--- a/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
+++ b/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
@@ -1,7 +1,18 @@
+.tabsRoot {
+    --tabs-stuck: 0;
+
+    &:has(.stickyTabsAndFilters[data-is-stuck='true']) {
+        --tabs-stuck: 1;
+    }
+}
+
 /* Wrapper for tabs and filters - always sticky together */
 .stickyTabsAndFilters {
     position: sticky;
     top: 0;
+    border-bottom: 1px solid transparent;
+    z-index: var(--dashboard-tabs-zindex);
+    transform: translate3d(0, 0, 0);
 
     /* When header is sticky above (edit mode), position below it */
     &[data-has-header-above='true'] {
@@ -9,8 +20,7 @@
     }
 
     &[data-is-stuck='true'] {
-        z-index: var(--dashboard-tabs-zindex);
-        border-bottom: 1px solid var(--mantine-color-ldGray-3);
+        border-color: var(--mantine-color-ldGray-3);
     }
 }
 


### PR DESCRIPTION
### Description:
Improved z-index handling for dashboard tiles and tabs to fix tooltip positioning issues. Removed hardcoded z-index values and implemented a CSS variable-based approach that dynamically adjusts tooltip positioning based on whether tabs are stuck or not. Added a CSS transform to ensure proper stacking context for sticky tabs and simplified border styling by using transparent borders that change color when stuck.
