### PR TITLE
fix: debounce tile hover state to prevent tooltip flashing

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
@@ -15,7 +15,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { useHover, useToggle } from '@mantine-8/hooks';
+import { useDebouncedValue, useHover, useToggle } from '@mantine-8/hooks';
 import { clsx, Menu } from '@mantine/core';
 import {
     IconArrowAutofitContent,
@@ -65,7 +65,14 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
         isDeletingChartThatBelongsToDashboard,
         setIsDeletingChartThatBelongsToDashboard,
     ] = useState(false);
-    const { hovered: containerHovered, ref: containerRef } = useHover();
+    const { hovered: rawContainerHovered, ref: containerRef } = useHover();
+    // Debounce unhover to prevent flashing when tooltips render outside container
+    const [debouncedContainerHovered] = useDebouncedValue(
+        rawContainerHovered,
+        200,
+    );
+    const containerHovered = rawContainerHovered || debouncedContainerHovered;
+
     const { isHovered: chartHovered, ...chartHoveredProps } = useDelayedHover({
         delay: 500,
     });


### PR DESCRIPTION
### Description:
Added debouncing to the container hover state in TileBaseV2 to prevent UI flashing when tooltips render outside the container. The implementation uses Mantine's `useDebouncedValue` hook with a 200ms delay when unhovered, while maintaining immediate response when hovering.

This change ensures a smoother user experience by preventing rapid toggling of the hover state when users interact with elements that extend beyond the tile container boundaries.