### PR TITLE
fix: support referencing a grouped metric

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -135,6 +135,9 @@ export const Legend: FC<Props> = ({ items }) => {
         const fieldSet = allEncodes.reduce<Set<string>>((acc, encode) => {
             acc.add(encode.xRef.field);
             if (encode.yRef.pivotValues !== undefined) {
+                // Add the simple metric name for convenience
+                acc.add(encode.yRef.field);
+                // Add the full pivot reference format
                 encode.yRef.pivotValues.forEach((pivotValue) => {
                     acc.add(
                         `${encode.yRef.field}.${pivotValue.field}.${pivotValue.value}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-555](https://linear.app/lightdash/issue/PROD-555/i-want-custom-tooltips-to-handle-grouped-charts)

### Description:

Improves tooltip and legend support for pivoted metrics by allowing users to reference metrics with a simpler syntax

- Adds support for referencing simple metric names (e.g., ${orders_amount_running_total}) in custom tooltip templates for pivoted charts
- Previously users had to use the full pivot path format (e.g., ${orders_amount_running_total.orders_status.completed})
- The simple reference automatically resolves to the correct pivot value based on the hovered series
- Works for both SQL pivot and legacy pivot modes
- Autocomplete suggestions now include simple metric names for pivoted charts

**Tested with both legacy and sql pivoting**
![CleanShot 2026-01-16 at 17.45.04.png](https://app.graphite.com/user-attachments/assets/81079aed-aa9b-401f-bda5-0877a5f17781.png)