### PR TITLE
feat: increase field set nesting limit from 1 to 3 levels

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -650,7 +650,33 @@ describe('convert tables from dbt models', () => {
             );
         });
 
-        it('throws when set has nested set references beyond one level', () => {
+        it('allows set references up to 3 levels', () => {
+            expect(
+                convertTable(
+                    SupportedDbtAdapter.BIGQUERY,
+                    {
+                        ...MODEL_WITH_NO_METRICS,
+                        meta: {
+                            sets: {
+                                level1: {
+                                    fields: ['user_id'],
+                                },
+                                level2: {
+                                    fields: ['level1*'],
+                                },
+                                level3: {
+                                    fields: ['level2*'],
+                                },
+                            },
+                        },
+                    },
+                    [],
+                    DEFAULT_SPOTLIGHT_CONFIG,
+                ),
+            ).toBeTruthy();
+        });
+
+        it('throws when set has nested set references beyond 3 levels', () => {
             expect(() =>
                 convertTable(
                     SupportedDbtAdapter.BIGQUERY,
@@ -658,14 +684,17 @@ describe('convert tables from dbt models', () => {
                         ...MODEL_WITH_NO_METRICS,
                         meta: {
                             sets: {
-                                base_set: {
+                                level1: {
                                     fields: ['user_id'],
                                 },
-                                middle_set: {
-                                    fields: ['base_set*'],
+                                level2: {
+                                    fields: ['level1*'],
                                 },
-                                top_set: {
-                                    fields: ['middle_set*'],
+                                level3: {
+                                    fields: ['level2*'],
+                                },
+                                level4: {
+                                    fields: ['level3*'],
                                 },
                             },
                         },
@@ -674,7 +703,7 @@ describe('convert tables from dbt models', () => {
                     DEFAULT_SPOTLIGHT_CONFIG,
                 ),
             ).toThrowError(
-                `Set "top_set" in model "myTable" references set "middle_set", which itself contains set references. Only one level of set nesting is allowed.`,
+                `Set "level4" in model "myTable" exceeds the maximum nesting level of 3.`,
             );
         });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2477

### Description:
Increases the maximum allowed nesting level for field sets from 1 to 3 levels. This enhancement allows for more complex and flexible field set definitions while still maintaining reasonable limits to prevent excessive nesting.

The implementation includes:
- Updated logic in `expandSingleSet` to track nesting depth and enforce the 3-level limit
- Modified error messages to reflect the new nesting limit
- Added test cases to verify proper expansion of sets with up to 3 levels of nesting
- Added validation to ensure sets don't exceed the maximum nesting depth


### Steps to reproduce

```
models:
  - name: payments
    config:
      meta:
        sets:
          base_set:
            fields:
              - orders.status
              - orders.shipping_method
              - orders.order_date
              - orders.order_id
          intermediate_set:
            fields:
              - amount
              - base_set*
          test_set:
            fields:
              - intermediate_set*
              - -orders.order_id
```

If you add another nesting, there will be an error:

<img width="1642" height="306" alt="CleanShot 2026-01-14 at 14 10 16@2x" src="https://github.com/user-attachments/assets/1392fe1b-7a41-4fc2-95bd-f81cf289cecd" />
