### PR TITLE
feat: update more modals to MantineModal

### DIFF
--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -8,10 +8,7 @@ import {
     Button,
     Divider,
     Group,
-    Modal,
-    Stack,
     Text,
-    Title,
 } from '@mantine-8/core';
 import { IconBook, IconInfoCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
@@ -25,6 +22,7 @@ import Logo from '../svgs/grey-icon-logo.svg?react';
 import { PageName, PageType, SectionName } from '../types/Events';
 import MantineIcon from './common/MantineIcon';
 import MantineLinkButton from './common/MantineLinkButton';
+import MantineModal from './common/MantineModal';
 import {
     FOOTER_HEIGHT,
     FOOTER_MARGIN,
@@ -117,13 +115,28 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                 </Group>
             </Box>
 
-            <Modal
+            <MantineModal
                 opened={isOpen}
                 onClose={() => setIsOpen(false)}
-                title={
-                    <Group align="center" justify="flex-start" gap="xs">
-                        <IconInfoCircle size={17} color="gray" /> About
-                        Lightdash
+                title="About Lightdash"
+                icon={IconInfoCircle}
+                cancelLabel={false}
+                actions={
+                    <Group gap="sm">
+                        <MantineLinkButton
+                            href="https://docs.lightdash.com/"
+                            target="_blank"
+                            variant="default"
+                        >
+                            Docs
+                        </MantineLinkButton>
+                        <MantineLinkButton
+                            href="https://github.com/lightdash/lightdash"
+                            target="_blank"
+                            variant="default"
+                        >
+                            Github
+                        </MantineLinkButton>
                     </Group>
                 }
             >
@@ -131,56 +144,37 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                     name={PageName.ABOUT_LIGHTDASH}
                     type={PageType.MODAL}
                 >
-                    <Stack mx="xs">
-                        <Title order={5} fw={500}>
-                            <b>Version:</b>{' '}
-                            {healthState.data
-                                ? `v${healthState.data.version}`
-                                : 'n/a'}
-                        </Title>
-                        {showUpdateBadge && (
-                            <Alert
-                                title="New version available!"
-                                color="blue"
-                                icon={<IconInfoCircle size={17} />}
-                            >
-                                <Text c="blue">
-                                    The version v
-                                    {healthState.data?.latest.version} is now
-                                    available. Please follow the instructions in
-                                    the{' '}
-                                    <Anchor
-                                        href="https://docs.lightdash.com/self-host/update-lightdash"
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        underline="always" // Required: link isn't differentiated from blue text without underline
-                                    >
-                                        How to update version
-                                    </Anchor>{' '}
-                                    documentation.
-                                </Text>
-                            </Alert>
-                        )}
-
-                        <Group justify="flex-end">
-                            <MantineLinkButton
-                                href="https://docs.lightdash.com/"
-                                target="_blank"
-                                variant="default"
-                            >
-                                Docs
-                            </MantineLinkButton>
-                            <MantineLinkButton
-                                href="https://github.com/lightdash/lightdash"
-                                target="_blank"
-                                variant="default"
-                            >
-                                Github
-                            </MantineLinkButton>
-                        </Group>
-                    </Stack>
+                    <Text fw={500}>
+                        <b>Version:</b>{' '}
+                        {healthState.data
+                            ? `v${healthState.data.version}`
+                            : 'n/a'}
+                    </Text>
+                    {showUpdateBadge && (
+                        <Alert
+                            title="New version available!"
+                            color="blue"
+                            icon={<IconInfoCircle size={17} />}
+                        >
+                            <Text c="blue">
+                                The version v
+                                {healthState.data?.latest.version} is now
+                                available. Please follow the instructions in
+                                the{' '}
+                                <Anchor
+                                    href="https://docs.lightdash.com/self-host/update-lightdash"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    underline="always"
+                                >
+                                    How to update version
+                                </Anchor>{' '}
+                                documentation.
+                            </Text>
+                        </Alert>
+                    )}
                 </TrackPage>
-            </Modal>
+            </MantineModal>
         </TrackSection>
     );
 };

--- a/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
+++ b/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
@@ -8,7 +8,6 @@ import {
     Group,
     JsonInput,
     LoadingOverlay,
-    Modal,
     Pagination,
     Paper,
     Stack,
@@ -24,6 +23,7 @@ import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useTableStyles } from '../../hooks/styles/useTableStyles';
 import { useProjectParametersList } from '../../hooks/useProjectParameters';
 import MantineIcon from '../common/MantineIcon';
+import MantineModal from '../common/MantineModal';
 import { SettingsCard } from '../common/Settings/SettingsCard';
 import { DEFAULT_PAGE_SIZE } from '../common/Table/constants';
 
@@ -44,18 +44,13 @@ const ConfigModal: FC<ConfigModalProps> = ({
     opened,
     onClose,
 }) => (
-    <Modal
+    <MantineModal
         opened={opened}
         onClose={onClose}
-        title={
-            <Group gap="xs">
-                <MantineIcon size="lg" icon={IconVariable} />
-                <Title order={4}>
-                    Parameter configuration: {parameterName}
-                </Title>
-            </Group>
-        }
+        title={`Parameter configuration: ${parameterName}`}
+        icon={IconVariable}
         size="lg"
+        cancelLabel={false}
     >
         <JsonInput
             value={JSON.stringify(config, null, 2)}
@@ -64,7 +59,7 @@ const ConfigModal: FC<ConfigModalProps> = ({
             readOnly
             autosize
         />
-    </Modal>
+    </MantineModal>
 );
 
 const ProjectParameters: FC<ProjectParametersProps> = ({ projectUuid }) => {

--- a/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
@@ -13,7 +13,6 @@ import {
     Divider,
     Group,
     Loader,
-    Modal,
     Stack,
     Text,
     useMantineTheme,
@@ -28,11 +27,12 @@ import {
 import dayjs from 'dayjs';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
+import MantineModal from '../common/MantineModal';
 import {
     formatTaskName,
     formatTime,
     getLogStatusIconWithoutTooltip,
-    getSchedulerIcon,
+    getSchedulerIconRaw,
 } from './SchedulersViewUtils';
 
 type JobSummary = {
@@ -667,16 +667,13 @@ const RunDetailsModal: FC<RunDetailsModalProps> = ({
     if (!run) return null;
 
     return (
-        <Modal
+        <MantineModal
             opened={opened}
             onClose={onClose}
-            title={
-                <Group gap="sm">
-                    {getSchedulerIcon(run)}
-                    <Text fw={600}>{run.schedulerName}</Text>
-                </Group>
-            }
+            title={run.schedulerName}
             size="lg"
+            icon={getSchedulerIconRaw(run)}
+            cancelLabel={false}
         >
             <Stack gap="lg">
                 {/* Run metadata */}
@@ -788,7 +785,7 @@ const RunDetailsModal: FC<RunDetailsModalProps> = ({
                     )}
                 </Box>
             </Stack>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -43,16 +43,40 @@ export type SchedulerColumnName =
     | 'deliveryStarted'
     | 'status';
 
+export const getSchedulerIconRaw = (item: { format: SchedulerFormat }) => {
+    switch (item.format) {
+        case SchedulerFormat.CSV:
+            return IconCsv;
+        case SchedulerFormat.XLSX:
+            return IconFileTypeXls;
+        case SchedulerFormat.IMAGE:
+            return IconPhoto;
+        case SchedulerFormat.GSHEETS:
+            return GSheetsIconFilled;
+        default:
+            return assertUnreachable(
+                item.format,
+                'Resource type not supported',
+            );
+    }
+};
+
 export const getSchedulerIcon = (item: { format: SchedulerFormat }) => {
     switch (item.format) {
         case SchedulerFormat.CSV:
-            return <IconBox icon={IconCsv} color="indigo.6" />;
+            return (
+                <IconBox icon={getSchedulerIconRaw(item)} color="indigo.6" />
+            );
         case SchedulerFormat.XLSX:
-            return <IconBox icon={IconFileTypeXls} color="indigo.6" />;
+            return (
+                <IconBox icon={getSchedulerIconRaw(item)} color="indigo.6" />
+            );
         case SchedulerFormat.IMAGE:
-            return <IconBox icon={IconPhoto} color="indigo.6" />;
+            return (
+                <IconBox icon={getSchedulerIconRaw(item)} color="indigo.6" />
+            );
         case SchedulerFormat.GSHEETS:
-            return <IconBox icon={GSheetsIconFilled} color="green" />;
+            return <IconBox icon={getSchedulerIconRaw(item)} color="green" />;
         default:
             return assertUnreachable(
                 item.format,

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsActionMenu.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsActionMenu.tsx
@@ -1,23 +1,10 @@
 import { type GroupWithMembers } from '@lightdash/common';
-import {
-    ActionIcon,
-    Button,
-    Group,
-    Menu,
-    Modal,
-    Stack,
-    Text,
-    Title,
-} from '@mantine-8/core';
-import {
-    IconAlertCircle,
-    IconDots,
-    IconEdit,
-    IconTrash,
-} from '@tabler/icons-react';
+import { ActionIcon, Button, Menu } from '@mantine-8/core';
+import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import { useGroupDeleteMutation } from '../../../hooks/useOrganizationGroups';
 import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
 
 interface GroupsActionMenuProps {
     group: GroupWithMembers;
@@ -80,43 +67,25 @@ const GroupsActionMenu: FC<GroupsActionMenuProps> = ({
                 </Menu.Dropdown>
             </Menu>
 
-            <Modal
+            <MantineModal
                 opened={isDeleteDialogOpen}
                 onClose={() =>
                     !isDeleting ? setIsDeleteDialogOpen(false) : undefined
                 }
-                title={
-                    <Group gap="xs">
-                        <MantineIcon
-                            size="lg"
-                            icon={IconAlertCircle}
-                            color="red"
-                        />
-                        <Title order={4}>Delete group "{group.name}"</Title>
-                    </Group>
+                title={`Delete group "${group.name}"`}
+                icon={IconTrash}
+                description="Are you sure you want to delete this group?"
+                cancelDisabled={isDeleting}
+                actions={
+                    <Button
+                        onClick={handleDelete}
+                        disabled={isDeleting}
+                        color="red"
+                    >
+                        Delete
+                    </Button>
                 }
-            >
-                <Stack gap="xs">
-                    <Text>Are you sure you want to delete this group?</Text>
-                    <Group gap="xs" justify="right">
-                        <Button
-                            disabled={isDeleting}
-                            onClick={() => setIsDeleteDialogOpen(false)}
-                            variant="outline"
-                            color="dark"
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            onClick={handleDelete}
-                            disabled={isDeleting}
-                            color="red"
-                        >
-                            Delete
-                        </Button>
-                    </Group>
-                </Stack>
-            </Modal>
+            />
         </>
     );
 };

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersActionMenu.tsx
@@ -10,8 +10,6 @@ import {
     Collapse,
     Group,
     Menu,
-    Modal,
-    Paper,
     Radio,
     Stack,
     Text,
@@ -37,6 +35,7 @@ import {
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
 import { PolymorphicGroupButton } from '../../common/PolymorphicGroupButton';
 import { UserSelect } from '../../common/UserSelect';
 
@@ -108,12 +107,6 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
             setIsProjectBreakdownOpen(false);
         }
     }, [isDeleteDialogOpen]);
-
-    const handleClose = useCallback(() => {
-        if (!isProcessing) {
-            setIsDeleteDialogOpen(false);
-        }
-    }, [isProcessing]);
 
     const handleDelete = useCallback(async () => {
         if (hasSchedulers && schedulerAction === SchedulerAction.REASSIGN) {
@@ -220,16 +213,23 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                 </Menu.Dropdown>
             </Menu>
 
-            <Modal
+            <MantineModal
                 opened={isDeleteDialogOpen}
-                onClose={handleClose}
-                title={
-                    <Group gap="xs">
-                        <Paper>
-                            <MantineIcon icon={IconAlertCircle} color="red" />
-                        </Paper>
-                        <Title order={4}>Delete user</Title>
-                    </Group>
+                onClose={() =>
+                    !isDeleting ? setIsDeleteDialogOpen(false) : undefined
+                }
+                title="Delete user"
+                icon={IconTrash}
+                cancelDisabled={isDeleting}
+                actions={
+                    <Button
+                        onClick={handleDelete}
+                        loading={isProcessing}
+                        disabled={!canConfirmDelete}
+                        color="red"
+                    >
+                        Delete
+                    </Button>
                 }
             >
                 <Stack gap="md">
@@ -359,27 +359,8 @@ const UsersActionMenu: FC<UsersActionMenuProps> = ({
                             </Text>
                         </Group>
                     )}
-
-                    <Group gap="xs" justify="flex-end" mt="md">
-                        <Button
-                            disabled={isProcessing}
-                            onClick={handleClose}
-                            variant="outline"
-                            color="dark"
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            onClick={handleDelete}
-                            loading={isProcessing}
-                            disabled={!canConfirmDelete}
-                            color="red"
-                        >
-                            Delete
-                        </Button>
-                    </Group>
                 </Stack>
-            </Modal>
+            </MantineModal>
         </>
     );
 };

--- a/packages/frontend/src/components/common/Callout.tsx
+++ b/packages/frontend/src/components/common/Callout.tsx
@@ -2,12 +2,13 @@ import { Alert, type AlertProps, type MantineColor } from '@mantine-8/core';
 import {
     IconAlertCircle,
     IconAlertTriangle,
+    IconCheck,
     IconInfoCircle,
 } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import MantineIcon from './MantineIcon';
 
-type CalloutVariant = 'danger' | 'warning' | 'info';
+type CalloutVariant = 'danger' | 'warning' | 'info' | 'success';
 
 const CALLOUT_CONFIG: Record<
     CalloutVariant,
@@ -27,6 +28,10 @@ const CALLOUT_CONFIG: Record<
     info: {
         color: 'blue',
         icon: IconInfoCircle,
+    },
+    success: {
+        color: 'green',
+        icon: IconCheck,
     },
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #

### Description:
Introduces a new `MantineModal` component to standardize modal UI across the application. This component replaces the standard Mantine Modal with a consistent interface that includes:

- Standardized header with icon support
- Consistent action button placement
- Better handling of cancel/confirm actions

The PR updates several modals throughout the application:
- AboutFooter modal
- ProjectParameters configuration modal
- SchedulersView run details modal
- AccessTokens panel modals
- UsersAndGroups panel modals

Also enhances the Callout component with a new "success" variant for positive feedback messages.