### PR TITLE
chore: check if ANTHROPIC_API_KEY is not 'undefined' as well

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -713,17 +713,19 @@ export const getAiConfig = () => ({
                   ),
               }
             : undefined,
-        anthropic: process.env.ANTHROPIC_API_KEY
-            ? {
-                  apiKey: process.env.ANTHROPIC_API_KEY,
-                  modelName:
-                      process.env.ANTHROPIC_MODEL_NAME ||
-                      DEFAULT_ANTHROPIC_MODEL_NAME,
-                  availableModels: getArrayFromCommaSeparatedList(
-                      'ANTHROPIC_AVAILABLE_MODELS',
-                  ),
-              }
-            : undefined,
+        anthropic:
+            process.env.ANTHROPIC_API_KEY &&
+            process.env.ANTHROPIC_API_KEY !== 'undefined'
+                ? {
+                      apiKey: process.env.ANTHROPIC_API_KEY,
+                      modelName:
+                          process.env.ANTHROPIC_MODEL_NAME ||
+                          DEFAULT_ANTHROPIC_MODEL_NAME,
+                      availableModels: getArrayFromCommaSeparatedList(
+                          'ANTHROPIC_AVAILABLE_MODELS',
+                      ),
+                  }
+                : undefined,
         openrouter: process.env.OPENROUTER_API_KEY
             ? {
                   apiKey: process.env.OPENROUTER_API_KEY,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Fix Anthropic API key validation to check for 'undefined' string value. This prevents the system from attempting to use an invalid API key when the environment variable is set to the string 'undefined' rather than being truly undefined.