### PR TITLE
fix: total label renders outside chart boundary

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2070,7 +2070,7 @@ const getStackTotalSeries = (
                 type: series[0].type,
                 connectNulls: true,
                 stack: stack,
-                clip: false,
+                clip: !isStack100,
                 label: {
                     ...getBarTotalLabelStyle(),
                     show: series[0].stackLabel?.show,


### PR DESCRIPTION
Closes: #19216

### Description:

Fixed clipping for totals labels when setting a max y-axis. Labels will be now clipped instead of rendering outside the chart boundaries.

![CleanShot 2026-01-06 at 16.06.15.png](https://app.graphite.com/user-attachments/assets/dcf818d0-d269-4480-a731-5b41d4642eb4.png)

> [!NOTE]
> Working on a solution to render totals at top (like 100% stack). Solution it's a bit tricky, so getting this out to solve the current issue first