### PR TITLE
fix: take nullsFirst sort into account when pivoting in the backend

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4391,11 +4391,34 @@ const models: TsoaRoute.Models = {
         enums: ['none', 'openstreetmap', 'light', 'dark', 'satellite'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MapFieldConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                label: { dataType: 'string' },
+                visible: { dataType: 'boolean' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.MapFieldConfig_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { ref: 'MapFieldConfig' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     MapChart: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                fieldConfig: { ref: 'Record_string.MapFieldConfig_' },
                 backgroundColor: { dataType: 'string' },
                 tileBackground: { ref: 'MapTileBackground' },
                 heatmapConfig: {
@@ -7206,7 +7229,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                chartUsage:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7229,7 +7252,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7259,6 +7282,12 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -7266,12 +7295,6 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7475,7 +7498,7 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    chartUsage:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7498,7 +7521,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    searchRank:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7528,6 +7551,12 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -7535,12 +7564,6 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -12451,6 +12474,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                nullsFirst: { dataType: 'boolean' },
                 direction: { ref: 'SortByDirection', required: true },
                 reference: { dataType: 'string', required: true },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4791,8 +4791,30 @@
                 "enum": ["none", "openstreetmap", "light", "dark", "satellite"],
                 "type": "string"
             },
+            "MapFieldConfig": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "visible": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "Record_string.MapFieldConfig_": {
+                "properties": {},
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/MapFieldConfig"
+                },
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
             "MapChart": {
                 "properties": {
+                    "fieldConfig": {
+                        "$ref": "#/components/schemas/Record_string.MapFieldConfig_"
+                    },
                     "backgroundColor": {
                         "type": "string"
                     },
@@ -8019,12 +8041,12 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -8032,10 +8054,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8044,8 +8066,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8139,12 +8161,12 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "chartUsage": {
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "searchRank": {
+                                                                                    "chartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -8152,10 +8174,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8164,8 +8186,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -12854,6 +12876,9 @@
             },
             "VizSortBy": {
                 "properties": {
+                    "nullsFirst": {
+                        "type": "boolean"
+                    },
                     "direction": {
                         "$ref": "#/components/schemas/SortByDirection"
                     },
@@ -23822,7 +23847,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2288.0",
+        "version": "0.2301.4",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -56,6 +56,7 @@ function getSortByForPivotConfiguration(
                         direction: sort.descending
                             ? SortByDirection.DESC
                             : SortByDirection.ASC,
+                        nullsFirst: sort.nullsFirst,
                     };
                 }
 

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -108,6 +108,7 @@ export type VizPivotLayoutOptions = {
 export type VizSortBy = {
     reference: string;
     direction: SortByDirection;
+    nullsFirst?: boolean;
 };
 
 export type VizPieChartDisplay = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/GLITCH-130/sql-pivot-pipeline-does-not-correctly-sort-null-values

### Description:
Added support for NULLS FIRST/LAST in query sorting when using backend pivoting.

Key changes:
- Added `nullsFirst` property to `VizSortBy` type
- Implemented `getNullsFirstLast` static method in `PivotQueryBuilder` to generate appropriate SQL clauses
- Updated SQL generation to include NULLS FIRST/LAST clauses in ORDER BY statements
- Modified anchor CTEs to use LEFT JOINs to preserve rows with NULL values
- Added comprehensive test coverage for the new functionality

**Before**
[before.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/c2086961-5c05-47ea-adaa-fb0ea13f539b.mov" />](https://app.graphite.com/user-attachments/video/c2086961-5c05-47ea-adaa-fb0ea13f539b.mov)

**After**

[after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/49ca1bfb-d86f-4ae3-b95e-d16c1a3b1a67.mov" />](https://app.graphite.com/user-attachments/video/49ca1bfb-d86f-4ae3-b95e-d16c1a3b1a67.mov)

