### PR TITLE
style: improve Custom tooltip ui on dark/light mode

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.module.css
@@ -1,0 +1,31 @@
+.editorWrapper {
+    overflow: hidden;
+
+    @mixin light {
+        background-color: white;
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+}
+
+/* Override Monaco editor styles for consistent rounded corners */
+.editorWrapper :global(.monaco-editor) {
+    overflow: hidden;
+}
+
+/* Override the existing border from monaco.css */
+.editorWrapper
+    :global(#tooltip-editor-wrapper .view-lines.monaco-mouse-cursor-text) {
+    border: none !important;
+}
+
+/* Thin scrollbar styling - width controlled via Monaco theme colors */
+.editorWrapper :global(.monaco-scrollable-element > .scrollbar) {
+    width: 6px !important;
+}
+
+.placeholderText {
+    pointer-events: none;
+    font-family: monospace;
+}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
@@ -1,27 +1,33 @@
 import {
-    Box,
     Collapse,
     getDefaultZIndex,
     Group,
-    Switch,
+    Paper,
     Text,
     Tooltip,
-} from '@mantine/core';
+    useMantineColorScheme,
+} from '@mantine-8/core';
+import { Switch } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
     Editor,
     type BeforeMount,
     type EditorProps,
     type Monaco,
+    type OnMount,
 } from '@monaco-editor/react';
 import { IconHelpCircle } from '@tabler/icons-react';
-import { type IDisposable, type languages } from 'monaco-editor';
-import { useCallback, useEffect, useState, type FC } from 'react';
+import { type editor, type IDisposable, type languages } from 'monaco-editor';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useDeepCompareEffect } from 'react-use';
+import { getLightdashMonacoTheme } from '../../../../features/sqlRunner/utils/monaco';
 import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../../common/Config';
+import styles from './TooltipConfig.module.css';
+
+import '../../../../styles/monaco.css';
 
 const MONACO_DEFAULT_OPTIONS: EditorProps['options'] = {
     cursorBlinking: 'smooth',
@@ -92,8 +98,18 @@ const registerCustomCompletionProvider = (
             triggerCharacters: ['$'],
         });
 };
