### PR TITLE
feat: add partial compilation mode for fields with errors

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -289,4 +289,7 @@ export const lightdashConfigMock: LightdashConfig = {
     editYamlInUi: {
         enabled: false,
     },
+    partialCompilation: {
+        enabled: false,
+    },
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -987,6 +987,14 @@ export type LightdashConfig = {
     editYamlInUi: {
         enabled: boolean;
     };
+    /**
+     * When enabled, fields that fail to compile will be marked with a
+     * compilationError instead of causing the entire explore to fail.
+     * This allows users to still access other fields in the explore.
+     */
+    partialCompilation: {
+        enabled: boolean;
+    };
 };
 
 export type SlackConfig = {
@@ -1762,6 +1770,9 @@ export const parseConfig = (): LightdashConfig => {
         },
         editYamlInUi: {
             enabled: process.env.EDIT_YAML_IN_UI_ENABLED === 'true',
+        },
+        partialCompilation: {
+            enabled: process.env.PARTIAL_COMPILATION_ENABLED === 'true',
         },
     };
 };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4872,11 +4872,23 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FieldCompilationError: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                message: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CompiledProperties: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                compilationError: { ref: 'FieldCompilationError' },
                 tablesRequiredAttributes: {
                     ref: 'Record_string.Record_string.string-or-string-Array__',
                 },
@@ -5186,11 +5198,38 @@ const models: TsoaRoute.Models = {
         enums: ['virtual', 'default'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    InlineErrorType: {
+        dataType: 'refEnum',
+        enums: [
+            'METADATA_PARSE_ERROR',
+            'NO_DIMENSIONS_FOUND',
+            'SKIPPED_JOIN',
+            'MISSING_TABLE',
+            'FIELD_ERROR',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    InlineError: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                message: { dataType: 'string', required: true },
+                type: { ref: 'InlineErrorType', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Explore: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                warnings: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'InlineError' },
+                },
                 parameters: { ref: 'Record_string.LightdashProjectParameter_' },
                 aiHint: {
                     dataType: 'union',
@@ -7137,11 +7176,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7229,7 +7268,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7252,7 +7291,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                chartUsage:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7282,12 +7321,6 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -7295,6 +7328,12 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7498,7 +7537,7 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7521,7 +7560,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    chartUsage:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7551,12 +7590,6 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -7564,6 +7597,12 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -7637,11 +7676,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7656,11 +7695,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7675,11 +7714,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7694,11 +7733,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7713,11 +7752,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17986,6 +18025,16 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                warnings: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'InlineError' },
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -18005,23 +18054,6 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    InlineErrorType: {
-        dataType: 'refEnum',
-        enums: ['METADATA_PARSE_ERROR', 'NO_DIMENSIONS_FOUND'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    InlineError: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                message: { dataType: 'string', required: true },
-                type: { ref: 'InlineErrorType', required: true },
             },
             validators: {},
         },
@@ -20198,6 +20230,16 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                warnings: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'InlineError' },
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -20437,6 +20479,16 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                warnings: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'InlineError' },
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -20460,6 +20512,10 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                compilationErrors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
                 parameterReferences: {
                     dataType: 'array',
                     array: { dataType: 'string' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5459,8 +5459,22 @@
                 "type": "object",
                 "description": "Construct a type with a set of properties K of type T"
             },
+            "FieldCompilationError": {
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "required": ["message"],
+                "type": "object",
+                "description": "Error information stored on a field when compilation fails but\npartial compilation mode is enabled."
+            },
             "CompiledProperties": {
                 "properties": {
+                    "compilationError": {
+                        "$ref": "#/components/schemas/FieldCompilationError",
+                        "description": "When partial compilation mode is enabled, fields that fail to compile\nwill have this property set instead of causing the entire explore to fail."
+                    },
                     "tablesRequiredAttributes": {
                         "$ref": "#/components/schemas/Record_string.Record_string.string-or-string-Array__"
                     },
@@ -5834,8 +5848,37 @@
                 "enum": ["virtual", "default"],
                 "type": "string"
             },
+            "InlineErrorType": {
+                "enum": [
+                    "METADATA_PARSE_ERROR",
+                    "NO_DIMENSIONS_FOUND",
+                    "SKIPPED_JOIN",
+                    "MISSING_TABLE",
+                    "FIELD_ERROR"
+                ],
+                "type": "string"
+            },
+            "InlineError": {
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/InlineErrorType"
+                    }
+                },
+                "required": ["message", "type"],
+                "type": "object"
+            },
             "Explore": {
                 "properties": {
+                    "warnings": {
+                        "items": {
+                            "$ref": "#/components/schemas/InlineError"
+                        },
+                        "type": "array",
+                        "description": "Non-fatal warnings from partial compilation.\nPresent when some joins or fields failed to compile but the explore is still usable.\nOnly populated when PARTIAL_COMPILATION_ENABLED=true."
+                    },
                     "parameters": {
                         "$ref": "#/components/schemas/Record_string.LightdashProjectParameter_"
                     },
@@ -8013,19 +8056,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -8041,12 +8071,12 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -8054,10 +8084,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8066,8 +8096,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8161,12 +8191,12 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "searchRank": {
+                                                                                    "chartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -8174,10 +8204,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8186,8 +8216,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -18715,6 +18745,13 @@
                     },
                     "parameters": {
                         "$ref": "#/components/schemas/Record_string.LightdashProjectParameter_"
+                    },
+                    "warnings": {
+                        "items": {
+                            "$ref": "#/components/schemas/InlineError"
+                        },
+                        "type": "array",
+                        "description": "Non-fatal warnings from partial compilation.\nPresent when some joins or fields failed to compile but the explore is still usable.\nOnly populated when PARTIAL_COMPILATION_ENABLED=true."
                     }
                 },
                 "type": "object",
@@ -18735,22 +18772,6 @@
                 "required": ["name", "label"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "InlineErrorType": {
-                "enum": ["METADATA_PARSE_ERROR", "NO_DIMENSIONS_FOUND"],
-                "type": "string"
-            },
-            "InlineError": {
-                "properties": {
-                    "message": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/InlineErrorType"
-                    }
-                },
-                "required": ["message", "type"],
-                "type": "object"
             },
             "ExploreError": {
                 "allOf": [
@@ -20962,6 +20983,13 @@
                                 "type": "array"
                             }
                         ]
+                    },
+                    "warnings": {
+                        "items": {
+                            "$ref": "#/components/schemas/InlineError"
+                        },
+                        "type": "array",
+                        "description": "Non-fatal warnings from partial compilation.\nPresent when some joins or fields failed to compile but the explore is still usable.\nOnly populated when PARTIAL_COMPILATION_ENABLED=true."
                     }
                 },
                 "required": ["name", "label", "tags"],
