### PR TITLE
fix(cli): add option to use dbt list in CLI compile command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -384,6 +384,12 @@ program
         'Compile without any warehouse credentials. Skips dbt compile + warehouse catalog',
     )
     .option(
+        '--use-dbt-list [true|false]',
+        'Use `dbt list` instead of `dbt compile` to generate dbt manifest.json',
+        parseUseDbtListOption,
+        true,
+    )
+    .option(
         '--disable-timestamp-conversion [true|false]',
         'Disable timestamp conversion to UTC for Snowflake warehouses. Only use this if your timestamp values are already in UTC.',
         parseDisableTimestampConversionOption,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2034

### Description:

Added a new CLI option `--use-dbt-list` that allows users to choose between using `dbt list` or `dbt compile` for generating the dbt manifest.json file. The option defaults to `true`, meaning `dbt list` will be used by default.

This provides flexibility for users who may need to use the traditional `dbt compile` approach in specific scenarios.