### PR TITLE
fix: optimize dimension lookup with cached dimension maps

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -18,8 +18,7 @@ import {
     ForbiddenError,
     getCustomRangeSelectSql,
     getDateDimension,
-    getDimensions,
-    getFieldQuoteChar,
+    getDimensionMapFromTables,
     getFixedWidthBinSelectSql,
     getItemId,
     getMetrics,
@@ -33,34 +32,38 @@ import {
     SortField,
     SupportedDbtAdapter,
     UserAttributeValueMap,
-    WarehouseClient,
     WeekDay,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import { intersection, isArray } from 'lodash';
 import { hasUserAttribute } from '../../services/UserAttributesService/UserAttributeUtils';
 
-export const getDimensionFromId = (
-    dimId: FieldId,
-    explore: Explore,
-    adapterType: SupportedDbtAdapter,
-    startOfWeek: WeekDay | null | undefined,
-    checkUnfilteredTables: boolean = true,
-): CompiledDimension => {
-    const dimensions = getDimensions(explore);
-    const dimension = dimensions.find((d) => getItemId(d) === dimId);
+export const getDimensionFromId = ({
+    dimId,
+    dimensions,
+    dimensionsWithoutAccess,
+    adapterType,
+    startOfWeek,
+}: {
+    dimId: FieldId;
+    dimensions: Record<string, CompiledDimension>;
+    dimensionsWithoutAccess?: Record<string, CompiledDimension>;
+    adapterType: SupportedDbtAdapter;
+    startOfWeek: WeekDay | null | undefined;
+}): CompiledDimension => {
+    const dimension = dimensions[dimId];
 
     if (!dimension) {
         const { baseDimensionId, newTimeFrame } = getDateDimension(dimId);
 
         if (baseDimensionId) {
-            const baseField = getDimensionFromId(
-                baseDimensionId,
-                explore,
+            const baseField = getDimensionFromId({
+                dimId: baseDimensionId,
+                dimensions,
+                dimensionsWithoutAccess,
                 adapterType,
                 startOfWeek,
-                checkUnfilteredTables,
-            );
+            });
             if (baseField && newTimeFrame)
                 return {
                     ...baseField,
@@ -75,20 +78,9 @@ export const getDimensionFromId = (
                 };
         }
 
-        // At this point, we couldn't find the dimension with the given id in the explore
-        // it is possible that the explore is a joined table and is filtered by user_attributes
-        // So we check if the dimension exists in the unfiltered tables
-        if (
-            checkUnfilteredTables &&
-            explore.unfilteredTables &&
-            getDimensionFromId(
-                dimId,
-                { ...explore, tables: explore.unfilteredTables },
-                adapterType,
-                startOfWeek,
-                false,
-            )
-        ) {
+        // At this point, we couldn't find the dimension with the given id
+        // it is possible that the it references a dimension that the user doesn't have access to
+        if (dimensionsWithoutAccess && dimensionsWithoutAccess[dimId]) {
             throw new AuthorizationError(
                 "You don't have authorization to access this explore",
             );
@@ -100,25 +92,34 @@ export const getDimensionFromId = (
     return dimension;
 };
 
-export const getDimensionFromFilterTargetId = (
-    filterTargetId: FieldId,
-    explore: Explore,
-    compiledCustomDimensions: CompiledCustomSqlDimension[],
-    adapterType: SupportedDbtAdapter,
-    startOfWeek: WeekDay | null | undefined,
-): CompiledDimension | CompiledCustomSqlDimension => {
+export const getDimensionFromFilterTargetId = ({
+    filterTargetId,
+    dimensions,
+    dimensionsWithoutAccess,
+    compiledCustomDimensions,
+    adapterType,
+    startOfWeek,
+}: {
+    filterTargetId: FieldId;
+    dimensions: Record<string, CompiledDimension>;
+    dimensionsWithoutAccess?: Record<string, CompiledDimension>;
+    compiledCustomDimensions: CompiledCustomSqlDimension[];
+    adapterType: SupportedDbtAdapter;
+    startOfWeek: WeekDay | null | undefined;
+}): CompiledDimension | CompiledCustomSqlDimension => {
     const dim = compiledCustomDimensions.find(
         (cd) => getItemId(cd) === filterTargetId,
     );
     if (dim && isCompiledCustomSqlDimension(dim)) {
         return dim;
     }
-    return getDimensionFromId(
-        filterTargetId,
-        explore,
+    return getDimensionFromId({
+        dimId: filterTargetId,
+        dimensions,
+        dimensionsWithoutAccess,
         adapterType,
         startOfWeek,
-    );
+    });
 };
 
 export const getMetricFromId = (
@@ -603,6 +604,10 @@ export const getCustomBinDimensionSql = ({
 
     const adapterType: SupportedDbtAdapter =
         warehouseSqlBuilder.getAdapterType();
+    const dimensions = getDimensionMapFromTables(explore.tables);
+    const dimensionsWithoutAccess = getDimensionMapFromTables(
+        explore.unfilteredTables ?? {},
+    );
     const ctes = customDimensions.reduce<string[]>((acc, customDimension) => {
         switch (customDimension.binType) {
             case BinType.FIXED_WIDTH:
@@ -610,12 +615,13 @@ export const getCustomBinDimensionSql = ({
                 // No need for cte
                 return acc;
             case BinType.FIXED_NUMBER:
-                const dimension = getDimensionFromId(
-                    customDimension.dimensionId,
-                    explore,
+                const dimension = getDimensionFromId({
+                    dimId: customDimension.dimensionId,
+                    dimensions,
+                    dimensionsWithoutAccess,
                     adapterType,
                     startOfWeek,
-                );
+                });
                 const baseTable = replaceUserAttributesRaw(
                     explore.tables[customDimension.table].sqlTable,
                     intrinsicUserAttributes,
@@ -667,12 +673,13 @@ export const getCustomBinDimensionSql = ({
     const selects: Record<string, string> = {};
 
     customDimensions.forEach((customDimension) => {
-        const dimension = getDimensionFromId(
-            customDimension.dimensionId,
-            explore,
+        const dimension = getDimensionFromId({
+            dimId: customDimension.dimensionId,
+            dimensions,
+            dimensionsWithoutAccess,
             adapterType,
             startOfWeek,
-        );
+        });
         // Check required attribute permission for parent dimension
         assertValidDimensionRequiredAttribute(
             dimension,

--- a/packages/common/src/utils/fields.ts
+++ b/packages/common/src/utils/fields.ts
@@ -60,8 +60,24 @@ const getTablesWithValidParameters = (
 };
 
 // Helper function to get a list of all dimensions in an explore
+/**
+ * @deprecated Use `getDimensionMapFromTables` instead
+ */
 export const getDimensions = (explore: Explore): CompiledDimension[] =>
     Object.values(explore.tables).flatMap((t) => Object.values(t.dimensions));
+
+export const getDimensionMapFromTables = (
+    tables: Explore['tables'],
+): Record<string, CompiledDimension> =>
+    Object.values(tables).reduce<Record<string, CompiledDimension>>(
+        (acc, table) => {
+            Object.values(table.dimensions).forEach((dimension) => {
+                acc[getItemId(dimension)] = dimension;
+            });
+            return acc;
+        },
+        {},
+    );
 
 export const getDimensionsWithValidParameters = (
     explore: Explore,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2317

### Description:

Refactored dimension lookup in MetricQueryBuilder to improve performance by using a map instead of iterating through all dimensions. Added a new utility function `getDimensionMapFromTables` that creates a record of dimensions indexed by their IDs, and updated the `getDimensionFromId` and `getDimensionFromFilterTargetId` functions to accept object parameters with the dimension maps. This change reduces the need to repeatedly scan all dimensions when building queries.

Before:

```
packages/backend dev: [compileQuery] getFieldsFromMetricQuery { sectionTimeMs: 2 }
packages/backend dev: [compileQuery] getDimensionsSQL + getMetricsSQL { sectionTimeMs: 303 }
packages/backend dev: [compileQuery] getJoinsSQL { sectionTimeMs: 1 }
packages/backend dev: [compileQuery] basic SQL parts assembly { sectionTimeMs: 0 }
packages/backend dev: [compileQuery] getExperimentalMetricsCteSQL { sectionTimeMs: 1 }
packages/backend dev: [compileQuery] table calculations preparation { sectionTimeMs: 0 }
packages/backend dev: [compileQuery] final query assembly { sectionTimeMs: 0 }
packages/backend dev: [compileQuery] parameter replacement { sectionTimeMs: 0 }
packages/backend dev: [executeAsyncUnderlyingDataQuery] Metric query prepared {
packages/backend dev:   sectionTimeMs: 325,
packages/backend dev:   sqlLength: 51765,
packages/backend dev:   fieldsCount: 1029,
packages/backend dev:   warningsCount: 20,
packages/backend dev:   parameterReferencesCount: 0
packages/backend dev: }
```

After: **303ms -> 28ms** :rocket:

```
packages/backend dev: [compileQuery] getDimensionsSQL + getMetricsSQL { sectionTimeMs: 28 }
packages/backend dev: [compileQuery] getJoinsSQL { sectionTimeMs: 0 }
packages/backend dev: [compileQuery] basic SQL parts assembly { sectionTimeMs: 1 }
packages/backend dev: [compileQuery] getExperimentalMetricsCteSQL { sectionTimeMs: 0 }
packages/backend dev: [compileQuery] table calculations preparation { sectionTimeMs: 0 }
packages/backend dev: [compileQuery] final query assembly { sectionTimeMs: 0 }
packages/backend dev: [compileQuery] parameter replacement { sectionTimeMs: 0 }
packages/backend dev: [executeAsyncUnderlyingDataQuery] Metric query prepared {
packages/backend dev:   sectionTimeMs: 117,
packages/backend dev:   sqlLength: 52781,
packages/backend dev:   fieldsCount: 1050,
packages/backend dev:   warningsCount: 20,
packages/backend dev:   parameterReferencesCount: 0
packages/backend dev: }
```