### PR TITLE
refactor: use composite model keys with provider and name

### DIFF
--- a/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
+++ b/packages/frontend/src/components/common/ModelSelector/ModelSelector.tsx
@@ -10,11 +10,12 @@ import {
 import { IconCheck, IconChevronDown } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../MantineIcon';
+import { getModelKey } from './utils';
 
 interface Props extends Omit<ButtonProps, 'value' | 'onChange'> {
     models: AiModelOption[];
     value: string | null;
-    onChange: (modelId: string) => void;
+    onChange: (modelKey: string) => void;
 }
 
 export const ModelSelector: FC<Props> = ({
@@ -24,7 +25,7 @@ export const ModelSelector: FC<Props> = ({
     ...buttonProps
 }) => {
     const selectedModel = useMemo(
-        () => models.find((m) => m.name === value),
+        () => models.find((m) => getModelKey(m) === value),
         [models, value],
     );
 
@@ -84,11 +85,12 @@ export const ModelSelector: FC<Props> = ({
                             )}
 
                             {providerModels.map((model) => {
-                                const isSelected = model.name === value;
+                                const modelKey = getModelKey(model);
+                                const isSelected = modelKey === value;
                                 return (
                                     <Menu.Item
-                                        key={model.name}
-                                        onClick={() => onChange(model.name)}
+                                        key={modelKey}
+                                        onClick={() => onChange(modelKey)}
                                         rightSection={
                                             isSelected ? (
                                                 <MantineIcon

--- a/packages/frontend/src/components/common/ModelSelector/utils.ts
+++ b/packages/frontend/src/components/common/ModelSelector/utils.ts
@@ -1,0 +1,5 @@
+import type { AiModelOption } from '@lightdash/common';
+
+// Composite key format: "provider:name"
+export const getModelKey = (model: AiModelOption): string =>
+    `${model.provider}:${model.name}`;

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -14,6 +14,7 @@ import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useOutletContext, useParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { getModelKey } from '../../../components/common/ModelSelector/utils';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
 import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultAgentButton/DefaultAgentButton';
@@ -36,14 +37,18 @@ const AiAgentNewThreadPage: FC = () => {
     );
     const { data: modelOptions } = useModelOptions({ projectUuid, agentUuid });
 
-    const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
+    const [selectedModelKey, setSelectedModelKey] = useState<string | null>(
+        null,
+    );
     const [extendedThinking, setExtendedThinking] = useState(false);
 
-    const handleSelectedModelIdChange = useCallback(
-        (modelId: string) => {
-            setSelectedModelId(modelId);
-            const selectedModel = modelOptions?.find((m) => m.name === modelId);
-            if (selectedModel && !selectedModel.supportsReasoning) {
+    const handleSelectedModelKeyChange = useCallback(
+        (modelKey: string) => {
+            setSelectedModelKey(modelKey);
+            const model = modelOptions?.find(
+                (m) => getModelKey(m) === modelKey,
+            );
+            if (model && !model.supportsReasoning) {
                 setExtendedThinking(false);
             }
         },
@@ -52,18 +57,18 @@ const AiAgentNewThreadPage: FC = () => {
 
     // Initialize to default model when data loads
     useEffect(() => {
-        if (modelOptions && !selectedModelId) {
+        if (modelOptions && !selectedModelKey) {
             const defaultModel = modelOptions.find((m) => m.default);
             if (defaultModel) {
-                handleSelectedModelIdChange(defaultModel.name);
+                handleSelectedModelKeyChange(getModelKey(defaultModel));
             }
         }
-    }, [modelOptions, selectedModelId, handleSelectedModelIdChange]);
+    }, [modelOptions, selectedModelKey, handleSelectedModelKeyChange]);
 
     // Only enable extended thinking toggle when selected model supports reasoning
     const selectedModel = useMemo(
-        () => modelOptions?.find((m) => m.name === selectedModelId),
-        [modelOptions, selectedModelId],
+        () => modelOptions?.find((m) => getModelKey(m) === selectedModelKey),
+        [modelOptions, selectedModelKey],
     );
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
 
@@ -181,8 +186,8 @@ const AiAgentNewThreadPage: FC = () => {
                         loading={isCreatingThread}
                         placeholder={`Ask ${agent.name} anything about your data...`}
                         models={modelOptions}
-                        selectedModelId={selectedModelId}
-                        onModelChange={handleSelectedModelIdChange}
+                        selectedModelId={selectedModelKey}
+                        onModelChange={handleSelectedModelKeyChange}
                         extendedThinking={
                             showExtendedThinking ? extendedThinking : undefined
                         }


### PR DESCRIPTION
### Description:
Implemented a composite key format for AI models to uniquely identify them by both provider and name. The key format is "provider:name", which allows for models with the same name but different providers to be distinguished. Updated the ModelSelector component and related code to use this new key format when selecting and identifying models.