### PR TITLE
feat: add validation errors for extra fields

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -799,6 +799,7 @@ export class ServiceRepository
                     dashboardModel: this.models.getDashboardModel(),
                     spaceModel: this.models.getSpaceModel(),
                     schedulerClient: this.clients.getSchedulerClient(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
                 }),
         );
     }

--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     AbilityAction,
     AnyType,
+    ChartType,
     DimensionType,
     Explore,
     ExploreError,
@@ -106,6 +107,15 @@ export const chartForValidation: Awaited<
             operator: FilterOperator.ENDS_WITH,
         },
     ],
+    chartType: ChartType.CARTESIAN,
+    chartConfig: {
+        layout: {
+            xField: 'table_dimension',
+            yField: ['table_metric'],
+        },
+        eChartsConfig: {},
+    },
+    pivotDimensions: [],
 };
 
 export const chartForValidationWithJoinedField: Awaited<
@@ -116,6 +126,15 @@ export const chartForValidationWithJoinedField: Awaited<
     dimensions: ['table_dimension', 'another_table_dimension'],
     metrics: ['table_metric', 'another_table_metric'],
     sorts: ['another_table_dimension'],
+    // Use both dimensions - one in x-axis, one in pivot
+    chartConfig: {
+        layout: {
+            xField: 'table_dimension',
+            yField: ['table_metric', 'another_table_metric'],
+        },
+        eChartsConfig: {},
+    },
+    pivotDimensions: ['another_table_dimension'],
 };
 
 export const chartForValidationWithCustomMetricFilters: Awaited<
@@ -142,6 +161,15 @@ export const chartForValidationWithCustomMetricFilters: Awaited<
             operator: FilterOperator.STARTS_WITH,
         },
     ],
