### PR TITLE
style: inherit font size in DateZoomInfoOnTileV2 text spans

### DIFF
--- a/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTileV2.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTileV2.tsx
@@ -14,13 +14,13 @@ export const DateZoomInfoOnTileV2: FC<DateZoomInfoOnTileProps> = ({
                 <>
                     <Text fz="xs">
                         Date zoom:{' '}
-                        <Text span fw={500}>
+                        <Text span fw={500} fz="inherit">
                             {dateZoomGranularity}
                         </Text>
                     </Text>
                     <Text fz="xs">
                         On:{' '}
-                        <Text span fw={500}>
+                        <Text span fw={500} fz="inherit">
                             {dateDimension?.label}
                         </Text>
                     </Text>


### PR DESCRIPTION
### Description:
Fixes font size inheritance in DateZoomInfoOnTileV2 component by adding `fz="inherit"` to the Text spans displaying the dateZoomGranularity and dateDimension label. This ensures consistent text sizing within the parent Text components.