### PR TITLE
fix: replace logger.warning with logger.warn method

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -574,7 +574,7 @@ export class CsvService extends BaseService {
                 try {
                     await fsPromise.unlink(filePath);
                 } catch (error) {
-                    this.logger.warning(
+                    this.logger.warn(
                         `Error deleting local file ${filePath}: ${error}`,
                     );
                 }
@@ -1272,7 +1272,7 @@ export class CsvService extends BaseService {
                 try {
                     await fsPromise.unlink(filePath);
                 } catch (error) {
-                    this.logger.warning(
+                    this.logger.warn(
                         `Error deleting local file ${filePath}: ${error}`,
                     );
                 }

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -274,7 +274,7 @@ export class PivotTableService extends BaseService {
                 try {
                     await fsPromise.unlink(filePath);
                 } catch (error) {
-                    this.logger.warning(
+                    this.logger.warn(
                         `Error deleting local file ${filePath}: ${error}`,
                     );
                 }


### PR DESCRIPTION
Sentry: https://lightdash.sentry.io/issues/7183332999/?project=5959292

### Description:
Fixed incorrect logger method calls by replacing `logger.warning()` with `logger.warn()` in CsvService and PivotTableService. This ensures consistent logging behavior when handling file deletion errors.