### PR TITLE
fix: Reorder dashboard filters is not working on new dashboard

### DIFF
--- a/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
+++ b/packages/frontend/src/features/dashboardTabsV2/tabs.module.css
@@ -12,7 +12,7 @@
     top: 0;
     border-bottom: 1px solid transparent;
     z-index: var(--dashboard-tabs-zindex);
-    transform: translate3d(0, 0, 0);
+    isolation: isolate;
 
     /* When header is sticky above (edit mode), position below it */
     &[data-has-header-above='true'] {


### PR DESCRIPTION
Closes #19279

### Description:
tldr; Fixing reordering filters by replacing tabs `transform` with `isolation` to properly create a new stacking context without affecting coordinate calcs.

I was using transform with translate3d to create a new stack context for the tabs+filters effect on scroll. The issue was that the drag and drop library relied on pointer coordinates to detect drop zones, which were broken after using this hack.
Using `isolation` is a better solution and solves the problem
