### PR TITLE
fix: Grouped charts made by AI agent don't save with group in chart config

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -284,6 +284,9 @@ export const AiChartQuickOptions = ({
                         tableName: metricQuery.exploreName,
                         chartConfig,
                         tableConfig: { columnOrder },
+                        pivotConfig: pivotDimensions?.length
+                            ? { columns: pivotDimensions }
+                            : undefined,
                     }}
                     onConfirm={onSaveChart}
                     onClose={close}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


Closes: [PROD-2436](https://linear.app/lightdash/issue/PROD-2436/grouped-charts-made-by-ai-agent-dont-save-with-group-in-chart-config) 

### Description:
Added support for pivot dimensions in the AI chart quick options. When pivot dimensions are present, they are now included in the chart configuration passed to the save chart modal, ensuring that pivot settings are preserved when saving charts generated by the AI copilot.
