### PR TITLE
fix: skip message processing if it contains bot mention

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService.ts
@@ -4150,8 +4150,13 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             return;
         }
 
-        const { teamId } = context;
+        const { teamId, botUserId } = context;
         if (!teamId) {
+            return;
+        }
+
+        // Skip if message contains bot mention - let handleAppMention handle it
+        if (botUserId && event.text?.includes(`<@${botUserId}>`)) {
             return;
         }
 


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19400  
  
Description:

Skip processing messages that contain bot mentions in the AI Agent Service, allowing `handleAppMention` to handle these messages instead. This prevents duplicate processing of messages that directly mention the bot.