### PR TITLE
fix: handle field name collision with group label in tree view

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/utils.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/utils.ts
@@ -65,8 +65,16 @@ const createNodeWithGroup = (
     const existingGroupNode: NodeMap[string] | undefined =
         existingNode[groupLabel];
 
+    // Handle collision: if a field exists with the same key as the group label,
+    // skip grouping and add the item at the current level instead
     if (existingGroupNode && !isGroupNode(existingGroupNode)) {
-        throw new Error('Existing group node is not a group node');
+        console.warn(
+            `Field "${item.key}" cannot be grouped under "${groupLabel}" because a field with that key already exists. Adding to current level instead.`,
+        );
+        return {
+            ...existingNode,
+            [item.key]: item,
+        };
     }
 
     const groupNode =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2226 / LIGHTDASH-FRONTEND-45J

### Description:
Fixed a bug where field grouping would throw an error when a field ID collides with a group label. Instead of throwing "Existing group node is not a group node", the code now gracefully handles the collision by adding the field to the current level and logging a warning message.

The fix addresses a Sentry error that occurred when:
1. A field has an itemId matching a group label (e.g., "orders_identifiers")
2. Another field tries to use that same label as a group

Added comprehensive tests to verify the collision handling works correctly.
<details>
<summary>Before/After</summary>

### Before
https://github.com/user-attachments/assets/7b6322eb-95d3-41ff-a1d0-0bb347d89266

### After
https://github.com/user-attachments/assets/021553a4-bee7-4db3-9053-9396b55da3f7

</details>



