### PR TITLE
fix: improve content-as-code validation

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -923,14 +923,10 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Path() slug: string,
         @Body()
-        chart: Omit<
-            ChartAsCode,
-            'metricQuery' | 'chartConfig' | 'description'
-        > & {
+        chart: Omit<ChartAsCode, 'chartConfig' | 'description'> & {
             skipSpaceCreate?: boolean;
             publicSpaceCreate?: boolean;
             chartConfig: AnyType;
-            metricQuery: AnyType;
             description?: string | null; // Allow both undefined and null
         },
         @Request() req: express.Request,
@@ -1020,13 +1016,9 @@ export class ProjectController extends BaseController {
         @Path() projectUuid: string,
         @Path() slug: string,
         @Body()
-        dashboard: Omit<
-            DashboardAsCode,
-            'filters' | 'tiles' | 'description'
-        > & {
+        dashboard: Omit<DashboardAsCode, 'tiles' | 'description'> & {
             skipSpaceCreate?: boolean;
             publicSpaceCreate?: boolean;
-            filters: AnyType;
             tiles: AnyType;
             description?: string | null; // Allow both undefined and null
         }, // Simplify filter type for tsoa

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10896,6 +10896,7 @@ const models: TsoaRoute.Models = {
             'model',
             'dimension',
             'custom metric',
+            'chart configuration',
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -17612,69 +17613,69 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ChartAsCode.Exclude_keyofChartAsCode.metricQuery-or-chartConfig-or-description__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    name: { dataType: 'string', required: true },
-                    updatedAt: { dataType: 'datetime', required: true },
-                    version: { dataType: 'double', required: true },
-                    slug: { dataType: 'string', required: true },
-                    tableName: { dataType: 'string', required: true },
-                    pivotConfig: {
-                        dataType: 'union',
-                        subSchemas: [
-                            {
-                                dataType: 'nestedObjectLiteral',
-                                nestedProperties: {
-                                    columns: {
-                                        dataType: 'array',
-                                        array: { dataType: 'string' },
-                                        required: true,
-                                    },
-                                },
-                            },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    tableConfig: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            columnOrder: {
-                                dataType: 'array',
-                                array: { dataType: 'string' },
-                                required: true,
-                            },
-                        },
-                        required: true,
-                    },
-                    dashboardSlug: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                        required: true,
-                    },
-                    spaceSlug: { dataType: 'string', required: true },
-                    downloadedAt: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'datetime' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                },
-                validators: {},
-            },
-        },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_ChartAsCode.metricQuery-or-chartConfig-or-description_': {
+    'Pick_ChartAsCode.Exclude_keyofChartAsCode.chartConfig-or-description__': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_ChartAsCode.Exclude_keyofChartAsCode.metricQuery-or-chartConfig-or-description__',
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                updatedAt: { dataType: 'datetime', required: true },
+                version: { dataType: 'double', required: true },
+                slug: { dataType: 'string', required: true },
+                tableName: { dataType: 'string', required: true },
+                metricQuery: { ref: 'MetricQuery', required: true },
+                pivotConfig: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                columns: {
+                                    dataType: 'array',
+                                    array: { dataType: 'string' },
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                tableConfig: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        columnOrder: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                dashboardSlug: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                    required: true,
+                },
+                spaceSlug: { dataType: 'string', required: true },
+                downloadedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_ChartAsCode.chartConfig-or-description_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_ChartAsCode.Exclude_keyofChartAsCode.chartConfig-or-description__',
             validators: {},
         },
     },
