### PR TITLE
chore: upgrade vega-lite and related dependencies to latest versions

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -122,7 +122,7 @@
         "react-scan": "^0.3.3",
         "react-use": "^17.6.0",
         "react-use-intercom": "^4.1.0",
-        "react-vega": "^7.6.0",
+        "react-vega": "^8.0.0",
         "recharts": "^2.15.0",
         "rehype-external-links": "^3.0.0",
         "reselect": "5.1.1",
@@ -138,7 +138,9 @@
         "use-context-selector": "^1.4.1",
         "use-local-storage-state": "17",
         "uuid": "^8.3.2",
-        "vega-lite": "^5.16.1",
+        "vega": "^6.2.0",
+        "vega-embed": "^7.1.0",
+        "vega-lite": "^6.4.1",
         "zod": "^3.25.55"
     },
     "devDependencies": {

--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -7,8 +7,8 @@ import { useVisualizationContext } from '../LightdashVisualization/useVisualizat
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 
-const VegaLite = lazy(() =>
-    import('react-vega').then((module) => ({ default: module.VegaLite })),
+const VegaEmbed = lazy(() =>
+    import('react-vega').then((module) => ({ default: module.VegaEmbed })),
 );
 
 type Props = {
@@ -114,17 +114,10 @@ const CustomVisualization: FC<Props> = ({
             }}
         >
             <Suspense fallback={<LoadingChart />}>
-                <VegaLite
+                <VegaEmbed
                     style={{
                         width: containerWidth,
                         height: containerHeight,
-                    }}
-                    config={{
-                        font: 'Inter, sans-serif',
-                        autosize: {
-                            type: 'fit',
-                            resize: true,
-                        },
                     }}
                     // TODO: We are ignoring some typescript errors here because the type
                     // that vegalite expects doesn't include a few of the properties
@@ -138,10 +131,18 @@ const CustomVisualization: FC<Props> = ({
                         width: 'container',
                         // @ts-ignore, see above
                         height: 'container',
-                        data: { name: 'values' },
+                        data: data,
+                        config: {
+                            font: 'Inter, sans-serif',
+                            autosize: {
+                                type: 'fit',
+                                resize: true,
+                            },
+                        },
                     }}
-                    data={data}
-                    actions={false}
+                    options={{
+                        actions: false,
+                    }}
                 />
             </Suspense>
         </div>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -34,9 +34,8 @@ const MONACO_DEFAULT_OPTIONS: EditorProps['options'] = {
 };
 
 const initVegaLazySchema = async () => {
-    const vegaLiteSchema = await import(
-        'vega-lite/build/vega-lite-schema.json'
-    );
+    // @ts-expect-error no types available for this
+    const vegaLiteSchema = await import('vega-lite/vega-lite-schema.json');
 
     return [
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,8 +1085,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-vega:
-        specifier: ^7.6.0
-        version: 7.6.0(react@19.2.0)(vega-lite@5.16.1(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13))
+        specifier: ^8.0.0
+        version: 8.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0))
       recharts:
         specifier: ^2.15.0
         version: 2.15.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1132,9 +1132,15 @@ importers:
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
+      vega:
+        specifier: ^6.2.0
+        version: 6.2.0
+      vega-embed:
+        specifier: ^7.1.0
+        version: 7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)
       vega-lite:
-        specifier: ^5.16.1
-        version: 5.16.1(vega@5.32.0(encoding@0.1.13))
+        specifier: ^6.4.1
+        version: 6.4.1(vega@6.2.0)
       zod:
         specifier: ^3.25.55
         version: 3.25.55
@@ -6529,6 +6535,9 @@ packages:
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/geojson@7946.0.4':
     resolution: {integrity: sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==}
 
@@ -7363,6 +7372,7 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
+    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -8084,6 +8094,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -8992,6 +9006,9 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       react: '>=16'
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@7.0.3:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
@@ -9918,6 +9935,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.4.0:
+    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
@@ -11097,8 +11118,8 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json-stringify-pretty-compact@3.0.0:
-    resolution: {integrity: sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==}
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -13495,12 +13516,12 @@ packages:
       react: '*'
       react-dom: '*'
 
-  react-vega@7.6.0:
-    resolution: {integrity: sha512-2oMML4wH9qWLnZPRxJm06ozwrVN/K+nkjqdI5/ofWWsrBnnH4iB9rRKrsV8px0nlWgZrwfdCH4g5RUiyyJHWSA==}
+  react-vega@8.0.0:
+    resolution: {integrity: sha512-euye4Gec2ScnUK1zbSA2tzZXUwBmbba8bfbzaRVhdEJTGQfaD78bSgqrccrl9b2fKZS1TZXR0NADEHVe6nxvBg==}
     peerDependencies:
-      react: ^16 || ^17 || ^18
-      vega: '*'
-      vega-lite: '*'
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+      vega-embed: ^7
 
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
@@ -14287,6 +14308,10 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
@@ -14734,9 +14759,6 @@ packages:
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
-  tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -15173,134 +15195,123 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vega-canvas@1.2.7:
-    resolution: {integrity: sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==}
+  vega-canvas@2.0.0:
+    resolution: {integrity: sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==}
 
-  vega-crossfilter@4.1.3:
-    resolution: {integrity: sha512-nyPJAXAUABc3EocUXvAL1J/IWotZVsApIcvOeZaUdEQEtZ7bt8VtP2nj3CLbHBA8FZZVV+K6SmdwvCOaAD4wFQ==}
+  vega-crossfilter@5.1.0:
+    resolution: {integrity: sha512-EmVhfP3p6AM7o/lPan/QAoqjblI19BxWUlvl2TSs0xjQd8KbaYYbS4Ixt3cmEvl0QjRdBMF6CdJJ/cy9DTS4Fw==}
 
-  vega-dataflow@5.7.8:
-    resolution: {integrity: sha512-jrllcIjSYU5Jh130RDR44o/SbUbJndLuoiM9IsKWW+a7HayKnfmbdHWm7MvCrj/YLupFZVojRaS1tTs53EXTdA==}
+  vega-dataflow@6.1.0:
+    resolution: {integrity: sha512-JxumGlODtFbzoQ4c/jQK8Tb/68ih0lrexlCozcMfTAwQ12XhTqCvlafh7MAKKTMBizjOfaQTHm4Jkyb1H5CfyQ==}
 
-  vega-embed@6.23.0:
-    resolution: {integrity: sha512-8Iava57LdROsatqsOhMLErHYaBpZBB7yZJlSVU3/xOK3l8Ft5WFnj5fm3OOAVML97/0yULE7LRVjXW5hV3fSpg==}
-    peerDependencies:
-      vega: ^5.21.0
-      vega-lite: '*'
-    bundledDependencies:
-      - yallist
-
-  vega-encode@4.10.2:
-    resolution: {integrity: sha512-fsjEY1VaBAmqwt7Jlpz0dpPtfQFiBdP9igEefvumSpy7XUxOJmDQcRDnT3Qh9ctkv3itfPfI9g8FSnGcv2b4jQ==}
-
-  vega-event-selector@3.0.1:
-    resolution: {integrity: sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==}
-
-  vega-expression@5.1.0:
-    resolution: {integrity: sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==}
-
-  vega-expression@5.2.1:
-    resolution: {integrity: sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==}
-
-  vega-force@4.2.2:
-    resolution: {integrity: sha512-cHZVaY2VNNIG2RyihhSiWniPd2W9R9kJq0znxzV602CgUVgxEfTKtx/lxnVCn8nNrdKAYrGiqIsBzIeKG1GWHw==}
-
-  vega-format@1.1.4:
-    resolution: {integrity: sha512-+oz6UvXjQSbweW9P8q+1o2qFYyBYPFax94j6a9PQMnCIWMovFSss1wEElljOT8CEpnHyS15yiGlmz4qbWTQwnQ==}
-
-  vega-functions@5.17.0:
-    resolution: {integrity: sha512-EoGvdCtv1Y4M/hLy83Kf0HTs4qInUfrBoanrnhbguzRl00rx7orjcv+bNZFHbCe4HkfVpbOnTrYmz3K2ivaOLw==}
-
-  vega-geo@4.4.3:
-    resolution: {integrity: sha512-+WnnzEPKIU1/xTFUK3EMu2htN35gp9usNZcC0ZFg2up1/Vqu6JyZsX0PIO51oXSIeXn9bwk6VgzlOmJUcx92tA==}
-
-  vega-hierarchy@4.1.3:
-    resolution: {integrity: sha512-0Z+TYKRgOEo8XYXnJc2HWg1EGpcbNAhJ9Wpi9ubIbEyEHqIgjCIyFVN8d4nSfsJOcWDzsSmRqohBztxAhOCSaw==}
-
-  vega-interpreter@1.0.5:
-    resolution: {integrity: sha512-po6oTOmeQqr1tzTCdD15tYxAQLeUnOVirAysgVEemzl+vfmvcEP7jQmlc51jz0jMA+WsbmE6oJywisQPu/H0Bg==}
-
-  vega-label@1.3.1:
-    resolution: {integrity: sha512-Emx4b5s7pvuRj3fBkAJ/E2snCoZACfKAwxVId7f/4kYVlAYLb5Swq6W8KZHrH4M9Qds1XJRUYW9/Y3cceqzEFA==}
-
-  vega-lite@5.16.1:
-    resolution: {integrity: sha512-3iXmzdAVZCGHrvdh6hIM8OY55auXA1EIDzFLaYdq27e99Dr+WXTEa00ilqQUPdrpS0sE1ZqK4Ikhgg5x8SOtLw==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      vega: ^5.24.0
-
-  vega-loader@4.5.4:
-    resolution: {integrity: sha512-AOJPsDVz009aTdD9hzigUaO/NFmuN1o83rzvZu/g37TJfhU+3DOvgnO0rnqJbnSOfcBkLWER6XghlKS3j77w4A==}
-
-  vega-parser@6.5.0:
-    resolution: {integrity: sha512-dPxFKn6IlDyWi6CgHGGv8htSPBAyLHWlJNNGD17eMXh+Kjn4hupSNOIboRcYb8gL5HYt1tYwS6oYZXK84Bc4tg==}
-
-  vega-projection@1.6.2:
-    resolution: {integrity: sha512-3pcVaQL9R3Zfk6PzopLX6awzrQUeYOXJzlfLGP2Xd93mqUepBa6m/reVrTUoSFXA3v9lfK4W/PS2AcVzD/MIcQ==}
-
-  vega-regression@1.3.1:
-    resolution: {integrity: sha512-AmccF++Z9uw4HNZC/gmkQGe6JsRxTG/R4QpbcSepyMvQN1Rj5KtVqMcmVFP1r3ivM4dYGFuPlzMWvuqp0iKMkQ==}
-
-  vega-runtime@6.2.1:
-    resolution: {integrity: sha512-b4eot3tWKCk++INWqot+6sLn3wDTj/HE+tRSbiaf8aecuniPMlwJEK7wWuhVGeW2Ae5n8fI/8TeTViaC94bNHA==}
-
-  vega-scale@7.4.3:
-    resolution: {integrity: sha512-f7SSN2YJowtrdkt7nJIR6YYhjDk8oB37q5So2/OxXQv5CBHipFPQSHS1ZVw9vD3V5wLnrZCxC4Ji27gmsTefgA==}
-
-  vega-scenegraph@4.13.2:
-    resolution: {integrity: sha512-eCutgcLzdUg23HLc6MTZ9pHCdH0hkqSmlbcoznspwT0ajjATk6M09JNyJddiaKR55HuQo03mBWsPeRCd5kOi0g==}
-
-  vega-schema-url-parser@2.2.0:
-    resolution: {integrity: sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==}
-
-  vega-selections@5.6.1:
-    resolution: {integrity: sha512-b7EwMkQcih4Sc+6i5eLUnIwtTisdyjIGUJ/U9Rog9scg5jPMe09BeqdMtiROGEnS/f/BI2vS68mz08OEVy308w==}
-
-  vega-statistics@1.9.0:
-    resolution: {integrity: sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==}
-
-  vega-themes@2.14.0:
-    resolution: {integrity: sha512-9dLmsUER7gJrDp8SEYKxBFmXmpyzLlToKIjxq3HCvYjz8cnNrRGyAhvIlKWOB3ZnGvfYV+vnv3ZRElSNL31nkA==}
+  vega-embed@7.1.0:
+    resolution: {integrity: sha512-ZmEIn5XJrQt7fSh2lwtSdXG/9uf3yIqZnvXFEwBJRppiBgrEWZcZbj6VK3xn8sNTFQ+sQDXW5sl/6kmbAW3s5A==}
     peerDependencies:
       vega: '*'
       vega-lite: '*'
 
-  vega-time@2.1.4:
-    resolution: {integrity: sha512-DBMRps5myYnSAlvQ+oiX8CycJZjGQNqyGE04xaZrpOgHll7vlvezpET2FnGZC7wS3DsqMcPjnpnI1h7+qJox1Q==}
+  vega-encode@5.1.0:
+    resolution: {integrity: sha512-q26oI7B+MBQYcTQcr5/c1AMsX3FvjZLQOBi7yI0vV+GEn93fElDgvhQiYrgeYSD4Exi/jBPeUXuN6p4bLz16kA==}
 
-  vega-tooltip@0.33.0:
-    resolution: {integrity: sha512-jMcvH2lP20UfyvO2KAEdloiwRyasikaiLuNFhzwrrzf2RamGTxP4G7B2OZ2QENfrGUH05Z9ei5tn/eErdzOaZQ==}
+  vega-event-selector@4.0.0:
+    resolution: {integrity: sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==}
 
-  vega-transforms@4.12.1:
-    resolution: {integrity: sha512-Qxo+xeEEftY1jYyKgzOGc9NuW4/MqGm1YPZ5WrL9eXg2G0410Ne+xL/MFIjHF4hRX+3mgFF4Io2hPpfy/thjLg==}
+  vega-expression@6.1.0:
+    resolution: {integrity: sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==}
 
-  vega-typings@1.5.0:
-    resolution: {integrity: sha512-tcZ2HwmiQEOXIGyBMP8sdCnoFoVqHn4KQ4H0MQiHwzFU1hb1EXURhfc+Uamthewk4h/9BICtAM3AFQMjBGpjQA==}
+  vega-force@5.1.0:
+    resolution: {integrity: sha512-wdnchOSeXpF9Xx8Yp0s6Do9F7YkFeOn/E/nENtsI7NOcyHpICJ5+UkgjUo9QaQ/Yu+dIDU+sP/4NXsUtq6SMaQ==}
 
-  vega-util@1.17.2:
-    resolution: {integrity: sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw==}
+  vega-format@2.1.0:
+    resolution: {integrity: sha512-i9Ht33IgqG36+S1gFDpAiKvXCPz+q+1vDhDGKK8YsgMxGOG4PzinKakI66xd7SdV4q97FgpR7odAXqtDN2wKqw==}
 
-  vega-util@1.17.3:
-    resolution: {integrity: sha512-nSNpZLUrRvFo46M5OK4O6x6f08WD1yOcEzHNlqivF+sDLSsVpstaF6fdJYwrbf/debFi2L9Tkp4gZQtssup9iQ==}
+  vega-functions@6.1.1:
+    resolution: {integrity: sha512-Due6jP0y0FfsGMTrHnzUGnEwXPu7VwE+9relfo+LjL/tRPYnnKqwWvzt7n9JkeBuZqjkgYjMzm/WucNn6Hkw5A==}
 
-  vega-util@1.17.4:
-    resolution: {integrity: sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==}
+  vega-geo@5.1.0:
+    resolution: {integrity: sha512-H8aBBHfthc3rzDbz/Th18+Nvp00J73q3uXGAPDQqizioDm/CoXCK8cX4pMePydBY9S6ikBiGJrLKFDa80wI20g==}
 
-  vega-view-transforms@4.6.1:
-    resolution: {integrity: sha512-RYlyMJu5kZV4XXjmyTQKADJWDB25SMHsiF+B1rbE1p+pmdQPlp5tGdPl9r5dUJOp3p8mSt/NGI8GPGucmPMxtw==}
+  vega-hierarchy@5.1.0:
+    resolution: {integrity: sha512-rZlU8QJNETlB6o73lGCPybZtw2fBBsRIRuFE77aCLFHdGsh6wIifhplVarqE9icBqjUHRRUOmcEYfzwVIPr65g==}
 
-  vega-view@5.15.0:
-    resolution: {integrity: sha512-bm8STHPsI8BjVu2gYlWU8KEVOA2JyTzdtb9cJj8NW6HpN72UxTYsg5y22u9vfcLYjzjmolrlr0756VXR0uI1Cg==}
+  vega-interpreter@2.2.1:
+    resolution: {integrity: sha512-o+4ZEme2mdFLewlpF76dwPWW2VkZ3TAF3DMcq75/NzA5KPvnN4wnlCM8At2FVawbaHRyGdVkJSS5ROF5KwpHPQ==}
 
-  vega-voronoi@4.2.4:
-    resolution: {integrity: sha512-lWNimgJAXGeRFu2Pz8axOUqVf1moYhD+5yhBzDSmckE9I5jLOyZc/XvgFTXwFnsVkMd1QW1vxJa+y9yfUblzYw==}
+  vega-label@2.1.0:
+    resolution: {integrity: sha512-/hgf+zoA3FViDBehrQT42Lta3t8In6YwtMnwjYlh72zNn1p3c7E3YUBwqmAqTM1x+tudgzMRGLYig+bX1ewZxQ==}
 
-  vega-wordcloud@4.1.6:
-    resolution: {integrity: sha512-lFmF3u9/ozU0P+WqPjeThQfZm0PigdbXDwpIUCxczrCXKYJLYFmZuZLZR7cxtmpZ0/yuvRvAJ4g123LXbSZF8A==}
+  vega-lite@6.4.1:
+    resolution: {integrity: sha512-KO3ybHNouRK4A0al/+2fN9UqgTEfxrd/ntGLY933Hg5UOYotDVQdshR3zn7OfXwQ7uj0W96Vfa5R+QxO8am3IQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      vega: ^6.0.0
 
-  vega@5.32.0:
-    resolution: {integrity: sha512-jANt/5+SpV7b7owB5u8+M1TZ/TrF1fK6WlcvKDW38tH3Gb6hM1nzIhv10E41w3GBmwF29BU/qH2ruNkaYKjI5g==}
+  vega-loader@5.1.0:
+    resolution: {integrity: sha512-GaY3BdSPbPNdtrBz8SYUBNmNd8mdPc3mtdZfdkFazQ0RD9m+Toz5oR8fKnTamNSk9fRTJX0Lp3uEqxrAlQVreg==}
+
+  vega-parser@7.1.0:
+    resolution: {integrity: sha512-g0lrYxtmYVW8G6yXpIS4J3Uxt9OUSkc0bLu5afoYDo4rZmoOOdll3x3ebActp5LHPW+usZIE+p5nukRS2vEc7Q==}
+
+  vega-projection@2.1.0:
+    resolution: {integrity: sha512-EjRjVSoMR5ibrU7q8LaOQKP327NcOAM1+eZ+NO4ANvvAutwmbNVTmfA1VpPH+AD0AlBYc39ND/wnRk7SieDiXA==}
+
+  vega-regression@2.1.0:
+    resolution: {integrity: sha512-HzC7MuoEwG1rIxRaNTqgcaYF03z/ZxYkQR2D5BN0N45kLnHY1HJXiEcZkcffTsqXdspLjn47yLi44UoCwF5fxQ==}
+
+  vega-runtime@7.1.0:
+    resolution: {integrity: sha512-mItI+WHimyEcZlZrQ/zYR3LwHVeyHCWwp7MKaBjkU8EwkSxEEGVceyGUY9X2YuJLiOgkLz/6juYDbMv60pfwYA==}
+
+  vega-scale@8.1.0:
+    resolution: {integrity: sha512-VEgDuEcOec8+C8+FzLcnAmcXrv2gAJKqQifCdQhkgnsLa978vYUgVfCut/mBSMMHbH8wlUV1D0fKZTjRukA1+A==}
+
+  vega-scenegraph@5.1.0:
+    resolution: {integrity: sha512-4gA89CFIxkZX+4Nvl8SZF2MBOqnlj9J5zgdPh/HPx+JOwtzSlUqIhxFpFj7GWYfwzr/PyZnguBLPihPw1Og/cA==}
+
+  vega-schema-url-parser@3.0.2:
+    resolution: {integrity: sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==}
+
+  vega-selections@6.1.2:
+    resolution: {integrity: sha512-xJ+V4qdd46nk2RBdwIRrQm2iSTMHdlu/omhLz1pqRL3jZDrkqNBXimrisci2kIKpH2WBpA1YVagwuZEKBmF2Qw==}
+
+  vega-statistics@2.0.0:
+    resolution: {integrity: sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==}
+
+  vega-themes@3.0.0:
+    resolution: {integrity: sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==}
+    peerDependencies:
+      vega: '*'
+      vega-lite: '*'
+
+  vega-time@3.1.0:
+    resolution: {integrity: sha512-G93mWzPwNa6UYQRkr8Ujur9uqxbBDjDT/WpXjbDY0yygdSkRT+zXF+Sb4gjhW0nPaqdiwkn0R6kZcSPMj1bMNA==}
+
+  vega-tooltip@1.0.0:
+    resolution: {integrity: sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==}
+
+  vega-transforms@5.1.0:
+    resolution: {integrity: sha512-mj/sO2tSuzzpiXX8JSl4DDlhEmVwM/46MTAzTNQUQzJPMI/n4ChCjr/SdEbfEyzlD4DPm1bjohZGjLc010yuMg==}
+
+  vega-typings@2.1.0:
+    resolution: {integrity: sha512-zdis4Fg4gv37yEvTTSZEVMNhp8hwyEl7GZ4X4HHddRVRKxWFsbyKvZx/YW5Z9Ox4sjxVA2qHzEbod4Fdx+SEJA==}
+
+  vega-util@2.1.0:
+    resolution: {integrity: sha512-PGfp0m0QCufDmcxKJCWQy4Ov23FoF8DSXmoJwSezi3itQaa2hbxK0+xwsTMP2vy4PR16Pu25HMzgMwXVW1+33w==}
+
+  vega-view-transforms@5.1.0:
+    resolution: {integrity: sha512-fpigh/xn/32t+An1ShoY3MLeGzNdlbAp2+HvFKzPpmpMTZqJEWkk/J/wHU7Swyc28Ta7W1z3fO+8dZkOYO5TWQ==}
+
+  vega-view@6.1.0:
+    resolution: {integrity: sha512-hmHDm/zC65lb23mb9Tr9Gx0wkxP0TMS31LpMPYxIZpvInxvUn7TYitkOtz1elr63k2YZrgmF7ztdGyQ4iCQ5fQ==}
+
+  vega-voronoi@5.1.0:
+    resolution: {integrity: sha512-uKdsoR9x60mz7eYtVG+NhlkdQXeVdMr6jHNAHxs+W+i6kawkUp5S9jp1xf1FmW/uZvtO1eqinHQNwATcDRsiUg==}
+
+  vega-wordcloud@5.1.0:
+    resolution: {integrity: sha512-sSdNmT8y2D7xXhM2h76dKyaYn3PA4eV49WUUkfYfqHz/vpcu10GSAoFxLhQQTkbZXR+q5ZB63tFUow9W2IFo6g==}
+
+  vega@6.2.0:
+    resolution: {integrity: sha512-BIwalIcEGysJdQDjeVUmMWB3e50jPDNAMfLJscjEvpunU9bSt7X1OYnQxkg3uBwuRRI4nWfFZO9uIW910nLeGw==}
 
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
@@ -15671,6 +15682,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -15768,6 +15783,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@13.3.2:
     resolution: {integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==}
 
@@ -15778,6 +15797,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -23074,6 +23097,8 @@ snapshots:
     dependencies:
       '@types/node': 22.13.1
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/geojson@7946.0.4': {}
 
   '@types/graceful-fs@4.1.5':
@@ -25025,6 +25050,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
+      wrap-ansi: 9.0.2
+
   clone@1.0.4: {}
 
   clone@2.1.2: {}
@@ -26006,6 +26037,8 @@ snapshots:
     dependencies:
       flairup: 1.0.0
       react: 19.2.0
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@7.0.3: {}
 
@@ -27345,6 +27378,8 @@ snapshots:
       node-source-walk: 7.0.0
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.4.0: {}
 
   get-intrinsic@1.2.4:
     dependencies:
@@ -28976,7 +29011,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-pretty-compact@3.0.0: {}
+  json-stringify-pretty-compact@4.0.0: {}
 
   json-stringify-safe@5.0.1: {}
 
@@ -31723,15 +31758,12 @@ snapshots:
       ts-easing: 0.2.0
       tslib: 2.8.1
 
-  react-vega@7.6.0(react@19.2.0)(vega-lite@5.16.1(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13)):
+  react-vega@8.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)):
     dependencies:
-      '@types/react': 19.2.2
       fast-deep-equal: 3.1.3
-      prop-types: 15.8.1
       react: 19.2.0
-      vega: 5.32.0(encoding@0.1.13)
-      vega-embed: 6.23.0(vega-lite@5.16.1(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13))
-      vega-lite: 5.16.1(vega@5.32.0(encoding@0.1.13))
+      react-dom: 19.2.0(react@19.2.0)
+      vega-embed: 7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)
 
   react@19.0.0: {}
 
@@ -32815,6 +32847,12 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.4.0
+      strip-ansi: 7.1.0
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
@@ -33299,8 +33337,6 @@ snapshots:
 
   tslib@2.3.0: {}
 
-  tslib@2.6.3: {}
-
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
@@ -33745,315 +33781,269 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vega-canvas@1.2.7: {}
+  vega-canvas@2.0.0: {}
 
-  vega-crossfilter@4.1.3(encoding@0.1.13):
+  vega-crossfilter@5.1.0:
     dependencies:
       d3-array: 3.2.4
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.0
 
-  vega-dataflow@5.7.8(encoding@0.1.13):
+  vega-dataflow@6.1.0:
     dependencies:
-      vega-format: 1.1.4
-      vega-loader: 4.5.4(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-format: 2.1.0
+      vega-loader: 5.1.0
+      vega-util: 2.1.0
 
-  vega-embed@6.23.0(vega-lite@5.16.1(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13)):
+  vega-embed@7.1.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0):
     dependencies:
       fast-json-patch: 3.1.1
-      json-stringify-pretty-compact: 3.0.0
+      json-stringify-pretty-compact: 4.0.0
       semver: 7.7.3
       tslib: 2.8.1
-      vega: 5.32.0(encoding@0.1.13)
-      vega-interpreter: 1.0.5
-      vega-lite: 5.16.1(vega@5.32.0(encoding@0.1.13))
-      vega-schema-url-parser: 2.2.0
-      vega-themes: 2.14.0(vega-lite@5.16.1(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13))
-      vega-tooltip: 0.33.0
+      vega: 6.2.0
+      vega-interpreter: 2.2.1
+      vega-lite: 6.4.1(vega@6.2.0)
+      vega-schema-url-parser: 3.0.2
+      vega-themes: 3.0.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)
+      vega-tooltip: 1.0.0
 
