### PR TITLE
fix: table cell menus not rendering correctly in dashboard v2

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/CellMenu.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/CellMenu.tsx
@@ -42,8 +42,8 @@ const CellMenu: FC<React.PropsWithChildren<CellMenuProps>> = ({
                             pointerEvents: 'none',
                             position: 'absolute',
                             zIndex: -1,
-                            left: elementBounds?.x ?? 0 + window.scrollX,
-                            top: elementBounds?.y ?? 0 + window.scrollY,
+                            left: (elementBounds?.x ?? 0) + window.scrollX,
+                            top: (elementBounds?.y ?? 0) + window.scrollY,
                             width: elementBounds?.width ?? 0,
                             height: elementBounds?.height ?? 0,
                         }}


### PR DESCRIPTION
### Description:
Fixing cell table positioning bug on dashboard v2. This happened because the `??` operator has less precedence than the `+`, creating wrong positioning for cell menus: `elementBounds?.x ?? 0 + window.scrollX` was evaluated as `elementBounds?.x ?? (0 + window.scrollX)` instead of `(elementBounds?.x ?? 0) + window.scrollX`. 
This affected dashboard v2 because we changed from container-based scrolling to full-page scrolling