### PR TITLE
feat: add graphite-cli to development environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,11 @@
         let
           pkgs = import nixpkgs {
             inherit system;
-            config = { };
+            config = {
+              allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+                "graphite-cli"
+              ];
+            };
           };
 
           # Python version to use for venvs
@@ -235,6 +239,8 @@
               google-cloud-sdk
               kubectl
               okteto
+
+              graphite-cli
             ];
 
             # Environment setup


### PR DESCRIPTION
### Description:
Add Graphite CLI to development environment by:
- Configuring `allowUnfreePredicate` to permit installation of `graphite-cli`
- Adding `graphite-cli` to the development environment packages list

This enables developers to use Graphite's CLI tools directly in the development environment.