### PR TITLE
feat: add monitoring for stuck scheduler jobs

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -171,6 +171,7 @@ const getTagsForTask: {
         'organization.uuid': payload.organizationUuid,
     }),
     [SCHEDULER_TASKS.GENERATE_SLACK_CHANNEL_SYNC_JOBS]: () => ({}),
+    [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: () => ({}),
 } as const;
 
 // Generic accessor function

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -99,6 +99,14 @@ export class SchedulerWorker extends SchedulerTask {
                         maxAttempts: 3,
                     },
                 },
+                {
+                    task: SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS,
+                    pattern: '*/30 * * * *', // Every 30 minutes
+                    options: {
+                        backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
+                        maxAttempts: 3,
+                    },
+                },
             ]),
             taskList: traceTasks(this.getTaskList()),
             events: schedulerWorkerEventEmitter,
@@ -982,6 +990,9 @@ export class SchedulerWorker extends SchedulerTask {
                 Logger.info(
                     `Completed generating Slack channel sync jobs: ${successful} successful, ${failed} failed out of ${organizationUuids.length} total`,
                 );
+            },
+            [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: async () => {
+                await this.schedulerService.checkForStuckJobs();
             },
         };
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -653,6 +653,7 @@ export class ServiceRepository
                     userModel: this.models.getUserModel(),
                     googleDriveClient: this.clients.getGoogleDriveClient(),
                     userService: this.getUserService(),
+                    jobModel: this.models.getJobModel(),
                 }),
         );
     }

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -67,6 +67,7 @@ export const SCHEDULER_TASKS = {
     DOWNLOAD_ASYNC_QUERY_RESULTS: 'downloadAsyncQueryResults',
     SYNC_SLACK_CHANNELS: 'syncSlackChannels',
     GENERATE_SLACK_CHANNEL_SYNC_JOBS: 'generateSlackChannelSyncJobs',
+    CHECK_FOR_STUCK_JOBS: 'checkForStuckJobs',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -103,6 +104,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: DownloadAsyncQueryResultsPayload;
     [SCHEDULER_TASKS.SYNC_SLACK_CHANNELS]: SyncSlackChannelsPayload;
     [SCHEDULER_TASKS.GENERATE_SLACK_CHANNEL_SYNC_JOBS]: TraceTaskBase;
+    [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2390

### Description:

Added a new scheduled task to detect and log stuck jobs in the scheduler. The task runs every 30 minutes and identifies jobs that have been locked for an extended period:

- Jobs locked for over 30 minutes are logged as warnings
- Jobs locked for over 1 hour are logged as errors and recorded in the database
- Added a new `getStuckJobs()` method to the SchedulerClient to query potentially stuck jobs
- Implemented `checkForStuckJobs()` in SchedulerService to analyze and categorize stuck jobs

This helps identify and track problematic long-running tasks that might be causing performance issues or resource contention.