### PR TITLE
chore: resolve 'Unexpected unnamed function' lint warnings

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -219,24 +219,27 @@ export class SearchModel {
                 'direct_charts.dashboard_uuid',
             )
             // Join with charts that are in dashboard through tiles
-            .leftJoin('dashboard_tiles', function () {
+            .leftJoin('dashboard_tiles', function joinDashboardTiles() {
                 this.on(
                     'dashboard_tiles.dashboard_version_id',
                     '=',
                     `last_version.dashboard_version_id`,
                 );
             })
-            .leftJoin('dashboard_tile_charts', function () {
-                this.on(
-                    'dashboard_tile_charts.dashboard_version_id',
-                    '=',
-                    'dashboard_tiles.dashboard_version_id',
-                ).andOn(
-                    'dashboard_tile_charts.dashboard_tile_uuid',
-                    '=',
-                    'dashboard_tiles.dashboard_tile_uuid',
-                );
-            })
+            .leftJoin(
+                'dashboard_tile_charts',
+                function joinDashboardTileCharts() {
+                    this.on(
+                        'dashboard_tile_charts.dashboard_version_id',
+                        '=',
+                        'dashboard_tiles.dashboard_version_id',
+                    ).andOn(
+                        'dashboard_tile_charts.dashboard_tile_uuid',
+                        '=',
+                        'dashboard_tiles.dashboard_tile_uuid',
+                    );
+                },
+            )
             .leftJoin(
                 `${SavedChartsTableName} as tile_charts`,
                 'tile_charts.saved_query_id',


### PR DESCRIPTION
Just a small chore to resolve a couple of lint warnings that I randomly spotted:

```commandline
backend:lint: /Users/lukas/Work/lightdash/packages/backend/src/models/SearchModel/index.ts
backend:lint:   222:42  warning  Unexpected unnamed function  func-names
backend:lint:   229:48  warning  Unexpected unnamed function  func-names
backend:lint:
backend:lint: ✖ 2 problems (0 errors, 2 warnings)
backend:lint:
```