### PR TITLE
chore: update map tiles

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
@@ -390,12 +390,10 @@ export const Display: FC = memo(() => {
                     <Select
                         data={[
                             { value: MapTileBackground.NONE, label: 'None' },
-                            { value: MapTileBackground.LIGHT, label: 'Light' },
                             {
                                 value: MapTileBackground.OPENSTREETMAP,
                                 label: 'OpenStreetMap',
                             },
-                            { value: MapTileBackground.DARK, label: 'Dark' },
                             {
                                 value: MapTileBackground.SATELLITE,
                                 label: 'Satellite',
@@ -403,7 +401,7 @@ export const Display: FC = memo(() => {
                         ]}
                         value={
                             validConfig.tileBackground ??
-                            MapTileBackground.LIGHT
+                            MapTileBackground.OPENSTREETMAP
                         }
                         onChange={(value) =>
                             setTileBackground(

--- a/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
+++ b/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
@@ -137,29 +137,6 @@ const getTileConfig = (
                 attribution: '',
             };
 
-        case MapTileBackground.OPENSTREETMAP:
-            // OpenStreetMap standard tiles.
-            // Community-run, attribution-only, fair-use. Suitable for low–moderate traffic.
-            // Not intended for heavy commercial usage or guaranteed SLA.
-            return {
-                url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                attribution:
-                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-            };
-
-        case MapTileBackground.DARK:
-            // Stamen Toner Lite (hosted by Stadia Maps).
-            // Open Stamen style with fair-use hosted tiles.
-            // No API key required for low usage; switch to keyed or self-hosted tiles if usage grows.
-            return {
-                url: 'https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.png',
-                attribution:
-                    '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a> ' +
-                    '&copy; <a href="https://stamen.com/">Stamen Design</a> ' +
-                    '&copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> ' +
-                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-            };
-
         // NOTE: Esri World Imagery is used under fair-use terms.
         // If usage increases, switch to a licensed or self-hosted provider.
         case MapTileBackground.SATELLITE:
@@ -171,14 +148,14 @@ const getTileConfig = (
 
         case MapTileBackground.LIGHT:
         default:
-            // Wikimedia OSM tiles.
-            // Neutral, clean cartography with OSM data.
-            // Fair-use, attribution-only; suitable as a safe default base map.
+        case MapTileBackground.OPENSTREETMAP:
+            // OpenStreetMap standard tiles.
+            // Community-run, attribution-only, fair-use. Suitable for low–moderate traffic.
+            // Not intended for heavy commercial usage or guaranteed SLA.
             return {
-                url: 'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png',
+                url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                 attribution:
-                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &mdash; ' +
-                    'Map data © <a href="https://wikimediafoundation.org/">Wikimedia Foundation</a>',
+                    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             };
     }
 };

--- a/packages/frontend/src/hooks/useMapChartConfig.ts
+++ b/packages/frontend/src/hooks/useMapChartConfig.ts
@@ -122,7 +122,7 @@ const useMapChartConfig = (
     >(initialConfig?.heatmapConfig);
     const [tileBackground, setTileBackgroundState] = useState<
         MapTileBackground | undefined
-    >(initialConfig?.tileBackground ?? MapTileBackground.LIGHT);
+    >(initialConfig?.tileBackground ?? MapTileBackground.OPENSTREETMAP);
     const [backgroundColor, setBackgroundColorState] = useState<
         string | undefined
     >(initialConfig?.backgroundColor);


### PR DESCRIPTION
### Description:

Updates the map tiles to use map servers with clearer fair use policies. We were using tiles that are commonly used, but don't explicitly allow light commercial usage. These new tile layers should be ok to use until we have a lot of usage, then we will need to host or buy tiles. (there is a ticket for tracking usage)

We can decide we don't need so many layer options, but for now this is at least move them to ones we can use. 

Updated to be only OSM and satellite tiles. We can add more as needed, but we have to get registered
