### PR TITLE
feat: add option to apply conditional formatting to text

### DIFF
--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -38,6 +38,7 @@ export type ConditionalFormattingConfigWithSingleColor = {
     target: FieldTarget | null;
     color: string;
     rules: ConditionalFormattingWithFilterOperator[];
+    applyTo?: ConditionalFormattingColorApplyTo;
 };
 
 export const isConditionalFormattingConfigWithSingleColor = (
@@ -49,6 +50,7 @@ export type ConditionalFormattingConfigWithColorRange = {
     target: FieldTarget | null;
     color: ConditionalFormattingColorRange;
     rule: ConditionalFormattingMinMax<number | 'auto'>;
+    applyTo?: ConditionalFormattingColorApplyTo;
 };
 
 export const isConditionalFormattingConfigWithColorRange = (
@@ -96,6 +98,11 @@ export enum ConditionalFormattingComparisonType {
     VALUES = 'values',
     TARGET_FIELD = 'target_field',
     TARGET_TO_VALUES = 'target_to_values',
+}
+
+export enum ConditionalFormattingColorApplyTo {
+    CELL = 'cell',
+    TEXT = 'text',
 }
 
 export type ConditionalRuleLabel = {

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -7,6 +7,7 @@ import type {
     ItemsMap,
 } from '..';
 import {
+    ConditionalFormattingColorApplyTo,
     isConditionalFormattingConfigWithColorRange,
     isConditionalFormattingConfigWithSingleColor,
     isConditionalFormattingWithCompareTarget,
@@ -635,6 +636,11 @@ type GetColorFromRangeFunction = (
     minMaxRange: ConditionalFormattingMinMax,
 ) => string | undefined;
 
+export type ConditionalFormattingColorResult = {
+    color: string;
+    applyTo: ConditionalFormattingColorApplyTo;
+};
+
 export const getConditionalFormattingColorWithColorRange = ({
     field,
     value,
@@ -647,7 +653,7 @@ export const getConditionalFormattingColorWithColorRange = ({
     config: ConditionalFormattingConfigWithColorRange;
     minMaxMap: ConditionalFormattingMinMaxMap | undefined;
     getColorFromRange: GetColorFromRangeFunction;
-}) => {
+}): ConditionalFormattingColorResult | undefined => {
     if (!field) return undefined;
 
     const numericValue = typeof value === 'string' ? parseFloat(value) : value;
@@ -682,14 +688,23 @@ export const getConditionalFormattingColorWithColorRange = ({
         max = config.rule.max;
     }
 
-    return getColorFromRange(convertedValue, config.color, { min, max });
+    const color = getColorFromRange(convertedValue, config.color, { min, max });
+    if (!color) return undefined;
+
+    return {
+        color,
+        applyTo: config.applyTo ?? ConditionalFormattingColorApplyTo.CELL,
+    };
 };
 
 export const getConditionalFormattingColorWithSingleColor = ({
     config,
 }: {
     config: ConditionalFormattingConfigWithSingleColor;
-}) => config.color;
+}): ConditionalFormattingColorResult => ({
+    color: config.color,
+    applyTo: config.applyTo ?? ConditionalFormattingColorApplyTo.CELL,
+});
 
 export const getConditionalFormattingColor = ({
     field,
@@ -703,7 +718,7 @@ export const getConditionalFormattingColor = ({
     config: ConditionalFormattingConfig | undefined;
     minMaxMap: ConditionalFormattingMinMaxMap | undefined;
     getColorFromRange: GetColorFromRangeFunction;
-}) => {
+}): ConditionalFormattingColorResult | undefined => {
     if (!config) return undefined;
 
     if (isConditionalFormattingConfigWithSingleColor(config)) {

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -1,4 +1,5 @@
 import {
+    ConditionalFormattingColorApplyTo,
     ConditionalFormattingComparisonType,
     ConditionalFormattingConfigType,
     assertUnreachable,
@@ -319,6 +320,17 @@ export const ConditionalFormattingItem: FC<Props> = ({
         [handleChange, config],
     );
 
+    const handleChangeApplyTo = useCallback(
+        (newApplyTo: ConditionalFormattingColorApplyTo) => {
+            handleChange(
+                produce(config, (draft) => {
+                    draft.applyTo = newApplyTo;
+                }),
+            );
+        },
+        [handleChange, config],
+    );
+
     const controlLabel = `Rule ${configIndex}`;
     const accordionValue = `${configIndex}`;
 
@@ -400,6 +412,28 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                     onColorChange={handleChangeSingleColor}
                                 />
                             ) : null}
+                        </Group>
+
+                        <Group spacing="xs">
+                            <Config.Label>Apply to</Config.Label>
+
+                            <SegmentedControl
+                                data={[
+                                    {
+                                        value: ConditionalFormattingColorApplyTo.CELL,
+                                        label: 'Cell',
+                                    },
+                                    {
+                                        value: ConditionalFormattingColorApplyTo.TEXT,
+                                        label: 'Text',
+                                    },
+                                ]}
+                                value={
+                                    config.applyTo ??
+                                    ConditionalFormattingColorApplyTo.CELL
+                                }
+                                onChange={handleChangeApplyTo}
+                            />
                         </Group>
 
                         {isConditionalFormattingConfigWithSingleColor(

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1,4 +1,5 @@
 import {
+    ConditionalFormattingColorApplyTo,
     formatItemValue,
     getConditionalFormattingColor,
     getConditionalFormattingConfig,
@@ -742,7 +743,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                         rowFields: rowFieldsForCell,
                                     });
 
-                                const conditionalFormattingColor =
+                                const conditionalFormattingResult =
                                     getConditionalFormattingColor({
                                         field: item,
                                         value: value?.raw,
@@ -767,6 +768,10 @@ const PivotTable: FC<PivotTableProps> = ({
                                         },
                                     });
 
+                                const applyToText =
+                                    conditionalFormattingResult?.applyTo ===
+                                    ConditionalFormattingColorApplyTo.TEXT;
+
                                 const conditionalFormatting = (() => {
                                     const tooltipContent =
                                         getConditionalFormattingDescription(
@@ -777,29 +782,33 @@ const PivotTable: FC<PivotTableProps> = ({
                                         );
 
                                     if (
-                                        !conditionalFormattingColor ||
+                                        !conditionalFormattingResult ||
                                         !isHexCodeColor(
-                                            conditionalFormattingColor,
+                                            conditionalFormattingResult.color,
                                         )
                                     ) {
                                         return undefined;
                                     }
 
-                                    return {
-                                        tooltipContent,
-                                        color: readableColor(
-                                            conditionalFormattingColor,
-                                        ),
-                                        backgroundColor:
-                                            conditionalFormattingColor,
-                                    };
+                                    // When applying to text, set color directly without background
+                                    // When applying to cell, set background and calculate readable text color
+                                    return applyToText
+                                        ? {
+                                              tooltipContent,
+                                              color: conditionalFormattingResult.color,
+                                          }
+                                        : {
+                                              tooltipContent,
+                                              color: readableColor(
+                                                  conditionalFormattingResult.color,
+                                              ),
+                                              backgroundColor:
+                                                  conditionalFormattingResult.color,
+                                          };
                                 })();
 
-                                // When conditional formatting is applied, always use calculated contrast color
-                                // to ensure text remains readable regardless of light/dark mode
-                                const fontColor = conditionalFormattingColor
-                                    ? readableColor(conditionalFormattingColor)
-                                    : undefined;
+                                // Font color is set by conditionalFormatting above
+                                const fontColor = conditionalFormatting?.color;
 
                                 const suppressContextMenu =
                                     (value === undefined ||

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -1,4 +1,5 @@
 import {
+    ConditionalFormattingColorApplyTo,
     getConditionalFormattingColor,
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
@@ -112,7 +113,7 @@ const TableRow: FC<TableRowProps> = ({
                         rowFields,
                     });
 
-                const conditionalFormattingColor =
+                const conditionalFormattingResult =
                     getConditionalFormattingColor({
                         field,
                         value: cellValue?.value?.raw,
@@ -131,10 +132,14 @@ const TableRow: FC<TableRowProps> = ({
                         },
                     });
 
-                // Frozen/locked rows should have a fixed background, unless there is a conditional formatting color
+                const applyToText =
+                    conditionalFormattingResult?.applyTo ===
+                    ConditionalFormattingColorApplyTo.TEXT;
+
+                // Frozen/locked rows should have a fixed background, unless there is a conditional formatting color applied to cell
                 let backgroundColor: string | undefined;
-                if (conditionalFormattingColor) {
-                    backgroundColor = conditionalFormattingColor;
+                if (conditionalFormattingResult && !applyToText) {
+                    backgroundColor = conditionalFormattingResult.color;
                 } else if (meta?.frozen) {
                     backgroundColor = FROZEN_COLUMN_BACKGROUND;
                 }
@@ -147,11 +152,16 @@ const TableRow: FC<TableRowProps> = ({
                 );
 
                 const toggleExpander = row.getToggleExpandedHandler();
-                // When conditional formatting is applied, always use calculated contrast color
-                // to ensure text remains readable regardless of light/dark mode
-                const fontColor = conditionalFormattingColor
-                    ? getReadableTextColor(conditionalFormattingColor)
-                    : undefined;
+                // When conditional formatting is applied to cell, use calculated contrast color
+                // When applied to text, use the formatting color directly
+                let fontColor: string | undefined;
+                if (conditionalFormattingResult) {
+                    fontColor = applyToText
+                        ? conditionalFormattingResult.color
+                        : getReadableTextColor(
+                              conditionalFormattingResult.color,
+                          );
+                }
 
                 const suppressContextMenu =
                     cell.getIsPlaceholder() || cell.getIsAggregated();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2369](https://linear.app/lightdash/issue/PROD-2369/i-want-conditional-formatting-to-set-the-colour-of-the-text-not-the-cell)

### Description:

Added a new feature to conditional formatting that allows users to choose whether to apply formatting to the entire cell or just the text. This introduces a new enum `ConditionalFormattingColorApplyTo` with two options: `CELL` (default) and `TEXT`.

The implementation includes:

- A new optional `applyTo` property in conditional formatting configurations
- Updated color result type to include both color and application method
- UI controls in the conditional formatting panel to select the application method
- Logic in both Table and PivotTable components to apply formatting differently based on the selected option
