### PR TITLE
feat: track DASHBOARD_UI_VERSION_TOGGLED event

### DIFF
--- a/packages/frontend/src/hooks/dashboard/useDashboardUIPreference.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardUIPreference.ts
@@ -1,5 +1,10 @@
 import { FeatureFlags } from '@lightdash/common';
 import { useLocalStorage } from '@mantine-8/hooks';
+import { useCallback } from 'react';
+import { useParams } from 'react-router';
+import useApp from '../../providers/App/useApp';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
 import { useFeatureFlagEnabled } from '../useFeatureFlagEnabled';
 
 export type DashboardUIVersion = 'v1' | 'v2';
@@ -15,6 +20,10 @@ const STORAGE_KEY = 'lightdash-dashboard-ui-version';
  * If the feature flag is disabled, users can opt-in to v2 via localStorage preference.
  */
 export const useDashboardUIPreference = () => {
+    const { track } = useTracking();
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { user } = useApp();
+
     const [preference, setPreference] = useLocalStorage<DashboardUIVersion>({
         key: STORAGE_KEY,
         defaultValue: 'v1',
@@ -24,6 +33,28 @@ export const useDashboardUIPreference = () => {
         FeatureFlags.DashboardRedesign,
     );
 
+    const handleSetPreference = useCallback(
+        (value: DashboardUIVersion) => {
+            setPreference(value);
+            track({
+                name: EventName.DASHBOARD_UI_VERSION_TOGGLED,
+                properties: {
+                    to: value,
+                    organizationId: user.data?.organizationUuid,
+                    projectId: projectUuid,
+                    userId: user.data?.userUuid,
+                },
+            });
+        },
+        [
+            projectUuid,
+            setPreference,
+            track,
+            user.data?.organizationUuid,
+            user.data?.userUuid,
+        ],
+    );
+
     // If feature flag is ON, force v2. Otherwise, use user preference.
     const isDashboardRedesignEnabled =
         isDashboardRedesignFlagEnabled || preference === 'v2';
@@ -31,6 +62,6 @@ export const useDashboardUIPreference = () => {
     return {
         isDashboardRedesignEnabled,
         isDashboardRedesignFlagEnabled,
-        setPreference,
+        setPreference: handleSetPreference,
     };
 };

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -458,6 +458,16 @@ type ThemeToggledEvent = {
     };
 };
 
+type DashboardUiVersionToggledEvent = {
+    name: EventName.DASHBOARD_UI_VERSION_TOGGLED;
+    properties: {
+        to: string;
+        organizationId: string | undefined;
+        projectId: string | undefined;
+        userId: string | undefined;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | FormClickedEvent
@@ -496,7 +506,8 @@ export type EventData =
     | AiAgentChartHowItsCalculatedClickedEvent
     | AiAgentChartCreatedEvent
     | AiAgentChartExploredEvent
-    | ThemeToggledEvent;
+    | ThemeToggledEvent
+    | DashboardUiVersionToggledEvent;
 
 export type IdentifyData = {
     id: string;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -163,4 +163,7 @@ export enum EventName {
 
     // Theme
     THEME_TOGGLED = 'theme.toggled',
+
+    // Dashboard UI Version Toggle
+    DASHBOARD_UI_VERSION_TOGGLED = 'dashboard_ui_version.toggled',
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-189](https://linear.app/lightdash/issue/ZAP-189/track-in-analytics-how-many-people-are-switching-to-v2-dashboards)

### Description:
Added tracking for dashboard UI version toggle. When users switch between dashboard UI versions (v1/v2), we now track this event with relevant user and project information.

The implementation:
- Created a new event type `DASHBOARD_UI_VERSION_TOGGLED` in the Events enum
- Added corresponding event type definition in the tracking provider
- Enhanced `useDashboardUIPreference` hook with tracking functionality that captures which version the user switched to, along with organization, project, and user IDs

![Screenshot 2026-01-08 at 10.19.44.png](https://app.graphite.com/user-attachments/assets/7bdb0964-e7e3-41c8-81e4-56a2a391e782.png)

