### PR TITLE
fix: derive selected tabs state and correctly check if all are selected

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormSetupTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormSetupTab.tsx
@@ -99,13 +99,15 @@ export const SchedulerFormSetupTab: FC<Props> = ({
         return SlackStates.SUCCESS;
     }, [isInitialLoading, organizationHasSlack, slackInstallation]);
 
-    const [allTabsSelected, setAllTabsSelected] = useState(
-        form.values.selectedTabs === null ||
+    const allTabsSelected = useMemo(() => {
+        return (
+            form.values.selectedTabs === null ||
             isEqual(
                 dashboard?.tabs.map((tab) => tab.uuid),
                 form.values.selectedTabs,
-            ), // make sure tab ids are identical
-    );
+            )
+        );
+    }, [form.values.selectedTabs, dashboard?.tabs]);
 
     const [emailValidationError, setEmailValidationError] = useState<
         string | undefined
@@ -343,7 +345,8 @@ export const SchedulerFormSetupTab: FC<Props> = ({
                                     position="top"
                                     withinPortal
                                     disabled={
-                                        (form.values.emailTargets?.length || 0) > 0
+                                        (form.values.emailTargets?.length ||
+                                            0) > 0
                                     }
                                 >
                                     <Box display="flex" w="fit-content">
@@ -488,7 +491,6 @@ export const SchedulerFormSetupTab: FC<Props> = ({
                         labelPosition="right"
                         checked={allTabsSelected}
                         onChange={(e) => {
-                            setAllTabsSelected((old) => !old);
                             form.setFieldValue(
                                 'selectedTabs',
                                 e.target.checked ? null : [],

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -100,10 +100,13 @@ export const getSelectedTabsForDashboardScheduler = (
     return (
         isDashboardScheduler(schedulerData) && {
             selectedTabs: isDashboardTabsAvailable
-                ? intersection(
-                      schedulerData.selectedTabs,
-                      dashboard?.tabs.map((tab) => tab.uuid),
-                  )
+                ? // Preserve null (means "all tabs"), only filter specific tab selections
+                  schedulerData.selectedTabs === null
+                    ? null
+                    : intersection(
+                          schedulerData.selectedTabs,
+                          dashboard?.tabs.map((tab) => tab.uuid),
+                      )
                 : null, // remove tabs that have been deleted
         }
     );
@@ -124,8 +127,8 @@ export const getFormValuesFromScheduler = (
             options.limit === Limit.TABLE
                 ? Limit.TABLE
                 : options.limit === Limit.ALL
-                ? Limit.ALL
-                : Limit.CUSTOM;
+                  ? Limit.ALL
+                  : Limit.CUSTOM;
         if (formOptions.limit === Limit.CUSTOM) {
             formOptions.customLimit = options.limit as number;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19373

### Description:

Fixed a bug in the scheduler form where the "All tabs" checkbox state was not properly synchronized with the form values. The implementation now uses `useMemo` to derive the checkbox state directly from form values instead of maintaining a separate state variable. This ensures the UI correctly reflects the current selection state.

Also improved the handling of selected tabs in dashboard schedulers by preserving the `null` value (which means "all tabs selected") when processing scheduler data, rather than potentially converting it to an array.

[CleanShot 2026-01-13 at 09.21.00.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/36fa3668-1ea7-427d-9c72-d099e8c1460a.mp4" />](https://app.graphite.com/user-attachments/video/36fa3668-1ea7-427d-9c72-d099e8c1460a.mp4)

