### PR TITLE
fix: chart tooltips mispositioned on mobile touch devices

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/tooltipStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/tooltipStyles.ts
@@ -22,19 +22,25 @@ const stylesToString = (styles: Record<string, unknown>) =>
 /**
  * Get base tooltip styling
  */
-export const getTooltipStyle = () => ({
+export const getTooltipStyle = ({
+    appendToBody = true,
+}: {
+    appendToBody?: boolean;
+} = {}) => ({
     padding: 8,
     borderColor: GRAY_3,
     borderWidth: 1,
     borderRadius: 8,
     backgroundColor: TOOLTIP_BACKGROUND,
-    appendToBody: true,
+    renderMode: 'html' as const,
+    confine: true,
     textStyle: {
         color: GRAY_7,
         fontSize: 12,
     },
     extraCssText:
         'box-shadow: 0px 8px 8px 0px rgba(0, 0, 0, 0.08), 0px 0px 1px 0px rgba(0, 0, 0, 0.25);',
+    ...(appendToBody ? { appendToBody: true } : {}),
 });
 
 /**

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -320,6 +320,19 @@ const VisualizationProvider: FC<
         ],
     );
 
+    // Detect if the device supports touch events
+    // This helps us avoid appendTo: 'body' on touch devices where drag-to-scroll
+    // causes tooltip positioning issues.
+    // Related: https://github.com/apache/echarts/issues/12776
+    const isTouchDevice = useMemo(() => {
+        return (
+            'ontouchstart' in window ||
+            navigator.maxTouchPoints > 0 ||
+            // @ts-ignore - msMaxTouchPoints is for older IE
+            navigator.msMaxTouchPoints > 0
+        );
+    }, []);
+
     const value: Omit<
         ReturnType<typeof useVisualizationContext>,
         'visualizationConfig'
@@ -346,6 +359,7 @@ const VisualizationProvider: FC<
         containerWidth,
         containerHeight,
         isDashboard,
+        isTouchDevice,
     };
 
     switch (chartConfig.type) {

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -53,6 +53,8 @@ type VisualizationContext = {
     containerWidth?: number;
     containerHeight?: number;
     isDashboard?: boolean;
+    // Touch device detection for tooltip positioning
+    isTouchDevice: boolean;
 };
 
 const Context = createContext<VisualizationContext | undefined>(undefined);

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2124,6 +2124,7 @@ const useEchartsCartesianConfig = (
         getSeriesColor,
         minimal,
         parameters,
+        isTouchDevice,
     } = useVisualizationContext();
 
     const theme = useMantineTheme();
@@ -2674,10 +2675,9 @@ const useEchartsCartesianConfig = (
             show: true,
             trigger: 'axis',
             enterable: true,
-            ...getTooltipStyle(),
-            confine: true,
+            ...getTooltipStyle({ appendToBody: !isTouchDevice }),
             extraCssText: `overflow-y: auto; max-height:280px; ${
-                getTooltipStyle().extraCssText
+                getTooltipStyle({ appendToBody: !isTouchDevice }).extraCssText
             }`,
             axisPointer: getAxisPointerStyle(hasLineAreaScatterSeries),
             formatter: buildCartesianTooltipFormatter({
@@ -2704,6 +2704,7 @@ const useEchartsCartesianConfig = (
         parameters,
         series,
         dataToRender,
+        isTouchDevice,
     ]);
 
     // Calculate max stack label padding for 100% stacking grid

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -54,8 +54,13 @@ const useEchartsFunnelConfig = (
     selectedLegends?: Record<string, boolean>,
     isInDashboard?: boolean,
 ) => {
-    const { visualizationConfig, itemsMap, colorPalette, parameters } =
-        useVisualizationContext();
+    const {
+        visualizationConfig,
+        itemsMap,
+        colorPalette,
+        parameters,
+        isTouchDevice,
+    } = useVisualizationContext();
 
     const theme = useMantineTheme();
 
@@ -232,7 +237,7 @@ const useEchartsFunnelConfig = (
                 fontFamily: theme?.other.chartFont as string | undefined,
             },
             tooltip: {
-                ...getTooltipStyle(),
+                ...getTooltipStyle({ appendToBody: !isTouchDevice }),
                 trigger: 'item' as const,
             },
             series: [funnelSeriesOptions],
@@ -250,6 +255,7 @@ const useEchartsFunnelConfig = (
         isInDashboard,
         theme,
         legendConfigWithTooltip,
+        isTouchDevice,
     ]);
 
     if (!itemsMap) return;

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -41,6 +41,7 @@ const useEchartsPieConfig = (
         getGroupColor,
         minimal,
         parameters,
+        isTouchDevice,
     } = useVisualizationContext();
 
     const theme = useMantineTheme();
@@ -263,7 +264,7 @@ const useEchartsPieConfig = (
             },
             tooltip: {
                 trigger: 'item',
-                ...getTooltipStyle(),
+                ...getTooltipStyle({ appendToBody: !isTouchDevice }),
             },
             series: [pieSeriesOption],
             animation: !(isInDashboard || minimal),
@@ -276,6 +277,7 @@ const useEchartsPieConfig = (
         selectedLegends,
         isInDashboard,
         minimal,
+        isTouchDevice,
     ]);
 
     if (!itemsMap) return;

--- a/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
@@ -19,8 +19,13 @@ import { useVisualizationContext } from '../../components/LightdashVisualization
 const EchartsTreemapType = 'treemap';
 
 const useEchartsTreemapConfig = (isInDashboard: boolean) => {
-    const { visualizationConfig, itemsMap, colorPalette, parameters } =
-        useVisualizationContext();
+    const {
+        visualizationConfig,
+        itemsMap,
+        colorPalette,
+        parameters,
+        isTouchDevice,
+    } = useVisualizationContext();
     const theme = useMantineTheme();
 
     const chartConfig = useMemo(() => {
@@ -194,7 +199,7 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
                 fontFamily: theme?.other?.chartFont as string | undefined,
             },
             tooltip: {
-                ...getTooltipStyle(),
+                ...getTooltipStyle({ appendToBody: !isTouchDevice }),
                 trigger: 'item' as const, //Even though this is the default, tooltips will not show up if this is not set.
             },
             series: [treemapSeriesOption],
@@ -205,6 +210,7 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
         treemapSeriesOption,
         isInDashboard,
         theme?.other?.chartFont,
+        isTouchDevice,
     ]);
     if (!itemsMap) return;
     if (!eChartsOption || !treemapSeriesOption) return;


### PR DESCRIPTION
Closes: #19286

### Description:
This PR improves tooltip behavior on touch devices by detecting touch support and adjusting tooltip configuration accordingly. On touch devices, tooltips are now confined to the chart container instead of being appended to the body, which fixes positioning issues when users drag to scroll.

This fixes the issue where tooltips would appear in incorrect positions when scrolling on touch devices, as documented in the related ECharts issue: https://github.com/apache/echarts/issues/12776

_After_

[CleanShot 2026-01-09 at 15.35.05.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/69d4bf81-c7e4-4271-81fb-4f5ce6fa7319.mp4" />](https://app.graphite.com/user-attachments/video/69d4bf81-c7e4-4271-81fb-4f5ce6fa7319.mp4)

_Before_

[CleanShot 2026-01-09 at 15.35.52.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/dbe7cc55-c802-4fd5-bf28-23fd8a7e7582.mp4" />](https://app.graphite.com/user-attachments/video/dbe7cc55-c802-4fd5-bf28-23fd8a7e7582.mp4)

