### PR TITLE
chore: drop docker compose version hint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
     minio:
         image: coollabsio/minio:latest

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 volumes:
     node_modules:
 

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 volumes:
     node_modules:
 

--- a/examples/full-jaffle-shop-demo/dbt/docker/docker-compose.yml
+++ b/examples/full-jaffle-shop-demo/dbt/docker/docker-compose.yml
@@ -1,16 +1,15 @@
-version: "3.9"
 services:
-  dbt:
-    image: fishtownanalytics/dbt:0.21.0
-    depends_on:
-      - postgres
-    volumes:
-      - "..:/usr/app"
-    entrypoint: /usr/app/docker/entrypoint.sh
-  postgres:
-    image: postgres
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: password
-    ports:
-      - "5432:5432"
+    dbt:
+        image: fishtownanalytics/dbt:0.21.0
+        depends_on:
+            - postgres
+        volumes:
+            - '..:/usr/app'
+        entrypoint: /usr/app/docker/entrypoint.sh
+    postgres:
+        image: postgres
+        restart: always
+        environment:
+            POSTGRES_PASSWORD: password
+        ports:
+            - '5432:5432'

--- a/examples/full-jaffle-shop-demo/docker-compose.yml
+++ b/examples/full-jaffle-shop-demo/docker-compose.yml
@@ -1,29 +1,28 @@
-version: "3.8"
 services:
-  lightdash:
-    build:
-      context: .
-      dockerfile: dockerfile
-    depends_on: 
-      - db
-    environment:
-      - PGHOST=db
-      - PGPASSWORD=password
-      - PGUSER=postgres
-      - PGPORT=5432
-      - PGDATABASE=postgres
-      - SECURE_COOKIES=false
-      - TRUST_PROXY=false
-      - LIGHTDASH_SECRET='not very secret'
+    lightdash:
+        build:
+            context: .
+            dockerfile: dockerfile
+        depends_on:
+            - db
+        environment:
+            - PGHOST=db
+            - PGPASSWORD=password
+            - PGUSER=postgres
+            - PGPORT=5432
+            - PGDATABASE=postgres
+            - SECURE_COOKIES=false
+            - TRUST_PROXY=false
+            - LIGHTDASH_SECRET='not very secret'
 
-    volumes:
-      - "./profiles:/usr/app/profiles"
-      - "./dbt:/usr/app/dbt"
-    ports:
-      - 8080:8080
+        volumes:
+            - './profiles:/usr/app/profiles'
+            - './dbt:/usr/app/dbt'
+        ports:
+            - 8080:8080
 
-  db:
-    image: postgres
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: password
+    db:
+        image: postgres
+        restart: always
+        environment:
+            POSTGRES_PASSWORD: password


### PR DESCRIPTION
### Description:
Fixes warning:

> [!WARNING] 
> WARN[0000] /.../docker/docker-compose.dev.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
...

Explanation: the `version` field has been obsolete for years at this point: https://docs.docker.com/reference/compose-file/version-and-name/

Given that we were pinning version 3.x, I'd assume it's safe to assume that everyone using these docker compose files is using a supported docker compose version (1.27+ from 2020).
