### PR TITLE
feat: update toaster styles

### DIFF
--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -7,6 +7,7 @@ import {
     Stack,
     Text,
     Tooltip,
+    useMantineTheme,
 } from '@mantine/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import MantineIcon from '../../components/common/MantineIcon';
@@ -19,6 +20,9 @@ const ApiErrorDisplay = ({
     apiError: ApiErrorDetail;
     onClose?: () => void;
 }) => {
+    const theme = useMantineTheme();
+    const isDark = theme.colorScheme === 'dark';
+
     switch (apiError.name) {
         case 'SnowflakeTokenError':
             return (
@@ -82,7 +86,7 @@ const ApiErrorDisplay = ({
                                 variant={'transparent'}
                             >
                                 <MantineIcon
-                                    color={'white'}
+                                    color={isDark ? 'white' : 'gray.7'}
                                     icon={copied ? IconCheck : IconCopy}
                                 />
                             </ActionIcon>

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
@@ -6,6 +6,7 @@ import {
     Stack,
     Text,
     Title,
+    useMantineTheme,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
@@ -23,20 +24,36 @@ const MultipleToastBody = ({
     toastsData: NotificationData[];
     onCloseError?: (errorData: NotificationData) => void;
 }) => {
+    const theme = useMantineTheme();
+    const isDark = theme.colorScheme === 'dark';
     const [listCollapsed, setListCollapsed] = useState(true);
 
     return (
         <Stack spacing="xs" align="stretch">
             <Group>
-                <Title order={6}>Errors</Title>
+                <Title order={6} color={isDark ? 'red.4' : 'red.9'}>
+                    Errors
+                </Title>
                 <Button
                     size="xs"
                     compact
                     variant="outline"
-                    color="red.1"
+                    color={isDark ? 'red.4' : 'red.8'}
+                    styles={{
+                        root: {
+                            backgroundColor: isDark
+                                ? theme.fn.darken(theme.colors.red[9], 0.6)
+                                : theme.colors.red[1],
+                            border: `1px solid ${
+                                isDark
+                                    ? theme.colors.red[9]
+                                    : theme.colors.red[2]
+                            }`,
+                        },
+                    }}
                     rightIcon={
                         <MantineIcon
-                            color="red.1"
+                            color={isDark ? 'red.4' : 'red.8'}
                             icon={
                                 listCollapsed ? IconChevronUp : IconChevronDown
                             }
@@ -44,9 +61,9 @@ const MultipleToastBody = ({
                     }
                     onClick={() => setListCollapsed(!listCollapsed)}
                 >
-                    <Text>{`${listCollapsed ? 'Show' : 'Hide'} ${
-                        toastsData.length
-                    }`}</Text>
+                    <Text color={isDark ? 'red.1' : 'red.9'}>{`${
+                        listCollapsed ? 'Show' : 'Hide'
+                    } ${toastsData.length}`}</Text>
                 </Button>
             </Group>
 
@@ -66,12 +83,19 @@ const MultipleToastBody = ({
                             position="apart"
                             spacing="xxs"
                             noWrap
-                            sx={(theme) => ({
+                            sx={{
                                 width: '100%',
-                                border: `1px solid ${theme.colors.red[3]}`,
+                                border: `1px solid ${
+                                    isDark
+                                        ? theme.colors.red[9]
+                                        : theme.colors.red[2]
+                                }`,
                                 borderRadius: '4px',
                                 padding: theme.spacing.xs,
-                            })}
+                                backgroundColor: isDark
+                                    ? theme.fn.darken(theme.colors.red[9], 0.7)
+                                    : theme.colors.red[0],
+                            }}
                         >
                             {toastData.apiError ? (
                                 <ApiErrorDisplay
@@ -81,7 +105,10 @@ const MultipleToastBody = ({
                             ) : (
                                 <>
                                     {toastData.title && (
-                                        <Title order={6}>
+                                        <Title
+                                            order={6}
+                                            color={isDark ? 'red.2' : 'red.9'}
+                                        >
                                             {toastData.title}
                                         </Title>
                                     )}
@@ -96,7 +123,9 @@ const MultipleToastBody = ({
                                             ]}
                                             style={{
                                                 backgroundColor: 'transparent',
-                                                color: 'white',
+                                                color: isDark
+                                                    ? theme.colors.red[2]
+                                                    : theme.colors.red[9],
                                                 fontSize: '12px',
                                             }}
                                         />
@@ -109,7 +138,10 @@ const MultipleToastBody = ({
                                 size="xs"
                                 onClick={() => onCloseError?.(toastData)}
                             >
-                                <MantineIcon icon={IconX} color="white" />
+                                <MantineIcon
+                                    icon={IconX}
+                                    color={isDark ? 'red.4' : 'red.9'}
+                                />
                             </ActionIcon>
                         </Group>
                     ))}

--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -1,7 +1,14 @@
 import type { ApiErrorDetail } from '@lightdash/common';
-import { Button, Stack } from '@mantine/core';
+import {
+    Box,
+    Button,
+    Stack,
+    useMantineColorScheme,
+    useMantineTheme,
+} from '@mantine/core';
 import { notifications, type NotificationProps } from '@mantine/notifications';
 import {
+    IconAlertCircleFilled,
     IconAlertTriangleFilled,
     IconCircleCheckFilled,
     IconInfoCircleFilled,
@@ -16,6 +23,9 @@ import MultipleToastBody from './MultipleToastBody';
 import { type NotificationData } from './types';
 
 const useToaster = () => {
+    const theme = useMantineTheme();
+    const { colorScheme } = useMantineColorScheme();
+    const isDark = colorScheme === 'dark';
     const openedKeys = useRef(new Set<string>());
     const currentErrors = useRef<Record<string, NotificationData[]>>({});
 
@@ -24,30 +34,59 @@ const useToaster = () => {
             key = uuid(),
             subtitle,
             action,
-            color: toastColor,
+            color = 'blue',
             autoClose = 5000,
             // isError = false,
             ...rest
         }: NotificationData) => {
             const commonProps = {
                 autoClose,
-                color: toastColor,
-                styles: toastColor
-                    ? {
-                          title: {
-                              color: 'white',
-                              fontWeight: 700,
-                              marginBottom:
-                                  !subtitle && !action ? 0 : undefined,
-                          },
-                          closeButton: {
-                              ':hover': {
-                                  background: 'rgba(255, 255, 255, 0.2)',
-                              },
-                              color: 'white',
-                          },
-                      }
-                    : undefined,
+                color,
+                styles: {
+                    root: {
+                        background: isDark
+                            ? theme.fn.darken(theme.colors[color][9], 0.6)
+                            : theme.fn.lighten(theme.colors[color][0], 0.5),
+                        border: `1px solid ${
+                            isDark
+                                ? theme.colors[color][9]
+                                : theme.colors[color][2]
+                        }`,
+                        borderRadius: theme.radius.md,
+                        boxShadow: theme.shadows.subtle,
+                    },
+                    title: {
+                        color: isDark
+                            ? theme.colors[color][1]
+                            : theme.fn.darken(theme.colors[color][9], 0.1),
+                        fontWeight: 700,
+                        marginBottom: !subtitle && !action ? 0 : undefined,
+                    },
+                    description: {
+                        color: isDark
+                            ? theme.colors[color][3]
+                            : theme.fn.darken(theme.colors[color][9], 0.4),
+                    },
+                    closeButton: {
+                        ':hover': {
+                            background: isDark
+                                ? theme.fn.darken(theme.colors[color][9], 0.4)
+                                : theme.colors[color][1],
+                        },
+                        padding: '4px',
+                        color: isDark
+                            ? theme.colors[color][2]
+                            : theme.colors[color][9],
+                    },
+                    icon: {
+                        backgroundColor: 'transparent',
+                        color: isDark
+                            ? theme.colors[color][4]
+                            : theme.colors[color][7],
+                        size: '12px',
+                        padding: '4px',
+                    },
+                },
                 message:
                     subtitle || action ? (
                         <Stack spacing="xs" align="flex-start">
@@ -62,28 +101,33 @@ const useToaster = () => {
                                     ]}
                                     style={{
                                         backgroundColor: 'transparent',
-                                        color: toastColor ? 'white' : undefined,
+                                        color: isDark
+                                            ? theme.colors[color][2]
+                                            : theme.colors[color][9],
                                         fontSize: '12px',
                                     }}
                                 />
                             ) : (
-                                <div
-                                    style={{
-                                        color: toastColor ? 'white' : undefined,
-                                        fontSize: '12px',
-                                        width: '100%',
-                                    }}
+                                <Box
+                                    c={
+                                        isDark
+                                            ? theme.colors[color][2]
+                                            : theme.colors[color][9]
+                                    }
+                                    fz="xs"
+                                    w="100%"
                                 >
                                     {subtitle}
-                                </div>
+                                </Box>
                             )}
 
                             {action && (
                                 <Button
                                     {...action}
                                     size="xs"
+                                    radius="md"
                                     variant="light"
-                                    color={toastColor}
+                                    color={color}
                                     leftIcon={
                                         action.icon ? (
                                             <MantineIcon icon={action.icon} />
@@ -143,14 +187,13 @@ const useToaster = () => {
                 ...rest,
             });
         },
-        [],
+        [isDark, theme],
     );
 
     const showToastSuccess = useCallback(
         (props: NotificationData) => {
             showToast({
                 color: 'green',
-                bg: 'green',
                 icon: <MantineIcon icon={IconCircleCheckFilled} size="xl" />,
                 ...props,
             });
@@ -162,8 +205,7 @@ const useToaster = () => {
         (props: NotificationData) => {
             showToast({
                 color: 'red',
-                bg: 'red',
-                icon: <MantineIcon icon={IconAlertTriangleFilled} size="xl" />,
+                icon: <MantineIcon icon={IconAlertCircleFilled} size="xl" />,
                 autoClose: 60000,
                 isError: true,
                 ...props,
@@ -188,7 +230,6 @@ const useToaster = () => {
 
             showToast({
                 color: 'red',
-                bg: 'red',
                 icon: <MantineIcon icon={IconAlertTriangleFilled} size="xl" />,
                 autoClose: 60000,
                 title,
@@ -202,6 +243,7 @@ const useToaster = () => {
     const showToastInfo = useCallback(
         (props: NotificationData) => {
             showToast({
+                color: 'indigo',
                 icon: <MantineIcon icon={IconInfoCircleFilled} size="xl" />,
                 ...props,
             });
@@ -213,7 +255,6 @@ const useToaster = () => {
         (props: NotificationData) => {
             showToast({
                 color: 'blue',
-                bg: 'blue',
                 icon: <MantineIcon icon={IconInfoCircleFilled} size="xl" />,
                 ...props,
             });
@@ -225,8 +266,7 @@ const useToaster = () => {
         (props: NotificationData) => {
             showToast({
                 color: 'yellow',
-                bg: 'yellow',
-                icon: <MantineIcon icon={IconAlertTriangleFilled} size="xl" />,
+                icon: <MantineIcon icon={IconAlertCircleFilled} size="xl" />,
                 ...props,
             });
         },

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -1,0 +1,226 @@
+import { Button, Group, Stack, Title } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { type Meta, type StoryObj } from '@storybook/react';
+import MultipleToastBody from '../hooks/toaster/MultipleToastBody';
+import useToaster from '../hooks/toaster/useToaster';
+
+const ToasterDemo = () => {
+    const {
+        showToastSuccess,
+        showToastError,
+        showToastInfo,
+        showToastPrimary,
+        showToastWarning,
+        showToastApiError,
+        addToastError,
+    } = useToaster();
+
+    return (
+        <Stack spacing="xl" p="xl" style={{ maxWidth: 800 }}>
+            <section>
+                <Title order={4} mb="md">
+                    Standard Toasts
+                </Title>
+                <Group>
+                    <Button
+                        color="green"
+                        onClick={() =>
+                            showToastSuccess({
+                                title: 'Success',
+                                subtitle:
+                                    'Your changes have been saved successfully!',
+                            })
+                        }
+                    >
+                        Success
+                    </Button>
+                    <Button
+                        color="red"
+                        onClick={() =>
+                            showToastError({
+                                title: 'Error',
+                                subtitle:
+                                    'Something went wrong while saving your changes.',
+                            })
+                        }
+                    >
+                        Error
+                    </Button>
+                    <Button
+                        color="indigo"
+                        onClick={() =>
+                            showToastInfo({
+                                title: 'Info',
+                                subtitle: 'This is an informational message.',
+                            })
+                        }
+                    >
+                        Info
+                    </Button>
+                    <Button
+                        color="blue"
+                        onClick={() =>
+                            showToastPrimary({
+                                title: 'Primary',
+                                subtitle: 'This is a primary action message.',
+                            })
+                        }
+                    >
+                        Primary
+                    </Button>
+                    <Button
+                        color="yellow"
+                        onClick={() =>
+                            showToastWarning({
+                                title: 'Warning',
+                                subtitle:
+                                    'Please review your changes before proceeding.',
+                            })
+                        }
+                    >
+                        Warning
+                    </Button>
+                </Group>
+            </section>
+
+            <section>
+                <Title order={4} mb="md">
+                    Advanced Toasts
+                </Title>
+                <Group>
+                    <Button
+                        variant="outline"
+                        color="red"
+                        onClick={() =>
+                            showToastApiError({
+                                title: 'API Error',
+                                apiError: {
+                                    name: 'ApiError',
+                                    message:
+                                        'The server responded with an error (500).',
+                                    statusCode: 500,
+                                    data: {
+                                        error: 'The server responded with an error (500).',
+                                    },
+                                },
+                            })
+                        }
+                    >
+                        API Error
+                    </Button>
+
+                    <Button
+                        variant="outline"
+                        color="red"
+                        onClick={() => {
+                            addToastError({
+                                title: 'Error 1',
+                                subtitle: 'The first error occurred.',
+                            });
+                            setTimeout(() => {
+                                addToastError({
+                                    title: 'Error 2',
+                                    subtitle: 'The second error occurred.',
+                                });
+                            }, 500);
+                        }}
+                    >
+                        Multiple Errors
+                    </Button>
+                </Group>
+            </section>
+
+            <section>
+                <Title order={4} mb="md">
+                    Custom Content
+                </Title>
+                <Group>
+                    <Button
+                        variant="subtle"
+                        onClick={() =>
+                            showToastSuccess({
+                                title: 'Action Toast',
+                                subtitle: 'This toast has an action button.',
+                                action: {
+                                    children: 'Undo',
+                                    onClick: () => console.log('Undo clicked'),
+                                },
+                            })
+                        }
+                    >
+                        With Action
+                    </Button>
+
+                    <Button
+                        variant="subtle"
+                        onClick={() =>
+                            showToastSuccess({
+                                title: 'Markdown Toast',
+                                subtitle:
+                                    'This toast uses **markdown** in the _subtitle_. [Click here](https://google.com)',
+                            })
+                        }
+                    >
+                        Markdown
+                    </Button>
+                </Group>
+            </section>
+
+            <section>
+                <Title order={4} mb="md">
+                    MultipleToastBody Component (Standalone)
+                </Title>
+                <div
+                    style={{
+                        border: '1px solid #eee',
+                        padding: '20px',
+                        borderRadius: '8px',
+                    }}
+                >
+                    <MultipleToastBody
+                        toastsData={[
+                            {
+                                title: 'First Error',
+                                subtitle: 'Detailed error message 1',
+                            },
+                            {
+                                title: 'Second Error',
+                                subtitle: 'Detailed error message 2',
+                            },
+                            {
+                                title: 'API Error',
+                                apiError: {
+                                    name: 'NetworkError',
+                                    message: 'Connection timed out',
+                                    statusCode: 502,
+                                    sentryEventId: '12345',
+                                    sentryTraceId: 'abcde',
+                                    data: {},
+                                },
+                            },
+                        ]}
+                        onCloseError={(data) => console.log('Closed:', data)}
+                    />
+                </div>
+            </section>
+
+            <Button variant="default" onClick={() => notifications.clean()}>
+                Clean All Notifications
+            </Button>
+        </Stack>
+    );
+};
+
+const meta: Meta = {
+    title: 'Hooks/useToaster',
+    component: ToasterDemo,
+    parameters: {
+        layout: 'centered',
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ToasterDemo>;
+
+export const Default: Story = {};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Improved toast notifications with dark mode support and enhanced styling. The changes include:

- Added dark mode compatibility to all toast components
- Enhanced color schemes for better contrast in both light and dark modes
- Refined error toast styling with appropriate colors for different themes
- Fixed icon colors in the API error display component
- Added proper styling for the multiple errors display

> [!TIP]
> Use storybook to see all toasts (on light/dark mode)

![Screenshot 2026-01-07 at 11.33.30.png](https://app.graphite.com/user-attachments/assets/ec08be47-73bd-4c78-a915-fdf79ac7a10c.png)

![Screenshot 2026-01-07 at 11.33.19.png](https://app.graphite.com/user-attachments/assets/369da7a3-f541-4d38-b4ec-2ad2f477019d.png)

