### PR TITLE
feat: add any_attributes for OR-based user attribute access control

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/customers.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/customers.yml
@@ -86,6 +86,16 @@ models:
         meta:
           dimension:
             type: string
+      - name: full_name
+        description: Customer's full name
+        config:
+          meta:
+            dimension:
+              type: string
+              sql: "CONCAT(${first_name}, ' ', ${last_name})"
+              any_attributes:
+                is_demo: true
+                name: [demo, demo2]
       - name: age
         description: Customer's age
         config:

--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -18,6 +18,7 @@ export type DbCatalog = {
     embedding_vector?: string;
     field_type?: string;
     required_attributes: Record<string, string | string[]> | null;
+    any_attributes: Record<string, string | string[]> | null;
     chart_usage: number | null;
     icon: CatalogItemIcon | null;
     table_name: string;
@@ -38,6 +39,7 @@ export type DbCatalogIn = Pick<
     | 'type'
     | 'field_type'
     | 'required_attributes'
+    | 'any_attributes'
     | 'chart_usage'
     | 'table_name'
     | 'spotlight_show'
@@ -83,6 +85,8 @@ export function getDbCatalogColumnFromCatalogProperty(
             return 'chart_usage';
         case 'requiredAttributes':
             return 'required_attributes';
+        case 'anyAttributes':
+            return 'any_attributes';
         case 'catalogSearchUuid':
             return 'catalog_search_uuid';
         case 'aiHints':

--- a/packages/backend/src/database/migrations/20251211000000_add-any-attributes-to-catalog.ts
+++ b/packages/backend/src/database/migrations/20251211000000_add-any-attributes-to-catalog.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('catalog_search', (table) => {
+        table.jsonb('any_attributes').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('catalog_search', (table) => {
+        table.dropColumn('any_attributes');
+    });
+}

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -445,6 +445,7 @@ export class AiAgentService {
                         doesExploreMatchRequiredAttributes(
                             explore.tables[explore.baseTable]
                                 .requiredAttributes,
+                            explore.tables[explore.baseTable].anyAttributes,
                             userAttributes,
                         ),
                     )

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1177,6 +1177,7 @@ export class McpService extends BaseService {
                         doesExploreMatchRequiredAttributes(
                             explore.tables[explore.baseTable]
                                 .requiredAttributes,
+                            explore.tables[explore.baseTable].anyAttributes,
                             userAttributes,
                         ),
                     )

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -429,6 +429,7 @@ export class CatalogModel {
                                             type: CatalogType.Field,
                                             field_type: FieldType.METRIC,
                                             required_attributes: {},
+                                            any_attributes: {},
                                             yaml_tags: [],
                                             ai_hints: null,
                                             chart_usage: 0,

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -108,6 +108,7 @@ export const convertExploresToCatalog = (
                 description: baseTable?.description || null,
                 type: CatalogType.Table,
                 required_attributes: baseTable.requiredAttributes ?? {}, // ! Initializing as {} so it is not NULL in the database which means it can't be accessed
+                any_attributes: baseTable.anyAttributes ?? {},
                 chart_usage: null, // Tables don't have chart usage
                 table_name: explore.baseTable,
                 spotlight_show: getSpotlightShow(explore.spotlight),
@@ -197,6 +198,10 @@ export const convertExploresToCatalog = (
                             field.requiredAttributes ??
                             baseTable.requiredAttributes ??
                             {}, // ! Initializing as {} so it is not NULL in the database which means it can't be accessed
+                        any_attributes:
+                            field.anyAttributes ??
+                            baseTable.anyAttributes ??
+                            {},
                         chart_usage: 0, // Fields are initialized with 0 chart usage
                         table_name: explore.baseTable,
                         spotlight_show: getSpotlightShow(

--- a/packages/backend/src/models/CatalogModel/utils/parser.test.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.test.ts
@@ -12,6 +12,7 @@ const createDbCatalog = (
     description: null,
     field_type: undefined,
     required_attributes: null,
+    any_attributes: null,
     chart_usage: 0,
     catalog_search_uuid: 'catalog-1',
     icon: null,

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -25,6 +25,7 @@ const parseFieldFromMetricOrDimension = (
         tags: string[];
         categories: Pick<Tag, 'tagUuid' | 'color' | 'name' | 'yamlReference'>[];
         requiredAttributes: Record<string, string | string[]> | undefined;
+        anyAttributes: Record<string, string | string[]> | undefined;
         chartUsage: number | undefined;
         icon: CatalogItemIcon | null;
         searchRank?: number;
@@ -43,6 +44,7 @@ const parseFieldFromMetricOrDimension = (
     type: CatalogType.Field,
     aiHints: convertToAiHints(field.aiHint) ?? null,
     requiredAttributes: catalogArgs.requiredAttributes,
+    anyAttributes: catalogArgs.anyAttributes,
     tags: catalogArgs.tags,
     categories: catalogArgs.categories,
     chartUsage: catalogArgs.chartUsage,
@@ -73,6 +75,7 @@ export const parseFieldsFromCompiledTable = (
             categories: [],
             requiredAttributes:
                 field.requiredAttributes ?? table.requiredAttributes,
+            anyAttributes: field.anyAttributes ?? table.anyAttributes,
             // ! since we're not pulling from the catalog search table these do not exist (keep compatibility with data catalog)
             chartUsage: undefined,
             catalogSearchUuid: '',
@@ -119,6 +122,7 @@ export const parseCatalog = (
             description: dbCatalog.description || undefined,
             type: CatalogType.Table,
             requiredAttributes: dbCatalog.required_attributes ?? undefined,
+            anyAttributes: dbCatalog.any_attributes ?? undefined,
             tags: dbCatalog.explore.tags,
             categories: dbCatalog.catalog_tags,
             chartUsage: dbCatalog.chart_usage ?? undefined,
@@ -163,6 +167,7 @@ export const parseCatalog = (
         tags: dbCatalog.explore.tags,
         categories: dbCatalog.catalog_tags,
         requiredAttributes: dbCatalog.required_attributes ?? undefined,
+        anyAttributes: dbCatalog.any_attributes ?? undefined,
         chartUsage: dbCatalog.chart_usage ?? 0,
         icon: dbCatalog.icon ?? null,
         searchRank: dbCatalog.search_rank,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -144,6 +144,7 @@ type RawSummaryRow = {
     baseTableRequiredAttributes:
         | Explore['tables'][string]['requiredAttributes']
         | null;
+    baseTableAnyAttributes: Explore['tables'][string]['anyAttributes'] | null;
     aiHint: Explore['aiHint'] | null;
 };
 
@@ -1136,6 +1137,7 @@ export class ProjectModel {
         Array<
             SummaryExplore & {
                 baseTableRequiredAttributes: Explore['tables'][string]['requiredAttributes'];
+                baseTableAnyAttributes: Explore['tables'][string]['anyAttributes'];
             }
         >
     > {
@@ -1154,6 +1156,7 @@ export class ProjectModel {
                     explore->'tables'->(explore->>'baseTable')->>'schema' as "baseTableSchema",
                     explore->'tables'->(explore->>'baseTable')->>'description' as "baseTableDescription",
                     explore->'tables'->(explore->>'baseTable')->'requiredAttributes' as "baseTableRequiredAttributes",
+                    explore->'tables'->(explore->>'baseTable')->'anyAttributes' as "baseTableAnyAttributes",
                     explore->'aiHint' as "aiHint"
                 `),
             )
@@ -1171,6 +1174,7 @@ export class ProjectModel {
             type: row.type ?? undefined,
             baseTableRequiredAttributes:
                 row.baseTableRequiredAttributes ?? undefined,
+            baseTableAnyAttributes: row.baseTableAnyAttributes ?? undefined,
             ...(row.errors ? { errors: row.errors } : {}), // Fatal errors from ExploreError
             ...(row.warnings ? { warnings: row.warnings } : {}), // Non-fatal warnings from partial compilation
         }));

--- a/packages/backend/src/queryCompiler.mock.ts
+++ b/packages/backend/src/queryCompiler.mock.ts
@@ -155,6 +155,7 @@ export const METRIC_QUERY_WITH_ADDITIONAL_METRICS_COMPILED: CompiledMetricQuery 
                 format: undefined,
                 filters: [],
                 requiredAttributes: undefined,
+                anyAttributes: undefined,
                 dimensionReference: undefined,
                 groups: [],
             },

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -153,6 +153,7 @@ export class CatalogService<
             if (
                 doesExploreMatchRequiredAttributes(
                     explore.tables[explore.baseTable].requiredAttributes,
+                    explore.tables[explore.baseTable].anyAttributes,
                     userAttributes,
                 )
             ) {
@@ -238,6 +239,7 @@ export class CatalogService<
             if (
                 doesExploreMatchRequiredAttributes(
                     explore.tables[explore.baseTable].requiredAttributes,
+                    explore.tables[explore.baseTable].anyAttributes,
                     userAttributes,
                 )
             ) {
@@ -358,6 +360,7 @@ export class CatalogService<
                 if (
                     !doesExploreMatchRequiredAttributes(
                         explore.tables[explore.baseTable].requiredAttributes,
+                        explore.tables[explore.baseTable].anyAttributes,
                         userAttributes,
                     )
                 ) {
@@ -767,6 +770,7 @@ export class CatalogService<
         if (
             !doesExploreMatchRequiredAttributes(
                 explore.tables[explore.baseTable].requiredAttributes,
+                explore.tables[explore.baseTable].anyAttributes,
                 userAttributes,
             )
         ) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4600,8 +4600,12 @@ export class ProjectService extends BaseService {
         const { userAttributes } = await this.getUserAttributes({ account });
 
         return exploreSummaries.reduce<SummaryExplore[]>((acc, summary) => {
-            const { baseTableRequiredAttributes, ...rest } = summary;
-            const summaryExplore: SummaryExplore = rest; // Just type assertion to remove the baseTableRequiredAttributes
+            const {
+                baseTableRequiredAttributes,
+                baseTableAnyAttributes,
+                ...rest
+            } = summary;
+            const summaryExplore: SummaryExplore = rest; // Just type assertion to remove the baseTableRequiredAttributes and baseTableAnyAttributes
 
             if (!includeErrors && 'errors' in summaryExplore) {
                 return acc;
@@ -4611,6 +4615,7 @@ export class ProjectService extends BaseService {
             if (
                 !doesExploreMatchRequiredAttributes(
                     baseTableRequiredAttributes,
+                    baseTableAnyAttributes,
                     userAttributes,
                 )
             ) {

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
@@ -22,6 +22,7 @@ describe('doesExploreMatchUserAttributes', () => {
                 EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables[
                     EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.baseTable
                 ].requiredAttributes,
+                undefined,
                 {},
             ),
         ).toStrictEqual(true);
@@ -30,6 +31,7 @@ describe('doesExploreMatchUserAttributes', () => {
                 EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables[
                     EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.baseTable
                 ].requiredAttributes,
+                undefined,
                 { test: ['1'] },
             ),
         ).toStrictEqual(true);
@@ -40,6 +42,7 @@ describe('doesExploreMatchUserAttributes', () => {
                 EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.tables[
                     EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.baseTable
                 ].requiredAttributes,
+                undefined,
                 { access_level: ['2'] },
             ),
         ).toStrictEqual(true);
@@ -50,6 +53,7 @@ describe('doesExploreMatchUserAttributes', () => {
                 EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.tables[
                     EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.baseTable
                 ].requiredAttributes,
+                undefined,
                 {},
             ),
         ).toStrictEqual(false);
@@ -58,6 +62,7 @@ describe('doesExploreMatchUserAttributes', () => {
                 EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.tables[
                     EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES.baseTable
                 ].requiredAttributes,
+                undefined,
                 { access_level: ['1'] },
             ),
         ).toStrictEqual(false);

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -114,26 +114,85 @@ export const hasUserAttributes = (
     });
 };
 
+/**
+ * Check if user has ANY of the specified attributes (OR logic).
+ * @param anyAttributes - Attributes where at least one must match
+ * @param userAttributes - User's actual attributes
+ * @returns true if at least one attribute condition is satisfied
+ */
+export const hasAnyUserAttributes = (
+    anyAttributes: Record<string, string | string[]>,
+    userAttributes: UserAttributeValueMap,
+): boolean => {
+    if (Object.keys(anyAttributes).length === 0) return true;
+
+    return Object.entries(anyAttributes).some((attribute) => {
+        const [attributeName, value] = attribute;
+        if (Array.isArray(value)) {
+            return value.some((v) =>
+                hasUserAttribute(userAttributes, attributeName, v),
+            );
+        }
+        return hasUserAttribute(userAttributes, attributeName, value);
+    });
+};
+
+/**
+ * Unified validation that handles both required (AND) and any (OR) attributes.
+ * @param requiredAttributes - All of these must match (AND logic)
+ * @param anyAttributes - At least one of these must match (OR logic)
+ * @param userAttributes - User's actual attributes
+ * @returns true if user has access (both checks pass when defined)
+ */
+export const checkUserAttributesAccess = (
+    requiredAttributes: Record<string, string | string[]> | undefined,
+    anyAttributes: Record<string, string | string[]> | undefined,
+    userAttributes: UserAttributeValueMap,
+): boolean => {
+    if (requiredAttributes === undefined && anyAttributes === undefined) {
+        return true;
+    }
+
+    const hasRequiredAccess =
+        requiredAttributes === undefined ||
+        hasUserAttributes(requiredAttributes, userAttributes);
+
+    const hasAnyAccess =
+        anyAttributes === undefined ||
+        hasAnyUserAttributes(anyAttributes, userAttributes);
+
+    return hasRequiredAccess && hasAnyAccess;
+};
+
 export const exploreHasFilteredAttribute = (explore: Explore) =>
     Object.values(explore.tables).some((table) => {
         if (!table) return false;
 
         return (
             table.requiredAttributes !== undefined ||
+            table.anyAttributes !== undefined ||
             Object.values(table.dimensions).some(
-                (dimension) => dimension?.requiredAttributes !== undefined,
+                (dimension) =>
+                    dimension?.requiredAttributes !== undefined ||
+                    dimension?.anyAttributes !== undefined,
             )
         );
     });
 
 export const doesExploreMatchRequiredAttributes = (
-    exploreAttributes:
+    exploreRequiredAttributes:
         | Explore['tables'][string]['requiredAttributes']
+        | undefined,
+    exploreAnyAttributes:
+        | Explore['tables'][string]['anyAttributes']
         | undefined,
     userAttributes: UserAttributeValueMap,
 ) =>
-    exploreAttributes === undefined ||
-    hasUserAttributes(exploreAttributes, userAttributes);
+    checkUserAttributesAccess(
+        exploreRequiredAttributes,
+        exploreAnyAttributes,
+        userAttributes,
+    );
 
 export const getFilteredExplore = (
     explore: Explore,
@@ -149,6 +208,7 @@ export const getFilteredExplore = (
     if (
         !doesExploreMatchRequiredAttributes(
             baseTable.requiredAttributes,
+            baseTable.anyAttributes,
             userAttributes,
         )
     ) {
@@ -160,7 +220,13 @@ export const getFilteredExplore = (
     const filteredTableNames: string[] = Object.values(explore.tables).reduce<
         string[]
     >((acc, table) => {
-        if (hasUserAttributes(table.requiredAttributes, userAttributes))
+        if (
+            checkUserAttributesAccess(
+                table.requiredAttributes,
+                table.anyAttributes,
+                userAttributes,
+            )
+        )
             return [...acc, table.name];
         return acc;
     }, []);
@@ -185,10 +251,12 @@ export const getFilteredExplore = (
                             ([metricName, metric]) => {
                                 if (!metric) return false;
 
-                                const canAccessMetric = hasUserAttributes(
-                                    metric.requiredAttributes,
-                                    userAttributes,
-                                );
+                                const canAccessMetric =
+                                    checkUserAttributesAccess(
+                                        metric.requiredAttributes,
+                                        metric.anyAttributes,
+                                        userAttributes,
+                                    );
                                 if (!canAccessMetric) return false;
                                 return (
                                     !metric.tablesReferences ||
@@ -215,10 +283,12 @@ export const getFilteredExplore = (
                                                 tableReference,
                                             ),
                                     );
-                                const canAccessDimension = hasUserAttributes(
-                                    dimension.requiredAttributes,
-                                    userAttributes,
-                                );
+                                const canAccessDimension =
+                                    checkUserAttributesAccess(
+                                        dimension.requiredAttributes,
+                                        dimension.anyAttributes,
+                                        userAttributes,
+                                    );
                                 return (
                                     canAccessAllTableReferences &&
                                     canAccessDimension

--- a/packages/common/src/compiler/lightdashModelConverter.ts
+++ b/packages/common/src/compiler/lightdashModelConverter.ts
@@ -50,6 +50,7 @@ export function convertLightdashModelToDbtModel(
             colors: dimension.colors,
             urls: dimension.urls,
             required_attributes: dimension.required_attributes,
+            any_attributes: dimension.any_attributes,
             ai_hint: dimension.ai_hint,
             tags: dimension.tags,
             compact: dimension.compact,
@@ -82,6 +83,7 @@ export function convertLightdashModelToDbtModel(
         sql_where: model.sql_where,
         sql_from: sqlFrom, // from_sql maps directly to sql_from
         required_attributes: model.required_attributes,
+        any_attributes: model.any_attributes,
         group_details: model.group_details,
         default_time_dimension: model.default_time_dimension,
         spotlight: model.spotlight,

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -234,6 +234,7 @@ export const BASE_LIGHTDASH_TABLE: Omit<Table, 'lineageGraph'> = {
     description: model.description,
     sqlWhere: undefined,
     requiredAttributes: undefined,
+    anyAttributes: undefined,
     primaryKey: undefined,
     dimensions: {
         myColumnName: {
@@ -241,6 +242,7 @@ export const BASE_LIGHTDASH_TABLE: Omit<Table, 'lineageGraph'> = {
             description: undefined,
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             format: undefined,
             groups: [],
             colors: undefined,
@@ -313,6 +315,7 @@ export const LIGHTDASH_TABLE_WITH_SINGLE_PRIMARY_KEY: Omit<
         user_id: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.STRING,
             sql: '${TABLE}.user_id',
@@ -345,6 +348,7 @@ export const LIGHTDASH_TABLE_WITH_COMPOSITE_PRIMARY_KEY: Omit<
         user_id: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.STRING,
             sql: '${TABLE}.user_id',
@@ -367,6 +371,7 @@ export const LIGHTDASH_TABLE_WITH_COMPOSITE_PRIMARY_KEY: Omit<
         order_id: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.STRING,
             sql: '${TABLE}.order_id',
@@ -437,6 +442,7 @@ export const LIGHTDASH_TABLE_WITH_GROUP_BLOCK: Omit<Table, 'lineageGraph'> = {
             description: undefined,
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             format: undefined,
             groups: [],
             colors: undefined,
@@ -470,6 +476,7 @@ export const LIGHTDASH_TABLE_WITH_GROUP_BLOCK: Omit<Table, 'lineageGraph'> = {
             name: 'user_id_count',
             percentile: undefined,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             round: undefined,
             showUnderlyingValues: undefined,
             source: undefined,
@@ -543,6 +550,7 @@ export const LIGHTDASH_TABLE_WITHOUT_AUTO_METRICS: Omit<Table, 'lineageGraph'> =
             user_id: {
                 fieldType: FieldType.DIMENSION,
                 requiredAttributes: undefined,
+                anyAttributes: undefined,
                 description: undefined,
                 type: DimensionType.STRING,
                 sql: '${TABLE}.user_id',
@@ -780,6 +788,7 @@ export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
         user_id: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.STRING,
             sql: '${TABLE}.user_id',
@@ -802,6 +811,7 @@ export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
         num_participating_athletes: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.NUMBER,
             sql: 'num_participating_men + num_participating_women',
@@ -844,6 +854,7 @@ export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
             index: 0,
             dimensionReference: 'myTable_user_id',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             spotlight: {
                 visibility: 'show',
                 categories: [],
@@ -870,6 +881,7 @@ export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
             index: 1,
             dimensionReference: 'myTable_num_participating_athletes',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             spotlight: {
                 visibility: 'show',
                 categories: [],
@@ -899,6 +911,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
         user_created: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.TIMESTAMP,
             sql: '${TABLE}.user_created',
@@ -921,6 +934,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
         user_created_raw: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.TIMESTAMP,
             sql: '${TABLE}.user_created',
@@ -943,6 +957,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
         user_created_day: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: 'TIMESTAMP_TRUNC(${TABLE}.user_created, DAY)',
@@ -965,6 +980,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
         user_created_week: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: 'TIMESTAMP_TRUNC(${TABLE}.user_created, WEEK)',
@@ -988,6 +1004,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
         user_created_month: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: 'TIMESTAMP_TRUNC(${TABLE}.user_created, MONTH)',
@@ -1012,6 +1029,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
             description: undefined,
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             format: undefined,
             groups: ['User created'],
             colors: undefined,
@@ -1033,6 +1051,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_BIGQUERY: Omi
         user_created_year: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: 'TIMESTAMP_TRUNC(${TABLE}.user_created, YEAR)',
@@ -1065,6 +1084,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
         user_created: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.TIMESTAMP,
             sql: "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.user_created))",
@@ -1087,6 +1107,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
         user_created_raw: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.TIMESTAMP,
             sql: "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.user_created))",
@@ -1109,6 +1130,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
         user_created_day: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: "DATE_TRUNC('DAY', TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.user_created)))",
@@ -1133,6 +1155,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
         user_created_week: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: "DATE_TRUNC('WEEK', TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.user_created)))",
@@ -1155,6 +1178,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
         user_created_month: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: "DATE_TRUNC('MONTH', TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.user_created)))",
@@ -1178,6 +1202,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
             description: undefined,
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             format: undefined,
             groups: ['User created'],
             colors: undefined,
@@ -1200,6 +1225,7 @@ export const LIGHTDASH_TABLE_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS_SNOWFLAKE: Om
         user_created_year: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: "DATE_TRUNC('YEAR', TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.user_created)))",
@@ -1244,6 +1270,7 @@ export const LIGHTDASH_TABLE_WITH_OFF_TIME_INTERVAL_DIMENSIONS: Omit<
         user_created: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.TIMESTAMP,
             sql: '${TABLE}.user_created',
@@ -1282,6 +1309,7 @@ export const LIGHTDASH_TABLE_WITH_CUSTOM_TIME_INTERVAL_DIMENSIONS: Omit<
         user_created: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: '${TABLE}.user_created',
@@ -1304,6 +1332,7 @@ export const LIGHTDASH_TABLE_WITH_CUSTOM_TIME_INTERVAL_DIMENSIONS: Omit<
         user_created_year: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.DATE,
             sql: 'DATE_TRUNC(${TABLE}.user_created, YEAR)',
@@ -1407,6 +1436,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
         metadata: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.STRING,
             sql: '${TABLE}.metadata',
@@ -1429,6 +1459,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
         version: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.NUMBER,
             sql: "${metadata}-->'version'",
@@ -1452,6 +1483,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
         created_at: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.TIMESTAMP,
             sql: "${metadata}-->'created_at'",
@@ -1486,6 +1518,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
             label: 'Created at day',
             name: 'created_at_day',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             round: undefined,
             source: undefined,
             sql: "DATE_TRUNC('DAY', ${metadata}-->'created_at')",
@@ -1509,6 +1542,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
             label: 'Created at month',
             name: 'created_at_month',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             round: undefined,
             source: undefined,
             sql: "DATE_TRUNC('MONTH', ${metadata}-->'created_at')",
@@ -1532,6 +1566,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
             label: 'Created at quarter',
             name: 'created_at_quarter',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             round: undefined,
             source: undefined,
             sql: "DATE_TRUNC('QUARTER', ${metadata}-->'created_at')",
@@ -1555,6 +1590,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
             label: 'Created at raw',
             name: 'created_at_raw',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             round: undefined,
             source: undefined,
             sql: "${metadata}-->'created_at'",
@@ -1578,6 +1614,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
             label: 'Created at week',
             name: 'created_at_week',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             round: undefined,
             source: undefined,
             sql: "DATE_TRUNC('WEEK', ${metadata}-->'created_at')",
@@ -1601,6 +1638,7 @@ export const LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS: Omit<
             label: 'Created at year',
             name: 'created_at_year',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             round: undefined,
             source: undefined,
             sql: "DATE_TRUNC('YEAR', ${metadata}-->'created_at')",
@@ -1811,6 +1849,7 @@ export const LIGHTDASH_TABLE_WITH_DIMENSION_AI_HINT: Omit<
         user_name: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.STRING,
             sql: '${TABLE}.user_name',
@@ -1841,6 +1880,7 @@ export const LIGHTDASH_TABLE_WITH_METRIC_AI_HINT: Omit<Table, 'lineageGraph'> =
             user_id: {
                 fieldType: FieldType.DIMENSION,
                 requiredAttributes: undefined,
+                anyAttributes: undefined,
                 description: undefined,
                 type: DimensionType.STRING,
                 sql: '${TABLE}.user_id',
@@ -1883,6 +1923,7 @@ export const LIGHTDASH_TABLE_WITH_METRIC_AI_HINT: Omit<Table, 'lineageGraph'> =
                 index: 0,
                 dimensionReference: 'myTable_user_id',
                 requiredAttributes: undefined,
+                anyAttributes: undefined,
                 spotlight: {
                     visibility: 'show',
                     categories: [],
@@ -1983,6 +2024,7 @@ export const LIGHTDASH_TABLE_WITH_MODEL_METRIC_AI_HINT: Omit<
             index: 0,
             dimensionReference: undefined,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             spotlight: {
                 visibility: 'show',
                 categories: [],
@@ -2006,6 +2048,7 @@ export const LIGHTDASH_TABLE_WITH_DIMENSION_AI_HINT_ARRAY: Omit<
         user_name: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.STRING,
             sql: '${TABLE}.user_name',
@@ -2038,6 +2081,7 @@ export const LIGHTDASH_TABLE_WITH_METRIC_AI_HINT_ARRAY: Omit<
         user_id: {
             fieldType: FieldType.DIMENSION,
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             description: undefined,
             type: DimensionType.STRING,
             sql: '${TABLE}.user_id',
@@ -2080,6 +2124,7 @@ export const LIGHTDASH_TABLE_WITH_METRIC_AI_HINT_ARRAY: Omit<
             index: 0,
             dimensionReference: 'myTable_user_id',
             requiredAttributes: undefined,
+            anyAttributes: undefined,
             spotlight: {
                 visibility: 'show',
                 categories: [],

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -191,6 +191,7 @@ const convertDimension = (
         round: meta.dimension?.round,
         compact: meta.dimension?.compact,
         requiredAttributes: meta.dimension?.required_attributes,
+        anyAttributes: meta.dimension?.any_attributes,
         colors: meta.dimension?.colors,
         ...(meta.dimension?.urls ? { urls: meta.dimension.urls } : {}),
         ...(meta.dimension?.image ? { image: meta.dimension.image } : {}),
@@ -718,6 +719,7 @@ export const convertTable = (
                             metric,
                             tableLabel,
                             requiredAttributes: dimension.requiredAttributes, // TODO Join dimension required_attributes with metric required_attributes
+                            anyAttributes: dimension.anyAttributes, // TODO Join dimension any_attributes with metric any_attributes
                             spotlightConfig: {
                                 ...spotlightConfig,
                                 default_visibility:
@@ -850,6 +852,7 @@ export const convertTable = (
             defaultFilters: meta.default_filters,
         }),
         requiredAttributes: meta.required_attributes,
+        anyAttributes: meta.any_attributes,
         groupDetails,
         ...(meta.default_time_dimension
             ? {

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -17,6 +17,23 @@
                 ]
             }
         },
+        "AnyAttributes": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": {
+                "oneOf": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
+            }
+        },
         "Compact": {
             "type": "string",
             "enum": [
@@ -181,6 +198,9 @@
                 },
                 "required_attributes": {
                     "$ref": "#/definitions/RequiredAttributes"
+                },
+                "any_attributes": {
+                    "$ref": "#/definitions/AnyAttributes"
                 }
             }
         },
@@ -227,6 +247,9 @@
                 },
                 "required_attributes": {
                     "$ref": "#/definitions/RequiredAttributes"
+                },
+                "any_attributes": {
+                    "$ref": "#/definitions/AnyAttributes"
                 }
             }
         },
@@ -402,6 +425,9 @@
                 },
                 "required_attributes": {
                     "$ref": "#/definitions/RequiredAttributes"
+                },
+                "any_attributes": {
+                    "$ref": "#/definitions/AnyAttributes"
                 }
             },
             "default": {}

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -483,6 +483,23 @@
                                     ]
                                 }
                             },
+                            "any_attributes": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": {
+                                    "oneOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                }
+                            },
                             "parameters": {
                                 "type": ["object", "null"],
                                 "description": "Define parameters that can be used in SQL queries",
@@ -1133,6 +1150,23 @@
                                                         ]
                                                     }
                                                 },
+                                                "any_attributes": {
+                                                    "type": "object",
+                                                    "properties": {},
+                                                    "additionalProperties": {
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "string"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
                                                 "spotlight": {
                                                     "type": "object",
                                                     "description": "Configure dimension visibility in the Metrics Explorer",
@@ -1318,6 +1352,23 @@
                                                             ]
                                                         },
                                                         "required_attributes": {
+                                                            "type": "object",
+                                                            "properties": {},
+                                                            "additionalProperties": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "any_attributes": {
                                                             "type": "object",
                                                             "properties": {},
                                                             "additionalProperties": {

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -81,6 +81,23 @@
                     },
                     "description": "Required user attributes for accessing this model"
                 },
+                "any_attributes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Any user attributes (OR logic) for accessing this model"
+                },
                 "group_details": {
                     "type": "object",
                     "additionalProperties": {
@@ -333,6 +350,23 @@
                     },
                     "description": "Required user attributes for accessing this dimension"
                 },
+                "any_attributes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Any user attributes (OR logic) for accessing this dimension"
+                },
                 "ai_hint": {
                     "oneOf": [
                         {
@@ -574,6 +608,23 @@
                         ]
                     },
                     "description": "Required user attributes for accessing this metric"
+                },
+                "any_attributes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Any user attributes (OR logic) for accessing this metric"
                 },
                 "ai_hint": {
                     "oneOf": [

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -79,7 +79,7 @@ export type CatalogField = Pick<
     Field,
     'name' | 'label' | 'fieldType' | 'tableLabel' | 'description'
 > &
-    Pick<Dimension, 'requiredAttributes'> & {
+    Pick<Dimension, 'requiredAttributes' | 'anyAttributes'> & {
         catalogSearchUuid: string;
         type: CatalogType.Field;
         basicType: 'string' | 'number' | 'date' | 'timestamp' | 'boolean';
@@ -99,7 +99,12 @@ export type CatalogField = Pick<
 
 export type CatalogTable = Pick<
     TableBase,
-    'name' | 'label' | 'groupLabel' | 'description' | 'requiredAttributes'
+    | 'name'
+    | 'label'
+    | 'groupLabel'
+    | 'description'
+    | 'requiredAttributes'
+    | 'anyAttributes'
 > & {
     catalogSearchUuid: string;
     errors?: InlineError[]; // For explore errors

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -128,6 +128,7 @@ export type DbtModelLightdashConfig = ExploreConfig &
         sql_where?: string; // alias for sql_filter
         sql_from?: string; // overrides dbt model relation_name
         required_attributes?: Record<string, string | string[]>;
+        any_attributes?: Record<string, string | string[]>;
         group_details?: Record<string, DbtModelGroup>;
         default_time_dimension?: {
             field: string;
@@ -197,6 +198,7 @@ export type DbtColumnLightdashDimension = {
     colors?: Record<string, string>;
     urls?: FieldUrl[];
     required_attributes?: Record<string, string | string[]>;
+    any_attributes?: Record<string, string | string[]>;
     ai_hint?: string | string[];
     image?: {
         url: string;
@@ -535,6 +537,7 @@ type ConvertModelMetricArgs = {
     tableLabel: string;
     dimensionReference?: string;
     requiredAttributes?: Record<string, string | string[]>;
+    anyAttributes?: Record<string, string | string[]>;
     spotlightConfig?: LightdashProjectConfig['spotlight'];
     modelCategories?: string[];
     modelOwner?: string;
@@ -548,6 +551,7 @@ export const convertModelMetric = ({
     tableLabel,
     dimensionReference,
     requiredAttributes,
+    anyAttributes,
     spotlightConfig,
     modelCategories = [],
     modelOwner,
@@ -591,6 +595,7 @@ export const convertModelMetric = ({
         percentile: metric.percentile,
         dimensionReference,
         requiredAttributes,
+        anyAttributes,
         ...(metric.urls ? { urls: metric.urls } : null),
         ...(metric.tags
             ? {
@@ -624,6 +629,7 @@ type ConvertColumnMetricArgs = Omit<ConvertModelMetricArgs, 'metric'> & {
     dimensionName?: string;
     dimensionSql: string;
     requiredAttributes?: Record<string, string | string[]>;
+    anyAttributes?: Record<string, string | string[]>;
     modelCategories?: string[];
 };
 
@@ -636,6 +642,7 @@ export const convertColumnMetric = ({
     source,
     tableLabel,
     requiredAttributes,
+    anyAttributes,
     spotlightConfig,
     modelCategories = [],
     modelOwner,
@@ -661,6 +668,7 @@ export const convertColumnMetric = ({
             ? getItemId({ table: modelName, name: dimensionName })
             : undefined,
         requiredAttributes,
+        anyAttributes,
         ...(metric.default_time_dimension
             ? {
                   defaultTimeDimension: {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -560,6 +560,7 @@ export interface Dimension extends Field {
      */
     group?: string;
     requiredAttributes?: Record<string, string | string[]>;
+    anyAttributes?: Record<string, string | string[]>;
     timeInterval?: TimeFrames;
     timeIntervalBaseDimensionName?: string;
     isAdditionalDimension?: boolean;
@@ -757,6 +758,7 @@ export interface Metric extends Field {
     formatOptions?: CustomFormat;
     dimensionReference?: string; // field id of the dimension this metric is based on
     requiredAttributes?: Record<string, string | string[]>; // Required attributes for the dimension this metric is based on
+    anyAttributes?: Record<string, string | string[]>; // Any of these attributes must match (OR logic)
     defaultTimeDimension?: DefaultTimeDimension; // Default time dimension for the metric when the user has not specified a time dimension
     spotlight?: {
         visibility: LightdashProjectConfig['spotlight']['default_visibility'];

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -34,6 +34,7 @@ export type TableBase = {
     requiredFilters?: ModelRequiredFilterRule[];
     hidden?: boolean;
     requiredAttributes?: Record<string, string | string[]>;
+    anyAttributes?: Record<string, string | string[]>;
     groupDetails?: Record<string, GroupType>;
     defaultTimeDimension?: DefaultTimeDimension;
     aiHint?: string | string[];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->Closes: [SPK-207](https://linear.app/lightdash/issue/SPK-207/when-adding-required-attributes-to-a-table-i-should-be-able-to-use-or)

### Description:

This PR adds support for "any_attributes" in the catalog system, which implements OR logic for user attribute access control. Previously, we only had "required_attributes" which used AND logic (all attributes must match). With this change, users can now define attributes where at least one must match to grant access.

The implementation includes:

- Database migration to add `any_attributes` column to the catalog_search table
- Updated schema definitions in JSON schemas and TypeScript types
- Modified attribute checking logic to support both AND (required) and OR (any) conditions
- Added example usage in the jaffle shop demo with a new `full_name` field that uses any_attributes

This enhancement provides more flexible access control options, allowing admins to grant access when users match at least one of several possible attributes rather than requiring all attributes to match.