### PR TITLE
feat: allow formatting date metrics in results table/ui

### DIFF
--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -158,6 +158,71 @@ export const isDateItem = (
     return true;
 };
 
+/**
+ * Gets the effective type for formatting purposes.
+ * For metrics that return date/timestamp values (MIN/MAX on date dimensions),
+ * returns the underlying dimension type instead of the metric type.
+ *
+ * @param item - The item to get the effective type for
+ * @param itemsMap - Optional itemsMap to look up dimension types
+ * @returns The effective type for formatting (DimensionType, MetricType, or TableCalculationType)
+ */
+export const getEffectiveItemType = (
+    item: ItemsMap[string] | AdditionalMetric | undefined,
+    itemsMap?: ItemsMap,
+): DimensionType | MetricType | TableCalculationType | undefined => {
+    if (!item) {
+        return undefined;
+    }
+
+    // For metrics with MIN/MAX on date dimensions, return the dimension type
+    if (
+        isMetric(item) &&
+        (item.type === MetricType.MIN || item.type === MetricType.MAX) &&
+        item.dimensionReference &&
+        itemsMap
+    ) {
+        const dimension = itemsMap[item.dimensionReference];
+        if (dimension && isDimension(dimension)) {
+            if (
+                dimension.type === DimensionType.DATE ||
+                dimension.type === DimensionType.TIMESTAMP
+            ) {
+                return dimension.type;
+            }
+        }
+    }
+
+    return getItemType(item);
+};
+
+/**
+ * Checks if a metric returns a date/timestamp value.
+ * This is true when:
+ * 1. The metric type is directly DATE or TIMESTAMP
+ * 2. The metric type is MIN or MAX and the underlying dimension (via dimensionReference) is a date/timestamp
+ *
+ * @param item - The metric to check
+ * @param itemsMap - Optional itemsMap to look up the dimension type from dimensionReference
+ * @returns true if the metric returns a date/timestamp value
+ */
+export const isMetricWithDateValue = (
+    item: ItemsMap[string] | AdditionalMetric | undefined,
+    itemsMap?: ItemsMap,
+): boolean => {
+    if (!item || !isMetric(item)) {
+        return false;
+    }
+    const effectiveType = getEffectiveItemType(item, itemsMap);
+    const dateTypes: (DimensionType | MetricType)[] = [
+        DimensionType.DATE,
+        DimensionType.TIMESTAMP,
+        MetricType.DATE,
+        MetricType.TIMESTAMP,
+    ];
+    return dateTypes.includes(effectiveType as DimensionType | MetricType);
+};
+
 export const replaceDimensionInExplore = (
     explore: Explore,
     dimension: CompiledDimension,

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -2,11 +2,13 @@ import {
     DimensionType,
     getItemId,
     getItemLabelWithoutTableName,
+    getItemMap,
     isCustomDimension,
     isDimension,
     isField,
     isFilterableField,
     isMetric,
+    isMetricWithDateValue,
     isNumericItem,
     isTableCalculation,
     isTimeBasedDimension,
@@ -23,6 +25,8 @@ import { useMemo, useState, type FC } from 'react';
 import {
     explorerActions,
     selectAdditionalMetrics,
+    selectTableCalculations,
+    selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
@@ -30,6 +34,7 @@ import {
     DeleteTableCalculationModal,
     UpdateTableCalculationModal,
 } from '../../../features/tableCalculation';
+import { useExplore } from '../../../hooks/useExplore';
 import { useFilters } from '../../../hooks/useFilters';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -57,7 +62,25 @@ const ContextMenu: FC<ContextMenuProps> = ({
     const sort = meta?.sort?.sort;
 
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+    const tableCalculations = useExplorerSelector(selectTableCalculations);
+    const tableName = useExplorerSelector(selectTableName);
     const dispatch = useExplorerDispatch();
+
+    // Get explore data to check if metrics return date values
+    const { data: exploreData } = useExplore(tableName, {
+        refetchOnMount: false,
+    });
+
+    const itemsMap = useMemo(() => {
+        if (exploreData) {
+            return getItemMap(
+                exploreData,
+                additionalMetrics,
+                tableCalculations,
+            );
+        }
+        return undefined;
+    }, [exploreData, additionalMetrics, tableCalculations]);
 
     const additionalMetric = useMemo(
         () =>
@@ -106,12 +129,14 @@ const ContextMenu: FC<ContextMenuProps> = ({
 
                 {isMetric(item) && (
                     <>
-                        {!isItemAdditionalMetric && isNumericItem(item) && (
-                            <>
-                                <FormatMenuOptions item={item} />
-                                <Menu.Divider />
-                            </>
-                        )}
+                        {!isItemAdditionalMetric &&
+                            (isNumericItem(item) ||
+                                isMetricWithDateValue(item, itemsMap)) && (
+                                <>
+                                    <FormatMenuOptions item={item} />
+                                    <Menu.Divider />
+                                </>
+                            )}
 
                         <QuickCalculationMenuOptions item={item} />
                         <Menu.Divider />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-904](https://linear.app/lightdash/issue/PROD-904/formatting-date-type-dimensionsmetrics-in-the-results-table)

### Description:
Improves date formatting for MIN/MAX metrics on date dimensions by adding support for detecting and properly formatting date values returned by metrics. This fixes issues where date values in tooltips were showing as "Invalid Date" when using MIN/MAX aggregations on date fields.

The implementation:
- Adds `getEffectiveItemType()` to determine the true data type for formatting purposes
- Adds `isMetricWithDateValue()` to detect metrics that return date values
- Enhances tooltip formatting to handle date values from metrics properly
- Updates the Format Modal and Column Header Context Menu to use the effective item type

![Screenshot 2026-01-12 at 10.33.46.png](https://app.graphite.com/user-attachments/assets/6793f14d-ff75-4be0-b36a-e2f4a3b0520d.png)

**Explore from here testing link** http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customers?create_saved_chart_version=%7B%22uuid%22%3A%22c087e29d-f439-4dc6-b7be-aa2643738434%22%2C%22projectUuid%22%3A%223675b69e-8324-4110-bdca-059031aa8da3%22%2C%22name%22%3A%22How+many+unique+customers+were+acquired+by+their+first+creation+date%3F%22%2C%22description%22%3A%22Distribution+of+unique+customer+count+across+the+timeline+of+when+customers+were+first+created%2C+showing+customer+acquisition+patterns+over+time.%22%2C%22tableName%22%3A%22customers%22%2C%22updatedAt%22%3A%222026-01-12T09%3A39%3A11.196Z%22%2C%22updatedByUser%22%3A%7B%22userUuid%22%3A%224ff03d1c-0b86-4822-88a7-83f9f387bb3e%22%2C%22firstName%22%3A%22Jojojo%22%2C%22lastName%22%3A%22Viviviv%22%7D%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22customers%22%2C%22dimensions%22%3A%5B%5D%2C%22metrics%22%3A%5B%22customers_date_of_first_created_customer%22%2C%22customers_date_of_most_recent_created_customer%22%2C%22customers_unique_customer_count%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22customers_date_of_first_created_customer%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22metricOverrides%22%3A%7B%22customers_date_of_first_created_customer%22%3A%7B%22formatOptions%22%3A%7B%22type%22%3A%22custom%22%2C%22custom%22%3A%22dd%2Fmm%2Fyyyy+HH%3Amm%22%2C%22separator%22%3A%22default%22%7D%7D%7D%2C%22dimensionOverrides%22%3A%7B%7D%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22stack%22%3A%22none%22%2C%22xField%22%3A%22customers_date_of_first_created_customer%22%2C%22yField%22%3A%5B%22customers_unique_customer_count%22%5D%2C%22flipAxes%22%3Atrue%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22customers_date_of_first_created_customer%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22customers_unique_customer_count%22%7D%7D%2C%22yAxisIndex%22%3A0%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22customers_date_of_first_created_customer%22%2C%22customers_date_of_most_recent_created_customer%22%2C%22customers_unique_customer_count%22%5D%7D%2C%22organizationUuid%22%3A%22172a2270-000f-42be-9c68-c4752c23ae51%22%2C%22spaceUuid%22%3A%22c85c523e-0aa6-4fad-a577-9c80c75e3a16%22%2C%22spaceName%22%3A%22Jaffle+shop%22%2C%22pinnedListUuid%22%3Anull%2C%22pinnedListOrder%22%3Anull%2C%22dashboardUuid%22%3Anull%2C%22dashboardName%22%3Anull%2C%22colorPalette%22%3A%5B%22%23ff63cc%22%2C%22%235c89ff%22%2C%22%2333e6ff%22%2C%22%23ffdd8a%22%2C%22%23ffdefa%22%2C%22%232eb9f2%22%2C%22%23ff8178%22%2C%22%23c43dff%22%2C%22%23ea7ccc%22%2C%22%2300e054%22%2C%22%2333ffb1%22%2C%22%2333ffe6%22%2C%22%2333e6ff%22%2C%22%2333b1ff%22%2C%22%23337dff%22%2C%22%233349ff%22%2C%22%235e33ff%22%2C%22%239233ff%22%2C%22%23c633ff%22%2C%22%23ff33e1%22%5D%2C%22slug%22%3A%22how-many-unique-customers-were-acquired-by-their-first-creation-date%22%2C%22isPrivate%22%3Afalse%2C%22access%22%3A%5B%7B%22userUuid%22%3A%224ff03d1c-0b86-4822-88a7-83f9f387bb3e%22%2C%22firstName%22%3A%22Jojojo%22%2C%22lastName%22%3A%22Viviviv%22%2C%22email%22%3A%22joao%2B99%40lightdash.com%22%2C%22role%22%3A%22admin%22%2C%22hasDirectAccess%22%3Afalse%2C%22inheritedRole%22%3A%22admin%22%2C%22inheritedFrom%22%3A%22organization%22%2C%22projectRole%22%3A%22admin%22%7D%5D%7D&isExploreFromHere=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves date handling across formatting and tooltips, especially for MIN/MAX metrics on date dimensions.
> 
> - **Common utils:** Add `getEffectiveItemType()` to resolve underlying date/timestamp types for metrics; add `isMetricWithDateValue()` to detect date-returning metrics
> - **Tooltips:** Enhance `getHeader` to fall back to raw axis value with `getFormattedValue`; use data-derived `rawHeaderValue` for header formatting; fixes "Invalid Date" and flipped-axis header issues
> - **Explorer UI:** `FormatModal` now builds `itemsMap` via `getItemMap`/`useExplore` and passes `getEffectiveItemType` to `FormatForm`; `ColumnHeaderContextMenu` enables `FormatMenuOptions` for metrics detected by `isMetricWithDateValue` and builds `itemsMap` similarly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed59390c466535a34c6badf0951b5509d219f347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->