### PR TITLE
fix: throw error for metrics missing SQL definition

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -731,6 +731,12 @@ export class ExploreCompiler {
         const currentRef = `${metric.table}.${metric.name}`;
         const currentShortRef = metric.name;
         let tablesReferences = new Set([metric.table]);
+        if (metric.sql === undefined || metric.sql === null) {
+            throw new CompileError(
+                `Metric "${metric.name}" in table "${metric.table}" is missing a sql definition`,
+                {},
+            );
+        }
         let renderedSql = metric.sql.replace(
             lightdashVariablePattern,
             (_, p1) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2425/typeerror-cannot-read-properties-of-undefined-reading-replace

Doesn't fix the issue, but checks sql is available for metric query (mandatory field) 

```
TypeError: Cannot read properties of undefined (reading 'replace')
    at ExploreCompiler.compileMetricSql (/usr/app/packages/common/dist/cjs/compiler/exploreCompiler.js:402:38)
    at compileAdditionalMetric (/queryCompiler.ts:209:44)
    at compiledAdditionalMetrics (/queryCompiler.ts:308:13)
    at Array.map (<anonymous>)
    at compileMetricQuery (/queryCompiler.ts:306:77)
    at AsyncQueryService.getMetricQueryFields (/services/AsyncQueryService/AsyncQueryService.ts:1601:55)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at AsyncQueryService.executeAsyncSavedChartQuery (/services/AsyncQueryService/AsyncQueryService.ts:2249:24)
    at {QueryController#2}.executeAsyncSavedChartQuery (/controllers/v2/QueryController.ts:204:25)
    at ExpressTemplateService.apiHandler (/usr/app/node_modules/.pnpm/@tsoa+runtime@6.6.0/node_modules/@tsoa/runtime/dist/routeGeneration/templates/express/expressTemplateService.js:10:26)
    at QueryController_executeAsyncSavedChartQuery (/generated/routes.ts:45729:17)
```

### Description:
Added validation to check if a metric's SQL definition is missing. The compiler now throws a clear error message when a metric in a table is missing its SQL definition, rather than potentially causing cryptic errors later in the compilation process.