### PR TITLE
feat: update credentials modals to use mantinemodal

### DIFF
--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -3,7 +3,6 @@ import {
     MantineProvider,
     Menu,
     Text,
-    Title,
     useMantineTheme,
 } from '@mantine/core';
 import { IconCheck, IconDatabaseCog, IconPlus } from '@tabler/icons-react';
@@ -197,14 +196,11 @@ const UserCredentialsSwitcher = () => {
                     <CreateCredentialsModal
                         opened={isCreatingCredentials}
                         title={
-                            showCreateModalOnPageLoad ? (
-                                <Title order={4}>
-                                    Login to{' '}
-                                    {getWarehouseLabel(
-                                        activeProject.warehouseConnection?.type,
-                                    )}
-                                </Title>
-                            ) : undefined
+                            showCreateModalOnPageLoad
+                                ? `Login to ${getWarehouseLabel(
+                                      activeProject.warehouseConnection?.type,
+                                  )}`
+                                : undefined
                         }
                         description={
                             showCreateModalOnPageLoad ? (

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/DeleteCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/DeleteCredentialsModal.tsx
@@ -1,19 +1,13 @@
 import { type UserWarehouseCredentials } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    Text,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { Button, Text } from '@mantine-8/core';
+import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useUserWarehouseCredentialsDeleteMutation } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
-import MantineIcon from '../../common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../common/MantineModal';
 
-type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
+type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     warehouseCredentialsToBeDeleted: UserWarehouseCredentials;
 };
 
@@ -26,48 +20,32 @@ export const DeleteCredentialsModal: FC<Props> = ({
         useUserWarehouseCredentialsDeleteMutation(
             warehouseCredentialsToBeDeleted.uuid,
         );
+
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <MantineIcon size="lg" icon={IconAlertCircle} color="red" />
-                    <Title order={4}>Delete credentials</Title>
-                </Group>
-            }
+        <MantineModal
             opened={opened}
             onClose={onClose}
+            title="Delete credentials"
+            icon={IconTrash}
+            cancelDisabled={isDeleting}
+            actions={
+                <Button
+                    color="red"
+                    onClick={async () => {
+                        await mutateAsync();
+                        onClose();
+                    }}
+                    loading={isDeleting}
+                    disabled={isDeleting}
+                >
+                    Delete
+                </Button>
+            }
         >
-            <Stack>
-                <Text fz="sm">
-                    Are you sure you want to delete credentials:{' '}
-                    <b>{warehouseCredentialsToBeDeleted.name}</b>?
-                </Text>
-
-                <Group position="right" spacing="xs">
-                    <Button
-                        size="xs"
-                        variant="outline"
-                        onClick={onClose}
-                        color="dark"
-                        disabled={isDeleting}
-                    >
-                        Cancel
-                    </Button>
-
-                    <Button
-                        size="xs"
-                        color="red"
-                        onClick={async () => {
-                            await mutateAsync();
-                            onClose();
-                        }}
-                        type="submit"
-                        disabled={isDeleting}
-                    >
-                        Delete
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+            <Text fz="sm">
+                Are you sure you want to delete credentials:{' '}
+                <b>{warehouseCredentialsToBeDeleted.name}</b>?
+            </Text>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -3,18 +3,14 @@ import {
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
 } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    TextInput,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
+import { Button, Stack, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconPencil } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useUserWarehouseCredentialsUpdateMutation } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../common/MantineModal';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
 const getCredentialsWithPlaceholders = (
@@ -44,8 +40,10 @@ const getCredentialsWithPlaceholders = (
     }
 };
 
+const FORM_ID = 'edit-credentials-form';
+
 export const EditCredentialsModal: FC<
-    Pick<ModalProps, 'opened' | 'onClose'> & {
+    Pick<MantineModalProps, 'opened' | 'onClose'> & {
         userCredentials: UserWarehouseCredentials;
     }
 > = ({ opened, onClose, userCredentials }) => {
@@ -61,18 +59,31 @@ export const EditCredentialsModal: FC<
     });
 
     return (
-        <Modal
-            title={<Title order={4}>Edit credentials</Title>}
+        <MantineModal
             opened={opened}
             onClose={onClose}
+            title="Edit credentials"
+            icon={IconPencil}
+            cancelDisabled={isSaving}
+            actions={
+                <Button
+                    type="submit"
+                    form={FORM_ID}
+                    disabled={isSaving}
+                    loading={isSaving}
+                >
+                    Save
+                </Button>
+            }
         >
             <form
+                id={FORM_ID}
                 onSubmit={form.onSubmit(async (formData) => {
                     await mutateAsync(formData);
                     onClose();
                 })}
             >
-                <Stack spacing="xs">
+                <Stack gap="xs">
                     <TextInput
                         required
                         size="xs"
@@ -86,24 +97,8 @@ export const EditCredentialsModal: FC<
                         form={form}
                         disabled={isSaving}
                     />
-
-                    <Group position="right" spacing="xs" mt="sm">
-                        <Button
-                            size="xs"
-                            variant="outline"
-                            color="dark"
-                            onClick={onClose}
-                            disabled={isSaving}
-                        >
-                            Cancel
-                        </Button>
-
-                        <Button size="xs" type="submit" disabled={isSaving}>
-                            Save
-                        </Button>
-                    </Group>
                 </Stack>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -2,7 +2,7 @@ import {
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
 } from '@lightdash/common';
-import { PasswordInput, TextInput } from '@mantine/core';
+import { PasswordInput, TextInput } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
 import { type FC } from 'react';
 import { useGoogleLoginPopup } from '../../../hooks/gdrive/useGdrive';

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CreateCredentialsModal.tsx
@@ -4,18 +4,24 @@ import {
     type CreateOrganizationWarehouseCredentials,
     type OrganizationWarehouseCredentials,
 } from '@lightdash/common';
-import { Button, Group, Modal, Title, type ModalProps } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconPlus } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import { useCreateOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../common/MantineModal';
 import { SnowflakeCredentialsForm } from './SnowflakeCredentialsForm';
 
-type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
-    title?: React.ReactNode;
+type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
+    title?: string;
     description?: React.ReactNode;
     nameValue?: string;
     onSuccess?: (data: OrganizationWarehouseCredentials) => void;
 };
+
+const FORM_ID = 'create-org-credentials-form';
 
 export const CreateCredentialsModal: FC<Props> = ({
     opened,
@@ -49,14 +55,28 @@ export const CreateCredentialsModal: FC<Props> = ({
             },
         },
     });
+
     return (
-        <Modal
-            size="lg"
-            title={title || <Title order={4}>Add new credentials</Title>}
+        <MantineModal
             opened={opened}
             onClose={onClose}
+            title={title ?? 'Add new credentials'}
+            icon={IconPlus}
+            size="lg"
+            cancelDisabled={isSaving}
+            actions={
+                <Button
+                    type="submit"
+                    form={FORM_ID}
+                    disabled={isSaving || !isAuthenticated}
+                    loading={isSaving}
+                >
+                    Save credentials
+                </Button>
+            }
         >
             <form
+                id={FORM_ID}
                 onSubmit={form.onSubmit(async (formData) => {
                     const result = await mutateAsync({
                         name: nameValue || formData.name,
@@ -67,35 +87,17 @@ export const CreateCredentialsModal: FC<Props> = ({
                     onClose();
                 })}
             >
-                {description}
+                <Stack gap="xs">
+                    {description}
 
-                <SnowflakeCredentialsForm
-                    form={form}
-                    disabled={isSaving}
-                    showName={!nameValue}
-                    onAuthenticated={setIsAuthenticated}
-                />
-
-                <Group position="right" spacing="xs" mt="sm">
-                    <Button
-                        size="xs"
-                        variant="outline"
-                        color="dark"
-                        onClick={onClose}
+                    <SnowflakeCredentialsForm
+                        form={form}
                         disabled={isSaving}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        size="xs"
-                        type="submit"
-                        disabled={isSaving || !isAuthenticated}
-                        loading={isSaving}
-                    >
-                        Save credentials
-                    </Button>
-                </Group>
+                        showName={!nameValue}
+                        onAuthenticated={setIsAuthenticated}
+                    />
+                </Stack>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/DeleteCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/DeleteCredentialsModal.tsx
@@ -1,19 +1,13 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import {
-    Button,
-    Group,
-    Modal,
-    Stack,
-    Text,
-    Title,
-    type ModalProps,
-} from '@mantine/core';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { Button, Text } from '@mantine-8/core';
+import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useDeleteOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
-import MantineIcon from '../../common/MantineIcon';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../common/MantineModal';
 
-type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
+type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     warehouseCredentialsToBeDeleted: OrganizationWarehouseCredentials;
 };
 
@@ -24,51 +18,34 @@ export const DeleteCredentialsModal: FC<Props> = ({
 }) => {
     const { mutateAsync, isLoading: isDeleting } =
         useDeleteOrganizationWarehouseCredentials();
+
     return (
-        <Modal
-            title={
-                <Group spacing="xs">
-                    <MantineIcon size="lg" icon={IconAlertCircle} color="red" />
-                    <Title order={4}>Delete credentials</Title>
-                </Group>
-            }
+        <MantineModal
             opened={opened}
             onClose={onClose}
+            title="Delete credentials"
+            icon={IconTrash}
+            cancelDisabled={isDeleting}
+            actions={
+                <Button
+                    color="red"
+                    onClick={async () => {
+                        await mutateAsync(
+                            warehouseCredentialsToBeDeleted.organizationWarehouseCredentialsUuid,
+                        );
+                        onClose();
+                    }}
+                    loading={isDeleting}
+                    disabled={isDeleting}
+                >
+                    Delete
+                </Button>
+            }
         >
-            <Stack>
-                <Text fz="sm">
-                    Are you sure you want to delete credentials:{' '}
-                    <b>{warehouseCredentialsToBeDeleted.name}</b>?
-                </Text>
-
-                <Group position="right" spacing="xs">
-                    <Button
-                        size="xs"
-                        variant="outline"
-                        onClick={onClose}
-                        color="dark"
-                        disabled={isDeleting}
-                    >
-                        Cancel
-                    </Button>
-
-                    <Button
-                        size="xs"
-                        color="red"
-                        onClick={async () => {
-                            await mutateAsync(
-                                warehouseCredentialsToBeDeleted.organizationWarehouseCredentialsUuid,
-                            );
-                            onClose();
-                        }}
-                        type="submit"
-                        loading={isDeleting}
-                        disabled={isDeleting}
-                    >
-                        Delete
-                    </Button>
-                </Group>
-            </Stack>
-        </Modal>
+            <Text fz="sm">
+                Are you sure you want to delete credentials:{' '}
+                <b>{warehouseCredentialsToBeDeleted.name}</b>?
+            </Text>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/EditCredentialsModal.tsx
@@ -4,14 +4,20 @@ import {
     type OrganizationWarehouseCredentials,
     type UpdateOrganizationWarehouseCredentials,
 } from '@lightdash/common';
-import { Button, Group, Modal, Title, type ModalProps } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconPencil } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import { useUpdateOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
+import MantineModal, {
+    type MantineModalProps,
+} from '../../common/MantineModal';
 import { SnowflakeCredentialsForm } from './SnowflakeCredentialsForm';
 
+const FORM_ID = 'edit-org-credentials-form';
+
 export const EditCredentialsModal: FC<
-    Pick<ModalProps, 'opened' | 'onClose'> & {
+    Pick<MantineModalProps, 'opened' | 'onClose'> & {
         organizationCredentials: OrganizationWarehouseCredentials;
     }
 > = ({ opened, onClose, organizationCredentials }) => {
@@ -48,13 +54,26 @@ export const EditCredentialsModal: FC<
     });
 
     return (
-        <Modal
-            size="lg"
-            title={<Title order={4}>Edit credentials</Title>}
+        <MantineModal
             opened={opened}
             onClose={onClose}
+            title="Edit credentials"
+            icon={IconPencil}
+            size="lg"
+            cancelDisabled={isSaving}
+            actions={
+                <Button
+                    type="submit"
+                    form={FORM_ID}
+                    disabled={isSaving || !isAuthenticated}
+                    loading={isSaving}
+                >
+                    Save
+                </Button>
+            }
         >
             <form
+                id={FORM_ID}
                 onSubmit={form.onSubmit(async (formData) => {
                     await mutateAsync({
                         uuid: organizationCredentials.organizationWarehouseCredentialsUuid,
@@ -67,33 +86,14 @@ export const EditCredentialsModal: FC<
                     onClose();
                 })}
             >
-                <SnowflakeCredentialsForm
-                    form={form}
-                    disabled={isSaving}
-                    onAuthenticated={setIsAuthenticated}
-                />
-
-                <Group position="right" spacing="xs" mt="sm">
-                    <Button
-                        size="xs"
-                        variant="outline"
-                        color="dark"
-                        onClick={onClose}
+                <Stack gap="xs">
+                    <SnowflakeCredentialsForm
+                        form={form}
                         disabled={isSaving}
-                    >
-                        Cancel
-                    </Button>
-
-                    <Button
-                        size="xs"
-                        type="submit"
-                        disabled={isSaving || !isAuthenticated}
-                        loading={isSaving}
-                    >
-                        Save
-                    </Button>
-                </Group>
+                        onAuthenticated={setIsAuthenticated}
+                    />
+                </Stack>
             </form>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/SnowflakeCredentialsForm.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/SnowflakeCredentialsForm.tsx
@@ -5,7 +5,7 @@ import {
     Switch,
     TextInput,
     Textarea,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
 import { type FC } from 'react';
 import { useToggle } from 'react-use';
@@ -39,7 +39,7 @@ export const SnowflakeCredentialsForm: FC<Props> = ({
     const [isOpen, toggleOpen] = useToggle(false);
 
     return (
-        <Stack spacing="xs">
+        <Stack gap="xs">
             {showName && (
                 <TextInput
                     required
@@ -69,6 +69,7 @@ export const SnowflakeCredentialsForm: FC<Props> = ({
             />
 
             <Select
+                size="xs"
                 name="warehouse.authenticationType"
                 {...form.getInputProps('warehouse.authenticationType')}
                 // TODO: default value is not being recognized. private key is always being selected
@@ -113,7 +114,7 @@ export const SnowflakeCredentialsForm: FC<Props> = ({
             />
 
             <FormSection isOpen={isOpen} name="advanced">
-                <Stack spacing="xs" style={{ marginTop: '8px' }}>
+                <Stack gap="xs" mt="xs">
                     <Switch
                         size="xs"
                         label="Always use this warehouse"
@@ -140,7 +141,7 @@ export const SnowflakeCredentialsForm: FC<Props> = ({
                         size="xs"
                         label="Keep client session alive"
                         description={
-                            <p>
+                            <>
                                 This is intended to keep Snowflake sessions
                                 alive beyond the typical 4 hour timeout limit.
                                 You can see more details in{' '}
@@ -148,11 +149,12 @@ export const SnowflakeCredentialsForm: FC<Props> = ({
                                     target="_blank"
                                     href="https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile#client_session_keep_alive"
                                     rel="noreferrer"
+                                    fz="9"
                                 >
                                     dbt documentation
                                 </Anchor>
                                 .
-                            </p>
+                            </>
                         }
                         disabled={disabled}
                         {...form.getInputProps(
@@ -167,18 +169,19 @@ export const SnowflakeCredentialsForm: FC<Props> = ({
                         size="xs"
                         label="Query tag"
                         description={
-                            <p>
+                            <>
                                 This is Snowflake query tags parameter. You can
                                 see more details in{' '}
                                 <Anchor
                                     target="_blank"
                                     href="https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile#query_tag"
                                     rel="noreferrer"
+                                    fz="9"
                                 >
                                     dbt documentation
                                 </Anchor>
                                 .
-                            </p>
+                            </>
                         }
                         disabled={disabled}
                         {...form.getInputProps('credentials.queryTag')}
@@ -187,14 +190,7 @@ export const SnowflakeCredentialsForm: FC<Props> = ({
                     <TextInput
                         size="xs"
                         label="Snowflake URL override"
-                        description={
-                            <p>
-                                Usually Lightdash would connect to a default
-                                url: account.snowflakecomputing.com. If you'd
-                                like to override this (e.g. for the dbt server)
-                                you can specify a full custom URL here.
-                            </p>
-                        }
+                        description="Usually Lightdash would connect to a default url: account.snowflakecomputing.com. If you'd like to override this (e.g. for the dbt server) you can specify a full custom URL here."
                         disabled={disabled}
                         {...form.getInputProps('credentials.accessUrl')}
                     />

--- a/packages/frontend/src/components/common/Authentication/SnowflakeOAuthInput.tsx
+++ b/packages/frontend/src/components/common/Authentication/SnowflakeOAuthInput.tsx
@@ -1,11 +1,13 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Anchor, Button, Text } from '@mantine/core';
+import { Anchor, Button, Text } from '@mantine-8/core';
+import { IconExternalLink } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import {
     useIsSnowflakeAuthenticated,
     useSnowflakeLoginPopup,
 } from '../../../hooks/useSnowflake';
 import { getWarehouseIcon } from '../../ProjectConnection/ProjectConnectFlow/utils';
+import MantineIcon from '../MantineIcon';
 
 type Props = {
     onAuthenticated?: (isAuthenticated: boolean) => void;
@@ -40,7 +42,7 @@ export const SnowflakeOAuthInput: FC<Props> = ({ onAuthenticated }) => {
 
     if (isAuthenticated) {
         return (
-            <Text mt="0" color="gray" fs="xs">
+            <Text mt="0" c="ldGray.8" fz="xs">
                 You are connected to Snowflake,{' '}
                 <Anchor
                     href="#"
@@ -56,13 +58,16 @@ export const SnowflakeOAuthInput: FC<Props> = ({ onAuthenticated }) => {
 
     return (
         <Button
+            size="xs"
             onClick={() => {
                 openLoginPopup();
             }}
             variant="default"
-            color="gray"
-            leftIcon={getWarehouseIcon(WarehouseTypes.SNOWFLAKE, 'sm')}
-            sx={{ ':hover': { textDecoration: 'underline' } }}
+            color="ldGray"
+            leftSection={getWarehouseIcon(WarehouseTypes.SNOWFLAKE, 'xs')}
+            rightSection={
+                <MantineIcon icon={IconExternalLink} color="ldGray.6" />
+            }
         >
             Sign in with Snowflake
         </Button>

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -4,6 +4,7 @@ import {
     Loader,
     Modal,
     MultiSelect,
+    PasswordInput,
     Pill,
     ScrollArea,
     Select,
@@ -215,6 +216,12 @@ export const getMantine8ThemeOverride = (
                     if (props.variant === 'subtle')
                         return subtleInputStyles(theme);
                     return {};
+                },
+            }),
+
+            PasswordInput: PasswordInput.extend({
+                defaultProps: {
+                    radius: 'md',
                 },
             }),
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Refactored credential modals to use the new MantineModal component, improving UI consistency and reducing code duplication. This includes:

- Migrated CreateCredentialsModal, DeleteCredentialsModal, and EditCredentialsModal to use MantineModal
- Updated form layouts to use the new Mantine 8 components
- Simplified modal actions by using the standardized actions prop
- Replaced inline title components with string titles
- Added appropriate icons for each modal type
- Fixed form submission by using form IDs
- Improved the Snowflake OAuth button styling

![Screenshot 2025-12-30 at 12.42.44.png](https://app.graphite.com/user-attachments/assets/e48cc30e-ce0c-46ad-8a53-c3d03df853fb.png)

![Screenshot 2025-12-30 at 12.49.16.png](https://app.graphite.com/user-attachments/assets/be239837-9d5c-4427-8854-11c45fa15fbd.png)

![Screenshot 2025-12-30 at 12.49.08.png](https://app.graphite.com/user-attachments/assets/ae6e53eb-ba48-4acd-9115-e4d16a508c39.png)

![Screenshot 2025-12-30 at 12.42.50.png](https://app.graphite.com/user-attachments/assets/e0ac1bf0-99e4-4d50-9d75-35f13701a1ad.png)

![Screenshot 2025-12-30 at 12.42.47.png](https://app.graphite.com/user-attachments/assets/3eec88d2-fbe0-40ba-9d74-e05ecbaecb96.png)

