### PR TITLE
fix: cartesian chart not resizing after running query

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -134,14 +134,27 @@ const SimpleChart: FC<SimpleChartProps> = memo(
         }, [resultsData]);
 
         useEffect(() => {
-            const listener = () => {
-                const eCharts = chartRef.current?.getEchartsInstance();
-                eCharts?.resize();
+            const eCharts = chartRef.current?.getEchartsInstance();
+            const dom = eCharts?.getDom();
+
+            const resizeChart = () => eCharts?.resize();
+
+            // Observe container size changes (e.g., collapsible card expand/collapse)
+            const observer = new ResizeObserver(() => {
+                resizeChart();
+            });
+
+            if (dom) {
+                observer.observe(dom);
+            }
+
+            // Also listen for window resize events
+            window.addEventListener('resize', resizeChart);
+
+            return () => {
+                window.removeEventListener('resize', resizeChart);
+                observer.disconnect();
             };
-
-            window.addEventListener('resize', listener);
-
-            return () => window.removeEventListener('resize', listener);
         });
 
         const onChartContextMenu = useCallback(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-395/charts-can-be-cut-off-when-adjusting-config-in-the-explore

### Description:
Improved chart resizing by implementing ResizeObserver to detect container size changes. This enhancement allows charts to properly resize when their containers change dimensions (such as when expanding/collapsing a card), not just on window resize events.

The implementation:
- Uses ResizeObserver to watch the chart's DOM element (similar to `packages/frontend/src/components/SimpleGauge/index.tsx`)
- Maintains the existing window resize event listener as a fallback
- Properly cleans up both event listeners and observers on component unmount

This change ensures charts will render correctly in dynamic layouts where container sizes may change without window resizing.

**Before**

[Screen Recording 2026-01-07 at 15.23.46.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/34bcacd8-b9c2-4643-9f78-0c6afc1974c5.mov" />](https://app.graphite.com/user-attachments/video/34bcacd8-b9c2-4643-9f78-0c6afc1974c5.mov)

**After**

[after.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/30f963c6-1089-4831-bcc8-7c69c1a5ee20.mov" />](https://app.graphite.com/user-attachments/video/30f963c6-1089-4831-bcc8-7c69c1a5ee20.mov)

