### PR TITLE
feat: validate Google Sheets files for scheduled deliveries

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -630,6 +630,8 @@ export class ServiceRepository
                     dashboardModel: this.models.getDashboardModel(),
                     catalogModel: this.models.getCatalogModel(),
                     permissionsService: this.getPermissionsService(),
+                    googleDriveClient: this.clients.getGoogleDriveClient(),
+                    userService: this.getUserService(),
                 }),
         );
     }
@@ -649,6 +651,8 @@ export class ServiceRepository
                     schedulerClient: this.clients.getSchedulerClient(),
                     slackClient: this.clients.getSlackClient(),
                     userModel: this.models.getUserModel(),
+                    googleDriveClient: this.clients.getGoogleDriveClient(),
+                    userService: this.getUserService(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2245

### Description:

We let users sync with any spreadsheet file in their GDrive. This causes issues when the file being synced is not a Google-native sheet. When a user tries syncing with an Excel spreadsheet that's been uploaded to GDrive, Google throws an error—it will only update Google Sheets files via the API.

We'll now check that the synced file is an actual Google Sheet.

Added validation for Google Sheets files in scheduled deliveries to prevent errors when users try to use non-spreadsheet files. The PR:

1. Adds a new `validateFileIsSpreadsheet` method to the GoogleDriveClient that checks if a file is actually a Google Sheets file
2. Implements validation when uploading metadata or writing data to Google Sheets
3. Adds specific error handling for "operation not supported" errors with clear user-facing messages
4. Integrates validation into both SavedChartService and SchedulerService when creating or updating schedulers with Google Sheets format

This prevents confusing errors when users try to use Excel files or other non-spreadsheet formats with Google Sheets delivery options.

### Failure from Excel File

![Screen Shot 2026-01-06 at 11.38.13 AM.png](https://app.graphite.com/user-attachments/assets/78b8edf2-8fca-4464-b82d-fe43d4179baa.png)

