### PR TITLE
fix: monkey patch `removeChild` and `insertBefore` to prevent react crash

### DIFF
--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -10,6 +10,9 @@ if (typeof Node !== 'undefined' && Node.prototype) {
     const originalRemoveChild = Node.prototype.removeChild;
     Node.prototype.removeChild = function <T extends Node>(child: T): T {
         if (child.parentNode !== this) {
+            console.warn(
+                '[DOM Monkey Patch] Suppressed removeChild error (likely caused by Google Translate)',
+            );
             return child;
         }
         return originalRemoveChild.call(this, child) as T;
@@ -21,6 +24,9 @@ if (typeof Node !== 'undefined' && Node.prototype) {
         referenceNode: Node | null,
     ): T {
         if (referenceNode && referenceNode.parentNode !== this) {
+            console.warn(
+                '[DOM Monkey Patch] Suppressed insertBefore error (likely caused by Google Translate)',
+            );
             return newNode;
         }
         return originalInsertBefore.call(this, newNode, referenceNode) as T;


### PR DESCRIPTION
### Description:
A Sentry error showed up about a crash in the frontend:

> React ErrorBoundary NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.

This issue was specifically triggered via the AI chat box, however there is likely other places to trigger it.
One of the ways to make it happen, is by using the Chrome "translate this page" feature as this manipulated the DOM and causes some de-sync with Reacts DOM.


This is a known issue in React, here's some literature about it:
- https://martijnhols.nl/blog/everything-about-google-translate-crashing-react
- https://github.com/facebook/react/issues/11538

#### Before the fix:

https://github.com/user-attachments/assets/2c43d87e-b334-4c01-9583-d81b13317666

#### After the fix:

https://github.com/user-attachments/assets/085474ff-e586-4b79-bf2d-3f7f96c64607



#### Alternatives:
We could also forbid the translation of the page via `<html lang="en" translate="no">`. But:
1) I don't think the user(s) that rely on the auto translation will be happy about it
2) There are probably other ways to trigger the issue (e.g. some addons), so blocking the translations would likely be only a partial "fix".
