### PR TITLE
chore: upgrade langchain and @langchain/core dependencies

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,7 +49,7 @@
         "@casl/ability": "^5.4.3",
         "@cubejs-client/core": "^0.35.23",
         "@godaddy/terminus": "^4.12.0",
-        "@langchain/core": "^0.3.58",
+      "@langchain/core": "^0.3.80",
         "@langchain/openai": "^0.4.2",
         "@lightdash/common": "workspace:*",
         "@lightdash/warehouses": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,7 +158,7 @@ importers:
         specifier: ^4.12.0
         version: 4.12.0
       '@langchain/core':
-        specifier: ^0.3.58
+        specifier: ^0.3.80
         version: 0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(openai@4.80.1(encoding@0.1.13)(ws@8.18.0)(zod@3.25.55))
       '@langchain/openai':
         specifier: ^0.4.2


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2192  
Closes: PROD-2193

### Description:

Upgrade LangChain dependencies to newer versions:

- `@langchain/core` from 0.3.36 to 0.3.58
- `langchain` from 0.3.13 to 0.3.37

This update includes new features and bug fixes from the LangChain ecosystem, and brings in OpenTelemetry support through the updated LangSmith dependency.