### PR TITLE
style: regulate z index for print ActionIcon in embed

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportPdf.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportPdf.tsx
@@ -1,5 +1,5 @@
 import { type Dashboard, type InteractivityOptions } from '@lightdash/common';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import { ActionIcon, getDefaultZIndex, Tooltip } from '@mantine/core';
 import { IconPrinter } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -54,6 +54,7 @@ const EmbedDashboardExportPdf: FC<Props> = ({
                     }
                 }}
                 size="lg"
+                radius="md"
                 sx={{
                     ...(inHeader
                         ? {}
@@ -62,10 +63,10 @@ const EmbedDashboardExportPdf: FC<Props> = ({
                               top: 20,
                               right: 72, // Make sure the button does not overlap the chart options
                           }),
-                    zIndex: 1000,
+                    zIndex: getDefaultZIndex('modal') - 1,
                 }}
             >
-                <MantineIcon size="xl" icon={IconPrinter} />
+                <MantineIcon icon={IconPrinter} />
             </ActionIcon>
         </Tooltip>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:
Enhances the PDF export button in embedded dashboards by:
- Adding a `radius="md"` property to the ActionIcon for rounded corners
- Using `getDefaultZIndex('modal') - 1` instead of hardcoded z-index value
- Removing the explicit size from the MantineIcon to use default sizing

These changes improve the visual consistency and z-index management of the PDF export button in the embedded dashboard interface.

![Screenshot 2026-01-12 at 15.40.48.png](https://app.graphite.com/user-attachments/assets/772f4cce-639d-4c3b-bb5d-8b366245d3fe.png)

![Screenshot 2026-01-12 at 15.40.53.png](https://app.graphite.com/user-attachments/assets/d1c46c0b-a2a9-4fd2-9e8f-b3d029a0836b.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves consistency of the embedded dashboard PDF export button.
> 
> - Use `getDefaultZIndex('modal') - 1` instead of hardcoded `zIndex: 1000`
> - Add `radius="md"` to `ActionIcon` for rounded corners
> - Remove explicit `size` from `MantineIcon` to use default sizing
> - Update imports to include `getDefaultZIndex`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a5bed89decf1c8709a28ea6267892a657eb2f85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->