### PR TITLE
feat: include private channels in Slack channel selection for AI Agent

### DIFF
--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -340,6 +340,7 @@ const SlackSettingsPanel: FC = () => {
                                         </Text>
 
                                         <SlackChannelSelect
+                                            includeGroups
                                             value={
                                                 form.values
                                                     .aiMultiAgentChannelId ??

--- a/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
+++ b/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
@@ -26,6 +26,8 @@ type CommonProps = {
     withRefresh?: boolean;
     /** Include direct messages in the channel list */
     includeDms?: boolean;
+    /** Include private channels (groups) in the channel list */
+    includeGroups?: boolean;
 };
 
 type SingleSelectProps = CommonProps & {
@@ -50,6 +52,7 @@ export const SlackChannelSelect: FC<
         size = 'xs',
         withRefresh = false,
         includeDms = false,
+        includeGroups = false,
     } = props;
 
     const [search, setSearch] = useState<string | undefined>(undefined);
@@ -95,7 +98,7 @@ export const SlackChannelSelect: FC<
         {
             excludeArchived: true,
             excludeDms: !includeDms,
-            excludeGroups: true,
+            excludeGroups: !includeGroups,
             includeChannelIds,
         },
         { enabled: !disabled },

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -737,6 +737,7 @@ export const AiAgentFormSetup = ({
                                             )}
                                         </Text>
                                         <SlackChannelSelect
+                                            includeGroups
                                             multiple
                                             withRefresh
                                             size="sm"


### PR DESCRIPTION
Related to: https://github.com/lightdash/lightdash/issues/19411  
  
Description:

Added support for private channels (groups) in Slack channel selection for AI multi-agent settings. The `includeGroups` prop has been added to the `SlackChannelSelect` component and implemented in both the user settings panel and AI agent form setup.