### PR TITLE
fix: infinite isLoading when there's no dashboard in the chart space

### DIFF
--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -202,7 +202,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
 
     const {
         data: selectedDashboard,
-        isLoading: isLoadingSelectedDashboard,
+        isFetching: isFetchingSelectedDashboard,
         isError: isSelectedDashboardError,
     } = useDashboardQuery(form.getInputProps('dashboardUuid').value);
     const { mutateAsync: createDashboard } = useCreateMutation(
@@ -303,7 +303,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
         (isCreatingNewSpace && form.getInputProps('spaceName').value === '') ||
         (!isCreatingNewDashboard &&
             form.getInputProps('dashboardUuid').value &&
-            (isLoadingSelectedDashboard ||
+            (isFetchingSelectedDashboard ||
                 isSelectedDashboardError ||
                 !selectedDashboard));
 
@@ -317,7 +317,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                 <Button
                     type="submit"
                     form={ADD_TO_DASHBOARD_FORM_ID}
-                    loading={isLoading || isLoadingSelectedDashboard}
+                    loading={isLoading || isFetchingSelectedDashboard}
                     disabled={isSubmitDisabled}
                 >
                     Add to dashboard


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2417/while-saving-a-chartalready-exists-to-a-new-dashboard-the-save-button

### Description:
Main issue was that when there wasn't a dashboard in the space of the chart, the code defaults to `undefined` which disables the `useQuery` hook and therefore `isLoading` becomes true because there's no cached request yet.

This is fixed by using `isFetching` instead of `isLoading` since `isFetching` depends only on network requests going out.

**Steps to reproduce**
1. Create a new empty space
2. Create a new chart
3. Try adding chart to dashboard

**Before**

[Screen Recording 2026-01-13 at 11.09.30.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/533ef2da-59a8-4b60-b4c9-1389ef1aeaa1.mov" />](https://app.graphite.com/user-attachments/video/533ef2da-59a8-4b60-b4c9-1389ef1aeaa1.mov)

**After**

[Screen Recording 2026-01-13 at 11.09.59.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ff127c9b-532d-429d-96b3-9450296c1da4.mov" />](https://app.graphite.com/user-attachments/video/ff127c9b-532d-429d-96b3-9450296c1da4.mov)