-  vega-encode@4.10.2(encoding@0.1.13):
+  vega-encode@5.1.0:
     dependencies:
       d3-array: 3.2.4
       d3-interpolate: 3.0.1
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-scale: 7.4.3
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-scale: 8.1.0
+      vega-util: 2.1.0
 
-  vega-event-selector@3.0.1: {}
+  vega-event-selector@4.0.0: {}
 
-  vega-expression@5.1.0:
+  vega-expression@6.1.0:
     dependencies:
       '@types/estree': 1.0.8
-      vega-util: 1.17.2
+      vega-util: 2.1.0
 
-  vega-expression@5.2.1:
-    dependencies:
-      '@types/estree': 1.0.8
-      vega-util: 1.17.4
-
-  vega-force@4.2.2(encoding@0.1.13):
+  vega-force@5.1.0:
     dependencies:
       d3-force: 3.0.0
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.0
 
-  vega-format@1.1.4:
+  vega-format@2.1.0:
     dependencies:
       d3-array: 3.2.4
       d3-format: 3.1.0
       d3-time-format: 4.1.0
-      vega-time: 2.1.4
-      vega-util: 1.17.4
+      vega-time: 3.1.0
+      vega-util: 2.1.0
 
-  vega-functions@5.17.0(encoding@0.1.13):
+  vega-functions@6.1.1:
     dependencies:
       d3-array: 3.2.4
       d3-color: 3.1.0
       d3-geo: 3.1.1
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-expression: 5.2.1
-      vega-scale: 7.4.3
-      vega-scenegraph: 4.13.2(encoding@0.1.13)
-      vega-selections: 5.6.1
-      vega-statistics: 1.9.0
-      vega-time: 2.1.4
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-expression: 6.1.0
+      vega-scale: 8.1.0
+      vega-scenegraph: 5.1.0
+      vega-selections: 6.1.2
+      vega-statistics: 2.0.0
+      vega-time: 3.1.0
+      vega-util: 2.1.0
 
