### PR TITLE
fix: resolve mantine type error

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -174,6 +174,7 @@
         "@types/topojson-specification": "^1.0.5",
         "@types/uuid": "^8.3.4",
         "@vitejs/plugin-react": "^4.4.1",
+        "csstype": "^3.2.3",
         "eslint-plugin-css-modules": "^2.11.0",
         "eslint-plugin-jest-dom": "^5.1.0",
         "eslint-plugin-jsx-a11y": "^6.6.1",

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -5,6 +5,7 @@ import {
     type MantineThemeOverride,
     type Tuple,
 } from '@mantine/core';
+import type {} from 'csstype';
 // eslint-disable-next-line css-modules/no-unused-class
 import styles from './styles/mantine-overrides/tooltip.module.css';
 
@@ -374,4 +375,4 @@ export const getMantineThemeOverride = (
                   }
                 : undefined),
         }),
-    } satisfies MantineThemeOverride);
+    }) satisfies MantineThemeOverride;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1235,6 +1235,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.4.1(vite@7.1.10(@types/node@24.3.1)(lightningcss@1.22.0)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.19.4)(yaml@2.7.0))
+      csstype:
+        specifier: ^3.2.3
+        version: 3.2.3
       eslint-plugin-css-modules:
         specifier: ^2.11.0
         version: 2.11.0(eslint@8.57.1)
@@ -8202,11 +8205,8 @@ packages:
   csstype@3.0.9:
     resolution: {integrity: sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==}
 
-  csstype@3.1.1:
-    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   csv-stringify@6.5.1:
     resolution: {integrity: sha512-+9lpZfwpLntpTIEpFbwQyWuW/hmI/eHuJZD1XzeZpfZTqkf1fyvBbBLXTJJMsBuuS11uTShMqPwzx4A6ffXgRQ==}
@@ -15333,6 +15333,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -18122,7 +18123,7 @@ snapshots:
       '@emotion/memoize': 0.8.0
       '@emotion/unitless': 0.8.0
       '@emotion/utils': 1.2.0
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@emotion/sheet@1.2.1': {}
 
@@ -22538,7 +22539,7 @@ snapshots:
 
   '@types/react@19.2.2':
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/readdir-glob@1.1.5':
     dependencies:
@@ -22587,7 +22588,7 @@ snapshots:
     dependencies:
       '@types/hoist-non-react-statics': 3.3.5
       '@types/react': 19.2.2
-      csstype: 3.1.1
+      csstype: 3.2.3
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -24603,9 +24604,7 @@ snapshots:
 
   csstype@3.0.9: {}
 
-  csstype@3.1.1: {}
-
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   csv-stringify@6.5.1: {}
 
@@ -25073,7 +25072,7 @@ snapshots:
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.28.3
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   dom-serializer@2.0.0:
     dependencies:
@@ -29420,7 +29419,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       css-tree: 1.1.3
-      csstype: 3.1.3
+      csstype: 3.2.3
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 7.0.1
       react: 19.2.0


### PR DESCRIPTION
### Description:
I've been seeing errors in the frontend repo whenever I tried to run all tests (`pnpm dev`) or similar. This PR should take care of it.

The errors I've been seeing:

```commandline
> lightdash@0.2329.0 frontend-build /Users/lukas/Work/lightdash
> pnpm -F frontend build


> @lightdash/frontend@0.2329.0 build /Users/lukas/Work/lightdash/packages/frontend
> pnpm run typecheck && NODE_OPTIONS=--max-old-space-size=8192 vite build


> @lightdash/frontend@0.2329.0 typecheck /Users/lukas/Work/lightdash/packages/frontend
> tsc --project tsconfig.json --noEmit

src/components/VisualizationConfigs/mantineTheme.ts:4:14 - error TS2742: The inferred type of 'getVizConfigThemeOverride' cannot be named without a reference to '.pnpm/csstype@3.1.3/node_modules/csstype'. This is likely not portable. A type annotation is necessary.

4 export const getVizConfigThemeOverride = (colorScheme: ColorScheme) =>
               ~~~~~~~~~~~~~~~~~~~~~~~~~

src/mantine8Theme.ts:67:14 - error TS2742: The inferred type of 'getMantine8ThemeOverride' cannot be named without a reference to '.pnpm/csstype@3.1.3/node_modules/csstype'. This is likely not portable. A type annotation is necessary.

67 export const getMantine8ThemeOverride = (
                ~~~~~~~~~~~~~~~~~~~~~~~~

src/mantineTheme.ts:129:14 - error TS2742: The inferred type of 'getMantineThemeOverride' cannot be named without a reference to '.pnpm/csstype@3.1.3/node_modules/csstype'. This is likely not portable. A type annotation is necessary.

129 export const getMantineThemeOverride = (
                 ~~~~~~~~~~~~~~~~~~~~~~~


Found 3 errors in 3 files.

Errors  Files
     1  src/components/VisualizationConfigs/mantineTheme.ts:4
     1  src/mantine8Theme.ts:67
     1  src/mantineTheme.ts:129
 ELIFECYCLE  Command failed with exit code 1.
/Users/lukas/Work/lightdash/packages/frontend:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @lightdash/frontend@0.2329.0 build: `pnpm run typecheck && NODE_OPTIONS=--max-old-space-size=8192 vite build`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
```
