### PR TITLE
feat: allow changing date/timestamp dimensions' formatting in results table

### DIFF
--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -180,6 +180,7 @@ export class ExploreController extends BaseController {
             additionalMetrics: body.additionalMetrics,
             customDimensions: body.customDimensions,
             metricOverrides: body.metricOverrides,
+            dimensionOverrides: body.dimensionOverrides,
         };
 
         const { jobId } = await req.services

--- a/packages/backend/src/controllers/runQueryController.ts
+++ b/packages/backend/src/controllers/runQueryController.ts
@@ -166,6 +166,7 @@ export class RunViewChartQueryController extends BaseController {
             customDimensions: body.customDimensions,
             timezone: body.timezone,
             metricOverrides: body.metricOverrides,
+            dimensionOverrides: body.dimensionOverrides,
         };
         const results: ApiQueryResults = await this.services
             .getProjectService()

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -153,6 +153,7 @@ export class QueryController extends BaseController {
             customDimensions: body.query.customDimensions,
             timezone: body.query.timezone,
             metricOverrides: body.query.metricOverrides,
+            dimensionOverrides: body.query.dimensionOverrides,
             periodOverPeriod: body.query.periodOverPeriod,
         };
 

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -7,6 +7,7 @@ import {
     CompactOrAlias,
     CustomFormat,
     DBFieldTypes,
+    DimensionOverrides,
     DimensionType,
     MetricFilterRule,
     MetricOverrides,
@@ -90,6 +91,7 @@ export type DbSavedChartVersion = {
     filters: AnyType;
     row_limit: number;
     metric_overrides: MetricOverrides | null; // JSONB
+    dimension_overrides: DimensionOverrides | null; // JSONB
     chart_type: ChartType;
     saved_query_id: number;
     chart_config: ChartConfig['config'] | null;
@@ -112,6 +114,7 @@ export type CreateDbSavedChartVersion = Pick<
     | 'filters'
     | 'row_limit'
     | 'metric_overrides'
+    | 'dimension_overrides'
     | 'chart_type'
     | 'pivot_dimensions'
     | 'chart_config'

--- a/packages/backend/src/database/migrations/20260108110951_add_dimension_overrides_column_to_saved_queries_versions.ts
+++ b/packages/backend/src/database/migrations/20260108110951_add_dimension_overrides_column_to_saved_queries_versions.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+const SavedQueriesVersionsTableName = 'saved_queries_versions';
+const DimensionOverridesColumnName = 'dimension_overrides';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SavedQueriesVersionsTableName, (table) => {
+        table.jsonb(DimensionOverridesColumnName).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SavedQueriesVersionsTableName, (table) => {
+        table.dropColumn(DimensionOverridesColumnName);
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2242,48 +2242,31 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    FieldType: {
+    CustomFormatType: {
         dataType: 'refEnum',
-        enums: ['metric', 'dimension'],
+        enums: [
+            'default',
+            'percent',
+            'currency',
+            'number',
+            'id',
+            'date',
+            'timestamp',
+            'bytes_si',
+            'bytes_iec',
+            'custom',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SourcePosition: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                character: { dataType: 'double', required: true },
-                line: { dataType: 'double', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    Source: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                content: { dataType: 'string', required: true },
-                highlight: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        end: { ref: 'SourcePosition', required: true },
-                        start: { ref: 'SourcePosition', required: true },
-                    },
-                },
-                range: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        end: { ref: 'SourcePosition', required: true },
-                        start: { ref: 'SourcePosition', required: true },
-                    },
-                    required: true,
-                },
-                path: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
+    NumberSeparator: {
+        dataType: 'refEnum',
+        enums: [
+            'default',
+            'commaPeriod',
+            'spacePeriod',
+            'periodComma',
+            'noSeparatorPeriod',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Compact: {
@@ -2346,6 +2329,87 @@ const models: TsoaRoute.Models = {
                     ],
                 },
             ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CustomFormat: {
+        dataType: 'refObject',
+        properties: {
+            type: { ref: 'CustomFormatType', required: true },
+            round: {
+                dataType: 'union',
+                subSchemas: [{ dataType: 'double' }, { dataType: 'undefined' }],
+            },
+            separator: { ref: 'NumberSeparator' },
+            currency: {
+                dataType: 'union',
+                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
+            },
+            compact: {
+                dataType: 'union',
+                subSchemas: [
+                    { ref: 'CompactOrAlias' },
+                    { dataType: 'undefined' },
+                ],
+            },
+            prefix: {
+                dataType: 'union',
+                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
+            },
+            suffix: {
+                dataType: 'union',
+                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
+            },
+            timeInterval: { ref: 'TimeFrames' },
+            custom: {
+                dataType: 'union',
+                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FieldType: {
+        dataType: 'refEnum',
+        enums: ['metric', 'dimension'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SourcePosition: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                character: { dataType: 'double', required: true },
+                line: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Source: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                content: { dataType: 'string', required: true },
+                highlight: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        end: { ref: 'SourcePosition', required: true },
+                        start: { ref: 'SourcePosition', required: true },
+                    },
+                },
+                range: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        end: { ref: 'SourcePosition', required: true },
+                        start: { ref: 'SourcePosition', required: true },
+                    },
+                    required: true,
+                },
+                path: { dataType: 'string', required: true },
+            },
             validators: {},
         },
     },
@@ -2427,6 +2491,7 @@ const models: TsoaRoute.Models = {
                     { dataType: 'array', array: { dataType: 'string' } },
                 ],
             },
+            formatOptions: { ref: 'CustomFormat' },
             image: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
@@ -2596,70 +2661,6 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CustomFormatType: {
-        dataType: 'refEnum',
-        enums: [
-            'default',
-            'percent',
-            'currency',
-            'number',
-            'id',
-            'date',
-            'timestamp',
-            'bytes_si',
-            'bytes_iec',
-            'custom',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    NumberSeparator: {
-        dataType: 'refEnum',
-        enums: [
-            'default',
-            'commaPeriod',
-            'spacePeriod',
-            'periodComma',
-            'noSeparatorPeriod',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CustomFormat: {
-        dataType: 'refObject',
-        properties: {
-            type: { ref: 'CustomFormatType', required: true },
-            round: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'double' }, { dataType: 'undefined' }],
-            },
-            separator: { ref: 'NumberSeparator' },
-            currency: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
-            },
-            compact: {
-                dataType: 'union',
-                subSchemas: [
-                    { ref: 'CompactOrAlias' },
-                    { dataType: 'undefined' },
-                ],
-            },
-            prefix: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
-            },
-            suffix: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
-            },
-            timeInterval: { ref: 'TimeFrames' },
-            custom: {
-                dataType: 'union',
-                subSchemas: [{ dataType: 'string' }, { dataType: 'undefined' }],
-            },
-        },
-        additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     TableCalculationType: {
@@ -3165,6 +3166,33 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_Dimension.formatOptions_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                formatOptions: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'CustomFormat' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DimensionOverrides: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { ref: 'Pick_Dimension.formatOptions_' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_CompiledDimension.label-or-name-or-table_': {
         dataType: 'refAlias',
         type: {
@@ -3235,6 +3263,7 @@ const models: TsoaRoute.Models = {
                     },
                 },
                 timezone: { dataType: 'string' },
+                dimensionOverrides: { ref: 'DimensionOverrides' },
                 metricOverrides: { ref: 'MetricOverrides' },
                 customDimensions: {
                     dataType: 'array',
@@ -4847,6 +4876,7 @@ const models: TsoaRoute.Models = {
                     { dataType: 'array', array: { dataType: 'string' } },
                 ],
             },
+            formatOptions: { ref: 'CustomFormat' },
             image: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
@@ -5645,6 +5675,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 periodOverPeriod: { ref: 'PeriodOverPeriodComparison' },
+                dimensionOverrides: { ref: 'DimensionOverrides' },
                 metricOverrides: { ref: 'MetricOverrides' },
                 timezone: { dataType: 'string' },
                 metadata: {
@@ -7137,11 +7168,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7637,11 +7668,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7656,11 +7687,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7675,11 +7706,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7694,11 +7725,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7713,11 +7744,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17435,7 +17466,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17445,7 +17476,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17455,7 +17486,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17468,7 +17499,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -20460,6 +20491,10 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                compilationErrors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
                 parameterReferences: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -21965,6 +22000,13 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { ref: 'MetricOverrides' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                dimensionOverrides: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DimensionOverrides' },
                         { dataType: 'undefined' },
                     ],
                 },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2439,59 +2439,30 @@
                 "type": "object",
                 "description": "Construct a type with a set of properties K of type T"
             },
-            "FieldType": {
-                "enum": ["metric", "dimension"],
+            "CustomFormatType": {
+                "enum": [
+                    "default",
+                    "percent",
+                    "currency",
+                    "number",
+                    "id",
+                    "date",
+                    "timestamp",
+                    "bytes_si",
+                    "bytes_iec",
+                    "custom"
+                ],
                 "type": "string"
             },
-            "SourcePosition": {
-                "properties": {
-                    "character": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "line": {
-                        "type": "number",
-                        "format": "double"
-                    }
-                },
-                "required": ["character", "line"],
-                "type": "object"
-            },
-            "Source": {
-                "properties": {
-                    "content": {
-                        "type": "string"
-                    },
-                    "highlight": {
-                        "properties": {
-                            "end": {
-                                "$ref": "#/components/schemas/SourcePosition"
-                            },
-                            "start": {
-                                "$ref": "#/components/schemas/SourcePosition"
-                            }
-                        },
-                        "required": ["end", "start"],
-                        "type": "object"
-                    },
-                    "range": {
-                        "properties": {
-                            "end": {
-                                "$ref": "#/components/schemas/SourcePosition"
-                            },
-                            "start": {
-                                "$ref": "#/components/schemas/SourcePosition"
-                            }
-                        },
-                        "required": ["end", "start"],
-                        "type": "object"
-                    },
-                    "path": {
-                        "type": "string"
-                    }
-                },
-                "required": ["content", "range", "path"],
-                "type": "object"
+            "NumberSeparator": {
+                "enum": [
+                    "default",
+                    "commaPeriod",
+                    "spacePeriod",
+                    "periodComma",
+                    "noSeparatorPeriod"
+                ],
+                "type": "string"
             },
             "Compact": {
                 "enum": [
@@ -2551,6 +2522,95 @@
                         ]
                     }
                 ]
+            },
+            "CustomFormat": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/CustomFormatType"
+                    },
+                    "round": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "separator": {
+                        "$ref": "#/components/schemas/NumberSeparator"
+                    },
+                    "currency": {
+                        "type": "string"
+                    },
+                    "compact": {
+                        "$ref": "#/components/schemas/CompactOrAlias"
+                    },
+                    "prefix": {
+                        "type": "string"
+                    },
+                    "suffix": {
+                        "type": "string"
+                    },
+                    "timeInterval": {
+                        "$ref": "#/components/schemas/TimeFrames"
+                    },
+                    "custom": {
+                        "type": "string"
+                    }
+                },
+                "required": ["type"],
+                "type": "object",
+                "additionalProperties": true
+            },
+            "FieldType": {
+                "enum": ["metric", "dimension"],
+                "type": "string"
+            },
+            "SourcePosition": {
+                "properties": {
+                    "character": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "line": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["character", "line"],
+                "type": "object"
+            },
+            "Source": {
+                "properties": {
+                    "content": {
+                        "type": "string"
+                    },
+                    "highlight": {
+                        "properties": {
+                            "end": {
+                                "$ref": "#/components/schemas/SourcePosition"
+                            },
+                            "start": {
+                                "$ref": "#/components/schemas/SourcePosition"
+                            }
+                        },
+                        "required": ["end", "start"],
+                        "type": "object"
+                    },
+                    "range": {
+                        "properties": {
+                            "end": {
+                                "$ref": "#/components/schemas/SourcePosition"
+                            },
+                            "start": {
+                                "$ref": "#/components/schemas/SourcePosition"
+                            }
+                        },
+                        "required": ["end", "start"],
+                        "type": "object"
+                    },
+                    "path": {
+                        "type": "string"
+                    }
+                },
+                "required": ["content", "range", "path"],
+                "type": "object"
             },
             "Format": {
                 "enum": [
@@ -2709,6 +2769,9 @@
                                 "type": "array"
                             }
                         ]
+                    },
+                    "formatOptions": {
+                        "$ref": "#/components/schemas/CustomFormat"
                     },
                     "image": {
                         "properties": {
@@ -2909,66 +2972,6 @@
                 },
                 "required": ["descending", "fieldId"],
                 "type": "object"
-            },
-            "CustomFormatType": {
-                "enum": [
-                    "default",
-                    "percent",
-                    "currency",
-                    "number",
-                    "id",
-                    "date",
-                    "timestamp",
-                    "bytes_si",
-                    "bytes_iec",
-                    "custom"
-                ],
-                "type": "string"
-            },
-            "NumberSeparator": {
-                "enum": [
-                    "default",
-                    "commaPeriod",
-                    "spacePeriod",
-                    "periodComma",
-                    "noSeparatorPeriod"
-                ],
-                "type": "string"
-            },
-            "CustomFormat": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/CustomFormatType"
-                    },
-                    "round": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "separator": {
-                        "$ref": "#/components/schemas/NumberSeparator"
-                    },
-                    "currency": {
-                        "type": "string"
-                    },
-                    "compact": {
-                        "$ref": "#/components/schemas/CompactOrAlias"
-                    },
-                    "prefix": {
-                        "type": "string"
-                    },
-                    "suffix": {
-                        "type": "string"
-                    },
-                    "timeInterval": {
-                        "$ref": "#/components/schemas/TimeFrames"
-                    },
-                    "custom": {
-                        "type": "string"
-                    }
-                },
-                "required": ["type"],
-                "type": "object",
-                "additionalProperties": true
             },
             "TableCalculationType": {
                 "enum": ["number", "string", "date", "timestamp", "boolean"],
@@ -3514,6 +3517,22 @@
                 },
                 "type": "object"
             },
