### PR TITLE
fix: formatting for quick calculations

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -568,7 +568,10 @@ const TableCalculationModal: FC<Props> = ({
                                     type="submit"
                                     ref={submitButtonRef}
                                     data-testid="table-calculation-save-button"
-                                    disabled={form.values.sql.length === 0}
+                                    disabled={
+                                        editMode === EditMode.SQL &&
+                                        form.values.sql.length === 0
+                                    }
                                 >
                                     {tableCalculation
                                         ? 'Save changes'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2374](https://linear.app/lightdash/issue/PROD-2374/edit-format-not-working-for-quick-table-calculations)

### Description:

Fix: When you use the quick table calculations and try to edit the format, the save button does not activate
