### PR TITLE
feat: add SCIM API examples and auto-verify emails for SCIM users

### DIFF
--- a/examples/api/scim.http
+++ b/examples/api/scim.http
@@ -1,0 +1,57 @@
+
+### Login
+// @no-log
+POST http://localhost:8080/api/v1/login
+Content-Type: application/json
+
+{
+    "email": "demo@lightdash.com",
+    "password": "demo_password!"
+}
+
+# To get a new scim token, check scim-org-tokens.http
+
+### Create a new user
+
+POST http://localhost:8080/api/v1/scim/v2/Users
+Content-Type: application/json
+Authorization: Bearer scim_9d95455ef43b7dd9077d9001e1c5b112
+
+{
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+    "userName": "new-user@example.com",
+    "name": {
+        "givenName": "New",
+        "familyName": "User"
+    },
+    "active": true,
+    "emails": [
+        {
+            "value": "new-user@example.com",
+            "primary": true
+        }
+    ]
+}
+
+
+### Update user userName (PUT - full replacement)
+PUT http://localhost:8080/api/v1/scim/v2/Users/fdc58e24-906e-4813-a7e7-8522424cb2ce
+Content-Type: application/json
+Authorization: Bearer scim_9d95455ef43b7dd9077d9001e1c5b112
+
+{
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+    "userName": "updated-user@example.com",
+    "name": {
+        "givenName": "New",
+        "familyName": "User"
+    },
+    "active": true,
+    "emails": [
+        {
+            "value": "updated-user@example.com",
+            "primary": true
+        }
+    ]
+}
+

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -566,6 +566,7 @@ export class ScimService extends BaseService {
                     email: emailToUpdate,
                     isActive: user.active ?? dbUser.isActive,
                 },
+                true, // automatically verify email
             );
 
             // Update user's organization role if provided in the extension schema


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/19363

## What the issue is

Some users are updating their okta email, but they get an error, because the new email gets unverified, causing this error when using tries to login again using OKTA

<img width="1064" height="278" alt="image" src="https://github.com/user-attachments/assets/03a5588b-8906-484e-beb7-ce86c86548b0" />


On SCIM, we create new emails if the email changes, but by default, those emails are `unverified`

Added some code to `automatically` verify emails when they are created from SCIM (existing pattern)

### How to test
- create a new user using scim.http
- Update scim user with a new username(email) using scim.http
- New email is unverified

* Before
<img width="944" height="78" alt="Screenshot from 2026-01-12 17-07-59" src="https://github.com/user-attachments/assets/73d27ee6-9223-41f2-a955-8ef64279cf3f" />

* After

<img width="928" height="58" alt="Screenshot from 2026-01-12 17-25-02" src="https://github.com/user-attachments/assets/bb814a0e-24af-4958-ba70-7a17f544886d" />

### Description:
Added automatic email verification for SCIM users when their email is updated. This ensures that when a user's email is changed through the SCIM API, the new email is automatically verified without requiring additional steps.

Also added an HTTP example file for SCIM API operations, including endpoints for creating and updating users, which serves as documentation for how to interact with the SCIM API.