### PR TITLE
feat: update mantine modals for sql,export dashboard,custommetrics

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -18,14 +18,13 @@ import {
 import {
     Accordion,
     Button,
-    Modal,
     NumberInput,
     Stack,
     Text,
     TextInput,
-    Title,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm } from '@mantine/form';
+import { IconSparkles } from '@tabler/icons-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { type ValueOf } from 'type-fest';
 import { v4 as uuidv4 } from 'uuid';
@@ -39,6 +38,7 @@ import {
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useExplore } from '../../../hooks/useExplore';
 import FiltersProvider from '../../common/Filters/FiltersProvider';
+import MantineModal from '../../common/MantineModal';
 import { FormatForm } from '../FormatForm';
 import { FilterForm, type MetricFilterRuleWithFieldId } from './FilterForm';
 import { useDataForFiltersProvider } from './hooks/useDataForFiltersProvider';
@@ -171,8 +171,8 @@ export const CustomMetricModal = memo(() => {
                 isEditing
                     ? label
                     : customMetricType
-                    ? `${friendlyName(customMetricType)} of ${label}`
-                    : '',
+                      ? `${friendlyName(customMetricType)} of ${label}`
+                      : '',
             );
         }
     }, [setFieldValue, item, customMetricType, isEditing]);
@@ -292,24 +292,35 @@ export const CustomMetricModal = memo(() => {
         value: ValueOf<CustomFormat>,
     ) => form.setFieldValue(`format.${path}`, value);
 
+    const CUSTOM_METRIC_FORM_ID = 'custom-metric-form';
+
     if (!isOpen) {
         return null;
     }
 
     return item ? (
-        <Modal
+        <MantineModal
             size="xl"
-            onClick={(e) => e.stopPropagation()}
             opened={isOpen}
             onClose={handleClose}
-            title={
-                <Title order={4}>
-                    {isEditing ? 'Edit' : 'Create'} Custom Metric
-                </Title>
+            title={`${isEditing ? 'Edit' : 'Create'} Custom Metric`}
+            icon={IconSparkles}
+            actions={
+                <Button
+                    type="submit"
+                    form={CUSTOM_METRIC_FORM_ID}
+                    disabled={!form.isValid()}
+                >
+                    {isEditing ? 'Save changes' : 'Create'}
+                </Button>
             }
         >
-            <form onSubmit={handleOnSubmit}>
-                <Stack>
+            <form
+                id={CUSTOM_METRIC_FORM_ID}
+                onSubmit={handleOnSubmit}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <Stack gap="md">
                     <TextInput
                         label="Label"
                         required
@@ -326,7 +337,12 @@ export const CustomMetricModal = memo(() => {
                             {...form.getInputProps('percentile')}
                         />
                     )}
-                    <Accordion chevronPosition="left" chevronSize="xs">
+                    <Accordion
+                        chevronPosition="left"
+                        chevronSize="xs"
+                        variant="separated"
+                        radius="md"
+                    >
                         {canApplyFormatting && (
                             <Accordion.Item value="format">
                                 <Accordion.Control>
@@ -354,12 +370,7 @@ export const CustomMetricModal = memo(() => {
                                             ? `(${customMetricFiltersWithIds.length}) `
                                             : ' '}
                                     </Text>
-                                    <Text
-                                        span
-                                        fz="xs"
-                                        color="ldGray.5"
-                                        fw={400}
-                                    >
+                                    <Text span fz="xs" c="ldGray.5" fw={400}>
                                         (optional)
                                     </Text>
                                 </Text>
@@ -390,16 +401,8 @@ export const CustomMetricModal = memo(() => {
                             </Accordion.Panel>
                         </Accordion.Item>
                     </Accordion>
-                    <Button
-                        display="block"
-                        ml="auto"
-                        type="submit"
-                        disabled={!form.isValid()}
-                    >
-                        {isEditing ? 'Save changes' : 'Create'}
-                    </Button>
                 </Stack>
             </form>
-        </Modal>
+        </MantineModal>
     ) : null;
 });

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -5,13 +5,12 @@ import {
     Box,
     Button,
     Group,
-    Modal,
     Stack,
     Table,
     Text,
     Title,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAlertCircle,
@@ -32,6 +31,7 @@ import useApp from '../../../providers/App/useApp';
 import ForbiddenPanel from '../../ForbiddenPanel';
 import LoadingState from '../../common/LoadingState';
 import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import UserAttributeModal from './UserAttributeModal';
 
@@ -46,8 +46,8 @@ const UserListItem: FC<{
     return (
         <tr>
             <td>
-                <Stack spacing="xs">
-                    <Group spacing="two">
+                <Stack gap="xs">
+                    <Group gap="two">
                         <Text>{orgUserAttribute.name}</Text>
                         {orgUserAttribute.description && (
                             <Tooltip
@@ -63,13 +63,13 @@ const UserListItem: FC<{
                             </Tooltip>
                         )}
                     </Group>
-                    <Group spacing="sm">
-                        <Text fz="xs" color="ldGray.6">
+                    <Group gap="sm">
+                        <Text fz="xs" c="ldGray.6">
                             {orgUserAttribute.users.length} user
                             {orgUserAttribute.users.length !== 1 ? 's' : ''}
                         </Text>
                         {isGroupManagementEnabled && (
-                            <Text fz="xs" color="ldGray.6">
+                            <Text fz="xs" c="ldGray.6">
                                 {orgUserAttribute.groups.length} group
                                 {orgUserAttribute.groups.length !== 1
                                     ? 's'
@@ -80,7 +80,7 @@ const UserListItem: FC<{
                 </Stack>
             </td>
             <td width="1%">
-                <Group noWrap spacing="xs">
+                <Group wrap="nowrap" gap="xs">
                     <ActionIcon
                         color="blue.4"
                         variant="outline"
@@ -97,32 +97,12 @@ const UserListItem: FC<{
                         <MantineIcon icon={IconTrash} />
                     </ActionIcon>
 
-                    <Modal
+                    <MantineModal
                         opened={isDeleteDialogOpen}
                         onClose={deleteDialog.close}
-                        title={
-                            <Group spacing="xs">
-                                <MantineIcon
-                                    size="lg"
-                                    icon={IconAlertCircle}
-                                    color="red"
-                                />
-                                <Title order={4}>Delete</Title>
-                            </Group>
-                        }
-                    >
-                        <Text pb="md">
-                            Are you sure you want to delete this user attribute
-                            ?
-                        </Text>
-                        <Group spacing="xs" position="right">
-                            <Button
-                                onClick={deleteDialog.close}
-                                variant="outline"
-                                color="dark"
-                            >
-                                Cancel
-                            </Button>
+                        title="Delete user attribute"
+                        icon={IconAlertCircle}
+                        actions={
                             <Button
                                 onClick={() => {
                                     deleteUserAttribute(orgUserAttribute.uuid);
@@ -131,8 +111,12 @@ const UserListItem: FC<{
                             >
                                 Delete
                             </Button>
-                        </Group>
-                    </Modal>
+                        }
+                    >
+                        <Text>
+                            Are you sure you want to delete this user attribute?
+                        </Text>
+                    </MantineModal>
                 </Group>
             </td>
         </tr>
@@ -181,8 +165,8 @@ const UserAttributesPanel: FC = () => {
 
     return (
         <Stack>
-            <Group position="apart">
-                <Group spacing="two">
+            <Group justify="space-between">
+                <Group gap="two">
                     <Title order={5}>
                         {isGroupManagementEnabled
                             ? 'User and group attributes'
@@ -215,7 +199,7 @@ const UserAttributesPanel: FC = () => {
                 <>
                     <Button
                         size="xs"
-                        leftIcon={<MantineIcon icon={IconPlus} />}
+                        leftSection={<MantineIcon icon={IconPlus} />}
                         onClick={addAttributeModal.open}
                     >
                         Add new attribute

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentsAdminLayout.tsx
@@ -253,7 +253,6 @@ export const AiAgentsAdminLayout = () => {
                                     isOpen={isSidebarOpen}
                                     onClose={handleCloseSidebar}
                                     showAddToEvalsButton
-                                    renderArtifactsInline
                                 />
                             )}
                         </Panel>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -5,7 +5,6 @@ import {
     Divider,
     Group,
     LoadingOverlay,
-    Modal,
     Title,
     Tooltip,
 } from '@mantine-8/core';
@@ -14,13 +13,7 @@ import { type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiAgentThread } from '../../hooks/useProjectAiAgents';
-import { clearArtifact } from '../../store/aiArtifactSlice';
-import {
-    useAiAgentStoreDispatch,
-    useAiAgentStoreSelector,
-} from '../../store/hooks';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
-import { AiArtifactPanel } from '../ChatElements/AiArtifactPanel';
 import { EvalAssessmentDisplay } from '../Evals/EvalAssessmentDisplay';
 
 type ThreadPreviewSidebarProps = {
@@ -29,7 +22,6 @@ type ThreadPreviewSidebarProps = {
     threadUuid: string;
     isOpen: boolean;
     onClose: () => void;
-    renderArtifactsInline?: boolean;
     showAddToEvalsButton?: boolean;
     evalUuid?: string;
     runUuid?: string;
@@ -41,15 +33,10 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
     threadUuid,
     isOpen,
     onClose,
-    renderArtifactsInline = false,
     showAddToEvalsButton = false,
     evalUuid,
     runUuid,
 }) => {
-    const dispatch = useAiAgentStoreDispatch();
-    const aiArtifact = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.artifact,
-    );
     const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
         projectUuid,
         agentUuid,
@@ -116,50 +103,24 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
             <Divider />
 
             {threadData && (
-                <>
-                    <Box
-                        mah="calc(100vh - 150px)"
-                        style={{ overflowY: 'auto' }}
-                    >
-                        {evalUuid && runUuid && (
-                            <EvalAssessmentDisplay
-                                projectUuid={projectUuid}
-                                agentUuid={agentUuid}
-                                evalUuid={evalUuid}
-                                runUuid={runUuid}
-                                threadUuid={threadUuid}
-                            />
-                        )}
-                        <AgentChatDisplay
-                            thread={threadData}
+                <Box mah="calc(100vh - 150px)" style={{ overflowY: 'auto' }}>
+                    {evalUuid && runUuid && (
+                        <EvalAssessmentDisplay
                             projectUuid={projectUuid}
                             agentUuid={agentUuid}
-                            showAddToEvalsButton={showAddToEvalsButton}
-                            renderArtifactsInline={renderArtifactsInline}
+                            evalUuid={evalUuid}
+                            runUuid={runUuid}
+                            threadUuid={threadUuid}
                         />
-                    </Box>
-                    {!!aiArtifact && !renderArtifactsInline && (
-                        <Modal
-                            withinPortal
-                            opened={!!aiArtifact}
-                            onClose={() => dispatch(clearArtifact())}
-                            size="lg"
-                            withCloseButton={false}
-                            centered
-                            mih="90vh"
-                            styles={{
-                                body: {
-                                    height: '500px',
-                                    padding: 0,
-                                },
-                            }}
-                        >
-                            {aiArtifact && (
-                                <AiArtifactPanel artifact={aiArtifact} />
-                            )}
-                        </Modal>
                     )}
-                </>
+                    <AgentChatDisplay
+                        thread={threadData}
+                        projectUuid={projectUuid}
+                        agentUuid={agentUuid}
+                        showAddToEvalsButton={showAddToEvalsButton}
+                        renderArtifactsInline
+                    />
+                </Box>
             )}
         </Box>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
@@ -263,7 +263,6 @@ export const EvalSectionLayout: FC<EvalSectionLayoutProps> = ({ children }) => {
                                     threadUuid={selectedThreadUuid}
                                     isOpen={isSidebarOpen}
                                     onClose={handleCloseSidebar}
-                                    renderArtifactsInline
                                     evalUuid={evalUuid}
                                     runUuid={runUuid}
                                 />

--- a/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/PresetsForm/index.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/PresetsForm/index.tsx
@@ -3,7 +3,7 @@ import {
     DashboardSummaryTone,
     type DashboardSummary,
 } from '@lightdash/common';
-import { Button, Flex, Select, Stack, Textarea } from '@mantine/core';
+import { Button, Flex, Select, Stack, Textarea } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import capitalize from 'lodash/capitalize';
 import { type FC } from 'react';
@@ -80,7 +80,6 @@ const PresetsForm: FC<PresetsFormProps> = ({
                 <Select
                     label="Tone of voice"
                     data={TONE_SELECT_DATA}
-                    withinPortal
                     w="25%"
                     {...form.getInputProps('tone')}
                 />
@@ -101,7 +100,7 @@ const PresetsForm: FC<PresetsFormProps> = ({
                 <Flex gap="md" justify="flex-end">
                     <Button
                         onClick={handleCancel}
-                        variant="subtle"
+                        variant="default"
                         disabled={isLoading}
                     >
                         Cancel

--- a/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/SummaryPreview.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/SummaryPreview.tsx
@@ -1,9 +1,10 @@
 import { type DashboardSummary } from '@lightdash/common';
-import { ActionIcon, Alert, Flex, Stack, Text, Tooltip } from '@mantine/core';
-import { IconExclamationCircle, IconRefresh } from '@tabler/icons-react';
+import { Button, Flex, Stack, Text } from '@mantine-8/core';
+import { IconRefresh } from '@tabler/icons-react';
 import ReactMarkdownPreview from '@uiw/react-markdown-preview';
 import { type FC } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
+import Callout from '../../../../../components/common/Callout';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useTimeAgo } from '../../../../../hooks/useTimeAgo';
 
@@ -23,15 +24,11 @@ const SummaryPreview: FC<SummaryPreviewProps> = ({
     return (
         <Stack align="flex-end">
             {dashboardVersionId !== summary.dashboardVersionId && (
-                <Alert
-                    color="orange"
+                <Callout
+                    variant="warning"
                     w="100%"
-                    icon={
-                        <MantineIcon icon={IconExclamationCircle} size="lg" />
-                    }
-                >
-                    Your dashboard has changed since this summary was generated.
-                </Alert>
+                    title="Your dashboard has changed since this summary was generated."
+                />
             )}
             <ReactMarkdownPreview
                 source={summary.summary}
@@ -40,16 +37,16 @@ const SummaryPreview: FC<SummaryPreviewProps> = ({
                     backgroundColor: 'transparent',
                 }}
             />
-            <Flex align="center" justify="space-between" mt="md" w="100%">
-                <Text
-                    color="ldGray.7"
-                    fz="xs"
-                >{`generated ${relativeDate}`}</Text>
-                <Tooltip label="Regenerate summary" position="left">
-                    <ActionIcon onClick={handleSummaryRegen} color="violet">
-                        <MantineIcon icon={IconRefresh} />
-                    </ActionIcon>
-                </Tooltip>
+            <Flex align="center" justify="space-between" w="100%">
+                <Text c="ldGray.7" fz="xs">{`Generated ${relativeDate}`}</Text>
+
+                <Button
+                    onClick={handleSummaryRegen}
+                    radius="md"
+                    leftSection={<MantineIcon icon={IconRefresh} />}
+                >
+                    Regenerate summary
+                </Button>
             </Flex>
         </Stack>
     );

--- a/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/index.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/aiDashboardSummary/index.tsx
@@ -1,9 +1,10 @@
 import { type DashboardSummary } from '@lightdash/common';
-import { Button, Modal, Tooltip } from '@mantine-8/core';
+import { Button, Tooltip } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import { IconWand } from '@tabler/icons-react';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
 import useToaster from '../../../../../hooks/toaster/useToaster';
 import {
     useCreateDashboardSummary,
@@ -79,15 +80,15 @@ const AIDashboardSummary: FC<DashboardAIProps> = ({
 
     return (
         <>
-            <Modal
+            <MantineModal
                 opened={opened}
                 onClose={closeModal}
                 size="xl"
                 title={
-                    summary
-                        ? 'Dashboard Summary'
-                        : 'Generated Dashboard Summary'
+                    summary ? 'Dashboard Summary' : 'Generate Dashboard Summary'
                 }
+                icon={IconWand}
+                cancelLabel={false}
             >
                 {summary && !isRegenerating ? (
                     <SummaryPreview
@@ -103,7 +104,7 @@ const AIDashboardSummary: FC<DashboardAIProps> = ({
                         handleCancel={cancelContextInput}
                     />
                 )}
-            </Modal>
+            </MantineModal>
 
             <Tooltip
                 label={

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
@@ -7,16 +7,12 @@ import {
     ActionIcon,
     Button,
     CopyButton,
-    Flex,
     Group,
-    Modal,
     Paper,
-    Stack,
     Table,
     Text,
-    Title,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import {
     IconCheck,
     IconCopy,
@@ -31,6 +27,7 @@ import {
     type SetStateAction,
 } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
 import { useTableStyles } from '../../../../../hooks/styles/useTableStyles';
 import {
     useDeleteScimToken,
@@ -50,7 +47,7 @@ const TokenItem: FC<{
                 </Text>
 
                 <td>
-                    <Group align="center" position="left" spacing="xs">
+                    <Group align="center" justify="flex-start" gap="xs">
                         <span>
                             {expiresAt
                                 ? formatDate(expiresAt)
@@ -87,7 +84,7 @@ const TokenItem: FC<{
                     )}
                 </td>
                 <td>
-                    <Group align="center" position="left" spacing="xs">
+                    <Group align="center" justify="flex-start" gap="xs">
                         <Tooltip
                             withinPortal
                             position="top"
@@ -106,10 +103,10 @@ const TokenItem: FC<{
                                     <ActionIcon
                                         size="xs"
                                         onClick={copy}
-                                        variant={'transparent'}
+                                        variant="transparent"
                                     >
                                         <MantineIcon
-                                            color={'ldGray.6'}
+                                            color="ldGray.6"
                                             icon={copied ? IconCheck : IconCopy}
                                         />
                                     </ActionIcon>
@@ -152,7 +149,7 @@ export const TokensTable = () => {
 
     return (
         <>
-            <Paper withBorder sx={{ overflow: 'hidden' }}>
+            <Paper withBorder style={{ overflow: 'hidden' }}>
                 <Table className={cx(classes.root, classes.alignLastTdRight)}>
                     <thead>
                         <tr>
@@ -175,46 +172,33 @@ export const TokensTable = () => {
                 </Table>
             </Paper>
 
-            <Modal
+            <MantineModal
                 opened={!!tokenToDelete}
                 onClose={() => !isDeleting && setTokenToDelete(undefined)}
-                title={
-                    <Title order={4}>
-                        Delete token {tokenToDelete?.description}
-                    </Title>
+                title={`Delete token ${tokenToDelete?.description}`}
+                icon={IconTrash}
+                cancelDisabled={isDeleting}
+                actions={
+                    <Button
+                        color="red"
+                        loading={isDeleting}
+                        onClick={() => {
+                            mutate(tokenToDelete?.uuid ?? '');
+                        }}
+                    >
+                        Delete
+                    </Button>
                 }
             >
-                <Stack spacing="xl">
-                    <Text>
-                        Are you sure? This will permanently delete the
-                        <Text fw={600} component="span">
-                            {' '}
-                            {tokenToDelete?.description}{' '}
-                        </Text>
-                        token.
+                <Text>
+                    Are you sure? This will permanently delete the
+                    <Text fw={600} component="span">
+                        {' '}
+                        {tokenToDelete?.description}{' '}
                     </Text>
-
-                    <Flex gap="sm" justify="flex-end">
-                        <Button
-                            color="dark"
-                            variant="outline"
-                            disabled={isDeleting}
-                            onClick={() => setTokenToDelete(undefined)}
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            color="red"
-                            disabled={isDeleting}
-                            onClick={() => {
-                                mutate(tokenToDelete?.uuid ?? '');
-                            }}
-                        >
-                            Delete
-                        </Button>
-                    </Flex>
-                </Stack>
-            </Modal>
+                    token.
+                </Text>
+            </MantineModal>
         </>
     );
 };

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -11,7 +11,7 @@ import {
     Radio,
     Stack,
     Text,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import {
     IconArrowsDiagonal,
     IconEye,
@@ -35,9 +35,9 @@ type PreviewAndCustomizeScreenshotProps = {
             selectedTabs: string[] | null;
         }
     >;
-    previewChoice: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined;
+    previewChoice: (typeof CUSTOM_WIDTH_OPTIONS)[number]['value'] | undefined;
     setPreviewChoice: (
-        prev: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined,
+        prev: (typeof CUSTOM_WIDTH_OPTIONS)[number]['value'] | undefined,
     ) => void;
     onPreviewClick?: () => Promise<void>;
     currentPreview?: string;
@@ -61,7 +61,7 @@ export const PreviewAndCustomizeScreenshot: FC<
         <Box>
             <LoadingOverlay visible={exportMutation.isLoading} />
 
-            <Stack spacing="md">
+            <Stack>
                 <Flex align="flex-start" justify="space-between">
                     <Radio.Group
                         name="customWidth"
@@ -96,38 +96,37 @@ export const PreviewAndCustomizeScreenshot: FC<
                     <Stack>
                         <Card withBorder p={0}>
                             <Box pos="relative">
-                                <Image
-                                    src={currentPreview}
-                                    onClick={() => {
-                                        if (currentPreview)
-                                            setIsImageModalOpen(true);
-                                    }}
-                                    width={350}
-                                    height={350}
-                                    styles={{
-                                        root: {
+                                {currentPreview ? (
+                                    <Image
+                                        src={currentPreview}
+                                        onClick={() =>
+                                            setIsImageModalOpen(true)
+                                        }
+                                        w={350}
+                                        h={350}
+                                        fit="cover"
+                                        style={{
                                             objectPosition: 'top',
-                                            cursor: currentPreview
-                                                ? 'pointer'
-                                                : 'default',
-                                        },
-                                    }}
-                                    withPlaceholder
-                                    placeholder={
-                                        <Flex
-                                            gap="md"
-                                            align="center"
-                                            direction="column"
-                                        >
-                                            <MantineIcon
-                                                icon={IconEyeClosed}
-                                                size={30}
-                                            />
-
-                                            <Text>No preview yet</Text>
-                                        </Flex>
-                                    }
-                                />
+                                            cursor: 'pointer',
+                                        }}
+                                    />
+                                ) : (
+                                    <Flex
+                                        w={350}
+                                        h={350}
+                                        gap="md"
+                                        align="center"
+                                        justify="center"
+                                        direction="column"
+                                        bg="gray.1"
+                                    >
+                                        <MantineIcon
+                                            icon={IconEyeClosed}
+                                            size={30}
+                                        />
+                                        <Text>No preview yet</Text>
+                                    </Flex>
+                                )}
                                 {currentPreview && (
                                     <ActionIcon
                                         pos="absolute"
@@ -136,10 +135,9 @@ export const PreviewAndCustomizeScreenshot: FC<
                                         variant="light"
                                         color="blue"
                                         size="sm"
-                                        onClick={() => {
-                                            if (currentPreview)
-                                                setIsImageModalOpen(true);
-                                        }}
+                                        onClick={() =>
+                                            setIsImageModalOpen(true)
+                                        }
                                     >
                                         <MantineIcon
                                             icon={IconArrowsDiagonal}
@@ -153,7 +151,7 @@ export const PreviewAndCustomizeScreenshot: FC<
                             display="block"
                             size="xs"
                             variant="default"
-                            leftIcon={<MantineIcon icon={IconEye} />}
+                            leftSection={<MantineIcon icon={IconEye} />}
                             disabled={!previewChoice || disabled}
                             onClick={async () => {
                                 if (onPreviewClick) {
@@ -174,16 +172,10 @@ export const PreviewAndCustomizeScreenshot: FC<
             >
                 <Image
                     src={currentPreview}
-                    onClick={() => {
-                        setIsImageModalOpen(false);
-                    }}
-                    width="100%"
-                    height="100%"
-                    styles={{
-                        root: {
-                            cursor: 'pointer',
-                        },
-                    }}
+                    onClick={() => setIsImageModalOpen(false)}
+                    w="100%"
+                    h="100%"
+                    style={{ cursor: 'pointer' }}
                 />
             </Modal>
         </Box>

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -23,6 +23,7 @@ const ApiErrorDisplay = ({
         case 'SnowflakeTokenError':
             return (
                 <>
+                    {/* FIXME: Replace with MantineModal when we migrate fully to Mantine 8 */}
                     <Modal
                         opened={true}
                         onClose={() => onClose?.()}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
This PR migrates several modal components to use the new `MantineModal` component, which provides a consistent UI across the application. The changes include:

- Replaced `Modal` with `MantineModal` in multiple components:
  - `CustomMetricModal`
  - `UserAttributesPanel`
  - `DashboardExportModal`
  - `ThreadPreviewSidebar`
  - `AIDashboardSummary`
  - `ScimAccessTokensPanel`
  - `SaveSqlChartModal`
  - `UpdateSqlChartModal`

- Updated form handling to use form IDs for better accessibility
- Improved modal actions with standardized button placement
- Updated imports to use `@mantine-8/core` instead of `@mantine/core`
- Enhanced UI components with better spacing, gap properties, and styling
- Simplified modal rendering with cleaner action handling

These changes provide a more consistent user experience and prepare the codebase for the Mantine 8 migration.