### PR TITLE
fix: preserve null selectedTabs in dashboard scheduler

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -100,11 +100,14 @@ export const getSelectedTabsForDashboardScheduler = (
     return (
         isDashboardScheduler(schedulerData) && {
             selectedTabs: isDashboardTabsAvailable
-                ? intersection(
-                      schedulerData.selectedTabs,
-                      dashboard?.tabs.map((tab) => tab.uuid),
-                  )
-                : null, // remove tabs that have been deleted
+                ? // null means "all tabs" - preserve that, otherwise filter out deleted tabs
+                  schedulerData.selectedTabs === null
+                    ? null
+                    : intersection(
+                          schedulerData.selectedTabs,
+                          dashboard?.tabs.map((tab) => tab.uuid),
+                      )
+                : null,
         }
     );
 };
@@ -124,8 +127,8 @@ export const getFormValuesFromScheduler = (
             options.limit === Limit.TABLE
                 ? Limit.TABLE
                 : options.limit === Limit.ALL
-                ? Limit.ALL
-                : Limit.CUSTOM;
+                  ? Limit.ALL
+                  : Limit.CUSTOM;
         if (formOptions.limit === Limit.CUSTOM) {
             formOptions.customLimit = options.limit as number;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [https://linear.app/lightdash/issue/PROD-2430/include-all-tabs-doesnt-persist-in-scheduled-deliveries-modal](https://linear.app/lightdash/issue/PROD-2430/include-all-tabs-doesnt-persist-in-scheduled-deliveries-modal)

### Description:

Fix dashboard scheduler to properly handle null selectedTabs value, which means "all tabs". Previously, the code was incorrectly filtering out tabs when selectedTabs was null, but this PR preserves the null value to maintain the "all tabs" selection behavior.

The PR also includes minor formatting adjustments to the ternary operator indentation in the limit handling code.