### PR TITLE
fix: show a better tooltip for no data in maps

### DIFF
--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -52,24 +52,52 @@ const getFormattedValue = (
     return field.value?.formatted ?? field.value?.raw ?? '';
 };
 
-// Shared tooltip content component
-type MapTooltipContentProps = {
+// Shared props for tooltip and popup content
+type MapContentBaseProps = {
     tooltipFields: TooltipFieldInfo[];
     rowData: Record<string, any>;
     lat?: number;
     lon?: number;
+    // For "no data" regions
+    noData?: {
+        locationLabel: string;
+        locationValue: string;
+    };
 };
 
+type MapTooltipContentProps = MapContentBaseProps;
+
+// NOTE: Using inline styles because this is rendered via renderToString
+// and Mantine styles won't be applied
 const MapTooltipContent: FC<MapTooltipContentProps> = ({
     tooltipFields,
     rowData,
     lat,
     lon,
+    noData,
 }) => {
     const visibleFields = tooltipFields.filter((f) => f.visible);
 
-    // Using inline styles because this is rendered via renderToString
-    // and Mantine styles won't be applied
+    if (noData) {
+        return (
+            <div style={{ padding: '4px 6px' }}>
+                <div style={{ fontSize: 14 }}>
+                    <strong>{noData.locationLabel}:</strong>{' '}
+                    {noData.locationValue}
+                </div>
+                <div
+                    style={{
+                        fontSize: 14,
+                        color: '#868e96',
+                        fontStyle: 'italic',
+                    }}
+                >
+                    No data
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div style={{ padding: '4px 6px' }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -95,12 +123,7 @@ const MapTooltipContent: FC<MapTooltipContentProps> = ({
     );
 };
 
-// Shared popup content component
-type MapPopupContentProps = {
-    tooltipFields: TooltipFieldInfo[];
-    rowData: Record<string, any>;
-    lat?: number;
-    lon?: number;
+type MapPopupContentProps = MapContentBaseProps & {
     onCopy?: () => void;
 };
 
@@ -110,9 +133,25 @@ const MapPopupContent: FC<MapPopupContentProps> = ({
     lat,
     lon,
     onCopy,
+    noData,
 }) => {
     const visibleFields = tooltipFields.filter((f) => f.visible);
     const hasMultipleFields = visibleFields.length > 1;
+
+    // Show "no data" popup for regions without matching data
+    if (noData) {
+        return (
+            <Box mt="xl" c="dark.9">
+                <Text size="sm">
+                    <strong>{noData.locationLabel}:</strong>{' '}
+                    {noData.locationValue}
+                </Text>
+                <Text size="sm" c="gray.6" fs="italic">
+                    No data
+                </Text>
+            </Box>
+        );
+    }
 
     // Build copy value - CSV format for multiple fields, single value otherwise
     const copyValue =
@@ -649,22 +688,33 @@ const SimpleMap: FC<SimpleMapProps> = memo(
             (feature: GeoJSON.Feature, layer: L.Layer) => {
                 // Use configured property key to match GeoJSON features to data
                 const propertyKey = mapConfig?.geoJsonPropertyKey || 'name';
-                const propertyValue = (
+                const rawPropertyValue =
                     feature.properties?.[propertyKey] ||
                     feature.properties?.name ||
                     feature.properties?.NAME ||
-                    ''
-                )
-                    .toString()
-                    .toLowerCase();
+                    '';
+                const propertyValue = rawPropertyValue.toString().toLowerCase();
                 const regionEntry = regionDataMap.get(propertyValue);
                 const rowData = regionEntry?.rowData || {};
+
+                // For "no data" regions, derive location label from tooltipFields
+                const locationFieldLabel =
+                    mapConfig?.tooltipFields.find(
+                        (f) => f.fieldId === mapConfig?.locationFieldId,
+                    )?.label || 'Location';
+                const noData = regionEntry
+                    ? undefined
+                    : {
+                          locationLabel: locationFieldLabel,
+                          locationValue: rawPropertyValue.toString(),
+                      };
 
                 // eslint-disable-next-line testing-library/render-result-naming-convention
                 const tooltipHtml = renderToString(
                     <MapTooltipContent
                         tooltipFields={mapConfig?.tooltipFields || []}
                         rowData={rowData}
+                        noData={noData}
                     />,
                 );
                 // eslint-disable-next-line testing-library/render-result-naming-convention
@@ -672,6 +722,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     <MapPopupContent
                         tooltipFields={mapConfig?.tooltipFields || []}
                         rowData={rowData}
+                        noData={noData}
                     />,
                 );
 
@@ -721,6 +772,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                 regionDataMap,
                 mapConfig?.geoJsonPropertyKey,
                 mapConfig?.tooltipFields,
+                mapConfig?.locationFieldId,
                 handlePopupCopyClick,
             ],
         );

--- a/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
+++ b/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
@@ -69,6 +69,8 @@ export type LeafletMapConfig = {
     showLegend: boolean;
     valueRange: { min: number; max: number } | null;
     valueFieldLabel: string | null;
+    // The field ID used for location matching (for deriving labels)
+    locationFieldId: string | null;
     // Field configuration for tooltips
     tooltipFields: TooltipFieldInfo[];
 };
@@ -418,6 +420,7 @@ const useLeafletMapConfig = ({
             showLegend: showLegend ?? false,
             valueRange,
             valueFieldLabel,
+            locationFieldId: locationFieldId ?? null,
             tooltipFields,
         };
     }, [chartConfig, resultsData, theme, itemsMap]);


### PR DESCRIPTION
### Description:

Shows a "No data" tooltip instead of empty values in maps

[Localhost repro](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/geo?create_saved_chart_version=%7B%22tableName%22%3A%22geo%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22geo%22%2C%22dimensions%22%3A%5B%22geo_sales_volume_usd%22%2C%22geo_state_province_name%22%2C%22geo_us_state_code%22%2C%22geo_country_code_3_digit%22%5D%2C%22metrics%22%3A%5B%22geo_customer_count_sum%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22geo_customer_count_sum%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A5000%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22geo_sales_volume_usd%22%2C%22geo_state_province_name%22%2C%22geo_us_state_code%22%2C%22geo_country_code_3_digit%22%2C%22geo_customer_count_sum%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22map%22%2C%22config%22%3A%7B%22mapType%22%3A%22world%22%2C%22locationType%22%3A%22area%22%2C%22locationFieldId%22%3A%22geo_country_code_3_digit%22%2C%22colorRange%22%3A%5B%22%23228be6%22%2C%22%23fa5252%22%5D%2C%22showLegend%22%3Afalse%2C%22saveMapExtent%22%3Atrue%2C%22defaultZoom%22%3A2%2C%22defaultCenterLat%22%3A-33.87041555094183%2C%22defaultCenterLon%22%3A0%2C%22tileBackground%22%3A%22light%22%2C%22fieldConfig%22%3A%7B%7D%7D%7D%7D&isExploreFromHere=true) (Requires re-seeding)

**Before**
<img width="339" height="246" alt="Screenshot 2026-01-05 at 19 10 08" src="https://github.com/user-attachments/assets/3a115750-57d5-4ba9-af8b-e54a79ec7787" />

**After**
<img width="564" height="347" alt="Screenshot 2026-01-05 at 19 08 17" src="https://github.com/user-attachments/assets/327dbe85-9e43-43da-b227-801e969ea167" />

