### PR TITLE
feat: allow toggling back and forth new dashboard ui experience

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -1,8 +1,4 @@
-import {
-    DashboardTileTypes,
-    FeatureFlags,
-    type Dashboard,
-} from '@lightdash/common';
+import { DashboardTileTypes, type Dashboard } from '@lightdash/common';
 import {
     Button,
     Group,
@@ -23,7 +19,7 @@ import {
 import { useCallback, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
+import { useDashboardUIPreference } from '../../hooks/dashboard/useDashboardUIPreference';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../common/MantineIcon';
 import AddChartTilesModal from './TileForms/AddChartTilesModal';
@@ -44,9 +40,7 @@ const AddTileButton: FC<Props> = ({
     dashboardTabs,
     radius,
 }) => {
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
         useState<boolean>(false);

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -98,6 +98,7 @@ import {
     type DashboardChartReadyQuery,
 } from '../../hooks/dashboard/useDashboardChartReadyQuery';
 import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFiltersForTile';
+import { useDashboardUIPreference } from '../../hooks/dashboard/useDashboardUIPreference';
 import { uploadGsheet } from '../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../hooks/organization/useOrganization';
 import useToaster from '../../hooks/toaster/useToaster';
@@ -524,9 +525,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const showExecutionTime = useFeatureFlagEnabled(
         FeatureFlags.ShowExecutionTime,
     );
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     const {
         tile: {
@@ -1549,9 +1548,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         top: number;
     }>();
     const [isDataExportModalOpen, setIsDataExportModalOpen] = useState(false);
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     const {
         tile: {

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     MARKDOWN_TILE_CLASS,
     type DashboardMarkdownTile,
 } from '@lightdash/common';
@@ -12,7 +11,7 @@ import { v4 as uuid4 } from 'uuid';
 import { DashboardTileComments } from '../../features/comments';
 import { appendNewTilesToBottom } from '../../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
+import { useDashboardUIPreference } from '../../hooks/dashboard/useDashboardUIPreference';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../common/MantineIcon';
 import TileBase from './TileBase/index';
@@ -35,9 +34,7 @@ const MarkdownTile: FC<Props> = (props) => {
         isEditMode,
     } = props;
 
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
     const hideFrame = isDashboardRedesignEnabled ? rawHideFrame : false;
 
     const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -1,5 +1,5 @@
-import { type Dashboard, FeatureFlags } from '@lightdash/common';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import { type Dashboard } from '@lightdash/common';
+import { useDashboardUIPreference } from '../../../hooks/dashboard/useDashboardUIPreference';
 import TileBaseV1 from './TileBaseV1';
 import TileBaseV2 from './TileBaseV2';
 import { type TileBaseProps } from './types';
@@ -7,9 +7,7 @@ import { type TileBaseProps } from './types';
 const TileBase = <T extends Dashboard['tiles'][number]>(
     props: TileBaseProps<T>,
 ) => {
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     return isDashboardRedesignEnabled ? (
         <TileBaseV2 {...props} />

--- a/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
@@ -1,20 +1,15 @@
-import {
-    FeatureFlags,
-    type DashboardMarkdownTileProperties,
-} from '@lightdash/common';
+import { type DashboardMarkdownTileProperties } from '@lightdash/common';
 import { Group, Stack, Switch, TextInput } from '@mantine/core';
 import { type UseFormReturnType } from '@mantine/form';
 import MDEditor from '@uiw/react-md-editor';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import { useDashboardUIPreference } from '../../../hooks/dashboard/useDashboardUIPreference';
 
 interface MarkdownTileFormProps {
     form: UseFormReturnType<DashboardMarkdownTileProperties['properties']>;
 }
 
 const MarkdownTileForm = ({ form }: MarkdownTileFormProps) => {
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     return (
         <Stack spacing="md">

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlags } from '@lightdash/common';
 import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
@@ -7,7 +6,7 @@ import {
     isChunkLoadError,
     triggerChunkErrorReload,
 } from '../../features/chunkErrorHandler';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
+import { useDashboardUIPreference } from '../../hooks/dashboard/useDashboardUIPreference';
 import { isTableVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import LoadingChart from '../common/LoadingChart';
@@ -44,9 +43,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
     onScreenshotError,
     ...rest
 }) => {
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
     const {
         columnOrder,
         itemsMap,

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -1,15 +1,12 @@
-import { FeatureFlags } from '@lightdash/common';
 import { type FC } from 'react';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import { useDashboardUIPreference } from '../../../hooks/dashboard/useDashboardUIPreference';
 import DashboardHeaderV1, {
     type DashboardHeaderProps,
 } from './DashboardHeaderV1';
 import DashboardHeaderV2 from './DashboardHeaderV2';
 
 const DashboardHeader: FC<DashboardHeaderProps> = (props) => {
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     return isDashboardRedesignEnabled ? (
         <DashboardHeaderV2 {...props} />

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeaderV1.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeaderV1.tsx
@@ -37,6 +37,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import AIDashboardSummary from '../../../ee/features/ambientAi/components/aiDashboardSummary';
+import { TryNewUIButton } from '../../../features/dashboardTabsV2/DashboardUIToggle';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
     usePromoteDashboardDiffMutation,
@@ -247,6 +248,8 @@ const DashboardHeaderV1 = ({
                         />
                     </Popover.Dropdown>
                 </Popover>
+
+                {!isFullscreen && <TryNewUIButton />}
 
                 {isEditMode && userCanManageDashboard && (
                     <ActionIcon

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeaderV2.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeaderV2.tsx
@@ -49,6 +49,7 @@ import { useProject } from '../../../hooks/useProject';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import { SwitchToClassicMenuItem } from '../../../features/dashboardTabsV2/DashboardUIToggle';
 import AddTileButton from '../../DashboardTiles/AddTileButton';
 import MantineIcon from '../MantineIcon';
 import PageHeader from '../Page/PageHeader';
@@ -580,6 +581,10 @@ const DashboardHeaderV2 = ({
                                         Export dashboard
                                     </Menu.Item>
                                 )}
+
+                                <Menu.Divider />
+
+                                <SwitchToClassicMenuItem />
 
                                 {userCanManageDashboard && (
                                     <>

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -1,4 +1,4 @@
-import { assertUnreachable, FeatureFlags } from '@lightdash/common';
+import { assertUnreachable } from '@lightdash/common';
 import {
     Box,
     Text,
@@ -25,8 +25,8 @@ import {
     type RefAttributes,
 } from 'react';
 import { useScroll } from 'react-use';
+import { useDashboardUIPreference } from '../../../hooks/dashboard/useDashboardUIPreference';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { SMALL_TEXT_LENGTH } from './constants';
 import {
     useTableCellStyles,
@@ -165,9 +165,7 @@ const TableComponent = forwardRef<HTMLTableElement, TableProps>(
     ) => {
         const { cx, classes } = useTableStyles();
         const theme = useMantineTheme();
-        const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-            FeatureFlags.DashboardRedesign,
-        );
+        const { isDashboardRedesignEnabled } = useDashboardUIPreference();
         const shouldRemoveBorders = isDashboard && isDashboardRedesignEnabled;
 
         const [isContainerInitialized, setIsContainerInitialized] =

--- a/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
@@ -1,6 +1,5 @@
-import { FeatureFlags } from '@lightdash/common';
 import { useRef, type FC } from 'react';
-import { useFeatureFlagEnabled } from '../../../../hooks/useFeatureFlagEnabled';
+import { useDashboardUIPreference } from '../../../../hooks/dashboard/useDashboardUIPreference';
 import { Table, TableScrollableWrapper } from '../Table.styles';
 import { useTableContext } from '../useTableContext';
 import TableBody from './TableBody';
@@ -20,9 +19,7 @@ const ScrollableTable: FC<ScrollableTableProps> = ({
 }) => {
     const { footer } = useTableContext();
     const tableContainerRef = useRef<HTMLDivElement>(null);
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     return (
         <TableScrollableWrapper

--- a/packages/frontend/src/features/dashboardTabsV2/DashboardUIToggle.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/DashboardUIToggle.tsx
@@ -1,0 +1,69 @@
+import { Button, Menu, Tooltip } from '@mantine-8/core';
+import { IconLayoutDashboard, IconSparkles } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+import { useDashboardUIPreference } from '../../hooks/dashboard/useDashboardUIPreference';
+
+/**
+ * Button to switch to new UI - used in DashboardHeaderV1 (classic view)
+ * Only shown when feature flag is OFF (allows users to opt-in)
+ */
+export const TryNewUIButton: FC = () => {
+    const { setPreference, isDashboardRedesignFlagEnabled } =
+        useDashboardUIPreference();
+
+    // Don't show toggle if feature flag is enabled (users are forced to use new UI)
+    if (isDashboardRedesignFlagEnabled) {
+        return null;
+    }
+
+    const handleClick = () => {
+        setPreference('v2');
+    };
+
+    return (
+        <Tooltip
+            label="We've made many improvements to the dashboard experience. Try it out and let us know what you think! You can always switch back to the classic view."
+            withinPortal
+            position="bottom"
+        >
+            <Button
+                variant="light"
+                size="compact-xs"
+                color="violet"
+                onClick={handleClick}
+                fz="xs"
+                leftSection={<MantineIcon icon={IconSparkles} />}
+            >
+                Try new Dashboard experience
+            </Button>
+        </Tooltip>
+    );
+};
+
+/**
+ * Menu item to switch to classic view - used in DashboardHeaderV2 (new view)
+ * Only shown when feature flag is OFF (allows users to opt-out)
+ */
+export const SwitchToClassicMenuItem: FC = () => {
+    const { setPreference, isDashboardRedesignFlagEnabled } =
+        useDashboardUIPreference();
+
+    // Don't show toggle if feature flag is enabled (users are forced to use new UI)
+    if (isDashboardRedesignFlagEnabled) {
+        return null;
+    }
+
+    const handleClick = () => {
+        setPreference('v1');
+    };
+
+    return (
+        <Menu.Item
+            leftSection={<MantineIcon icon={IconLayoutDashboard} />}
+            onClick={handleClick}
+        >
+            Switch to classic view
+        </Menu.Item>
+    );
+};

--- a/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTile.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomInfoOnTile.tsx
@@ -1,14 +1,11 @@
-import { FeatureFlags } from '@lightdash/common';
 import { type FC } from 'react';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import { useDashboardUIPreference } from '../../../hooks/dashboard/useDashboardUIPreference';
 import { DateZoomInfoOnTileV1 } from './DateZoomInfoOnTileV1';
 import { DateZoomInfoOnTileV2 } from './DateZoomInfoOnTileV2';
 import { type DateZoomInfoOnTileProps } from './types';
 
 export const DateZoomInfoOnTile: FC<DateZoomInfoOnTileProps> = (props) => {
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     return isDashboardRedesignEnabled ? (
         <DateZoomInfoOnTileV2 {...props} />

--- a/packages/frontend/src/hooks/dashboard/useDashboardUIPreference.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardUIPreference.ts
@@ -1,0 +1,36 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useLocalStorage } from '@mantine-8/hooks';
+import { useFeatureFlagEnabled } from '../useFeatureFlagEnabled';
+
+export type DashboardUIVersion = 'v1' | 'v2';
+
+const STORAGE_KEY = 'lightdash-dashboard-ui-version';
+
+/**
+ * Hook to manage user preference for Dashboard UI version.
+ * Allows users to toggle between the classic (v1) and new (v2) dashboard UI.
+ * The preference is persisted in localStorage.
+ *
+ * If the DashboardRedesign feature flag is enabled, users are forced to use v2.
+ * If the feature flag is disabled, users can opt-in to v2 via localStorage preference.
+ */
+export const useDashboardUIPreference = () => {
+    const [preference, setPreference] = useLocalStorage<DashboardUIVersion>({
+        key: STORAGE_KEY,
+        defaultValue: 'v1',
+    });
+
+    const isDashboardRedesignFlagEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
+
+    // If feature flag is ON, force v2. Otherwise, use user preference.
+    const isDashboardRedesignEnabled =
+        isDashboardRedesignFlagEnabled || preference === 'v2';
+
+    return {
+        isDashboardRedesignEnabled,
+        isDashboardRedesignFlagEnabled,
+        setPreference,
+    };
+};

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -8,7 +8,6 @@ import {
     CustomFormatType,
     DimensionType,
     evaluateConditionalFormatExpression,
-    FeatureFlags,
     formatItemValue,
     formatNumberValue,
     formatValueWithExpression,
@@ -92,12 +91,12 @@ import {
     legendTopSpacing,
 } from '../../components/VisualizationConfigs/ChartConfigPanel/Grid/constants';
 import { EMPTY_X_AXIS } from '../cartesianChartConfig/useCartesianChartConfig';
+import { useDashboardUIPreference } from '../dashboard/useDashboardUIPreference';
 import {
     getPivotedDataFromPivotDetails,
     getPlottedData,
     type RowKeyMap,
 } from '../plottedData/getPlottedData';
-import { useFeatureFlagEnabled } from '../useFeatureFlagEnabled';
 import { type InfiniteQueryResults } from '../useQueryResults';
 import {
     computeSeriesColorsWithPop,
@@ -2123,9 +2122,7 @@ const useEchartsCartesianConfig = (
     } = useVisualizationContext();
 
     const theme = useMantineTheme();
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     const validCartesianConfig = useMemo(() => {
         if (!isCartesianVisualizationConfig(visualizationConfig)) return;

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,5 @@
 import {
     ContentType,
-    FeatureFlags,
     type DashboardTile,
     type Dashboard as IDashboard,
 } from '@lightdash/common';
@@ -29,10 +28,10 @@ import {
     useUpdateDashboard,
 } from '../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
+import { useDashboardUIPreference } from '../hooks/dashboard/useDashboardUIPreference';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
-import { useFeatureFlagEnabled } from '../hooks/useFeatureFlagEnabled';
 import useApp from '../providers/App/useApp';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
@@ -149,9 +148,7 @@ const Dashboard: FC = () => {
     } = useFullscreen();
     const { showToastError } = useToaster();
 
-    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
-        FeatureFlags.DashboardRedesign,
-    );
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
 
     const { data: organization } = useOrganization();
     const hasTemporaryFilters = useMemo(
@@ -802,6 +799,7 @@ const Dashboard: FC = () => {
                         onConfirm={duplicateModalHandlers.close}
                     />
                 )}
+
             </Page>
         </>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19183


### Description:
This PR introduces a new `useDashboardUIPreference` hook that allows users to toggle between classic (v1) and new (v2) dashboard UI experiences. The implementation:

- Creates a new hook that stores user preference in localStorage
- Adds UI elements to switch between views:
  - "Try new Dashboard experience" button in classic view
  - "Switch to classic view" menu item in new view
- Replaces all direct feature flag checks with the new hook
- Only shows toggle options when the feature flag is OFF (allowing opt-in/opt-out)

**Forces v2 UI when the feature flag is enabled**

![Screenshot 2026-01-05 at 11.29.48.png](https://app.graphite.com/user-attachments/assets/b8316f13-04c1-4f81-bf62-ae9cf675227c.png)

![Screenshot 2026-01-05 at 11.29.27.png](https://app.graphite.com/user-attachments/assets/da6ed019-409d-44f7-8b83-ea1c56d0f391.png)

