### PR TITLE
feat: hide app navigation when scrolling dashboards

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import { Stack } from '@mantine/core';
 import { type FC } from 'react';
 import { Navigate, Outlet, useParams, type RouteObject } from 'react-router';
@@ -9,6 +10,7 @@ import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
 import UserCompletionModal from './components/UserCompletionModal';
 import { MetricCatalogView } from './features/metricsCatalog/types';
+import { useFeatureFlagEnabled } from './hooks/useFeatureFlagEnabled';
 import AuthPopupResult from './pages/AuthPopupResult';
 import Catalog from './pages/Catalog';
 import ChartHistory from './pages/ChartHistory';
@@ -45,10 +47,13 @@ import { PageName } from './types/Events';
 
 const DashboardPageWrapper: FC = () => {
     const { dashboardUuid } = useParams<{ dashboardUuid: string }>();
+    const isDashboardRedesignEnabled = useFeatureFlagEnabled(
+        FeatureFlags.DashboardRedesign,
+    );
 
     return (
         <>
-            <NavBar />
+            <NavBar isFixed={!isDashboardRedesignEnabled} />
             <TrackPage name={PageName.DASHBOARD}>
                 <Dashboard key={dashboardUuid} />
             </TrackPage>

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -108,7 +108,8 @@
     }
 }
 
