### PR TITLE
fix: apply correct conditional formatting for pivoted columns

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -458,6 +458,19 @@ const PivotTable: FC<PivotTableProps> = ({
                 data.indexValues[rowIndex] ?? [],
             );
 
+            // Include row dimension values from indexValues
+            const rowDimensionFields =
+                currentIndexDims.reduce<ConditionalFormattingRowFields>(
+                    (acc, dim) => {
+                        const field = getField(dim.fieldId);
+                        if (field && isDimension(field)) {
+                            acc[dim.fieldId] = { field, value: dim.value };
+                        }
+                        return acc;
+                    },
+                    {},
+                );
+
             const metricFields =
                 data.indexValues.reduce<ConditionalFormattingRowFields>(
                     (acc, indexValueRow, metricRowIdx) => {
@@ -492,8 +505,12 @@ const PivotTable: FC<PivotTableProps> = ({
                     {},
                 );
 
-            // Merge pivoted dimensions with metrics
-            return { ...pivotedDimensionFields, ...metricFields };
+            // Merge pivoted dimensions, row dimensions, and metrics
+            return {
+                ...pivotedDimensionFields,
+                ...rowDimensionFields,
+                ...metricFields,
+            };
         },
         [
             data.indexValues,


### PR DESCRIPTION
### Description:
When a dimension is pivoted from rows to columns, its values are stored in `headerInfo`. Before this fix, conditional formatting rules that compared against the pivoted dimension couldn't find the field in `rowFields`. Now, the pivoted dimension values are extracted from `headerInfo` and included in `rowFields`, allowing conditional formatting rules to evaluate correctly.


### Example Conditional formatting:
<img width="367" height="530" alt="image" src="https://github.com/user-attachments/assets/56147058-e761-46ae-913f-fe66c90407a0" />


### Before:
<img width="2623" height="555" alt="before" src="https://github.com/user-attachments/assets/e73fc052-b248-4a9d-8107-d42fd22058fc" />


### After:
<img width="2623" height="555" alt="after" src="https://github.com/user-attachments/assets/3d368f0a-2cc9-43fd-849d-0a49445d88a7" />


