### PR TITLE
fix: handle file deletion errors gracefully in CSV and pivot table services

### DIFF
--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -271,7 +271,13 @@ export class PivotTableService extends BaseService {
 
             // Delete local file in 10 minutes, we could still read from the local file to upload to google sheets
             setTimeout(async () => {
-                await fsPromise.unlink(filePath);
+                try {
+                    await fsPromise.unlink(filePath);
+                } catch (error) {
+                    this.logger.warning(
+                        `Error deleting local file ${filePath}: ${error}`,
+                    );
+                }
             }, 60 * 10 * 1000);
 
             return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2262

### Description:

Added error handling when deleting local files in CsvService and PivotTableService. Now if a file deletion fails, the error is logged as a warning instead of causing an unhandled exception. This improves robustness when temporary files cannot be deleted for any reason.