### PR TITLE
chore: limit test workers to 50%

### DIFF
--- a/packages/backend/jest.config.js
+++ b/packages/backend/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
         '/dist/',
         '.*\\.integration\\.test\\.ts$',
     ],
+    maxWorkers: '50%',
 };

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
     testEnvironment: 'node',
     automock: false,
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+    maxWorkers: '50%',
 };

--- a/packages/common/jest.config.js
+++ b/packages/common/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
     testEnvironment: 'node',
     automock: false,
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+    maxWorkers: '50%',
 };

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -130,6 +130,11 @@ export default defineConfig({
             VITE_REACT_SCAN_ENABLED: 'false',
             VITE_REACT_QUERY_DEVTOOLS_ENABLED: 'false',
         },
+        poolOptions: {
+            forks: {
+                maxForks: '50%',
+            },
+        },
     },
     server: {
         port: FE_PORT,

--- a/packages/warehouses/jest.config.js
+++ b/packages/warehouses/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
     testEnvironment: 'node',
     automock: false,
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+    maxWorkers: '50%',
 };


### PR DESCRIPTION
### Description:
Jest tends to be super greedy when it comes to taking resources and so it's even able to hang up my brand new Macbook Pro.
One common remedy for this is to limit the `maxWorkers`. I took the existing [backend/jest.config.dev.js](https://github.com/lightdash/lightdash/blob/main/packages/backend/jest.config.dev.js#L11) as a baseline and did some testing with different percentages.


Command used: 
```
pnpm clean-build-cache && time pnpm test
```

Results:

30% -> 125s
50% -> 120s
70% -> 150s


As for the CI: there is a good chance that it won't negatively affect CI times, because as seen in the limited testing above, less resources doesn't necessarily mean that it becomes slower, plus there is gonna be a lot of caching in CI anyways, but let's keep an eye on it.