### PR TITLE
style: update 'your settings' section to mantine 8

### DIFF
--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, Stack, Title } from '@mantine/core';
+import { Button, Group, Stack, Title } from '@mantine-8/core';
 import { IconKey } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useAccessToken } from '../../../hooks/useAccessToken';
@@ -16,7 +16,7 @@ const AccessTokensPanel: FC = () => {
         <Stack mb="lg">
             {hasAvailableTokens ? (
                 <>
-                    <Group position="apart">
+                    <Group justify="space-between">
                         <Title order={5}>Personal access tokens</Title>
                         <Button onClick={() => setIsCreatingToken(true)}>
                             Generate new token

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CredentialsTable.tsx
@@ -1,6 +1,6 @@
 import { type UserWarehouseCredentials } from '@lightdash/common';
-import { ActionIcon, Group, Paper, Table, Text } from '@mantine/core';
-import { IconEdit, IconTrash } from '@tabler/icons-react';
+import { ActionIcon, Menu, Paper, Table, Text } from '@mantine-8/core';
+import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import { getWarehouseLabel } from '../../ProjectConnection/ProjectConnectFlow/utils';
@@ -29,37 +29,44 @@ const CredentialsItem: FC<
     setWarehouseCredentialsToBeDeleted,
     setWarehouseCredentialsToBeEdited,
 }) => (
-    <tr>
-        <Text component="td" fw={500}>
-            {credentials.name}
-        </Text>
-        <td>{getWarehouseLabel(credentials.credentials.type)}</td>
-        <td
-            style={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                alignItems: 'center',
-            }}
-        >
-            <Group>
-                <ActionIcon
-                    onClick={() =>
-                        setWarehouseCredentialsToBeEdited(credentials)
-                    }
-                >
-                    <MantineIcon icon={IconEdit} />
-                </ActionIcon>
-
-                <ActionIcon
-                    onClick={() =>
-                        setWarehouseCredentialsToBeDeleted(credentials)
-                    }
-                >
-                    <MantineIcon icon={IconTrash} />
-                </ActionIcon>
-            </Group>
-        </td>
-    </tr>
+    <Table.Tr>
+        <Table.Td>
+            <Text fw={500}>{credentials.name}</Text>
+        </Table.Td>
+        <Table.Td>{getWarehouseLabel(credentials.credentials.type)}</Table.Td>
+        <Table.Td w="1%">
+            <Menu withinPortal position="bottom-end">
+                <Menu.Target>
+                    <ActionIcon
+                        variant="transparent"
+                        size="sm"
+                        color="ldGray.6"
+                    >
+                        <MantineIcon icon={IconDots} />
+                    </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    <Menu.Item
+                        leftSection={<MantineIcon icon={IconEdit} />}
+                        onClick={() =>
+                            setWarehouseCredentialsToBeEdited(credentials)
+                        }
+                    >
+                        Edit
+                    </Menu.Item>
+                    <Menu.Item
+                        leftSection={<MantineIcon icon={IconTrash} />}
+                        color="red"
+                        onClick={() =>
+                            setWarehouseCredentialsToBeDeleted(credentials)
+                        }
+                    >
+                        Delete
+                    </Menu.Item>
+                </Menu.Dropdown>
+            </Menu>
+        </Table.Td>
+    </Table.Tr>
 );
 
 export const CredentialsTable: FC<CredentialsTableProps> = ({
@@ -67,22 +74,21 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
     setWarehouseCredentialsToBeEdited,
     setWarehouseCredentialsToBeDeleted,
 }) => {
-    const { cx, classes } = useTableStyles();
+    const { cx, classes: tableClasses } = useTableStyles();
 
     return (
-        <Paper withBorder sx={{ overflow: 'hidden' }}>
+        <Paper withBorder style={{ overflow: 'hidden' }}>
             <Table
-                className={cx(classes.root, classes.alignLastTdRight)}
-                ta="left"
+                className={cx(tableClasses.root, tableClasses.alignLastTdRight)}
             >
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Warehouse</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
+                <Table.Thead>
+                    <Table.Tr>
+                        <Table.Th>Name</Table.Th>
+                        <Table.Th>Warehouse</Table.Th>
+                        <Table.Th></Table.Th>
+                    </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
                     {credentials?.map((c) => (
                         <CredentialsItem
                             key={c.uuid}
@@ -95,7 +101,7 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
                             }
                         />
                     ))}
-                </tbody>
+                </Table.Tbody>
             </Table>
         </Paper>
     );

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
@@ -1,5 +1,5 @@
 import { type UserWarehouseCredentials } from '@lightdash/common';
