### PR TITLE
feat: use parameter values in filter autocomplete

### DIFF
--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -28,6 +28,7 @@ import {
     selectIsEditMode,
     selectIsFiltersExpanded,
     selectMetricQuery,
+    selectParameters,
     selectTableCalculations,
     selectTableName,
     useExplorerDispatch,
@@ -54,6 +55,7 @@ const FiltersCard: FC = memo(() => {
     const tableCalculations = useExplorerSelector(selectTableCalculations);
     const filters = useExplorerSelector(selectFilters);
     const isEditMode = useExplorerSelector(selectIsEditMode);
+    const parameterValues = useExplorerSelector(selectParameters);
     const dispatch = useExplorerDispatch();
 
     const tableName = useExplorerSelector(selectTableName);
@@ -319,6 +321,7 @@ const FiltersCard: FC = memo(() => {
                         withinPortal: true,
                     }}
                     baseTable={data?.baseTable}
+                    parameterValues={parameterValues}
                 >
                     <FiltersForm
                         isEditMode={isEditMode}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -71,7 +71,8 @@ const FilterStringAutoComplete: FC<Props> = ({
     ...rest
 }) => {
     const multiSelectRef = useRef<HTMLInputElement>(null);
-    const { projectUuid, getAutocompleteFilterGroup } = useFiltersContext();
+    const { projectUuid, getAutocompleteFilterGroup, parameterValues } =
+        useFiltersContext();
     if (!projectUuid) {
         throw new Error('projectUuid is required in FiltersProvider');
     }
@@ -110,6 +111,7 @@ const FilterStringAutoComplete: FC<Props> = ({
         {
             refetchOnMount: 'always',
         },
+        parameterValues,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -3,6 +3,7 @@ import {
     type DashboardFilters,
     type FilterRule,
     type FilterableItem,
+    type ParametersValuesMap,
     type WeekDay,
 } from '@lightdash/common';
 import { type PopoverProps } from '@mantine/core';
@@ -17,6 +18,7 @@ type Props<T extends DefaultFieldsMap> = {
     startOfWeek?: WeekDay;
     dashboardFilters?: DashboardFilters;
     popoverProps?: Omit<PopoverProps, 'children'>;
+    parameterValues?: ParametersValuesMap;
     children?: ReactNode;
 };
 
@@ -27,6 +29,7 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
     startOfWeek,
     dashboardFilters,
     popoverProps,
+    parameterValues,
     children,
 }: Props<T>) => {
     const getField = useCallback(
@@ -65,6 +68,7 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
                 getField,
                 getAutocompleteFilterGroup,
                 popoverProps,
+                parameterValues,
             }}
         >
             {children}

--- a/packages/frontend/src/components/common/Filters/context.ts
+++ b/packages/frontend/src/components/common/Filters/context.ts
@@ -3,6 +3,7 @@ import {
     type FilterableItem,
     type FilterRule,
     type ItemsMap,
+    type ParametersValuesMap,
     type WeekDay,
 } from '@lightdash/common';
 import { type PopoverProps } from '@mantine/core';
@@ -24,6 +25,7 @@ export type FiltersContext<T extends DefaultFieldsMap = DefaultFieldsMap> = {
         item: FilterableItem,
     ) => AndFilterGroup | undefined;
     popoverProps?: Omit<PopoverProps, 'children'>;
+    parameterValues?: ParametersValuesMap;
 };
 
 const Context = createContext<FiltersContext | undefined>(undefined);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1996 / #18862

### Description:
This PR enhances the filter autocomplete functionality by combining request parameters with defaults from parameter definitions. The changes ensure that parameter values are properly passed through the filter autocomplete flow, from the frontend components to the backend service.

Key improvements:
- Added parameter values support in the FiltersProvider context
- Modified ProjectService to combine parameters with defaults before executing autocomplete queries
- Fixed caching mechanism for autocomplete results
- Optimized result handling by using a Set to deduplicate values
- Properly disconnecting SSH tunnel when returning cached results
- Passing parameter values from Explorer to filter components

These changes ensure that filter autocomplete queries respect the current parameter values set in the UI, providing more accurate and contextual autocomplete suggestions.

### Explorer
<img width="792" height="376" alt="Screenshot 2026-01-01 at 16 52 24" src="https://github.com/user-attachments/assets/5668bc54-5120-4968-b436-6e8d8e41aa44" />

### Dashboard
<img width="400" height="342" alt="Screenshot 2026-01-01 at 16 52 45" src="https://github.com/user-attachments/assets/8f0224e1-49a6-4df9-b4a5-95c7f64ddb54" />
