### PR TITLE
fix: groups enabled feature flag checking

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -573,3 +573,16 @@ test('should set useSqlPivotResults only when the environment variable is set', 
     const falseConfig = parseConfig();
     expect(falseConfig.query.useSqlPivotResults).toBe(false);
 });
+
+test('should set groups.enabled only when the environment variable is set', () => {
+    const undefinedConfig = parseConfig();
+    expect(undefinedConfig.groups.enabled).toBeUndefined();
+
+    process.env.GROUPS_ENABLED = 'true';
+    const trueConfig = parseConfig();
+    expect(trueConfig.groups.enabled).toBe(true);
+
+    process.env.GROUPS_ENABLED = 'false';
+    const falseConfig = parseConfig();
+    expect(falseConfig.groups.enabled).toBe(false);
+});

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -864,7 +864,7 @@ export type LightdashConfig = {
         };
     };
     groups: {
-        enabled: boolean;
+        enabled: boolean | undefined;
     };
     extendedUsageAnalytics: {
         enabled: boolean;
@@ -1634,7 +1634,9 @@ export const parseConfig = (): LightdashConfig => {
             },
         },
         groups: {
-            enabled: process.env.GROUPS_ENABLED === 'true',
+            enabled: process.env.GROUPS_ENABLED
+                ? process.env.GROUPS_ENABLED === 'true'
+                : undefined,
         },
         extendedUsageAnalytics: {
             enabled: process.env.EXTENDED_USAGE_ANALYTICS === 'true',

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -81,7 +81,7 @@ export class FeatureFlagModel {
         featureFlagId,
     }: FeatureFlagLogicArgs) {
         const enabled =
-            this.lightdashConfig.groups.enabled ||
+            this.lightdashConfig.groups.enabled ??
             (user
                 ? await isFeatureFlagEnabled(
                       FeatureFlags.UserGroupsEnabled,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Updated the `groups.enabled` configuration to be optional by changing its type from `boolean` to `boolean | undefined`. 

The environment variable `GROUPS_ENABLED` now sets the value only when explicitly defined, otherwise it remains `undefined`. 

Updated the feature flag logic to use the nullish coalescing operator (`??`) instead of logical OR (`||`) when checking if groups are enabled.

This fixes the fact that we were always falling back to `posthog` even when the environment variable was explicitly set to false