### PR TITLE
fix: display sql table chart full-width

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -23,6 +23,7 @@ import {
 import { useParams } from 'react-router';
 import { useSavedSqlChartResults } from '../../features/sqlRunner/hooks/useSavedSqlChartResults';
 import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFiltersForTile';
+import { useDashboardUIPreference } from '../../hooks/dashboard/useDashboardUIPreference';
 import useSearchParams from '../../hooks/useSearchParams';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
@@ -78,6 +79,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
     const context = useSearchParams('context') || undefined;
     const savedSqlUuid = tile.properties.savedSqlUuid || undefined;
     const [isDataExportModalOpen, setIsDataExportModalOpen] = useState(false);
+    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
     const canManageSqlRunner = user.data?.ability?.can(
         'manage',
         subject('SqlRunner', {
@@ -256,6 +258,10 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
             tile={tile}
             title={tile.properties.title || tile.properties.chartName || ''}
             chartKind={chartData.config.type}
+            fullWidth={
+                isDashboardRedesignEnabled &&
+                chartData.config.type === ChartKind.TABLE
+            }
             {...rest}
             extraMenuItems={
                 projectUuid &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Display sql runner table chart full-width  


Before: 

![CleanShot 2026-01-12 at 12.28.25@2x.png](https://app.graphite.com/user-attachments/assets/d9a19b03-ae7e-4a13-a050-b5225ed04563.png)



After: 



![image.png](https://app.graphite.com/user-attachments/assets/698b0ea2-c1fb-4a91-9284-1ceb31442850.png)



  
