### PR TITLE
feat: implement cross-filtering between dashboard tiles based on field overlap

### DIFF
--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -1,14 +1,18 @@
 import {
+    getItemId,
     isField,
     type DashboardFilters,
-    type FilterRule,
+    type DashboardTile,
+    type FilterableDimension,
     type FilterableItem,
+    type FilterRule,
     type ParametersValuesMap,
     type WeekDay,
 } from '@lightdash/common';
 import { type PopoverProps } from '@mantine/core';
 import { useCallback, type ReactNode } from 'react';
 import { v4 as uuid4 } from 'uuid';
+import { doesFilterApplyToTile } from '../../../features/dashboardFiltersV2/FilterConfiguration/utils';
 import Context, { type DefaultFieldsMap } from './context';
 
 type Props<T extends DefaultFieldsMap> = {
@@ -17,6 +21,8 @@ type Props<T extends DefaultFieldsMap> = {
     baseTable?: string;
     startOfWeek?: WeekDay;
     dashboardFilters?: DashboardFilters;
+    dashboardTiles?: DashboardTile[];
+    filterableFieldsByTileUuid?: Record<string, FilterableDimension[]>;
     popoverProps?: Omit<PopoverProps, 'children'>;
     parameterValues?: ParametersValuesMap;
     children?: ReactNode;
@@ -28,6 +34,8 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
     baseTable,
     startOfWeek,
     dashboardFilters,
+    dashboardTiles,
+    filterableFieldsByTileUuid,
     popoverProps,
     parameterValues,
     children,
@@ -40,23 +48,94 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
         },
         [itemsMap],
     );
+
     const getAutocompleteFilterGroup = useCallback(
         (filterId: string, item: FilterableItem) => {
             if (!dashboardFilters || !isField(item)) {
                 return undefined;
             }
+
+            const currentFieldId = getItemId(item);
+
+            // Find the current filter to get its tileTargets
+            const currentFilter = dashboardFilters.dimensions.find(
+                (f) => f.id === filterId,
+            );
+
+            // Get tiles that the current filter applies to
+            const currentFilterTileUuids =
+                dashboardTiles && filterableFieldsByTileUuid
+                    ? new Set(
+                          dashboardTiles
+                              .filter((tile) => {
+                                  // For new filters (not yet in dashboardFilters),
+                                  // check if tile has the field
+                                  if (!currentFilter) {
+                                      const tileFields =
+                                          filterableFieldsByTileUuid[tile.uuid];
+                                      return tileFields?.some(
+                                          (f) =>
+                                              getItemId(f) === currentFieldId,
+                                      );
+                                  }
+                                  // For existing filters, use doesFilterApplyToTile
+                                  return doesFilterApplyToTile(
+                                      currentFilter,
+                                      tile,
+                                      filterableFieldsByTileUuid,
+                                  );
+                              })
+                              .map((tile) => tile.uuid),
+                      )
+                    : null;
+
             return {
                 id: uuid4(),
                 and: dashboardFilters.dimensions.filter(
                     (dimensionFilterRule) => {
-                        const isNotSelectedFilter =
-                            dimensionFilterRule.id !== filterId;
-                        return isNotSelectedFilter;
+                        // Exclude the current filter itself
+                        if (dimensionFilterRule.id === filterId) {
+                            return false;
+                        }
+
+                        // Exclude same-field filters - otherwise the autocomplete
+                        // would be over-restricted (e.g., if Status=completed is set,
+                        // another Status filter would only see "completed").
+                        if (
+                            dimensionFilterRule.target.fieldId ===
+                            currentFieldId
+                        ) {
+                            return false;
+                        }
+
+                        // For different-field filters, exclude if no tile overlap.
+                        // Filters on different tabs shouldn't affect each other's
+                        // autocomplete queries.
+                        if (
+                            currentFilterTileUuids &&
+                            dashboardTiles &&
+                            filterableFieldsByTileUuid
+                        ) {
+                            const hasOverlap = dashboardTiles.some(
+                                (tile) =>
+                                    currentFilterTileUuids.has(tile.uuid) &&
+                                    doesFilterApplyToTile(
+                                        dimensionFilterRule,
+                                        tile,
+                                        filterableFieldsByTileUuid,
+                                    ),
+                            );
+                            if (!hasOverlap) {
+                                return false;
+                            }
+                        }
+
+                        return true;
                     },
                 ),
             };
         },
-        [dashboardFilters],
+        [dashboardFilters, dashboardTiles, filterableFieldsByTileUuid],
     );
     return (
         <Context.Provider

--- a/packages/frontend/src/features/dashboardFiltersV2/index.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/index.tsx
@@ -35,6 +35,10 @@ const DashboardFiltersV2: FC<Props> = ({ isEditMode, activeTabUuid }) => {
     const addDimensionDashboardFilter = useDashboardContext(
         (c) => c.addDimensionDashboardFilter,
     );
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const filterableFieldsByTileUuid = useDashboardContext(
+        (c) => c.filterableFieldsByTileUuid,
+    );
 
     const handleSaveNew = useCallback(
         (
@@ -72,6 +76,8 @@ const DashboardFiltersV2: FC<Props> = ({ isEditMode, activeTabUuid }) => {
                 project.data?.warehouseConnection?.startOfWeek ?? undefined
             }
             dashboardFilters={allFilters}
+            dashboardTiles={dashboardTiles}
+            filterableFieldsByTileUuid={filterableFieldsByTileUuid}
         >
             <AddFilterButton
                 isEditMode={isEditMode}


### PR DESCRIPTION
### Description:
Improved dashboard filter behavior to respect tile boundaries. Filters now only apply to tiles that contain the filtered field, preventing cross-filtering between unrelated dashboard tabs. The implementation adds logic to check for tile overlap when determining which filters should be applied together, ensuring that filters on one tab don't affect visualizations on other tabs unless they share the same fields.