### PR TITLE
chore: update AI agent integration tests to run weekly instead of daily

### DIFF
--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -3,8 +3,8 @@ name: AI Agent Integration Tests
 on:
     schedule:
         # Runs on Monday to Friday at 8:00 UTC
-        # Use https://crontab.guru/#0_8_*_*_1-5 for reference
-        - cron: '0 8 * * 1-5'
+        # Use https://crontab.guru/#0_8_*_*_1 for reference
+        - cron: '0 8 * * 1'
     workflow_dispatch: # Allow manual trigger from GitHub Actions UI
     pull_request:
         paths:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Changed the AI agent integration tests schedule from running every weekday (Monday to Friday) to running only on Mondays at 8:00 UTC.
