### PR TITLE
fix: flash empty tile tooltip

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
@@ -84,6 +84,9 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
     const isMarkdownTileTitleEmpty =
         tile.type === DashboardTileTypes.MARKDOWN && !title;
 
+    const hasMenuContent = isEditMode || !!extraMenuItems;
+    const shouldShowHoverMenu = !minimal && hasMenuContent;
+
     return (
         <div ref={containerRef} className={styles.tileWrapper}>
             {containerHovered && isEditMode && !minimal && (
@@ -103,129 +106,132 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
 
             {((containerHovered && !titleHovered && !chartHovered) ||
                 isMenuOpen ||
-                lockHeaderVisibility) && (
-                <Paper
-                    p={5}
-                    className={clsx('non-draggable', styles.tileTooltip)}
-                    shadow="sm"
-                    pos="absolute"
-                    top={-6}
-                    right={-2}
-                >
-                    <Group gap={5} wrap="nowrap">
-                        {titleLeftIcon}
+                lockHeaderVisibility) &&
+                shouldShowHoverMenu && (
+                    <Paper
+                        p={5}
+                        className={clsx('non-draggable', styles.tileTooltip)}
+                        shadow="sm"
+                        pos="absolute"
+                        top={-6}
+                        right={-2}
+                    >
+                        <Group gap={5} wrap="nowrap">
+                            {titleLeftIcon}
 
-                        {visibleHeaderElement && (
-                            <Group gap="xs" className="non-draggable">
-                                {visibleHeaderElement}
-                            </Group>
-                        )}
+                            {visibleHeaderElement && (
+                                <Group gap="xs" className="non-draggable">
+                                    {visibleHeaderElement}
+                                </Group>
+                            )}
 
-                        {extraHeaderElement}
+                            {extraHeaderElement}
 
-                        {(isEditMode || (!isEditMode && extraMenuItems)) && (
-                            <Menu
-                                withArrow
-                                withinPortal
-                                shadow="md"
-                                position="bottom-end"
-                                offset={4}
-                                arrowOffset={10}
-                                opened={isMenuOpen}
-                                onOpen={() => toggleMenu(true)}
-                                onClose={() => toggleMenu(false)}
-                            >
-                                <Menu.Dropdown>
-                                    {extraMenuItems}
-                                    {isEditMode && extraMenuItems && (
-                                        <Menu.Divider />
-                                    )}
-                                    {isEditMode && (
-                                        <>
-                                            <Box>
-                                                <Menu.Item
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={IconEdit}
-                                                        />
-                                                    }
-                                                    onClick={() =>
-                                                        setIsEditingTileContent(
-                                                            true,
-                                                        )
-                                                    }
-                                                >
-                                                    Edit tile content
-                                                </Menu.Item>
-                                            </Box>
-                                            {tabs && tabs.length > 1 && (
-                                                <Menu.Item
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={
-                                                                IconArrowAutofitContent
-                                                            }
-                                                        />
-                                                    }
-                                                    onClick={() =>
-                                                        setIsMovingTabs(true)
-                                                    }
-                                                >
-                                                    Move to another tab
-                                                </Menu.Item>
-                                            )}
+                            {hasMenuContent && (
+                                <Menu
+                                    withArrow
+                                    withinPortal
+                                    shadow="md"
+                                    position="bottom-end"
+                                    offset={4}
+                                    arrowOffset={10}
+                                    opened={isMenuOpen}
+                                    onOpen={() => toggleMenu(true)}
+                                    onClose={() => toggleMenu(false)}
+                                >
+                                    <Menu.Dropdown>
+                                        {extraMenuItems}
+                                        {isEditMode && extraMenuItems && (
                                             <Menu.Divider />
-                                            {belongsToDashboard ? (
-                                                <Menu.Item
-                                                    color="red"
-                                                    onClick={() =>
-                                                        setIsDeletingChartThatBelongsToDashboard(
-                                                            true,
-                                                        )
-                                                    }
-                                                >
-                                                    Delete chart
-                                                </Menu.Item>
-                                            ) : (
-                                                <Menu.Item
-                                                    color="red"
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={IconTrash}
-                                                        />
-                                                    }
-                                                    onClick={() =>
-                                                        onDelete(tile)
-                                                    }
-                                                >
-                                                    Remove tile
-                                                </Menu.Item>
-                                            )}
-                                        </>
-                                    )}
-                                </Menu.Dropdown>
+                                        )}
+                                        {isEditMode && (
+                                            <>
+                                                <Box>
+                                                    <Menu.Item
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={IconEdit}
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            setIsEditingTileContent(
+                                                                true,
+                                                            )
+                                                        }
+                                                    >
+                                                        Edit tile content
+                                                    </Menu.Item>
+                                                </Box>
+                                                {tabs && tabs.length > 1 && (
+                                                    <Menu.Item
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconArrowAutofitContent
+                                                                }
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            setIsMovingTabs(
+                                                                true,
+                                                            )
+                                                        }
+                                                    >
+                                                        Move to another tab
+                                                    </Menu.Item>
+                                                )}
+                                                <Menu.Divider />
+                                                {belongsToDashboard ? (
+                                                    <Menu.Item
+                                                        color="red"
+                                                        onClick={() =>
+                                                            setIsDeletingChartThatBelongsToDashboard(
+                                                                true,
+                                                            )
+                                                        }
+                                                    >
+                                                        Delete chart
+                                                    </Menu.Item>
+                                                ) : (
+                                                    <Menu.Item
+                                                        color="red"
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={IconTrash}
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            onDelete(tile)
+                                                        }
+                                                    >
+                                                        Remove tile
+                                                    </Menu.Item>
+                                                )}
+                                            </>
+                                        )}
+                                    </Menu.Dropdown>
 
-                                <Menu.Target>
-                                    <ActionIcon
-                                        size="sm"
-                                        variant="subtle"
-                                        color="gray"
-                                        style={{
-                                            position: 'relative',
-                                            zIndex: 1,
-                                        }}
-                                    >
-                                        <MantineIcon
-                                            data-testid="tile-icon-more"
-                                            icon={IconDots}
-                                        />
-                                    </ActionIcon>
-                                </Menu.Target>
-                            </Menu>
-                        )}
-                    </Group>
-                </Paper>
-            )}
+                                    <Menu.Target>
+                                        <ActionIcon
+                                            size="sm"
+                                            variant="subtle"
+                                            color="gray"
+                                            style={{
+                                                position: 'relative',
+                                                zIndex: 1,
+                                            }}
+                                        >
+                                            <MantineIcon
+                                                data-testid="tile-icon-more"
+                                                icon={IconDots}
+                                            />
+                                        </ActionIcon>
+                                    </Menu.Target>
+                                </Menu>
+                            )}
+                        </Group>
+                    </Paper>
+                )}
 
             <Card
                 className={styles.tileCard}


### PR DESCRIPTION
### Description:
Prevents the hover menu Paper element from rendering when not needed (minimal, empty menus, loading state). 

![CleanShot 2025-12-30 at 17.58.05.png](https://app.graphite.com/user-attachments/assets/19b823b5-eb42-490b-befa-9347dfdfa0d3.png)

