### PR TITLE
fix: use null coalescing check for useSqlPivotResults feature flag

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -560,3 +560,16 @@ describe('parseAndSanitizeSchedulerTasks', () => {
         });
     });
 });
+
+test('should set useSqlPivotResults only when the environment variable is set', () => {
+    const undefinedConfig = parseConfig();
+    expect(undefinedConfig.query.useSqlPivotResults).toBeUndefined();
+
+    process.env.USE_SQL_PIVOT_RESULTS = 'true';
+    const trueConfig = parseConfig();
+    expect(trueConfig.query.useSqlPivotResults).toBe(true);
+
+    process.env.USE_SQL_PIVOT_RESULTS = 'false';
+    const falseConfig = parseConfig();
+    expect(falseConfig.query.useSqlPivotResults).toBe(false);
+});

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -820,7 +820,7 @@ export type LightdashConfig = {
         csvCellsLimit: number;
         timezone: string | undefined;
         maxPageSize: number;
-        useSqlPivotResults: boolean;
+        useSqlPivotResults: boolean | undefined;
     };
     pivotTable: {
         maxColumnLimit: number;
@@ -1530,7 +1530,9 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'LIGHTDASH_QUERY_MAX_PAGE_SIZE',
                 ) || 2500, // Defaults to default limit * 5
-            useSqlPivotResults: process.env.USE_SQL_PIVOT_RESULTS === 'true',
+            useSqlPivotResults: process.env.USE_SQL_PIVOT_RESULTS
+                ? process.env.USE_SQL_PIVOT_RESULTS === 'true'
+                : undefined,
         },
         chart: {
             versionHistory: {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -108,7 +108,7 @@ export class FeatureFlagModel {
         featureFlagId,
     }: FeatureFlagLogicArgs) {
         const enabled =
-            this.lightdashConfig.query.useSqlPivotResults ||
+            this.lightdashConfig.query.useSqlPivotResults ??
             (user
                 ? await isFeatureFlagEnabled(
                       FeatureFlags.UseSqlPivotResults,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Makes `useSqlPivotResults` config property optional by:
- Changing the type from `boolean` to `boolean | undefined` in the `LightdashConfig` type
- Updating the config parsing to set the value to `undefined` when the environment variable is not set
- Modifying the feature flag logic to use the nullish coalescing operator (`??`) instead of logical OR (`||`) to properly handle the undefined case

This fixes an issue where we were always falling back to posthog for the pivot sql flag when it was `false`

test-frontend
test-backend