### PR TITLE
fix: underlying data not prioritizing base table dimensions

### DIFF
--- a/packages/common/src/utils/fields.mock.ts
+++ b/packages/common/src/utils/fields.mock.ts
@@ -174,3 +174,106 @@ export const metricFilterRule = (args?: {
     settings: args?.settings || undefined,
     values: args?.values || [14],
 });
+
+/**
+ * Explore with joined tables for testing getDimensionsWithValidParameters.
+ * The joined table "a_joined_table" is alphabetically before the base table "z_base_table"
+ * to verify that base table dimensions are returned first regardless of alphabetical order.
+ */
+export const exploreWithJoinedTables: Explore = {
+    ...exploreBase,
+    baseTable: 'z_base_table',
+    joinedTables: [
+        {
+            table: 'a_joined_table',
+            sqlOn: '${z_base_table.id} = ${a_joined_table.base_id}',
+            compiledSqlOn: '"z_base_table".id = "a_joined_table".base_id',
+        },
+    ],
+    tables: {
+        a_joined_table: {
+            name: 'a_joined_table',
+            label: 'A Joined Table',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: 'test.a_joined_table',
+            sqlWhere: undefined,
+            dimensions: {
+                joined_dim1: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'joined_dim1',
+                    label: 'Joined Dim 1',
+                    table: 'a_joined_table',
+                    tableLabel: 'A Joined Table',
+                    sql: '${TABLE}.joined_dim1',
+                    compiledSql: '"a_joined_table".joined_dim1',
+                    tablesReferences: ['a_joined_table'],
+                    source: sourceMock,
+                    hidden: false,
+                    groups: [],
+                },
+                joined_dim2: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    name: 'joined_dim2',
+                    label: 'Joined Dim 2',
+                    table: 'a_joined_table',
+                    tableLabel: 'A Joined Table',
+                    sql: '${TABLE}.joined_dim2',
+                    compiledSql: '"a_joined_table".joined_dim2',
+                    tablesReferences: ['a_joined_table'],
+                    source: sourceMock,
+                    hidden: false,
+                    groups: [],
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+            groupLabel: undefined,
+            source: sourceMock,
+        },
+        z_base_table: {
+            name: 'z_base_table',
+            label: 'Z Base Table',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: 'test.z_base_table',
+            sqlWhere: undefined,
+            dimensions: {
+                base_dim1: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'base_dim1',
+                    label: 'Base Dim 1',
+                    table: 'z_base_table',
+                    tableLabel: 'Z Base Table',
+                    sql: '${TABLE}.base_dim1',
+                    compiledSql: '"z_base_table".base_dim1',
+                    tablesReferences: ['z_base_table'],
+                    source: sourceMock,
+                    hidden: false,
+                    groups: [],
+                },
+                base_dim2: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    name: 'base_dim2',
+                    label: 'Base Dim 2',
+                    table: 'z_base_table',
+                    tableLabel: 'Z Base Table',
+                    sql: '${TABLE}.base_dim2',
+                    compiledSql: '"z_base_table".base_dim2',
+                    tablesReferences: ['z_base_table'],
+                    source: sourceMock,
+                    hidden: false,
+                    groups: [],
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+            groupLabel: undefined,
+            source: sourceMock,
+        },
+    },
+};

--- a/packages/common/src/utils/fields.test.ts
+++ b/packages/common/src/utils/fields.test.ts
@@ -1,12 +1,16 @@
 import { getFieldsFromMetricQuery } from '../index';
 import { CustomFormatType, isField, NumberSeparator } from '../types/field';
 import { FilterOperator, UnitOfTime } from '../types/filter';
-import { compareMetricAndCustomMetric } from './fields';
+import {
+    compareMetricAndCustomMetric,
+    getDimensionsWithValidParameters,
+} from './fields';
 import {
     customMetric,
     emptyExplore,
     emptyMetricQuery,
     explore,
+    exploreWithJoinedTables,
     metric,
     metricFilterRule,
     metricQuery,
@@ -291,5 +295,33 @@ describe('compareMetricAndCustomMetric', () => {
         });
         expect(result6.isExactMatch).toEqual(false);
         expect(result6.isSuggestedMatch).toEqual(false);
+    });
+});
+
+describe('getDimensionsWithValidParameters', () => {
+    test('should return base table dimensions before joined table dimensions', () => {
+        const result = getDimensionsWithValidParameters(
+            exploreWithJoinedTables,
+            {},
+        );
+
+        // Should have 4 dimensions total (2 from base, 2 from joined)
+        expect(result).toHaveLength(4);
+
+        // Get dimension names in order
+        const dimensionNames = result.map((d) => d.name);
+
+        // Base table dimensions (base_dim1, base_dim2) should come before
+        // joined table dimensions (joined_dim1, joined_dim2)
+        const baseDim1Idx = dimensionNames.indexOf('base_dim1');
+        const baseDim2Idx = dimensionNames.indexOf('base_dim2');
+        const joinedDim1Idx = dimensionNames.indexOf('joined_dim1');
+        const joinedDim2Idx = dimensionNames.indexOf('joined_dim2');
+
+        // All base table dimensions should come before any joined table dimension
+        expect(baseDim1Idx).toBeLessThan(joinedDim1Idx);
+        expect(baseDim1Idx).toBeLessThan(joinedDim2Idx);
+        expect(baseDim2Idx).toBeLessThan(joinedDim1Idx);
+        expect(baseDim2Idx).toBeLessThan(joinedDim2Idx);
     });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2416/view-underlying-data-shows-wrong-table-columns-due-to-alphabetical

### Description:
Modified `getDimensionsWithValidParameters` to prioritize base table dimensions over joined table dimensions in the returned results. Previously, dimensions were returned in the order of tables, which could be alphabetical. Now, base table dimensions are always returned first, followed by joined table dimensions.

Added a test case with a mock explore where the joined table name alphabetically precedes the base table name to verify that base table dimensions are still returned first regardless of alphabetical order.