### PR TITLE
feat: support wide site logo

### DIFF
--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -40,7 +40,14 @@ export const MainNavBarContent: FC<Props> = ({
                     component={Link}
                     to={homeUrl}
                     title="Home"
-                    size="lg"
+                    sx={{
+                        width: 'auto',
+                        height: 34,
+                        '& svg': {
+                            height: 32,
+                            width: 'auto',
+                        },
+                    }}
                 >
                     <Logo />
                 </ActionIcon>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/19073

### Description:
Display wider site logo if the asset is changed.

<!-- Add a description of the changes proposed in the pull request. -->
If the site's logo is changed to a rectangular, horizontally wider, image then allow the container to grow to accommodate it. The default square logo looks the same as before this change.

<!-- Even better add a screenshot / gif / loom -->
**BEFORE**
<img width="185" height="69" alt="image" src="https://github.com/user-attachments/assets/68b68f9a-261d-4514-b707-1d9379064cb3" />

**AFTER**
<img width="186" height="67" alt="image" src="https://github.com/user-attachments/assets/f286b24f-a0a8-49b5-8b2d-3d364fdb3d12" />

**WIDE LOGO - BEFORE**
<img width="186" height="72" alt="image" src="https://github.com/user-attachments/assets/8982f02d-2d45-4b2f-bbb3-b686a12d81f7" />

**WIDE LOGO - AFTER**
<img width="352" height="64" alt="image" src="https://github.com/user-attachments/assets/fe79f5ad-4b9a-40c8-bc98-09db710dd61f" />