-  vega-geo@4.4.3(encoding@0.1.13):
+  vega-geo@5.1.0:
     dependencies:
       d3-array: 3.2.4
       d3-color: 3.1.0
       d3-geo: 3.1.1
-      vega-canvas: 1.2.7
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-projection: 1.6.2
-      vega-statistics: 1.9.0
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-canvas: 2.0.0
+      vega-dataflow: 6.1.0
+      vega-projection: 2.1.0
+      vega-statistics: 2.0.0
+      vega-util: 2.1.0
 
-  vega-hierarchy@4.1.3(encoding@0.1.13):
+  vega-hierarchy@5.1.0:
     dependencies:
       d3-hierarchy: 3.1.2
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.0
 
-  vega-interpreter@1.0.5: {}
-
-  vega-label@1.3.1(encoding@0.1.13):
+  vega-interpreter@2.2.1:
     dependencies:
-      vega-canvas: 1.2.7
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-scenegraph: 4.13.2(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-util: 2.1.0
 
-  vega-lite@5.16.1(vega@5.32.0(encoding@0.1.13)):
+  vega-label@2.1.0:
     dependencies:
-      json-stringify-pretty-compact: 3.0.0
-      tslib: 2.6.3
-      vega: 5.32.0(encoding@0.1.13)
-      vega-event-selector: 3.0.1
-      vega-expression: 5.1.0
-      vega-util: 1.17.2
-      yargs: 17.7.2
+      vega-canvas: 2.0.0
+      vega-dataflow: 6.1.0
+      vega-scenegraph: 5.1.0
+      vega-util: 2.1.0
 
-  vega-loader@4.5.4(encoding@0.1.13):
+  vega-lite@6.4.1(vega@6.2.0):
+    dependencies:
+      json-stringify-pretty-compact: 4.0.0
+      tslib: 2.8.1
+      vega: 6.2.0
+      vega-event-selector: 4.0.0
+      vega-expression: 6.1.0
+      vega-util: 2.1.0
+      yargs: 18.0.0
+
+  vega-loader@5.1.0:
     dependencies:
       d3-dsv: 3.0.1
-      node-fetch: 2.7.0(encoding@0.1.13)
       topojson-client: 3.1.0
-      vega-format: 1.1.4
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-format: 2.1.0
+      vega-util: 2.1.0
 
-  vega-parser@6.5.0(encoding@0.1.13):
+  vega-parser@7.1.0:
     dependencies:
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-event-selector: 3.0.1
-      vega-functions: 5.17.0(encoding@0.1.13)
-      vega-scale: 7.4.3
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-event-selector: 4.0.0
+      vega-functions: 6.1.1
+      vega-scale: 8.1.0
+      vega-util: 2.1.0
 
-  vega-projection@1.6.2:
+  vega-projection@2.1.0:
     dependencies:
       d3-geo: 3.1.1
       d3-geo-projection: 4.0.0
-      vega-scale: 7.4.3
+      vega-scale: 8.1.0
 
-  vega-regression@1.3.1(encoding@0.1.13):
+  vega-regression@2.1.0:
     dependencies:
       d3-array: 3.2.4
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-statistics: 1.9.0
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-statistics: 2.0.0
+      vega-util: 2.1.0
 
-  vega-runtime@6.2.1(encoding@0.1.13):
+  vega-runtime@7.1.0:
     dependencies:
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.0
 
-  vega-scale@7.4.3:
+  vega-scale@8.1.0:
     dependencies:
       d3-array: 3.2.4
       d3-interpolate: 3.0.1
       d3-scale: 4.0.2
       d3-scale-chromatic: 3.1.0
-      vega-time: 2.1.4
-      vega-util: 1.17.4
+      vega-time: 3.1.0
+      vega-util: 2.1.0
 
-  vega-scenegraph@4.13.2(encoding@0.1.13):
+  vega-scenegraph@5.1.0:
     dependencies:
       d3-path: 3.1.0
       d3-shape: 3.2.0
-      vega-canvas: 1.2.7
-      vega-loader: 4.5.4(encoding@0.1.13)
-      vega-scale: 7.4.3
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-canvas: 2.0.0
+      vega-loader: 5.1.0
+      vega-scale: 8.1.0
+      vega-util: 2.1.0
 
-  vega-schema-url-parser@2.2.0: {}
+  vega-schema-url-parser@3.0.2: {}
 
-  vega-selections@5.6.1:
+  vega-selections@6.1.2:
     dependencies:
       d3-array: 3.2.4
-      vega-expression: 5.2.1
-      vega-util: 1.17.4
+      vega-expression: 6.1.0
+      vega-util: 2.1.0
 
-  vega-statistics@1.9.0:
+  vega-statistics@2.0.0:
     dependencies:
       d3-array: 3.2.4
 
-  vega-themes@2.14.0(vega-lite@5.16.1(vega@5.32.0(encoding@0.1.13)))(vega@5.32.0(encoding@0.1.13)):
+  vega-themes@3.0.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0):
     dependencies:
