### PR TITLE
fix: log error instead of throwing when scheduler is disabled

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2860,8 +2860,21 @@ export default class SchedulerTask {
                   );
 
         if (!scheduler.enabled) {
-            // This should not happen, if schedulers are not enabled, we should remove the scheduled jobs from the queue
-            throw new Error('Scheduler is disabled');
+            await this.schedulerService.logSchedulerJob({
+                task: SCHEDULER_TASKS.HANDLE_SCHEDULED_DELIVERY,
+                schedulerUuid,
+                jobId,
+                jobGroup: jobId,
+                scheduledTime,
+                status: SchedulerJobStatus.ERROR,
+                details: {
+                    error: `Scheduler is disabled, skipping scheduled delivery.`,
+                    projectUuid: schedulerPayload.projectUuid,
+                    organizationUuid: schedulerPayload.organizationUuid,
+                    createdByUserUuid: schedulerPayload.userUuid,
+                },
+            });
+            return;
         }
 
         this.analytics.track({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2258

### Description:

Improved error handling for disabled schedulers in the `handleScheduledDelivery` task. Instead of throwing an error when a scheduler is disabled, the task now logs the error and gracefully exits, preventing job failures in the queue.