### PR TITLE
feat: add expiration time to support file uploads

### DIFF
--- a/packages/backend/src/clients/Aws/S3Client.ts
+++ b/packages/backend/src/clients/Aws/S3Client.ts
@@ -116,14 +116,32 @@ export class S3Client extends S3BaseClient {
         return { fileName, url };
     }
 
-    async uploadTxt(txt: Buffer, id: string): Promise<string> {
-        return this.uploadFile(`${id}.txt`, txt, { contentType: 'text/plain' });
+    async uploadTxt(
+        txt: Buffer,
+        id: string,
+        expiresIn?: number,
+    ): Promise<string> {
+        return this.uploadFile(
+            `${id}.txt`,
+            txt,
+            { contentType: 'text/plain' },
+            expiresIn ? { expiresIn } : undefined,
+        );
     }
 
-    async uploadImage(image: Buffer, imageId: string): Promise<string> {
-        return this.uploadFile(`${imageId}.png`, image, {
-            contentType: 'image/png',
-        });
+    async uploadImage(
+        image: Buffer,
+        imageId: string,
+        expiresIn?: number,
+    ): Promise<string> {
+        return this.uploadFile(
+            `${imageId}.png`,
+            image,
+            {
+                contentType: 'image/png',
+            },
+            expiresIn ? { expiresIn } : undefined,
+        );
     }
 
     async uploadCsv(

--- a/packages/backend/src/ee/services/SupportService/SupportService.ts
+++ b/packages/backend/src/ee/services/SupportService/SupportService.ts
@@ -20,6 +20,8 @@ import { BaseService } from '../../../services/BaseService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
 import { UnfurlService } from '../../../services/UnfurlService/UnfurlService';
 
+const SUPPORT_FILE_EXPIRATION_TIME = 604800; // 7 days in seconds
+
 type SupportServiceArguments = {
     dashboardModel: DashboardModel;
     savedChartModel: SavedChartModel;
@@ -89,6 +91,7 @@ export class SupportService extends BaseService {
                 return await this.s3Client.uploadTxt(
                     networkBuffer,
                     `support-${name}-${nanoid()}`,
+                    SUPPORT_FILE_EXPIRATION_TIME,
                 );
             }
         } catch (error) {
@@ -112,6 +115,7 @@ export class SupportService extends BaseService {
         const chartconfigS3Url = await this.s3Client.uploadTxt(
             chartkBuffer,
             `support-chartconfig-${nanoid()}`,
+            SUPPORT_FILE_EXPIRATION_TIME,
         );
 
         const query = await this.projectService.compileQuery({
@@ -124,6 +128,7 @@ export class SupportService extends BaseService {
         const sqlS3Url = await this.s3Client.uploadTxt(
             queryBuffer,
             `support-sql-${nanoid()}`,
+            SUPPORT_FILE_EXPIRATION_TIME,
         );
         return {
             type: 'section',
@@ -182,6 +187,7 @@ export class SupportService extends BaseService {
             imageUrl = await this.s3Client.uploadImage(
                 buffer,
                 `support-screenshot-${nanoid()}`,
+                SUPPORT_FILE_EXPIRATION_TIME,
             );
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Added file expiration for support files uploaded to S3. Support files (text files, images, SQL queries, chart configurations) now expire after 7 days, preventing unnecessary storage of temporary support files.

The PR updates the `uploadTxt` and `uploadImage` methods in the S3Client to accept an optional `expiresIn` parameter, and modifies the SupportService to use this parameter with a 7-day expiration time constant.