-      vega: 5.32.0(encoding@0.1.13)
-      vega-lite: 5.16.1(vega@5.32.0(encoding@0.1.13))
+      vega: 6.2.0
+      vega-lite: 6.4.1(vega@6.2.0)
 
-  vega-time@2.1.4:
+  vega-time@3.1.0:
     dependencies:
       d3-array: 3.2.4
       d3-time: 3.1.0
-      vega-util: 1.17.4
+      vega-util: 2.1.0
 
-  vega-tooltip@0.33.0:
+  vega-tooltip@1.0.0:
     dependencies:
-      vega-util: 1.17.3
+      vega-util: 2.1.0
 
-  vega-transforms@4.12.1(encoding@0.1.13):
+  vega-transforms@5.1.0:
     dependencies:
       d3-array: 3.2.4
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-statistics: 1.9.0
-      vega-time: 2.1.4
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-statistics: 2.0.0
+      vega-time: 3.1.0
+      vega-util: 2.1.0
 
-  vega-typings@1.5.0:
+  vega-typings@2.1.0:
     dependencies:
-      '@types/geojson': 7946.0.4
-      vega-event-selector: 3.0.1
-      vega-expression: 5.2.1
-      vega-util: 1.17.4
+      '@types/geojson': 7946.0.16
+      vega-event-selector: 4.0.0
+      vega-expression: 6.1.0
+      vega-util: 2.1.0
 
