### PR TITLE
style: clarify copy/structure on embed settings page

### DIFF
--- a/packages/frontend/src/components/common/Settings/SettingsCard.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsCard.tsx
@@ -6,7 +6,7 @@ const SettingsCard: FC<React.PropsWithChildren<PaperProps>> = ({
     ...rest
 }) => {
     return (
-        <Paper shadow="sm" withBorder p="md" {...rest}>
+        <Paper shadow="subtle" withBorder p="md" radius="md" {...rest}>
             {children}
         </Paper>
     );

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
@@ -4,9 +4,9 @@ import {
     type SavedChart,
     type UpdateEmbed,
 } from '@lightdash/common';
-import { Button, Flex, MultiSelect, Stack, Switch } from '@mantine/core';
+import { Button, Flex, MultiSelect, Stack, Switch } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
-import React, { type FC } from 'react';
+import { type FC } from 'react';
 
 const EmbedAllowListForm: FC<{
     disabled: boolean;
@@ -63,7 +63,6 @@ const EmbedAllowListForm: FC<{
                                 : 'Select a dashboard...'
                         }
                         searchable
-                        withinPortal
                         description="Only these dashboards will be allowed to be embedded."
                         {...form.getInputProps('dashboardUuids')}
                     />
@@ -95,7 +94,6 @@ const EmbedAllowListForm: FC<{
                                 : 'Select a chart...'
                         }
                         searchable
-                        withinPortal
                         description="Only these charts will be allowed to be embedded."
                         {...form.getInputProps('chartUuids')}
                     />

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -7,9 +7,15 @@ import {
     isDashboardUuidContent,
     type CreateEmbedJwt,
 } from '@lightdash/common';
-import { Tabs } from '@mantine/core';
+import { Tabs } from '@mantine-8/core';
 import { Prism } from '@mantine/prism';
+import {
+    IconBrandGolang,
+    IconBrandNodejs,
+    IconBrandPython,
+} from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
 import useToaster from '../../../../hooks/toaster/useToaster';
 
 // Not sure why lint-staged is removing the value of this enum.
@@ -557,9 +563,30 @@ const EmbedCodeSnippet: FC<{
     return (
         <Tabs defaultValue="node">
             <Tabs.List>
-                <Tabs.Tab value="node">NodeJS</Tabs.Tab>
-                <Tabs.Tab value="python">Python</Tabs.Tab>
-                <Tabs.Tab value="go">Go</Tabs.Tab>
+                <Tabs.Tab
+                    value="node"
+                    leftSection={
+                        <MantineIcon icon={IconBrandNodejs} size="sm" />
+                    }
+                >
+                    NodeJS
+                </Tabs.Tab>
+                <Tabs.Tab
+                    value="python"
+                    leftSection={
+                        <MantineIcon icon={IconBrandPython} size="sm" />
+                    }
+                >
+                    Python
+                </Tabs.Tab>
+                <Tabs.Tab
+                    value="go"
+                    leftSection={
+                        <MantineIcon icon={IconBrandGolang} size="sm" />
+                    }
+                >
+                    Go
+                </Tabs.Tab>
             </Tabs.List>
             <Tabs.Panel value="node" pt="xs">
                 <Prism language="javascript" onCopy={handleCopySnippet}>

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
@@ -7,7 +7,14 @@ import {
     type DashboardFilterInteractivityOptions,
     type SavedChartsInfoForDashboardAvailableFilters,
 } from '@lightdash/common';
-import { Checkbox, Flex, Group, Select, Stack, Text } from '@mantine/core';
+import {
+    Checkbox,
+    Divider,
+    Group,
+    SegmentedControl,
+    Stack,
+    Text,
+} from '@mantine-8/core';
 import { useCallback, useMemo } from 'react';
 import { type FieldsWithSuggestions } from '../../../../components/Explorer/FiltersCard/useFieldsWithSuggestions';
 import { getConditionalRuleLabelFromItem } from '../../../../components/common/Filters/FilterInputs/utils';
@@ -130,36 +137,44 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
     );
 
     return (
-        <Stack mt="sm">
-            <Flex align="center" gap="sm">
-                <Text size="sm">Users can change:</Text>
-                <Select
-                    defaultValue={FilterInteractivityValues.none}
-                    onChange={(value: FilterInteractivityValues) => {
-                        setInteractivityOptions({ enabled: value });
+        <Stack gap="sm">
+            <Group gap="xs">
+                <Text size="sm" fw={500}>
+                    Users can change:
+                </Text>
+                <SegmentedControl
+                    radius="md"
+                    value={interactivityOptions.enabled as string}
+                    onChange={(value: string) => {
+                        setInteractivityOptions({
+                            enabled: value as FilterInteractivityValues,
+                        });
                     }}
                     data={[
                         {
-                            value: FilterInteractivityValues.none,
                             label: getFilterInteractivityValueLabel(
                                 FilterInteractivityValues.none,
                             ),
+                            value: FilterInteractivityValues.none,
                         },
                         {
-                            value: FilterInteractivityValues.some,
                             label: getFilterInteractivityValueLabel(
                                 FilterInteractivityValues.some,
                             ),
+                            value: FilterInteractivityValues.some,
+                            disabled: dashboardFilters?.length === 0,
                         },
                         {
-                            value: FilterInteractivityValues.all,
                             label: getFilterInteractivityValueLabel(
                                 FilterInteractivityValues.all,
                             ),
+                            value: FilterInteractivityValues.all,
+                            disabled: dashboardFilters?.length === 0,
                         },
                     ]}
+                    size="xs"
                 />
-            </Flex>
+            </Group>
             {interactivityOptions.enabled ===
                 FilterInteractivityValues.some && (
                 <Checkbox.Group
@@ -168,7 +183,7 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                         setInteractivityOptions({ allowedFilters: values });
                     }}
                 >
-                    <Group spacing="lg">
+                    <Group>
                         {dashboardFilters &&
                             dashboardFilters.map((filter) => {
                                 const field =
@@ -189,22 +204,31 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                                         value={filter.id}
                                         label={
                                             <>
-                                                <Text fw={600} span>
+                                                <Text fw={600} span fz="xs">
                                                     {labels.field}{' '}
                                                 </Text>
                                                 {filter.disabled ? (
-                                                    <Text span color="ldGray.6">
+                                                    <Text
+                                                        span
+                                                        c="ldGray.6"
+                                                        fz="xs"
+                                                    >
                                                         is any value
                                                     </Text>
                                                 ) : (
                                                     <>
                                                         <Text
                                                             span
-                                                            color="ldGray.7"
+                                                            c="ldGray.7"
+                                                            fz="xs"
                                                         >
                                                             {labels.operator}{' '}
                                                         </Text>
-                                                        <Text fw={700} span>
+                                                        <Text
+                                                            fw={700}
+                                                            span
+                                                            fz="xs"
+                                                        >
                                                             {labels.value}
                                                         </Text>
                                                     </>
@@ -217,6 +241,7 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                     </Group>
                 </Checkbox.Group>
             )}
+            <Divider />
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
@@ -12,15 +12,17 @@ import {
     Flex,
     Group,
     Input,
+    Paper,
+    SegmentedControl,
     Select,
     Stack,
     Switch,
     Text,
     TextInput,
     Title,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm } from '@mantine/form';
-import { IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
+import { IconEye, IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
 import { useCallback, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
@@ -136,6 +138,18 @@ const EmbedPreviewChartForm: FC<{
         [projectUuid],
     );
 
+    const handlePreview = useCallback(async () => {
+        const state = form.validate();
+        if (state.hasErrors) {
+            return;
+        }
+
+        const data = await createEmbedUrl(
+            convertFormValuesToCreateEmbedJwt(formValues, true),
+        );
+        window.open(data.url, '_blank');
+    }, [formValues, form, convertFormValuesToCreateEmbedJwt, createEmbedUrl]);
+
     const generateUrl = useCallback(async () => {
         const data = await createEmbedUrl(
             convertFormValuesToCreateEmbedJwt(form.values),
@@ -148,124 +162,183 @@ const EmbedPreviewChartForm: FC<{
 
     return (
         <form id="generate-embed-url" onSubmit={handleCopySubmit}>
-            <Stack mb={'md'}>
-                <Stack spacing="xs">
-                    <Title order={5}>Preview</Title>
-                    <Text color="dimmed">
-                        Preview your embed URL and copy it to your clipboard.
-                    </Text>
-                </Stack>
+            <Stack gap="md" mb="md">
                 <Select
                     required
-                    label={'Chart'}
+                    label="Chart"
                     data={charts.map((chart) => ({
                         value: chart.uuid,
                         label: chart.name,
                     }))}
                     placeholder="Select a chart..."
                     searchable
-                    withinPortal
                     {...form.getInputProps('chartUuid')}
                 />
-                <Select
-                    required
-                    label={'Expires in'}
-                    data={['1 hour', '1 day', '1 week', '30 days', '1 year']}
-                    withinPortal
-                    {...form.getInputProps('expiresIn')}
-                />
-                <Input.Wrapper label="User identifier">
-                    <TextInput
-                        size={'xs'}
-                        placeholder="1234"
-                        {...form.getInputProps(`externalId`)}
-                    />
-                </Input.Wrapper>
-                <Input.Wrapper label="User email">
-                    <TextInput
-                        size={'xs'}
-                        placeholder="Type an email to add as intrinsic user attribute"
-                        {...form.getInputProps('email')}
-                    />
-                </Input.Wrapper>
-                <Input.Wrapper label="User attributes">
-                    {form.values.userAttributes.map((item, index) => (
-                        <Group key={item.uuid} mt="xs">
-                            <TextInput
-                                size={'xs'}
-                                placeholder="E.g. user_country"
-                                {...form.getInputProps(
-                                    `userAttributes.${index}.key`,
-                                )}
-                            />
-                            <TextInput
-                                size={'xs'}
-                                placeholder="E.g. US"
-                                {...form.getInputProps(
-                                    `userAttributes.${index}.value`,
-                                )}
-                            />
-                            <ActionIcon
-                                variant="light"
-                                onClick={() =>
-                                    form.removeListItem('userAttributes', index)
-                                }
-                            >
-                                <MantineIcon color="red" icon={IconTrash} />
-                            </ActionIcon>
-                        </Group>
-                    ))}
-                    <Group>
-                        <Button
-                            size="xs"
-                            mr="xxs"
-                            variant="default"
-                            mt="xs"
-                            leftIcon={<MantineIcon icon={IconPlus} />}
-                            onClick={() =>
-                                form.insertListItem('userAttributes', {
-                                    key: '',
-                                    value: '',
-                                    uuid: uuidv4(),
-                                })
-                            }
-                        >
-                            Add attribute
-                        </Button>
-                    </Group>
-                </Input.Wrapper>
 
-                <Switch
-                    {...form.getInputProps(`canExportCsv`)}
-                    labelPosition="left"
-                    label={`Can export CSV`}
-                />
-                <Switch
-                    {...form.getInputProps(`canExportImages`)}
-                    labelPosition="left"
-                    label={`Can export Images`}
-                />
-                <Switch
-                    {...form.getInputProps(`canViewUnderlyingData`)}
-                    labelPosition="left"
-                    label={`Can view underlying data`}
-                />
+                <Stack gap="xs">
+                    <Text size="sm" fw={500}>
+                        Expires in
+                    </Text>
+                    <SegmentedControl
+                        value={form.values.expiresIn}
+                        onChange={(value) =>
+                            form.setFieldValue('expiresIn', value)
+                        }
+                        radius="md"
+                        data={[
+                            { label: '1 hour', value: '1 hour' },
+                            { label: '1 day', value: '1 day' },
+                            { label: '1 week', value: '1 week' },
+                            { label: '30 days', value: '30 days' },
+                            { label: '1 year', value: '1 year' },
+                        ]}
+                        size="xs"
+                    />
+                </Stack>
+
+                <Paper p="md" withBorder>
+                    <Stack gap="md">
+                        <Title order={6}>Identification & Security</Title>
+                        <Stack gap="xs">
+                            <Input.Wrapper label="User identifier">
+                                <TextInput
+                                    size="xs"
+                                    placeholder="1234"
+                                    {...form.getInputProps('externalId')}
+                                />
+                            </Input.Wrapper>
+
+                            <Input.Wrapper label="User email">
+                                <TextInput
+                                    size="xs"
+                                    placeholder="Type an email to add as intrinsic user attribute"
+                                    {...form.getInputProps('email')}
+                                />
+                            </Input.Wrapper>
+
+                            <Input.Wrapper label="User attributes">
+                                <Stack gap="xs" mt="xs">
+                                    {form.values.userAttributes.map(
+                                        (item, index) => (
+                                            <Group
+                                                key={item.uuid}
+                                                gap="xs"
+                                                wrap="nowrap"
+                                            >
+                                                <TextInput
+                                                    size="xs"
+                                                    placeholder="E.g. user_country"
+                                                    style={{ flex: 1 }}
+                                                    {...form.getInputProps(
+                                                        `userAttributes.${index}.key`,
+                                                    )}
+                                                />
+                                                <TextInput
+                                                    size="xs"
+                                                    placeholder="E.g. US"
+                                                    style={{ flex: 1 }}
+                                                    {...form.getInputProps(
+                                                        `userAttributes.${index}.value`,
+                                                    )}
+                                                />
+                                                <ActionIcon
+                                                    variant="light"
+                                                    color="red"
+                                                    onClick={() =>
+                                                        form.removeListItem(
+                                                            'userAttributes',
+                                                            index,
+                                                        )
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                    />
+                                                </ActionIcon>
+                                            </Group>
+                                        ),
+                                    )}
+                                    <Button
+                                        size="xs"
+                                        variant="default"
+                                        leftSection={
+                                            <MantineIcon icon={IconPlus} />
+                                        }
+                                        onClick={() =>
+                                            form.insertListItem(
+                                                'userAttributes',
+                                                {
+                                                    key: '',
+                                                    value: '',
+                                                    uuid: uuidv4(),
+                                                },
+                                            )
+                                        }
+                                    >
+                                        Add attribute
+                                    </Button>
+                                </Stack>
+                            </Input.Wrapper>
+                        </Stack>
+                    </Stack>
+                </Paper>
+
+                <Paper p="md" withBorder>
+                    <Stack gap="md">
+                        <Title order={6}>Interactivity & Permissions</Title>
+                        <Stack gap="xs">
+                            <Text size="sm" fw={500}>
+                                Users can:
+                            </Text>
+                            <Switch
+                                {...form.getInputProps('canExportCsv', {
+                                    type: 'checkbox',
+                                })}
+                                label="Export CSV"
+                            />
+                            <Switch
+                                {...form.getInputProps('canExportImages', {
+                                    type: 'checkbox',
+                                })}
+                                label="Export Images"
+                            />
+                            <Switch
+                                {...form.getInputProps(
+                                    'canViewUnderlyingData',
+                                    {
+                                        type: 'checkbox',
+                                    },
+                                )}
+                                label="View underlying data"
+                            />
+                        </Stack>
+                    </Stack>
+                </Paper>
+
                 <Flex justify="flex-end" gap="sm">
                     <Button
-                        variant={'outline'}
+                        variant="light"
+                        leftSection={<MantineIcon icon={IconEye} />}
+                        onClick={handlePreview}
+                    >
+                        Preview
+                    </Button>
+                    <Button
+                        variant="default"
                         type="submit"
-                        leftIcon={<MantineIcon icon={IconLink} />}
+                        leftSection={<MantineIcon icon={IconLink} />}
                     >
                         Generate & copy URL
                     </Button>
                 </Flex>
             </Stack>
-            <Stack mb="md">
-                <Stack spacing="xs">
+
+            <Stack gap="md" mb="md">
+                <Stack gap="xs">
                     <Title order={5}>Code snippet</Title>
-                    <Text color="dimmed">
+                    <Text c="dimmed" fz="sm">
                         Copy and paste this code snippet into your application
-                        to generate embed urls.
+                        to generate embed URLs.
                     </Text>
                 </Stack>
                 <EmbedCodeSnippet

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -11,16 +11,19 @@ import {
 import {
     ActionIcon,
     Button,
+    Divider,
     Flex,
     Group,
     Input,
+    Paper,
+    SegmentedControl,
     Select,
     Stack,
     Switch,
     Text,
     TextInput,
     Title,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { IconEye, IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
@@ -114,7 +117,7 @@ const EmbedPreviewDashboardForm: FC<{
             },
         },
     });
-    const { onSubmit, validate, values: formValues } = form;
+    const { onSubmit, values: formValues } = form;
 
     const convertFormValuesToCreateEmbedJwt = useCallback(
         (values: FormValues, isPreview: boolean = false): CreateEmbedJwt => {
@@ -161,7 +164,7 @@ const EmbedPreviewDashboardForm: FC<{
     );
 
     const handlePreview = useCallback(async () => {
-        const state = validate();
+        const state = form.validate();
         if (state.hasErrors) {
             return;
         }
@@ -171,12 +174,7 @@ const EmbedPreviewDashboardForm: FC<{
         );
         //Open data.url on new tab
         window.open(data.url, '_blank');
-    }, [
-        formValues,
-        validate,
-        convertFormValuesToCreateEmbedJwt,
-        createEmbedUrl,
-    ]);
+    }, [formValues, form, convertFormValuesToCreateEmbedJwt, createEmbedUrl]);
 
     const generateUrl = useCallback(async () => {
         const data = await createEmbedUrl(
@@ -190,176 +188,237 @@ const EmbedPreviewDashboardForm: FC<{
 
     return (
         <form id="generate-embed-url" onSubmit={handleCopySubmit}>
-            <Stack mb={'md'}>
-                <Stack spacing="xs">
-                    <Title order={5}>Preview</Title>
-                    <Text color="dimmed">
-                        Preview your embed URL and copy it to your clipboard.
-                    </Text>
-                </Stack>
+            <Stack gap="md" mb="md">
                 <Select
                     required
-                    label={'Dashboard'}
+                    label="Dashboard"
                     data={dashboards.map((dashboard) => ({
                         value: dashboard.uuid,
                         label: dashboard.name,
                     }))}
                     placeholder="Select a dashboard..."
                     searchable
-                    withinPortal
                     {...form.getInputProps('dashboardUuid')}
                 />
-                <Select
-                    required
-                    label={'Expires in'}
-                    data={['1 hour', '1 day', '1 week', '30 days', '1 year']}
-                    withinPortal
-                    {...form.getInputProps('expiresIn')}
-                />
-                <Input.Wrapper label="User identifier">
-                    <TextInput
-                        size={'xs'}
-                        placeholder="1234"
-                        {...form.getInputProps(`externalId`)}
-                    />
-                </Input.Wrapper>
-                <Input.Wrapper label="User email">
-                    <TextInput
-                        size={'xs'}
-                        placeholder="Type an email to add as intrinsic user attribute"
-                        {...form.getInputProps('email')}
-                    />
-                </Input.Wrapper>
-                <Input.Wrapper label="User attributes">
-                    {form.values.userAttributes.map((item, index) => (
-                        <Group key={item.uuid} mt="xs">
-                            <TextInput
-                                size={'xs'}
-                                placeholder="E.g. user_country"
-                                {...form.getInputProps(
-                                    `userAttributes.${index}.key`,
-                                )}
-                            />
-                            <TextInput
-                                size={'xs'}
-                                placeholder="E.g. US"
-                                {...form.getInputProps(
-                                    `userAttributes.${index}.value`,
-                                )}
-                            />
-                            <ActionIcon
-                                variant="light"
-                                onClick={() =>
-                                    form.removeListItem('userAttributes', index)
-                                }
-                            >
-                                <MantineIcon color="red" icon={IconTrash} />
-                            </ActionIcon>
-                        </Group>
-                    ))}
-                    <Group>
-                        <Button
-                            size="xs"
-                            mr="xxs"
-                            variant="default"
-                            mt="xs"
-                            leftIcon={<MantineIcon icon={IconPlus} />}
-                            onClick={() =>
-                                form.insertListItem('userAttributes', {
-                                    key: '',
-                                    value: '',
-                                    uuid: uuidv4(),
-                                })
-                            }
-                        >
-                            Add attribute
-                        </Button>
-                    </Group>
-                </Input.Wrapper>
-                <Input.Wrapper label="Interactivity">
-                    <EmbedFiltersInteractivity
-                        dashboardUuid={
-                            form.getInputProps('dashboardUuid').value
-                        }
-                        onInteractivityOptionsChange={(
-                            interactivityOptions,
-                        ) => {
-                            form.setFieldValue(
-                                'dashboardFiltersInteractivity',
-                                interactivityOptions,
-                            );
-                        }}
-                        interactivityOptions={
-                            form.getInputProps('dashboardFiltersInteractivity')
-                                .value
-                        }
-                    />
-                </Input.Wrapper>
 
-                <Switch
-                    checked={form.values.parameterInteractivity.enabled}
-                    onChange={(event) =>
-                        form.setFieldValue('parameterInteractivity', {
-                            enabled: event.currentTarget.checked,
-                        })
-                    }
-                    labelPosition="left"
-                    label={`Allow users to change parameters`}
-                />
-                <Switch
-                    {...form.getInputProps(`canExportCsv`)}
-                    labelPosition="left"
-                    label={`Can export CSV`}
-                />
-                <Switch
-                    {...form.getInputProps(`canExportImages`)}
-                    labelPosition="left"
-                    label={`Can export Images`}
-                />
-                <Switch
-                    {...form.getInputProps(`canExportPagePdf`)}
-                    labelPosition="left"
-                    label={`Can export page to PDF`}
-                    defaultChecked={true}
-                />
-                <Switch
-                    {...form.getInputProps(`canDateZoom`)}
-                    labelPosition="left"
-                    label={`Can date zoom`}
-                />
-                <Switch
-                    {...form.getInputProps(`canExplore`)}
-                    labelPosition="left"
-                    label={`Can explore charts`}
-                />
-                <Switch
-                    {...form.getInputProps(`canViewUnderlyingData`)}
-                    labelPosition="left"
-                    label={`Can view underlying data`}
-                />
+                <Stack gap="xs">
+                    <Text size="sm" fw={500}>
+                        Expires in
+                    </Text>
+                    <SegmentedControl
+                        value={form.values.expiresIn}
+                        radius="md"
+                        onChange={(value) =>
+                            form.setFieldValue('expiresIn', value)
+                        }
+                        data={[
+                            { label: '1 hour', value: '1 hour' },
+                            { label: '1 day', value: '1 day' },
+                            { label: '1 week', value: '1 week' },
+                            { label: '30 days', value: '30 days' },
+                            { label: '1 year', value: '1 year' },
+                        ]}
+                        size="xs"
+                    />
+                </Stack>
+
+                <Paper p="md" withBorder>
+                    <Stack gap="md">
+                        <Title order={6}>Identification & Security</Title>
+                        <Stack gap="xs">
+                            <Input.Wrapper label="User identifier">
+                                <TextInput
+                                    size="xs"
+                                    placeholder="1234"
+                                    {...form.getInputProps('externalId')}
+                                />
+                            </Input.Wrapper>
+
+                            <Input.Wrapper label="User email">
+                                <TextInput
+                                    size="xs"
+                                    placeholder="Type an email to add as intrinsic user attribute"
+                                    {...form.getInputProps('email')}
+                                />
+                            </Input.Wrapper>
+
+                            <Input.Wrapper label="User attributes">
+                                <Stack gap="xs" mt="xs">
+                                    {form.values.userAttributes.map(
+                                        (item, index) => (
+                                            <Group
+                                                key={item.uuid}
+                                                gap="xs"
+                                                wrap="nowrap"
+                                            >
+                                                <TextInput
+                                                    size="xs"
+                                                    placeholder="E.g. user_country"
+                                                    style={{ flex: 1 }}
+                                                    {...form.getInputProps(
+                                                        `userAttributes.${index}.key`,
+                                                    )}
+                                                />
+                                                <TextInput
+                                                    size="xs"
+                                                    placeholder="E.g. US"
+                                                    style={{ flex: 1 }}
+                                                    {...form.getInputProps(
+                                                        `userAttributes.${index}.value`,
+                                                    )}
+                                                />
+                                                <ActionIcon
+                                                    variant="light"
+                                                    color="red"
+                                                    onClick={() =>
+                                                        form.removeListItem(
+                                                            'userAttributes',
+                                                            index,
+                                                        )
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                    />
+                                                </ActionIcon>
+                                            </Group>
+                                        ),
+                                    )}
+                                    <Button
+                                        size="xs"
+                                        variant="default"
+                                        leftSection={
+                                            <MantineIcon icon={IconPlus} />
+                                        }
+                                        onClick={() =>
+                                            form.insertListItem(
+                                                'userAttributes',
+                                                {
+                                                    key: '',
+                                                    value: '',
+                                                    uuid: uuidv4(),
+                                                },
+                                            )
+                                        }
+                                    >
+                                        Add attribute
+                                    </Button>
+                                </Stack>
+                            </Input.Wrapper>
+                        </Stack>
+                    </Stack>
+                </Paper>
+
+                <Paper p="md" withBorder>
+                    <Stack gap="sm">
+                        <Title order={6}>Interactivity & Permissions</Title>
+                        <Stack gap="md">
+                            <EmbedFiltersInteractivity
+                                dashboardUuid={form.values.dashboardUuid}
+                                onInteractivityOptionsChange={(
+                                    interactivityOptions,
+                                ) => {
+                                    form.setFieldValue(
+                                        'dashboardFiltersInteractivity',
+                                        interactivityOptions,
+                                    );
+                                }}
+                                interactivityOptions={
+                                    form.values.dashboardFiltersInteractivity
+                                }
+                            />
+
+                            <Stack gap="xs">
+                                <Text size="sm" fw={500}>
+                                    Users can:
+                                </Text>
+                                <Switch
+                                    checked={
+                                        form.values.parameterInteractivity
+                                            .enabled
+                                    }
+                                    onChange={(event) =>
+                                        form.setFieldValue(
+                                            'parameterInteractivity',
+                                            {
+                                                enabled:
+                                                    event.currentTarget.checked,
+                                            },
+                                        )
+                                    }
+                                    label="Change parameters"
+                                />
+                                <Switch
+                                    {...form.getInputProps('canExportCsv', {
+                                        type: 'checkbox',
+                                    })}
+                                    label="Export CSV"
+                                />
+                                <Switch
+                                    {...form.getInputProps('canExportImages', {
+                                        type: 'checkbox',
+                                    })}
+                                    label="Export Images"
+                                />
+                                <Switch
+                                    {...form.getInputProps('canExportPagePdf', {
+                                        type: 'checkbox',
+                                    })}
+                                    label="Export page to PDF"
+                                    defaultChecked={true}
+                                />
+                                <Switch
+                                    {...form.getInputProps('canDateZoom', {
+                                        type: 'checkbox',
+                                    })}
+                                    label="Date zoom"
+                                />
+                                <Switch
+                                    {...form.getInputProps('canExplore', {
+                                        type: 'checkbox',
+                                    })}
+                                    label="Explore charts"
+                                />
+                                <Switch
+                                    {...form.getInputProps(
+                                        'canViewUnderlyingData',
+                                        {
+                                            type: 'checkbox',
+                                        },
+                                    )}
+                                    label="View underlying data"
+                                />
+                            </Stack>
+                        </Stack>
+                    </Stack>
+                </Paper>
+
                 <Flex justify="flex-end" gap="sm">
                     <Button
-                        variant={'light'}
-                        leftIcon={<MantineIcon icon={IconEye} />}
+                        variant="light"
+                        leftSection={<MantineIcon icon={IconEye} />}
                         onClick={handlePreview}
                     >
                         Preview
                     </Button>
                     <Button
-                        variant={'outline'}
+                        variant="default"
                         type="submit"
-                        leftIcon={<MantineIcon icon={IconLink} />}
+                        leftSection={<MantineIcon icon={IconLink} />}
                     >
                         Generate & copy URL
                     </Button>
                 </Flex>
             </Stack>
-            <Stack mb="md">
-                <Stack spacing="xs">
+
+            <Divider mb="md" />
+
+            <Stack gap="md" mb="md">
+                <Stack gap="xs">
                     <Title order={5}>Code snippet</Title>
-                    <Text color="dimmed">
+                    <Text c="dimmed" fz="sm">
                         Copy and paste this code snippet into your application
-                        to generate embed urls.
+                        to generate embed URLs.
                     </Text>
                 </Stack>
                 <EmbedCodeSnippet

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -7,20 +7,22 @@ import {
     Anchor,
     Button,
     Flex,
-    Paper,
     PasswordInput,
     Stack,
     Tabs,
     Text,
     Title,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconAlertCircle, IconKey } from '@tabler/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import React, { useMemo, type FC } from 'react';
+import { useMemo, type FC } from 'react';
 import { lightdashApi } from '../../../../api';
 import { EmptyState } from '../../../../components/common/EmptyState';
 import MantineIcon from '../../../../components/common/MantineIcon';
-import { SettingsGridCard } from '../../../../components/common/Settings/SettingsCard';
+import {
+    SettingsCard,
+    SettingsGridCard,
+} from '../../../../components/common/Settings/SettingsCard';
 import SuboptimalState from '../../../../components/common/SuboptimalState/SuboptimalState';
 import { useDashboards } from '../../../../hooks/dashboard/useDashboards';
 import useToaster from '../../../../hooks/toaster/useToaster';
@@ -191,17 +193,24 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     return (
         <Stack mb="lg">
             <SettingsGridCard>
-                <Stack spacing="sm">
-                    <Title order={4}>Embed secret</Title>
-                    <Text color="dimmed">
-                        The secret is used to generate embed tokens for
-                        embedding dashboards.
-                    </Text>
-                    <Text color="dimmed" fz="xs">
-                        Read more about using embed secret in our{' '}
-                        <Anchor href="https://docs.lightdash.com/references/embedding">
+                <Stack gap="sm">
+                    <Stack gap="xs">
+                        <Title order={4}>Embed secret</Title>
+                        <Text c="dimmed" fz="sm">
+                            Use this secret to generate embed tokens for
+                            embedding dashboards and charts.
+                        </Text>
+                    </Stack>
+                    <Text c="dimmed" fz="xs">
+                        Learn more on how to use your embed secret in our{' '}
+                        <Anchor
+                            href="https://docs.lightdash.com/references/embedding"
+                            fz="xs"
+                            target="_blank"
+                        >
                             docs guide
                         </Anchor>
+                        .
                     </Text>
                 </Stack>
                 <Stack>
@@ -224,9 +233,12 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     </Flex>
                 </Stack>
             </SettingsGridCard>
-            <Paper shadow="sm" withBorder p="md">
-                <Stack spacing="sm" mb="md">
-                    <Title order={4}>Allowed dashboards and charts</Title>
+            <SettingsCard>
+                <Stack gap="xs" mb="md">
+                    <Title order={4}>Allowed content</Title>
+                    <Text c="dimmed" fz="sm">
+                        Select the content you want to allow to be embedded.
+                    </Text>
                 </Stack>
                 <EmbedAllowListForm
                     disabled={isSaving}
@@ -235,10 +247,13 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     charts={charts || []}
                     onSave={updateEmbedConfig}
                 />
-            </Paper>
-            <Paper shadow="sm" withBorder p="md">
-                <Stack spacing="sm" mb="md">
+            </SettingsCard>
+            <SettingsCard>
+                <Stack gap="xs" mb="md">
                     <Title order={4}>Preview & code snippet</Title>
+                    <Text c="dimmed" fz="sm">
+                        Preview your embed URL and copy it to your clipboard.
+                    </Text>
                 </Stack>
                 <Tabs defaultValue="dashboards" keepMounted>
                     <Tabs.List>
@@ -264,7 +279,7 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                         </Stack>
                     </Tabs.Panel>
                 </Tabs>
-            </Paper>
+            </SettingsCard>
         </Stack>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
This PR updates the UI for the embed settings page with improved styling and layout. Key changes include:

- Updated the `SettingsCard` component with a more subtle shadow and rounded corners
- Redesigned the embed forms with a clearer structure using Paper components for logical grouping
- Replaced Select dropdowns with SegmentedControl for better UX in expiration selection
- Added icons to the code snippet tabs for better visual identification
- Improved form layouts with consistent spacing and better organization
- Updated button styling and positioning for a more modern look
- Removed deprecated `withinPortal` props from select components
- Added a Preview button to the chart embed form
- Enhanced typography with better hierarchy and color contrast
- Migrated components to use the Mantine 8 imports

[CleanShot 2026-01-13 at 15.16.21.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7f6586ca-a3ac-4f5b-9498-4570c719d75b.mp4" />](https://app.graphite.com/user-attachments/video/7f6586ca-a3ac-4f5b-9498-4570c719d75b.mp4)

