### PR TITLE
fix: generate correct verification hash for pylon

### DIFF
--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -69,6 +69,7 @@ export const BaseResponse: HealthState = {
     posthog: undefined,
     pylon: {
         appId: '',
+        verificationHash: undefined,
     },
     query: {
         csvCellsLimit: 100000,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -106,17 +106,7 @@ export class HealthService extends BaseService {
             intercom: this.lightdashConfig.intercom,
             pylon: {
                 appId: this.lightdashConfig.pylon.appId,
-                verificationHash:
-                    this.lightdashConfig.pylon.identityVerificationSecret &&
-                    user?.email
-                        ? createHmac(
-                              'sha256',
-                              this.lightdashConfig.pylon
-                                  .identityVerificationSecret,
-                          )
-                              .update(user?.email)
-                              .digest('hex')
-                        : undefined,
+                verificationHash: this.getPylonVerificationHash(user?.email),
             },
             siteUrl: this.lightdashConfig.siteUrl,
             staticIp: this.lightdashConfig.staticIp,
@@ -243,5 +233,18 @@ export class HealthService extends BaseService {
             this.lightdashConfig.auth.google.oauth2ClientSecret !== undefined &&
             this.lightdashConfig.auth.google.enabled
         );
+    }
+
+    private getPylonVerificationHash(email: string | undefined) {
+        if (!this.lightdashConfig.pylon.identityVerificationSecret || !email) {
+            return undefined;
+        }
+
+        const secretBytes = Buffer.from(
+            this.lightdashConfig.pylon.identityVerificationSecret,
+            'hex',
+        );
+
+        return createHmac('sha256', secretBytes).update(email).digest('hex');
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2479/update-pylon-chat-verification

### Description:
Refactored Pylon verification hash generation into a dedicated method `getPylonVerificationHash` in the `HealthService` class. The new method properly handles the identity verification secret by converting it from a hex string to a Buffer before using it with HMAC.

Pylon docs with code example here: https://docs.usepylon.com/pylon-docs/chat-widget/identity-verification