### PR TITLE
fix: preserve column order in SQL chart exports

### DIFF
--- a/packages/common/src/utils/charts.ts
+++ b/packages/common/src/utils/charts.ts
@@ -106,6 +106,15 @@ export function getColumnOrderFromVizTableConfig(
     config: VizTableConfig | undefined,
 ): string[] {
     if (!config?.columns) return [];
+    // If none of the columns have an empty property, return an empty list
+    // for sql queries, we will order the columns based on the results
+    if (
+        Object.values(config.columns).every(
+            (column) => column.order === undefined,
+        )
+    ) {
+        return [];
+    }
 
     return Object.entries(config.columns)
         .sort(([_, a], [__, b]) => (a.order ?? 0) - (b.order ?? 0))


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2423/inconsistent-csv-column-ordering-in-lightdash-exports

Columns on CSv export are consistent for: 

- saved chart on explore results
- saved chart on table results
- saved chart on dashboard scheduled delivery
- sql chart on table results 

But not for `sql charts on dashboard scheduled delivery`

This PR fixes that inconsistency

### What the issue is

Sql runner charts don't have column config , when downloading form table, we pass from the UI the column based on the results. 

There are multiple ways to fix this, we could push the columnorder calculation inside the asynqueryservice, but that is abit messy and it is more generic. 

**This fix is only targeted to calculate the columnorder for sql chart deliveries when columnorder is null by getting the first row (from s3)**

<img width="1109" height="643" alt="Screenshot from 2026-01-13 10-21-40" src="https://github.com/user-attachments/assets/9936e877-24e7-4ac5-baa7-b75ed810d26f" />

Before
<img width="696" height="213" alt="Screenshot from 2026-01-13 10-50-11" src="https://github.com/user-attachments/assets/a5cd1cea-3b1f-43b5-a2b2-6e8bc1f69b32" />

After

<img width="702" height="211" alt="Screenshot from 2026-01-13 11-28-56" src="https://github.com/user-attachments/assets/218b6e8c-c80c-421e-b8c8-6190bed91a39" />





### Description:
Fixed column order in SQL chart exports by preserving the original data column order when no explicit order is specified in the visualization configuration.

Previously, when exporting SQL chart results to CSV/Excel, the column order could be scrambled due to JSONB storage alphabetically sorting keys. This change ensures that:

1. When no explicit column order is provided in the visualization, we use the column order from the actual data
2. The CSV service now supports dynamically determining column order from the first row of data
3. The chart utility function now returns an empty array when no explicit order is set, signaling to use the original data order

This provides a more intuitive export experience where the columns in the exported file match what users see in the UI.