### PR TITLE
fix: do not replace smart quote

### DIFF
--- a/packages/warehouses/src/utils/sql.ts
+++ b/packages/warehouses/src/utils/sql.ts
@@ -41,5 +41,4 @@ export function getDefaultMetricSql(sql: string, type: MetricType): string {
 export const normalizeUnicode = (value: string): string =>
     value
         .normalize('NFC') // Normalize composition
-        .replace(/[\u2019\u2018]/g, "'") // Smart quotes to ASCII
         .replace(/[\uFEFF\u200B]/g, ''); // Remove zero-width chars

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -133,12 +133,6 @@ describe('PostgresSqlBuilder escaping', () => {
         );
     });
 
-    test('Should escape unicode characters in postgres', () => {
-        expect(postgresSqlBuilder.escapeString('single\u2019quote')).toBe(
-            "single''quote",
-        );
-    });
-
     test('Should escape backslashes and quotes in postgres', () => {
         expect(postgresSqlBuilder.escapeString("\\') OR (1=1) --")).toBe(
             "\\\\'') OR (1=1) ",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19187


### Description:
Remove smart quotes normalization from the `normalizeUnicode` function. This change preserves smart quotes -> ’ in the text rather than converting them to ASCII single quotes.