### PR TITLE
fix: handle undefined metrics and tableCalculations in dashboard filters

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -307,14 +307,14 @@ export class DashboardModel {
                             : undefined,
                     })) ?? [],
                 metrics:
-                    version.filters?.metrics.map((filter) => ({
+                    version.filters?.metrics?.map((filter) => ({
                         ...filter,
                         tileTargets: filter.tileTargets
                             ? pick(filter.tileTargets, tileUuids)
                             : undefined,
                     })) ?? [],
                 tableCalculations:
-                    version.filters?.tableCalculations.map((filter) => ({
+                    version.filters?.tableCalculations?.map((filter) => ({
                         ...filter,
                         tileTargets: filter.tileTargets
                             ? pick(filter.tileTargets, tileUuids)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2254 / LIGHTDASH-BACKEND-BJ3

### Description:
Fixed potential null reference errors in the DashboardModel by adding optional chaining operators to the `metrics` and `tableCalculations` map functions. This prevents errors when these properties might be undefined.