+            "Pick_Dimension.formatOptions_": {
+                "properties": {
+                    "formatOptions": {
+                        "$ref": "#/components/schemas/CustomFormat"
+                    }
+                },
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "DimensionOverrides": {
+                "properties": {},
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/Pick_Dimension.formatOptions_"
+                },
+                "type": "object"
+            },
             "Pick_CompiledDimension.label-or-name-or-table_": {
                 "properties": {
                     "name": {
@@ -3589,6 +3608,9 @@
                     },
                     "timezone": {
                         "type": "string"
+                    },
+                    "dimensionOverrides": {
+                        "$ref": "#/components/schemas/DimensionOverrides"
                     },
                     "metricOverrides": {
                         "$ref": "#/components/schemas/MetricOverrides"
@@ -5417,6 +5439,9 @@
                             }
                         ]
                     },
+                    "formatOptions": {
+                        "$ref": "#/components/schemas/CustomFormat"
+                    },
                     "image": {
                         "properties": {
                             "fit": {
@@ -6412,6 +6437,9 @@
                 "properties": {
                     "periodOverPeriod": {
                         "$ref": "#/components/schemas/PeriodOverPeriodComparison"
+                    },
+                    "dimensionOverrides": {
+                        "$ref": "#/components/schemas/DimensionOverrides"
                     },
                     "metricOverrides": {
                         "$ref": "#/components/schemas/MetricOverrides"
@@ -8003,19 +8031,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -18200,22 +18215,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -21177,6 +21192,12 @@
             },
             "ApiCompiledQueryResults": {
                 "properties": {
+                    "compilationErrors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "parameterReferences": {
                         "items": {
                             "type": "string"
@@ -22615,6 +22636,9 @@
                     },
                     "metricOverrides": {
                         "$ref": "#/components/schemas/MetricOverrides"
+                    },
+                    "dimensionOverrides": {
+                        "$ref": "#/components/schemas/DimensionOverrides"
                     },
                     "periodOverPeriod": {
                         "$ref": "#/components/schemas/PeriodOverPeriodComparison"

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -25,6 +25,7 @@ import {
     LightdashUser,
     MetricFilterRule,
     MetricOverrides,
+    DimensionOverrides,
     NotFoundError,
     Organization,
     PeriodOverPeriodComparison,
@@ -88,6 +89,7 @@ type DbSavedChartDetails = {
     filters: AnyType;
     row_limit: number;
     metric_overrides: MetricOverrides | null;
+    dimension_overrides: DimensionOverrides | null;
     chart_type: ChartConfig['type'];
     chart_config: ChartConfig['config'] | undefined;
     pivot_dimensions: string[] | undefined;
@@ -183,6 +185,7 @@ const createSavedChartVersion = async (
         metricQuery: {
             limit,
             metricOverrides,
+            dimensionOverrides,
             filters,
             dimensions,
             metrics,
@@ -207,10 +210,17 @@ const createSavedChartVersion = async (
                 metrics.includes(key),
             ),
         );
+        // Only save overrides for existing dimensions
+        const validDimensionOverrides = Object.fromEntries(
+            Object.entries(dimensionOverrides || {}).filter(([key]) =>
+                dimensions.includes(key),
+            ),
+        );
         const [version] = await trx('saved_queries_versions')
             .insert({
                 row_limit: limit,
                 metric_overrides: validMetricOverrides || null,
+                dimension_overrides: validDimensionOverrides || null,
                 filters: JSON.stringify(filters),
                 explore_name: tableName,
                 saved_query_id: savedChartId,
@@ -869,6 +879,7 @@ export class SavedChartModel {
                         'saved_queries_versions.filters',
                         'saved_queries_versions.row_limit',
                         'saved_queries_versions.metric_overrides',
+                        'saved_queries_versions.dimension_overrides',
                         'saved_queries_versions.chart_type',
                         'saved_queries_versions.created_at',
                         'saved_queries_versions.chart_config',
@@ -1074,6 +1085,8 @@ export class SavedChartModel {
                         limit: savedQuery.row_limit,
                         metricOverrides:
                             savedQuery.metric_overrides || undefined,
+                        dimensionOverrides:
+                            savedQuery.dimension_overrides || undefined,
                         tableCalculations: tableCalculations.map(
                             (tableCalculation) =>
                                 ({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1654,16 +1654,19 @@ export class AsyncQueryService extends ProjectService {
 
         const fieldsWithOverrides: ItemsMap = Object.fromEntries(
             Object.entries(fullQuery.fields).map(([key, value]) => {
-                const metricOverrides = metricQuery.metricOverrides?.[key];
-                if (metricOverrides) {
-                    const { formatOptions } = metricOverrides;
+                // Check for metric or dimension overrides
+                const override =
+                    metricQuery.metricOverrides?.[key] ||
+                    metricQuery.dimensionOverrides?.[key];
+                if (override) {
+                    const { formatOptions } = override;
 
                     if (formatOptions) {
                         return [
                             key,
                             {
                                 ...value,
-                                // Override the format expression with the metric query override instead of adding `formatOptions` to the item
+                                // Override the format expression with the metric/dimension query override instead of adding `formatOptions` to the item
                                 // This ensures that legacy `formatOptions` are kept as is and we don't need to change logic over which format takes precedence
                                 format: convertCustomFormatToFormatExpression(
                                     formatOptions,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3282,15 +3282,16 @@ export class ProjectService extends BaseService {
 
                     const fieldsWithOverrides: ItemsMap = Object.fromEntries(
                         Object.entries(fullQuery.fields).map(([key, value]) => {
-                            if (
-                                metricQuery.metricOverrides &&
-                                metricQuery.metricOverrides[key]
-                            ) {
+                            // Check for metric or dimension overrides
+                            const override =
+                                metricQuery.metricOverrides?.[key] ||
+                                metricQuery.dimensionOverrides?.[key];
+                            if (override) {
                                 return [
                                     key,
                                     {
                                         ...value,
-                                        ...metricQuery.metricOverrides[key],
+                                        ...override,
                                     },
                                 ];
                             }

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -566,6 +566,7 @@ export interface Dimension extends Field {
     colors?: Record<string, string>;
     isIntervalBase?: boolean;
     aiHint?: string | string[];
+    formatOptions?: CustomFormat;
     image?: {
         url: string;
         width?: number;
@@ -591,6 +592,12 @@ export const isDimension = (
     field: ItemsMap[string] | AdditionalMetric | undefined, // NOTE: `ItemsMap converts AdditionalMetric to Metric
 ): field is Dimension =>
     isField(field) && field.fieldType === FieldType.DIMENSION;
+
+export const isTimeBasedDimension = (
+    item: ItemsMap[string] | AdditionalMetric | undefined,
+): item is Dimension =>
+    isDimension(item) &&
+    (item.type === DimensionType.DATE || item.type === DimensionType.TIMESTAMP);
 
 export interface FilterableDimension extends Dimension {
     type:
@@ -846,3 +853,4 @@ export function getCompactOptionsForFormatType(
         Compact.TRILLIONS,
     ];
 }
+

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -13,6 +13,7 @@ import {
     type CompiledTableCalculation,
     type CustomDimension,
     type CustomFormat,
+    type Dimension,
     type FieldId,
     type Format,
     type Metric,
@@ -58,6 +59,10 @@ export const getCustomMetricDimensionId = (metric: AdditionalMetric) =>
 
 export type MetricOverrides = { [key: string]: Pick<Metric, 'formatOptions'> }; // Don't use Record to avoid issues in TSOA
 
+export type DimensionOverrides = {
+    [key: string]: Pick<Dimension, 'formatOptions'>;
+};
+
 // Object used to query an explore. Queries only happen within a single explore
 export type MetricQuery = {
     exploreName: string;
@@ -70,6 +75,7 @@ export type MetricQuery = {
     additionalMetrics?: AdditionalMetric[]; // existing metric type
     customDimensions?: CustomDimension[];
     metricOverrides?: MetricOverrides; // Override format options for fields in "metrics"
+    dimensionOverrides?: DimensionOverrides; // Override format options for fields in "dimensions"
     timezone?: string; // Local timezone to use for the query
     metadata?: {
         hasADateDimension: Pick<CompiledDimension, 'label' | 'name' | 'table'>;
@@ -173,6 +179,7 @@ export type MetricQueryRequest = {
     metadata?: MetricQuery['metadata'];
     timezone?: string;
     metricOverrides?: MetricOverrides;
+    dimensionOverrides?: DimensionOverrides;
     periodOverPeriod?: PeriodOverPeriodComparison;
 };
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -718,7 +718,7 @@ export function convertCustomFormatToFormatExpression(
         case CustomFormatType.ID:
         case CustomFormatType.DATE:
         case CustomFormatType.TIMESTAMP: {
-            // No implementation yet
+            // No format expression needed
             break;
         }
         default: {

--- a/packages/frontend/src/components/Explorer/FormatForm/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatForm/index.tsx
@@ -1,19 +1,40 @@
 import {
     CompactConfigMap,
     CustomFormatType,
+    DimensionType,
+    MetricType,
     NumberSeparator,
-    applyCustomFormat,
+    TableCalculationType,
     convertCustomFormatToFormatExpression,
     currencies,
     findCompactConfig,
+    formatValueWithExpression,
     getCompactOptionsForFormatType,
     type CustomFormat,
 } from '@lightdash/common';
-import { Anchor, Flex, Select, Stack, Text, TextInput } from '@mantine-8/core';
+import {
+    Anchor,
+    Box,
+    Flex,
+    Group,
+    Paper,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
 import { NumberInput } from '@mantine/core';
 import { type GetInputProps } from '@mantine/form/lib/types';
+import {
+    IconCalendar,
+    IconClockHour4,
+    IconExternalLink,
+} from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import { type ValueOf } from 'type-fest';
+import MantineIcon from '../../common/MantineIcon';
+import { PolymorphicPaperButton } from '../../common/PolymorphicPaperButton';
 
 type Props = {
     formatInputProps: (
@@ -24,9 +45,10 @@ type Props = {
         path: keyof CustomFormat,
         value: ValueOf<CustomFormat>,
     ) => void;
+    itemType?: DimensionType | MetricType | TableCalculationType;
 };
 
-const formatTypeOptions = [
+const numericFormatTypeOptions = [
     CustomFormatType.DEFAULT,
     CustomFormatType.PERCENT,
     CustomFormatType.CURRENCY,
@@ -35,6 +57,37 @@ const formatTypeOptions = [
     CustomFormatType.BYTES_IEC,
     CustomFormatType.CUSTOM,
 ];
+
+const dateFormatTypeOptions = [
+    CustomFormatType.DEFAULT,
+    CustomFormatType.DATE,
+    CustomFormatType.TIMESTAMP,
+];
+
+const getFormatTypeLabel = (type: CustomFormatType): string => {
+    switch (type) {
+        case CustomFormatType.BYTES_SI:
+            return 'Bytes (SI)';
+        case CustomFormatType.BYTES_IEC:
+            return 'Bytes (IEC)';
+        case CustomFormatType.DATE:
+            return 'Date';
+        case CustomFormatType.TIMESTAMP:
+            return 'Timestamp';
+        case CustomFormatType.DEFAULT:
+            return 'Default';
+        case CustomFormatType.PERCENT:
+            return 'Percent';
+        case CustomFormatType.CURRENCY:
+            return 'Currency';
+        case CustomFormatType.NUMBER:
+            return 'Number';
+        case CustomFormatType.CUSTOM:
+            return 'Custom';
+        default:
+            return type;
+    }
+};
 
 const formatSeparatorOptions = [
     {
@@ -73,12 +126,42 @@ const formatCurrencyOptions = currencies.map((c) => {
     };
 });
 
+// Common date and timestamp format presets
+const DATE_FORMATS = [
+    'dd/mm/yyyy',
+    'mm-dd-yyyy',
+    'd mmm yyyy',
+    'mmmm d, yyyy',
+    'yyyy-mm-dd',
+    'ddd, MMM d, yyyy',
+];
+
+const TIMESTAMP_FORMATS = [
+    'yyyy-mm-dd HH:mm:ss',
+    'dd/mm/yyyy HH:mm',
+    'mmmm d, yyyy h:mm AM/PM',
+    'ddd, MMM d, yyyy HH:mm',
+    'HH:mm:ss',
+    'h:mm:ss AM/PM',
+];
+
 export const FormatForm: FC<Props> = ({
     formatInputProps,
     setFormatFieldValue,
     format,
+
+    itemType,
 }) => {
     const formatType = format.type;
+
+    const isDateField = useMemo(() => {
+        return (
+            itemType === DimensionType.DATE ||
+            itemType === DimensionType.TIMESTAMP
+        );
+    }, [itemType]);
+
+    const sampleDate = useMemo(() => new Date(), []);
 
     const validCompactValue = useMemo(() => {
         const currentCompact = format.compact;
@@ -92,76 +175,239 @@ export const FormatForm: FC<Props> = ({
             : null;
     }, [format.compact, formatType]);
 
+    const formatTypeOptions = isDateField
+        ? dateFormatTypeOptions
+        : numericFormatTypeOptions;
+
+    // Show date-specific UI for date fields with custom format (not default)
+    const isDateType =
+        formatType === CustomFormatType.DATE ||
+        formatType === CustomFormatType.TIMESTAMP ||
+        (isDateField && formatType === CustomFormatType.CUSTOM);
+
+    // Generate examples based on item type (dimension/metric type)
+    const isTimestampField =
+        itemType === DimensionType.TIMESTAMP ||
+        itemType === MetricType.TIMESTAMP ||
+        itemType === TableCalculationType.TIMESTAMP;
+
+    const dateExamples = useMemo(() => {
+        const formats = isTimestampField ? TIMESTAMP_FORMATS : DATE_FORMATS;
+
+        return formats.map((fmt) => ({
+            format: fmt,
+            example: formatValueWithExpression(fmt, sampleDate),
+        }));
+    }, [isTimestampField, sampleDate]);
+
+    // Generate preview for date formats
+    const datePreview = useMemo(() => {
+        if (!isDateType) return null;
+        if (!format.custom) return null;
+        try {
+            return formatValueWithExpression(format.custom, sampleDate);
+        } catch {
+            return 'Invalid format';
+        }
+    }, [isDateType, format.custom, sampleDate]);
+
     return (
-        <Stack>
-            <Flex>
+        <Stack gap="lg">
+            {/* Format Type Selection */}
+            {isDateField ? (
+                <Stack gap="xs">
+                    <Text size="sm" fw={500}>
+                        Format
+                    </Text>
+                    <SegmentedControl
+                        w="fit-content"
+                        size="sm"
+                        radius="md"
+                        data={[
+                            {
+                                label: 'Default',
+                                value: CustomFormatType.DEFAULT,
+                            },
+                            { label: 'Custom', value: 'custom' },
+                        ]}
+                        value={
+                            format.type === CustomFormatType.DEFAULT
+                                ? CustomFormatType.DEFAULT
+                                : 'custom'
+                        }
+                        onChange={(value) => {
+                            if (value === CustomFormatType.DEFAULT) {
+                                setFormatFieldValue(
+                                    'type',
+                                    CustomFormatType.DEFAULT,
+                                );
+                                setFormatFieldValue('custom', undefined);
+                            } else {
+                                // Use CUSTOM type for date/timestamp custom formats
+                                setFormatFieldValue(
+                                    'type',
+                                    CustomFormatType.CUSTOM,
+                                );
+                            }
+                        }}
+                    />
+                </Stack>
+            ) : (
                 <Select
                     w={200}
-                    label="Type"
+                    label="Format type"
                     data={formatTypeOptions.map((type) => ({
                         value: type,
-                        label:
-                            type === CustomFormatType.BYTES_SI
-                                ? 'bytes (SI)'
-                                : type === CustomFormatType.BYTES_IEC
-                                ? 'bytes (IEC)'
-                                : type,
+                        label: getFormatTypeLabel(type),
                     }))}
                     {...{
                         ...formatInputProps('type'),
                         onChange: (value) => {
                             if (value) {
-                                setFormatFieldValue('type', value);
+                                setFormatFieldValue(
+                                    'type',
+                                    value as CustomFormatType,
+                                );
                                 setFormatFieldValue('compact', undefined);
+                                // Clear custom format when switching to non-custom types
+                                if (
+                                    value !== CustomFormatType.CUSTOM &&
+                                    value !== CustomFormatType.DATE &&
+                                    value !== CustomFormatType.TIMESTAMP
+                                ) {
+                                    setFormatFieldValue('custom', undefined);
+                                }
                             }
                         },
                     }}
                 />
+            )}
 
-                {formatType !== CustomFormatType.DEFAULT && (
-                    <Text ml="md" mt={30} w={200} c="ldGray.6">
-                        {'Looks like: '}
-                        {applyCustomFormat(
-                            CustomFormatType.PERCENT === formatType
-                                ? '0.754321'
-                                : '1234.56789',
-                            format,
+            {/* Date/Timestamp Format Section */}
+            {isDateType && (
+                <Stack gap="md">
+                    <Flex align="flex-end" gap="md">
+                        {/* Format Input with Icon */}
+                        <TextInput
+                            style={{ flex: 1 }}
+                            maw={400}
+                            leftSection={
+                                <MantineIcon
+                                    icon={
+                                        isTimestampField
+                                            ? IconClockHour4
+                                            : IconCalendar
+                                    }
+                                    color="ldGray.6"
+                                />
+                            }
+                            label="Custom format"
+                            placeholder="e.g. dd/mm/yyyy or mmmm d, yyyy"
+                            {...formatInputProps('custom')}
+                        />
+
+                        {/* Preview Area */}
+                        {format.custom && (
+                            <Box pb={2}>
+                                <Text size="xs" c="ldGray.6" fw={500} mb={4}>
+                                    Result
+                                </Text>
+                                <Paper
+                                    withBorder
+                                    px="md"
+                                    h={36}
+                                    display="flex"
+                                    style={{ alignItems: 'center' }}
+                                    radius="md"
+                                    bg="ldGray.0"
+                                >
+                                    <Text
+                                        size="sm"
+                                        fw={600}
+                                        c={
+                                            datePreview === 'Invalid format'
+                                                ? 'red.6'
+                                                : 'inherit'
+                                        }
+                                    >
+                                        {datePreview || '...'}
+                                    </Text>
+                                </Paper>
+                            </Box>
                         )}
-                    </Text>
-                )}
-                {[
-                    CustomFormatType.CURRENCY,
-                    CustomFormatType.NUMBER,
-                    CustomFormatType.PERCENT,
-                    CustomFormatType.BYTES_SI,
-                    CustomFormatType.BYTES_IEC,
-                ].includes(formatType) && (
-                    <Text ml="md" mt={30} w={200} color="ldGray.6">
-                        {'Format: '}
-                        {convertCustomFormatToFormatExpression(format)}
-                    </Text>
-                )}
-            </Flex>
-            {formatType === CustomFormatType.CUSTOM && (
+                    </Flex>
+
+                    {/* Format Examples */}
+                    <Stack gap="xs">
+                        <Group gap="xs">
+                            <Text size="xs" c="ldGray.6" fw={500}>
+                                Common formats
+                            </Text>
+                            <Group gap="two">
+                                <Anchor
+                                    href="https://customformats.com"
+                                    target="_blank"
+                                    size="xs"
+                                >
+                                    <MantineIcon
+                                        icon={IconExternalLink}
+                                        size="sm"
+                                        color="blue.6"
+                                    />
+                                </Anchor>
+                            </Group>
+                        </Group>
+                        <Flex gap="xs" wrap="wrap">
+                            {dateExamples.map(({ format: fmt, example }) => (
+                                <PolymorphicPaperButton
+                                    key={fmt}
+                                    withBorder
+                                    p="xs"
+                                    shadow="none"
+                                    radius="md"
+                                    onClick={() =>
+                                        setFormatFieldValue('custom', fmt)
+                                    }
+                                >
+                                    <Text size="xs" c="ldDark.8" fw={500}>
+                                        {example}
+                                    </Text>
+                                    <Text size="xs" c="ldGray.5">
+                                        {fmt}
+                                    </Text>
+                                </PolymorphicPaperButton>
+                            ))}
+                        </Flex>
+                    </Stack>
+                </Stack>
+            )}
+
+            {/* Custom Format Expression (non-date fields only) */}
+            {formatType === CustomFormatType.CUSTOM && !isDateField && (
                 <TextInput
                     label="Format expression"
-                    placeholder="E.g. #.#0"
+                    placeholder="e.g. #,##0.00"
                     description={
-                        <p>
-                            To help you build your format expression, we
-                            recommend using{' '}
+                        <Group gap="two">
+                            <MantineIcon
+                                icon={IconExternalLink}
+                                size="sm"
+                                color="blue.6"
+                            />
                             <Anchor
                                 href="https://customformats.com"
                                 target="_blank"
+                                size="xs"
                             >
-                                https://customformats.com
+                                Build your format at customformats.com
                             </Anchor>
-                            .
-                        </p>
+                        </Group>
                     }
                     {...formatInputProps('custom')}
                 />
             )}
+
+            {/* Numeric Format Options */}
             {[
                 CustomFormatType.CURRENCY,
                 CustomFormatType.NUMBER,
@@ -169,63 +415,62 @@ export const FormatForm: FC<Props> = ({
                 CustomFormatType.BYTES_SI,
                 CustomFormatType.BYTES_IEC,
             ].includes(formatType) && (
-                <Flex>
-                    {formatType === CustomFormatType.CURRENCY && (
-                        <Select
-                            mr="md"
+                <>
+                    <Flex gap="md" wrap="wrap">
+                        {formatType === CustomFormatType.CURRENCY && (
+                            <Select
+                                w={200}
+                                searchable
+                                label="Currency"
+                                data={formatCurrencyOptions}
+                                {...formatInputProps('currency')}
+                            />
+                        )}
+                        <NumberInput
+                            type="number"
+                            min={0}
                             w={200}
-                            searchable
-                            label="Currency"
-                            data={formatCurrencyOptions}
-                            {...formatInputProps('currency')}
+                            label="Decimal places"
+                            placeholder="Auto"
+                            radius="md"
+                            {...{
+                                ...formatInputProps('round'),
+                                onChange: (value) => {
+                                    setFormatFieldValue(
+                                        'round',
+                                        value === '' ? undefined : value,
+                                    );
+                                },
+                            }}
                         />
-                    )}
-                    <NumberInput
-                        // NOTE: Mantine's NumberInput component is not working properly when initial value in useForm is undefined
-                        type="number"
-                        min={0}
-                        w={200}
-                        label="Round"
-                        radius="md"
-                        placeholder="Number of decimal places"
-                        {...{
-                            ...formatInputProps('round'),
-                            // Explicitly set value to undefined so the API doesn't received invalid values
-                            onChange: (value) => {
-                                setFormatFieldValue(
-                                    'round',
-                                    value === '' ? undefined : value,
-                                );
-                            },
-                        }}
-                    />
-                    <Select
-                        w={200}
-                        ml="md"
-                        label="Separator style"
-                        data={formatSeparatorOptions}
-                        {...formatInputProps('separator')}
-                    />
-                </Flex>
+                        <Select
+                            w={200}
+                            label="Separator style"
+                            data={formatSeparatorOptions}
+                            {...formatInputProps('separator')}
+                        />
+                    </Flex>
+                </>
             )}
+
+            {/* Compact and Prefix/Suffix Options */}
             {[
                 CustomFormatType.CURRENCY,
                 CustomFormatType.NUMBER,
                 CustomFormatType.BYTES_SI,
                 CustomFormatType.BYTES_IEC,
             ].includes(formatType) && (
-                <Flex>
+                <Flex gap="md" wrap="wrap">
                     <Select
-                        mr="md"
                         w={200}
                         clearable
                         label="Compact"
                         placeholder={
                             formatType === CustomFormatType.BYTES_SI
-                                ? 'E.g. kilobytes (KB)'
+                                ? 'e.g. kilobytes (KB)'
                                 : formatType === CustomFormatType.BYTES_IEC
-                                ? 'E.g. kibibytes (KiB)'
-                                : 'E.g. thousands (K)'
+                                ? 'e.g. kibibytes (KiB)'
+                                : 'e.g. thousands (K)'
                         }
                         data={getCompactOptionsForFormatType(formatType).map(
                             (c) => ({
@@ -235,10 +480,8 @@ export const FormatForm: FC<Props> = ({
                         )}
                         {...{
                             ...formatInputProps('compact'),
-                            // Override value to ensure invalid compact values are cleared
                             value: validCompactValue,
                             onChange: (value) => {
-                                // Explicitly set value to undefined so the API doesn't received invalid values
                                 setFormatFieldValue(
                                     'compact',
                                     !value || !(value in CompactConfigMap)
@@ -253,20 +496,36 @@ export const FormatForm: FC<Props> = ({
                         <>
                             <TextInput
                                 w={200}
-                                mr="md"
                                 label="Prefix"
-                                placeholder="E.g. GBP revenue:"
+                                placeholder="e.g. $"
                                 {...formatInputProps('prefix')}
                             />
                             <TextInput
                                 w={200}
                                 label="Suffix"
-                                placeholder="E.g. km/h"
+                                placeholder="e.g. km/h"
                                 {...formatInputProps('suffix')}
                             />
                         </>
                     )}
                 </Flex>
+            )}
+
+            {/* Format Expression Display (for numeric types) */}
+            {[
+                CustomFormatType.CURRENCY,
+                CustomFormatType.NUMBER,
+                CustomFormatType.PERCENT,
+                CustomFormatType.BYTES_SI,
+                CustomFormatType.BYTES_IEC,
+            ].includes(formatType) && (
+                <Text size="xs" c="ldGray.5">
+                    Format expression:{' '}
+                    <Text span fw={500} c="ldGray.7">
+                        {convertCustomFormatToFormatExpression(format) ||
+                            'default'}
+                    </Text>
+                </Text>
             )}
         </Stack>
     );

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -1,12 +1,15 @@
 import {
+    DimensionType,
     getItemId,
     getItemLabelWithoutTableName,
     isCustomDimension,
+    isDimension,
     isField,
     isFilterableField,
     isMetric,
     isNumericItem,
     isTableCalculation,
+    isTimeBasedDimension,
     type TableCalculation,
 } from '@lightdash/common';
 import { ActionIcon, Menu, Text } from '@mantine/core';
@@ -92,6 +95,15 @@ const ContextMenu: FC<ContextMenuProps> = ({
                 <ColumnHeaderSortMenuOptions item={item} sort={sort} />
 
                 <Menu.Divider />
+
+                {isTimeBasedDimension(item) ||
+                (isDimension(item) && item.type === DimensionType.NUMBER) ? (
+                    <>
+                        <FormatMenuOptions item={item} />
+                        <Menu.Divider />
+                    </>
+                ) : null}
+
                 {isMetric(item) && (
                     <>
                         {!isItemAdditionalMetric && isNumericItem(item) && (

--- a/packages/frontend/src/components/Explorer/ResultsCard/FormatMenuOptions.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/FormatMenuOptions.tsx
@@ -1,4 +1,4 @@
-import { type Metric } from '@lightdash/common';
+import { type Dimension, type Metric } from '@lightdash/common';
 import { Menu } from '@mantine/core';
 import { type FC } from 'react';
 import {
@@ -9,7 +9,7 @@ import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 
 type Props = {
-    item: Metric;
+    item: Metric | Dimension;
 };
 
 const FormatMenuOptions: FC<Props> = ({ item }) => {
@@ -17,7 +17,7 @@ const FormatMenuOptions: FC<Props> = ({ item }) => {
     const dispatch = useExplorerDispatch();
 
     const onCreate = () => {
-        dispatch(explorerActions.toggleFormatModal({ metric: item }));
+        dispatch(explorerActions.toggleFormatModal({ item }));
         track({
             name: EventName.FORMAT_METRIC_BUTTON_CLICKED,
         });

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -375,7 +375,7 @@ const explorerSlice = createSlice({
         },
         toggleFormatModal: (
             state,
-            action: PayloadAction<{ metric?: Metric } | undefined>,
+            action: PayloadAction<{ item?: Metric | Dimension } | undefined>,
         ) => {
             state.modals.format = {
                 isOpen: !state.modals.format.isOpen,
@@ -395,6 +395,24 @@ const explorerSlice = createSlice({
                 state.unsavedChartVersion.metricQuery.metricOverrides = {};
             }
             state.unsavedChartVersion.metricQuery.metricOverrides[metricId] = {
+                formatOptions,
+            };
+        },
+        updateDimensionFormat: (
+            state,
+            action: PayloadAction<{
+                dimension: Dimension;
+                formatOptions: CustomFormat | undefined;
+            }>,
+        ) => {
+            const { dimension, formatOptions } = action.payload;
+            const dimensionId = getItemId(dimension);
+            if (!state.unsavedChartVersion.metricQuery.dimensionOverrides) {
+                state.unsavedChartVersion.metricQuery.dimensionOverrides = {};
+            }
+            state.unsavedChartVersion.metricQuery.dimensionOverrides[
+                dimensionId
+            ] = {
                 formatOptions,
             };
         },

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -10,6 +10,7 @@ import {
     removeEmptyProperties,
     type AdditionalMetric,
     type CustomDimension,
+    type DimensionOverrides,
     type Explore,
     type MetricOverrides,
     type ParametersValuesMap,
@@ -20,6 +21,7 @@ import { ExplorerSection } from '../../../providers/Explorer/types';
 import { cleanConfig } from '../../../providers/Explorer/utils';
 
 const EMPTY_METRIC_OVERRIDES: MetricOverrides = {};
+const EMPTY_DIMENSION_OVERRIDES: DimensionOverrides = {};
 const EMPTY_PARAMETERS: ParametersValuesMap = {};
 
 // Base selectors
@@ -136,6 +138,11 @@ export const selectMetrics = createSelector(
 export const selectMetricOverrides = createSelector(
     [selectMetricQuery],
     (metricQuery) => metricQuery.metricOverrides || EMPTY_METRIC_OVERRIDES,
+);
+
+export const selectDimensionOverrides = createSelector(
+    [selectMetricQuery],
+    (metricQuery) => metricQuery.dimensionOverrides || EMPTY_DIMENSION_OVERRIDES,
 );
 
 // Parameter selectors

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -124,8 +124,8 @@ export const getFormValuesFromScheduler = (
             options.limit === Limit.TABLE
                 ? Limit.TABLE
                 : options.limit === Limit.ALL
-                  ? Limit.ALL
-                  : Limit.CUSTOM;
+                ? Limit.ALL
+                : Limit.CUSTOM;
         if (formOptions.limit === Limit.CUSTOM) {
             formOptions.customLimit = options.limit as number;
         }
@@ -174,7 +174,6 @@ export const transformFormValues = (
     values: SchedulerFormValues,
     resourceType: 'chart' | 'dashboard' | undefined,
 ): CreateSchedulerAndTargetsWithoutIds => {
-    console.log(values);
     let options = {};
     if ([SchedulerFormat.CSV, SchedulerFormat.XLSX].includes(values.format)) {
         options = {

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -438,8 +438,6 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
         currentParameterValues,
     });
 
-    console.log(form.values);
-
     return (
         <SchedulerFormProvider form={form}>
             <MantineModal

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -675,7 +675,12 @@ const seriesValueFormatter = (
             round: item.round,
             compact: item.compact,
         });
-        const formatOptions = isMetric(item) ? item.formatOptions : undefined;
+        // Check for formatOptions from both metrics and dimension overrides
+        // Dimension overrides add formatOptions to the item via the itemsMap
+        const formatOptions =
+            isMetric(item) || isDimension(item)
+                ? item.formatOptions
+                : undefined;
         return applyCustomFormat(value, formatOptions || defaultFormatOptions);
     }
 };

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -157,7 +157,8 @@ const formatBarDisplayCell = (
     // This ensures percentage values stored as decimals (0.05) are properly scaled
     // to match the min/max values calculated by convertFormattedValue (5, 15)
     const convertedValue = convertFormattedValue(value, item);
-    const numericConvertedValue = typeof convertedValue === 'number' ? convertedValue : value;
+    const numericConvertedValue =
+        typeof convertedValue === 'number' ? convertedValue : value;
 
     return (
         <TableCellBar

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -65,6 +65,7 @@ export enum ActionType {
     TOGGLE_CUSTOM_DIMENSION_MODAL,
     TOGGLE_FORMAT_MODAL,
     UPDATE_METRIC_FORMAT,
+    UPDATE_DIMENSION_FORMAT,
     REPLACE_FIELDS,
     SET_PARAMETER_REFERENCES,
 }
@@ -187,11 +188,18 @@ export type Action =
       }
     | {
           type: ActionType.TOGGLE_FORMAT_MODAL;
-          payload?: { metric: Metric };
+          payload?: { item: Metric | Dimension };
       }
     | {
           type: ActionType.UPDATE_METRIC_FORMAT;
           payload: { metric: Metric; formatOptions: CustomFormat | undefined };
+      }
+    | {
+          type: ActionType.UPDATE_DIMENSION_FORMAT;
+          payload: {
+              dimension: Dimension;
+              formatOptions: CustomFormat | undefined;
+          };
       }
     | {
           type: ActionType.REPLACE_FIELDS;
@@ -227,7 +235,7 @@ export interface ExplorerReduceState {
     modals: {
         format: {
             isOpen: boolean;
-            metric?: Metric;
+            item?: Metric | Dimension;
         };
         additionalMetric: {
             isOpen: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [PROD-904](https://linear.app/lightdash/issue/PROD-904/formatting-date-type-dimensionsmetrics-in-the-results-table)

> [!IMPORTANT]
> Wanted to only do it just for date/timestamp dimensions first, so we agree on implementation. A PR on top of this one would cover metrics of date type, like MIN/MAX of a date dimension.

### Description:

This PR adds support for dimension formatting overrides, allowing users to customize how dimension values are displayed in charts and tables. The implementation includes:

- Added a new `dimensionOverrides` field to the metric query model
- Created a database migration to add the `dimension_overrides` column to saved queries versions
- Updated controllers to pass dimension overrides to the query service
- Enhanced the format modal to work with both metrics and dimensions
- Improved the format form with date/timestamp specific formatting options
- Added support for custom date formats with examples and preview

This feature is particularly useful for date and timestamp dimensions, allowing users to customize date formats (e.g., "dd/mm/yyyy", "mmmm d, yyyy") directly from the UI without having to modify the underlying data model.



![Screenshot 2026-01-08 at 15.13.27.png](https://app.graphite.com/user-attachments/assets/fdb295a8-9a5e-423c-9545-8ce4f6dbe4b0.png)

![Screenshot 2026-01-08 at 15.13.06.png](https://app.graphite.com/user-attachments/assets/1462353d-25aa-41f1-8fdd-e37479aa8c13.png)

![Screenshot 2026-01-08 at 15.12.59.png](https://app.graphite.com/user-attachments/assets/8a700232-214a-47bd-bbcb-02f633920bcf.png)