+    // Use both dimensions - one in x-axis, one in pivot
+    chartConfig: {
+        layout: {
+            xField: 'table_dimension',
+            yField: ['table_metric'],
+        },
+        eChartsConfig: {},
+    },
+    pivotDimensions: ['another_table_dimension'],
 };
 
 export const dashboardForValidation: {

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -47,6 +48,9 @@ const validationModel = {
 const dashboardModel = {
     findDashboardsForValidation: jest.fn(async () => [dashboardForValidation]),
 };
+const featureFlagModel = {
+    get: jest.fn(async () => ({ id: 'test', enabled: false })),
+};
 
 describe('validation', () => {
     const validationService = new ValidationService({
@@ -58,6 +62,7 @@ describe('validation', () => {
         lightdashConfig: config,
         spaceModel: {} as SpaceModel,
         schedulerClient: {} as SchedulerClient,
+        featureFlagModel: featureFlagModel as unknown as FeatureFlagModel,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -11,9 +11,11 @@ import {
     Explore,
     ExploreError,
     ExploreType,
+    FeatureFlags,
     ForbiddenError,
     getFilterRules,
     getItemId,
+    getUnusedDimensions,
     InlineErrorType,
     isChartValidationError,
     isDashboardFieldTarget,
@@ -37,6 +39,7 @@ import * as Sentry from '@sentry/node';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -54,6 +57,7 @@ type ValidationServiceArguments = {
     dashboardModel: DashboardModel;
     spaceModel: SpaceModel;
     schedulerClient: SchedulerClient;
+    featureFlagModel: FeatureFlagModel;
 };
 
 export class ValidationService extends BaseService {
@@ -73,6 +77,8 @@ export class ValidationService extends BaseService {
 
     schedulerClient: SchedulerClient;
 
+    featureFlagModel: FeatureFlagModel;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -82,6 +88,7 @@ export class ValidationService extends BaseService {
         dashboardModel,
         spaceModel,
         schedulerClient,
+        featureFlagModel,
     }: ValidationServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -92,6 +99,7 @@ export class ValidationService extends BaseService {
         this.dashboardModel = dashboardModel;
         this.spaceModel = spaceModel;
         this.schedulerClient = schedulerClient;
+        this.featureFlagModel = featureFlagModel;
     }
 
     static getTableCalculationFieldIds(
@@ -248,6 +256,13 @@ export class ValidationService extends BaseService {
             projectUuid,
         );
 
+        // Check if SQL pivot results (backend pivoting) is enabled
+        // This determines whether to validate unused dimensions in chart configurations
+        const useSqlPivotResultsFlag = await this.featureFlagModel.get({
+            featureFlagId: FeatureFlags.UseSqlPivotResults,
+        });
+        const useSqlPivotResults = useSqlPivotResultsFlag.enabled;
+
         // Only validate charts that are using selected explores
         const results = charts
             .filter((c) => {
@@ -276,6 +291,9 @@ export class ValidationService extends BaseService {
                     customMetricsBaseDimensions,
                     customMetricsFilters,
                     tableCalculations,
+                    chartType,
+                    chartConfig,
+                    pivotDimensions,
                 }) => {
                     const availableDimensionIds =
                         exploreFields[tableName]?.dimensionIds || [];
@@ -444,6 +462,35 @@ export class ValidationService extends BaseService {
                         [],
                     );
 
+                    // Check for unused dimensions in chart configuration
+                    // This only applies to cartesian charts with backend pivoting (when USE_SQL_PIVOT_RESULTS is enabled)
+                    // Only check dimensions that exist (skip those already flagged as "no longer exists")
+                    let unusedDimensionErrors: CreateChartValidation[] = [];
+                    if (useSqlPivotResults) {
+                        const dimensionsWithErrors = new Set(
+                            dimensionErrors.map((e) => e.fieldName),
+                        );
+                        const existingDimensions = dimensions.filter(
+                            (d) => !dimensionsWithErrors.has(d),
+                        );
+                        const { unusedDimensions } = getUnusedDimensions({
+                            chartType,
+                            chartConfig,
+                            pivotDimensions,
+                            queryDimensions: existingDimensions,
+                        });
+
+                        unusedDimensionErrors = unusedDimensions.map(
+                            (dimension) => ({
+                                ...commonValidation,
+                                error: `Chart configuration error: dimension '${dimension}' is not used in the chart configuration (x-axis, y-axis, or group by). This can cause incorrect rendering.`,
+                                errorType:
+                                    ValidationErrorType.ChartConfiguration,
+                                fieldName: dimension,
+                            }),
+                        );
+                    }
+
                     return [
                         ...dimensionErrors,
                         ...metricErrors,
@@ -451,6 +498,7 @@ export class ValidationService extends BaseService {
                         ...sortErrors,
                         ...customMetricsErrors,
                         ...customMetricFilterErrors,
+                        ...unusedDimensionErrors,
                     ];
                 },
             );

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -172,6 +172,7 @@ export { default as assertUnreachable } from './utils/assertUnreachable';
 export * from './utils/catalogMetricsTree';
 export * from './utils/changeset';
 export * from './utils/charts';
+export * from './utils/chartValidation';
 export * from './utils/colors';
 export * from './utils/conditionalFormatExpressions';
 export * from './utils/conditionalFormatting';

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -102,6 +102,7 @@ export enum ValidationErrorType {
     Model = 'model',
     Dimension = 'dimension',
     CustomMetric = 'custom metric',
+    ChartConfiguration = 'chart configuration',
 }
 
 export enum DashboardFilterValidationErrorType {

--- a/packages/common/src/utils/chartValidation.ts
+++ b/packages/common/src/utils/chartValidation.ts
@@ -1,0 +1,87 @@
+import {
+    ChartType,
+    type CartesianChart,
+    type ChartConfig,
+} from '../types/savedCharts';
+
+/**
+ * Input for detecting unused dimensions in a cartesian chart.
+ */
+export type UnusedDimensionsInput = {
+    /** The chart configuration */
+    chartType: ChartType;
+    /** The chart config object (contains layout for cartesian charts) */
+    chartConfig: ChartConfig['config'] | undefined;
+    /** Pivot/group by dimension field IDs */
+    pivotDimensions: string[];
+    /** All dimension field IDs in the metric query */
+    queryDimensions: string[];
+};
+
+/**
+ * Detects dimensions in the query that are not used in the chart configuration.
+ *
+ * For cartesian charts, dimensions should be used in one of:
+ * - x-axis (xField)
+ * - y-axis (yField) - though typically metrics go here
+ * - group by / pivot (pivotDimensions)
+ *
+ * If a dimension is in the query but not used in any of these places,
+ * it may cause incorrect results when using backend pivoting.
+ *
+ * @returns Array of unused dimension field IDs, or empty array if none
+ */
+export function getUnusedDimensions(input: UnusedDimensionsInput): {
+    unusedDimensions: string[];
+} {
+    const { chartType, chartConfig, pivotDimensions, queryDimensions } = input;
+
+    if (chartType !== ChartType.CARTESIAN) {
+        return { unusedDimensions: [] };
+    }
+
+    if (queryDimensions.length === 0) {
+        return { unusedDimensions: [] };
+    }
+
+    const usedDimensions = new Set<string>();
+
+    // Get layout from cartesian chart config
+    // We cast to CartesianChart since we've already verified chartType is CARTESIAN
+    const cartesianConfig = chartConfig as CartesianChart | undefined;
+    const layout = cartesianConfig?.layout;
+
+    // Add xField if it's a dimension (i.e., in the queryDimensions list)
+    if (layout?.xField && queryDimensions.includes(layout.xField)) {
+        usedDimensions.add(layout.xField);
+    }
+
+    // Add yField items if they're dimensions
+    if (layout?.yField) {
+        for (const field of layout.yField) {
+            if (queryDimensions.includes(field)) {
+                usedDimensions.add(field);
+            }
+        }
+    }
+
+    // Add all pivot dimensions (these are always dimensions by definition)
+    for (const pivotDim of pivotDimensions) {
+        usedDimensions.add(pivotDim);
+    }
+
+    // Find query dimensions that are not used anywhere
+    const unusedDimensions = queryDimensions.filter(
+        (dim) => !usedDimensions.has(dim),
+    );
+
+    return { unusedDimensions };
+}
+
+/**
+ * Checks if a chart has unused dimensions that may cause incorrect results.
+ * This is a convenience wrapper around getUnusedDimensions.
+ */
+export function hasUnusedDimensions(input: UnusedDimensionsInput): boolean {
+    return getUnusedDimensions(input).unusedDimensions.length > 0;
+}

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
@@ -4,6 +4,7 @@ import {
     isChartValidationError,
     isDashboardValidationError,
     isTableValidationError,
+    ValidationErrorType,
     type ValidationResponse,
 } from '@lightdash/common';
 import { Mark, Stack, Text } from '@mantine/core';
@@ -28,6 +29,20 @@ const ErrorMessageByType: FC<{
     validationError: ValidationResponse;
 }> = ({ validationError }) => {
     if (isChartValidationError(validationError)) {
+        // Handle chart configuration errors (unused dimensions)
+        if (
+            validationError.errorType === ValidationErrorType.ChartConfiguration
+        ) {
+            return (
+                <Text>
+                    <CustomMark>{validationError.fieldName}</CustomMark> is
+                    included in the query but not used in the chart
+                    configuration (x-axis, y-axis, or group by). This can cause
+                    incorrect rendering. We recommend removing unused dimensions
+                    from the query.
+                </Text>
+            );
+        }
         return (
             <Text>
                 <CustomMark>{validationError.fieldName}</CustomMark> no longer

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -2,6 +2,7 @@ import {
     isChartValidationError,
     isDashboardValidationError,
     isTableValidationError,
+    ValidationErrorType,
     type ValidationErrorChartResponse,
     type ValidationErrorDashboardResponse,
     type ValidationResponse,
@@ -156,19 +157,22 @@ const TableValidationItem = forwardRef<
             </td>
             <td>
                 <Box w={24}>
-                    {hovered && isChartValidationError(validationError) && (
-                        <Button
-                            variant="outline"
-                            onClick={(
-                                e: React.MouseEvent<HTMLButtonElement>,
-                            ) => {
-                                onSelectValidationError(validationError);
-                                e.stopPropagation();
-                            }}
-                        >
-                            Fix
-                        </Button>
-                    )}
+                    {hovered &&
+                        isChartValidationError(validationError) &&
+                        validationError.errorType !==
+                            ValidationErrorType.ChartConfiguration && (
+                            <Button
+                                variant="outline"
+                                onClick={(
+                                    e: React.MouseEvent<HTMLButtonElement>,
+                                ) => {
+                                    onSelectValidationError(validationError);
+                                    e.stopPropagation();
+                                }}
+                            >
+                                Fix
+                            </Button>
+                        )}
                 </Box>
             </td>
             <td>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19312, GLITCH-136

### Description:

Adds a validator error for charts with extra dimensions that may cause incorrect rendering with the new pivoting pipeline. 
- There is a new validator rule and it will show an error for each extra dimension in charts
- The new validation only runs when `USE_SQL_PIVOT_RESULTS` is enabled
- For now, the fix button is hidden - there are a couple options for how that could work and I will follow up, but this part is always necessary
- Works for the CLI and UI

**Note**
This is the first time we are adding validation for chart config. All of the other validations have to do with project compilation. Does anyone see any issues with this? I'm not 100% sure how customers use the validator. If we need to we could make it optional to validate these. 

**UI**
<img width="915" height="379" alt="Screenshot 2026-01-12 at 16 53 21" src="https://github.com/user-attachments/assets/6c4fe27a-bf48-4200-ac10-f7a63948af52" />

**CLI**
<img width="858" height="300" alt="Screenshot 2026-01-12 at 17 06 19" src="https://github.com/user-attachments/assets/cdc52be2-dc82-426f-b9e0-9d0936e452f9" />
