### PR TITLE
fix: set higher zIndex for scheduler delete modal

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
@@ -1,6 +1,7 @@
 import {
     Box,
     Button,
+    getDefaultZIndex,
     Group,
     Loader,
     Modal,
@@ -42,7 +43,7 @@ export const SchedulerDeleteModal: FC<SchedulerDeleteModalProps> = ({
     return (
         <Modal
             opened={opened}
-            zIndex={210}
+            zIndex={getDefaultZIndex('popover')}
             title={
                 <Group gap="xs">
                     <MantineIcon icon={IconTrash} size="lg" color="red" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19118 / PROD-2207

### Description:
Added a zIndex property with value 210 to the Modal component in SchedulerDeleteModal to ensure proper layering in the UI.

<details>
<summary>There it is!</summary>

<img width="1864" height="1120" alt="localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_saved_f57a1dad-3ccb-44fd-83b1-4a62e1993adb_edit_fromDashboard=f3af30ef-98b5-4101-99ab-389c7ef8889d" src="https://github.com/user-attachments/assets/bf198eff-3cf5-470d-9557-92c2ac7a5767" />
</details>