### PR TITLE
fix: improve screenshot readiness detection for empty charts and tables

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -102,12 +102,16 @@ const SimpleChart: FC<SimpleChartProps> = memo(
             if (hasSignaledScreenshotReady.current || !onScreenshotReady)
                 return;
 
-            const isReady =
+            const isReadyWithData =
                 !isLoading &&
                 eChartsOptions &&
                 resultsData?.hasFetchedAllRows !== false;
 
-            if (isReady) {
+            // Also signal ready when chart is empty (no options but not loading/error)
+            const isReadyEmpty =
+                !isLoading && !eChartsOptions && !resultsData?.error;
+
+            if (isReadyWithData || isReadyEmpty) {
                 onScreenshotReady();
                 hasSignaledScreenshotReady.current = true;
             }
@@ -115,6 +119,7 @@ const SimpleChart: FC<SimpleChartProps> = memo(
             isLoading,
             eChartsOptions,
             resultsData?.hasFetchedAllRows,
+            resultsData?.error,
             onScreenshotReady,
         ]);
 

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -108,7 +108,8 @@ const SimpleTable: FC<SimpleTableProps> = ({
             return;
         }
 
-        if (loadResultsStatus === 'success') {
+        // Signal ready for both success and idle (idle = no data to fetch)
+        if (loadResultsStatus === 'success' || loadResultsStatus === 'idle') {
             onScreenshotReady?.();
             hasSignaledScreenshotReady.current = true;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Improves screenshot readiness detection for empty charts and tables.

For SimpleChart, we now signal readiness when the chart is empty (no options but not loading/error) in addition to when it has data. For SimpleTable, we now signal readiness when the load status is 'idle' (no data to fetch) in addition to 'success'.

This ensures that screenshots are properly captured for visualizations that are intentionally empty, rather than waiting indefinitely for data that will never arrive.
