### PR TITLE
feat: add tooltip sorting options for pivot charts

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -370,6 +370,16 @@ export type EchartsGrid = {
     height?: string;
 };
 
+export const TooltipSortByOptions = {
+    DEFAULT: 'default',
+    ALPHABETICAL: 'alphabetical',
+    VALUE_ASCENDING: 'value_ascending',
+    VALUE_DESCENDING: 'value_descending',
+} as const;
+
+export type TooltipSortBy =
+    typeof TooltipSortByOptions[keyof typeof TooltipSortByOptions];
+
 export type CompleteEChartsConfig = {
     legend?: EchartsLegend;
     grid?: EchartsGrid;
@@ -377,6 +387,7 @@ export type CompleteEChartsConfig = {
     xAxis: XAxis[];
     yAxis: Axis[];
     tooltip?: string;
+    tooltipSort?: TooltipSortBy;
     showAxisTicks?: boolean;
     axisLabelFontSize?: number;
     axisTitleFontSize?: number;

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
@@ -3,6 +3,7 @@ import {
     getDefaultZIndex,
     Group,
     Paper,
+    Stack,
     Text,
     Tooltip,
     useMantineColorScheme,
@@ -248,78 +249,73 @@ export const TooltipConfig: FC<Props> = ({ fields }) => {
 
     if (!monacoOptions) return null; // we should not load monaco before options are set with the overflowWidgetsDomNode
     return (
-        <Config>
-            <Config.Section>
-                <Group gap="xs" align="center">
-                    <Config.Heading>Custom Tooltip</Config.Heading>
-                    <Tooltip
-                        withinPortal={true}
-                        maw={350}
-                        variant="xs"
-                        multiline
-                        label="Use this input to enhance chart tooltips with additional content. You can incorporate HTML code and include dynamic values using the format ${variable_name}.
-                                    Click here to read more about this on our docs."
-                    >
-                        <MantineIcon
-                            onClick={() => {
-                                window.open(
-                                    'https://docs.lightdash.com/references/custom-tooltip',
-                                    '_blank',
-                                );
-                            }}
-                            icon={IconHelpCircle}
-                            size="md"
-                            display="inline"
-                            color="ldGray.5"
-                        />
-                    </Tooltip>
-                    <Switch checked={show} onChange={() => setShow(!show)} />
-                </Group>
+        <Stack gap="xs">
+            <Group gap="xs" align="center">
+                <Config.Label>Custom</Config.Label>
+                <Tooltip
+                    withinPortal={true}
+                    maw={350}
+                    variant="xs"
+                    multiline
+                    label="Use this input to enhance chart tooltips with additional content. You can incorporate HTML code and include dynamic values using the format ${variable_name}.
+                                Click here to read more about this on our docs."
+                >
+                    <MantineIcon
+                        onClick={() => {
+                            window.open(
+                                'https://docs.lightdash.com/references/custom-tooltip',
+                                '_blank',
+                            );
+                        }}
+                        icon={IconHelpCircle}
+                        size="md"
+                        display="inline"
+                        color="ldGray.5"
+                        style={{ cursor: 'pointer' }}
+                    />
+                </Tooltip>
+                <Switch checked={show} onChange={() => setShow(!show)} />
+            </Group>
 
-                <Collapse in={show}>
-                    {/* Monaco does not support placeholders, so this is a workaround to show the example tooltip
-                    we show some text, by giving position absolute, it is placed on top of the editor*/}
-                    <Paper
-                        className={styles.editorWrapper}
-                        p="xs"
-                        pos="relative"
-                    >
-                        {tooltipValue?.length === 0 ? (
-                            <Text
-                                ml="sm"
-                                pos="absolute"
-                                w="400px"
-                                c="ldGray.5"
-                                fz="xs"
-                                className={styles.placeholderText}
-                                style={{
-                                    zIndex: getDefaultZIndex('overlay'),
-                                }}
-                            >
-                                {`- Total orders: \${orders_total_amount}`}
-                            </Text>
-                        ) : null}
-                        <Editor
-                            beforeMount={beforeMount}
-                            onMount={onMount}
-                            value={tooltipValue}
-                            options={monacoOptions}
-                            onChange={handleEditorOnChange}
-                            language={'html'}
-                            height={`${editorHeight}px`}
-                            width="100%"
-                            theme={
-                                colorScheme === 'dark'
-                                    ? 'lightdash-dark'
-                                    : 'lightdash-light'
-                            }
-                            wrapperProps={{
-                                id: 'tooltip-editor-wrapper',
+            <Collapse in={show}>
+                {/* Monaco does not support placeholders, so this is a workaround to show the example tooltip
+                we show some text, by giving position absolute, it is placed on top of the editor*/}
+                <Paper className={styles.editorWrapper} p="xs" pos="relative">
+                    {tooltipValue?.length === 0 ? (
+                        <Text
+                            ml="sm"
+                            pos="absolute"
+                            w="400px"
+                            c="ldGray.5"
+                            fz="xs"
+                            className={styles.placeholderText}
+                            style={{
+                                zIndex: getDefaultZIndex('overlay'),
                             }}
-                        />
-                    </Paper>
-                </Collapse>
-            </Config.Section>
-        </Config>
+                        >
+                            {`- Total orders: \${orders_total_amount}`}
+                        </Text>
+                    ) : null}
+                    <Editor
+                        beforeMount={beforeMount}
+                        onMount={onMount}
+                        value={tooltipValue}
+                        options={monacoOptions}
+                        onChange={handleEditorOnChange}
+                        language={'html'}
+                        height={`${editorHeight}px`}
+                        width="100%"
+                        theme={
+                            colorScheme === 'dark'
+                                ? 'lightdash-dark'
+                                : 'lightdash-light'
+                        }
+                        wrapperProps={{
+                            id: 'tooltip-editor-wrapper',
+                        }}
+                    />
+                </Paper>
+            </Collapse>
+        </Stack>
     );
 };

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipSortConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipSortConfig.tsx
@@ -1,0 +1,44 @@
+import { TooltipSortByOptions, type TooltipSortBy } from '@lightdash/common';
+import { Group, Select } from '@mantine/core';
+import { type FC } from 'react';
+import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
+import { Config } from '../../common/Config';
+
+const TOOLTIP_SORT_OPTIONS = [
+    { value: TooltipSortByOptions.DEFAULT, label: 'Default' },
+    { value: TooltipSortByOptions.ALPHABETICAL, label: 'Alphabetical' },
+    {
+        value: TooltipSortByOptions.VALUE_DESCENDING,
+        label: 'Value (descending)',
+    },
+    { value: TooltipSortByOptions.VALUE_ASCENDING, label: 'Value (ascending)' },
+];
+
+export const TooltipSortConfig: FC = () => {
+    const { visualizationConfig } = useVisualizationContext();
+
+    if (!isCartesianVisualizationConfig(visualizationConfig)) return null;
+
+    const { tooltipSort, setTooltipSort } = visualizationConfig.chartConfig;
+
+    const handleChange = (value: string | null) => {
+        if (value === null || value === TooltipSortByOptions.DEFAULT) {
+            setTooltipSort(undefined);
+        } else {
+            setTooltipSort(value as TooltipSortBy);
+        }
+    };
+
+    return (
+        <Group spacing="xs">
+            <Config.Label>Sort by</Config.Label>
+            <Select
+                data={TOOLTIP_SORT_OPTIONS}
+                value={tooltipSort ?? TooltipSortByOptions.DEFAULT}
+                onChange={handleChange}
+                w={160}
+            />
+        </Group>
+    );
+};

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -25,6 +25,7 @@ import { useVisualizationContext } from '../../../LightdashVisualization/useVisu
 import { Config } from '../../common/Config';
 import { UnitInputsGrid } from '../common/UnitInputsGrid';
 import { ReferenceLines } from './ReferenceLines';
+import { TooltipSortConfig } from './TooltipSortConfig';
 
 // Lazy load because it imports heavy module "@monaco-editor/react"
 const TooltipConfig = lazy(() =>
@@ -223,11 +224,17 @@ export const Legend: FC<Props> = ({ items }) => {
             {projectUuid && (
                 <ReferenceLines items={items} projectUuid={projectUuid} />
             )}
-            {projectUuid && (
-                <Suspense fallback={<Loader size="sm" />}>
-                    <TooltipConfig fields={autocompleteFieldsTooltip} />
-                </Suspense>
-            )}
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Tooltips</Config.Heading>
+                    <TooltipSortConfig />
+                    {projectUuid && (
+                        <Suspense fallback={<Loader size="sm" />}>
+                            <TooltipConfig fields={autocompleteFieldsTooltip} />
+                        </Suspense>
+                    )}
+                </Config.Section>
+            </Config>
         </Stack>
     );
 };

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -19,6 +19,7 @@ import {
     type Series,
     type SeriesMetadata,
     type TableCalculationMetadata,
+    type TooltipSortBy,
     type XAxis,
 } from '@lightdash/common';
 import { produce } from 'immer';
@@ -967,6 +968,10 @@ const useCartesianChartConfig = ({
     const [tooltip, setTooltip] = useState<string | undefined>(
         dirtyEchartsConfig?.tooltip,
     );
+
+    const [tooltipSort, setTooltipSort] = useState<TooltipSortBy | undefined>(
+        dirtyEchartsConfig?.tooltipSort,
+    );
     // Generate expected series
     useEffect(() => {
         if (isCompleteLayout(dirtyLayout) && resultsData?.hasFetchedAllRows) {
@@ -1040,11 +1045,12 @@ const useCartesianChartConfig = ({
                           (serie) => !serie.isFilteredOut,
                       ),
                       tooltip,
+                      tooltipSort,
                   },
                   metadata: dirtyMetadata,
               }
             : EMPTY_CARTESIAN_CHART_CONFIG;
-    }, [dirtyLayout, dirtyEchartsConfig, dirtyMetadata, tooltip]);
+    }, [dirtyLayout, dirtyEchartsConfig, dirtyMetadata, tooltip, tooltipSort]);
 
     const { dirtyChartType } = useMemo(() => {
         const firstSeriesType =
@@ -1108,6 +1114,8 @@ const useCartesianChartConfig = ({
         setReferenceLines,
         tooltip,
         setTooltip,
+        tooltipSort,
+        setTooltipSort,
         updateMetadata,
     };
 };

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2140,6 +2140,11 @@ const useEchartsCartesianConfig = (
         return visualizationConfig.chartConfig.tooltip;
     }, [visualizationConfig]);
 
+    const tooltipSortConfig = useMemo(() => {
+        if (!isCartesianVisualizationConfig(visualizationConfig)) return;
+        return visualizationConfig.chartConfig.tooltipSort;
+    }, [visualizationConfig]);
+
     const [pivotedKeys, nonPivotedKeys] = useMemo(() => {
         if (
             itemsMap &&
@@ -2688,6 +2693,7 @@ const useEchartsCartesianConfig = (
                 originalValues,
                 series,
                 tooltipHtmlTemplate: tooltipConfig,
+                tooltipSort: tooltipSortConfig,
                 pivotValuesColumnsMap,
                 parameters,
                 rows: dataToRender,
@@ -2699,6 +2705,7 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.xField,
         tooltipConfig,
+        tooltipSortConfig,
         pivotValuesColumnsMap,
         originalValues,
         parameters,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/19060

### Description:
Added tooltip sorting options for pivot charts. Users can now sort tooltip items in four ways:
- Default (original order)

<img width="1508" height="479" alt="Screenshot from 2026-01-15 16-01-24" src="https://github.com/user-attachments/assets/c43504e5-e14b-40d8-8334-5a8718313b54" />


- Alphabetical (by series name)
<img width="1508" height="479" alt="Screenshot from 2026-01-15 16-01-33" src="https://github.com/user-attachments/assets/3917d56d-c3ab-400f-9d91-09e0068551b8" />


- Value ascending

<img width="1508" height="479" alt="Screenshot from 2026-01-15 16-01-16" src="https://github.com/user-attachments/assets/1358f667-aba8-4614-b023-dacbaa4dcc74" />

- Value descending

<img width="1508" height="479" alt="Screenshot from 2026-01-15 16-01-10" src="https://github.com/user-attachments/assets/9a38dfd5-dc30-41d3-adca-f86a68a37fdc" />
<img width="1110" height="375" alt="image" src="https://github.com/user-attachments/assets/3af57ef2-4d71-49ce-951a-06c574452242" />


This feature is particularly useful for pivot tables with many series, making it easier to identify the highest or lowest values in tooltips.

![Tooltip sorting options](https://example.com/tooltip-sort-demo.gif)