### PR TITLE
feat: add project filtering for Slack multi-agent channel

### DIFF
--- a/packages/backend/src/database/entities/slackAuthentication.ts
+++ b/packages/backend/src/database/entities/slackAuthentication.ts
@@ -15,6 +15,7 @@ export type DbSlackAuthTokens = {
     ai_thread_access_consent: boolean;
     ai_require_oauth: boolean;
     ai_multi_agent_channel_id: string | null;
+    ai_multi_agent_project_uuids: string[] | null;
     // Channel sync status
     channels_last_sync_at: Date | null;
     channels_sync_started_at: Date | null;
@@ -36,6 +37,7 @@ export type UpdateDbSlackAuthTokens = Partial<
         | 'ai_thread_access_consent'
         | 'ai_require_oauth'
         | 'ai_multi_agent_channel_id'
+        | 'ai_multi_agent_project_uuids'
         | 'channels_last_sync_at'
         | 'channels_sync_started_at'
         | 'channels_sync_status'

--- a/packages/backend/src/database/migrations/20260114193648_add_multi_agent_project_filter.ts
+++ b/packages/backend/src/database/migrations/20260114193648_add_multi_agent_project_filter.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const SlackAuthTokensTableName = 'slack_auth_tokens';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table.specificType('ai_multi_agent_project_uuids', 'text[]').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table.dropColumn('ai_multi_agent_project_uuids');
+    });
+}

--- a/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
+++ b/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
@@ -51,6 +51,7 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
             aiThreadAccessConsent: row.ai_thread_access_consent ?? false,
             aiRequireOAuth: row.ai_require_oauth,
             aiMultiAgentChannelId: row.ai_multi_agent_channel_id ?? undefined,
