### PR TITLE
fix: limit available dimensions to 50 when no explicit column list exists

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2695,7 +2695,8 @@ export class AsyncQueryService extends ProjectService {
             dimension: CustomDimension | CompiledDimension,
         ) => !isCustomDimension(dimension) && !dimension.hidden;
 
-        const availableDimensions = allDimensions.filter((dimension, index) => {
+        let validDimensionsCount = 0;
+        const availableDimensions = allDimensions.filter((dimension) => {
             const isValid =
                 availableTables.has(dimension.table) &&
                 (isValidNonCustomDimension(dimension) ||
@@ -2707,8 +2708,13 @@ export class AsyncQueryService extends ProjectService {
                 itemShowUnderlyingValues.includes(dimension.name) &&
                 itemShowUnderlyingTable === dimension.table;
             if (isValid) {
+                if (hasExplicitColumnList) {
+                    return isInExplicitColumnList;
+                }
+
+                validDimensionsCount += 1;
                 // If there is no explicit column list, we can show up to 50 dimensions
-                return hasExplicitColumnList ? isInExplicitColumnList : index <= 50;
+                return validDimensionsCount <= 50;
             }
             return false;
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2351

### Description:
Limits the number of dimensions shown in the UI to 50 when there is no explicit column list. Previously, all dimensions would be shown, which could lead to performance issues or overwhelming UI when dealing with tables that have a large number of dimensions.

This change only affects the filtering of available dimensions when no explicit column list is provided, ensuring a more manageable user experience while still allowing all dimensions to be shown when explicitly requested.

