### PR TITLE
feat: use feature flag for screenshot ready indicator

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -736,6 +736,7 @@ export class ServiceRepository
                     analytics: this.context.lightdashAnalytics,
                     slackAuthenticationModel:
                         this.models.getSlackAuthenticationModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Refactored the screenshot ready indicator functionality to use a feature flag instead of a configuration setting. This allows for more flexible control over when to use the screenshot ready indicator during unfurling operations. The feature flag `ScreenshotReadyIndicator` now determines whether to wait for the indicator element to appear before taking screenshots.

The implementation injects the feature flag model into the UnfurlService and checks the flag status for each organization/user context when processing unfurl requests.