### PR TITLE
fix: filter third-party SyntaxErrors in Sentry reporting

### DIFF
--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -81,10 +81,11 @@ const useSentry = (
                     if (error instanceof SyntaxError) {
                         const frames =
                             event.exception?.values?.[0]?.stacktrace?.frames;
-                        const hasInAppFrame = frames?.some(
-                            (frame) => frame.in_app === true,
-                        );
-                        if (!hasInAppFrame) {
+                        const hasInAppFrame =
+                            frames &&
+                            frames.length > 0 &&
+                            frames.some((frame) => frame.in_app === true);
+                        if (frames && frames.length > 0 && !hasInAppFrame) {
                             return null;
                         }
                     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2229 / LIGHTDASH-FRONTEND-446

### Description:
Filter out SyntaxErrors that originate entirely from third-party code in Sentry error reporting. These errors are typically caused by network issues, browser extensions, or CDN serving corrupted bundles and are not actionable by our team. The change checks if a SyntaxError has any in-app frames in its stack trace before reporting it to Sentry.