-.tileTooltip {
+.tileTooltip,
+.dragHandleIcon {
     /* When tabs are not stuck: show tooltip above tabs (zindex + 1)
        When tabs are stuck: show tooltip below tabs (zindex - 1) */
     z-index: calc(

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBaseV2.tsx
@@ -98,7 +98,6 @@ const TileBaseV2 = <T extends Dashboard['tiles'][number]>({
                     left={-2}
                     px={5}
                     py={8}
-                    style={{ zIndex: 10 }}
                 >
                     <MantineIcon icon={IconGripVertical} color="ldGray" />
                 </Paper>

--- a/packages/frontend/src/components/NavBar/PreviewBanner.tsx
+++ b/packages/frontend/src/components/NavBar/PreviewBanner.tsx
@@ -5,7 +5,9 @@ import { BANNER_HEIGHT } from '../common/Page/constants';
 
 export const PreviewBanner = () => (
     <Center
+        id="preview-banner"
         pos="fixed"
+        top={0}
         w="100%"
         h={BANNER_HEIGHT}
         bg="blue.6"

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -39,7 +39,11 @@ const useNavBarMode = () => {
     };
 };
 
-const NavBar = memo(() => {
+interface NavBarProps {
+    isFixed?: boolean;
+}
+
+const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { isFullscreen } = useFullscreen();
 
@@ -58,6 +62,10 @@ const NavBar = memo(() => {
 
     const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
 
+    // Calculate placeholder height: navbar + banner (if preview project)
+    const headerContainerHeight =
+        NAVBAR_HEIGHT + (isCurrentProjectPreview ? BANNER_HEIGHT : 0);
+
     const getHeaderStyles = useCallback(
         (theme: MantineTheme) => ({
             ...defaultNavbarStyles,
@@ -70,8 +78,6 @@ const NavBar = memo(() => {
         }),
         [navBarMode],
     );
-    const headerContainerHeight =
-        NAVBAR_HEIGHT + (isCurrentProjectPreview ? BANNER_HEIGHT : 0);
 
     const renderNavBarContent = () => {
         switch (navBarMode) {
@@ -95,19 +101,19 @@ const NavBar = memo(() => {
     return (
         <MantineProvider theme={darkTheme}>
             {isCurrentProjectPreview && <PreviewBanner />}
-            {/* hack to make navbar fixed and maintain space */}
-            <Box h={!isFullscreen ? headerContainerHeight : 0} />
             <Header
                 height={NAVBAR_HEIGHT}
-                fixed
+                fixed={isFixed}
                 mt={isCurrentProjectPreview ? BANNER_HEIGHT : 0}
                 display={isFullscreen ? 'none' : 'flex'}
                 px="md"
-                zIndex={getDefaultZIndex('app')}
+                zIndex={isFixed ? getDefaultZIndex('app') : undefined}
                 styles={(theme) => ({ root: getHeaderStyles(theme) })}
             >
                 {renderNavBarContent()}
             </Header>
+            {/* Placeholder to reserve space when navbar is fixed */}
+            {isFixed && !isFullscreen && <Box h={headerContainerHeight} />}
         </MantineProvider>
     );
 });

--- a/packages/frontend/src/components/common/Dashboard/Dashboard.module.css
+++ b/packages/frontend/src/components/common/Dashboard/Dashboard.module.css
@@ -3,4 +3,8 @@
     top: 0;
     z-index: var(--dashboard-header-zindex);
     background-color: var(--mantine-color-body);
+
+    :global(body:has(#preview-banner)) & {
+        top: var(--banner-height);
+    }
 }

--- a/packages/frontend/src/components/common/Dashboard/dashboard.constants.ts
+++ b/packages/frontend/src/components/common/Dashboard/dashboard.constants.ts
@@ -1,11 +1,14 @@
+import { BANNER_HEIGHT } from '../Page/constants';
+
 export const DASHBOARD_HEADER_HEIGHT = 50;
-export const DASHBOARD_HEADER_ZINDEX = 100;
+export const DASHBOARD_HEADER_ZINDEX = 99;
 const DASHBOARD_TAB_HEIGHT = 50;
-const DASHBOARD_TABS_ZINDEX = 99;
+const DASHBOARD_TABS_ZINDEX = 98;
 
 export const dashboardCSSVars = {
     '--dashboard-header-height': `${DASHBOARD_HEADER_HEIGHT}px`,
     '--dashboard-header-zindex': `${DASHBOARD_HEADER_ZINDEX}`,
     '--dashboard-tab-height': `${DASHBOARD_TAB_HEIGHT}px`,
     '--dashboard-tabs-zindex': `${DASHBOARD_TABS_ZINDEX}`,
+    '--banner-height': `${BANNER_HEIGHT}px`,
 } as const;

--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -43,23 +43,29 @@ type StyleProps = {
     noSidebarPadding?: boolean;
     isSidebarResizing?: boolean;
     backgroundColor?: string;
+    fullPageScroll?: boolean;
 };
 
 const usePageStyles = createStyles<string, StyleProps>((theme, params) => {
     let containerHeight = '100vh';
 
-    if (params.withNavbar) {
+    if (params.withNavbar && !params.fullPageScroll) {
         containerHeight = `calc(${containerHeight} - ${NAVBAR_HEIGHT}px)`;
     }
     if (params.withHeader) {
         containerHeight = `calc(${containerHeight} - ${PAGE_HEADER_HEIGHT}px)`;
     }
-    if (params.hasBanner) {
+    if (params.hasBanner && !params.fullPageScroll) {
         containerHeight = `calc(${containerHeight} - ${BANNER_HEIGHT}px)`;
     }
+
     return {
         root: {
-            ...(params.withFullHeight
+            ...(params.fullPageScroll
+                ? {
+                      minHeight: '100%',
+                  }
+                : params.withFullHeight
                 ? {
                       height: containerHeight,
                       maxHeight: containerHeight,
@@ -131,7 +137,7 @@ const usePageStyles = createStyles<string, StyleProps>((theme, params) => {
                       height: '100%',
                       maxHeight: '100%',
 
-                      overflowY: 'auto',
+                      ...(params.fullPageScroll ? {} : { overflowY: 'auto' }),
                   }
                 : {}),
 
@@ -195,7 +201,7 @@ type Props = {
     isRightSidebarOpen?: boolean;
     rightSidebarWidthProps?: SidebarWidthProps;
     header?: React.ReactNode;
-} & Omit<StyleProps, 'withSidebar' | 'withHeader'>;
+} & Omit<StyleProps, 'withSidebar' | 'withHeader' | 'hasBanner'>;
 
 const Page: FC<React.PropsWithChildren<Props>> = ({
     title,
@@ -222,6 +228,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
     noSidebarPadding = false,
     flexContent = false,
     backgroundColor,
+    fullPageScroll = false,
     children,
 }) => {
     const { ref: mainRef, width: mainWidth } = useElementSize();
@@ -260,6 +267,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
             flexContent,
             isSidebarResizing,
             backgroundColor,
+            fullPageScroll,
         },
         { name: 'Page' },
     );

--- a/packages/frontend/src/components/common/ScrollToTop.tsx
+++ b/packages/frontend/src/components/common/ScrollToTop.tsx
@@ -9,7 +9,7 @@ type ScrollToTopProps = {
      */
     show: boolean;
     /**
-     * Optional scroll container. Defaults to document.body
+     * Optional scroll container. Defaults to window scrolling.
      */
     scrollContainer?: HTMLElement | null;
 };
@@ -23,12 +23,17 @@ export const ScrollToTop: FC<ScrollToTopProps> = ({
     scrollContainer,
 }) => {
     const handleScrollToTop = () => {
-        const container = scrollContainer || document.body;
-
-        container.scrollTo({
-            top: 0,
-            behavior: 'smooth',
-        });
+        if (!scrollContainer) {
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth',
+            });
+        } else {
+            scrollContainer.scrollTo({
+                top: 0,
+                behavior: 'smooth',
+            });
+        }
     };
 
     return (

--- a/packages/frontend/src/components/common/StickyWithDetection.tsx
+++ b/packages/frontend/src/components/common/StickyWithDetection.tsx
@@ -10,7 +10,7 @@ type StickyWithDetectionProps = {
      */
     offset?: number;
     /**
-     * Optional scrolling container element. Defaults to document.body
+     * Optional scrolling container element, defaults to viewport
      */
     scrollContainer?: HTMLElement | null;
     /**
@@ -51,16 +51,13 @@ export const StickyWithDetection: FC<StickyWithDetectionProps> = ({
         const sentinel = sentinelRef.current;
         if (!sentinel) return;
 
-        const container = scrollContainer || document.body;
-
         const rootMargin = offset > 0 ? `-${offset}px 0px 0px 0px` : '0px';
-
         const observer = new IntersectionObserver(
             ([entry]) => {
                 onStuckChangeRef.current(!entry.isIntersecting);
             },
             {
-                root: container,
+                root: scrollContainer,
                 threshold: 0,
                 rootMargin,
             },

--- a/packages/frontend/src/features/dashboardTabsV2/index.tsx
+++ b/packages/frontend/src/features/dashboardTabsV2/index.tsx
@@ -94,6 +94,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
 }) => {
     const gridProps = getResponsiveGridLayoutProps();
     const [currentCols, setCurrentCols] = useState(gridProps.cols.lg);
+
     const handleUpdateTilesWithScaling = async (layout: Layout[]) => {
         const unscaledLayout = convertLayoutToBaseCoordinates(
             layout,
@@ -182,10 +183,6 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
             : [];
     const hasDashboardTiles = dashboardTiles && dashboardTiles.length > 0;
     const tabsEnabled = dashboardTabs && dashboardTabs.length > 1;
-
-    // Get the scroll container (Page component's main element)
-    const scrollContainer =
-        document.querySelector<HTMLElement>('#page-root main');
 
     // Compute whether there are required filters that apply to the current tab
     // Note: We use doesFilterApplyToTile because getTabUuidsForFilterRules from common
@@ -477,7 +474,6 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                                         isEditMode ? DASHBOARD_HEADER_HEIGHT : 0
                                     }
                                     onStuckChange={setIsHeaderStuck}
-                                    scrollContainer={scrollContainer}
                                 >
                                     <div
                                         className={styles.stickyTabsAndFilters}
@@ -757,10 +753,7 @@ const DashboardTabsV2: FC<DashboardTabsProps> = ({
                 )}
             </Droppable>
 
-            <ScrollToTop
-                show={isHeaderStuck}
-                scrollContainer={scrollContainer}
-            />
+            <ScrollToTop show={isHeaderStuck} />
         </DragDropContext>
     );
 };

--- a/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
+++ b/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
@@ -22,6 +22,14 @@
     &[data-is-stuck='true'] {
         border-color: var(--mantine-color-ldGray-3);
     }
+
+    :global(body:has(#preview-banner)) & {
+        top: var(--banner-height);
+    }
+
+    :global(body:has(#preview-banner)) &[data-has-header-above='true'] {
+        top: calc(var(--dashboard-header-height) + var(--banner-height));
+    }
 }
 
 .list {

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -701,6 +701,7 @@ const Dashboard: FC = () => {
                 title={dashboard.name}
                 noContentPadding={isDashboardRedesignEnabled}
                 withFullHeight
+                fullPageScroll={isDashboardRedesignEnabled}
                 header={
                     isDashboardRedesignEnabled ? null : (
                         <DashboardHeader {...dashboardHeaderProps} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19123

### Description:

- Made NavBar position configurable with `isFixed` prop to support the new dashboard layout
- Improved sticky header behavior with preview banner
- Added CSS to properly handle preview banner positioning in dashboard components
- Implemented `fullPageScroll` mode for Page component to support full-page scrolling in redesigned dashboards

### [CleanShot 2026-01-05 at 16.21.19.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/05778349-a3b2-480a-a3f8-f5d5b4b7d09b.mp4" />](https://app.graphite.com/user-attachments/video/05778349-a3b2-480a-a3f8-f5d5b4b7d09b.mp4)

[CleanShot 2026-01-05 at 16.21.52.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/b0605a4c-973f-4fbc-8a2b-86158ca047be.mp4" />](https://app.graphite.com/user-attachments/video/b0605a4c-973f-4fbc-8a2b-86158ca047be.mp4)

