### PR TITLE
fix: add field context to dimension reference error messages

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.mock.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.mock.ts
@@ -331,7 +331,7 @@ export const exploreError: ExploreError = {
     errors: [
         {
             message:
-                'Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension',
+                'Model "valid_explore" in metric "some_metric" has a dimension reference: ${is_completed} which matches no dimension',
             type: InlineErrorType.METADATA_PARSE_ERROR,
         },
     ],

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -150,14 +150,14 @@ describe('validation', () => {
             createdAt: undefined,
             name: 'valid_explore',
             modelName: 'valid_explore',
-            error: 'Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension',
+            error: 'Model "valid_explore" in metric "some_metric" has a dimension reference: ${is_completed} which matches no dimension',
             errorType: 'model',
             projectUuid: 'projectUuid',
             source: 'table',
         });
 
         expect(errors[0]!.error).toEqual(
-            'Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension',
+            'Model "valid_explore" in metric "some_metric" has a dimension reference: ${is_completed} which matches no dimension',
         );
     });
 
@@ -212,14 +212,14 @@ describe('validation', () => {
             createdAt: undefined,
             name: 'valid_explore',
             modelName: 'valid_explore',
-            error: 'Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension',
+            error: 'Model "valid_explore" in metric "some_metric" has a dimension reference: ${is_completed} which matches no dimension',
             errorType: 'model',
             projectUuid: 'projectUuid',
             source: 'table',
         });
 
         expect(errors[0]!.error).toEqual(
-            'Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension',
+            'Model "valid_explore" in metric "some_metric" has a dimension reference: ${is_completed} which matches no dimension',
         );
     });
 
@@ -238,7 +238,7 @@ describe('validation', () => {
         );
 
         const expectedErrors: string[] = [
-            'Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension',
+            'Model "valid_explore" in metric "some_metric" has a dimension reference: ${is_completed} which matches no dimension',
         ];
 
         expect(errors.map((error) => error.error)).toEqual(expectedErrors);
@@ -310,7 +310,7 @@ describe('validation', () => {
         );
 
         const expectedErrors: string[] = [
-            'Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension',
+            'Model "valid_explore" in metric "some_metric" has a dimension reference: ${is_completed} which matches no dimension',
             "Dimension error: the field 'table_dimension' no longer exists",
             "Filter error: the field 'table_dimension' no longer exists",
             "Sorting error: the field 'table_dimension' no longer exists",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [SPK-321](https://linear.app/lightdash/issue/SPK-321/improve-reference-error-messages-when-compiling)

### Description:
Improved error messages for dimension and metric references by adding context about which field contains the invalid reference. Now when a reference like `${is_completed}` doesn't match any dimension, the error message specifies which metric, dimension, custom dimension, join, or SQL where clause contains the problematic reference.

For example, instead of:
`Model "valid_explore" has a dimension reference: ${is_completed} which matches no dimension`

The error now shows:
`Model "valid_explore" in metric "some_metric" has a dimension reference: ${is_completed} which matches no dimension`