### PR TITLE
feat: add projectType parameter to agent availability check

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -4727,6 +4727,9 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     organizationUuid,
                     userUuid,
                     slackSettings,
+                    {
+                        projectType: ProjectType.DEFAULT,
+                    },
                 );
 
                 if (availableAgents.length === 0) {


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19398  
  
Description:

Added `projectType: ProjectType.DEFAULT` parameter to the agent availability check in `AiAgentService.ts`. This ensures that only agents compatible with the default project type are considered when checking availability.