### PR TITLE
fix: prevent screenshot ready indicator when query results are loading

### DIFF
--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -59,7 +59,10 @@ const MinimalExplorerContent = memo(() => {
     const savedChart = useExplorerSelector(selectSavedChart);
 
     const isLoadingQueryResults =
-        query.isFetching || queryResults.isFetchingRows;
+        query.isFetching ||
+        queryResults.isFetchingRows ||
+        !query.data?.queryUuid ||
+        queryResults.queryUuid !== query.data.queryUuid;
 
     const [isScreenshotReady, setIsScreenshotReady] = useState(false);
     const hasSignaledReady = useRef(false);
@@ -113,7 +116,7 @@ const MinimalExplorerContent = memo(() => {
                 </Box>
             </MantineProvider>
 
-            {isScreenshotReady && !isLoadingQueryResults && (
+            {isScreenshotReady && (
                 <ScreenshotReadyIndicator
                     tilesTotal={1}
                     tilesReady={1}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixed a bug in the MinimalSavedExplorer component where the ScreenshotReadyIndicator was being displayed even when query results were still loading.

<details>
<summary>How it went</summary>

### Debugging
Started by taking a look at the loading states - there are 2 spinners and a message about missing required parameters in the mix.

https://github.com/user-attachments/assets/39801e3a-c1ce-469d-9b84-07b1a3ad44f1

Also reproduced locally:
<img width="682" height="454" alt="Screenshot 2025-12-30 at 16 55 44" src="https://github.com/user-attachments/assets/92ab2c69-6b08-4fe8-9874-3544416842ec" />

OK, so the indicator would appear after the first "loading" is done. But then there's another when we resolve the parameters.

Yay, works (don't mind the temp debugging bar):
<img width="652" height="426" alt="Screenshot 2025-12-30 at 16 58 20" src="https://github.com/user-attachments/assets/f2ad18f0-c625-47ad-9963-a88308ad11cf" />
</details>

