### PR TITLE
chore: update headless browser to chromium 2.38.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,8 @@ services:
             - db-data:/var/lib/postgresql/data
 
     headless-browser:
-        image: ghcr.io/browserless/chromium:v2.24.3
+        build:
+            dockerfile: docker/Dockerfile.headless-browser
         restart: always
         ports:
             - '3001:3000'

--- a/docker/Dockerfile.headless-browser
+++ b/docker/Dockerfile.headless-browser
@@ -1,1 +1,1 @@
-FROM ghcr.io/browserless/chromium:v2.24.3
+FROM ghcr.io/browserless/chromium:v2.38.2

--- a/docker/docker-compose.dev.mini.yml
+++ b/docker/docker-compose.dev.mini.yml
@@ -29,7 +29,8 @@ services:
             - postgres_data:/var/lib/postgresql/data
 
     headless-browser:
-        image: ghcr.io/browserless/chromium:v2.24.3
+        build:
+            dockerfile: Dockerfile.headless-browser
         restart: always
         ports:
             - '3001:3000'

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -167,7 +167,8 @@ services:
             - ./dev-configs/sshd_config:/config/sshd/sshd_config
 
     headless-browser:
-        image: ghcr.io/browserless/chromium:v2.24.3
+        build:
+            dockerfile: Dockerfile.headless-browser
         restart: always
         ports:
             - '3001:3000'

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -18,7 +18,8 @@ services:
             - '5432'
 
     headless-browser:
-        image: ghcr.io/browserless/chromium:v2.24.3
+        build:
+            dockerfile: Dockerfile.headless-browser
         restart: always
         ports:
             - '3000'


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19214

### Description:
After inspecting the headless-browser docker container I noticed that it was fairly outdated and therefore stuck with some older fonts (e.g. fonts-noto-color-emoji from September 2020).
I re-tested the issue with the most up-to-date version and the emoji started rendering:

<img width="1139" height="835" alt="image" src="https://github.com/user-attachments/assets/841986d8-6b31-4458-a203-66b0ee8e3fd0" />


P.S. I figured it's more convenient that the docker-compose files reference our own dockerfile that we already have in place, this way we only need to adjust the chromium version in 1 place.

