### PR TITLE
fix: custom tooltip values when sql pivoting

### DIFF
--- a/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
@@ -1,0 +1,93 @@
+import { VizAggregationOptions } from '../types';
+import { translatePivotRef } from './tooltipFormatter';
+
+describe('translatePivotRef', () => {
+    const pivotValuesColumnsMap = {
+        orders_unique_order_count_any_completed: {
+            referenceField: 'orders_unique_order_count',
+            pivotColumnName: 'orders_unique_order_count_any_completed',
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    referenceField: 'orders_status',
+                    value: 'completed',
+                    formatted: 'completed',
+                },
+            ],
+        },
+        orders_unique_order_count_any_shipped: {
+            referenceField: 'orders_unique_order_count',
+            pivotColumnName: 'orders_unique_order_count_any_shipped',
+            aggregation: VizAggregationOptions.ANY,
+            pivotValues: [
+                {
+                    referenceField: 'orders_status',
+                    value: 'shipped',
+                    formatted: 'shipped',
+                },
+            ],
+        },
+    };
+
+    it('returns undefined when pivotValuesColumnsMap is undefined', () => {
+        expect(translatePivotRef('metric.dim.val', undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for invalid ref format (less than 3 parts)', () => {
+        expect(
+            translatePivotRef('metric', pivotValuesColumnsMap),
+        ).toBeUndefined();
+        expect(
+            translatePivotRef('metric.dim', pivotValuesColumnsMap),
+        ).toBeUndefined();
+    });
+
+    it('returns undefined for invalid ref format (even number of parts)', () => {
+        expect(
+            translatePivotRef('metric.dim.val.extra', pivotValuesColumnsMap),
+        ).toBeUndefined();
+    });
+
+    it('translates pivot ref to SQL pivot column name', () => {
+        expect(
+            translatePivotRef(
+                'orders_unique_order_count.orders_status.completed',
+                pivotValuesColumnsMap,
+            ),
+        ).toBe('orders_unique_order_count_any_completed');
+
+        expect(
+            translatePivotRef(
+                'orders_unique_order_count.orders_status.shipped',
+                pivotValuesColumnsMap,
+            ),
+        ).toBe('orders_unique_order_count_any_shipped');
+    });
+
+    it('returns undefined when metric does not match', () => {
+        expect(
+            translatePivotRef(
+                'unknown_metric.orders_status.completed',
+                pivotValuesColumnsMap,
+            ),
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when pivot value does not match', () => {
+        expect(
+            translatePivotRef(
+                'orders_unique_order_count.orders_status.pending',
+                pivotValuesColumnsMap,
+            ),
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when pivot dimension does not match', () => {
+        expect(
+            translatePivotRef(
+                'orders_unique_order_count.wrong_dimension.completed',
+                pivotValuesColumnsMap,
+            ),
+        ).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Relates to: [PROD-555](https://linear.app/lightdash/issue/PROD-555/i-want-custom-tooltips-to-handle-grouped-charts)

## Summary

Fixes custom tooltip variable references not rendering when `USE_SQL_PIVOT_RESULTS` flag is enabled (backend pivoting).

**Problem**: When using backend SQL pivoting, pivoted field references like `${orders_unique_order_count.orders_status.completed}` in custom tooltips would not render - they'd be replaced with empty strings.

**Root cause**: Naming convention mismatch between frontend and SQL pivot formats:

| Mode                      | Row Key Format             | Example                                             |
| ------------------------- | -------------------------- | --------------------------------------------------- |
| Frontend pivot (flag off) | `metric.dimension.value`   | `orders_unique_order_count.orders_status.completed` |
| SQL pivot (flag on)       | `metric_aggregation_value` | `orders_unique_order_count_any_completed`           |

The tooltip formatter did direct `row[ref]` lookups using the user's dot-separated reference, but SQL pivot rows use underscore-separated keys.

## Changes

-   Added `translatePivotRef()` helper in `tooltipFormatter.ts` that parses user references (`metric.dimension.value`) and finds the matching SQL pivot column name using `pivotValuesColumnsMap`
-   Applied translation fallback in both tuple mode (stacked charts) and dataset mode (regular charts)


![CleanShot 2026-01-16 at 19.38.47@2x.png](https://app.graphite.com/user-attachments/assets/ad76d98a-b394-4b88-96ad-a844551f303a.png)

