### PR TITLE
feat: update virtual-view modals to mantinemodal

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
@@ -4,7 +4,6 @@ import {
     Box,
     Button,
     Group,
-    Modal,
     SegmentedControl,
     Stack,
     Text,
@@ -26,6 +25,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useLocation, useNavigate } from 'react-router';
 import LinkButton from '../../../../../components/common/LinkButton';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
 import useHealth from '../../../../../hooks/health/useHealth';
@@ -260,22 +260,15 @@ export const AiAgentsAdminLayout = () => {
                     </>
                 )}
             </PanelGroup>
-            <Modal
+            <MantineModal
                 opened={isAnalyticsEmbedOpen}
                 size="xl"
                 onClose={toggleAnalyticsEmbed}
-                title={<Text fw={700}>AI Agents Insights</Text>}
-                padding="0"
-                centered
-                styles={{
-                    header: {
-                        borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
-                        padding: theme.spacing.md,
-                    },
-                }}
+                title="AI Agents Insights"
+                icon={IconChartDots}
             >
                 <AnalyticsEmbedDashboard />
-            </Modal>
+            </MantineModal>
         </Stack>
     );
 };

--- a/packages/frontend/src/features/virtualView/components/CreateVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/CreateVirtualViewModal.tsx
@@ -1,19 +1,13 @@
 import { DbtProjectType, snakeCaseName } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    Text,
-    TextInput,
-    Tooltip,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, Stack, TextInput, Tooltip } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconInfoCircle, IconTableAlias } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { z } from 'zod';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../../components/common/MantineModal';
 import { useGitIntegration } from '../../../hooks/gitIntegration/useGitIntegration';
 import useHealth from '../../../hooks/health/useHealth';
 import { useProject } from '../../../hooks/useProject';
@@ -26,7 +20,9 @@ const validationSchema = z.object({
 
 type FormValues = z.infer<typeof validationSchema>;
 
-type Props = ModalProps;
+type Props = Pick<MantineModalProps, 'opened' | 'onClose'>;
+
+const FORM_ID = 'create-virtual-view-form';
 
 export const CreateVirtualViewModal: FC<Props> = ({ opened, onClose }) => {
     const health = useHealth();
@@ -79,74 +75,49 @@ export const CreateVirtualViewModal: FC<Props> = ({ opened, onClose }) => {
     );
 
     return (
-        <Modal
+        <MantineModal
             opened={opened}
             onClose={onClose}
-            keepMounted={false}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        icon={IconTableAlias}
-                        size="lg"
-                        color="ldGray.7"
-                    />
-                    <Text fw={500}>Create virtual view</Text>
-                    <Tooltip
-                        variant="xs"
-                        withinPortal
-                        multiline
-                        maw={300}
-                        label={`Create a virtual view so others can reuse this query in Lightdash. The query won’t be saved to or managed in your dbt project. ${
-                            canWriteToDbtProject
-                                ? 'If you’re expecting to reuse this query regularly, we suggest writing it back to dbt.'
-                                : ''
-                        } `}
-                    >
-                        <MantineIcon
-                            color="ldGray.7"
-                            icon={IconInfoCircle}
-                            size={16}
-                        />
-                    </Tooltip>
-                </Group>
+            title="Create virtual view"
+            icon={IconTableAlias}
+            size="md"
+            cancelDisabled={isLoadingVirtual}
+            headerActions={
+                <Tooltip
+                    variant="xs"
+                    withinPortal
+                    multiline
+                    maw={300}
+                    label={`Create a virtual view so others can reuse this query in Lightdash. The query won't be saved to or managed in your dbt project. ${
+                        canWriteToDbtProject
+                            ? "If you're expecting to reuse this query regularly, we suggest writing it back to dbt."
+                            : ''
+                    } `}
+                >
+                    <MantineIcon color="ldGray.7" icon={IconInfoCircle} />
+                </Tooltip>
             }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.ldGray[4]}` },
-                body: { padding: 0 },
-            })}
+            actions={
+                <Button
+                    type="submit"
+                    form={FORM_ID}
+                    disabled={!form.values.name || !sql}
+                    loading={isLoadingVirtual}
+                >
+                    Create
+                </Button>
+            }
         >
-            <form onSubmit={form.onSubmit(handleSubmit)}>
-                <Stack p="md">
+            <form id={FORM_ID} onSubmit={form.onSubmit(handleSubmit)}>
+                <Stack>
                     <TextInput
-                        radius="md"
                         label="Name"
                         required
                         {...form.getInputProps('name')}
                         error={!!error?.error}
                     />
                 </Stack>
-
-                <Group position="right" w="100%" p="md">
-                    <Button
-                        color="ldGray.7"
-                        onClick={onClose}
-                        variant="outline"
-                        disabled={isLoadingVirtual}
-                        size="xs"
-                    >
-                        Cancel
-                    </Button>
-
-                    <Button
-                        type="submit"
-                        disabled={!form.values.name || !sql}
-                        loading={isLoadingVirtual}
-                        size="xs"
-                    >
-                        Create
-                    </Button>
-                </Group>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/features/virtualView/components/DeleteVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/DeleteVirtualViewModal.tsx
@@ -1,6 +1,6 @@
-import { Button, Group, Modal, Stack, Text } from '@mantine/core';
+import { Button } from '@mantine-8/core';
 import { IconTrash } from '@tabler/icons-react';
-import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
 import { useDeleteVirtualView } from '../../virtualView/hooks/useVirtualView';
 
 export const DeleteVirtualViewModal = ({
@@ -17,41 +17,21 @@ export const DeleteVirtualViewModal = ({
     const { mutate, isLoading } = useDeleteVirtualView(projectUuid);
     const onDelete = () => {
         mutate({ projectUuid, name: virtualViewName });
-        // TODO: run validation query
         onClose();
     };
+
     return (
-        <Modal
+        <MantineModal
             opened={opened}
             onClose={onClose}
-            keepMounted={false}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon icon={IconTrash} size="lg" color="ldGray.7" />
-                    <Text fw={500}>Delete virtual view</Text>
-                </Group>
+            title="Delete virtual view"
+            icon={IconTrash}
+            description="Are you sure you want to delete this virtual view? This action cannot be undone and charts based on this virtual view will break."
+            actions={
+                <Button loading={isLoading} color="red" onClick={onDelete}>
+                    Delete
+                </Button>
             }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.ldGray[4]}` },
-            })}
-        >
-            <Stack pt="sm">
-                <Text>
-                    Are you sure you want to delete this virtual view? This
-                    action cannot be undone and charts based on this virtual
-                    view will break.
-                </Text>
-
-                <Group position="right" mt="sm">
-                    <Button color="dark" variant="outline" onClick={onClose}>
-                        Cancel
-                    </Button>
-
-                    <Button loading={isLoading} color="red" onClick={onDelete}>
-                        Delete
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+        />
     );
 };

