### PR TITLE
fix: creating charts from editing doesn't respect tabs

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -19,6 +19,8 @@ const EditChartMenuItem: FC<Props> = ({ tile, ...props }) => {
     const haveTilesChanged = useDashboardContext((c) => c.haveTilesChanged);
     const haveFiltersChanged = useDashboardContext((c) => c.haveFiltersChanged);
     const dashboard = useDashboardContext((c) => c.dashboard);
+    const activeTab = useDashboardContext((c) => c.activeTab);
+    const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
 
     const { storeDashboard } = useDashboardStorage();
 
@@ -43,6 +45,8 @@ const EditChartMenuItem: FC<Props> = ({ tile, ...props }) => {
                         haveFiltersChanged,
                         dashboard?.uuid,
                         dashboard?.name,
+                        activeTab?.uuid,
+                        dashboardTabs,
                     );
                 }
             }}


### PR DESCRIPTION
### Description:
Added `activeTab` and `dashboardTabs` to the `EditChartMenuItem` component by retrieving them from the dashboard context. These values are now passed to the handler function when editing a chart, ensuring the chart editor has access to the current tab information.

This covers the case of creating orphan tab charts from dashboard, I think there are other scenarios that could lead to this `tabUuid = null` that I still need to investigate