### PR TITLE
feat: add variant delete to MantineModal

### DIFF
--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -330,30 +330,14 @@ export const TokensTable = () => {
             <MantineModal
                 opened={!!tokenToDelete}
                 onClose={() => !isDeleting && setTokenToDelete(undefined)}
-                title={`Delete token ${tokenToDelete?.description}`}
-                icon={IconTrash}
+                title="Delete token"
+                variant="delete"
+                resourceType="token"
+                resourceLabel={tokenToDelete?.description}
                 cancelDisabled={isDeleting}
-                actions={
-                    <Button
-                        color="red"
-                        disabled={isDeleting}
-                        onClick={() => {
-                            mutate(tokenToDelete?.uuid ?? '');
-                        }}
-                    >
-                        Delete
-                    </Button>
-                }
-            >
-                <Text>
-                    Are you sure? This will permanently delete the
-                    <Text fw={600} component="span">
-                        {' '}
-                        {tokenToDelete?.description}{' '}
-                    </Text>
-                    token.
-                </Text>
-            </MantineModal>
+                onConfirm={() => mutate(tokenToDelete?.uuid ?? '')}
+                confirmDisabled={isDeleting}
+            />
 
             <MantineModal
                 opened={!!tokenToCopy}

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/DeletePaletteModal.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/DeletePaletteModal.tsx
@@ -1,12 +1,11 @@
 import { type OrganizationColorPalette } from '@lightdash/common';
 import {
     type ModalProps,
-    Button,
     Center,
     ColorSwatch,
     SimpleGrid,
+    Text,
 } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineModal from '../../common/MantineModal';
 
@@ -24,16 +23,16 @@ export const DeletePaletteModal: FC<DeletePaletteModalProps> = ({
     <MantineModal
         opened={opened}
         onClose={onClose}
-        title={`Delete "${palette.name}" Palette`}
-        icon={IconTrash}
+        title="Delete color palette"
+        variant="delete"
+        resourceType="color palette"
+        resourceLabel={palette.name}
         size="md"
-        actions={
-            <Button color="red" onClick={onConfirm}>
-                Delete Palette
-            </Button>
-        }
-        description="Are you sure you want to delete this color palette? This action cannot be undone."
+        onConfirm={onConfirm}
     >
+        <Text fz="sm" c="dimmed">
+            This action cannot be undone.
+        </Text>
         <Center>
             <SimpleGrid cols={10} spacing="xs">
                 {palette.colors.map((color, index) => (

--- a/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationModal.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationModal.tsx
@@ -1,5 +1,4 @@
-import { Button, Text, TextInput, type ModalProps } from '@mantine-8/core';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { Text, TextInput, type ModalProps } from '@mantine-8/core';
 import { useState, type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useDeleteOrganizationMutation } from '../../../hooks/organization/useOrganizationDeleteMultation';
@@ -31,27 +30,20 @@ export const OrganizationDeleteModal: FC<
             opened={opened}
             onClose={handleOnClose}
             title="Delete Organization"
-            icon={IconAlertCircle}
+            variant="delete"
+            resourceType="organization"
+            resourceLabel={organization.name}
             size="md"
-            actions={
-                <Button
-                    color="red"
-                    disabled={
-                        confirmOrgName?.toLowerCase() !==
-                        organization.name.toLowerCase()
-                    }
-                    loading={isDeleting}
-                    onClick={() => handleConfirm()}
-                >
-                    Delete
-                </Button>
+            onConfirm={handleConfirm}
+            confirmDisabled={
+                confirmOrgName?.toLowerCase() !==
+                organization.name.toLowerCase()
             }
+            confirmLoading={isDeleting}
         >
-            <Text>
-                Type the name of this organization{' '}
-                <b>{organization.name}</b> to confirm you want to delete
-                this organization and its users. This action is not
-                reversible.
+            <Text fz="sm" c="dimmed">
+                Type the name of this organization to confirm. This action
+                will delete all users and is not reversible.
             </Text>
 
             <TextInput

--- a/packages/frontend/src/components/UserSettings/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -1,5 +1,4 @@
-import { Button, Text, TextInput, type ModalProps } from '@mantine-8/core';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { Text, TextInput, type ModalProps } from '@mantine-8/core';
 import { useState, type FC } from 'react';
 import { useDeleteActiveProjectMutation } from '../../../hooks/useActiveProject';
 import { useProject } from '../../../hooks/useProject';
@@ -39,29 +38,19 @@ export const ProjectDeleteModal: FC<
             opened={opened}
             onClose={handleOnClose}
             title="Delete Project"
-            icon={IconAlertCircle}
+            variant="delete"
+            resourceType="project"
+            resourceLabel={project.name}
             size="md"
-            actions={
-                <Button
-                    color="red"
-                    disabled={
-                        confirmOrgName?.toLowerCase() !==
-                        project.name.toLowerCase()
-                    }
-                    loading={isDeleting}
-                    onClick={() => handleConfirm()}
-                >
-                    Delete
-                </Button>
+            onConfirm={handleConfirm}
+            confirmDisabled={
+                confirmOrgName?.toLowerCase() !== project.name.toLowerCase()
             }
+            confirmLoading={isDeleting}
         >
-            <Text>
-                Type the name of this project{' '}
-                <Text span fw={600}>
-                    {project.name}
-                </Text>{' '}
-                to confirm you want to delete this project and its users.
-                This action is not reversible.
+            <Text fz="sm" c="dimmed">
+                Type the name of this project to confirm. This action is not
+                reversible.
             </Text>
 
             <TextInput

--- a/packages/frontend/src/components/UserSettings/DeleteProjectPanel/ProjectDeleteInBulkModal.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteProjectPanel/ProjectDeleteInBulkModal.tsx
@@ -1,6 +1,5 @@
 import { ProjectType, type OrganizationProject } from '@lightdash/common';
-import { Button, List, Text, TextInput, type ModalProps } from '@mantine-8/core';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { List, Text, TextInput, type ModalProps } from '@mantine-8/core';
 import { useMemo, useState, type FC } from 'react';
 import { useDeleteActiveProjectMutation } from '../../../hooks/useActiveProject';
 import { useDeleteProjectMutation } from '../../../hooks/useProjects';
@@ -113,23 +112,17 @@ export const ProjectDeleteInBulkModal: FC<Props> = ({
             opened={opened}
             onClose={handleOnClose}
             title="Delete projects in bulk"
-            icon={IconAlertCircle}
+            variant="delete"
+            resourceType="projects"
             size="md"
-            actions={
-                <Button
-                    color="red"
-                    disabled={
-                        confirmationText.toLowerCase() !==
-                        CONFIRMATION_TEXT.toLowerCase()
-                    }
-                    loading={isDeleting || isDeletingActive}
-                    onClick={() => handleConfirm()}
-                >
-                    Delete
-                </Button>
+            onConfirm={handleConfirm}
+            confirmDisabled={
+                confirmationText.toLowerCase() !==
+                CONFIRMATION_TEXT.toLowerCase()
             }
+            confirmLoading={isDeleting || isDeletingActive}
         >
-            <Text>You are about to delete:</Text>
+            <Text fz="sm">You are about to delete:</Text>
 
             <List size="sm">
                 {statsText.map((text, index) => (
@@ -137,7 +130,7 @@ export const ProjectDeleteInBulkModal: FC<Props> = ({
                 ))}
             </List>
 
-            <Text>
+            <Text fz="sm" c="dimmed">
                 Type in{' '}
                 <Text span fw={500}>
                     "{CONFIRMATION_TEXT}"

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/DeleteCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/DeleteCredentialsModal.tsx
@@ -1,6 +1,4 @@
 import { type UserWarehouseCredentials } from '@lightdash/common';
-import { Button, Text } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useUserWarehouseCredentialsDeleteMutation } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
 import MantineModal, {
@@ -21,31 +19,22 @@ export const DeleteCredentialsModal: FC<Props> = ({
             warehouseCredentialsToBeDeleted.uuid,
         );
 
+    const handleConfirm = async () => {
+        await mutateAsync();
+        onClose();
+    };
+
     return (
         <MantineModal
             opened={opened}
             onClose={onClose}
             title="Delete credentials"
-            icon={IconTrash}
+            variant="delete"
+            resourceType="credentials"
+            resourceLabel={warehouseCredentialsToBeDeleted.name}
             cancelDisabled={isDeleting}
-            actions={
-                <Button
-                    color="red"
-                    onClick={async () => {
-                        await mutateAsync();
-                        onClose();
-                    }}
-                    loading={isDeleting}
-                    disabled={isDeleting}
-                >
-                    Delete
-                </Button>
-            }
-        >
-            <Text fz="sm">
-                Are you sure you want to delete credentials:{' '}
-                <b>{warehouseCredentialsToBeDeleted.name}</b>?
-            </Text>
-        </MantineModal>
+            onConfirm={handleConfirm}
+            confirmLoading={isDeleting}
+        />
     );
 };

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/DeleteCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/DeleteCredentialsModal.tsx
@@ -1,6 +1,4 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Button, Text } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useDeleteOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
 import MantineModal, {
@@ -19,33 +17,24 @@ export const DeleteCredentialsModal: FC<Props> = ({
     const { mutateAsync, isLoading: isDeleting } =
         useDeleteOrganizationWarehouseCredentials();
 
+    const handleConfirm = async () => {
+        await mutateAsync(
+            warehouseCredentialsToBeDeleted.organizationWarehouseCredentialsUuid,
+        );
+        onClose();
+    };
+
     return (
         <MantineModal
             opened={opened}
             onClose={onClose}
             title="Delete credentials"
-            icon={IconTrash}
+            variant="delete"
+            resourceType="credentials"
+            resourceLabel={warehouseCredentialsToBeDeleted.name}
             cancelDisabled={isDeleting}
-            actions={
-                <Button
-                    color="red"
-                    onClick={async () => {
-                        await mutateAsync(
-                            warehouseCredentialsToBeDeleted.organizationWarehouseCredentialsUuid,
-                        );
-                        onClose();
-                    }}
-                    loading={isDeleting}
-                    disabled={isDeleting}
-                >
-                    Delete
-                </Button>
-            }
-        >
-            <Text fz="sm">
-                Are you sure you want to delete credentials:{' '}
-                <b>{warehouseCredentialsToBeDeleted.name}</b>?
-            </Text>
-        </MantineModal>
+            onConfirm={handleConfirm}
+            confirmLoading={isDeleting}
+        />
     );
 };

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -13,7 +13,6 @@ import {
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
-    IconAlertCircle,
     IconEdit,
     IconInfoCircle,
     IconPlus,
@@ -101,22 +100,13 @@ const UserListItem: FC<{
                         opened={isDeleteDialogOpen}
                         onClose={deleteDialog.close}
                         title="Delete user attribute"
-                        icon={IconAlertCircle}
-                        actions={
-                            <Button
-                                onClick={() => {
-                                    deleteUserAttribute(orgUserAttribute.uuid);
-                                }}
-                                color="red"
-                            >
-                                Delete
-                            </Button>
+                        variant="delete"
+                        resourceType="user attribute"
+                        resourceLabel={orgUserAttribute.name}
+                        onConfirm={() =>
+                            deleteUserAttribute(orgUserAttribute.uuid)
                         }
-                    >
-                        <Text>
-                            Are you sure you want to delete this user attribute?
-                        </Text>
-                    </MantineModal>
+                    />
                 </Group>
             </td>
         </tr>

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsActionMenu.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsActionMenu.tsx
@@ -1,5 +1,5 @@
 import { type GroupWithMembers } from '@lightdash/common';
-import { ActionIcon, Button, Menu } from '@mantine-8/core';
+import { ActionIcon, Menu } from '@mantine-8/core';
 import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import { useGroupDeleteMutation } from '../../../hooks/useOrganizationGroups';
@@ -72,19 +72,13 @@ const GroupsActionMenu: FC<GroupsActionMenuProps> = ({
                 onClose={() =>
                     !isDeleting ? setIsDeleteDialogOpen(false) : undefined
                 }
-                title={`Delete group "${group.name}"`}
-                icon={IconTrash}
-                description="Are you sure you want to delete this group?"
+                title="Delete group"
+                variant="delete"
+                resourceType="group"
+                resourceLabel={group.name}
                 cancelDisabled={isDeleting}
-                actions={
-                    <Button
-                        onClick={handleDelete}
-                        disabled={isDeleting}
-                        color="red"
-                    >
-                        Delete
-                    </Button>
-                }
+                onConfirm={handleDelete}
+                confirmLoading={isDeleting}
             />
         </>
     );

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -14,15 +14,70 @@ import {
     Stack,
     Text,
 } from '@mantine-8/core';
-import { type Icon as IconType } from '@tabler/icons-react';
+import { IconTrash, type Icon as IconType } from '@tabler/icons-react';
 import React from 'react';
 import MantineIcon from '../MantineIcon';
 import classes from './MantineModal.module.css';
+
+/**
+ * Modal variants for common action patterns.
+ * - `default`: Standard modal with no preset styling
+ * - `delete`: Destructive action modal with red styling and trash icon
+ */
+export type MantineModalVariant = 'default' | 'delete';
+
+const VARIANT_CONFIG: Record<
+    MantineModalVariant,
+    { icon?: IconType; color?: string; confirmLabel: string }
+> = {
+    default: {
+        confirmLabel: 'Confirm',
+    },
+    delete: {
+        icon: IconTrash,
+        color: 'red',
+        confirmLabel: 'Delete',
+    },
+};
+
+/**
+ * Generates a default description for the delete variant.
+ */
+const getVariantDescription = (
+    variant: MantineModalVariant,
+    resourceType?: string,
+    resourceLabel?: string,
+): string | undefined => {
+    if (variant === 'delete' && resourceType) {
+        if (resourceLabel) {
+            return `Are you sure you want to delete the ${resourceType} "${resourceLabel}"?`;
+        }
+        return `Are you sure you want to delete this ${resourceType}?`;
+    }
+    return undefined;
+};
 
 export type MantineModalProps = {
     opened: boolean;
     onClose: () => void;
     title: string;
+    /**
+     * Modal variant for common action patterns.
+     * - `delete`: Adds IconTrash, red action buttons, and auto-generates description
+     * @default 'default'
+     */
+    variant?: MantineModalVariant;
+    /**
+     * The type of resource being acted upon (e.g., "chart", "dashboard", "space").
+     * Used with `variant="delete"` to auto-generate description.
+     */
+    resourceType?: string;
+    /**
+     * The specific name/label of the resource being acted upon.
+     * Used with `variant="delete"` and `resourceType` to generate:
+     * "Are you sure you want to delete the {resourceType} "{resourceLabel}"?"
+     */
+    resourceLabel?: string;
     icon?: IconType;
     /**
      * Modal size. Accepts Mantine's built-in sizes ('xs', 'sm', 'md', 'lg', 'xl') or a custom number/string.
@@ -45,6 +100,7 @@ export type MantineModalProps = {
      * Simple text description for the modal body.
      * Use this for simple confirmation dialogs instead of children.
      * Renders above children if both are provided.
+     * For `variant="delete"`, this is auto-generated if `resourceType` is provided.
      */
     description?: string;
     /**
@@ -52,8 +108,28 @@ export type MantineModalProps = {
      */
     children?: React.ReactNode;
     /**
-     * Action buttons to display in the footer (right side).
-     * A Cancel button is automatically prepended unless `cancelLabel` is set to `false`.
+     * Handler for the primary confirm action button.
+     * When provided, renders a confirm button with variant-appropriate styling.
+     */
+    onConfirm?: () => void;
+    /**
+     * Label for the confirm button.
+     * @default "Confirm" for default variant, "Delete" for delete variant
+     */
+    confirmLabel?: string;
+    /**
+     * Whether the confirm button is disabled.
+     * @default false
+     */
+    confirmDisabled?: boolean;
+    /**
+     * Whether the confirm button shows a loading state.
+     * @default false
+     */
+    confirmLoading?: boolean;
+    /**
+     * Additional action buttons to display in the footer (right side), before the confirm button.
+     * Use for secondary actions. For the primary action, prefer using `onConfirm`.
      */
     actions?: React.ReactNode;
     /**
@@ -93,12 +169,19 @@ const MantineModal: React.FC<MantineModalProps> = ({
     opened,
     onClose,
     title,
+    variant = 'default',
+    resourceType,
+    resourceLabel,
     icon,
     size = 'lg',
     fullScreen = false,
     withCloseButton = true,
     description,
     children,
+    onConfirm,
+    confirmLabel,
+    confirmDisabled = false,
+    confirmLoading = false,
     actions,
     leftActions,
     headerActions,
@@ -110,6 +193,18 @@ const MantineModal: React.FC<MantineModalProps> = ({
     modalBodyProps,
     modalActionsProps,
 }) => {
+    const config = VARIANT_CONFIG[variant];
+
+    const effectiveIcon = icon ?? config.icon;
+
+    const effectiveDescription =
+        description ??
+        getVariantDescription(variant, resourceType, resourceLabel);
+
+    const effectiveConfirmLabel = confirmLabel ?? config.confirmLabel;
+
+    const confirmButtonColor = config.color;
+
     const renderBody = () => {
         if (fullScreen) {
             // Fullscreen mode: no ScrollArea, body fills available space
@@ -120,7 +215,9 @@ const MantineModal: React.FC<MantineModalProps> = ({
                         py={modalBodyProps?.py ?? 'md'}
                         h="100%"
                     >
-                        {description && <Text fz="sm">{description}</Text>}
+                        {effectiveDescription && (
+                            <Text fz="sm">{effectiveDescription}</Text>
+                        )}
                         {children}
                     </Box>
                 </Modal.Body>
@@ -141,7 +238,9 @@ const MantineModal: React.FC<MantineModalProps> = ({
                         mah={modalBodyProps?.mah}
                         mih={modalBodyProps?.mih}
                     >
-                        {description && <Text fz="sm">{description}</Text>}
+                        {effectiveDescription && (
+                            <Text fz="sm">{effectiveDescription}</Text>
+                        )}
                         {children}
                     </Stack>
                 </ScrollArea.Autosize>
@@ -168,9 +267,9 @@ const MantineModal: React.FC<MantineModalProps> = ({
                     {...modalHeaderProps}
                 >
                     <Group gap="sm" flex={1} wrap="nowrap" align="flex-start">
-                        {icon ? (
+                        {effectiveIcon ? (
                             <Paper p="6px" withBorder radius="md">
-                                <MantineIcon icon={icon} size="md" />
+                                <MantineIcon icon={effectiveIcon} size="md" />
                             </Paper>
                         ) : null}
                         <Text c="ldDark.9" fw={700} fz="md" lh="28px">
@@ -187,7 +286,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
 
                 {renderBody()}
 
-                {(actions || leftActions) && !fullScreen ? (
+                {(onConfirm || actions || leftActions) && !fullScreen ? (
                     <Flex
                         className={classes.actions}
                         px="xl"
@@ -208,6 +307,16 @@ const MantineModal: React.FC<MantineModalProps> = ({
                                 </Button>
                             )}
                             {actions}
+                            {onConfirm && (
+                                <Button
+                                    color={confirmButtonColor}
+                                    onClick={onConfirm}
+                                    disabled={confirmDisabled}
+                                    loading={confirmLoading}
+                                >
+                                    {effectiveConfirmLabel}
+                                </Button>
+                            )}
                         </Group>
                     </Flex>
                 ) : null}

--- a/packages/frontend/src/components/common/SpaceActionModal/DeleteSpaceModal.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/DeleteSpaceModal.tsx
@@ -1,8 +1,8 @@
-import { Button, List, TextInput } from '@mantine-8/core';
+import { List, TextInput } from '@mantine-8/core';
 import { useState, type FC } from 'react';
 import { type DeleteSpaceModalBody } from '.';
-import MantineModal from '../MantineModal';
 import Callout from '../Callout';
+import MantineModal from '../MantineModal';
 
 const DeleteSpaceTextInputConfirmation: FC<{
     data: DeleteSpaceModalBody['data'];
@@ -71,7 +71,6 @@ export const DeleteSpaceModal: FC<DeleteSpaceModalBody> = ({
     data,
     title,
     onClose,
-    icon,
     form,
     handleSubmit,
     isLoading,
@@ -83,19 +82,13 @@ export const DeleteSpaceModal: FC<DeleteSpaceModalBody> = ({
             opened
             onClose={onClose}
             title={title}
-            icon={icon}
+            variant="delete"
+            resourceType="space"
+            resourceLabel={data?.name}
             size="lg"
-            description={`Are you sure you want to delete space "${data?.name}"?`}
-            actions={
-                <Button
-                    color="red"
-                    disabled={!canDelete || isLoading}
-                    loading={isLoading}
-                    onClick={() => form.onSubmit(handleSubmit)()}
-                >
-                    Delete Space
-                </Button>
-            }
+            onConfirm={() => form.onSubmit(handleSubmit)()}
+            confirmDisabled={!canDelete || isLoading}
+            confirmLoading={isLoading}
         >
             <DeleteSpaceModalContent data={data} />
             <DeleteSpaceTextInputConfirmation

--- a/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
@@ -1,11 +1,4 @@
-import {
-    Anchor,
-    Button,
-    List,
-    ScrollArea,
-    type ModalProps,
-} from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
+import { Anchor, List, ScrollArea, type ModalProps } from '@mantine-8/core';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';
 import { useDashboardsContainingChart } from '../../../hooks/dashboard/useDashboards';
@@ -54,22 +47,11 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
             opened={modalProps.opened}
             onClose={modalProps.onClose}
             title="Delete Chart"
-            icon={IconTrash}
-            actions={
-                <Button
-                    color="red"
-                    loading={isDeleting}
-                    onClick={handleConfirm}
-                >
-                    Delete
-                </Button>
-            }
-            description={`
-                    Are you sure you want to delete the chart 
-                   
-                        "${chart.name}"
-                    ?
-                    `}
+            variant="delete"
+            resourceType="chart"
+            resourceLabel={chart.name}
+            onConfirm={handleConfirm}
+            confirmLoading={isDeleting}
         >
             {relatedDashboards.length > 0 && (
                 <Callout

--- a/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
@@ -2,15 +2,7 @@ import {
     hasChartsInDashboard,
     isDashboardChartTileType,
 } from '@lightdash/common';
-import {
-    Button,
-    List,
-    ScrollArea,
-    Stack,
-    Text,
-    type ModalProps,
-} from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
+import { List, ScrollArea, type ModalProps } from '@mantine-8/core';
 import { type FC } from 'react';
 import {
     useDashboardDeleteMutation,
@@ -55,56 +47,31 @@ const DashboardDeleteModal: FC<DashboardDeleteModalProps> = ({
             opened={opened}
             onClose={onClose}
             title="Delete dashboard"
-            icon={IconTrash}
-            actions={
-                <Button
-                    color="red"
-                    loading={isDeleting}
-                    onClick={handleConfirm}
-                >
-                    Delete
-                </Button>
-            }
+            variant="delete"
+            resourceType="dashboard"
+            resourceLabel={dashboard.name}
+            onConfirm={handleConfirm}
+            confirmLoading={isDeleting}
         >
-            <Stack>
-                {hasChartsInDashboard(dashboard) ? (
-                    <>
-                        <Text fz="sm">
-                            Are you sure you want to delete the dashboard{' '}
-                            <b>"{dashboard.name}"</b>?
-                        </Text>
-                        <Text fz="sm">
-                            This action will also permanently delete the
-                            following charts that were created from within it:
-                        </Text>
-                        <Callout
-                            variant="danger"
-                            title="This action will also permanently delete the following charts that were created from within it:"
-                        >
-                            <ScrollArea.Autosize mah="300px" scrollbars="y">
-                                <List pr={'md'}>
-                                    {chartsInDashboardTiles.map(
-                                        (tile) =>
-                                            isDashboardChartTileType(tile) && (
-                                                <List.Item
-                                                    key={tile.uuid}
-                                                    fz="xs"
-                                                >
-                                                    {tile.properties.chartName}
-                                                </List.Item>
-                                            ),
-                                    )}
-                                </List>
-                            </ScrollArea.Autosize>
-                        </Callout>
-                    </>
-                ) : (
-                    <Text>
-                        Are you sure you want to delete the dashboard{' '}
-                        <b>"{dashboard.name}"</b>?
-                    </Text>
-                )}
-            </Stack>
+            {hasChartsInDashboard(dashboard) && (
+                <Callout
+                    variant="danger"
+                    title="This action will also permanently delete the following charts that were created from within it:"
+                >
+                    <ScrollArea.Autosize mah="300px" scrollbars="y">
+                        <List pr={'md'}>
+                            {chartsInDashboardTiles.map(
+                                (tile) =>
+                                    isDashboardChartTileType(tile) && (
+                                        <List.Item key={tile.uuid} fz="xs">
+                                            {tile.properties.chartName}
+                                        </List.Item>
+                                    ),
+                            )}
+                        </List>
+                    </ScrollArea.Autosize>
+                </Callout>
+            )}
         </MantineModal>
     );
 };

--- a/packages/frontend/src/components/common/modal/DeleteChartTileThatBelongsToDashboardModal.tsx
+++ b/packages/frontend/src/components/common/modal/DeleteChartTileThatBelongsToDashboardModal.tsx
@@ -1,5 +1,4 @@
-import { Button, type ModalProps } from '@mantine-8/core';
-import { IconAlertCircle } from '@tabler/icons-react';
+import { type ModalProps } from '@mantine-8/core';
 import { type FC } from 'react';
 import Callout from '../Callout';
 import MantineModal from '../MantineModal';
@@ -21,14 +20,11 @@ const DeleteChartTileThatBelongsToDashboardModal: FC<Props> = ({
         opened={opened}
         onClose={onClose}
         title="Delete chart"
-        icon={IconAlertCircle}
+        variant="delete"
+        resourceType="chart"
+        resourceLabel={name}
         modalRootProps={{ className }}
-        description={`Are you sure you want to delete the chart "${name}"?`}
-        actions={
-            <Button color="red" onClick={onConfirm}>
-                Delete
-            </Button>
-        }
+        onConfirm={onConfirm}
     >
         <Callout variant="warning" title="This change cannot be undone.">
             This chart was created from within the dashboard, so removing the

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -815,13 +815,10 @@ export const AiAgentFormSetup = ({
                 opened={deleteModalOpen}
                 onClose={handleCancelDelete}
                 title="Delete Agent"
-                icon={IconTrash}
-                description="Are you sure you want to delete this agent? This action cannot be undone."
-                actions={
-                    <Button color="red" onClick={handleDelete}>
-                        Delete
-                    </Button>
-                }
+                variant="delete"
+                resourceType="agent"
+                description="This action cannot be undone."
+                onConfirm={handleDelete}
             />
         </>
     );

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesDeleteModal.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesDeleteModal.tsx
@@ -1,5 +1,4 @@
-import { Button, Text } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
+import { Text } from '@mantine-8/core';
 import { type FC } from 'react';
 
 import { type RoleWithScopes } from '@lightdash/common';
@@ -25,21 +24,13 @@ export const CustomRolesDeleteModal: FC<DeleteModalProps> = ({
             opened={isOpen}
             onClose={onClose}
             title="Delete custom role"
-            icon={IconTrash}
+            variant="delete"
+            resourceType="role"
+            resourceLabel={role.name}
             cancelDisabled={isDeleting}
-            actions={
-                <Button color="red" onClick={onDelete} loading={isDeleting}>
-                    Delete role
-                </Button>
-            }
+            onConfirm={onDelete}
+            confirmLoading={isDeleting}
         >
-            <Text fz="sm">
-                Are you sure you want to delete the role{' '}
-                <Text component="span" fw={700}>
-                    {role.name}
-                </Text>
-                ?
-            </Text>
             <Text fz="sm" c="dimmed">
                 This action cannot be undone. Users and groups will no longer be
                 able to use this role.

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
@@ -175,30 +175,14 @@ export const TokensTable = () => {
             <MantineModal
                 opened={!!tokenToDelete}
                 onClose={() => !isDeleting && setTokenToDelete(undefined)}
-                title={`Delete token ${tokenToDelete?.description}`}
-                icon={IconTrash}
+                title="Delete token"
+                variant="delete"
+                resourceType="token"
+                resourceLabel={tokenToDelete?.description}
                 cancelDisabled={isDeleting}
-                actions={
-                    <Button
-                        color="red"
-                        loading={isDeleting}
-                        onClick={() => {
-                            mutate(tokenToDelete?.uuid ?? '');
-                        }}
-                    >
-                        Delete
-                    </Button>
-                }
-            >
-                <Text>
-                    Are you sure? This will permanently delete the
-                    <Text fw={600} component="span">
-                        {' '}
-                        {tokenToDelete?.description}{' '}
-                    </Text>
-                    token.
-                </Text>
-            </MantineModal>
+                onConfirm={() => mutate(tokenToDelete?.uuid ?? '')}
+                confirmLoading={isDeleting}
+            />
         </>
     );
 };

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsDeleteModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsDeleteModal.tsx
@@ -1,5 +1,3 @@
-import { Button, Text } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
 
 import { type ServiceAccount } from '@lightdash/common';
@@ -25,27 +23,12 @@ export const ServiceAccountsDeleteModal: FC<Props> = ({
             opened={isOpen}
             onClose={onClose}
             title="Delete service account"
-            icon={IconTrash}
+            variant="delete"
+            resourceType="service account"
+            resourceLabel={serviceAccount?.description}
             cancelDisabled={isDeleting}
-            actions={
-                <Button
-                    color="red"
-                    loading={isDeleting}
-                    onClick={() => {
-                        onDelete(serviceAccount?.uuid ?? '');
-                    }}
-                >
-                    Delete
-                </Button>
-            }
-        >
-            <Text fz="sm">
-                Are you sure? This will permanently delete the{' '}
-                <Text fw={600} component="span">
-                    {serviceAccount?.description}
-                </Text>{' '}
-                service account.
-            </Text>
-        </MantineModal>
+            onConfirm={() => onDelete(serviceAccount?.uuid ?? '')}
+            confirmLoading={isDeleting}
+        />
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
@@ -1,5 +1,4 @@
-import { Button, getDefaultZIndex, Loader, Stack, Text } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
+import { getDefaultZIndex, Loader, Stack, Text } from '@mantine-8/core';
 import { useCallback, useEffect, type FC } from 'react';
 import ErrorState from '../../../components/common/ErrorState';
 import MantineModal, {
@@ -39,19 +38,12 @@ export const SchedulerDeleteModal: FC<SchedulerDeleteModalProps> = ({
             onClose={onClose}
             modalRootProps={{ zIndex: getDefaultZIndex('popover') }}
             title="Delete scheduled delivery"
-            icon={IconTrash}
+            variant="delete"
+            resourceType="scheduled delivery"
+            resourceLabel={scheduler.data?.name}
             size="md"
-            actions={
-                scheduler.isSuccess ? (
-                    <Button
-                        loading={mutation.isLoading}
-                        onClick={handleConfirm}
-                        color="red"
-                    >
-                        Delete
-                    </Button>
-                ) : undefined
-            }
+            onConfirm={scheduler.isSuccess ? handleConfirm : undefined}
+            confirmLoading={mutation.isLoading}
         >
             {scheduler.isInitialLoading ? (
                 <Stack h={200} w="100%" align="center" justify="center">
@@ -60,15 +52,7 @@ export const SchedulerDeleteModal: FC<SchedulerDeleteModalProps> = ({
                 </Stack>
             ) : scheduler.isError ? (
                 <ErrorState error={scheduler.error.error} />
-            ) : (
-                <Text>
-                    Are you sure you want to delete{' '}
-                    <Text fw={700} span>
-                        "{scheduler.data?.name}"
-                    </Text>
-                    ?
-                </Text>
-            )}
+            ) : null}
         </MantineModal>
     );
 };

--- a/packages/frontend/src/features/sqlRunner/components/DeleteSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/DeleteSqlChartModal.tsx
@@ -1,5 +1,3 @@
-import { Button, Text } from '@mantine-8/core';
-import { IconChartBar } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import MantineModal, {
     type MantineModalProps,
@@ -37,24 +35,11 @@ export const DeleteSqlChartModal: FC<Props> = ({
             opened={opened}
             onClose={onClose}
             title="Delete chart"
-            icon={IconChartBar}
-            actions={
-                <Button
-                    loading={isLoading}
-                    color="red"
-                    onClick={() => mutate()}
-                >
-                    Delete
-                </Button>
-            }
-        >
-            <Text>
-                Are you sure you want to delete the chart{' '}
-                <Text span fw={600}>
-                    "{name}"
-                </Text>
-                ?
-            </Text>
-        </MantineModal>
+            variant="delete"
+            resourceType="chart"
+            resourceLabel={name}
+            onConfirm={mutate}
+            confirmLoading={isLoading}
+        />
     );
 };

--- a/packages/frontend/src/features/tableCalculation/components/DeleteTableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/DeleteTableCalculationModal.tsx
@@ -1,6 +1,5 @@
 import { type TableCalculation } from '@lightdash/common';
-import { Button, type ModalProps } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
+import { type ModalProps } from '@mantine-8/core';
 import { useCallback, type FC } from 'react';
 import MantineModal from '../../../components/common/MantineModal';
 import {
@@ -21,7 +20,7 @@ export const DeleteTableCalculationModal: FC<Props> = ({
     const dispatch = useExplorerDispatch();
     const { track } = useTracking();
 
-    const onConfirm = useCallback(() => {
+    const handleConfirm = useCallback(() => {
         dispatch(explorerActions.deleteTableCalculation(tableCalculation.name));
         track({
             name: EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED,
@@ -34,13 +33,9 @@ export const DeleteTableCalculationModal: FC<Props> = ({
             opened
             onClose={onClose}
             title="Delete Table Calculation"
-            icon={IconTrash}
-            description="Are you sure you want to delete this table calculation?"
-            actions={
-                <Button color="red" onClick={onConfirm}>
-                    Delete
-                </Button>
-            }
+            variant="delete"
+            resourceType="table calculation"
+            onConfirm={handleConfirm}
         />
     );
 };

--- a/packages/frontend/src/features/virtualView/components/DeleteVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/DeleteVirtualViewModal.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@mantine-8/core';
-import { IconTrash } from '@tabler/icons-react';
+import { Text } from '@mantine-8/core';
 import MantineModal from '../../../components/common/MantineModal';
 import { useDeleteVirtualView } from '../../virtualView/hooks/useVirtualView';
 
@@ -15,7 +14,7 @@ export const DeleteVirtualViewModal = ({
     projectUuid: string;
 }) => {
     const { mutate, isLoading } = useDeleteVirtualView(projectUuid);
-    const onDelete = () => {
+    const handleConfirm = () => {
         mutate({ projectUuid, name: virtualViewName });
         onClose();
     };
@@ -25,13 +24,16 @@ export const DeleteVirtualViewModal = ({
             opened={opened}
             onClose={onClose}
             title="Delete virtual view"
-            icon={IconTrash}
-            description="Are you sure you want to delete this virtual view? This action cannot be undone and charts based on this virtual view will break."
-            actions={
-                <Button loading={isLoading} color="red" onClick={onDelete}>
-                    Delete
-                </Button>
-            }
-        />
+            variant="delete"
+            resourceType="virtual view"
+            resourceLabel={virtualViewName}
+            onConfirm={handleConfirm}
+            confirmLoading={isLoading}
+        >
+            <Text fz="sm" c="dimmed">
+                This action cannot be undone and charts based on this virtual
+                view will break.
+            </Text>
+        </MantineModal>
     );
 };

--- a/packages/frontend/src/stories/Modal.stories.tsx
+++ b/packages/frontend/src/stories/Modal.stories.tsx
@@ -48,32 +48,34 @@ export default meta;
 type Story = StoryObj<typeof MantineModal>;
 
 /**
- * Simple confirmation modal using the `description` prop.
- * This is the cleanest pattern for simple yes/no dialogs.
+ * Simple delete confirmation using the `variant="delete"` prop.
+ * The variant automatically adds IconTrash, red button styling, and generates
+ * a description from `resourceType` and `resourceLabel`.
  */
 export const SimpleConfirmation: Story = {
     args: {
         opened: true,
         onClose: () => {},
         title: 'Delete Agent',
-        icon: IconTrash,
-        description:
-            'Are you sure you want to delete this agent? This action cannot be undone.',
-        actions: <Button color="red">Delete</Button>,
+        variant: 'delete',
+        resourceType: 'agent',
+        resourceLabel: 'Sales Assistant',
+        onConfirm: () => {},
     },
 };
 
 /**
  * Delete confirmation with additional warning content.
- * Uses both `description` and `children` for complex content.
+ * Uses `variant="delete"` for auto-generated description plus `children` for extra warnings.
  */
 export const DeleteWithWarning: Story = {
     args: {
         opened: true,
         onClose: () => {},
         title: 'Delete Space',
-        icon: IconTrash,
-        description: 'Are you sure you want to delete space "Jaffle Shop"?',
+        variant: 'delete',
+        resourceType: 'space',
+        resourceLabel: 'Jaffle Shop',
         children: (
             <Callout
                 variant="danger"
@@ -88,7 +90,8 @@ export const DeleteWithWarning: Story = {
                 </List>
             </Callout>
         ),
-        actions: <Button color="red">Delete Space</Button>,
+        onConfirm: () => {},
+        confirmLabel: 'Delete Space',
     },
 };
 
@@ -447,9 +450,9 @@ export const ScrollableListInAlert: Story = {
         opened: true,
         onClose: () => {},
         title: 'Delete Chart',
-        icon: IconTrash,
-        description:
-            'Are you sure you want to delete "Monthly Revenue"? This action cannot be undone.',
+        variant: 'delete',
+        resourceType: 'chart',
+        resourceLabel: 'Monthly Revenue',
         children: (
             <Callout
                 variant="warning"
@@ -484,7 +487,8 @@ export const ScrollableListInAlert: Story = {
                 </ScrollArea.Autosize>
             </Callout>
         ),
-        actions: <Button color="red">Delete Anyway</Button>,
+        onConfirm: () => {},
+        confirmLabel: 'Delete Anyway',
     },
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Standardized delete modals across the application by introducing a new `variant="delete"` prop to the `MantineModal` component. This creates a consistent delete experience with:

- Automatic red styling for action buttons
- Standard trash icon
- Auto-generated confirmation messages based on resource type and name
- Simplified modal content structure


This change reduces code duplication and ensures a consistent UX pattern for destructive actions throughout the application.

![image.png](https://app.graphite.com/user-attachments/assets/27b0c3c5-2a69-4628-97f1-07225d617fae.png)

