### PR TITLE
feat: update last references of migratable Mantine modals

### DIFF
--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -156,7 +156,7 @@ const SaveChartButton: FC<{ isExplorer?: boolean; disabled?: boolean }> = ({
 
             {unsavedChartVersion && (
                 <ChartCreateModal
-                    isOpen={isQueryModalOpen}
+                    opened={isQueryModalOpen}
                     savedData={unsavedChartVersion}
                     onClose={() => {
                         setIsQueryModalOpen(false);

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -722,7 +722,7 @@ const SavedChartsHeader: FC = () => {
 
             {unsavedChartVersion && (
                 <ChartCreateModal
-                    isOpen={isQueryModalOpen}
+                    opened={isQueryModalOpen}
                     savedData={unsavedChartVersion}
                     onClose={queryModalHandlers.close}
                     onConfirm={queryModalHandlers.close}

--- a/packages/frontend/src/components/Explorer/WriteBackModal/CreatedPullRequestModalContent.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/CreatedPullRequestModalContent.tsx
@@ -1,6 +1,6 @@
-import { Anchor, Button, Group, Modal, Stack, Text } from '@mantine/core';
+import { Anchor, Button, Stack, Text } from '@mantine-8/core';
 import { IconGitBranch } from '@tabler/icons-react';
-import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
 
 export const CreatedPullRequestModalContent = ({
     onClose,
@@ -10,49 +10,30 @@ export const CreatedPullRequestModalContent = ({
     data: { prUrl: string };
 }) => {
     return (
-        <Modal
-            size="xl"
-            onClick={(e) => e.stopPropagation()}
-            opened={true}
+        <MantineModal
+            size="auto"
+            opened
             onClose={onClose}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        icon={IconGitBranch}
-                        size="lg"
-                        color="ldGray.7"
-                    />
-                    <Text fw={500}>Write back to dbt</Text>
-                </Group>
-            }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.ldGray[4]}` },
-                body: { padding: 0 },
-            })}
+            title="Write back to dbt"
+            icon={IconGitBranch}
+            actions={<Button onClick={onClose}>Close</Button>}
+            modalRootProps={{
+                onClick: (e) => e.stopPropagation(),
+            }}
         >
-            <Stack p="md">
+            <Stack gap="md">
                 <Text>
                     Your pull request{' '}
-                    <Anchor href={data.prUrl} target="_blank" span fw={700}>
+                    <Anchor href={data.prUrl} target="_blank" fw={700}>
                         #{data.prUrl.split('/').pop()}
                     </Anchor>{' '}
                     was successfully created on git.
-                    <Text pt="md">
-                        Once it is merged, refresh your dbt connection to see
-                        your updated metrics and dimensions.
-                    </Text>
+                </Text>
+                <Text>
+                    Once it is merged, refresh your dbt connection to see your
+                    updated metrics and dimensions.
                 </Text>
             </Stack>
-            <Group position="right" w="100%" p="md">
-                <Button
-                    color="ldGray.7"
-                    onClick={onClose}
-                    variant="outline"
-                    size="xs"
-                >
-                    Close
-                </Button>
-            </Group>
-        </Modal>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -10,24 +10,24 @@ import {
     Checkbox,
     Group,
     List,
-    Modal,
+    Paper,
     Stack,
     Text,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { Prism } from '@mantine/prism';
-import { IconGitBranch, IconInfoCircle } from '@tabler/icons-react';
+import { IconGitBranch } from '@tabler/icons-react';
 import * as yaml from 'js-yaml';
 import { memo, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-
 import {
     explorerActions,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
-import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
+import { PolymorphicGroupButton } from '../../common/PolymorphicGroupButton';
 import { CreatedPullRequestModalContent } from './CreatedPullRequestModalContent';
 import {
     useIsGitProject,
@@ -140,73 +140,14 @@ export const SingleItemModalContent = ({
     const itemLabel = getItemLabel(item);
 
     return (
-        <Modal
-            size="lg"
-            onClick={(e) => e.stopPropagation()}
+        <MantineModal
+            size="xl"
             opened={true}
             onClose={handleClose}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        icon={IconGitBranch}
-                        size="lg"
-                        color="ldGray.7"
-                    />
-                    <Text fw={500}>Write back to dbt</Text>
-                    <Tooltip
-                        variant="xs"
-                        withinPortal
-                        multiline
-                        maw={300}
-                        label={`Convert this ${texts[type].name} into a ${texts[type].baseName} in your dbt project. This will create a new branch and open a pull request.`}
-                    >
-                        <MantineIcon
-                            color="ldGray.7"
-                            icon={IconInfoCircle}
-                            size={16}
-                        />
-                    </Tooltip>
-                </Group>
-            }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.ldGray[4]}` },
-                body: { padding: 0 },
-            })}
-        >
-            <Stack p="md">
-                <Text>
-                    Create a pull request in your dbt project's git repository
-                    for the following {texts[type].name}:
-                </Text>
-                <List spacing="xs" pl="xs">
-                    <List.Item fz="xs" ff="monospace">
-                        {itemLabel}
-                    </List.Item>
-                </List>
-                <CollapsableCard
-                    isOpen={showDiff}
-                    title={`Show ${texts[type].baseName} code`}
-                    onToggle={() => setShowDiff(!showDiff)}
-                >
-                    <Stack ml={36}>
-                        <Prism language="yaml" withLineNumbers trim={false}>
-                            {error || previewCode}
-                        </Prism>
-                    </Stack>
-                </CollapsableCard>
-            </Stack>
-
-            <Group position="right" w="100%" p="md">
-                <Button
-                    color="ldGray.7"
-                    onClick={handleClose}
-                    variant="outline"
-                    disabled={isLoading}
-                    size="xs"
-                >
-                    Cancel
-                </Button>
-
+            title="Write back to dbt"
+            icon={IconGitBranch}
+            description={`Convert this ${texts[type].name} into a ${texts[type].baseName} in your dbt project. This will create a new branch and open a pull request.`}
+            actions={
                 <Tooltip
                     label={errorTooltipLabel}
                     disabled={disableErrorTooltip}
@@ -234,8 +175,31 @@ export const SingleItemModalContent = ({
                         </Button>
                     </div>
                 </Tooltip>
-            </Group>
-        </Modal>
+            }
+        >
+            <Stack>
+                <Text fz="sm">
+                    Create a pull request in your dbt project's git repository
+                    for the following {texts[type].name}:
+                </Text>
+                <List spacing="xs" pl="xs">
+                    <List.Item fz="xs" ff="monospace">
+                        {itemLabel}
+                    </List.Item>
+                </List>
+                <CollapsableCard
+                    isOpen={showDiff}
+                    title={`Show ${texts[type].baseName} code`}
+                    onToggle={() => setShowDiff(!showDiff)}
+                >
+                    <Stack ml={36}>
+                        <Prism language="yaml" withLineNumbers trim={false}>
+                            {error || previewCode}
+                        </Prism>
+                    </Stack>
+                </CollapsableCard>
+            </Stack>
+        </MantineModal>
     );
 };
 
@@ -328,137 +292,14 @@ const MultipleItemsModalContent = ({
     const buttonDisabled =
         isLoading || !disableErrorTooltip || selectedItemIds.length === 0;
     return (
-        <Modal
-            size="xl"
-            onClick={(e) => e.stopPropagation()}
+        <MantineModal
+            size="auto"
             opened={true}
             onClose={handleClose}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        icon={IconGitBranch}
-                        size="lg"
-                        color="ldGray.7"
-                    />
-                    <Text fw={500}>Write back to dbt</Text>
-                </Group>
-            }
-            styles={() => ({
-                body: { padding: 0, height: '435px' },
-            })}
-        >
-            <Text
-                pl="md"
-                pb="sm"
-                fz="s"
-                color="ldGray.7"
-                sx={(theme) => ({
-                    borderBottom: `1px solid ${theme.colors.ldGray[4]}`,
-                })}
-            >
-                Create a pull request in your dbt project's git repository for
-                the following {texts[type].baseName}s
-            </Text>
-
-            <Stack p="md">
-                <Group align="flex-start" h="305px">
-                    <Stack w="30%" h="100%">
-                        <Text>
-                            Available {texts[type].name}s (
-                            {selectedItemIds.length} selected)
-                        </Text>
-
-                        <Stack
-                            h="100%"
-                            p="sm"
-                            sx={{
-                                border: '1px solid #e0e0e0',
-                                borderRadius: '4px',
-                                overflowY: 'auto',
-                            }}
-                        >
-                            {items.map((item) => {
-                                const itemId = getItemId(item);
-                                const itemLabel = getItemLabel(item);
-                                return (
-                                    <Tooltip
-                                        label={itemLabel}
-                                        key={itemId}
-                                        position="right"
-                                    >
-                                        <Group
-                                            noWrap
-                                            key={itemId}
-                                            onClick={() =>
-                                                setSelectedItemIds(
-                                                    !selectedItemIds.includes(
-                                                        itemId,
-                                                    )
-                                                        ? [
-                                                              ...selectedItemIds,
-                                                              itemId,
-                                                          ]
-                                                        : selectedItemIds.filter(
-                                                              (name) =>
-                                                                  name !==
-                                                                  itemId,
-                                                          ),
-                                                )
-                                            }
-                                            sx={{ cursor: 'pointer' }}
-                                        >
-                                            <Checkbox
-                                                size="xs"
-                                                checked={selectedItemIds.includes(
-                                                    itemId,
-                                                )}
-                                            />
-                                            <Text truncate="end">
-                                                {itemLabel}
-                                            </Text>
-                                        </Group>
-                                    </Tooltip>
-                                );
-                            })}
-                        </Stack>
-                    </Stack>
-                    <Stack w="calc(70% - 18px)" h="100%">
-                        <Text>
-                            {capitalize(texts[type].baseName)} YAML to be
-                            created:
-                        </Text>
-
-                        <Stack
-                            h="100%"
-                            sx={{
-                                overflowY: 'auto',
-                                border: '1px solid #e0e0e0',
-                                borderRadius: '4px',
-                            }}
-                        >
-                            <Prism
-                                language="yaml"
-                                trim={false}
-                                noCopy={previewCode === ''}
-                            >
-                                {error || previewCode}
-                            </Prism>
-                        </Stack>
-                    </Stack>
-                </Group>
-            </Stack>
-
-            <Group position="right" w="100%" p="md">
-                <Button
-                    color="ldGray.7"
-                    onClick={handleClose}
-                    variant="outline"
-                    disabled={isLoading}
-                    size="xs"
-                >
-                    Cancel
-                </Button>
-
+            title="Write back to dbt"
+            icon={IconGitBranch}
+            description={`Create a pull request in your dbt project's git repository for the following ${texts[type].baseName}s`}
+            actions={
                 <Tooltip
                     label={errorTooltipLabel}
                     disabled={disableErrorTooltip}
@@ -490,8 +331,88 @@ const MultipleItemsModalContent = ({
                         </Button>
                     </div>
                 </Tooltip>
+            }
+        >
+            <Group align="flex-start" h="305px">
+                <Stack w="30%" h="100%">
+                    <Text>
+                        Available {texts[type].name}s ({selectedItemIds.length}{' '}
+                        selected)
+                    </Text>
+
+                    <Stack
+                        h="100%"
+                        p="sm"
+                        style={{
+                            border: '1px solid var(--mantine-color-ldGray-3)',
+                            borderRadius: '4px',
+                            overflowY: 'auto',
+                        }}
+                    >
+                        {items.map((item) => {
+                            const itemId = getItemId(item);
+                            const itemLabel = getItemLabel(item);
+                            return (
+                                <Tooltip
+                                    label={itemLabel}
+                                    key={itemId}
+                                    position="right"
+                                >
+                                    <PolymorphicGroupButton
+                                        wrap="nowrap"
+                                        key={itemId}
+                                        onClick={() =>
+                                            setSelectedItemIds(
+                                                !selectedItemIds.includes(
+                                                    itemId,
+                                                )
+                                                    ? [
+                                                          ...selectedItemIds,
+                                                          itemId,
+                                                      ]
+                                                    : selectedItemIds.filter(
+                                                          (name) =>
+                                                              name !== itemId,
+                                                      ),
+                                            )
+                                        }
+                                    >
+                                        <Checkbox
+                                            size="xs"
+                                            checked={selectedItemIds.includes(
+                                                itemId,
+                                            )}
+                                        />
+                                        <Text truncate="end">{itemLabel}</Text>
+                                    </PolymorphicGroupButton>
+                                </Tooltip>
+                            );
+                        })}
+                    </Stack>
+                </Stack>
+                <Stack w="calc(70% - 18px)" h="100%">
+                    <Text>
+                        {capitalize(texts[type].baseName)} YAML to be created:
+                    </Text>
+
+                    <Paper
+                        h="100%"
+                        withBorder
+                        style={{
+                            overflowY: 'auto',
+                        }}
+                    >
+                        <Prism
+                            language="yaml"
+                            trim={false}
+                            noCopy={previewCode === ''}
+                        >
+                            {error || previewCode}
+                        </Prism>
+                    </Paper>
+                </Stack>
             </Group>
-        </Modal>
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
@@ -14,12 +14,12 @@ import {
     Group,
     Highlight,
     Radio,
+    Select,
     Stack,
     Text,
     TextInput,
     Tooltip,
 } from '@mantine-8/core';
-import { Select } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconTool } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
@@ -61,13 +61,13 @@ export const FixValidationErrorModal: FC<Props> = ({
         () =>
             Object.entries(fields?.fields || {})
                 .sort(([groupA], [groupB]) => groupA.localeCompare(groupB)) // Sort groups alphabetically
-                .flatMap(([group, items]) =>
-                    items.map((item) => ({
+                .map(([group, items]) => ({
+                    group,
+                    items: items.map((item) => ({
                         value: item,
                         label: item,
-                        group,
                     })),
-                ),
+                })),
         [fields],
     );
 
@@ -165,9 +165,9 @@ export const FixValidationErrorModal: FC<Props> = ({
                 </Button>
             }
         >
-            <Text>
+            <Text fz="sm">
                 Fix{' '}
-                <Text span fw={500}>
+                <Text span fz="sm">
                     {validationError.source}
                 </Text>{' '}
                 error:{' '}
@@ -178,7 +178,10 @@ export const FixValidationErrorModal: FC<Props> = ({
                     )}
                     target="_blank"
                 >
-                    <Text span>{validationError?.name}</Text>
+                    <Text span fz="sm">
+                        {' '}
+                        {validationError?.name}
+                    </Text>
                 </Anchor>
             </Text>
 
@@ -230,17 +233,14 @@ export const FixValidationErrorModal: FC<Props> = ({
                             >
                                 <div>
                                     <Select
-                                        itemComponent={({
-                                            label,
-                                            ...others
-                                        }) => (
+                                        renderOption={({ option }) => (
                                             <Highlight
                                                 highlight={search}
-                                                {...others}
+                                                {...option}
                                                 fz="sm"
-                                                highlightColor="yellow"
+                                                color="yellow"
                                             >
-                                                {label}
+                                                {option.label}
                                             </Highlight>
                                         )}
                                         onSearchChange={setSearch}
@@ -250,7 +250,6 @@ export const FixValidationErrorModal: FC<Props> = ({
                                         required
                                         disabled={isErrorFields}
                                         searchable
-                                        withinPortal
                                         label="New field"
                                         placeholder={`Select a field to rename to`}
                                         onChange={(e) => {
@@ -287,20 +286,19 @@ export const FixValidationErrorModal: FC<Props> = ({
                             <Select
                                 searchValue={search}
                                 onSearchChange={setSearch}
-                                itemComponent={({ label, ...others }) => (
+                                renderOption={({ option }) => (
                                     <Highlight
                                         highlight={search}
-                                        {...others}
+                                        {...option}
                                         fz="sm"
-                                        highlightColor="yellow"
+                                        color="yellow"
                                     >
-                                        {label}
+                                        {option.label}
                                     </Highlight>
                                 )}
                                 data={explores?.map((e) => e.name) || []}
                                 required
                                 searchable
-                                withinPortal
                                 label="New model"
                                 placeholder={`Select a model to rename to`}
                                 onChange={(e) => {

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/ChartCreateModal.module.css
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/ChartCreateModal.module.css
@@ -1,0 +1,7 @@
+.footer {
+    position: sticky;
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+    bottom: 0;
+    z-index: 2;
+    padding: var(--mantine-spacing-md);
+}

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -5,7 +5,14 @@ import {
     type CreateDashboardChartTile,
     type CreateSavedChartVersion,
 } from '@lightdash/common';
-import { Button, Group, Stack, Text, TextInput, Textarea } from '@mantine/core';
+import {
+    Button,
+    Group,
+    Stack,
+    Text,
+    TextInput,
+    Textarea,
+} from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
@@ -18,6 +25,7 @@ import {
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useCreateMutation } from '../../../../hooks/useSavedQuery';
+import classes from './ChartCreateModal.module.css';
 import { DEFAULT_CHART_METADATA, type ChartMetadata } from './types';
 
 type Props = {
@@ -159,8 +167,8 @@ export const SaveToDashboard: FC<Props> = ({
                 handleSaveChartInDashboard(values),
             )}
         >
-            <Stack p="md">
-                <Stack spacing="xs">
+            <Stack gap="md" p="md">
+                <Stack gap="xs">
                     <TextInput
                         label="Chart name"
                         placeholder="eg. How many weekly active users do we have?"
@@ -176,25 +184,17 @@ export const SaveToDashboard: FC<Props> = ({
                         {...form.getInputProps('description')}
                     />
                 </Stack>
-                <Stack spacing="xxs">
+                <Stack gap={4}>
                     <Text fw={500}>Saving to "{dashboardName}" dashboard</Text>
-                    <Text fw={400} color="ldGray.6" fz="xs">
+                    <Text fw={400} c="ldGray.6" fz="xs">
                         This chart will be saved exclusively to the dashboard "
                         {dashboardName}", keeping your space clutter-free.
                     </Text>
                 </Stack>
             </Stack>
 
-            <Group
-                position="right"
-                w="100%"
-                sx={(theme) => ({
-                    borderTop: `1px solid ${theme.colors.ldGray[4]}`,
-                    bottom: 0,
-                    padding: theme.spacing.md,
-                })}
-            >
-                <Button onClick={onClose} variant="outline">
+            <Group justify="flex-end" gap="sm" className={classes.footer}>
+                <Button onClick={onClose} variant="default">
                     Cancel
                 </Button>
 

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -10,7 +10,6 @@ import {
     type SavedChart,
 } from '@lightdash/common';
 import {
-    Box,
     Button,
     Group,
     LoadingOverlay,
@@ -19,7 +18,7 @@ import {
     Text,
     TextInput,
     Textarea,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconPlus } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
@@ -35,7 +34,8 @@ import { useCreateMutation } from '../../../../hooks/useSavedQuery';
 import { useSpaceManagement } from '../../../../hooks/useSpaceManagement';
 import { useSpaceSummaries } from '../../../../hooks/useSpaces';
 import useApp from '../../../../providers/App/useApp';
-import MantineIcon from '../../../common/MantineIcon';
+import MantineIcon from '../../MantineIcon';
+import classes from './ChartCreateModal.module.css';
 import SaveToDashboardForm from './SaveToDashboardForm';
 import SaveToSpaceForm from './SaveToSpaceForm';
 import {
@@ -376,9 +376,9 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
         >
             <LoadingOverlay visible={isLoading} />
 
-            <Box p="md">
+            <Stack gap="xs" p="md">
                 {currentStep === ModalStep.InitialInfo && (
-                    <Stack spacing="xs">
+                    <>
                         <TextInput
                             label="Chart name"
                             placeholder="eg. How many weekly active users do we have?"
@@ -396,39 +396,29 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                             value={form.values.description ?? ''}
                         />
 
-                        <Stack spacing="sm" mt="sm">
+                        <Stack gap="sm" mt="sm">
                             <Text fw={500}>Save to</Text>
 
                             <Radio.Group
                                 value={saveDestination}
-                                onChange={(value: SaveDestination) =>
-                                    setSaveDestination(value)
+                                onChange={(value) =>
+                                    setSaveDestination(value as SaveDestination)
                                 }
                             >
-                                <Stack spacing="xs">
+                                <Stack gap="xs">
                                     <Radio
                                         value={SaveDestination.Space}
                                         label="Space"
-                                        styles={(theme) => ({
-                                            label: {
-                                                paddingLeft: theme.spacing.xs,
-                                            },
-                                        })}
                                         disabled={!spaces || isLoadingSpaces}
                                     />
                                     <Radio
                                         value={SaveDestination.Dashboard}
                                         label="Dashboard"
-                                        styles={(theme) => ({
-                                            label: {
-                                                paddingLeft: theme.spacing.xs,
-                                            },
-                                        })}
                                     />
                                 </Stack>
                             </Radio.Group>
                         </Stack>
-                    </Stack>
+                    </>
                 )}
 
                 {currentStep === ModalStep.SelectDestination && (
@@ -459,65 +449,65 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                         )}
                     </>
                 )}
-            </Box>
-            <Group
-                position="right"
-                w="100%"
-                sx={(theme) => ({
-                    borderTop: `1px solid ${theme.colors.ldGray[4]}`,
-                    bottom: 0,
-                    padding: theme.spacing.md,
-                })}
-            >
-                {currentStep === ModalStep.InitialInfo ? (
-                    <>
-                        <Button onClick={onClose} variant="outline">
-                            Cancel
-                        </Button>
-                        <Button
-                            onClick={(
-                                e: React.MouseEvent<HTMLButtonElement>,
-                            ) => {
-                                e.preventDefault();
-                                handleNextStep();
-                            }}
-                            disabled={!form.values.name}
-                            type="button"
-                        >
-                            Next
-                        </Button>
-                    </>
-                ) : (
-                    <>
-                        {shouldShowNewSpaceButton && (
-                            <Button
-                                variant="subtle"
-                                size="xs"
-                                leftIcon={<MantineIcon icon={IconPlus} />}
-                                onClick={openCreateSpaceForm}
-                                mr="auto"
-                            >
-                                New Space
-                            </Button>
-                        )}
+            </Stack>
 
-                        <Button onClick={handleBack} variant="outline">
-                            Back
-                        </Button>
-                        <Button
-                            type="submit"
-                            loading={
-                                isSavingChart ||
-                                spaceManagement.createSpaceMutation.isLoading ||
-                                (!!form.values.dashboardUuid &&
-                                    isLoadingSelectedDashboard)
-                            }
-                            disabled={!isFormReadyToSave}
-                        >
-                            Save
-                        </Button>
-                    </>
+            <Group
+                justify={
+                    shouldShowNewSpaceButton ? 'space-between' : 'flex-end'
+                }
+                className={classes.footer}
+            >
+                {shouldShowNewSpaceButton && (
+                    <Button
+                        variant="subtle"
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        onClick={openCreateSpaceForm}
+                    >
+                        New Space
+                    </Button>
                 )}
+
+                <Group gap="sm">
+                    {currentStep === ModalStep.InitialInfo ? (
+                        <>
+                            <Button onClick={onClose} variant="default">
+                                Cancel
+                            </Button>
+                            <Button
+                                onClick={(
+                                    e: React.MouseEvent<HTMLButtonElement>,
+                                ) => {
+                                    e.preventDefault();
+                                    handleNextStep();
+                                }}
+                                disabled={!form.values.name}
+                                type="button"
+                            >
+                                Next
+                            </Button>
+                        </>
+                    ) : (
+                        <>
+                            <Button onClick={handleBack} variant="default">
+                                Back
+                            </Button>
+                            <Button
+                                type="submit"
+                                loading={
+                                    isSavingChart ||
+                                    spaceManagement.createSpaceMutation
+                                        .isLoading ||
+                                    (!!form.values.dashboardUuid &&
+                                        isLoadingSelectedDashboard)
+                                }
+                                disabled={!isFormReadyToSave}
+                            >
+                                Save
+                            </Button>
+                        </>
+                    )}
+                </Group>
             </Group>
         </form>
     );

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -1,18 +1,16 @@
 import { type CreateSavedChartVersion } from '@lightdash/common';
-import { Group, Modal, Text } from '@mantine/core';
 import { IconChartBar } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
-import MantineIcon from '../../MantineIcon';
+import MantineModal, { type MantineModalProps } from '../../MantineModal';
 import { SaveToDashboard } from './SaveToDashboard';
 import { SaveToSpaceOrDashboard } from './SaveToSpaceOrDashboard';
 import { type ChartMetadata } from './types';
 
-interface ChartCreateModalProps {
+interface ChartCreateModalProps
+    extends Pick<MantineModalProps, 'opened' | 'onClose'> {
     savedData: CreateSavedChartVersion;
-    isOpen: boolean;
-    onClose: () => void;
     defaultSpaceUuid?: string;
     onConfirm: (savedData: CreateSavedChartVersion) => void;
     chartMetadata?: ChartMetadata;
@@ -25,7 +23,7 @@ enum SaveMode {
 
 const ChartCreateModal: FC<ChartCreateModalProps> = ({
     savedData,
-    isOpen,
+    opened,
     onClose,
     defaultSpaceUuid,
     onConfirm,
@@ -48,30 +46,19 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
 
     const getModalTitle = useCallback(() => {
         if (saveMode === SaveMode.TO_DASHBOARD) {
-            return `Save chart "${editingDashboardInfo.name}"`;
+            return `Save chart to "${editingDashboardInfo.name}"`;
         }
         return 'Save chart';
     }, [saveMode, editingDashboardInfo]);
 
     return (
-        <Modal
-            opened={isOpen}
+        <MantineModal
+            opened={opened}
             onClose={onClose}
-            keepMounted={false}
-            title={
-                <Group spacing="xs">
-                    <MantineIcon
-                        icon={IconChartBar}
-                        size="lg"
-                        color="ldGray.7"
-                    />
-                    <Text fw={500}>{getModalTitle()}</Text>
-                </Group>
-            }
-            styles={(theme) => ({
-                header: { borderBottom: `1px solid ${theme.colors.ldGray[4]}` },
-                body: { padding: 0 },
-            })}
+            title={getModalTitle()}
+            icon={IconChartBar}
+            cancelLabel={false}
+            modalBodyProps={{ px: 0, py: 0 }}
         >
             {saveMode === SaveMode.TO_DASHBOARD && (
                 <SaveToDashboard
@@ -98,7 +85,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
                     chartMetadata={chartMetadata}
                 />
             )}
-        </Modal>
+        </MantineModal>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
This PR updates the modals in the Explorer component to use the new Mantine v8 components and the common MantineModal component. The changes include:

1. Migrating from `isOpen` prop to `opened` prop in ChartCreateModal
2. Refactoring WriteBackModal to use MantineModal for consistent styling
3. Updating the CreatedPullRequestModalContent to use the new modal structure
4. Adding a new ChartCreateModal.module.css for styling the modal footer
5. Improving the layout and styling of modal actions and content

These changes provide a more consistent UI experience across all modals in the Explorer component.

![Screenshot 2025-12-30 at 16.22.31.png](https://app.graphite.com/user-attachments/assets/2603099f-660f-4a2d-aa3f-04b648eadafe.png)

![Screenshot 2025-12-30 at 16.51.44.png](https://app.graphite.com/user-attachments/assets/82d7bdbe-8f70-45c7-9b38-ca98d98c4459.png)

![Screenshot 2025-12-30 at 16.44.39.png](https://app.graphite.com/user-attachments/assets/0a8ea05e-eda5-49f7-ba08-f2f621cba886.png)

![image.png](https://app.graphite.com/user-attachments/assets/c6d8e05c-57b5-4c67-8ae7-ef4a5d5ba6fe.png)

