### PR TITLE
fix: dont run underlying data query when unopened

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
@@ -42,7 +42,7 @@ import ExportResults from '../ExportResults';
 import UnderlyingDataResultsTable from './UnderlyingDataResultsTable';
 import { useMetricQueryDataContext } from './useMetricQueryDataContext';
 
-const UnderlyingDataModal: FC = () => {
+const UnderlyingDataModalContent: FC = () => {
     const projectUuid = useProjectUuid();
     const {
         isUnderlyingDataModalOpen,
@@ -392,6 +392,18 @@ const UnderlyingDataModal: FC = () => {
             )}
         </MantineModal>
     );
+};
+
+// Only mounts the content when the modal is open
+// This prevents the underlying data query from running on every mount
+const UnderlyingDataModal: FC = () => {
+    const { isUnderlyingDataModalOpen } = useMetricQueryDataContext();
+
+    if (!isUnderlyingDataModalOpen) {
+        return null;
+    }
+
+    return <UnderlyingDataModalContent />;
 };
 
 export default UnderlyingDataModal;


### PR DESCRIPTION
### Description:

We were mounting the underlying data modal even when it wasnt opened. This caused use to run the underlying data query every time it was mounted. 

This just makes it so it only mounts (and runs the query) when opened. 
