### PR TITLE
fix: accept clientSessionKeepAlive on snowflake

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -283,6 +283,9 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             ...(credentials.accessUrl?.length
                 ? { accessUrl: credentials.accessUrl }
                 : {}),
+            ...(credentials.clientSessionKeepAlive !== undefined
+                ? { clientSessionKeepAlive: credentials.clientSessionKeepAlive }
+                : {}),
             sfRetryMaxLoginRetries: 3, // Number of retries for the login request.
             retryTimeout: 15000, // according to docs: The max login timeout value. This value is either 0 or over 300.
         };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:

Added support for the `clientSessionKeepAlive` option in the Snowflake warehouse client. This allows users to specify whether they want to keep the client session alive between queries, which can improve performance for applications that make frequent database calls.

> [!IMPORTANT]
> reverts https://github.com/lightdash/lightdash/pull/8099 This could help with "socket hang up" errors reported in `query_history` 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables session keepalive configuration for Snowflake connections.
> 
> - Adds optional `clientSessionKeepAlive` from `credentials` into Snowflake `connectionOptions` in `SnowflakeWarehouseClient.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a7b06a7db359facd5aa779f29fb8f2043722cac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->