### PR TITLE
feat: add dark mode support for custom visualizations

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -141,6 +141,7 @@
         "vega": "^6.2.0",
         "vega-embed": "^7.1.0",
         "vega-lite": "^6.4.1",
+        "vega-themes": "^3.0.0",
         "zod": "^3.25.55"
     },
     "devDependencies": {

--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -1,6 +1,8 @@
-import { Anchor, Text } from '@mantine/core';
+import { Anchor, Text, useMantineColorScheme } from '@mantine/core';
 import { IconGraphOff } from '@tabler/icons-react';
-import { Suspense, lazy, useEffect, useRef, type FC } from 'react';
+import { Suspense, lazy, useEffect, useMemo, useRef, type FC } from 'react';
+// @ts-expect-error - vega-themes ESM export not resolved by TS moduleResolution
+import { dark as vegaDarkTheme } from 'vega-themes';
 import { type CustomVisualizationConfigAndData } from '../../hooks/useCustomVisualizationConfig';
 import { isCustomVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -24,6 +26,9 @@ const CustomVisualization: FC<Props> = ({
     onScreenshotError,
     ...props
 }) => {
+    const { colorScheme } = useMantineColorScheme();
+    const isDarkMode = colorScheme === 'dark';
+
     const {
         isLoading,
         visualizationConfig,
@@ -33,6 +38,19 @@ const CustomVisualization: FC<Props> = ({
     } = useVisualizationContext();
 
     const hasSignaledScreenshotReady = useRef(false);
+
+    const vegaConfig = useMemo(
+        () => ({
+            ...(isDarkMode ? vegaDarkTheme : {}),
+            background: 'transparent',
+            font: 'Inter, sans-serif',
+            autosize: {
+                type: 'fit' as const,
+                resize: true,
+            },
+        }),
+        [isDarkMode],
+    );
 
     useEffect(() => {
         if (hasSignaledScreenshotReady.current) return;
@@ -133,13 +151,7 @@ const CustomVisualization: FC<Props> = ({
                         // @ts-ignore, see above
                         height: 'container',
                         data: data,
-                        config: {
-                            font: 'Inter, sans-serif',
-                            autosize: {
-                                type: 'fit',
-                                resize: true,
-                            },
-                        },
+                        config: vegaConfig,
                     }}
                     options={{
                         actions: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1141,6 +1141,9 @@ importers:
       vega-lite:
         specifier: ^6.4.1
         version: 6.4.1(vega@6.2.0)
+      vega-themes:
+        specifier: ^3.0.0
+        version: 3.0.0(vega-lite@6.4.1(vega@6.2.0))(vega@6.2.0)
       zod:
         specifier: ^3.25.55
         version: 3.25.55


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/19302

### Description:

Added dark mode support for custom visualizations by integrating the vega-themes library. The PR adds automatic theme switching based on the user's Mantine color scheme preference, applying the dark theme when in dark mode while maintaining a transparent background. Also improved the configuration by centralizing Vega config options in a useMemo hook for better performance.