### PR TITLE
feat: add roleUuid to project memberships and improve permission checks

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1444,6 +1444,7 @@ export class ProjectModel {
         projectUuid: string,
         email: string,
         role: ProjectMemberRole,
+        roleUuid?: string,
     ): Promise<void> {
         try {
             const [project] = await this.database('projects')
@@ -1471,6 +1472,7 @@ export class ProjectModel {
             await this.database('project_memberships').insert({
                 project_id: project.project_id,
                 role,
+                role_uuid: roleUuid || null,
                 user_id: user.user_id,
             });
         } catch (error: AnyType) {

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -6,6 +6,7 @@ import {
     Project,
     ProjectType,
     friendlyName,
+    getErrorMessage,
     isExploreError,
     type LightdashProjectConfig,
     type Tag,
@@ -110,8 +111,32 @@ export const deploy = async (
         options.projectUuid,
     );
 
-    await replaceProjectYamlTags(options.projectUuid, lightdashProjectConfig);
-    await replaceProjectParameters(options.projectUuid, lightdashProjectConfig);
+    // These two methods are not critical to the deployment process, so we can ignore errors and show warnings instead
+    try {
+        await replaceProjectYamlTags(
+            options.projectUuid,
+            lightdashProjectConfig,
+        );
+    } catch (e) {
+        console.error(
+            styles.warning(
+                `\nError replacing YAML tags: ${getErrorMessage(e)}\n`,
+            ),
+        );
+    }
+
+    try {
+        await replaceProjectParameters(
+            options.projectUuid,
+            lightdashProjectConfig,
+        );
+    } catch (e) {
+        console.error(
+            styles.warning(
+                `\nError replacing project parameters: ${getErrorMessage(e)}\n`,
+            ),
+        );
+    }
 
     await lightdashApi<null>({
         method: 'PUT',

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
 import {
     CreateProjectTableConfiguration,
+    getErrorMessage,
     Project,
     ProjectType,
 } from '@lightdash/common';
@@ -81,8 +82,8 @@ const cleanupProject = async (
         });
         teardownSpinner.succeed(`  Cleaned up`);
     } catch (e) {
-        console.error('Error during cleanup:', e);
-        teardownSpinner.fail(`  Cleanup failed`);
+        // console.error(styles.error(`Error during cleanup: ${getErrorMessage(e)}`));
+        teardownSpinner.fail(`  Cleanup failed: ${getErrorMessage(e)}`);
     }
 };
 
@@ -338,7 +339,7 @@ export const previewHandler = async (
         ]);
         pressToShutdown.clear();
     } catch (e) {
-        spinner.fail('Error creating developer preview');
+        spinner.fail(`Error creating developer preview: ${getErrorMessage(e)}`);
 
         await deletePreviewProject(project.projectUuid);
         await unsetPreviewProject();

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -1892,78 +1892,92 @@ describe('Project member permissions', () => {
             membership: PROJECT_ADMIN,
             canCreatePreview: true,
             canDeleteTheirOwnPreview: true,
+            canDeleteOthersPreview: true, // Admins can delete any project
         },
         {
             membership: PROJECT_DEVELOPER,
             canCreatePreview: true,
             canDeleteTheirOwnPreview: true,
+            canDeleteOthersPreview: false,
         },
         {
             membership: PROJECT_EDITOR,
             canCreatePreview: false,
             canDeleteTheirOwnPreview: false,
+            canDeleteOthersPreview: false,
         },
         {
             membership: PROJECT_INTERACTIVE_VIEWER,
             canCreatePreview: false,
             canDeleteTheirOwnPreview: false,
+            canDeleteOthersPreview: false,
         },
         {
             membership: PROJECT_VIEWER,
             canCreatePreview: false,
             canDeleteTheirOwnPreview: false,
+            canDeleteOthersPreview: false,
         },
-    ].forEach(({ membership, canCreatePreview, canDeleteTheirOwnPreview }) => {
-        describe('test project preview permissions', () => {
-            const ability = defineAbilityForProjectMember(membership);
+    ].forEach(
+        ({
+            membership,
+            canCreatePreview,
+            canDeleteTheirOwnPreview,
+            canDeleteOthersPreview,
+        }) => {
+            describe('test project preview permissions', () => {
+                const ability = defineAbilityForProjectMember(membership);
 
-            it('checks if user can create PREVIEW projects', () => {
-                expect(
-                    ability.can(
-                        'create',
-                        subject('Project', {
-                            upstreamProjectUuid: projectUuid,
-                            type: ProjectType.PREVIEW,
-                        }),
-                    ),
-                ).toEqual(canCreatePreview);
-            });
+                it('checks if user can create PREVIEW projects', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('Project', {
+                                upstreamProjectUuid: projectUuid,
+                                type: ProjectType.PREVIEW,
+                            }),
+                        ),
+                    ).toEqual(canCreatePreview);
+                });
 
-            it('checks that users cannot create regular projects', () => {
-                expect(
-                    ability.can(
-                        'create',
-                        subject('Project', {
-                            upstreamProjectUuid: projectUuid,
-                            type: ProjectType.DEFAULT,
-                        }),
-                    ),
-                ).toEqual(false);
-            });
+                it('checks that users cannot create regular projects', () => {
+                    expect(
+                        ability.can(
+                            'create',
+                            subject('Project', {
+                                upstreamProjectUuid: projectUuid,
+                                type: ProjectType.DEFAULT,
+                            }),
+                        ),
+                    ).toEqual(false);
+                });
 
-            it('checks if user can delete their own PREVIEW projects', () => {
-                expect(
-                    ability.can(
-                        'delete',
-                        subject('Project', {
-                            createdByUserUuid: membership.userUuid,
-                            type: ProjectType.PREVIEW,
-                        }),
-                    ),
-                ).toEqual(canDeleteTheirOwnPreview);
-            });
+                it('checks if user can delete their own PREVIEW projects', () => {
+                    expect(
+                        ability.can(
+                            'delete',
+                            subject('Project', {
+                                projectUuid,
+                                createdByUserUuid: membership.userUuid,
+                                type: ProjectType.PREVIEW,
+                            }),
+                        ),
+                    ).toEqual(canDeleteTheirOwnPreview);
+                });
 
-            it('checks that users cannot delete other users PREVIEW projects', () => {
-                expect(
-                    ability.can(
-                        'delete',
-                        subject('Project', {
-                            createdByUserUuid: '1234',
-                            type: ProjectType.PREVIEW,
-                        }),
-                    ),
-                ).toEqual(false);
+                it('checks if user can delete other users PREVIEW projects', () => {
+                    expect(
+                        ability.can(
+                            'delete',
+                            subject('Project', {
+                                projectUuid,
+                                createdByUserUuid: '1234',
+                                type: ProjectType.PREVIEW,
+                            }),
+                        ),
+                    ).toEqual(canDeleteOthersPreview);
+                });
             });
-        });
-    });
+        },
+    );
 });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -208,6 +208,7 @@ export const projectMemberAbilities: Record<
         });
 
         can('delete', 'Project', {
+            projectUuid: member.projectUuid,
             type: ProjectType.PREVIEW,
             createdByUserUuid: member.userUuid,
         });
