### PR TITLE
fix: filter dashboard parameters by active tab

### DIFF
--- a/packages/frontend/src/features/dashboardFiltersV2/DashboardFiltersBar.tsx
+++ b/packages/frontend/src/features/dashboardFiltersV2/DashboardFiltersBar.tsx
@@ -108,6 +108,7 @@ export const DashboardFiltersBar: FC<Props> = ({
 
                                     <ParametersV2
                                         isEditMode={isEditMode}
+                                        activeTabUuid={activeTabUuid}
                                         parameterValues={parameterValues}
                                         onParameterChange={onParameterChange}
                                         onClearAll={onParameterClearAll}

--- a/packages/frontend/src/features/parametersV2/components/Parameters.tsx
+++ b/packages/frontend/src/features/parametersV2/components/Parameters.tsx
@@ -4,8 +4,9 @@ import {
     type ParameterValue,
 } from '@lightdash/common';
 import { Group, Skeleton } from '@mantine-8/core';
-import { useCallback, useState, type FC, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
 import { useParams } from 'react-router';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import Parameter from './Parameter';
 
 type Props = {
@@ -21,6 +22,8 @@ type Props = {
     isError?: boolean;
     /** Separator element to render with the first parameter (so they wrap together) */
     separator?: ReactNode;
+    /** Active tab UUID for filtering parameters by tab context */
+    activeTabUuid?: string;
 };
 
 export const Parameters: FC<Props> = ({
@@ -31,9 +34,15 @@ export const Parameters: FC<Props> = ({
     isLoading,
     missingRequiredParameters = [],
     separator,
+    activeTabUuid,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [openPopoverId, setOpenPopoverId] = useState<string | undefined>();
+
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const tileParameterReferences = useDashboardContext(
+        (c) => c.tileParameterReferences,
+    );
 
     const handlePopoverOpen = useCallback((popoverId: string) => {
         setOpenPopoverId(popoverId);
@@ -42,6 +51,39 @@ export const Parameters: FC<Props> = ({
     const handlePopoverClose = useCallback(() => {
         setOpenPopoverId(undefined);
     }, []);
+
+    const getTabsForParameter = useCallback(
+        (paramKey: string): string[] => {
+            if (!dashboardTiles) return [];
+            const tabs: string[] = [];
+            for (const tile of dashboardTiles) {
+                const tileParams = tileParameterReferences[tile.uuid] || [];
+                if (tileParams.includes(paramKey)) {
+                    // Tile has no tabUuid = applies to all tabs (backwards compat)
+                    if (!tile.tabUuid) {
+                        return []; // Empty array signals "applies everywhere"
+                    }
+                    tabs.push(tile.tabUuid);
+                }
+            }
+            return [...new Set(tabs)];
+        },
+        [dashboardTiles, tileParameterReferences],
+    );
+
+    const visibleParamEntries = useMemo(() => {
+        if (!parameters) return [];
+        return Object.entries(parameters).filter(([paramKey]) => {
+            const appliesToTabs = getTabsForParameter(paramKey);
+            // Empty appliesToTabs = applies to all tabs OR no tabs loaded
+            // !activeTabUuid = no active tab (single tab mode) = show all
+            const appliedToCurrentTab =
+                !activeTabUuid ||
+                appliesToTabs.length === 0 ||
+                appliesToTabs.includes(activeTabUuid);
+            return appliedToCurrentTab;
+        });
+    }, [parameters, getTabsForParameter, activeTabUuid]);
 
     if (!parameters || Object.keys(parameters).length === 0) {
         return null;
@@ -57,11 +99,13 @@ export const Parameters: FC<Props> = ({
         );
     }
 
-    const paramEntries = Object.entries(parameters);
+    if (visibleParamEntries.length === 0) {
+        return null;
+    }
 
     return (
         <>
-            {paramEntries.map(([paramKey, parameter], index) => {
+            {visibleParamEntries.map(([paramKey, parameter], index) => {
                 const paramComponent = (
                     <Parameter
                         key={paramKey}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2454](https://linear.app/lightdash/issue/PROD-2454/parameter-widgets-remain-visible-when-switching-dashboard-tabs-where)

### Description:
Added tab-specific parameter filtering to dashboard filters. Parameters now only appear when they are relevant to the active dashboard tab, improving the user experience by showing only contextually relevant filters.

The implementation passes the active tab UUID to the Parameters component and filters parameters based on which dashboard tiles reference them and which tab those tiles belong to.
