### PR TITLE
fix: simplify table scroll-to-top behavior

### DIFF
--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -169,12 +169,8 @@ const LogsTable: FC<LogsTableProps> = ({
 
     // Scroll to top when filters change
     useEffect(() => {
-        if (rowVirtualizerInstanceRef.current) {
-            try {
-                rowVirtualizerInstanceRef.current.scrollToIndex(0);
-            } catch (e) {
-                console.error(e);
-            }
+        if (tableContainerRef.current) {
+            tableContainerRef.current.scrollTop = 0;
         }
     }, [debouncedSearchAndFilters]);
 

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -249,12 +249,8 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
 
     // Scroll to top when sorting or filters change
     useEffect(() => {
-        if (rowVirtualizerInstanceRef.current) {
-            try {
-                rowVirtualizerInstanceRef.current.scrollToIndex(0);
-            } catch (e) {
-                console.error(e);
-            }
+        if (tableContainerRef.current) {
+            tableContainerRef.current.scrollTop = 0;
         }
     }, [debouncedSearchAndFilters]);
 

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
@@ -106,12 +106,8 @@ const GroupsTable: FC<GroupsTableProps> = ({ onAddClick, onEditGroup }) => {
 
     // Scroll to top when search changes
     useEffect(() => {
-        if (rowVirtualizerInstanceRef.current) {
-            try {
-                rowVirtualizerInstanceRef.current.scrollToIndex(0);
-            } catch (e) {
-                console.error(e);
-            }
+        if (tableContainerRef.current) {
+            tableContainerRef.current.scrollTop = 0;
         }
     }, [debouncedSearchValue]);
 

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -132,12 +132,8 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
 
     // Scroll to top when search changes
     useEffect(() => {
-        if (rowVirtualizerInstanceRef.current) {
-            try {
-                rowVirtualizerInstanceRef.current.scrollToIndex(0);
-            } catch (e) {
-                console.error(e);
-            }
+        if (tableContainerRef.current) {
+            tableContainerRef.current.scrollTop = 0;
         }
     }, [debouncedSearchValue]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2227 / LIGHTDASH-FRONTEND-45H

### Description:
Simplified table scrolling behavior by replacing the complex `rowVirtualizerInstanceRef.scrollToIndex(0)` method with direct `tableContainerRef.current.scrollTop = 0` manipulation. This change improves reliability by eliminating try/catch blocks and potential errors when scrolling tables back to the top after filter changes.

The fix applies to multiple table components including LogsTable, SchedulersTable, GroupsTable, and UsersTable, ensuring consistent scrolling behavior throughout the application.

<details>
<summary>Repro/fix demo</summary>

### Repro

https://github.com/user-attachments/assets/c2970aa8-725f-4d1b-8cd8-88b9468cc5c4

### Fix demo

https://github.com/user-attachments/assets/77eee1c0-0ce7-4401-97a5-e3b2dfcc7e04

</details>