### PR TITLE
fix: overflow-hidden appended to body when MDEditor is used

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormCustomizationTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormCustomizationTab.tsx
@@ -42,8 +42,12 @@ export const SchedulerFormCustomizationTab = () => {
                     commands.divider,
                     commands.link,
                 ]}
+                maxHeight={300}
+                minHeight={100}
+                visibleDragbar
                 value={form.values.message}
                 onChange={(value) => form.setFieldValue('message', value || '')}
+                overflow={false}
             />
         </Stack>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


Closes: #19372

Initially had: https://app.graphite.com/github/pr/lightdash/lightdash/19382/fix-handle-scroll-lock%2C-mount-on-opened-when-scheduled-deliveries-modal
But decided to fix it differently based on @tatianainama's suggestions.
Then opened: https://app.graphite.com/github/pr/lightdash/lightdash/19439/fix-add-useMantineModalStack-and-unlock-scroll-for-stack-of-modals#lines-packages/frontend/src/features/scheduler/components/SchedulerModal.tsx-R68-R88

And found it strange we had to mutate `body` to remove the `overflow: hidden`. 

Then... it was all because of `MDEditor` 🤦‍♂️ 

### Description:
Enhanced the RichTextEditor in the SchedulerFormCustomizationTab by adding height constraints and a visible drag bar. The editor now has a maximum height of 300px and a minimum height of 100px, allowing users to resize it within these bounds. Also disabled overflow to improve the UI experience.


## Changes:
- Added `maxHeight={300}` and `minHeight={100}` to set boundaries for the editor
- Enabled `visibleDragbar` to allow users to resize the editor
- Set `overflow={false}` to prevent content from overflowing the editor