### PR TITLE
fix: load embed chart on generate & copy URL action in embed settings

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -176,10 +176,15 @@ export class EmbedService extends BaseService {
             expiresIn || '1h',
         );
 
-        const url = new URL(
-            `/embed/${projectUuid}#${jwtToken}`,
-            this.lightdashConfig.siteUrl,
-        );
+        // Generate different URL paths based on content type
+        let urlPath: string;
+        if (jwtData.content.type === 'chart') {
+            urlPath = `/embed/${projectUuid}/chart/${jwtData.content.contentId}#${jwtToken}`;
+        } else {
+            urlPath = `/embed/${projectUuid}#${jwtToken}`;
+        }
+
+        const url = new URL(urlPath, this.lightdashConfig.siteUrl);
         return {
             url: url.href,
         };

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -13,6 +13,7 @@ import AiAgentNewThreadPage from './pages/AiAgents/AiAgentNewThreadPage';
 import AiAgentsNotAuthorizedPage from './pages/AiAgents/AiAgentsNotAuthorizedPage';
 import { AiAgentsRootLayout } from './pages/AiAgents/AiAgentsRootLayout';
 import ProjectAiAgentEditPage from './pages/AiAgents/ProjectAiAgentEditPage';
+import EmbedChart from './pages/EmbedChart';
 import EmbedDashboard from './pages/EmbedDashboard';
 import EmbedExplore from './pages/EmbedExplore';
 import { SlackAuthSuccess } from './pages/SlackAuthSuccess';
@@ -35,6 +36,14 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
                 element: (
                     <TrackPage name={PageName.EMBED_DASHBOARD}>
                         <EmbedDashboard />
+                    </TrackPage>
+                ),
+            },
+            {
+                path: '/embed/:projectUuid/chart/:chartUuid',
+                element: (
+                    <TrackPage name={PageName.EMBED_SAVED_CHART}>
+                        <EmbedChart />
                     </TrackPage>
                 ),
             },

--- a/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
@@ -112,7 +112,15 @@ const EmbedChart: FC<Props> = ({ containerStyles, savedQueryUuid }) => {
     }
 
     return (
-        <div style={containerStyles}>
+        <div
+            style={
+                containerStyles ?? {
+                    height: '100vh',
+                    overflowY: 'auto',
+                    margin: '16px',
+                }
+            }
+        >
             <MinimalSavedExplorer savedQueryUuid={savedQueryUuid} />
         </div>
     );

--- a/packages/frontend/src/ee/pages/EmbedChart.tsx
+++ b/packages/frontend/src/ee/pages/EmbedChart.tsx
@@ -1,5 +1,6 @@
 import { IconUnlink } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { useParams } from 'react-router';
 import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
 import EmbedChart from '../features/embed/EmbedChart/components/EmbedChart';
 import useEmbed from '../providers/Embed/useEmbed';