@@ -17829,7 +17830,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.filters-or-tiles-or-description__':
+    'Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.tiles-or-description__':
         {
             dataType: 'refAlias',
             type: {
@@ -17839,6 +17840,26 @@ const models: TsoaRoute.Models = {
                     updatedAt: { dataType: 'datetime', required: true },
                     version: { dataType: 'double', required: true },
                     slug: { dataType: 'string', required: true },
+                    filters: {
+                        dataType: 'intersection',
+                        subSchemas: [
+                            { ref: 'Omit_DashboardFilters.dimensions_' },
+                            {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    dimensions: {
+                                        dataType: 'array',
+                                        array: {
+                                            dataType: 'refAlias',
+                                            ref: 'Omit_DashboardFilterRule.id_',
+                                        },
+                                        required: true,
+                                    },
+                                },
+                            },
+                        ],
+                        required: true,
+                    },
                     tabs: {
                         dataType: 'array',
                         array: { dataType: 'refAlias', ref: 'DashboardTab' },
@@ -17857,10 +17878,10 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_DashboardAsCode.filters-or-tiles-or-description_': {
+    'Omit_DashboardAsCode.tiles-or-description_': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.filters-or-tiles-or-description__',
+            ref: 'Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.tiles-or-description__',
             validators: {},
         },
     },
@@ -38640,9 +38661,7 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'intersection',
             subSchemas: [
-                {
-                    ref: 'Omit_ChartAsCode.metricQuery-or-chartConfig-or-description_',
-                },
+                { ref: 'Omit_ChartAsCode.chartConfig-or-description_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -38653,7 +38672,6 @@ export function RegisterRoutes(app: Router) {
                                 { dataType: 'enum', enums: [null] },
                             ],
                         },
-                        metricQuery: { ref: 'AnyType', required: true },
                         chartConfig: { ref: 'AnyType', required: true },
                         publicSpaceCreate: { dataType: 'boolean' },
                         skipSpaceCreate: { dataType: 'boolean' },
@@ -38880,9 +38898,7 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'intersection',
             subSchemas: [
-                {
-                    ref: 'Omit_DashboardAsCode.filters-or-tiles-or-description_',
-                },
+                { ref: 'Omit_DashboardAsCode.tiles-or-description_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -38894,7 +38910,6 @@ export function RegisterRoutes(app: Router) {
                             ],
                         },
                         tiles: { ref: 'AnyType', required: true },
-                        filters: { ref: 'AnyType', required: true },
                         publicSpaceCreate: { dataType: 'boolean' },
                         skipSpaceCreate: { dataType: 'boolean' },
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11208,7 +11208,8 @@
                     "metric",
                     "model",
                     "dimension",
-                    "custom metric"
+                    "custom metric",
+                    "chart configuration"
                 ],
                 "type": "string"
             },
