### PR TITLE
fix: exclude streamed query results from headless browser paginated query endpoint regex

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -70,7 +70,7 @@ const uuidRegex = new RegExp(uuid, 'g');
 const nanoid = '[\\w-]{21}';
 const nanoidRegex = new RegExp(nanoid);
 const createQueryEndpointRegex = /\/query/;
-const paginatedQueryEndpointRegex = new RegExp(`/query/${uuid}`);
+const paginatedQueryEndpointRegex = new RegExp(`/query/${uuid}(?!/results)`);
 
 const viewport = {
     width: 1400,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Changed the regex so that only responses from the actual pagination endpoint `(GET /query/{uuid}`) are parsed as API responses, while responses from the streaming endpoint (`GET￼/query/{uuid}/results`) are ignored by this response handler in `UnfurlService`