### PR TITLE
fix: add descriptive error messages to ForbiddenError exceptions

### DIFF
--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -142,7 +142,9 @@ export class RolesService extends BaseService {
                 }),
             )
         ) {
-            throw new ForbiddenError();
+            throw new ForbiddenError(
+                'You do not have permission to manage this organization',
+            );
         }
     }
 
@@ -182,7 +184,9 @@ export class RolesService extends BaseService {
                     }),
                 )
             ) {
-                throw new ForbiddenError();
+                throw new ForbiddenError(
+                    'You do not have permission to manage this project',
+                );
             }
         }
     }
@@ -562,10 +566,7 @@ export class RolesService extends BaseService {
     ): Promise<RoleAssignment> {
         const { roleId } = request;
         const project = await this.projectModel.getSummary(projectUuid);
-        RolesService.validateOrganizationAccess(
-            account,
-            project.organizationUuid,
-        );
+
         await this.validateProjectAccess(account, projectUuid);
         const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/19331

- Allow project admins to adjust permission without being "org admin"
- Update error message on forbidden

Before

<img width="910" height="421" alt="Screenshot from 2026-01-12 11-03-15" src="https://github.com/user-attachments/assets/be284f61-690d-4445-b048-83812b5a368c" />

After

Being project admin
<img width="901" height="385" alt="Screenshot from 2026-01-12 11-06-26" src="https://github.com/user-attachments/assets/6e0fdc4c-a6c4-4521-8fd5-dee2ebc23d75" />

Being project editor

<img width="909" height="401" alt="Screenshot from 2026-01-12 11-08-23" src="https://github.com/user-attachments/assets/7834e50f-5775-4075-acee-599582ea5ab0" />


### Description:
Added descriptive error messages to ForbiddenError instances in the RolesService to provide clearer feedback when users lack permissions to manage organizations or projects. Also removed redundant organization access validation in the getRoleAssignment method since project access validation already includes organization validation.