### PR TITLE
fix: e2e test not finding mantine 8 modal

### DIFF
--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -47,18 +47,18 @@ describe('Space', () => {
         cy.contains('Save chart').click();
         cy.contains('Chart name');
 
-        cy.get('.mantine-Modal-body').find('button').should('be.disabled');
+        cy.get('.mantine-8-Modal-body').find('button').should('be.disabled');
         cy.get('[data-testid="ChartCreateModal/NameInput"]')
             .type(`Private chart ${timestamp}`)
             .should('have.value', `Private chart ${timestamp}`);
 
         // Saves to space by default
-        cy.get('.mantine-Modal-body')
+        cy.get('.mantine-8-Modal-body')
             .find('button')
             .should('not.be.disabled')
             .contains('Next')
             .click();
-        cy.get('.mantine-Modal-body')
+        cy.get('.mantine-8-Modal-body')
             .find('button')
             .should('not.be.disabled')
             .contains('Save')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Updated the Cypress test selectors for the Modal component from `.mantine-Modal-body` to `.mantine-8-Modal-body` to match the updated class naming convention in the Mantine library.