### PR TITLE
fix: avoid intermediate axis ticks for all series types

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1266,6 +1266,7 @@ export const getCategoryDateAxisConfig = (
     axisField?: Field | TableCalculation | CustomDimension,
     rows?: ResultRow[],
     axisType?: string,
+    series?: Series[],
 ) => {
     if (!axisId || !rows || !axisField || axisType !== 'category') return {};
     if (!('timeInterval' in axisField)) return {};
@@ -1278,6 +1279,13 @@ export const getCategoryDateAxisConfig = (
     const maxDateValue = dayjs.utc(maxX);
     if (!minDateValue.isValid() || !maxDateValue.isValid()) return {};
 
+    // Bar charts need boundary gap for proper bar spacing, but line/area charts
+    // look better extending to the edges
+    const hasBarSeries = series?.some(
+        (s) => s.type === CartesianSeriesType.BAR,
+    );
+    const boundaryGap = hasBarSeries;
+
     if (timeInterval === TimeFrames.WEEK) {
         const continuousRange: string[] = [];
         let nextDate = dayjs.utc(minX);
@@ -1289,6 +1297,7 @@ export const getCategoryDateAxisConfig = (
         return {
             data: continuousRange,
             axisTick: { alignWithLabel: true, interval: 0 },
+            boundaryGap,
         };
     }
 
@@ -1303,6 +1312,7 @@ export const getCategoryDateAxisConfig = (
         return {
             data: continuousRange,
             axisTick: { alignWithLabel: true, interval: 0 },
+            boundaryGap,
         };
     }
 
@@ -1318,6 +1328,7 @@ export const getCategoryDateAxisConfig = (
         return {
             data: continuousRange,
             axisTick: { alignWithLabel: true, interval: 0 },
+            boundaryGap,
         };
     }
 
@@ -1332,6 +1343,7 @@ export const getCategoryDateAxisConfig = (
         return {
             data: continuousRange,
             axisTick: { alignWithLabel: true, interval: 0 },
+            boundaryGap,
         };
     }
 
@@ -1506,29 +1518,34 @@ const getEchartAxes = ({
         itemsMap,
         resultsData?.pivotDetails,
     );
+    const eChartsSeries = validCartesianConfig.eChartsConfig.series;
     const bottomAxisExtraConfig = getCategoryDateAxisConfig(
         bottomAxisXId,
         bottomAxisXField,
         resultsData?.rows,
         bottomAxisType,
+        eChartsSeries,
     );
     const topAxisExtraConfig = getCategoryDateAxisConfig(
         topAxisXId,
         topAxisXField,
         resultsData?.rows,
         topAxisType,
+        eChartsSeries,
     );
     const rightAxisExtraConfig = getCategoryDateAxisConfig(
         rightAxisYId,
         rightAxisYField,
         resultsData?.rows,
         rightAxisType,
+        eChartsSeries,
     );
     const leftAxisExtraConfig = getCategoryDateAxisConfig(
         leftAxisYId,
         leftAxisYField,
         resultsData?.rows,
         leftAxisType,
+        eChartsSeries,
     );
 
     const axisLabelFontSize =


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-2462/weekly-chart-showing-additional-unnecessary-axis-labels

### Description:
Chart types other than "Bar Chart" have the potential issue of displaying more axis points than necessary. E.g. if you have a weekly dimension it could easily lead to showing daily values, which adds some confusion to users.

Since there was already a fix in place for the "Bar Charts", I tried it out for the "Line Charts" and it worked just fine. It also doesn't seem to break anything else at first glance.

### Example scenario:
In my example scenario the x-axis is "Order dates weekly" and there are only 2 dates in the result (2024-02-10 and 2024-02-14), so 1 week apart. The expectation would be that only those two values are displayed on the x-axis - no extra ones in-between:
<img width="2217" height="351" alt="image" src="https://github.com/user-attachments/assets/6c8bce87-e519-4d3a-ba7b-3c62c41b5e4a" />


### Before:
<img width="2217" height="1171" alt="Before" src="https://github.com/user-attachments/assets/1c2c5e64-fdad-427a-b2e9-afa5c720a753" />


### After:
<img width="2217" height="1171" alt="After" src="https://github.com/user-attachments/assets/9663dbff-4132-4ce2-b29a-f51f89e2fc2d" />


### Other Relevant Chart Types:
<img width="2217" height="819" alt="Screenshot 2026-01-15 at 16 48 10" src="https://github.com/user-attachments/assets/436ec694-d0da-4499-9998-2b736a8c39be" />
<img width="2217" height="819" alt="Screenshot 2026-01-15 at 16 48 20" src="https://github.com/user-attachments/assets/60b86f28-8492-4116-9da9-8c67107af762" />
<img width="2217" height="819" alt="Screenshot 2026-01-15 at 16 48 28" src="https://github.com/user-attachments/assets/c56d644d-4c80-4bad-a59e-f2aaa8e75c60" />