-import { Anchor, Button, Group, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Button, Group, Stack, Text, Title } from '@mantine-8/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useUserWarehouseCredentials } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
@@ -21,7 +21,7 @@ export const MyWarehouseConnectionsPanel = () => {
     ] = useState<UserWarehouseCredentials | undefined>(undefined);
 
     const personalConnectionsCallout = (
-        <Text c="dimmed">
+        <Text c="dimmed" fz="xs">
             These credentials are only used for projects that require user
             credentials -{' '}
             <Anchor
@@ -29,6 +29,7 @@ export const MyWarehouseConnectionsPanel = () => {
                 href="https://docs.lightdash.com/references/personal-warehouse-connections"
                 target="_blank"
                 rel="noreferrer"
+                fz="xs"
             >
                 learn more
             </Anchor>
@@ -41,8 +42,8 @@ export const MyWarehouseConnectionsPanel = () => {
             <Stack mb="lg">
                 {credentials && credentials.length > 0 ? (
                     <>
-                        <Group position="apart">
-                            <Stack spacing="one">
+                        <Group justify="space-between">
+                            <Stack gap="one">
                                 <Title order={5}>
                                     My Warehouse connections
                                 </Title>
@@ -53,7 +54,7 @@ export const MyWarehouseConnectionsPanel = () => {
                             </Stack>
                             <Button
                                 size="xs"
-                                leftIcon={<MantineIcon icon={IconPlus} />}
+                                leftSection={<MantineIcon icon={IconPlus} />}
                                 onClick={() => setIsCreatingCredentials(true)}
                             >
                                 Add new credentials

--- a/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationPanel/index.tsx
@@ -1,5 +1,5 @@
 import { getOrganizationNameSchema } from '@lightdash/common';
-import { Button, Flex, Stack, TextInput } from '@mantine/core';
+import { Button, Flex, Stack, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, type FC } from 'react';
@@ -68,7 +68,6 @@ const OrganizationPanel: FC = () => {
                     )}
 
                     <Button
-                        display="block"
                         type="submit"
                         disabled={isLoading || !form.isDirty()}
                         loading={isLoading}

--- a/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/PasswordPanel/index.tsx
@@ -1,5 +1,5 @@
 import { getPasswordSchema } from '@lightdash/common';
-import { Button, Flex, PasswordInput, Stack } from '@mantine/core';
+import { Button, Flex, PasswordInput, Stack } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { z } from 'zod';
@@ -92,7 +92,6 @@ const PasswordPanel: FC = () => {
 
                     <Button
                         type="submit"
-                        display="block"
                         loading={isUpdatingUserPassword}
                         disabled={isUpdatingUserPassword}
                     >

--- a/packages/frontend/src/components/UserSettings/SocialLoginsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SocialLoginsPanel/index.tsx
@@ -4,7 +4,7 @@ import {
     type HealthState,
     type OpenIdIdentitySummary,
 } from '@lightdash/common';
-import { ActionIcon, Card, Group, Stack, Text } from '@mantine/core';
+import { ActionIcon, Card, Group, Stack, Text } from '@mantine-8/core';
 import { IconTrash } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import { type Entries } from 'type-fest';
@@ -66,7 +66,7 @@ const SocialLoginsPanel: FC = () => {
     if (!health) return null;
 
     return (
-        <Stack spacing="md">
+        <Stack gap="md">
             {(
                 Object.entries(userSocialLogins ?? {}) as Entries<
                     typeof userSocialLogins
@@ -74,7 +74,7 @@ const SocialLoginsPanel: FC = () => {
             ).map(
                 ([issuerType, logins]) =>
                     isIssuerTypeAvailable(health, issuerType) && (
-                        <Stack key={issuerType} spacing="xs">
+                        <Stack key={issuerType} gap="xs">
                             <Text tt="capitalize" fw={600}>
                                 {issuerType}
                             </Text>
@@ -85,7 +85,7 @@ const SocialLoginsPanel: FC = () => {
                                           withBorder
                                           padding="xs"
                                       >
-                                          <Group position="apart">
+                                          <Group justify="space-between">
                                               {login.email}
                                               <ActionIcon
                                                   size="xs"
@@ -107,7 +107,7 @@ const SocialLoginsPanel: FC = () => {
                                       </Card>
                                   ))
                                 : null}
-                            <Group position="left" spacing="xs">
+                            <Group justify="flex-start" gap="xs">
                                 <ThirdPartySignInButton
                                     size="xs"
                                     providerName={issuerType}

--- a/packages/frontend/src/pages/Settings.module.css
+++ b/packages/frontend/src/pages/Settings.module.css
@@ -1,0 +1,4 @@
+.sidebarStack {
+    flex-grow: 1;
+    overflow: hidden;
+}

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
-import { Box, ScrollArea, Stack, Text, Title } from '@mantine/core';
+import { Box, ScrollArea, Stack, Text, Title } from '@mantine-8/core';
 import {
     IconBrain,
     IconBrowser,
@@ -77,6 +77,7 @@ import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName, PageName } from '../types/Events';
 import ProjectSettings from './ProjectSettings';
+import classes from './Settings.module.css';
 
 const Settings: FC = () => {
     const { data: embeddingEnabled } = useFeatureFlag(
@@ -183,7 +184,7 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/password',
                 element: (
-                    <Stack spacing="xl">
+                    <Stack gap="xl">
                         <SettingsGridCard>
                             <Title order={4}>Password settings</Title>
                             <PasswordPanel />
@@ -202,7 +203,7 @@ const Settings: FC = () => {
         allowedRoutes.push({
             path: '/myWarehouseConnections',
             element: (
-                <Stack spacing="xl">
+                <Stack gap="xl">
                     <MyWarehouseConnectionsPanel />
                 </Stack>
             ),
@@ -211,7 +212,7 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/organization',
                 element: (
-                    <Stack spacing="xl">
+                    <Stack gap="xl">
                         <SettingsGridCard>
                             <Title order={4}>General</Title>
                             <OrganizationPanel />
@@ -477,7 +478,7 @@ const Settings: FC = () => {
             withPaddedContent
             title="Settings"
             sidebar={
-                <Stack sx={{ flexGrow: 1, overflow: 'hidden' }}>
+                <Stack className={classes.sidebarStack}>
                     <PageBreadcrumbs
                         items={[{ title: 'Settings', active: true }]}
                     />
@@ -486,7 +487,7 @@ const Settings: FC = () => {
                         offsetScrollbars
                         scrollbarSize={8}
                     >
-                        <Stack spacing="lg">
+                        <Stack gap="lg">
                             <Box>
                                 <Title order={6} fw={600} mb="xs">
                                     Your settings


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Migrated user settings components to Mantine 8, including:
- Updated imports from `@mantine/core` to `@mantine-8/core`
- Replaced deprecated props:
  - `position="apart"` → `justify="space-between"`
  - `spacing` → `gap` in Stack components
  - `leftIcon` → `leftSection` in Button components
- Restructured table components using the new Mantine 8 Table API with `Table.Tr`, `Table.Td`, etc.
- Replaced action buttons in CredentialsTable with a dropdown menu for better UX
- Added proper styling for text elements
- Created a dedicated CSS module for Settings page styles