--- a/packages/frontend/src/features/virtualView/components/EditVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/EditVirtualViewModal.tsx
@@ -1,14 +1,5 @@
 import { type Explore } from '@lightdash/common';
-import {
-    Button,
-    Center,
-    Group,
-    Loader,
-    Modal,
-    Stack,
-    Text,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, Center, Loader, Modal, Stack, Text } from '@mantine-8/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import {
     Suspense,
@@ -19,7 +10,9 @@ import {
     type FC,
 } from 'react';
 import { useNavigate } from 'react-router';
-import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../../components/common/MantineModal';
 import {
     explorerActions,
     selectTableName,
@@ -29,7 +22,7 @@ import {
 import useSearchParams from '../../../hooks/useSearchParams';
 import { defaultState } from '../../../providers/Explorer/defaultState';
 
-type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
+type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     activeTableName: string;
     setIsEditVirtualViewOpen: (value: boolean) => void;
     explore: Explore;
@@ -71,82 +64,67 @@ export const EditVirtualViewModal: FC<Props> = ({
         }
     };
 
-    return (
-        <Modal
-            opened={opened}
-            closeOnClickOutside={false}
-            withCloseButton={false}
-            onClose={handleClose}
-            title={
-                modalStep === 'unsavedChanges' ? (
-                    <Group spacing="xs">
-                        <MantineIcon icon={IconAlertCircle} />
-                        <Text fw={500}>You have unsaved changes</Text>
-                    </Group>
-                ) : null
-            }
-            size={modalStep === 'editVirtualView' ? '97vw' : 'lg'}
-            yOffset={modalStep === 'editVirtualView' ? '3vh' : undefined}
-            xOffset={modalStep === 'editVirtualView' ? '2vw' : undefined}
-            centered={modalStep !== 'editVirtualView'}
-            styles={(theme) => ({
-                header: {
-                    padding:
-                        modalStep === 'editVirtualView' ? 0 : theme.spacing.md,
-                },
-                body: {
-                    padding:
-                        modalStep === 'editVirtualView' ? 0 : theme.spacing.md,
-                },
-            })}
-        >
-            {modalStep === 'unsavedChanges' && (
-                <Stack>
-                    <Text fz="sm">
-                        Are you sure you want to leave this page? Changes you've
-                        made to your query will not be saved.
-                    </Text>
-                    <Group position="right">
-                        <Button variant="outline" onClick={onClose}>
-                            Cancel
-                        </Button>
-                        <Button
-                            color="red"
-                            onClick={() => {
-                                startTransition(() => {
-                                    handleClearQuery();
-                                    setModalStep('editVirtualView');
-                                });
-                            }}
-                            loading={isPending}
-                        >
-                            Discard & continue
-                        </Button>
-                    </Group>
-                </Stack>
-            )}
-            {modalStep === 'editVirtualView' && (
-                <Suspense
-                    fallback={
-                        <Center h="95vh" w="95vw">
-                            <Stack align="center" justify="center">
-                                <Loader variant="bars" />
-                                <Text fw={500}>Loading SQL Runner...</Text>
-                            </Stack>
-                        </Center>
-                    }
-                >
-                    <SqlRunnerPage
-                        isEditMode
-                        virtualViewState={{
-                            name: explore.name,
-                            label: explore.label,
-                            sql: explore.tables[activeTableName].sqlTable,
-                            onCloseEditVirtualView: onClose,
+    if (modalStep === 'unsavedChanges') {
+        return (
+            <MantineModal
+                opened={opened}
+                onClose={onClose}
+                title="You have unsaved changes"
+                icon={IconAlertCircle}
+                description="Are you sure you want to leave this page? Changes you've made to your query will not be saved."
+                actions={
+                    <Button
+                        color="red"
+                        onClick={() => {
+                            startTransition(() => {
+                                handleClearQuery();
+                                setModalStep('editVirtualView');
+                            });
                         }}
-                    />
-                </Suspense>
-            )}
-        </Modal>
+                        loading={isPending}
+                    >
+                        Discard & continue
+                    </Button>
+                }
+            />
+        );
+    }
+
+    return (
+        <Modal.Root
+            opened={opened && modalStep === 'editVirtualView'}
+            onClose={handleClose}
+            size="97vw"
+            centered={false}
+            yOffset="3vh"
+            xOffset="2vw"
+            closeOnClickOutside={false}
+        >
+            <Modal.Overlay />
+            <Modal.Content>
+                <Modal.Body p={0}>
+                    <Suspense
+                        fallback={
+                            <Center h="95vh" w="95vw">
+                                <Stack align="center" justify="center">
+                                    <Loader type="bars" />
+                                    <Text fw={500}>Loading SQL Runner...</Text>
+                                </Stack>
+                            </Center>
+                        }
+                    >
+                        <SqlRunnerPage
+                            isEditMode
+                            virtualViewState={{
+                                name: explore.name,
+                                label: explore.label,
+                                sql: explore.tables[activeTableName].sqlTable,
+                                onCloseEditVirtualView: onClose,
+                            }}
+                        />
+                    </Suspense>
+                </Modal.Body>
+            </Modal.Content>
+        </Modal.Root>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Refactored modal components in the virtual view and AI agents features to use the common `MantineModal` component instead of the basic Mantine `Modal`. This standardizes the modal UI across the application with consistent styling, header formatting, and action buttons.

The changes include:
- Replaced `Modal` with `MantineModal` in AiAgentsAdminLayout
- Updated CreateVirtualViewModal to use the common component with proper form handling
- Simplified DeleteVirtualViewModal by leveraging the built-in actions and description props
- Restructured EditVirtualViewModal to better handle the different modal states

![Screenshot 2025-12-30 at 12.35.06.png](https://app.graphite.com/user-attachments/assets/c4174b0a-17ab-43c9-a6c0-0c6e9775cd0b.png)

![Screenshot 2025-12-30 at 12.31.38.png](https://app.graphite.com/user-attachments/assets/a2e339d1-ef62-40b2-b8dd-5127386611c7.png)

![Screenshot 2025-12-30 at 12.37.07.png](https://app.graphite.com/user-attachments/assets/b640922b-d892-4a57-ae35-1506c859c965.png)

![Screenshot 2025-12-30 at 12.35.51.png](https://app.graphite.com/user-attachments/assets/caa5fc2e-a50e-43c8-86a0-78f8969ec4b1.png)

