### PR TITLE
feat: improve notification loading icon size

### DIFF
--- a/packages/frontend/src/hooks/toaster/useToaster.tsx
+++ b/packages/frontend/src/hooks/toaster/useToaster.tsx
@@ -43,6 +43,9 @@ const useToaster = () => {
                 autoClose,
                 color,
                 styles: {
+                    loader: {
+                        padding: theme.spacing.xxs,
+                    },
                     root: {
                         background: isDark
                             ? theme.fn.darken(theme.colors[color][9], 0.6)
@@ -141,29 +144,6 @@ const useToaster = () => {
                                     }}
                                 />
                             )}
-                            {/*isError && (
-                                <Button
-                                    size="xs"
-                                    variant="light"
-                                    color={toastColor}
-                                    leftIcon={<IconSos />}
-                                    style={{
-                                        alignSelf: 'flex-end',
-                                    }}
-                                    onClick={() => {
-                                        modals.open({
-                                            id: 'support-drawer',
-                                            title: 'Share with Lightdash Support',
-                                            size: 'lg',
-                                            children: <SupportDrawerContent />,
-                                            yOffset: 100,
-                                            zIndex: 1000,
-                                        });
-                                    }}
-                                >
-                                    Share with Lightdash
-                                </Button>
-                            )*/}
                         </Stack>
                     ) : undefined,
                 onClose: (props: NotificationProps) => {

--- a/packages/frontend/src/stories/Toaster.stories.tsx
+++ b/packages/frontend/src/stories/Toaster.stories.tsx
@@ -80,6 +80,18 @@ const ToasterDemo = () => {
                     >
                         Warning
                     </Button>
+                    <Button
+                        color="gray"
+                        onClick={() =>
+                            showToastInfo({
+                                title: 'Loading',
+                                subtitle: 'Processing your request...',
+                                loading: true,
+                            })
+                        }
+                    >
+                        Loading
+                    </Button>
                 </Group>
             </section>
 


### PR DESCRIPTION
### Description:
Added padding to the loader in toast notifications to match other notification icons size. Cleaned up code and added Loading button story 

![CleanShot 2026-01-15 at 11.38.40.png](https://app.graphite.com/user-attachments/assets/66e942a4-f28e-40f5-9bc3-6e2726b36aef.png)

_Before_

![CleanShot 2026-01-15 at 11.40.00.png](https://app.graphite.com/user-attachments/assets/16f46091-4d38-493f-bb6a-7289c93e7368.png)

