### PR TITLE
style: truncate multiselect when charts are long when adding tiles to dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -274,6 +274,7 @@ const AddChartTilesModal: FC<Props> = ({ onAddTiles, onClose }) => {
                             paddingBottom: 4,
                         },
                     })}
+                    maw={550}
                     id="saved-charts"
                     label={`Select the charts you want to add to this dashboard`}
                     data={allSavedCharts}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Added a maximum width constraint (`maw={550}`) to the chart selection dropdown in the AddChartTilesModal component to improve the UI layout and prevent the dropdown from stretching too wide.