### PR TITLE
feat: detect login page redirects in screenshot service

### DIFF
--- a/packages/common/src/constants/screenshot.ts
+++ b/packages/common/src/constants/screenshot.ts
@@ -66,6 +66,17 @@ export const DASHBOARD_GRID_CLASS = 'react-grid-layout';
 export const ERROR_BOUNDARY_ID = 'lightdash-error-boundary';
 
 /**
+ * ID of the element rendered on the login page.
+ * The UnfurlService checks for this element to detect when authentication failed
+ * and the user was redirected to the login page instead of the requested content.
+ *
+ * Usage:
+ * - Frontend: Rendered by LoginLanding Card component
+ * - Backend: Checked by UnfurlService.saveScreenshot() to detect auth redirects
+ */
+export const LOGIN_PAGE_ID = 'lightdash-login-page';
+
+/**
  * CSS Selectors (with prefix for direct use in querySelector/CSS)
  */
 export const SCREENSHOT_SELECTORS = {
@@ -81,4 +92,6 @@ export const SCREENSHOT_SELECTORS = {
     DASHBOARD_GRID: `.${DASHBOARD_GRID_CLASS}`,
     /** ID selector: #lightdash-error-boundary */
     ERROR_BOUNDARY: `#${ERROR_BOUNDARY_ID}`,
+    /** ID selector: #lightdash-login-page */
+    LOGIN_PAGE: `#${LOGIN_PAGE_ID}`,
 } as const;

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -5,6 +5,7 @@ import {
     isOpenIdIdentityIssuerType,
     LightdashMode,
     LocalIssuerTypes,
+    LOGIN_PAGE_ID,
     SEED_ORG_1_ADMIN_EMAIL,
     SEED_ORG_1_ADMIN_PASSWORD,
     type OpenIdIdentityIssuerType,
@@ -67,8 +68,8 @@ const Login: FC<{}> = () => {
     const redirectUrl = location.state?.from
         ? `${location.state.from.pathname}${location.state.from.search}`
         : redirectParam
-        ? redirectParam
-        : '/';
+          ? redirectParam
+          : '/';
 
     const form = useForm<LoginParams>({
         initialValues: {
@@ -203,7 +204,7 @@ const Login: FC<{}> = () => {
             <Box mx="auto" my="lg">
                 <LightdashLogo />
             </Box>
-            <Card p="xl" radius="xs" withBorder shadow="xs">
+            <Card id={LOGIN_PAGE_ID} p="xl" radius="xs" withBorder shadow="xs">
                 <Title order={3} ta="center" mb="md">
                     Sign in
                 </Title>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19506

### Description:
Improved error detection in UnfurlService by adding login page detection to catch authentication failures during screenshot generation. 

The PR refactors the error detection logic in the screenshot service to:
1. Check for both error boundaries and login page redirects
2. Provide more specific error messages when authentication fails
3. Add a unique ID to the login page component for reliable detection

This enhancement helps diagnose issues where users are unexpectedly redirected to the login page instead of seeing their requested content in screenshots.