### PR TITLE
feat: improve stack label display in 100% stacked charts

### DIFF
--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -387,6 +387,7 @@ export type EChartsSeries = {
         /** The field ID of the base metric this PoP series compares against */
         baseFieldId: string;
     };
+    clip?: boolean;
 };
 
 /**

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2058,6 +2058,7 @@ const getStackTotalSeries = (
     itemsMap: ItemsMap,
     flipAxis: boolean | undefined,
     selectedLegendNames: LegendValues,
+    isStack100: boolean,
 ) => {
     const seriesGroupedByStack = groupBy(seriesWithStack, 'stack');
     return Object.entries(seriesGroupedByStack).reduce<EChartsSeries[]>(
@@ -2069,6 +2070,7 @@ const getStackTotalSeries = (
                 type: series[0].type,
                 connectNulls: true,
                 stack: stack,
+                clip: false,
                 label: {
                     ...getBarTotalLabelStyle(),
                     show: series[0].stackLabel?.show,
@@ -2087,7 +2089,7 @@ const getStackTotalSeries = (
                     position: flipAxis ? 'right' : 'top',
                 },
                 labelLayout: {
-                    hideOverlap: true,
+                    hideOverlap: !isStack100,
                 },
                 tooltip: {
                     show: false,
@@ -2368,6 +2370,7 @@ const useEchartsCartesianConfig = (
                 itemsMap,
                 validCartesianConfig?.layout.flipAxes,
                 validCartesianConfigLegend,
+                isStack100,
             ),
         ];
     }, [
@@ -2701,6 +2704,74 @@ const useEchartsCartesianConfig = (
         dataToRender,
     ]);
 
+    // Calculate max stack label padding for 100% stacking grid
+    // Returns { right, top } padding values based on chart orientation
+    const stackLabelPaddingCalc = useMemo(() => {
+        const isStack100 =
+            validCartesianConfig?.layout?.stack === StackType.PERCENT;
+        if (
+            !isStack100 ||
+            !stackedSeriesWithColorAssignments ||
+            !itemsMap ||
+            !rows
+        )
+            return { right: 0, top: 0 };
+
+        const hasStackLabels = stackedSeriesWithColorAssignments.some(
+            (s) => s.stackLabel?.show,
+        );
+        if (!hasStackLabels) return { right: 0, top: 0 };
+
+        const flipAxis = validCartesianConfig?.layout?.flipAxes;
+        const seriesWithStack = stackedSeriesWithColorAssignments.filter(
+            (s) => s.stack,
+        );
+
+        // Group by stack and calculate max formatted label width
+        const seriesGroupedByStack = groupBy(seriesWithStack, 'stack');
+        let maxCharCount = 0;
+
+        Object.entries(seriesGroupedByStack).forEach(([stack, stackSeries]) => {
+            if (!stack || !stackSeries[0]?.stackLabel?.show) return;
+
+            const stackTotalData = getStackTotalRows(
+                rows,
+                stackSeries,
+                flipAxis,
+                validCartesianConfigLegend,
+            );
+            const fieldId = stackSeries[0].pivotReference?.field;
+
+            if (fieldId) {
+                stackTotalData.forEach((dataPoint) => {
+                    const total = dataPoint[2];
+                    const formatted = getFormattedValue(
+                        total,
+                        fieldId,
+                        itemsMap,
+                    );
+                    maxCharCount = Math.max(maxCharCount, formatted.length);
+                });
+            }
+        });
+
+        if (flipAxis) {
+            // ~7px per character + 10px buffer
+            return { right: maxCharCount * 7 + 10, top: 0 };
+        } else {
+            // Vertical bars: labels on top, need height-based padding
+            // Fixed ~25px for label height (font size + small margin)
+            return { right: 0, top: maxCharCount > 0 ? 25 : 0 };
+        }
+    }, [
+        stackedSeriesWithColorAssignments,
+        itemsMap,
+        rows,
+        validCartesianConfig?.layout?.stack,
+        validCartesianConfig?.layout?.flipAxes,
+        validCartesianConfigLegend,
+    ]);
+
     const currentGrid = useMemo(() => {
         const enableDataZoom =
             validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.enableDataZoom;
@@ -2804,13 +2875,26 @@ const useEchartsCartesianConfig = (
                 : grid.left,
             right:
                 isPxValue(gridRight) && !enableDataZoom
-                    ? addPx(gridRight, defaultAxisLabelGap + extraRightPadding)
+                    ? addPx(
+                          gridRight,
+                          defaultAxisLabelGap +
+                              extraRightPadding +
+                              stackLabelPaddingCalc.right,
+                      )
                     : isPxValue(gridRight) && enableDataZoom && flipAxes
                     ? addPx(
                           gridRight,
-                          defaultAxisLabelGap + extraRightPadding + 30,
+                          defaultAxisLabelGap +
+                              extraRightPadding +
+                              stackLabelPaddingCalc.right +
+                              30,
                       )
                     : grid.right,
+            // Add extra top spacing for 100% stacking labels when not flipped (vertical bars)
+            top:
+                stackLabelPaddingCalc.top > 0 && isPxValue(grid.top)
+                    ? addPx(grid.top, stackLabelPaddingCalc.top)
+                    : grid.top,
             // Add extra bottom spacing for dataZoom slider when not flipped
             bottom:
                 enableDataZoom && !flipAxes && isPxValue(gridBottom)
@@ -2823,6 +2907,7 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.eChartsConfig.legend,
         validCartesianConfig?.layout?.flipAxes,
         series,
+        stackLabelPaddingCalc,
         isDashboardRedesignEnabled,
     ]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #18912

### Description:
Added support for proper display of stack labels in 100% stacked charts. This PR:

- Adds a `clip` property to the `EChartsSeries` type to control whether series data is clipped
- Disables clipping for stack total series to ensure labels are always visible
- Prevents label overlap hiding in 100% stacked charts to show all percentage values
- Calculates and applies appropriate padding for stack labels based on:
  - Chart orientation (horizontal/vertical)
  - Maximum formatted label length
  - Whether stack labels are enabled

This ensures stack labels in 100% stacked charts are fully visible and properly positioned without being cut off by chart boundaries.

<details>
<summary>Before/After</summary>

### Before

Cut off
<img width="2564" height="1382" alt="localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_tables_orders_create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_shipping (1)" src="https://github.com/user-attachments/assets/ffad67b1-6fa5-4bf4-a0c1-60d2728b26e1" />

Or just disappear
<img width="2564" height="1382" alt="localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_tables_orders_create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_shipping (2)" src="https://github.com/user-attachments/assets/ab98ce12-4f5c-430e-9385-49879f8681a2" />

### After
Extra (dynamic) padding
<img width="2564" height="1382" alt="localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_tables_orders_create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_shipping_met" src="https://github.com/user-attachments/assets/c0991f4a-6a20-4851-b181-caa448644a10" />

Showing all labels!
<img width="2564" height="1382" alt="localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_saved_3b9f400f-cc2e-46fe-91d3-a7ff4a17c4a9_edit_fromDashboard=10d3e6c8-2217-4282-aedc-3291bc7da4b6" src="https://github.com/user-attachments/assets/547f44f3-4312-4a68-a95c-b15ee6cd0807" />

Works for vertical bars!
<img width="1684" height="680" alt="localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_tables_subscriptions_create_saved_chart_version=%7B%22tableName%22%3A%22subscriptions%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22subscriptions%22%2C%22dimensions%22%3A (1)" src="https://github.com/user-attachments/assets/dc29fd29-1fee-499a-afd8-6ebfa08f4d8e" />

</details>