### PR TITLE
fix: show fix dialog for chart config in validator

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -2,7 +2,6 @@ import {
     isChartValidationError,
     isDashboardValidationError,
     isTableValidationError,
-    ValidationErrorType,
     type ValidationErrorChartResponse,
     type ValidationErrorDashboardResponse,
     type ValidationResponse,
@@ -157,22 +156,19 @@ const TableValidationItem = forwardRef<
             </td>
             <td>
                 <Box w={24}>
-                    {hovered &&
-                        isChartValidationError(validationError) &&
-                        validationError.errorType !==
-                            ValidationErrorType.ChartConfiguration && (
-                            <Button
-                                variant="outline"
-                                onClick={(
-                                    e: React.MouseEvent<HTMLButtonElement>,
-                                ) => {
-                                    onSelectValidationError(validationError);
-                                    e.stopPropagation();
-                                }}
-                            >
-                                Fix
-                            </Button>
-                        )}
+                    {hovered && isChartValidationError(validationError) && (
+                        <Button
+                            variant="outline"
+                            onClick={(
+                                e: React.MouseEvent<HTMLButtonElement>,
+                            ) => {
+                                onSelectValidationError(validationError);
+                                e.stopPropagation();
+                            }}
+                        >
+                            Fix
+                        </Button>
+                    )}
                 </Box>
             </td>
             <td>


### PR DESCRIPTION
### Description:

Shows a dialog with more information about how to fix chart config errors in the validator. This was already implemented, but there was a bug with the condition. 

<img width="636" height="467" alt="Screenshot 2026-01-14 at 17 18 18" src="https://github.com/user-attachments/assets/ced2ca6b-c634-40ba-8e9c-a5cb6c31c036" />
