### PR TITLE
fix: do not run and disable scheduled deliveries when there are no targets

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -8,6 +8,7 @@ import {
     SchedulerFormat,
     SessionUser,
     SmptError,
+    type PartialFailure,
 } from '@lightdash/common';
 import { marked } from 'marked';
 import * as nodemailer from 'nodemailer';
@@ -54,7 +55,7 @@ type EmailTemplate = {
         | boolean
         | number
         | AttachmentUrl[]
-        | { chartName: string; error: string }[]
+        | PartialFailure[]
         | undefined
     >;
     attachments?: (Mail.Attachment | AttachmentUrl)[] | undefined;
@@ -632,7 +633,7 @@ export default class EmailClient {
         expirationDays?: number,
         asAttachment?: boolean,
         format?: SchedulerFormat,
-        failures?: { chartName: string; error: string }[],
+        failures?: PartialFailure[],
     ) {
         const csvUrls = attachments.filter(
             (attachment) => !attachment.truncated,

--- a/packages/common/src/types/schedulerLog.ts
+++ b/packages/common/src/types/schedulerLog.ts
@@ -12,6 +12,7 @@ export type SchedulerTargetType = 'email' | 'slack' | 'gsheets' | 'msteams';
 
 // Partial failure types for different scenarios
 export enum PartialFailureType {
+    MISSING_TARGETS = 'missing_targets',
     DASHBOARD_CHART = 'dashboard_chart',
     DASHBOARD_SQL_CHART = 'dashboard_sql_chart',
 }
@@ -32,10 +33,15 @@ export type DashboardSqlChartPartialFailure = {
     error: string;
 };
 
+export type MissingTargetsPartialFailure = {
+    type: PartialFailureType.MISSING_TARGETS;
+};
+
 // Union of all partial failure types
 export type PartialFailure =
     | DashboardChartPartialFailure
-    | DashboardSqlChartPartialFailure;
+    | DashboardSqlChartPartialFailure
+    | MissingTargetsPartialFailure;
 
 export type SchedulerDetails = {
     projectUuid?: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/GLITCH-144/scheduled-deliveries-with-no-targets-shouldnt-run

### Description:
Added support for a new partial failure type `MISSING_TARGETS` to handle cases where scheduled deliveries have no recipients configured. The scheduler will now:

1. Detect when a scheduler has no targets and disable it automatically
2. Log this as a specific failure type rather than silently failing
3. Display a user-friendly message in the UI about missing recipients

This improves the user experience by providing clear feedback when scheduled deliveries fail due to configuration issues rather than data problems.

![CleanShot 2026-01-16 at 11.21.31.png](https://app.graphite.com/user-attachments/assets/64fb8dde-e574-4f1a-96f5-56b595b5673f.png)

