### PR TITLE
feat: add update instructions based on CLI installation method

### DIFF
--- a/packages/cli/src/env.ts
+++ b/packages/cli/src/env.ts
@@ -11,3 +11,37 @@ export const { version: CLI_VERSION } = packageJson;
 
 export const DEFAULT_DBT_PROJECT_DIR = process.env.DBT_PROJECT_DIR || '.';
 export const DEFAULT_DBT_PROFILES_DIR: string = findDbtDefaultProfile();
+
+type InstallMethod = 'npm' | 'homebrew' | 'binary';
+
+export const getInstallMethod = (): InstallMethod => {
+    // pkg-compiled binary
+    if ((process as NodeJS.Process & { pkg?: unknown }).pkg) {
+        return 'binary';
+    }
+
+    const { execPath } = process;
+    // Homebrew: macOS (Apple Silicon, Intel) or Linux (Linuxbrew)
+    if (
+        execPath.includes('/opt/homebrew/') ||
+        execPath.includes('/usr/local/Cellar/') ||
+        execPath.includes('linuxbrew')
+    ) {
+        return 'homebrew';
+    }
+
+    return 'npm';
+};
+
+export const getUpdateInstructions = (version: string): string => {
+    const method = getInstallMethod();
+    switch (method) {
+        case 'homebrew':
+            return 'running: brew upgrade lightdash';
+        case 'binary':
+            return 'downloading from: https://github.com/lightdash/lightdash/releases';
+        case 'npm':
+        default:
+            return `running: npm install -g @lightdash/cli@${version}`;
+    }
+};

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -13,7 +13,7 @@ import {
 import fetch, { BodyInit } from 'node-fetch';
 import { URL } from 'url';
 import { getConfig } from '../../config';
-import { CLI_VERSION } from '../../env';
+import { CLI_VERSION, getUpdateInstructions } from '../../env';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
 import { buildRequestHeaders } from '../utils';
@@ -203,8 +203,8 @@ export const checkLightdashVersion = async (): Promise<void> => {
                     health.version
                 }) on ${
                     config.context?.serverUrl
-                }.\n         Some commands may fail, consider upgrading your CLI by doing: ${styles.secondary(
-                    `npm install -g @lightdash/cli@${health.version}`,
+                }.\n         Some commands may fail, consider upgrading your CLI by ${styles.secondary(
+                    getUpdateInstructions(health.version),
                 )}`,
             );
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19160

### Description:
Added functionality to detect the CLI installation method (npm, homebrew, or binary) and provide appropriate update instructions based on the detected method. This improves the user experience when the CLI version is outdated by showing installation-specific upgrade commands instead of always suggesting npm.

Depending on how the CLI was installed, the message will display:
 - "consider upgrading your CLI by running: npm install -g @lightdash/cli@X.X.X"
  - "consider upgrading your CLI by running: brew upgrade lightdash"
  - "consider upgrading your CLI by downloading from: https://..."
