### PR TITLE
fix: correct interval syntax in stuck job query

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1219,7 +1219,7 @@ export class SchedulerClient {
                 WHERE locked_by IS NOT NULL
                   AND locked_at IS NOT NULL
                   AND run_at < now()
-                  AND locked_at > now() - interval $1
+                  AND locked_at > now() - $1::interval
                 ORDER BY locked_at ASC
             `,
                 [`${SchedulerClient.STUCK_JOB_WINDOW} hours`],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Fixed SQL query syntax for interval parameter in the `SchedulerClient`. Changed from `locked_at > now() - interval $1` to `locked_at > now() - $1::interval` to properly cast the parameter as an interval type.