### PR TITLE
feat: improve mantine modals position

### DIFF
--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -253,7 +253,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
             opened={opened}
             onClose={onClose}
             size={fullScreen ? 'auto' : size}
-            centered
+            yOffset="8dvh"
             {...modalRootProps}
         >
             <Modal.Overlay />

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -214,7 +214,6 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
             icon={IconLayoutDashboard}
             size="xl"
             actions={renderActions()}
-            modalRootProps={{ yOffset: '3vh' }}
         >
             <Stack gap="md">
                 <SegmentedControl

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -237,14 +237,6 @@ export const getMantineThemeOverride = (
                 },
             },
 
-            Modal: {
-                defaultProps: {
-                    // FIXME: This makes the mantine modals line up exactly with the Blueprint ones.
-                    // It could be made a less-magic number once we migrate
-                    yOffset: 140,
-                },
-            },
-
             Alert: {
                 styles: (_theme, _params) => ({
                     title: {


### PR DESCRIPTION
### Description:
Standardizes modal positioning across the application by:
- Replacing the `centered` prop with a consistent `yOffset="8dvh"` in the MantineModal component

This change creates a more consistent vertical positioning for all modals in the application.

![CleanShot 2026-01-12 at 12.45.30.png](https://app.graphite.com/user-attachments/assets/ca21e236-4741-4a57-97e7-30df8056e7fb.png)

----

_Before_

![CleanShot 2026-01-12 at 12.46.10.png](https://app.graphite.com/user-attachments/assets/0fa44a7f-842b-4dd4-a189-b7119116d655.png)