-  vega-util@1.17.2: {}
+  vega-util@2.1.0: {}
 
-  vega-util@1.17.3: {}
-
-  vega-util@1.17.4: {}
-
-  vega-view-transforms@4.6.1(encoding@0.1.13):
+  vega-view-transforms@5.1.0:
     dependencies:
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-scenegraph: 4.13.2(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-scenegraph: 5.1.0
+      vega-util: 2.1.0
 
-  vega-view@5.15.0(encoding@0.1.13):
+  vega-view@6.1.0:
     dependencies:
       d3-array: 3.2.4
       d3-timer: 3.0.1
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-format: 1.1.4
-      vega-functions: 5.17.0(encoding@0.1.13)
-      vega-runtime: 6.2.1(encoding@0.1.13)
-      vega-scenegraph: 4.13.2(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-format: 2.1.0
+      vega-functions: 6.1.1
+      vega-runtime: 7.1.0
+      vega-scenegraph: 5.1.0
+      vega-util: 2.1.0
 
-  vega-voronoi@4.2.4(encoding@0.1.13):
+  vega-voronoi@5.1.0:
     dependencies:
       d3-delaunay: 6.0.4
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-dataflow: 6.1.0
+      vega-util: 2.1.0
 
-  vega-wordcloud@4.1.6(encoding@0.1.13):
+  vega-wordcloud@5.1.0:
     dependencies:
-      vega-canvas: 1.2.7
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-scale: 7.4.3
-      vega-statistics: 1.9.0
-      vega-util: 1.17.4
-    transitivePeerDependencies:
-      - encoding
+      vega-canvas: 2.0.0
+      vega-dataflow: 6.1.0
+      vega-scale: 8.1.0
+      vega-statistics: 2.0.0
+      vega-util: 2.1.0
 
-  vega@5.32.0(encoding@0.1.13):
+  vega@6.2.0:
     dependencies:
-      vega-crossfilter: 4.1.3(encoding@0.1.13)
-      vega-dataflow: 5.7.8(encoding@0.1.13)
-      vega-encode: 4.10.2(encoding@0.1.13)
-      vega-event-selector: 3.0.1
-      vega-expression: 5.2.1
-      vega-force: 4.2.2(encoding@0.1.13)
-      vega-format: 1.1.4
-      vega-functions: 5.17.0(encoding@0.1.13)
-      vega-geo: 4.4.3(encoding@0.1.13)
-      vega-hierarchy: 4.1.3(encoding@0.1.13)
-      vega-label: 1.3.1(encoding@0.1.13)
-      vega-loader: 4.5.4(encoding@0.1.13)
-      vega-parser: 6.5.0(encoding@0.1.13)
-      vega-projection: 1.6.2
-      vega-regression: 1.3.1(encoding@0.1.13)
-      vega-runtime: 6.2.1(encoding@0.1.13)
-      vega-scale: 7.4.3
-      vega-scenegraph: 4.13.2(encoding@0.1.13)
-      vega-statistics: 1.9.0
-      vega-time: 2.1.4
-      vega-transforms: 4.12.1(encoding@0.1.13)
-      vega-typings: 1.5.0
-      vega-util: 1.17.4
-      vega-view: 5.15.0(encoding@0.1.13)
-      vega-view-transforms: 4.6.1(encoding@0.1.13)
-      vega-voronoi: 4.2.4(encoding@0.1.13)
-      vega-wordcloud: 4.1.6(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
+      vega-crossfilter: 5.1.0
+      vega-dataflow: 6.1.0
+      vega-encode: 5.1.0
+      vega-event-selector: 4.0.0
+      vega-expression: 6.1.0
+      vega-force: 5.1.0
+      vega-format: 2.1.0
+      vega-functions: 6.1.1
+      vega-geo: 5.1.0
+      vega-hierarchy: 5.1.0
+      vega-label: 2.1.0
+      vega-loader: 5.1.0
+      vega-parser: 7.1.0
+      vega-projection: 2.1.0
+      vega-regression: 2.1.0
+      vega-runtime: 7.1.0
+      vega-scale: 8.1.0
+      vega-scenegraph: 5.1.0
+      vega-statistics: 2.0.0
+      vega-time: 3.1.0
+      vega-transforms: 5.1.0
+      vega-typings: 2.1.0
+      vega-util: 2.1.0
+      vega-view: 6.1.0
+      vega-view-transforms: 5.1.0
+      vega-voronoi: 5.1.0
+      vega-wordcloud: 5.1.0
 
   verror@1.10.0:
     dependencies:
@@ -34471,6 +34461,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.0
+
   wrappy@1.0.2: {}
 
   write-file-atomic@4.0.2:
@@ -34524,6 +34520,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@13.3.2:
     dependencies:
       cliui: 5.0.0
@@ -34556,6 +34554,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2270
Closes: PROD-2269

### Description:
Upgrade Vega visualization libraries to their latest versions to address two security vulnerabilities related to peer dependencies (`vega-selections` and `vega-functions`):
- Updated `react-vega` from 7.6.0 to 8.0.0
- Updated `vega-lite` from 5.16.1 to 6.4.1
- Added `vega` 6.2.0 and `vega-embed` 7.1.0 as direct dependencies

The upgrade required changes to the CustomVisualization component:
- Replaced `VegaLite` with `VegaEmbed` component
- Updated the component props structure to match the new API
- Adjusted how data and configuration options are passed to the component

Also fixed the import path for the vega-lite schema in the CustomVisConfig component.