@@ -18348,7 +18349,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_ChartAsCode.Exclude_keyofChartAsCode.metricQuery-or-chartConfig-or-description__": {
+            "Pick_ChartAsCode.Exclude_keyofChartAsCode.chartConfig-or-description__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -18366,6 +18367,9 @@
                     },
                     "tableName": {
                         "type": "string"
+                    },
+                    "metricQuery": {
+                        "$ref": "#/components/schemas/MetricQuery"
                     },
                     "pivotConfig": {
                         "properties": {
@@ -18408,14 +18412,15 @@
                     "version",
                     "slug",
                     "tableName",
+                    "metricQuery",
                     "tableConfig",
                     "spaceSlug"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_ChartAsCode.metricQuery-or-chartConfig-or-description_": {
-                "$ref": "#/components/schemas/Pick_ChartAsCode.Exclude_keyofChartAsCode.metricQuery-or-chartConfig-or-description__",
+            "Omit_ChartAsCode.chartConfig-or-description_": {
+                "$ref": "#/components/schemas/Pick_ChartAsCode.Exclude_keyofChartAsCode.chartConfig-or-description__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "Pick_SqlChart.name-or-description-or-slug-or-sql-or-limit-or-config-or-chartKind_": {
@@ -18622,7 +18627,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.filters-or-tiles-or-description__": {
+            "Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.tiles-or-description__": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -18637,6 +18642,25 @@
                     },
                     "slug": {
                         "type": "string"
+                    },
+                    "filters": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Omit_DashboardFilters.dimensions_"
+                            },
+                            {
+                                "properties": {
+                                    "dimensions": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/Omit_DashboardFilterRule.id_"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["dimensions"],
+                                "type": "object"
+                            }
+                        ]
                     },
                     "tabs": {
                         "items": {
@@ -18657,14 +18681,15 @@
                     "updatedAt",
                     "version",
                     "slug",
+                    "filters",
                     "tabs",
                     "spaceSlug"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_DashboardAsCode.filters-or-tiles-or-description_": {
-                "$ref": "#/components/schemas/Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.filters-or-tiles-or-description__",
+            "Omit_DashboardAsCode.tiles-or-description_": {
+                "$ref": "#/components/schemas/Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.tiles-or-description__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "ApiRefreshResults": {
@@ -24126,7 +24151,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2332.0",
+        "version": "0.2346.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -32731,16 +32756,13 @@
                             "schema": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/components/schemas/Omit_ChartAsCode.metricQuery-or-chartConfig-or-description_"
+                                        "$ref": "#/components/schemas/Omit_ChartAsCode.chartConfig-or-description_"
                                     },
                                     {
                                         "properties": {
                                             "description": {
                                                 "type": "string",
                                                 "nullable": true
-                                            },
-                                            "metricQuery": {
-                                                "$ref": "#/components/schemas/AnyType"
                                             },
                                             "chartConfig": {
                                                 "$ref": "#/components/schemas/AnyType"
@@ -32752,10 +32774,7 @@
                                                 "type": "boolean"
                                             }
                                         },
-                                        "required": [
-                                            "metricQuery",
-                                            "chartConfig"
-                                        ],
+                                        "required": ["chartConfig"],
                                         "type": "object"
                                     }
                                 ]
@@ -32960,7 +32979,7 @@
                             "schema": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/components/schemas/Omit_DashboardAsCode.filters-or-tiles-or-description_"
+                                        "$ref": "#/components/schemas/Omit_DashboardAsCode.tiles-or-description_"
                                     },
                                     {
                                         "properties": {
@@ -32971,9 +32990,6 @@
                                             "tiles": {
                                                 "$ref": "#/components/schemas/AnyType"
                                             },
-                                            "filters": {
-                                                "$ref": "#/components/schemas/AnyType"
-                                            },
                                             "publicSpaceCreate": {
                                                 "type": "boolean"
                                             },
@@ -32981,7 +32997,7 @@
                                                 "type": "boolean"
                                             }
                                         },
-                                        "required": ["tiles", "filters"],
+                                        "required": ["tiles"],
                                         "type": "object"
                                     }
                                 ]

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -786,7 +786,9 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                     (changes[`${type} with errors`] ?? 0) + 1;
                 console.error(
                     styles.error(
-                        `Error upserting ${type}: ${getErrorMessage(error)}`,
+                        `Error upserting ${type}:\n\t"${item.name}" (slug: "${
+                            item.slug
+                        }")\n\t${getErrorMessage(error)}`,
                     ),
                 );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related:

https://linear.app/lightdash/issue/PROD-2410/typeerror-cannot-read-properties-of-undefined-reading-fieldid
https://linear.app/lightdash/issue/PROD-2427/typeerror-cannot-read-properties-of-undefined-reading-map

Error message shown on `lightdash upload`:

![CleanShot 2026-01-13 at 11.55.30@2x.png](https://app.graphite.com/user-attachments/assets/ffc2776e-53da-4db9-9600-2bc36c624b03.png)

![CleanShot 2026-01-13 at 11.55.46@2x.png](https://app.graphite.com/user-attachments/assets/d280e369-a5a5-40a2-aad6-71bca12de9ee.png)

### Description:

This PR improves the API type definitions for charts and dashboards by:

1. Fixing the type definitions for `ChartAsCode` and `DashboardAsCode` in the project controller to properly use the existing types rather than overriding them with `AnyType`
2. Allowing `null` values for `tabUuid` in dashboard tiles
3. Adding support for new chart properties:
    - `customPercentageLabel` and `showPercentage` for gauge charts
    - `geoJsonPropertyKey` for map charts
4. Improving error messages in the CLI download handler to include the name and slug of failed items