### PR TITLE
fix: add organizationUuid to Tags subject in permission check

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6696,6 +6696,7 @@ export class ProjectService extends BaseService {
                 'manage',
                 subject('Tags', {
                     projectUuid,
+                    organizationUuid,
                 }),
             )
         ) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added `organizationUuid` to the Tags subject in the ProjectService's authorization check. This ensures that organization context is properly included when checking permissions for tag management operations.