### PR TITLE
fix: only allow users with google openid identity to be reassigned to google sheets sync

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -195,6 +195,7 @@ export class OrganizationController extends BaseController {
         @Query() page?: number,
         @Query() searchQuery?: string,
         @Query() projectUuid?: string,
+        @Query() googleOidcOnly?: boolean,
     ): Promise<ApiOrganizationMemberProfiles> {
         this.setStatus(200);
         let paginateArgs: KnexPaginateArgs | undefined;
@@ -216,6 +217,7 @@ export class OrganizationController extends BaseController {
                     paginateArgs,
                     searchQuery,
                     projectUuid,
+                    googleOidcOnly,
                 ),
         };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -18832,6 +18832,7 @@ const models: TsoaRoute.Models = {
                     },
                     required: true,
                 },
+                hasGsheetsSchedulers: { dataType: 'boolean', required: true },
                 totalCount: { dataType: 'double', required: true },
             },
             validators: {},
@@ -39387,6 +39388,11 @@ export function RegisterRoutes(app: Router) {
         page: { in: 'query', name: 'page', dataType: 'double' },
         searchQuery: { in: 'query', name: 'searchQuery', dataType: 'string' },
         projectUuid: { in: 'query', name: 'projectUuid', dataType: 'string' },
+        googleOidcOnly: {
+            in: 'query',
+            name: 'googleOidcOnly',
+            dataType: 'boolean',
+        },
     };
     app.get(
         '/api/v1/org/users',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -19613,12 +19613,15 @@
                         },
                         "type": "array"
                     },
+                    "hasGsheetsSchedulers": {
+                        "type": "boolean"
+                    },
                     "totalCount": {
                         "type": "number",
                         "format": "double"
                     }
                 },
