### PR TITLE
fix: pass schedulerTabsSelected to DashboardProvider for correct screenshot tile filtering

### DIFF
--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -347,6 +347,7 @@ const MinimalDashboard: FC = () => {
         <DashboardProvider
             schedulerFilters={schedulerFilters}
             schedulerParameters={schedulerParameters}
+            schedulerTabsSelected={schedulerTabsSelected}
             dateZoom={dateZoom}
             defaultInvalidateCache={true}
         >

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -69,6 +69,7 @@ const DashboardProvider: React.FC<
     React.PropsWithChildren<{
         schedulerFilters?: DashboardFilterRule[] | undefined;
         schedulerParameters?: ParametersValuesMap | undefined;
+        schedulerTabsSelected?: string[] | undefined;
         dateZoom?: DateGranularity | undefined;
         projectUuid?: string;
         embedToken?: string;
@@ -79,6 +80,7 @@ const DashboardProvider: React.FC<
 > = ({
     schedulerFilters,
     schedulerParameters,
+    schedulerTabsSelected,
     dateZoom,
     projectUuid,
     embedToken,
@@ -417,6 +419,18 @@ const DashboardProvider: React.FC<
     const expectedScreenshotTileUuids = useMemo(() => {
         if (!dashboardTiles) return [];
 
+        // When schedulerTabsSelected is provided, use it to filter tiles for screenshots
+        if (schedulerTabsSelected && schedulerTabsSelected.length > 0) {
+            return dashboardTiles
+                .filter(
+                    (tile) =>
+                        isDashboardChartTileType(tile) ||
+                        isDashboardSqlChartTile(tile),
+                )
+                .filter((tile) => schedulerTabsSelected.includes(tile.tabUuid!))
+                .map((tile) => tile.uuid);
+        }
+
         if (dashboardTabs && dashboardTabs.length > 0 && !activeTab) return [];
 
         return dashboardTiles
@@ -430,7 +444,7 @@ const DashboardProvider: React.FC<
                 return !tile.tabUuid || tile.tabUuid === activeTab.uuid;
             })
             .map((tile) => tile.uuid);
-    }, [dashboardTiles, activeTab, dashboardTabs]);
+    }, [dashboardTiles, activeTab, dashboardTabs, schedulerTabsSelected]);
 
     const isReadyForScreenshot = useMemo(() => {
         if (expectedScreenshotTileUuids.length === 0) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:

 Root Cause

  When exporting a dashboard with only a specific tab selected (via selectedTabs URL parameter):

  1. MinimalDashboard filtered tiles using schedulerTabsSelected (e.g., second tab's UUID)
  2. DashboardProvider calculated expectedScreenshotTileUuids using activeTab which defaulted to first tab
  3. The screenshot ready indicator waited for first tab's tiles to report ready, but only second tab's tiles were rendered
  4. Result: Screenshot never became "ready" → timeout → failure

  Fix

  1. Added schedulerTabsSelected prop to DashboardProvider
  2. Updated expectedScreenshotTileUuids to use schedulerTabsSelected when provided, so it waits for the correct tiles
  3. Passed schedulerTabsSelected from MinimalDashboard to DashboardProvider

