### PR TITLE
feat: render sql chart loading skeleton based on chart type

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -194,6 +194,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
                 isLoading={!!savedSqlUuid && isChartLoading}
                 hasError
                 title={tileTitle}
+                chartKind={null}
                 {...rest}
             >
                 {(!savedSqlUuid || !isChartLoading) && (
@@ -217,6 +218,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
                 title={tile.properties.title || tile.properties.chartName || ''}
                 isLoading={isChartResultsLoading}
                 hasError={!!chartResultsError}
+                chartKind={chartData.config.type}
                 {...rest}
                 titleHref={`/projects/${projectUuid}/sql-runner/${chartData.slug}`}
                 extraMenuItems={
@@ -253,6 +255,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
             titleHref={`/projects/${projectUuid}/sql-runner/${chartData.slug}`}
             tile={tile}
             title={tile.properties.title || tile.properties.chartName || ''}
+            chartKind={chartData.config.type}
             {...rest}
             extraMenuItems={
                 projectUuid &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-182](https://linear.app/lightdash/issue/ZAP-182/update-dashboardsqlcharttile-to-support-chart-kind-loaders)

### Description:

Added `chartKind` property to the DashboardSqlChartTile component to properly display the chart type in the dashboard. This allows the UI to show the appropriate chart type indicator for SQL charts in various states (loading, error, and normal).

The property is set to:

- `null` when there's an error and no saved SQL UUID
- The chart's configuration type when displaying chart results
- The chart's configuration type when rendering the chart normally

This enhancement improves the visual consistency with other chart types in the dashboard.
