### PR TITLE
fix: useTracking hook throws error in scheduled deliveries

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -27,7 +27,7 @@ const UrlMenuItem: FC<{
     row: Record<string, Record<string, ResultValue>>;
     showError?: boolean;
 }> = ({ urlConfig, itemsMap, itemIdsInRow, value, row, showError = true }) => {
-    const tracking = useTracking(true);
+    const tracking = useTracking({ failSilently: true });
     const [url, renderError] = useMemo(() => {
         let parsedUrl: string | undefined = undefined;
         let errorMessage: string | undefined = undefined;

--- a/packages/frontend/src/components/FunnelChart/FunnelChartContextMenu.tsx
+++ b/packages/frontend/src/components/FunnelChart/FunnelChartContextMenu.tsx
@@ -43,7 +43,7 @@ const FunnelChartContextMenu: FC<FunnelChartContextMenuProps> = ({
 
     const { showToastSuccess } = useToaster();
     const clipboard = useClipboard({ timeout: 200 });
-    const tracking = useTracking(true);
+    const tracking = useTracking({ failSilently: true });
     const metricQueryData = useMetricQueryDataContext(true);
 
     if (!value || !tracking || !metricQueryData || !project) {

--- a/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
+++ b/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
@@ -50,7 +50,7 @@ const PieChartContextMenu: FC<PieChartContextMenuProps> = ({
 
     const { showToastSuccess } = useToaster();
     const clipboard = useClipboard({ timeout: 200 });
-    const tracking = useTracking(true);
+    const tracking = useTracking({ failSilently: true });
     const metricQueryData = useMetricQueryDataContext(true);
     const { itemsMap } = useVisualizationContext();
 

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -44,7 +44,7 @@ const ValueCellMenu: FC<React.PropsWithChildren<ValueCellMenuProps>> = ({
     onCopy,
 }) => {
     const { user } = useApp();
-    const tracking = useTracking(true);
+    const tracking = useTracking({ failSilently: true });
     const metricQueryData = useMetricQueryDataContext(true);
 
     // FIXME: get rid of this from here

--- a/packages/frontend/src/hooks/dashboard/useDashboardUIPreference.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardUIPreference.ts
@@ -20,7 +20,7 @@ const STORAGE_KEY = 'lightdash-dashboard-ui-version';
  * If the feature flag is disabled, users can opt-in to v2 via localStorage preference.
  */
 export const useDashboardUIPreference = () => {
-    const { track } = useTracking();
+    const tracking = useTracking({ failSilently: true });
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { user } = useApp();
 
@@ -36,7 +36,7 @@ export const useDashboardUIPreference = () => {
     const handleSetPreference = useCallback(
         (value: DashboardUIVersion) => {
             setPreference(value);
-            track({
+            tracking?.track({
                 name: EventName.DASHBOARD_UI_VERSION_TOGGLED,
                 properties: {
                     to: value,
@@ -49,7 +49,7 @@ export const useDashboardUIPreference = () => {
         [
             projectUuid,
             setPreference,
-            track,
+            tracking,
             user.data?.organizationUuid,
             user.data?.userUuid,
         ],

--- a/packages/frontend/src/providers/Tracking/useTracking.ts
+++ b/packages/frontend/src/providers/Tracking/useTracking.ts
@@ -2,9 +2,13 @@ import { useContext } from 'react';
 import TrackingContext from './context';
 import { type TrackingContextType } from './types';
 
-function useTracking<S extends boolean = false>(
-    failSilently?: S,
-): S extends false ? TrackingContextType : TrackingContextType | undefined {
+function useTracking<S extends boolean = false>({
+    failSilently,
+}: {
+    failSilently?: S;
+} = {}): S extends false
+    ? TrackingContextType
+    : TrackingContextType | undefined {
     const context = useContext(TrackingContext);
 
     if (context === undefined && failSilently !== true) {


### PR DESCRIPTION


### Description:
Updated the `useTracking` hook to accept an options object with `failSilently` parameter instead of a direct boolean parameter. This change improves the API consistency and readability across the codebase.

The PR updates all existing calls to `useTracking(true)` to use the new object parameter syntax `useTracking({ failSilently: true })` in various components including UrlMenuItem, FunnelChartContextMenu, PieChartContextMenu, ValueCellMenu, and useDashboardUIPreference.