@@ -7,7 +8,14 @@ import useEmbed from '../providers/Embed/useEmbed';
 const EmbedChartPage: FC<{
     containerStyles?: React.CSSProperties;
 }> = ({ containerStyles }) => {
+    const { chartUuid: chartUuidFromParams } = useParams<{
+        chartUuid?: string;
+    }>();
     const { embedToken, savedQueryUuid } = useEmbed();
+
+    // Prioritize savedQueryUuid from embed context over URL params to avoid edge cases
+    // where SDK customers might have chartUuid in their app that doesn't point to a Lightdash chart
+    const chartUuid = savedQueryUuid ?? chartUuidFromParams;
 
     if (!embedToken) {
         return (
@@ -20,7 +28,7 @@ const EmbedChartPage: FC<{
         );
     }
 
-    if (!savedQueryUuid) {
+    if (!chartUuid) {
         return (
             <div style={{ marginTop: '20px' }}>
                 <SuboptimalState title="Missing chart ID" icon={IconUnlink} />
@@ -31,7 +39,7 @@ const EmbedChartPage: FC<{
     return (
         <EmbedChart
             containerStyles={containerStyles}
-            savedQueryUuid={savedQueryUuid}
+            savedQueryUuid={chartUuid}
         />
     );
 };

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -6,6 +6,8 @@ import { useParams } from 'react-router';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
 import LightdashVisualization from '../components/LightdashVisualization';
 import VisualizationProvider from '../components/LightdashVisualization/VisualizationProvider';
+import MetricQueryDataProvider from '../components/MetricQueryData/MetricQueryDataProvider';
+import UnderlyingDataModal from '../components/MetricQueryData/UnderlyingDataModal';
 import {
     buildInitialExplorerState,
     createExplorerStore,
@@ -44,7 +46,7 @@ const MinimalExplorerContent = memo(() => {
     } = useElementSize();
 
     // Get query state from hook
-    const { query, queryResults } = useExplorerQuery();
+    const { query, queryResults, explore } = useExplorerQuery();
 
     const resultsData = useMemo(
         () => ({
@@ -91,39 +93,48 @@ const MinimalExplorerContent = memo(() => {
     }
 
     return (
-        <VisualizationProvider
-            minimal
-            chartConfig={savedChart.chartConfig}
-            initialPivotDimensions={savedChart.pivotConfig?.columns}
-            resultsData={resultsData}
-            isLoading={isLoadingQueryResults}
-            columnOrder={savedChart.tableConfig.columnOrder}
-            pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
-            savedChartUuid={savedChart.uuid}
-            colorPalette={savedChart.colorPalette}
+        <MetricQueryDataProvider
+            metricQuery={query.data?.metricQuery}
+            tableName={savedChart.tableName ?? ''}
+            explore={explore}
+            queryUuid={query.data?.queryUuid}
             parameters={query.data?.usedParametersValues}
-            containerWidth={containerWidth}
-            containerHeight={containerHeight}
         >
-            <MantineProvider inherit theme={themeOverride}>
-                <Box mih="inherit" h="100%">
-                    <LightdashVisualization
-                        ref={measureRef}
-                        // get rid of the classNames once you remove analytics providers
-                        className="sentry-block ph-no-capture"
-                        data-testid="visualization"
-                    />
-                </Box>
-            </MantineProvider>
+            <VisualizationProvider
+                minimal
+                chartConfig={savedChart.chartConfig}
+                initialPivotDimensions={savedChart.pivotConfig?.columns}
+                resultsData={resultsData}
+                isLoading={isLoadingQueryResults}
+                columnOrder={savedChart.tableConfig.columnOrder}
+                pivotTableMaxColumnLimit={health.data.pivotTable.maxColumnLimit}
+                savedChartUuid={savedChart.uuid}
+                colorPalette={savedChart.colorPalette}
+                parameters={query.data?.usedParametersValues}
+                containerWidth={containerWidth}
+                containerHeight={containerHeight}
+            >
+                <MantineProvider inherit theme={themeOverride}>
+                    <Box mih="inherit" h="100%">
+                        <LightdashVisualization
+                            ref={measureRef}
+                            // get rid of the classNames once you remove analytics providers
+                            className="sentry-block ph-no-capture"
+                            data-testid="visualization"
+                        />
+                    </Box>
+                </MantineProvider>
 
-            {isScreenshotReady && (
-                <ScreenshotReadyIndicator
-                    tilesTotal={1}
-                    tilesReady={1}
-                    tilesErrored={0}
-                />
-            )}
-        </VisualizationProvider>
+                {isScreenshotReady && (
+                    <ScreenshotReadyIndicator
+                        tilesTotal={1}
+                        tilesReady={1}
+                        tilesErrored={0}
+                    />
+                )}
+            </VisualizationProvider>
+            <UnderlyingDataModal />
+        </MetricQueryDataProvider>
     );
 });
 

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -48,6 +48,7 @@ export enum PageName {
     VERIFY_EMAIL = 'verify_email',
     JOIN_ORGANIZATION = 'join_organization',
     EMBED_DASHBOARD = 'embed_dashboard',
+    EMBED_SAVED_CHART = 'embed_saved_chart',
     EMBED_EXPLORE = 'embed_explore',
     CATALOG = 'catalog',
     METRICS_CATALOG = 'metrics_catalog',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:

Added support for embedding individual charts with dedicated URLs. This PR creates a new route for embedded charts (`/embed/:projectUuid/chart/:chartUuid`) and updates the embed service to generate chart-specific URLs when the content type is a chart.

The implementation includes:

- New URL path generation in the EmbedService based on content type
- Added EmbedChart route in CommercialRoutes
- Updated EmbedChart component to use chart UUID from URL parameters
- Enhanced MinimalSavedExplorer with MetricQueryDataProvider to support underlying data functionality in embedded charts

This change allows for more granular embedding of specific charts rather than only embedding entire dashboards.



![Screenshot 2026-01-14 at 13.05.55.png](https://app.graphite.com/user-attachments/assets/65702b02-8119-48cc-9f52-86943f62b618.png)![Screenshot 2026-01-14 at 13.06.03.png](https://app.graphite.com/user-attachments/assets/5a7f8102-2cc9-4911-8367-e3b9edf5fbc4.png)