@@ -21154,6 +21182,13 @@
                                 "type": "array"
                             }
                         ]
+                    },
+                    "warnings": {
+                        "items": {
+                            "$ref": "#/components/schemas/InlineError"
+                        },
+                        "type": "array",
+                        "description": "Non-fatal warnings from partial compilation.\nPresent when some joins or fields failed to compile but the explore is still usable.\nOnly populated when PARTIAL_COMPILATION_ENABLED=true."
                     }
                 },
                 "required": [
@@ -21177,6 +21212,12 @@
             },
             "ApiCompiledQueryResults": {
                 "properties": {
+                    "compilationErrors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "parameterReferences": {
                         "items": {
                             "type": "string"
@@ -23847,7 +23888,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2301.4",
+        "version": "0.2318.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -128,7 +128,8 @@ type RawSummaryRow = {
     tags: Explore['tags'];
     groupLabel: Explore['groupLabel'] | null;
     type: Explore['type'] | null;
-    errors: ExploreError['errors'] | null;
+    errors: ExploreError['errors'] | null; // Fatal errors from ExploreError
+    warnings: Explore['warnings'] | null; // Non-fatal warnings from partial compilation
     baseTable: Explore['baseTable'];
     baseTableDatabase: Explore['tables'][string]['database'];
     baseTableSchema: Explore['tables'][string]['schema'];
@@ -1135,6 +1136,7 @@ export class ProjectModel {
                     explore->'groupLabel' as "groupLabel",
                     explore->'type' as type,
                     explore->'errors' as errors,
+                    explore->'warnings' as warnings,
                     explore->'baseTable' as "baseTable",
                     explore->'tables'->(explore->>'baseTable')->>'database' as "baseTableDatabase",
                     explore->'tables'->(explore->>'baseTable')->>'schema' as "baseTableSchema",
@@ -1157,7 +1159,8 @@ export class ProjectModel {
             type: row.type ?? undefined,
             baseTableRequiredAttributes:
                 row.baseTableRequiredAttributes ?? undefined,
-            ...(row.errors ? { errors: row.errors } : {}), // Only add errors key if errors are present
+            ...(row.errors ? { errors: row.errors } : {}), // Fatal errors from ExploreError
+            ...(row.warnings ? { warnings: row.warnings } : {}), // Non-fatal warnings from partial compilation
         }));
     }
 

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -147,6 +147,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
     public async compileAllExplores(
         trackingParams?: TrackingParams,
         loadSources: boolean = false,
+        allowPartialCompilation: boolean = false,
     ): Promise<(Explore | ExploreError)[]> {
         Logger.debug('Install dependencies');
         // Install dependencies for dbt and fetch the manifest - may raise error meaning no explores compile
@@ -251,6 +252,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 this.warehouseClient,
                 lightdashProjectConfig,
                 disableTimestampConversion,
+                allowPartialCompilation,
             );
             Logger.info('Finished compiling explores');
             return [...lazyExplores, ...failedExplores];
@@ -296,6 +298,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     this.warehouseClient,
                     lightdashProjectConfig,
                     disableTimestampConversion,
+                    allowPartialCompilation,
                 );
                 Logger.info(
                     'Finished compiling explores after missing catalog error',

--- a/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitProjectAdapter.ts
@@ -216,9 +216,17 @@ export class DbtGitProjectAdapter
         }
     }
 