@@ -219,6 +220,11 @@ export const projectMemberAbilities: Record<
 
         can('update', 'Project', {
             projectUuid: member.projectUuid,
+        });
+        can('update', 'Project', {
+            projectUuid: member.projectUuid,
+            type: ProjectType.PREVIEW,
+            createdByUserUuid: member.userUuid,
         });
         can('manage', 'SpotlightTableConfig', {
             projectUuid: member.projectUuid,

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -76,6 +76,7 @@ const BASE_ROLE_SCOPES = {
         'create:Project@preview', // Preview projects
         'delete:Project@self', // Preview projects created by user
         'update:Project',
+        'update:Project@self',
         'view:JobStatus', // All jobs in project
         'view:SourceCode',
         'manage:SourceCode',

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -1746,6 +1746,7 @@ describe('scopeAbilityBuilder', () => {
                 ability.can(
                     'delete',
                     subject('Project', {
+                        projectUuid: 'project-123',
                         createdByUserUuid: 'user-456',
                         type: ProjectType.PREVIEW,
                     }),
@@ -1756,6 +1757,7 @@ describe('scopeAbilityBuilder', () => {
                 ability.can(
                     'delete',
                     subject('Project', {
+                        projectUuid: 'project-123',
                         createdByUserUuid: 'different-user',
                         type: ProjectType.PREVIEW,
                     }),
@@ -1780,6 +1782,7 @@ describe('scopeAbilityBuilder', () => {
                 ability.can(
                     'delete',
                     subject('Project', {
+                        projectUuid: 'project-123',
                         createdByUserUuid: 'user-456',
                         type: ProjectType.PREVIEW,
                     }),
@@ -1791,6 +1794,7 @@ describe('scopeAbilityBuilder', () => {
                 ability.can(
                     'delete',
                     subject('Project', {
+                        projectUuid: 'project-123',
                         createdByUserUuid: 'user-456',
                         type: ProjectType.DEFAULT,
                     }),

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -248,6 +248,19 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'update:Project@self',
+        description: 'Update projects created by the user',
+        isEnterprise: false,
+        group: ScopeGroup.PROJECT_MANAGEMENT,
+        getConditions: (context) => [
+            {
+                projectUuid: context.projectUuid,
+                createdByUserUuid: context.userUuid || false,
+                type: ProjectType.PREVIEW,
+            },
+        ],
+    },
+    {
         name: 'delete:Project',
         description: 'Delete projects',
         isEnterprise: false,
@@ -261,6 +274,7 @@ const scopes: Scope[] = [
         group: ScopeGroup.PROJECT_MANAGEMENT,
         getConditions: (context) => [
             {
+                projectUuid: context.projectUuid,
                 createdByUserUuid: context.userUuid || false,
                 type: ProjectType.PREVIEW,
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A





### Description


Before

<img width="563" height="323" alt="Screenshot from 2026-01-07 14-07-34" src="https://github.com/user-attachments/assets/f2b6fa74-382c-4901-8297-ad5c1a65c282" />


After

<img width="1055" height="395" alt="Screenshot from 2026-01-07 15-48-46" src="https://github.com/user-attachments/assets/3a3afc56-6150-4869-870b-6a5f9c43f61e" />



There were a few issues that were preventing a  `member/viewer` on the org, to `create previews` using `custom roles`



#### first issue: 

> we were not copying the custom role uuid to the new project

Before
<img width="939" height="185" alt="Screenshot from 2026-01-07 14-30-39" src="https://github.com/user-attachments/assets/6515a9a3-e157-4e54-ae91-0f7314ce796d" />

After

<img width="939" height="185" alt="Screenshot from 2026-01-07 14-30-25" src="https://github.com/user-attachments/assets/75a65b1c-e8c2-4ffe-9148-8bbe18f0cbe8" />

#### second issue: 

> casl checkcs were checking `projectuuid,organizationUuid` , and this is not true at the org level. 

It is possible this issue is present on other parts of the code, outside the `create preview` .

See comment for example.

#### Third issue: 

we were missing update@self scope for users to update their own previews. 

### changes:


This PR enhances project permissions by adding more granular access controls:

1. Adds a new `update:Project@self` scope that allows users to update projects they created themselves
2. Adds support for `roleUuid` in project memberships
3. Improves permission checks in ProjectService by:
   - Using more specific project attributes for authorization checks
   - Adding more descriptive error messages when permissions are denied
4. Fixes permission checks for managing YAML tags by requiring both 'manage' and 'view' permissions

These changes ensure that permissions are properly enforced while providing clearer feedback when access is denied.