### PR TITLE
test: update expected revenue value from 855 to 1,682 in e2e tests

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -104,7 +104,7 @@ describe('Dashboard', () => {
 
         cy.findAllByText('Loading chart').should('have.length', 0); // Finish loading
 
-        cy.contains('855').click();
+        cy.contains('1,682').click();
         cy.contains('View underlying data').click();
 
         cy.get('section[role="dialog"]').within(() => {

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -124,7 +124,7 @@ describe('Date tests', () => {
         cy.get('.react-grid-layout').within(() => {
             cy.contains(`What's our total revenue to date?`)
                 .parents('.react-grid-item')
-                .contains('855');
+                .contains('1,682');
         });
 
         // Add filter

--- a/packages/e2e/cypress/e2e/app/minimal.cy.ts
+++ b/packages/e2e/cypress/e2e/app/minimal.cy.ts
@@ -82,7 +82,7 @@ describe('Minimal pages', () => {
                 'Lightdash is an open source analytics for your dbt project.',
             ); // markdown
 
-            cy.contains('855'); // big number
+            cy.contains('1,682'); // big number
 
             cy.contains(`What's the average spend per customer?`); // bar chart
             cy.contains('Average order size'); // bar chart


### PR DESCRIPTION
### Description:

Updated the expected value in e2e tests from '855' to '1,682' for the total revenue metric. This change affects dashboard, dates, and minimal page tests to ensure they correctly validate the updated revenue figure.

test-frontend
test-backend
test-cli  
test-all