### PR TITLE
fix: mark tile as errored for screenshot system when chart is deleted/orphaned

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1827,6 +1827,16 @@ export const GenericDashboardChartTile: FC<
         dashboardUuid: string;
     }>();
     const { user } = useApp();
+    const markTileScreenshotErrored = useDashboardContext(
+        (c) => c.markTileScreenshotErrored,
+    );
+
+    // Mark tile as errored for screenshot system when chart is deleted/orphaned
+    useEffect(() => {
+        if (error !== null) {
+            markTileScreenshotErrored(tile.uuid);
+        }
+    }, [error, tile.uuid, markTileScreenshotErrored]);
 
     const userCanManageChart =
         dashboardChartReadyQuery?.chart &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added functionality to mark dashboard chart tiles as errored for the screenshot system when a chart is deleted or orphaned. This ensures that the screenshot system properly handles cases where charts cannot be rendered due to errors.

The implementation uses the `markTileScreenshotErrored` function from the dashboard context and triggers it via a useEffect hook when an error is detected in the chart tile.
