### PR TITLE
feat: populate SQL for additional metrics in Slack artifact blocks

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3334,6 +3334,13 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             this.lightdashConfig.siteUrl,
             this.lightdashConfig.ai.copilot.maxQueryLimit,
             createShareUrl,
+            (exploreName) =>
+                this.getExplore(
+                    user,
+                    slackPrompt.projectUuid,
+                    null,
+                    exploreName,
+                ),
             threadArtifacts,
         );
         const proposeChangeBlocks = getProposeChangeBlocks(


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19434

### Description:
Enhanced Slack artifact blocks to include additional metrics and table calculations in the column order. Added a function to retrieve explore data and populate SQL for custom metrics, ensuring that all field types (dimensions, metrics, additional metrics, and table calculations) are properly displayed in the visualization.