### PR TITLE
fix: handle additional foreign key constraints in validation error handling

### DIFF
--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -98,13 +98,19 @@ export class ValidationModel {
                 );
             } catch (error: unknown) {
                 const FOREIGN_KEY_VIOLATION_ERROR_CODE = '23503';
+                const handledConstraints = [
+                    'validations_project_uuid_foreign',
+                    'validations_saved_chart_uuid_foreign',
+                    'validations_dashboard_uuid_foreign',
+                ];
                 if (
                     error instanceof DatabaseError &&
                     error.code === FOREIGN_KEY_VIOLATION_ERROR_CODE &&
-                    error.constraint === 'validations_project_uuid_foreign'
+                    error.constraint &&
+                    handledConstraints.includes(error.constraint)
                 ) {
                     Logger.warn(
-                        `Failed to insert validations: Project UUID (${validations[0].projectUuid}) does not exist. This may happen if the project was deleted during validation.`,
+                        `Failed to insert validations: Foreign key constraint violation (${error.constraint}). This may happen if the project, chart, or dashboard was deleted during validation.`,
                     );
                     return;
                 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2261/error-insert-into-validations-chart-name-error-error-type-field-name

> insert into "validations" ("chart_name", "error", "error_type", "field_name", "job_id", "project_uuid", "saved_chart_uuid", "source") values ($1, $2, $3, $4, $5, $6, $7, $8), ($9, $10, $11, $12, $13, $14, ..., $768) - insert or update on table "validations" violates foreign key constraint "validations_saved_chart_uuid_foreign"

This issue is likely to be caused by a race condition. We tried to add a foreign key to a chart that has been deleted during validation. 


### Description:
Enhance error handling for foreign key violations in ValidationModel by supporting additional constraints. Previously, only project UUID foreign key violations were handled gracefully, but now the system also handles violations related to saved charts and dashboards. This prevents unnecessary error propagation when referenced entities are deleted during validation.