-    public async compileAllExplores(trackingParams?: TrackingParams) {
+    public async compileAllExplores(
+        trackingParams?: TrackingParams,
+        loadSources?: boolean,
+        allowPartialCompilation?: boolean,
+    ) {
         await this._refreshRepo();
-        return super.compileAllExplores(trackingParams);
+        return super.compileAllExplores(
+            trackingParams,
+            loadSources,
+            allowPartialCompilation,
+        );
     }
 
     public async test() {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -12,6 +12,7 @@ import {
     ExploreError,
     ExploreType,
     FieldType,
+    isExploreError,
     Job,
     JobLabels,
     JobStatusType,
@@ -553,7 +554,8 @@ export const exploreToSummaryWithAttributes = (
 ): SummaryExplore & {
     baseTableRequiredAttributes?: Record<string, string | string[]>;
 } => {
-    if ('errors' in explore) {
+    // ExploreError: completely failed to compile (no tables field)
+    if (isExploreError(explore)) {
         return {
             name: explore.name,
             label: explore.label,
@@ -562,6 +564,7 @@ export const exploreToSummaryWithAttributes = (
         };
     }
 
+    // Working Explore (may have partial compilation warnings)
     const baseTable = explore.tables[explore.baseTable];
     return {
         name: explore.name,
@@ -572,5 +575,6 @@ export const exploreToSummaryWithAttributes = (
         description: baseTable.description,
         type: explore.type,
         baseTableRequiredAttributes: baseTable.requiredAttributes,
+        ...(explore.warnings ? { warnings: explore.warnings } : {}),
     };
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1639,6 +1639,9 @@ export class ProjectService extends BaseService {
                             return {
                                 explores: await adapter.compileAllExplores(
                                     trackingParams,
+                                    false, // loadSources
+                                    this.lightdashConfig.partialCompilation
+                                        .enabled,
                                 ),
                                 lightdashProjectConfig:
                                     await adapter.getLightdashProjectConfig(
@@ -1969,6 +1972,8 @@ export class ProjectService extends BaseService {
                             };
                             const explores = await adapter.compileAllExplores(
                                 trackingParams,
+                                false, // loadSources
+                                this.lightdashConfig.partialCompilation.enabled,
                             );
                             const lightdashProjectConfig =
                                 await adapter.getLightdashProjectConfig(
@@ -4026,7 +4031,11 @@ export class ProjectService extends BaseService {
                 organizationUuid: project.organizationUuid,
                 userUuid: user.userUuid,
             };
-            const explores = await adapter.compileAllExplores(trackingParams);
+            const explores = await adapter.compileAllExplores(
+                trackingParams,
+                false, // loadSources
+                this.lightdashConfig.partialCompilation.enabled,
+            );
             this.analytics.track({
                 event: 'project.compiled',
                 userId: user.userUuid,

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -17,10 +17,14 @@ export interface ProjectAdapter {
     /**
      * Compile all explores
      * @param trackingParams - Optional tracking parameters to track the compilation and lightdash project config (lightdash.config.yml) overrides
+     * @param loadSources - Whether to load source information for each explore
+     * @param allowPartialCompilation - When true, fields that fail to compile will be marked with errors instead of failing the entire explore
      * @returns A promise that resolves to an array of explores or explore errors
      */
     compileAllExplores(
         trackingParams: TrackingParams | undefined,
+        loadSources?: boolean,
+        allowPartialCompilation?: boolean,
     ): Promise<(Explore | ExploreError)[]>;
 
     getDbtPackages(): Promise<DbtPackages | undefined>;

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -95,6 +95,7 @@ const getExploresFromLightdashYmlProject = async (
         warehouseSqlBuilder,
         lightdashProjectConfig,
         disableTimestampConversion,
+        process.env.PARTIAL_COMPILATION_ENABLED === 'true',
     );
 
     return validExplores;
@@ -260,6 +261,7 @@ export const compile = async (options: CompileHandlerOptions) => {
             warehouseSqlBuilder,
             lightdashProjectConfig,
             options.disableTimestampConversion,
+            process.env.PARTIAL_COMPILATION_ENABLED === 'true',
         );
         console.error('');
 

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -869,6 +869,7 @@ export const convertExplores = async (
     warehouseSqlBuilder: WarehouseSqlBuilder,
     lightdashProjectConfig: LightdashProjectConfig,
     disableTimestampConversion?: boolean,
+    allowPartialCompilation?: boolean,
 ): Promise<(Explore | ExploreError)[]> => {
     const tableLineage = translateDbtModelsToTableLineage(models);
     const [tables, exploreErrors] = models.reduce(
@@ -941,7 +942,9 @@ export const convertExplores = async (
         (model) => tableLookup[model.name] !== undefined,
     );
 
-    const exploreCompiler = new ExploreCompiler(warehouseSqlBuilder);
+    const exploreCompiler = new ExploreCompiler(warehouseSqlBuilder, {
+        allowPartialCompilation,
+    });
     const explores: (Explore | ExploreError)[] = validModels.reduce<
         (Explore | ExploreError)[]
     >((acc, model) => {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -574,6 +574,14 @@ export interface Dimension extends Field {
     };
 }
 
+/**
+ * Error information stored on a field when compilation fails but
+ * partial compilation mode is enabled.
+ */
+export type FieldCompilationError = {
+    message: string;
+};
+
 type CompiledProperties = {
     compiledSql: string; // sql string with resolved template variables
     tablesReferences: Array<string> | undefined;
@@ -581,9 +589,21 @@ type CompiledProperties = {
         string,
         Record<string, string | string[]>
     >;
+    /**
+     * When partial compilation mode is enabled, fields that fail to compile
+     * will have this property set instead of causing the entire explore to fail.
+     */
+    compilationError?: FieldCompilationError;
 };
 export type CompiledDimension = Dimension & CompiledProperties;
 export type CompiledMetric = Metric & CompiledProperties;
+
+/**
+ * Type guard to check if a compiled field has a compilation error.
+ */
+export const hasFieldCompilationError = (
+    field: CompiledDimension | CompiledMetric,
+): boolean => field.compilationError !== undefined;
 
 export type CompiledField = CompiledDimension | CompiledMetric;
 

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -6,8 +6,14 @@ import {
     findReplaceableCustomMetrics,
     getMetrics,
 } from '@lightdash/common';
-import { ActionIcon, Group, Menu, Stack, Text } from '@mantine/core';
-import { IconCode, IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
+import { ActionIcon, Group, HoverCard, Menu, Stack, Text } from '@mantine/core';
+import {
+    IconAlertTriangle,
+    IconCode,
+    IconDots,
+    IconPencil,
+    IconTrash,
+} from '@tabler/icons-react';
 import {
     memo,
     useCallback,
@@ -43,6 +49,7 @@ import ExploreTree from '../ExploreTree';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
 import ExploreYamlModal from '../ExploreYamlModal';
+import WarningsHoverCardContent from '../WarningsHoverCard';
 import { useIsGitProject } from '../WriteBackModal/hooks';
 import { VisualizationConfigPortalId } from './constants';
 
@@ -195,7 +202,37 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                 }}
             >
                 <Group position="apart">
-                    <PageBreadcrumbs size="md" items={breadcrumbs} />
+                    <Group spacing="xs">
+                        <PageBreadcrumbs size="md" items={breadcrumbs} />
+                        {explore.warnings && explore.warnings.length > 0 && (
+                            <HoverCard
+                                withinPortal
+                                position="right"
+                                withArrow
+                                radius="md"
+                                shadow="subtle"
+                            >
+                                <HoverCard.Target>
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="yellow"
+                                        size="sm"
+                                    >
+                                        <MantineIcon
+                                            icon={IconAlertTriangle}
+                                            color="yellow.9"
+                                        />
+                                    </ActionIcon>
+                                </HoverCard.Target>
+                                <HoverCard.Dropdown maw={400} p="xs">
+                                    <WarningsHoverCardContent
+                                        type="warnings"
+                                        warnings={explore.warnings}
+                                    />
+                                </HoverCard.Dropdown>
+                            </HoverCard>
+                        )}
+                    </Group>
                     {explore.type === ExploreType.VIRTUAL && (
                         <Can
                             I="create"

--- a/packages/frontend/src/components/Explorer/WarningsHoverCard.tsx
+++ b/packages/frontend/src/components/Explorer/WarningsHoverCard.tsx
@@ -1,0 +1,41 @@
+import { type InlineError } from '@lightdash/common';
+import { Box, Stack, Text } from '@mantine/core';
+import type { FC } from 'react';
+
+type WarningsHoverCardContentProps = {
+    type: 'warnings' | 'errors';
+    warnings: InlineError[];
+};
+
+/**
+ * Content for the warnings and errors HoverCard dropdown.
+ * Shows a list of partial compilation warnings or errors with a header and scrollable list.
+ */
+const WarningsHoverCardContent: FC<WarningsHoverCardContentProps> = ({
+    type,
+    warnings,
+}) => (
+    <>
+        <Text fz="sm" fw={600} mb="xs">
+            Compilation {type} ({warnings.length})
+        </Text>
+        <Stack spacing="xs" sx={{ maxHeight: 250, overflow: 'auto' }}>
+            {warnings.map((warning, idx) => (
+                <Box
+                    key={idx}
+                    p="xs"
+                    sx={(theme) => ({
+                        backgroundColor: theme.colors.ldGray[0],
+                        borderRadius: 4,
+                    })}
+                >
+                    <Text fz="xs" sx={{ wordBreak: 'break-word' }}>
+                        {warning.message}
+                    </Text>
+                </Box>
+            ))}
+        </Stack>
+    </>
+);
+
+export default WarningsHoverCardContent;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/19268

Before

<img width="752" height="457" alt="Screenshot from 2026-01-08 15-48-22" src="https://github.com/user-attachments/assets/bf0561d4-beb5-41ca-b948-06553304ba60" />

After
<img width="814" height="469" alt="image" src="https://github.com/user-attachments/assets/005cef67-dcb1-4fbf-94f7-0442da99b334" />


<img width="686" height="345" alt="image" src="https://github.com/user-attachments/assets/e08c25c3-a4b4-41d8-94f7-832f6b2abd4d" />

### Description:
Adds a new partial compilation feature that allows explores to load even when some fields fail to compile. When enabled, fields with compilation errors are marked with a `compilationError` property instead of causing the entire explore to fail.

This feature is controlled by a new configuration option `partialCompilation.enabled` which can be set via the `PARTIAL_COMPILATION_ENABLED` environment variable.

The implementation:
- Adds the new configuration option to `LightdashConfig`
- Updates the `ExploreCompiler` to handle field compilation errors gracefully
- Passes the partial compilation flag through the project adapter chain
- Adds error handling for dimensions, metrics, and joins that fail to compile