### PR TITLE
fix: logging individual scheduler targets when batch jobs are created

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2966,8 +2966,12 @@ export default class SchedulerTask {
 
             // Create scheduled jobs for targets
             await Promise.all(
-                scheduledJobs.map(({ target, jobId: targetJobId }) =>
-                    this.logScheduledTarget(
+                scheduledJobs.map(({ target, jobId: targetJobId }) => {
+                    if (!target) {
+                        return Promise.resolve();
+                    }
+
+                    return this.logScheduledTarget(
                         scheduler.format,
                         target,
                         targetJobId,
@@ -2979,8 +2983,8 @@ export default class SchedulerTask {
                             organizationUuid: schedulerPayload.organizationUuid,
                             createdByUserUuid: schedulerPayload.userUuid,
                         },
-                    ),
-                ),
+                    );
+                }),
             );
 
             // Use page failures directly as partialFailures for logging


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added a undefined check for target in the scheduler task to prevent errors when processing undefined targets. The code now safely skips processing when a target is undefined instead of attempting to log it, which could cause runtime errors.

**Why we need this check?**
After introducing batch jobs we log the notifications differently and return an explicit `undefined` target.
Without this check it is throwing: `error: Missing target for scheduler format {format}`