### PR TITLE
feat: add field descriptions to metric labels in PivotTable tooltips

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -810,6 +810,25 @@ const PivotTable: FC<PivotTableProps> = ({
                                 // Font color is set by conditionalFormatting above
                                 const fontColor = conditionalFormatting?.color;
 
+                                // Get field description for label cells (metric labels when metricsAsRows is enabled)
+                                const labelFieldDescription = (() => {
+                                    if (meta?.type !== 'label')
+                                        return undefined;
+                                    const labelInfo = data.indexValues[
+                                        rowIndex
+                                    ]?.find(
+                                        (indexValue) =>
+                                            indexValue.type === 'label',
+                                    );
+                                    if (!labelInfo) return undefined;
+                                    const labelField = getField(
+                                        labelInfo.fieldId,
+                                    );
+                                    return isField(labelField)
+                                        ? labelField.description
+                                        : undefined;
+                                })();
+
                                 const suppressContextMenu =
                                     (value === undefined ||
                                         cell.getIsPlaceholder()) &&
@@ -833,6 +852,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                             conditionalFormatting?.backgroundColor
                                         }
                                         withTooltip={
+                                            labelFieldDescription ||
                                             conditionalFormatting?.tooltipContent
                                         }
                                         withInteractions={allowInteractions}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19406

### Description:
Added tooltips for metric labels in the pivot table when metricsAsRows is enabled. The tooltip now displays the field description for label cells, enhancing the user experience by providing additional context for the displayed metrics.