### PR TITLE
fix: badge click to run history and enable resizing columns in log history table

### DIFF
--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -183,6 +183,24 @@ const LogsTable: FC<LogsTableProps> = ({
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
+    // Re-measure virtualizer when container becomes visible (fixes virtualization when switching tabs)
+    // Note: depends on isLoading because the table container only exists after loading completes
+    useEffect(() => {
+        const container = tableContainerRef.current;
+        if (!container) return;
+
+        const resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                if (entry.contentRect.height > 0) {
+                    rowVirtualizerInstanceRef.current?.measure?.();
+                }
+            }
+        });
+
+        resizeObserver.observe(container);
+        return () => resizeObserver.disconnect();
+    }, [isLoading]);
+
     const theme = useMantineTheme();
     const [isConfirmOpen, setIsConfirmOpen] = useState(false);
     const [selectedScheduler, setSelectedScheduler] = useState<{
@@ -471,6 +489,7 @@ const LogsTable: FC<LogsTableProps> = ({
                 accessorKey: 'actions',
                 header: '',
                 enableSorting: false,
+                enableResizing: false,
                 size: 60,
                 Cell: ({ row }) => {
                     const { run } = row.original;
@@ -545,7 +564,7 @@ const LogsTable: FC<LogsTableProps> = ({
     const table = useMantineReactTable({
         columns,
         data: tableData,
-        enableColumnResizing: false,
+        enableColumnResizing: true,
         enableRowNumbers: false,
         enablePagination: false,
         enableFilters: false,
@@ -601,11 +620,14 @@ const LogsTable: FC<LogsTableProps> = ({
             withColumnBorders: Boolean(tableData.length),
         },
         mantineTableHeadCellProps: (props) => {
-            const isFirstColumn =
-                props.table.getAllColumns().indexOf(props.column) === 0;
             const isLastColumn =
                 props.table.getAllColumns().indexOf(props.column) ===
                 props.table.getAllColumns().length - 1;
+
+            const isAnyColumnResizing = props.table
+                .getAllColumns()
+                .some((c) => c.getIsResizing());
+            const canResize = props.column.getCanResize();
 
             return {
                 bg: 'ldGray.0',
@@ -613,23 +635,41 @@ const LogsTable: FC<LogsTableProps> = ({
                 pos: 'relative',
                 style: {
                     userSelect: 'none',
+                    justifyContent: 'center',
                     padding: `${theme.spacing.xs} ${theme.spacing.xl}`,
+                    borderTop: `1px solid ${theme.colors.ldGray[2]}`,
                     borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
                     borderRight: props.column.getIsResizing()
                         ? `2px solid ${theme.colors.blue[3]}`
                         : `1px solid ${
-                              isLastColumn || isFirstColumn
+                              isLastColumn
                                   ? 'transparent'
                                   : theme.colors.ldGray[2]
                           }`,
-                    borderTop: 'none',
                     borderLeft: 'none',
+                },
+                sx: {
+                    '&:hover': canResize
+                        ? {
+                              borderRight: !isAnyColumnResizing
+                                  ? `2px solid ${theme.colors.blue[3]} !important`
+                                  : undefined,
+                              transition: `border-right ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                          }
+                        : {},
                 },
             };
         },
         mantineTableHeadRowProps: {
             sx: {
                 boxShadow: 'none',
+                'th > div > div:last-child': {
+                    top: -10,
+                    right: -5,
+                },
+                'th > div > div:last-child > .mantine-Divider-root': {
+                    border: 'none',
+                },
             },
         },
         mantineTableBodyCellProps: () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixes virtualization issues in the LogsTable component when switching tabs by adding a ResizeObserver to re-measure the virtualizer when the container becomes visible.

Enables column resizing for the table while disabling it specifically for the actions column. Improves the styling of table headers with proper borders and hover effects for resizable columns.

**Before**

[Screen Recording 2025-12-30 at 12.47.36.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/778af723-cbff-4942-8bf7-f9144354acc6.mov" />](https://app.graphite.com/user-attachments/video/778af723-cbff-4942-8bf7-f9144354acc6.mov)

**After**

[Screen Recording 2025-12-30 at 12.47.13.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/620155da-e372-4292-bd5e-31b37dae8d2f.mov" />](https://app.graphite.com/user-attachments/video/620155da-e372-4292-bd5e-31b37dae8d2f.mov)

