### PR TITLE
chore: allow controlling slack image previews on link share

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1000,6 +1000,11 @@ export type SlackConfig = {
     channelsCachedTime: number;
     supportUrl: string;
     multiAgentChannelEnabled: boolean;
+    /*
+     This is the setting that controls whether we generate image previews for link shares in Slack
+     @default true
+    */
+    linkShareImagePreviewEnabled: boolean;
 };
 export type HeadlessBrowserConfig = {
     host?: string;
@@ -1580,6 +1585,8 @@ export const parseConfig = (): LightdashConfig => {
             supportUrl: process.env.SLACK_SUPPORT_URL || '',
             multiAgentChannelEnabled:
                 process.env.SLACK_MULTI_AGENT_CHANNEL_ENABLED === 'true',
+            linkShareImagePreviewEnabled:
+                process.env.SLACK_LINK_SHARE_IMAGE_PREVIEW_ENABLED !== 'false',
         },
         scheduler: {
             enabled: process.env.SCHEDULER_ENABLED !== 'false',

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1494,6 +1494,14 @@ export class UnfurlService extends BaseService {
 
                     await this.sendUnfurl(event, l.url, details, client);
 
+                    // Skip image generation if link preview images are disabled
+                    if (
+                        !this.lightdashConfig.slack
+                            ?.linkShareImagePreviewEnabled
+                    ) {
+                        return;
+                    }
+
                     const imageId = `slack-image-${useNanoid()}`;
                     const authUserUuid =
                         await this.slackAuthenticationModel.getUserUuid(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added a new configuration option `linkShareImagePreviewEnabled` to control whether image previews are generated for link shares in Slack. The setting defaults to true and can be disabled by setting the environment variable `SLACK_LINK_SHARE_IMAGE_PREVIEW_ENABLED` to 'false'.

This gives administrators more control over the Slack integration's behavior, allowing them to disable image preview generation if needed.

![Screenshot 2026-01-06 at 15.38.26.png](https://app.graphite.com/user-attachments/assets/fcfcf72d-58a9-4ed2-bb14-e76444d0c35c.png)

