### PR TITLE
fix: add 'is_archived' to unrecoverable Slack errors

### DIFF
--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -19,6 +19,7 @@ export const UNRECOVERABLE_SLACK_ERRORS = [
     'missing_scope', // Missing required OAuth scope
     'channel_not_found', // Channel doesn't exist
     'not_in_channel', // Bot/app isn't in the channel
+    'is_archived', // Channel has been archived
 ] as const;
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2263

### Description:

Added 'is_archived' to the list of unrecoverable Slack errors. This ensures that when a channel has been archived, it's properly handled as an unrecoverable error case.