### PR TITLE
fix: load context menu for pie and funnel charts on dashboard v1&v2

### DIFF
--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -92,11 +92,12 @@ const FunnelChart: FC<FunnelChartProps> = memo(
                 const event = e.event?.event as unknown as PointerEvent;
                 const data = e.data as FunnelSeriesDataPoint;
 
+                // Use pageX/pageY (document coordinates) to account for scroll
                 setMenuProps({
                     value: data.meta.value,
                     position: {
-                        left: event.clientX,
-                        top: event.clientY,
+                        left: event.pageX,
+                        top: event.pageY,
                     },
                     rows: data.meta.rows,
                 });

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -84,11 +84,12 @@ const SimplePieChart: FC<SimplePieChartProps> = memo(
                 const event = e.event?.event as unknown as PointerEvent;
                 const data = e.data as PieSeriesDataPoint;
 
+                // Use pageX/pageY (document coordinates) to account for scroll
                 setMenuProps({
                     value: data.meta.value,
                     position: {
-                        left: event.clientX,
-                        top: event.clientY,
+                        left: event.pageX,
+                        top: event.pageY,
                     },
                     rows: data.meta.rows,
                 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [PROD-2413](https://linear.app/lightdash/issue/PROD-2413/cannot-view-underlying-data-for-table-tiles-in-embedded-dashboards)

### Description:

Fixed context menu positioning in FunnelChart and SimplePieChart components by using `pageX/pageY` instead of `clientX/clientY` coordinates. This ensures the context menu appears in the correct position when the page is scrolled, as page coordinates account for scroll position while client coordinates don't.

## Before/After

Before: Context menus would appear in incorrect positions when the page was scrolled.
After: Context menus now appear at the correct position of the click regardless of page scroll.

![Screenshot 2026-01-13 at 11.49.31.png](https://app.graphite.com/user-attachments/assets/2fdad0b3-44a5-4bff-816c-2abee9e78bdc.png)

![Screenshot 2026-01-13 at 11.49.34.png](https://app.graphite.com/user-attachments/assets/043bc532-65d0-4ebb-993e-f221267305df.png)

![Screenshot 2026-01-13 at 11.49.53.png](https://app.graphite.com/user-attachments/assets/148f1b6c-89cc-421a-a74a-b9766a603031.png)

![Screenshot 2026-01-13 at 11.50.05.png](https://app.graphite.com/user-attachments/assets/8a6cdc5b-5580-41ab-a5c6-862d97eef4ab.png)