### PR TITLE
fix: move metric lookup to class instance for better encapsulation

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -6,7 +6,6 @@ import {
     CompiledDimension,
     CompiledExploreJoin,
     CompiledMetric,
-    CompiledMetricQuery,
     CompiledTable,
     CustomBinDimension,
     CustomDimension,
@@ -21,7 +20,6 @@ import {
     getDimensionMapFromTables,
     getFixedWidthBinSelectSql,
     getItemId,
-    getMetrics,
     getSqlForTruncatedDate,
     IntrinsicUserAttributes,
     isCompiledCustomSqlDimension,
@@ -120,23 +118,6 @@ export const getDimensionFromFilterTargetId = ({
         adapterType,
         startOfWeek,
     });
-};
-
-export const getMetricFromId = (
-    metricId: FieldId,
-    explore: Explore,
-    compiledMetricQuery: CompiledMetricQuery,
-) => {
-    const metrics = [
-        ...getMetrics(explore),
-        ...(compiledMetricQuery.compiledAdditionalMetrics || []),
-    ];
-    const metric = metrics.find((m) => getItemId(m) === metricId);
-    if (metric === undefined)
-        throw new FieldReferenceError(
-            `Tried to reference metric with unknown field id: ${metricId}`,
-        );
-    return metric;
 };
 
 const getWrapChars = (wrapChar: string): [string, string] => {

--- a/packages/common/src/utils/fields.ts
+++ b/packages/common/src/utils/fields.ts
@@ -92,8 +92,22 @@ export const getDimensionsWithValidParameters = (
     );
 
 // Helper function to get a list of all metrics in an explore
+// @deprecated Use `getMetricsMapFromTables` instead
 export const getMetrics = (explore: Explore): CompiledMetric[] =>
     Object.values(explore.tables).flatMap((t) => Object.values(t.metrics));
+
+export const getMetricsMapFromTables = (
+    tables: Explore['tables'],
+): Record<string, CompiledMetric> =>
+    Object.values(tables).reduce<Record<string, CompiledMetric>>(
+        (acc, table) => {
+            Object.values(table.metrics).forEach((metric) => {
+                acc[getItemId(metric)] = metric;
+            });
+            return acc;
+        },
+        {},
+    );
 
 export const getMetricsWithValidParameters = (
     explore: Explore,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2350

### Description:
Refactored the `MetricQueryBuilder` class to store available metrics in an instance property rather than fetching them repeatedly. This change:

1. Added a new `availableMetrics` property to the `MetricQueryBuilder` class that combines metrics from the Explore and custom metrics from the metric query
2. Moved the `getMetricFromId` function from utils.ts into the `MetricQueryBuilder` class as an instance method
3. Updated all references to the old utility function to use the new instance method
4. Added a new `getMetricsMapFromTables` utility function in common/src/utils/fields.ts and marked the existing `getMetrics` function as deprecated

This refactoring improves code organization and reduces redundant metric lookups throughout the query building process.

Before:
```
packages/backend dev: [executeAsyncUnderlyingDataQuery] Metric query prepared {
packages/backend dev:   sectionTimeMs: 1377,
packages/backend dev:   sqlLength: 62279,
packages/backend dev:   fieldsCount: 1050,
packages/backend dev:   warningsCount: 1020,
packages/backend dev:   parameterReferencesCount: 0
packages/backend dev: }
```

After: **1277ms -> 24ms** 🚀 
```
packages/backend dev: [executeAsyncUnderlyingDataQuery] Metric query prepared {
packages/backend dev:   sectionTimeMs: 34,
packages/backend dev:   sqlLength: 62279,
packages/backend dev:   fieldsCount: 1050,
packages/backend dev:   warningsCount: 1020,
packages/backend dev:   parameterReferencesCount: 0
packages/backend dev: }
```