### PR TITLE
feat: use feature flag/env var for multi-agent slack channel

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -24,6 +24,8 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
                 this.getAiCopilotFlag.bind(this),
             [CommercialFeatureFlags.AgentReasoning]:
                 CommercialFeatureFlagModel.getAgentReasoningFlag.bind(this),
+            [CommercialFeatureFlags.MultiAgentChannel]:
+                this.getMultiAgentChannelFlag.bind(this),
         };
     }
 
@@ -124,6 +126,35 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
                   },
               )
             : false;
+        return {
+            id: featureFlagId,
+            enabled,
+        };
+    }
+
+    private async getMultiAgentChannelFlag({
+        user,
+        featureFlagId,
+    }: FeatureFlagLogicArgs) {
+        let enabled = false;
+        if (this.lightdashConfig.slack?.multiAgentChannelEnabled) {
+            enabled = true;
+        } else {
+            enabled = user
+                ? await isFeatureFlagEnabled(
+                      CommercialFeatureFlags.MultiAgentChannel as AnyType as FeatureFlags,
+                      {
+                          userUuid: user.userUuid,
+                          organizationUuid: user.organizationUuid,
+                          organizationName: user.organizationName,
+                      },
+                      {
+                          throwOnTimeout: false,
+                      },
+                  )
+                : false;
+        }
+
         return {
             id: featureFlagId,
             enabled,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -21,9 +21,6 @@ export const BaseResponse: HealthState = {
     hasGitlab: false,
     hasHeadlessBrowser: false,
     hasSlack: false,
-    slack: {
-        multiAgentChannelEnabled: false,
-    },
     auth: {
         disablePasswordAuthentication: false,
         google: {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -129,11 +129,6 @@ export class HealthService extends BaseService {
             },
             pivotTable: this.lightdashConfig.pivotTable,
             hasSlack: this.hasSlackConfig(),
-            slack: {
-                multiAgentChannelEnabled:
-                    this.lightdashConfig.slack?.multiAgentChannelEnabled ??
-                    false,
-            },
             hasGithub: process.env.GITHUB_PRIVATE_KEY !== undefined,
             hasGitlab:
                 this.lightdashConfig.gitlab.clientId !== undefined &&

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -5,4 +5,5 @@ export enum CommercialFeatureFlags {
     ServiceAccounts = 'service-accounts',
     OrganizationWarehouseCredentials = 'organization-warehouse-credentials',
     AgentReasoning = 'agent-reasoning',
+    MultiAgentChannel = 'multi-agent-channel',
 }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -392,9 +392,6 @@ export type HealthState = {
         maxColumnLimit: number;
     };
     hasSlack: boolean;
-    slack: {
-        multiAgentChannelEnabled: boolean;
-    };
     hasGithub: boolean;
     hasGitlab: boolean;
     hasHeadlessBrowser: boolean;

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -31,7 +31,6 @@ import {
 import { useEffect, type FC } from 'react';
 import { Link } from 'react-router';
 import { z } from 'zod';
-import useHealth from '../../../hooks/health/useHealth';
 import {
     useDeleteSlack,
     useGetSlack,
@@ -74,12 +73,13 @@ const SlackSettingsPanel: FC = () => {
     const { data: aiCopilotFlag } = useFeatureFlag(
         CommercialFeatureFlags.AiCopilot,
     );
-    const { data: health } = useHealth();
+    const { data: multiAgentChannelFlag } = useFeatureFlag(
+        CommercialFeatureFlags.MultiAgentChannel,
+    );
     const { data: slackInstallation, isInitialLoading } = useGetSlack();
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
 
-    const isSlackMultiAgentChannelEnabled =
-        health?.slack?.multiAgentChannelEnabled ?? false;
+    const isSlackMultiAgentChannelEnabled = !!multiAgentChannelFlag?.enabled;
 
     const { mutate: deleteSlack } = useDeleteSlack();
     const { mutate: updateCustomSettings } =

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -46,9 +46,6 @@ export default function mockHealthResponse(
             maxColumnLimit: 100,
         },
         hasSlack: false,
-        slack: {
-            multiAgentChannelEnabled: false,
-        },
         auth: {
             disablePasswordAuthentication: false,
             google: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Refactored the multi-agent channel feature flag implementation by:
- Adding a new `MultiAgentChannel` commercial feature flag
- Implementing the `getMultiAgentChannelFlag` method in `CommercialFeatureFlagModel`
- Removing the `slack.multiAgentChannelEnabled` property from the `HealthState` type
- Updating the Slack settings panel to use the feature flag instead of the health endpoint

This change improves the consistency of feature flag management by moving the multi-agent channel configuration from the health service to the commercial feature flag system.