### PR TITLE
feat: process Slack messages after OAuth authentication completes

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7283,11 +7283,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7783,11 +7783,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7802,11 +7802,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7821,11 +7821,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7840,11 +7840,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7859,11 +7859,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8158,6 +8158,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]

--- a/packages/backend/src/models/OpenIdIdentitiesModel.ts
+++ b/packages/backend/src/models/OpenIdIdentitiesModel.ts
@@ -235,4 +235,19 @@ export class OpenIdIdentityModel {
             .where('user_id', user.user_id)
             .delete();
     }
+
+    async findIdentityByUserUuid(
+        userUuid: string,
+        issuerType: OpenIdIdentityIssuerType,
+    ): Promise<OpenIdIdentity | null> {
+        const [identity] = await this.getOpenIdQueryBuilder()
+            .where('users.user_uuid', userUuid)
+            .andWhere('issuer_type', issuerType);
+
+        if (!identity) {
+            return null;
+        }
+
+        return OpenIdIdentityModel._parseDbIdentity(identity);
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19527  
  
Description:

Improves the Slack OAuth flow for AI Agent by automatically processing the original message after authentication completes. This enhancement:

1. Stores response URLs in a temporary cache to update the ephemeral "Redirected to Lightdash..." message
2. Adds a new `processPendingSlackMessage` method to handle the original query after OAuth completes
3. Encodes message context in button action IDs to maintain context through the OAuth flow
4. Shows a success message after authentication and automatically processes the original query
5. Cleans up ephemeral messages after successful authentication

This creates a much smoother user experience as users no longer need to re-type their query after authenticating.