### PR TITLE
fix: chart warnings shouldnt cause dashboard errors

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -791,13 +791,20 @@ export class ValidationService extends BaseService {
                   )
                 : [];
 
+        // Only treat blocking chart errors as dashboard-breaking; warnings like
+        // chart configuration issues should not surface as dashboard errors.
+        const blockingChartErrors = chartErrors.filter(
+            (error) =>
+                error.errorType !== ValidationErrorType.ChartConfiguration,
+        );
+
         const dashboardErrors =
             !hasValidationTargets ||
             validationTargets.has(ValidationTarget.DASHBOARDS)
                 ? await this.validateDashboards(
                       projectUuid,
                       existingFields,
-                      chartErrors,
+                      blockingChartErrors,
                   )
                 : [];
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19460

### Description:

Chart config warnings in dashboard charts were causing the validator to report dashboard errors.

<img width="947" height="246" alt="Screenshot 2026-01-15 at 11 51 49" src="https://github.com/user-attachments/assets/d031999e-4ffd-4789-91d4-09acadc06b22" />

This just removes those warnings from the dashboard error calculation