-                "required": ["byProject", "totalCount"],
+                "required": ["byProject", "hasGsheetsSchedulers", "totalCount"],
                 "type": "object"
             },
             "ApiSuccess_UserSchedulersSummary_": {
@@ -23819,7 +23822,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2287.0",
+        "version": "0.2288.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -33341,6 +33344,14 @@
                         "required": false,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "googleOidcOnly",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ]

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -218,6 +218,7 @@ export class OrganizationService extends BaseService {
         paginateArgs?: KnexPaginateArgs,
         searchQuery?: string,
         projectUuid?: string,
+        googleOidcOnly?: boolean,
     ): Promise<KnexPaginatedData<OrganizationMemberProfile[]>> {
         const { organizationUuid } = user;
 
@@ -239,11 +240,13 @@ export class OrganizationService extends BaseService {
                   includeGroups,
                   paginateArgs,
                   searchQuery,
+                  googleOidcOnly,
               )
             : await this.organizationMemberProfileModel.getOrganizationMembers({
                   organizationUuid,
                   paginateArgs,
                   searchQuery,
+                  googleOidcOnly,
               });
 
         let members = organizationMembers.filter((member) =>

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -375,6 +375,7 @@ export type ApiReassignSchedulerOwnerResponse = ApiSuccess<
 
 export type UserSchedulersSummary = {
     totalCount: number;
+    hasGsheetsSchedulers: boolean;
     byProject: Array<{
         projectUuid: string;
         projectName: string;

--- a/packages/frontend/src/components/SchedulersView/ReassignSchedulerOwnerModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/ReassignSchedulerOwnerModal.tsx
@@ -1,6 +1,8 @@
 import { Button, Group, Modal, Stack, Text } from '@mantine-8/core';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import { useSchedulerReassignOwnerMutation } from '../../features/scheduler/hooks/useSchedulerReassignOwnerMutation';
+import MantineIcon from '../common/MantineIcon';
 import { UserSelect } from '../common/UserSelect';
 
 type ReassignSchedulerOwnerModalProps = {
@@ -10,6 +12,8 @@ type ReassignSchedulerOwnerModalProps = {
     schedulerUuids: string[];
     excludedUserUuid?: string;
     onSuccess?: () => void;
+    /** When true, only shows users with an active Google connection */
+    hasGsheetsSchedulers?: boolean;
 };
 
 const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
@@ -19,6 +23,7 @@ const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
     schedulerUuids,
     excludedUserUuid,
     onSuccess,
+    hasGsheetsSchedulers = false,
 }) => {
     const [selectedUserUuid, setSelectedUserUuid] = useState<string | null>(
         null,
@@ -81,7 +86,22 @@ const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
                     value={selectedUserUuid}
                     onChange={setSelectedUserUuid}
                     excludedUserUuid={excludedUserUuid}
+                    requireGoogleToken={hasGsheetsSchedulers}
                 />
+
+                {hasGsheetsSchedulers && (
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon
+                            icon={IconInfoCircle}
+                            color="ldGray.6"
+                            size="lg"
+                        />
+                        <Text fz="xs" c="dimmed">
+                            You can only transfer ownership of a Google Sheets
+                            sync to a user with an active Google connection.
+                        </Text>
+                    </Group>
+                )}
 
                 <Group justify="flex-end" gap="sm">
                     <Button variant="default" onClick={handleClose}>

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -892,6 +892,14 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
         }
     }, [isBulkReassign, table]);
 
+    // Check if any schedulers being reassigned are GSHEETS format
+    const hasGsheetsSchedulers = useMemo(() => {
+        return schedulerUuidsToReassign.some((uuid) => {
+            const scheduler = flatData.find((s) => s.schedulerUuid === uuid);
+            return scheduler?.format === SchedulerFormat.GSHEETS;
+        });
+    }, [schedulerUuidsToReassign, flatData]);
+
     return (
         <>
             <MantineReactTable table={table} />
@@ -902,6 +910,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                 schedulerUuids={schedulerUuidsToReassign}
                 excludedUserUuid={excludedUserUuid}
                 onSuccess={handleReassignSuccess}
+                hasGsheetsSchedulers={hasGsheetsSchedulers}
             />
         </>
     );

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
@@ -22,6 +22,7 @@ import {
     IconChevronDown,
     IconChevronUp,
     IconDots,
+    IconInfoCircle,
     IconMail,
     IconTrash,
 } from '@tabler/icons-react';
@@ -319,18 +320,41 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                             </Radio.Group>
 
                             {schedulerAction === SchedulerAction.REASSIGN && (
-                                <UserSelect
-                                    label="New owner"
-                                    value={selectedNewOwner}
-                                    onChange={setSelectedNewOwner}
-                                    excludedUserUuid={user.userUuid}
-                                />
+                                <Stack gap="xs">
+                                    <UserSelect
+                                        label="New owner"
+                                        value={selectedNewOwner}
+                                        onChange={setSelectedNewOwner}
+                                        excludedUserUuid={user.userUuid}
+                                        requireGoogleToken={
+                                            schedulersSummary?.hasGsheetsSchedulers
+                                        }
+                                    />
+                                    {schedulersSummary?.hasGsheetsSchedulers && (
+                                        <Group gap="xs" wrap="nowrap">
+                                            <MantineIcon
+                                                icon={IconInfoCircle}
+                                                color="ldGray.6"
+                                                size="lg"
+                                            />
+                                            <Text fz="xs" c="dimmed">
+                                                You can only transfer ownership
+                                                of a Google Sheets sync to a
+                                                user with an active Google
+                                                connection.
+                                            </Text>
+                                        </Group>
+                                    )}
+                                </Stack>
                             )}
                         </>
                     ) : (
                         <Group gap="xs">
-                            <MantineIcon icon={IconAlertCircle} color="gray" />
-                            <Text fz="xs" c="ldGray.6" span>
+                            <MantineIcon
+                                icon={IconAlertCircle}
+                                color="ldGray.6"
+                            />
+                            <Text fz="xs" c="dimmed" span>
                                 This user has no scheduled deliveries.
                             </Text>
                         </Group>

--- a/packages/frontend/src/components/common/UserSelect/index.tsx
+++ b/packages/frontend/src/components/common/UserSelect/index.tsx
@@ -23,6 +23,8 @@ type UserSelectProps = {
     label?: string;
     placeholder?: string;
     disabled?: boolean;
+    /** When true, only shows users with an active Google connection (refresh token) */
+    requireGoogleToken?: boolean;
 };
 
 export const UserSelect: FC<UserSelectProps> = ({
@@ -32,6 +34,7 @@ export const UserSelect: FC<UserSelectProps> = ({
     label,
     placeholder = 'Search for a user...',
     disabled = false,
+    requireGoogleToken = false,
 }) => {
     const [searchValue, setSearchValue] = useState('');
     const [debouncedSearchValue] = useDebouncedValue(searchValue, 300);
@@ -47,6 +50,7 @@ export const UserSelect: FC<UserSelectProps> = ({
         {
             searchInput: debouncedSearchValue,
             pageSize: DEFAULT_PAGE_SIZE,
+            googleOidcOnly: requireGoogleToken || undefined,
         },
         { keepPreviousData: true },
     );
@@ -123,7 +127,11 @@ export const UserSelect: FC<UserSelectProps> = ({
             value={value}
             onChange={handleChange}
             data={selectData}
-            nothingFoundMessage="No users found"
+            nothingFoundMessage={
+                requireGoogleToken
+                    ? 'No users with an active Google connection found'
+                    : 'No users found'
+            }
             maxDropdownHeight={250}
             disabled={disabled}
             rightSection={

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -22,6 +22,7 @@ const getOrganizationUsersQuery = async (params?: {
     paginateArgs?: KnexPaginateArgs;
     searchQuery?: string;
     projectUuid?: string;
+    googleOidcOnly?: boolean;
 }) => {
     const urlParams = new URLSearchParams({
         ...(params?.paginateArgs
@@ -35,6 +36,9 @@ const getOrganizationUsersQuery = async (params?: {
             : {}),
         ...(params?.searchQuery ? { searchQuery: params.searchQuery } : {}),
         ...(params?.projectUuid ? { projectUuid: params.projectUuid } : {}),
+        ...(params?.googleOidcOnly
+            ? { googleOidcOnly: String(params.googleOidcOnly) }
+            : {}),
     }).toString();
 
     return lightdashApi<ApiOrganizationMemberProfiles['results']>({
@@ -100,11 +104,13 @@ export const useInfiniteOrganizationUsers = (
         includeGroups,
         pageSize,
         projectUuid,
+        googleOidcOnly,
     }: {
         searchInput?: string;
         includeGroups?: number;
         projectUuid?: string;
         pageSize: number;
+        googleOidcOnly?: boolean;
     },
     infinityQueryOpts: UseInfiniteQueryOptions<
         ApiOrganizationMemberProfiles['results'],
@@ -120,6 +126,7 @@ export const useInfiniteOrganizationUsers = (
                 pageSize,
                 searchInput,
                 projectUuid,
+                googleOidcOnly,
             ],
             queryFn: ({ pageParam }) => {
                 return getOrganizationUsersQuery({
@@ -130,6 +137,7 @@ export const useInfiniteOrganizationUsers = (
                     },
                     searchQuery: searchInput,
                     projectUuid,
+                    googleOidcOnly,
                 });
             },
             onError: (result) => setErrorResponse(result),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [https://linear.app/lightdash/issue/GLITCH-125/only-allow-to-transfer-ownership-of-gsheets-sync-to-users-with-refresh](https://linear.app/lightdash/issue/GLITCH-125/only-allow-to-transfer-ownership-of-gsheets-sync-to-users-with-refresh)

Closes: [https://linear.app/lightdash/issue/PROD-881/when-a-user-gets-deleted-i-want-to-be-able-to-transfer-ownership-of](https://linear.app/lightdash/issue/PROD-881/when-a-user-gets-deleted-i-want-to-be-able-to-transfer-ownership-of)

### Description:

Added support for filtering organization users by Google OIDC connection status. This enables:

1. Filtering users who have an active Google connection (with refresh token) when transferring ownership of Google Sheets scheduled deliveries
2. Showing warning messages when transferring Google Sheets schedulers to inform users about the Google connection requirement
3. Checking if a user has Google Sheets schedulers before allowing ownership transfer

This ensures that Google Sheets scheduled deliveries can only be transferred to users who have the necessary Google authentication to manage them.

**Steps to test**

1. Create google sheet sync with one user
2. Login with another user
3. Try to delete the previous owner of the google sheets sync - No users should show on the list because there are no other users with google integration
4. Sign in with google or create a google sheets sync with another user
5. Now it should show just the new user

**AC**

1. When reassigning schedulers (either individual, bulk or via user delete) it should only show users with google sheets sync on the list if any scheduler is a google sheets sync
2. If schedulers to be reassigned don't have google sheets sync then users list shouldn't be filtered by users only containing google openid_identity

**User delete - no schedulers**
![Screenshot 2025-12-30 at 13.16.28.png](https://app.graphite.com/user-attachments/assets/2259e72a-e21f-41d0-b208-37b165196b22.png)

**User delete - with google sheets sync**
![Screenshot 2025-12-30 at 13.16.34.png](https://app.graphite.com/user-attachments/assets/21fe588b-b0a9-4664-a966-6daceb503108.png)

**Reassign via schedulers table**
![Screenshot 2025-12-30 at 13.16.40.png](https://app.graphite.com/user-attachments/assets/95ddc70d-4970-4ad0-96ef-fed76b81632e.png)

**No users with google**
![Screenshot 2025-12-30 at 13.16.47.png](https://app.graphite.com/user-attachments/assets/3e749e3b-4b9b-474e-be69-9e1cb1fa5114.png)