### PR TITLE
fix: can view underlying data in non-cartesian tiles if enabled on embedded content

### DIFF
--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -8,7 +8,7 @@ import useEchartsFunnelConfig, {
     type FunnelSeriesDataPoint,
 } from '../../hooks/echarts/useEchartsFunnelConfig';
 import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
-import useApp from '../../providers/App/useApp';
+import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import EChartsReact from '../EChartsReactWrapper';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import LoadingChart from '../common/LoadingChart';
@@ -40,7 +40,8 @@ const EchartOptions: Opts = { renderer: 'svg' };
 
 const FunnelChart: FC<FunnelChartProps> = memo(
     ({ onScreenshotReady, onScreenshotError, ...props }) => {
-        const { chartRef, isLoading, resultsData } = useVisualizationContext();
+        const { chartRef, isLoading, resultsData, minimal } =
+            useVisualizationContext();
         const { selectedLegends, onLegendChange } =
             useLegendDoubleClickSelection();
 
@@ -48,8 +49,10 @@ const FunnelChart: FC<FunnelChartProps> = memo(
             selectedLegends,
             props.isInDashboard,
         );
-
-        const { user } = useApp();
+        const { shouldShowMenu, canViewUnderlyingData } =
+            useContextMenuPermissions({
+                minimal,
+            });
 
         const [isOpen, { open, close }] = useDisclosure();
 
@@ -145,13 +148,14 @@ const FunnelChart: FC<FunnelChartProps> = memo(
                     }}
                 />
 
-                {user.data && (
+                {shouldShowMenu && (
                     <FunnelChartContextMenu
                         value={menuProps?.value}
                         menuPosition={menuProps?.position}
                         rows={menuProps?.rows}
                         opened={isOpen}
                         onClose={handleCloseContextMenu}
+                        canViewUnderlyingData={canViewUnderlyingData}
                     />
                 )}
             </>

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -7,7 +7,7 @@ import useEchartsPieConfig, {
     type PieSeriesDataPoint,
 } from '../../hooks/echarts/useEchartsPieConfig';
 import { useLegendDoubleClickSelection } from '../../hooks/echarts/useLegendDoubleClickSelection';
-import useApp from '../../providers/App/useApp';
+import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import EChartsReact from '../EChartsReactWrapper';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import LoadingChart from '../common/LoadingChart';
@@ -39,7 +39,8 @@ const EchartOptions: Opts = { renderer: 'svg' };
 
 const SimplePieChart: FC<SimplePieChartProps> = memo(
     ({ onScreenshotReady, onScreenshotError, ...props }) => {
-        const { chartRef, isLoading, resultsData } = useVisualizationContext();
+        const { chartRef, isLoading, resultsData, minimal } =
+            useVisualizationContext();
         const { selectedLegends, onLegendChange } =
             useLegendDoubleClickSelection();
 
@@ -47,7 +48,10 @@ const SimplePieChart: FC<SimplePieChartProps> = memo(
             selectedLegends,
             props.isInDashboard,
         );
-        const { user } = useApp();
+        const { shouldShowMenu, canViewUnderlyingData } =
+            useContextMenuPermissions({
+                minimal,
+            });
 
         const [isOpen, { open, close }] = useDisclosure();
         const [menuProps, setMenuProps] = useState<{
@@ -137,13 +141,14 @@ const SimplePieChart: FC<SimplePieChartProps> = memo(
                     }}
                 />
 
-                {user.data && (
+                {shouldShowMenu && (
                     <PieChartContextMenu
                         value={menuProps?.value}
                         menuPosition={menuProps?.position}
                         rows={menuProps?.rows}
                         opened={isOpen}
                         onClose={handleCloseContextMenu}
+                        canViewUnderlyingData={canViewUnderlyingData}
                     />
                 )}
             </>

--- a/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
@@ -1,17 +1,23 @@
-import { isField, type ResultValue } from '@lightdash/common';
+import { isDimension, isField, type ResultValue } from '@lightdash/common';
 import { Menu } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy } from '@tabler/icons-react';
+import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
 import useToaster from '../../hooks/toaster/useToaster';
 import MantineIcon from '../common/MantineIcon';
 import { type CellContextMenuProps } from '../common/Table/types';
+import { UnderlyingDataMenuItem } from '../DashboardTiles/UnderlyingDataMenuItem';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
+import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
 
 const MinimalCellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({
     cell,
 }) => {
     const { showToastSuccess } = useToaster();
+    const { openUnderlyingDataModal, metricQuery } =
+        useMetricQueryDataContext();
+
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
 
@@ -20,12 +26,28 @@ const MinimalCellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({
         [cell],
     );
 
+    const fieldValues = useMemo(
+        () => mapValues(cell.row.original, (v) => v?.value) || {},
+        [cell.row.original],
+    );
+
     const clipboard = useClipboard({ timeout: 200 });
 
     const handleCopyToClipboard = useCallback(() => {
         clipboard.copy(value.formatted);
         showToastSuccess({ title: 'Copied to clipboard!' });
     }, [clipboard, showToastSuccess, value.formatted]);
+
+    const handleViewUnderlyingData = useCallback(() => {
+        if (meta === undefined) return;
+
+        openUnderlyingDataModal({
+            item: meta.item,
+            value,
+            fieldValues,
+            pivotReference: meta?.pivotReference,
+        });
+    }, [openUnderlyingDataModal, meta, value, fieldValues]);
 
     return (
         <>
@@ -41,6 +63,13 @@ const MinimalCellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({
             >
                 Copy value
             </Menu.Item>
+
+            {item && !isDimension(item) && metricQuery && (
+                <UnderlyingDataMenuItem
+                    metricQuery={metricQuery}
+                    onViewUnderlyingData={handleViewUnderlyingData}
+                />
+            )}
         </>
     );
 };

--- a/packages/frontend/src/components/common/LinkButton.tsx
+++ b/packages/frontend/src/components/common/LinkButton.tsx
@@ -25,7 +25,7 @@ const LinkButton: FC<LinkButtonProps> = ({
     ...rest
 }) => {
     const navigate = useNavigate();
-    const { track } = useTracking();
+    const tracking = useTracking({ failSilently: true });
 
     return (
         <Button
@@ -49,7 +49,7 @@ const LinkButton: FC<LinkButtonProps> = ({
 
                 onClick?.(e);
 
-                if (trackingEvent) track(trackingEvent);
+                if (trackingEvent && tracking) tracking.track(trackingEvent);
             }}
         />
     );

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -878,6 +878,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                 }
                                                 onClose={onClose}
                                                 onCopy={onCopy}
+                                                isMinimal={isMinimal}
                                             >
                                                 {render()}
                                             </ValueCellMenu>

--- a/packages/frontend/src/hooks/useContextMenuPermissions.ts
+++ b/packages/frontend/src/hooks/useContextMenuPermissions.ts
@@ -1,0 +1,119 @@
+import { subject } from '@casl/ability';
+import { useMemo } from 'react';
+import { useAbilityContext } from '../providers/Ability/useAbilityContext';
+import { useProject } from './useProject';
+import { useProjectUuid } from './useProjectUuid';
+import { useAccount } from './user/useAccount';
+
+type UseContextMenuPermissionsParams = {
+    /**
+     * Optional override for organizationUuid. If not provided, will be derived from project or account.
+     */
+    organizationUuid?: string;
+    /**
+     * Optional override for projectUuid. If not provided, will be fetched from URL params or embed context.
+     */
+    projectUuid?: string;
+    /**
+     * Whether the component is in minimal mode (e.g., browserless/screenshot mode).
+     */
+    minimal?: boolean;
+};
+
+type UseContextMenuPermissionsReturn = {
+    shouldShowMenu: boolean;
+    canViewUnderlyingData: boolean;
+    canViewExplore: boolean;
+    canDrillInto: boolean;
+    isMinimal: boolean;
+};
+
+/**
+ * Centralized hook for context menu permissions and visibility logic.
+ * Provides standardized permission checks across all chart components.
+ *
+ * Automatically fetches projectUuid, organizationUuid, and account data.
+ * You can optionally override organizationUuid and projectUuid for specific contexts
+ * (e.g., when checking permissions for a specific chart's project).
+ */
+export const useContextMenuPermissions = ({
+    organizationUuid: overrideOrganizationUuid,
+    projectUuid: overrideProjectUuid,
+    minimal = false,
+}: UseContextMenuPermissionsParams = {}): UseContextMenuPermissionsReturn => {
+    const { data: account } = useAccount();
+    const ability = useAbilityContext();
+    const projectUuidFromContext = useProjectUuid();
+    const { data: project } = useProject(
+        overrideProjectUuid || projectUuidFromContext,
+    );
+
+    // Determine the actual organizationUuid and projectUuid to use
+    const projectUuid = overrideProjectUuid || project?.projectUuid;
+    const organizationUuid =
+        overrideOrganizationUuid ||
+        project?.organizationUuid ||
+        account?.organization?.organizationUuid;
+
+    const shouldShowMenu = useMemo(() => {
+        // Show menu if account exists OR in minimal mode
+        return !!(account || minimal);
+    }, [account, minimal]);
+
+    const canViewUnderlyingData = useMemo(() => {
+        if (!organizationUuid || !projectUuid) {
+            return false;
+        }
+        return ability.can(
+            'view',
+            subject('UnderlyingData', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+    }, [ability, organizationUuid, projectUuid]);
+
+    const canViewExplore = useMemo(() => {
+        if (!organizationUuid || !projectUuid) {
+            return false;
+        }
+        return ability.can(
+            'view',
+            subject('Explore', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+    }, [ability, organizationUuid, projectUuid]);
+
+    const canDrillInto = useMemo(() => {
+        if (!organizationUuid || !projectUuid) {
+            return false;
+        }
+        return ability.can(
+            'manage',
+            subject('Explore', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+    }, [ability, organizationUuid, projectUuid]);
+
+    const result = useMemo(() => {
+        return {
+            shouldShowMenu,
+            canViewUnderlyingData,
+            canViewExplore,
+            canDrillInto,
+            isMinimal: minimal,
+        };
+    }, [
+        shouldShowMenu,
+        canViewUnderlyingData,
+        canViewExplore,
+        canDrillInto,
+        minimal,
+    ]);
+
+    return result;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2413](https://linear.app/lightdash/issue/PROD-2413/cannot-view-underlying-data-for-table-tiles-in-embedded-dashboards)

### Description:
Refactored chart context menus to use a shared `UnderlyingDataMenuItem` component across different visualization types (FunnelChart, SimplePieChart, SimpleStatistic, SimpleTable, PivotTable). This centralizes the logic for displaying the "View underlying data" option, improving code maintainability and consistency.

Added support for minimal mode in context menus, ensuring appropriate menu items are displayed when charts are rendered in minimal contexts. This includes conditionally showing/hiding certain menu options based on the visualization's minimal state.

Related to: https://github.com/lightdash/lightdash/pull/16792

demo

[CleanShot 2026-01-12 at 15.29.59.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d632c1b1-47bc-4089-8bf4-489930d18b35.mp4" />](https://app.graphite.com/user-attachments/video/d632c1b1-47bc-4089-8bf4-489930d18b35.mp4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a unified permissions hook and shared menu items to standardize context menus and enable underlying data in embedded/minimal views.
> 
> - Adds `useContextMenuPermissions` to derive `shouldShowMenu`, `canViewUnderlyingData`, `canViewExplore`, and `canDrillInto` (with minimal-mode support)
> - Refactors context menus in `FunnelChart`, `SimplePieChart`, `SimpleStatistic` (BigNumber), `SimpleTable` (MinimalCell), and `PivotTable` to use `UnderlyingDataMenuItem` and the new permissions hook
> - Replaces scattered `Ability`/`Can` checks and removes redundant tracking calls in menu handlers; consolidates drill-into visibility behind `canDrillInto`
> - Updates `DashboardChartTile` (regular/minimal) to use the new hook for explore/underlying-data/drill permissions; minor cleanup of `showTableNames` nullish coalescing
> - Makes `LinkButton` tracking fail-safe
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56a688306490ec7574425996b8e239fe05430fd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->