+            aiMultiAgentProjectUuids: row.ai_multi_agent_project_uuids ?? null,
         };
 
         const slackChannelProjectMappingRows = await this.database(
@@ -107,9 +108,16 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
             aiThreadAccessConsent,
             aiRequireOAuth,
             aiMultiAgentChannelId,
+            aiMultiAgentProjectUuids,
         }: SlackAppCustomSettings,
     ) {
         const organizationId = await this.getOrganizationId(organizationUuid);
+
+        // Convert empty array to null for text[] column
+        const projectUuidsToSave =
+            aiMultiAgentProjectUuids && aiMultiAgentProjectUuids.length > 0
+                ? aiMultiAgentProjectUuids
+                : null;
 
         await this.database.transaction(async (trx) => {
             await trx(SlackAuthTokensTableName)
@@ -119,6 +127,7 @@ export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel
                     ai_thread_access_consent: aiThreadAccessConsent ?? false,
                     ai_require_oauth: aiRequireOAuth ?? false,
                     ai_multi_agent_channel_id: aiMultiAgentChannelId ?? null,
+                    ai_multi_agent_project_uuids: projectUuidsToSave,
                 })
                 .where('organization_id', organizationId);
 

--- a/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
+++ b/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
@@ -22,7 +22,9 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
 
     async getInstallationFromOrganizationUuid(user: SessionUser) {
         const organizationUuid = user?.organizationUuid;
-        if (!organizationUuid) throw new ForbiddenError();
+        if (!organizationUuid) {
+            throw new ForbiddenError();
+        }
 
         const installation =
             await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
@@ -41,14 +43,15 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
             scopes: installation.scopes,
             notificationChannel: installation.notificationChannel,
             appProfilePhotoUrl: installation.appProfilePhotoUrl,
-            slackChannelProjectMappings:
-                installation.slackChannelProjectMappings,
             hasRequiredScopes: this.slackClient.hasRequiredScopes(
                 installation.scopes,
             ),
+            slackChannelProjectMappings:
+                installation.slackChannelProjectMappings,
             aiThreadAccessConsent: installation.aiThreadAccessConsent,
             aiRequireOAuth: installation.aiRequireOAuth,
             aiMultiAgentChannelId: installation.aiMultiAgentChannelId,
+            aiMultiAgentProjectUuids: installation.aiMultiAgentProjectUuids,
         };
 
         return response;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4170,11 +4170,17 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ConditionalFormattingColorApplyTo: {
+        dataType: 'refEnum',
+        enums: ['cell', 'text'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ConditionalFormattingConfigWithSingleColor: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                applyTo: { ref: 'ConditionalFormattingColorApplyTo' },
                 rules: {
                     dataType: 'array',
                     array: {
@@ -4240,6 +4246,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                applyTo: { ref: 'ConditionalFormattingColorApplyTo' },
                 rule: {
                     ref: 'ConditionalFormattingMinMax_number-or-auto_',
                     required: true,
@@ -14121,6 +14128,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                aiMultiAgentProjectUuids: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 aiMultiAgentChannelId: { dataType: 'string' },
                 aiRequireOAuth: { dataType: 'boolean' },
                 aiThreadAccessConsent: { dataType: 'boolean' },
@@ -14157,6 +14171,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                aiMultiAgentProjectUuids: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 aiMultiAgentChannelId: { dataType: 'string' },
                 aiRequireOAuth: { dataType: 'boolean' },
                 hasRequiredScopes: { dataType: 'boolean', required: true },
@@ -20386,6 +20407,19 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FunnelConversionWindowUnit: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['hours'] },
+                { dataType: 'enum', enums: ['days'] },
+                { dataType: 'enum', enums: ['weeks'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     FunnelQueryRequest: {
         dataType: 'refAlias',
         type: {
@@ -20396,12 +20430,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         unit: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'enum', enums: ['hours'] },
-                                { dataType: 'enum', enums: ['days'] },
-                                { dataType: 'enum', enums: ['weeks'] },
-                            ],
+                            ref: 'FunnelConversionWindowUnit',
                             required: true,
                         },
                         value: { dataType: 'double', required: true },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4527,8 +4527,15 @@
                     }
                 ]
             },
+            "ConditionalFormattingColorApplyTo": {
+                "enum": ["cell", "text"],
+                "type": "string"
+            },
             "ConditionalFormattingConfigWithSingleColor": {
                 "properties": {
+                    "applyTo": {
+                        "$ref": "#/components/schemas/ConditionalFormattingColorApplyTo"
+                    },
                     "rules": {
                         "items": {
                             "$ref": "#/components/schemas/ConditionalFormattingWithFilterOperator"
@@ -4594,6 +4601,9 @@
             },
             "ConditionalFormattingConfigWithColorRange": {
                 "properties": {
+                    "applyTo": {
+                        "$ref": "#/components/schemas/ConditionalFormattingColorApplyTo"
+                    },
                     "rule": {
                         "$ref": "#/components/schemas/ConditionalFormattingMinMax_number-or-auto_"
                     },
@@ -14532,6 +14542,13 @@
             },
             "SlackAppCustomSettings": {
                 "properties": {
+                    "aiMultiAgentProjectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
+                    },
                     "aiMultiAgentChannelId": {
                         "type": "string"
                     },
@@ -14561,6 +14578,13 @@
             },
             "SlackSettings": {
                 "properties": {
+                    "aiMultiAgentProjectUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
+                    },
                     "aiMultiAgentChannelId": {
                         "type": "string"
                     },
@@ -21160,6 +21184,10 @@
                     }
                 ]
             },
+            "FunnelConversionWindowUnit": {
+                "type": "string",
+                "enum": ["hours", "days", "weeks"]
+            },
             "FunnelQueryRequest": {
                 "properties": {
                     "breakdownDimensionId": {
@@ -21168,8 +21196,7 @@
                     "conversionWindow": {
                         "properties": {
                             "unit": {
-                                "type": "string",
-                                "enum": ["hours", "days", "weeks"]
+                                "$ref": "#/components/schemas/FunnelConversionWindowUnit"
                             },
                             "value": {
                                 "type": "number",
@@ -24151,7 +24178,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2346.0",
+        "version": "0.2348.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -99,6 +99,7 @@ export class SlackIntegrationService<
                 installation.scopes,
             ),
         };
+
         return response;
     }
 

--- a/packages/common/src/types/slack.ts
+++ b/packages/common/src/types/slack.ts
@@ -25,6 +25,7 @@ export type SlackAppCustomSettings = {
     aiThreadAccessConsent?: boolean;
     aiRequireOAuth?: boolean;
     aiMultiAgentChannelId?: string;
+    aiMultiAgentProjectUuids?: string[] | null;
 };
 
 export type ApiSlackGetInstallationResponse = ApiSuccess<

--- a/packages/common/src/types/slackSettings.ts
+++ b/packages/common/src/types/slackSettings.ts
@@ -14,4 +14,5 @@ export type SlackSettings = {
     hasRequiredScopes: boolean;
     aiRequireOAuth?: boolean;
     aiMultiAgentChannelId?: string;
+    aiMultiAgentProjectUuids?: string[] | null;
 };

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/ProjectSelect.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/ProjectSelect.tsx
@@ -1,0 +1,162 @@
+import { ProjectType } from '@lightdash/common';
+import {
+    Combobox,
+    Input,
+    Pill,
+    PillsInput,
+    Tooltip,
+    useCombobox,
+} from '@mantine-8/core';
+import { useMemo, useState, type FC } from 'react';
+import { useProjects } from '../../../hooks/useProjects';
+
+type ProjectSelectProps = {
+    value: string[];
+    onChange: (value: string[]) => void;
+    disabled?: boolean;
+};
+
+export const ProjectSelect: FC<ProjectSelectProps> = ({
+    value,
+    onChange,
+    disabled,
+}) => {
+    const { data: projects } = useProjects();
+    const combobox = useCombobox({
+        onDropdownClose: () => combobox.resetSelectedOption(),
+        onDropdownOpen: () => combobox.updateSelectedOptionIndex('active'),
+    });
+    const [search, setSearch] = useState('');
+
+    const projectOptions = useMemo(
+        () =>
+            projects
+                ?.filter((p) => p.type === ProjectType.DEFAULT)
+                .map((p) => ({
+                    value: p.projectUuid,
+                    label: p.name,
+                })) ?? [],
+        [projects],
+    );
+
+    const isDeleted = (uuid: string) =>
+        !projects?.some((p) => p.projectUuid === uuid);
+
+    const getLabel = (uuid: string) => {
+        const project = projects?.find((p) => p.projectUuid === uuid);
+        return project?.name ?? 'Deleted project';
+    };
+
+    const handleValueSelect = (val: string) => {
+        if (value.includes(val)) {
+            onChange(value.filter((v) => v !== val));
+        } else {
+            onChange([...value, val]);
+        }
+    };
+
+    const handleValueRemove = (val: string) => {
+        onChange(value.filter((v) => v !== val));
+    };
+
+    const filteredOptions = projectOptions.filter(
+        (item) =>
+            !value.includes(item.value) &&
+            item.label.toLowerCase().includes(search.toLowerCase().trim()),
+    );
+
+    const pills = value.map((uuid) => {
+        const deleted = isDeleted(uuid);
+        const label = getLabel(uuid);
+
+        const pill = (
+            <Pill
+                key={uuid}
+                withRemoveButton
+                onRemove={() => handleValueRemove(uuid)}
+                bg={deleted ? 'red.1' : undefined}
+                c={deleted ? 'red.7' : undefined}
+            >
+                {label}
+            </Pill>
+        );
+
+        if (deleted) {
+            return (
+                <Tooltip
+                    key={uuid}
+                    label="This project has been deleted"
+                    withArrow
+                >
+                    {pill}
+                </Tooltip>
+            );
+        }
+
+        return pill;
+    });
+
+    return (
+        <Input.Wrapper label="Filter agents by project" size="xs">
+            <Combobox
+                store={combobox}
+                onOptionSubmit={handleValueSelect}
+                disabled={disabled}
+            >
+                <Combobox.DropdownTarget>
+                    <PillsInput
+                        size="xs"
+                        onClick={() => combobox.openDropdown()}
+                        disabled={disabled}
+                    >
+                        <Pill.Group>
+                            {pills}
+                            <Combobox.EventsTarget>
+                                <PillsInput.Field
+                                    onFocus={() => combobox.openDropdown()}
+                                    onBlur={() => combobox.closeDropdown()}
+                                    value={search}
+                                    placeholder="Select projects"
+                                    onChange={(event) => {
+                                        combobox.updateSelectedOptionIndex();
+                                        setSearch(event.currentTarget.value);
+                                    }}
+                                    onKeyDown={(event) => {
+                                        if (
+                                            event.key === 'Backspace' &&
+                                            search.length === 0
+                                        ) {
+                                            event.preventDefault();
+                                            handleValueRemove(
+                                                value[value.length - 1],
+                                            );
+                                        }
+                                    }}
+                                    disabled={disabled}
+                                />
+                            </Combobox.EventsTarget>
+                        </Pill.Group>
+                    </PillsInput>
+                </Combobox.DropdownTarget>
+
+                <Combobox.Dropdown>
+                    <Combobox.Options>
+                        {filteredOptions.length > 0 ? (
+                            filteredOptions.map((item) => (
+                                <Combobox.Option
+                                    value={item.value}
+                                    key={item.value}
+                                    active={value.includes(item.value)}
+                                >
+                                    {item.label}
+                                </Combobox.Option>
+                            ))
+                        ) : (
+                            <Combobox.Empty>No projects found</Combobox.Empty>
+                        )}
+                    </Combobox.Options>
+                </Combobox.Dropdown>
+            </Combobox>
+        </Input.Wrapper>
+    );
+};

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -19,7 +19,7 @@ import {
     TextInput,
     Title,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import {
     IconAlertCircle,
@@ -44,6 +44,7 @@ import { ComingSoonBadge } from '../../common/ComingSoonBadge';
 import { default as MantineIcon } from '../../common/MantineIcon';
 import { SettingsGridCard } from '../../common/Settings/SettingsCard';
 import { SlackChannelSelect } from '../../common/SlackChannelSelect';
+import { ProjectSelect } from './ProjectSelect';
 
 const SLACK_INSTALL_URL = `/api/v1/slack/install/`;
 
@@ -66,6 +67,7 @@ const formSchema = z.object({
     aiThreadAccessConsent: z.boolean().optional(),
     aiRequireOAuth: z.boolean().optional(),
     aiMultiAgentChannelId: z.string().min(1).optional(),
+    aiMultiAgentProjectUuids: z.array(z.string().uuid()).nullable().optional(),
 });
 
 const SlackSettingsPanel: FC = () => {
@@ -93,6 +95,7 @@ const SlackSettingsPanel: FC = () => {
             aiThreadAccessConsent: false,
             aiRequireOAuth: false,
             aiMultiAgentChannelId: undefined,
+            aiMultiAgentProjectUuids: null,
         },
         validate: zodResolver(formSchema),
     });
@@ -112,6 +115,8 @@ const SlackSettingsPanel: FC = () => {
             aiRequireOAuth: slackInstallation.aiRequireOAuth ?? false,
             aiMultiAgentChannelId:
                 slackInstallation.aiMultiAgentChannelId ?? undefined,
+            aiMultiAgentProjectUuids:
+                slackInstallation.aiMultiAgentProjectUuids ?? null,
         };
 
         if (form.initialized) {
@@ -135,9 +140,9 @@ const SlackSettingsPanel: FC = () => {
 
     return (
         <SettingsGridCard>
-            <Stack spacing="sm">
+            <Stack gap="sm">
                 <Box>
-                    <Group spacing="sm">
+                    <Group gap="sm">
                         <Avatar src={slackSvg} size="md" />
                         <Title order={4}>Slack</Title>
                     </Group>
@@ -145,9 +150,9 @@ const SlackSettingsPanel: FC = () => {
             </Stack>
 
             <Stack>
-                <Stack spacing="sm">
+                <Stack gap="sm">
                     {organizationHasSlack && (
-                        <Group spacing="xs">
+                        <Group gap="xs">
                             <Text fw={500}>Added to the Slack workspace: </Text>{' '}
                             <Badge
                                 radius="xs"
@@ -155,18 +160,21 @@ const SlackSettingsPanel: FC = () => {
                                 color="green"
                                 w="fit-content"
                             >
-                                <Text span fw={500}>
+                                <Text span fw={500} fz="inherit">
                                     {slackInstallation.slackTeamName}
                                 </Text>
                             </Badge>
                         </Group>
                     )}
 
-                    <Text color="dimmed" fz="xs">
+                    <Text c="dimmed" fz="xs">
                         Sharing in Slack allows you to unfurl Lightdash URLs and
                         schedule deliveries to specific people or channels
                         within your Slack workspace.{' '}
-                        <Anchor href="https://docs.lightdash.com/references/slack-integration">
+                        <Anchor
+                            fz="inherit"
+                            href="https://docs.lightdash.com/references/slack-integration"
+                        >
                             View docs
                         </Anchor>
                     </Text>
@@ -174,16 +182,15 @@ const SlackSettingsPanel: FC = () => {
 
                 {organizationHasSlack ? (
                     <form onSubmit={handleSubmit}>
-                        <Stack spacing="sm">
+                        <Stack gap="sm">
                             <SlackChannelSelect
                                 label={
-                                    <Group spacing="two" mb="two">
-                                        <Text>
+                                    <Group gap="two" mb={2}>
+                                        <Text fz="inherit">
                                             Select a notification channel
                                         </Text>
                                         <Tooltip
                                             multiline
-                                            variant="xs"
                                             maw={250}
                                             label="Choose a channel where to send notifications to every time a scheduled delivery fails. You have to add this Slack App to this channel to enable notifications"
                                         >
@@ -205,7 +212,7 @@ const SlackSettingsPanel: FC = () => {
                             <Title order={6} fw={500}>
                                 Slack bot avatar
                             </Title>
-                            <Group spacing="xl">
+                            <Group gap="sm">
                                 <Avatar
                                     size="lg"
                                     src={form.values?.appProfilePhotoUrl}
@@ -213,7 +220,7 @@ const SlackSettingsPanel: FC = () => {
                                     bg="ldGray.1"
                                 />
                                 <TextInput
-                                    sx={{ flexGrow: 1 }}
+                                    flex={1}
                                     label="Profile photo URL"
                                     size="xs"
                                     placeholder="https://lightdash.cloud/photo.jpg"
@@ -229,15 +236,14 @@ const SlackSettingsPanel: FC = () => {
                                 />
                             </Group>
                             {aiCopilotFlag?.enabled && (
-                                <Stack spacing="sm">
-                                    <Group spacing="two">
+                                <Stack gap="sm">
+                                    <Group gap="two">
                                         <Title order={6} fw={500}>
                                             AI Agents thread access consent
                                         </Title>
 
                                         <Tooltip
                                             multiline
-                                            variant="xs"
                                             maw={250}
                                             label="The longer the thread, the more context the AI Agents will have to work with."
                                         >
@@ -272,21 +278,21 @@ const SlackSettingsPanel: FC = () => {
                                         <Anchor
                                             component={Link}
                                             to={`/projects/${activeProjectUuid}/ai-agents`}
+                                            fz="inherit"
                                         >
                                             here
                                         </Anchor>
                                         .
                                     </Text>
 
-                                    <Stack spacing="sm">
-                                        <Group spacing="two">
+                                    <Stack gap="sm">
+                                        <Group gap="two">
                                             <Title order={6} fw={500}>
                                                 AI Agents OAuth requirement
                                             </Title>
 
                                             <Tooltip
                                                 multiline
-                                                variant="xs"
                                                 maw={250}
                                                 label="When enabled, users must authenticate with OAuth to use AI Agent features."
                                             >
@@ -308,8 +314,8 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                     </Stack>
 
-                                    <Stack spacing="xs">
-                                        <Group spacing="xs">
+                                    <Stack gap="xs">
+                                        <Group gap="xs">
                                             <Title order={6} fw={500}>
                                                 Multi-agent channel
                                             </Title>
@@ -317,7 +323,6 @@ const SlackSettingsPanel: FC = () => {
                                             {isSlackMultiAgentChannelEnabled && (
                                                 <Tooltip
                                                     multiline
-                                                    variant="xs"
                                                     maw={250}
                                                     label="Select a channel where users can interact with any AI agent (excluding from preview projects). When users start a thread in this channel, they'll see a dropdown to select which agent to use."
                                                 >
@@ -361,13 +366,61 @@ const SlackSettingsPanel: FC = () => {
                                                     : 'Feature not available'
                                             }
                                         />
+
+                                        {form.values.aiMultiAgentChannelId && (
+                                            <Stack gap="xs">
+                                                <Switch
+                                                    label="Allow all project agents to appear"
+                                                    checked={
+                                                        form.values
+                                                            .aiMultiAgentProjectUuids ===
+                                                        null
+                                                    }
+                                                    disabled={
+                                                        !isSlackMultiAgentChannelEnabled
+                                                    }
+                                                    onChange={(event) => {
+                                                        setFieldValue(
+                                                            'aiMultiAgentProjectUuids',
+                                                            event.currentTarget
+                                                                .checked
+                                                                ? null
+                                                                : [],
+                                                        );
+                                                    }}
+                                                />
+
+                                                {form.values
+                                                    .aiMultiAgentProjectUuids !==
+                                                    null && (
+                                                    <ProjectSelect
+                                                        value={
+                                                            form.values
+                                                                .aiMultiAgentProjectUuids ??
+                                                            []
+                                                        }
+                                                        onChange={(value) => {
+                                                            setFieldValue(
+                                                                'aiMultiAgentProjectUuids',
+                                                                value.length > 0
+                                                                    ? value
+                                                                    : [],
+                                                            );
+                                                        }}
+                                                        disabled={
+                                                            !isSlackMultiAgentChannelEnabled
+                                                        }
+                                                    />
+                                                )}
+                                            </Stack>
+                                        )}
                                     </Stack>
                                 </Stack>
                             )}
                         </Stack>
                         <Stack align="end" mt="xl">
-                            <Group spacing="sm">
-                                <Group spacing="xs">
+                            <Group gap="sm">
+                                <Group gap="xs">
                                     <ActionIcon
                                         variant="default"
                                         size="md"
@@ -384,7 +437,7 @@ const SlackSettingsPanel: FC = () => {
                                         target="_blank"
                                         variant="default"
                                         href={SLACK_INSTALL_URL}
-                                        leftIcon={
+                                        leftSection={
                                             <MantineIcon icon={IconRefresh} />
                                         }
                                     >
@@ -394,7 +447,7 @@ const SlackSettingsPanel: FC = () => {
                                 <Button
                                     size="xs"
                                     type="submit"
-                                    leftIcon={
+                                    leftSection={
                                         <MantineIcon icon={IconDeviceFloppy} />
                                     }
                                 >


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19402

### Description:
Add project filtering capability to Slack multi-agent channel. This allows admins to restrict which project agents can appear in the multi-agent channel by:

1. Adding a new `ai_multi_agent_project_uuids` column to the `slack_auth_tokens` table
2. Implementing a UI in the Slack settings panel to select specific projects
3. Adding filtering logic in the AI agent service to only show agents from selected projects
4. Handling validation of project UUIDs to prevent errors from deleted projects

This enhancement gives organizations more control over which AI agents are accessible in their Slack channels.