### PR TITLE
style: make inactive badge lighter

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -184,15 +184,13 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
                                             : user.email}
                                     </Text>
                                     <Badge
-                                        variant="filled"
-                                        color="red.4"
+                                        variant="light"
+                                        color="red"
                                         radius="xs"
                                         style={{ textTransform: 'none' }}
                                         px="xxs"
                                     >
-                                        <Text fz="xs" fw={400} c="ldGray.8">
-                                            Inactive
-                                        </Text>
+                                        Inactive
                                     </Badge>
                                 </Stack>
                             ) : user.isPending ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:

Updated the styling of the "Inactive" badge in the UsersTable component to use a light variant with red color instead of a filled variant with red.4 color. Also simplified the badge by removing the nested Text component.

**before**

![Screenshot 2026-01-08 at 10.24.09.png](https://app.graphite.com/user-attachments/assets/be381bd2-9b57-4d36-bc7c-7eed4cce5821.png)

**after**

![Screenshot 2026-01-08 at 10.23.48.png](https://app.graphite.com/user-attachments/assets/ebdb1e80-4f52-4c2e-8cee-441d9574a777.png)

![Screenshot 2026-01-08 at 10.23.53.png](https://app.graphite.com/user-attachments/assets/ef167396-3619-4f18-958e-0a15f82b70d7.png)

