### PR TITLE
chore: remove unused CronInput component and clean up form context exports

### DIFF
--- a/packages/frontend/src/components/ReactHookForm/CronInput/index.tsx
+++ b/packages/frontend/src/components/ReactHookForm/CronInput/index.tsx
@@ -1,4 +1,3 @@
-import { type AnyType } from '@lightdash/common';
 import { Group } from '@mantine/core';
 import {
     useCallback,
@@ -7,12 +6,7 @@ import {
     type FC,
     type PropsWithChildren,
 } from 'react';
-import {
-    Controller,
-    useFormContext,
-    type ControllerRenderProps,
-    type FieldValues,
-} from 'react-hook-form';
+import { type ControllerRenderProps, type FieldValues } from 'react-hook-form';
 import CustomInputs from './CustomInputs';
 import DailyInputs from './DailyInputs';
 import FrequencySelect from './FrequencySelect';
@@ -90,32 +84,3 @@ export const CronInternalInputs: FC<
         </Group>
     );
 };
-
-const CronInput: FC<{
-    disabled?: boolean;
-    rules?: React.ComponentProps<typeof Controller>['rules'];
-    name: string;
-    defaultValue?: AnyType;
-}> = ({ name, rules, defaultValue, disabled }) => {
-    const {
-        control,
-        formState: { errors },
-    } = useFormContext();
-    return (
-        <Controller
-            control={control}
-            name={name}
-            rules={rules}
-            defaultValue={defaultValue}
-            render={({ field }) => (
-                <CronInternalInputs
-                    disabled={disabled}
-                    {...field}
-                    errors={errors}
-                />
-            )}
-        />
-    );
-};
-
-export default CronInput;

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -49,11 +49,10 @@ export interface SchedulerFormValues {
     notificationFrequency?: NotificationFrequency;
 }
 
-export const [
-    SchedulerFormProvider,
-    useSchedulerFormContext,
-    useSchedulerForm,
-] = createFormContext<SchedulerFormValues>();
+const [SchedulerFormProvider, useSchedulerFormContext, useSchedulerForm] =
+    createFormContext<SchedulerFormValues>();
+
+export { SchedulerFormProvider, useSchedulerForm, useSchedulerFormContext };
 
 export const DEFAULT_VALUES: SchedulerFormValues = {
     name: '',
@@ -125,8 +124,8 @@ export const getFormValuesFromScheduler = (
             options.limit === Limit.TABLE
                 ? Limit.TABLE
                 : options.limit === Limit.ALL
-                ? Limit.ALL
-                : Limit.CUSTOM;
+                  ? Limit.ALL
+                  : Limit.CUSTOM;
         if (formOptions.limit === Limit.CUSTOM) {
             formOptions.customLimit = options.limit as number;
         }

--- a/packages/frontend/src/features/sync/components/syncModalFormContext.ts
+++ b/packages/frontend/src/features/sync/components/syncModalFormContext.ts
@@ -14,11 +14,10 @@ export interface SyncModalFormValues {
     saveInNewTab: boolean;
 }
 
-export const [
-    SyncModalFormProvider,
-    useSyncModalFormContext,
-    useSyncModalForm,
-] = createFormContext<SyncModalFormValues>();
+const [SyncModalFormProvider, useSyncModalFormContext, useSyncModalForm] =
+    createFormContext<SyncModalFormValues>();
+
+export { SyncModalFormProvider, useSyncModalForm, useSyncModalFormContext };
 
 export const DEFAULT_VALUES: SyncModalFormValues = {
     name: '',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Refactored form context implementations to improve code organization and reduce unnecessary imports:

1. Removed the unused `CronInput` component from `CronInput/index.tsx`, keeping only the `CronInternalInputs` component.
2. Cleaned up imports by removing unused dependencies like `@lightdash/common` and React Hook Form components.
3. Standardized the export pattern in form context files by first declaring the context variables and then exporting them individually, improving readability in both `schedulerFormContext.ts` and `syncModalFormContext.ts`.