### PR TITLE
feat: small export dashboard modal improvements

### DIFF
--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -7,6 +7,7 @@ import {
     MultiSelect,
     SegmentedControl,
     Stack,
+    Text,
     Tooltip,
 } from '@mantine-8/core';
 import {
@@ -175,18 +176,12 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     const renderActions = () => {
         if (exportType === 'csv') {
             return (
-                <Tooltip
-                    withinPortal
-                    position="bottom"
-                    label="Export results in table for all charts in a zip file"
+                <Button
+                    onClick={handleCsvExport}
+                    leftSection={<MantineIcon icon={IconCsv} />}
                 >
-                    <Button
-                        onClick={handleCsvExport}
-                        leftSection={<MantineIcon icon={IconCsv} />}
-                    >
-                        Export CSV
-                    </Button>
-                </Tooltip>
+                    Export CSV
+                </Button>
             );
         }
 
@@ -214,21 +209,29 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
             icon={IconLayoutDashboard}
             size="xl"
             actions={renderActions()}
-            modalRootProps={{ yOffset: '3vh' }}
         >
             <Stack gap="md">
-                <SegmentedControl
-                    data={[
-                        { label: 'Image', value: 'image' },
-                        { label: '.csv', value: 'csv' },
-                    ]}
-                    w="min-content"
-                    radius="md"
-                    value={exportType}
-                    onChange={(value) =>
-                        setExportType(value as 'image' | 'csv')
-                    }
-                />
+                <Stack gap="xs">
+                    <Input.Label>Export format</Input.Label>
+                    <SegmentedControl
+                        data={[
+                            { label: 'Image', value: 'image' },
+                            { label: '.csv', value: 'csv' },
+                        ]}
+                        w="min-content"
+                        radius="md"
+                        value={exportType}
+                        onChange={(value) =>
+                            setExportType(value as 'image' | 'csv')
+                        }
+                    />
+                    {exportType === 'csv' && (
+                        <Text fs="italic" fz="sm" c="dimmed">
+                            All charts from all tabs will be exported as tables
+                            in a ZIP file.
+                        </Text>
+                    )}
+                </Stack>
 
                 {exportType === 'csv' && (
                     <>

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -35,9 +35,9 @@ type PreviewAndCustomizeScreenshotProps = {
             selectedTabs: string[] | null;
         }
     >;
-    previewChoice: (typeof CUSTOM_WIDTH_OPTIONS)[number]['value'] | undefined;
+    previewChoice: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined;
     setPreviewChoice: (
-        prev: (typeof CUSTOM_WIDTH_OPTIONS)[number]['value'] | undefined,
+        prev: typeof CUSTOM_WIDTH_OPTIONS[number]['value'] | undefined,
     ) => void;
     onPreviewClick?: () => Promise<void>;
     currentPreview?: string;
@@ -118,7 +118,7 @@ export const PreviewAndCustomizeScreenshot: FC<
                                         align="center"
                                         justify="center"
                                         direction="column"
-                                        bg="gray.1"
+                                        bg="ldGray.1"
                                     >
                                         <MantineIcon
                                             icon={IconEyeClosed}


### PR DESCRIPTION
### Description:
Enhances the Dashboard Export Modal UI by:
- Adding a label for the export format selection
- Move tooltip content from the CSV export button into element in modal 

![CleanShot 2026-01-12 at 12.49.47.png](https://app.graphite.com/user-attachments/assets/b5cc7084-4616-46aa-b246-b2cbe8669280.png)

![CleanShot 2026-01-12 at 12.49.55.png](https://app.graphite.com/user-attachments/assets/dd79405a-c01c-432a-b8c2-ab04bfd30e7a.png)