+
+const MONACO_LINE_HEIGHT = 19;
+const MONACO_PADDING = 16;
+const MAX_LINES = 10;
+
+const calculateEditorHeight = (lineCount: number): number => {
+    const lines = Math.min(lineCount || 1, MAX_LINES);
+    return lines * MONACO_LINE_HEIGHT + MONACO_PADDING;
+};
 export const TooltipConfig: FC<Props> = ({ fields }) => {
     const { visualizationConfig } = useVisualizationContext();
+    const { colorScheme } = useMantineColorScheme();
     const isCartesianChart =
         isCartesianVisualizationConfig(visualizationConfig);
 
@@ -101,6 +117,11 @@ export const TooltipConfig: FC<Props> = ({ fields }) => {
         (isCartesianChart && visualizationConfig.chartConfig.tooltip) || '',
     );
     const [debouncedTooltipValue] = useDebouncedValue(tooltipValue, 1000);
+    const [editorHeight, setEditorHeight] = useState<number>(
+        calculateEditorHeight(1),
+    );
+    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+    const disposableRef = useRef<IDisposable | null>(null);
 
     useEffect(() => {
         if (!isCartesianChart) return;
@@ -116,6 +137,9 @@ export const TooltipConfig: FC<Props> = ({ fields }) => {
 
     const handleEditorOnChange = (value: string | undefined) => {
         setTooltipValue(value ?? '');
+        // Update height based on line count
+        const lineCount = (value ?? '').split('\n').length;
+        setEditorHeight(calculateEditorHeight(lineCount));
     };
 
     const [show, setShow] = useState<boolean>(
@@ -149,17 +173,59 @@ export const TooltipConfig: FC<Props> = ({ fields }) => {
     const beforeMount: BeforeMount = useCallback(
         (monaco) => {
             registerCustomCompletionProvider(monaco, 'html', fields);
+
+            // Get Lightdash theme colors (editor colors only, no SQL syntax rules needed for HTML)
+            const lightTheme = getLightdashMonacoTheme('light');
+            const darkTheme = getLightdashMonacoTheme('dark');
+
+            // Define themes with Lightdash editor colors + thin scrollbar + dark mode suggestions
+            monaco.editor.defineTheme('lightdash-light', {
+                base: 'vs',
+                inherit: true,
+                rules: [], // No syntax rules needed for HTML editor
+                colors: {
+                    ...lightTheme.colors,
+                },
+            });
+            monaco.editor.defineTheme('lightdash-dark', {
+                base: 'vs-dark',
+                inherit: true,
+                rules: [], // No syntax rules needed for HTML editor
+                colors: {
+                    ...darkTheme.colors,
+                },
+            });
         },
         [fields],
     );
+
+    const onMount: OnMount = useCallback((editor) => {
+        editorRef.current = editor;
+        // Calculate initial height
+        const model = editor.getModel();
+        if (model) {
+            const lineCount = model.getLineCount();
+            setEditorHeight(calculateEditorHeight(lineCount));
+            // Listen to content changes to update height (handles paste, etc.)
+            disposableRef.current = model.onDidChangeContent(() => {
+                const newLineCount = model.getLineCount();
+                setEditorHeight(calculateEditorHeight(newLineCount));
+            });
+        }
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            disposableRef.current?.dispose();
+        };
+    }, []);
 
     if (!monacoOptions) return null; // we should not load monaco before options are set with the overflowWidgetsDomNode
     return (
         <Config>
             <Config.Section>
-                <Group spacing="xs" align="center">
+                <Group gap="xs" align="center">
                     <Config.Heading>Custom Tooltip</Config.Heading>
-                    <Switch checked={show} onChange={() => setShow(!show)} />
                     <Tooltip
                         withinPortal={true}
                         maw={350}
@@ -178,47 +244,54 @@ export const TooltipConfig: FC<Props> = ({ fields }) => {
                             icon={IconHelpCircle}
                             size="md"
                             display="inline"
-                            color="gray"
+                            color="ldGray.5"
                         />
                     </Tooltip>
+                    <Switch checked={show} onChange={() => setShow(!show)} />
                 </Group>
 
                 <Collapse in={show}>
                     {/* Monaco does not support placeholders, so this is a workaround to show the example tooltip
                     we show some text, by giving position absolute, it is placed on top of the editor*/}
-                    {tooltipValue?.length === 0 ? (
-                        <Text
-                            ml="xxs"
-                            pos="absolute"
-                            width="400px"
-                            color="ldGray.5"
-                            sx={{
-                                pointerEvents: 'none',
-                                zIndex: getDefaultZIndex('overlay'),
-                                fontFamily: 'monospace',
-                            }}
-                        >
-                            {`- Total orders: \${orders_total_amount}`}
-                        </Text>
-                    ) : null}
-                    <Box
-                        sx={(theme) => ({
-                            boxShadow: theme.shadows.subtle,
-                        })}
+                    <Paper
+                        className={styles.editorWrapper}
+                        p="xs"
+                        pos="relative"
                     >
+                        {tooltipValue?.length === 0 ? (
+                            <Text
+                                ml="sm"
+                                pos="absolute"
+                                w="400px"
+                                c="ldGray.5"
+                                fz="xs"
+                                className={styles.placeholderText}
+                                style={{
+                                    zIndex: getDefaultZIndex('overlay'),
+                                }}
+                            >
+                                {`- Total orders: \${orders_total_amount}`}
+                            </Text>
+                        ) : null}
                         <Editor
                             beforeMount={beforeMount}
+                            onMount={onMount}
                             value={tooltipValue}
                             options={monacoOptions}
                             onChange={handleEditorOnChange}
                             language={'html'}
-                            height="76px"
+                            height={`${editorHeight}px`}
                             width="100%"
+                            theme={
+                                colorScheme === 'dark'
+                                    ? 'lightdash-dark'
+                                    : 'lightdash-light'
+                            }
                             wrapperProps={{
                                 id: 'tooltip-editor-wrapper',
                             }}
                         />
-                    </Box>
+                    </Paper>
                 </Collapse>
             </Config.Section>
         </Config>

--- a/packages/frontend/src/styles/monaco.css
+++ b/packages/frontend/src/styles/monaco.css
@@ -24,33 +24,62 @@
 }
 
 #tooltip-editor-wrapper .view-lines.monaco-mouse-cursor-text {
-    border: 1px solid #e6e6e6;
+    @mixin light {
+        border: 1px solid var(--mantine-color-ldGray-3);
+    }
+    @mixin dark {
+        border: 1px solid var(--mantine-color-ldDark-4);
+    }
     border-radius: 4px;
 }
 
 #monaco-overflow-container .suggest-widget {
     border-radius: 4px;
-    background-color: white;
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    border: 1px solid #e5e7eb;
     width: 700px !important;
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+        border: 1px solid var(--mantine-color-ldGray-3);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-9);
+        border: 1px solid var(--mantine-color-ldDark-4);
+    }
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 
 #monaco-overflow-container .suggest-widget .monaco-list .monaco-list-row {
     transition: background-color 0.15s ease;
     border-radius: 4px;
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-2);
+    }
 }
 
 #monaco-overflow-container .suggest-widget .monaco-list .monaco-list-row:hover {
-    background-color: #f3f4f6;
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-2);
+    }
 }
 
 #monaco-overflow-container
     .suggest-widget
     .monaco-list
     .monaco-list-row.focused {
-    background-color: #f3f4f6;
-    color: #111827;
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-1);
+        color: var(--mantine-color-ldGray-9);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-ldDark-9);
+        background-color: var(--mantine-color-ldDark-3);
+    }
 }
 
 #monaco-overflow-container
@@ -73,7 +102,18 @@
 }
 
 #monaco-overflow-container .suggest-widget .details {
-    border-top: 1px solid #e5e7eb;
-    background-color: #f9fafb;
+    border-top: 1px solid var(--mantine-color-ldGray-3);
     border-radius: 0 0 8px 8px;
+
+    @mixin light {
+        border-top: 1px solid var(--mantine-color-ldGray-3);
+        background-color: var(--mantine-color-ldGray-0);
+        border-radius: 0 0 8px 8px;
+    }
+
+    @mixin dark {
+        border-top: 1px solid var(--mantine-color-ldDark-4);
+        background-color: var(--mantine-color-ldDark-6);
+        border-radius: 0 0 8px 8px;
+    }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #[issue number]

### Description:
Enhanced the tooltip editor in the chart configuration panel with improved styling and functionality:

- Added responsive height adjustment based on content
- Implemented dark mode support with appropriate color schemes
- Created custom Monaco editor themes for both light and dark modes
- Added rounded corners and consistent styling for the editor
- Improved scrollbar appearance with thinner, more subtle design
- Fixed placeholder text styling and positioning
- Upgraded the code completion dropdown to match the application theme


[CleanShot 2026-01-15 at 16.17.58.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0e03f75b-ac56-4cbe-b0ad-3ea43732fb28.mp4" />](https://app.graphite.com/user-attachments/video/0e03f75b-ac56-4cbe-b0ad-3ea43732fb28.mp4)

