### PR TITLE
fix: preserve query params in Slack auth redirect

### DIFF
--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -185,7 +185,11 @@ apiV1Router.get(
         if (req.user?.userUuid) {
             return next();
         }
-        return res.redirect('/login?redirect=/api/v1/auth/slack');
+        // Preserve query params (team, channel, message, thread_ts) in redirect
+        const redirectPath = req.originalUrl;
+        return res.redirect(
+            `/login?redirect=${encodeURIComponent(redirectPath)}`,
+        );
     },
     storeSlackContext,
     passport.authenticate('slack'),


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19528  
  
Description:

Preserve query parameters when redirecting to login from Slack authentication. This ensures that important context like team, channel, message, and thread_ts are maintained after the user completes the login flow.