### PR TITLE
feat: add chart debug data copy button in dev mode

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorerHeader/DevCopyChartDebugData.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/DevCopyChartDebugData.tsx
@@ -1,0 +1,27 @@
+import { ActionIcon, CopyButton, Tooltip } from '@mantine-8/core';
+import { IconCheck, IconCode } from '@tabler/icons-react';
+import {
+    selectUnsavedChartVersion,
+    useExplorerSelector,
+} from '../../../features/explorer/store';
+import MantineIcon from '../../common/MantineIcon';
+
+export const DevCopyChartDebugData = () => {
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
+
+    return (
+        <CopyButton value={JSON.stringify({ unsavedChartVersion }, null, 2)}>
+            {({ copied, copy }) => (
+                <Tooltip
+                    label={copied ? 'Copied!' : 'Copy chart debug data'}
+                    withArrow
+                    position="bottom"
+                >
+                    <ActionIcon onClick={copy} variant="default" size="md">
+                        <MantineIcon icon={copied ? IconCheck : IconCode} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+        </CopyButton>
+    );
+};

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -29,6 +29,7 @@ import MantineIcon from '../../common/MantineIcon';
 import ShareShortLinkButton from '../../common/ShareShortLinkButton';
 import TimeZonePicker from '../../common/TimeZonePicker';
 import SaveChartButton from '../SaveChartButton';
+import { DevCopyChartDebugData } from './DevCopyChartDebugData';
 import QueryWarnings from './QueryWarnings';
 
 const ExplorerHeader: FC = memo(() => {
@@ -217,6 +218,7 @@ const ExplorerHeader: FC = memo(() => {
                         url={urlToShare}
                     />
                 </Can>
+                {import.meta.env.DEV && <DevCopyChartDebugData />}
             </Group>
         </Group>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a debug button in the Explorer header that allows developers to copy chart data to the clipboard. This button is only visible in development mode and helps with debugging chart-related issues by providing easy access to the unsaved chart version data.
