### PR TITLE
fix: remove duplicate users from user options select list

### DIFF
--- a/packages/frontend/src/components/common/UserSelect/index.tsx
+++ b/packages/frontend/src/components/common/UserSelect/index.tsx
@@ -55,10 +55,19 @@ export const UserSelect: FC<UserSelectProps> = ({
         { keepPreviousData: true },
     );
 
-    const organizationUsers = useMemo(
-        () => infiniteUsers?.pages.flatMap((page) => page.data) ?? [],
-        [infiniteUsers],
-    );
+    const organizationUsers = useMemo(() => {
+        const allUsers =
+            infiniteUsers?.pages.flatMap((page) => page.data) ?? [];
+        // Deduplicate by userUuid to handle edge cases where offset-based
+        // pagination returns the same user in multiple pages due to data
+        // changes between page fetches
+        const seen = new Set<string>();
+        return allUsers.filter((user) => {
+            if (seen.has(user.userUuid)) return false;
+            seen.add(user.userUuid);
+            return true;
+        });
+    }, [infiniteUsers]);
 
     const eligibleUsers = useMemo(() => {
         if (!organizationUsers) return [];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2552/error-mantinecore-duplicate-options-are-not-supported-option-with

### Description:
Fixes a bug in the `UserSelect` component where the same user could appear multiple times in the dropdown due to offset-based pagination issues. The PR adds deduplication logic based on `userUuid` to ensure each user only appears once in the list, even when data changes between page fetches.

**Note:** Couldn't exactly reproduce this but this should ensure duplicates are not on the list, more of a defensive measure