### PR TITLE
fix: remove dashboard redesign check for markdown tile hideFrame property

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -11,7 +11,6 @@ import { v4 as uuid4 } from 'uuid';
 import { DashboardTileComments } from '../../features/comments';
 import { appendNewTilesToBottom } from '../../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
-import { useDashboardUIPreference } from '../../hooks/dashboard/useDashboardUIPreference';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../common/MantineIcon';
 import TileBase from './TileBase/index';
@@ -28,14 +27,11 @@ const MarkdownTile: FC<Props> = (props) => {
 
     const {
         tile: {
-            properties: { title, content, hideFrame: rawHideFrame },
+            properties: { title, content, hideFrame },
             uuid,
         },
         isEditMode,
     } = props;
-
-    const { isDashboardRedesignEnabled } = useDashboardUIPreference();
-    const hideFrame = isDashboardRedesignEnabled ? rawHideFrame : false;
 
     const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
     const showComments = useDashboardContext(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2407](https://linear.app/lightdash/issue/PROD-2407/exported-dashboards-show-tile-frameswhite-spaces-for-markdown-blocks)

### Description:

Removed the `useDashboardUIPreference` hook and simplified the `hideFrame` logic in the `DashboardMarkdownTile` component. Previously, the component was conditionally applying the `hideFrame` property based on whether the dashboard redesign was enabled. This change removes this conditional logic and directly uses the `hideFrame` property from the tile properties.
