### PR TITLE
chore: introduce lightdash visualization / visualization provider to v2 spotlight

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -1,22 +1,11 @@
-import {
-    MetricExplorerComparison,
-    getDefaultDateRangeFromInterval,
-    isDimension,
-    type CatalogField,
-    type FilterRule,
-    type MetricExplorerDateRange,
-    type MetricExplorerQuery,
-    type TimeDimensionConfig,
-} from '@lightdash/common';
+import { ECHARTS_DEFAULT_COLORS, type CatalogField } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
-    Center,
-    Divider,
     Group,
     Kbd,
+    LoadingOverlay,
     Modal,
-    Stack,
     Text,
     Tooltip,
     type ModalProps,
@@ -27,38 +16,31 @@ import {
     IconChevronUp,
     IconInfoCircle,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
-import useTracking from '../../../providers/Tracking/useTracking';
-import { EventName } from '../../../types/Events';
+import LightdashVisualization from '../../../components/LightdashVisualization';
+import VisualizationProvider from '../../../components/LightdashVisualization/VisualizationProvider';
+import MetricQueryDataProvider from '../../../components/MetricQueryData/MetricQueryDataProvider';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
-import { useMetric } from '../hooks/useMetricsCatalog';
-import { useRunMetricExplorerQuery } from '../hooks/useRunMetricExplorerQuery';
+import { useMetricVisualization } from '../hooks/useMetricVisualization';
 
 type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
     metrics: CatalogField[];
 };
 
 /**
- * V2: New MetricExploreModal implementation using echarts via VisualizationProvider
+ * V2: MetricExploreModal implementation using echarts via VisualizationProvider
  * This is enabled when the MetricsCatalogEchartsVisualization feature flag is ON
- *
- * TODO: Replace placeholder visualization with VisualizationProvider + LightdashVisualization
  */
 export const MetricExploreModalV2: FC<Props> = ({
     opened,
     onClose,
     metrics,
 }) => {
-    const { track } = useTracking();
+    const { data: organization } = useOrganization();
 
-    const userUuid = useAppSelector(
-        (state) => state.metricsCatalog.user?.userUuid,
-    );
-    const organizationUuid = useAppSelector(
-        (state) => state.metricsCatalog.organizationUuid,
-    );
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
@@ -70,249 +52,73 @@ export const MetricExploreModalV2: FC<Props> = ({
 
     const navigate = useNavigate();
     const location = useLocation();
-    const [query, setQuery] = useState<MetricExplorerQuery>({
-        comparison: MetricExplorerComparison.NONE,
-        segmentDimension: null,
-    });
 
-    const [dateRange, setDateRange] = useState<MetricExplorerDateRange | null>(
-        null,
+    // Color palette from organization settings
+    const colorPalette = useMemo(
+        () => organization?.chartColors ?? ECHARTS_DEFAULT_COLORS,
+        [organization?.chartColors],
     );
-    const [timeDimensionOverride, setTimeDimensionOverride] = useState<
-        TimeDimensionConfig | undefined
-    >();
-    const [filter, setFilter] = useState<FilterRule | undefined>(undefined);
 
-    const resetQueryState = useCallback(() => {
-        setQuery({
-            comparison: MetricExplorerComparison.NONE,
-            segmentDimension: null,
-        });
-        setTimeDimensionOverride(undefined);
-        setDateRange(null);
-        setFilter(undefined);
-    }, [setQuery, setTimeDimensionOverride, setDateRange]);
+    // Metric navigation logic
+    const currentMetricIndex = useMemo(
+        () =>
+            metrics.findIndex(
+                (metric) =>
+                    metric.name === metricName &&
+                    metric.tableName === tableName,
+            ),
+        [metrics, metricName, tableName],
+    );
 
-    const currentMetricIndex = useMemo(() => {
-        return metrics.findIndex(
-            (metric) =>
-                metric.name === metricName && metric.tableName === tableName,
-        );
-    }, [metrics, metricName, tableName]);
-
-    const nextMetricInList = useMemo(() => {
-        return metrics[currentMetricIndex + 1];
-    }, [currentMetricIndex, metrics]);
-
-    const previousMetricInList = useMemo(() => {
-        return metrics[currentMetricIndex - 1];
-    }, [currentMetricIndex, metrics]);
+    const nextMetricInList = metrics[currentMetricIndex + 1];
+    const previousMetricInList = metrics[currentMetricIndex - 1];
 
     const navigateToMetric = useCallback(
         (metric: CatalogField) => {
-            resetQueryState();
-
             void navigate({
                 pathname: `/projects/${projectUuid}/metrics/peek/${metric.tableName}/${metric.name}`,
                 search: location.search,
             });
         },
-        [navigate, projectUuid, resetQueryState, location.search],
+        [navigate, projectUuid, location.search],
     );
 
     const handleGoToNextMetric = useCallback(() => {
-        if (nextMetricInList) {
-            navigateToMetric(nextMetricInList);
-        }
+        if (nextMetricInList) navigateToMetric(nextMetricInList);
     }, [navigateToMetric, nextMetricInList]);
 
     const handleGoToPreviousMetric = useCallback(() => {
-        if (previousMetricInList) {
-            navigateToMetric(previousMetricInList);
-        }
+        if (previousMetricInList) navigateToMetric(previousMetricInList);
     }, [navigateToMetric, previousMetricInList]);
-
-    const metricQuery = useMetric({
-        projectUuid,
-        tableName,
-        metricName,
-    });
-
-    const queryHasEmptyMetric = useMemo(() => {
-        return (
-            query.comparison === MetricExplorerComparison.DIFFERENT_METRIC &&
-            query.metric.name === '' &&
-            query.metric.table === ''
-        );
-    }, [query]);
-
-    const isQueryEnabled =
-        (!!projectUuid &&
-            !!tableName &&
-            !!metricName &&
-            !!query &&
-            !!dateRange &&
-            (query.comparison !== MetricExplorerComparison.DIFFERENT_METRIC ||
-                (query.comparison ===
-                    MetricExplorerComparison.DIFFERENT_METRIC &&
-                    query.metric.name !== '' &&
-                    query.metric.table !== ''))) ||
-        queryHasEmptyMetric;
-
-    const metricResultsQuery = useRunMetricExplorerQuery(
-        {
-            projectUuid,
-            exploreName: tableName,
-            metricName,
-            dateRange: dateRange ?? undefined,
-            query: queryHasEmptyMetric
-                ? {
-                      comparison: MetricExplorerComparison.NONE,
-                      segmentDimension: null,
-                  }
-                : query,
-            timeDimensionOverride,
-            filter,
-        },
-        {
-            enabled: isQueryEnabled,
-            keepPreviousData: true,
-        },
-    );
-
-    const timeDimensionBaseField: TimeDimensionConfig | undefined =
-        useMemo(() => {
-            const timeDimensionField = Object.entries(
-                metricResultsQuery.data?.fields ?? {},
-            ).find(
-                ([_, field]) => 'timeInterval' in field && isDimension(field),
-            )?.[1];
-
-            if (
-                !isDimension(timeDimensionField) ||
-                !timeDimensionField.timeInterval ||
-                !timeDimensionField.timeIntervalBaseDimensionName
-            )
-                return undefined;
-
-            return {
-                field: timeDimensionField.timeIntervalBaseDimensionName,
-                interval: timeDimensionField.timeInterval,
-                table: timeDimensionField.table,
-            };
-        }, [metricResultsQuery.data?.fields]);
-
-    useEffect(
-        function setInitialDateRange() {
-            if (metricQuery.isSuccess && !dateRange) {
-                const timeDimension = metricQuery.data?.timeDimension;
-                if (timeDimension) {
-                    setDateRange(
-                        getDefaultDateRangeFromInterval(timeDimension.interval),
-                    );
-                }
-            }
-        },
-        [metricQuery.isSuccess, metricQuery.data, dateRange],
-    );
-
-    useEffect(
-        function handleTimeDimensionChange() {
-            if (
-                timeDimensionOverride &&
-                timeDimensionOverride.interval !==
-                    timeDimensionBaseField?.interval &&
-                !dateRange
-            ) {
-                setDateRange(
-                    getDefaultDateRangeFromInterval(
-                        timeDimensionOverride.interval,
-                    ),
-                );
-            }
-        },
-        [timeDimensionOverride, timeDimensionBaseField, dateRange, track],
-    );
 
     const handleClose = useCallback(() => {
         void navigate({
             pathname: `/projects/${projectUuid}/metrics`,
             search: location.search,
         });
-
-        resetQueryState();
-
         onClose();
-    }, [navigate, onClose, projectUuid, resetQueryState, location.search]);
+    }, [navigate, onClose, projectUuid, location.search]);
 
-    useEffect(() => {
-        if (timeDimensionOverride) {
-            track({
-                name: EventName.METRICS_CATALOG_EXPLORE_TIME_DIMENSION_OVERRIDE_APPLIED,
-                properties: {
-                    userId: userUuid,
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
-                    metricName,
-                    tableName,
-                },
-            });
-        }
-    }, [
-        timeDimensionOverride,
-        organizationUuid,
+    // All data fetching, query execution, and config building in one hook
+    const {
+        metricField,
+        explore,
+        metricQuery,
+        chartConfig,
+        resultsData,
+        columnOrder,
+        isLoading,
+        hasData,
+    } = useMetricVisualization({
         projectUuid,
-        metricName,
         tableName,
-        track,
-        userUuid,
-    ]);
-
-    useEffect(() => {
-        if (query.comparison === MetricExplorerComparison.PREVIOUS_PERIOD) {
-            track({
-                name: EventName.METRICS_CATALOG_EXPLORE_COMPARE_LAST_PERIOD,
-                properties: {
-                    userId: userUuid,
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
-                    metricName,
-                    tableName,
-                },
-            });
-        }
-
-        if (
-            !queryHasEmptyMetric &&
-            query.comparison === MetricExplorerComparison.DIFFERENT_METRIC
-        ) {
-            track({
-                name: EventName.METRICS_CATALOG_EXPLORE_COMPARE_ANOTHER_METRIC,
-                properties: {
-                    userId: userUuid,
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
-                    metricName,
-                    tableName,
-                    compareMetricName: query.metric.name,
-                    compareTableName: query.metric.table,
-                },
-            });
-        }
-    }, [
-        query,
-        organizationUuid,
-        projectUuid,
         metricName,
-        tableName,
-        track,
-        queryHasEmptyMetric,
-        userUuid,
-    ]);
+    });
 
+    // Keyboard navigation
     useHotkeys([
-        ['ArrowUp', () => handleGoToPreviousMetric()],
-        ['ArrowDown', () => handleGoToNextMetric()],
+        ['ArrowUp', handleGoToPreviousMetric],
+        ['ArrowDown', handleGoToNextMetric],
     ]);
 
     return (
@@ -399,11 +205,11 @@ export const MetricExploreModalV2: FC<Props> = ({
                             </Tooltip>
                         </Group>
                         <Text fw={600} fz="md" color="ldGray.8">
-                            {metricQuery.data?.label}
+                            {metricField?.label}
                         </Text>
                         <Tooltip
-                            label={metricQuery.data?.description}
-                            disabled={!metricQuery.data?.description}
+                            label={metricField?.description}
+                            disabled={!metricField?.description}
                         >
                             <MantineIcon
                                 color="ldGray.5"
@@ -422,28 +228,29 @@ export const MetricExploreModalV2: FC<Props> = ({
                     miw={800}
                     mih={600}
                 >
-                    <Divider orientation="vertical" color="ldGray.2" />
-
-                    {/* TODO: Replace with VisualizationProvider + LightdashVisualization */}
-                    <Box w="100%" py="xl" px="xxl">
-                        <Center
-                            h="100%"
-                            sx={(theme) => ({
-                                backgroundColor: theme.colors.ldGray[0],
-                                borderRadius: theme.radius.md,
-                                border: `2px dashed ${theme.colors.ldGray[3]}`,
-                            })}
-                        >
-                            <Stack align="center" spacing="xs">
-                                <Text c="ldGray.5" fw={500} fz="lg">
-                                    V2 Visualization Placeholder
-                                </Text>
-                                <Text c="ldGray.4" fz="sm">
-                                    ECharts via VisualizationProvider coming
-                                    soon
-                                </Text>
-                            </Stack>
-                        </Center>
+                    <Box w="100%" py="xl" px="xxl" pos="relative">
+                        <LoadingOverlay visible={isLoading} />
+                        {hasData && metricQuery && tableName && explore && (
+                            <MetricQueryDataProvider
+                                metricQuery={metricQuery}
+                                tableName={tableName}
+                                explore={explore}
+                            >
+                                <VisualizationProvider
+                                    resultsData={resultsData}
+                                    chartConfig={chartConfig}
+                                    columnOrder={columnOrder}
+                                    initialPivotDimensions={undefined}
+                                    colorPalette={colorPalette}
+                                    isLoading={isLoading}
+                                    onSeriesContextMenu={undefined}
+                                    onChartConfigChange={undefined}
+                                    pivotTableMaxColumnLimit={60}
+                                >
+                                    <LightdashVisualization />
+                                </VisualizationProvider>
+                            </MetricQueryDataProvider>
+                        )}
                     </Box>
                 </Modal.Body>
             </Modal.Content>

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
@@ -1,0 +1,216 @@
+import {
+    CartesianSeriesType,
+    ChartType,
+    getFieldIdForDateDimension,
+    getItemId,
+    type ApiError,
+    type ChartConfig,
+    type MetricQuery,
+    type MetricWithAssociatedTimeDimension,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import { type VisualizationProviderProps } from '../../../components/LightdashVisualization/VisualizationProvider';
+import { type MetricQueryDataContext } from '../../../components/MetricQueryData/context';
+import { useExplore } from '../../../hooks/useExplore';
+import { type QueryResultsProps } from '../../../hooks/useQueryResults';
+import { useQueryExecutor } from '../../../providers/Explorer/useQueryExecutor';
+import { useMetric } from './useMetricsCatalog';
+
+
+const buildMetricQueryFromField = (
+    field: MetricWithAssociatedTimeDimension,
+): MetricQuery => {
+    const timeDimensionConfig = field.timeDimension;
+    const timeDimensionName =
+        timeDimensionConfig?.field && timeDimensionConfig.interval
+        ? getFieldIdForDateDimension(
+              timeDimensionConfig.field,
+              timeDimensionConfig.interval,
+          )
+        : undefined;
+    const timeDimensionFieldId =
+        timeDimensionConfig && timeDimensionName
+            ? getItemId({
+                  name: timeDimensionName,
+                  table: timeDimensionConfig.table,
+              })
+            : undefined;
+    return {
+        exploreName: field.table,
+        dimensions: timeDimensionFieldId ? [timeDimensionFieldId] : [],
+        metrics: [getItemId(field)],
+        filters: {},
+        sorts: [],
+        limit: 5000,
+        tableCalculations: [],
+        // TODO: implement period over period
+        // ...(timeDimensionConfig && timeDimensionName
+        //     ? {
+        //           periodOverPeriod: {
+        //               type: 'previousPeriod',
+        //               granularity: TimeFrames.MONTH,
+        //               periodOffset: 12,
+        //               field: {
+        //                   name: timeDimensionName,
+        //                   table: timeDimensionConfig.table,
+        //               },
+        //           },
+        //       }
+        //     : {}),
+    };
+};
+
+/**
+ * Builds a line chart configuration for a single metric over time
+ */
+const buildLineChartConfig = (
+    metricQuery: MetricQuery,
+    metricLabel: string,
+): ChartConfig => {
+    const timeDimensionFieldId = metricQuery.dimensions[0];
+    const metricFieldId = metricQuery.metrics[0];
+
+    return {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: {
+                xField: timeDimensionFieldId,
+                yField: [metricFieldId],
+            },
+            eChartsConfig: {
+                series: [
+                    {
+                        encode: {
+                            xRef: { field: timeDimensionFieldId },
+                            yRef: { field: metricFieldId },
+                        },
+                        type: CartesianSeriesType.LINE,
+                        name: metricLabel,
+                    },
+                ],
+            },
+        },
+    };
+};
+
+export type MetricVisualizationResult = {
+    metricField: MetricWithAssociatedTimeDimension | undefined;
+    explore: MetricQueryDataContext['explore'];
+
+    metricQuery: MetricQueryDataContext['metricQuery'];
+
+    chartConfig: VisualizationProviderProps['chartConfig'];
+    resultsData: VisualizationProviderProps['resultsData'];
+    columnOrder: VisualizationProviderProps['columnOrder'];
+
+    hasData: boolean;
+    isLoading: VisualizationProviderProps['isLoading'];
+    error: ApiError | null;
+};
+
+type UseMetricVisualizationProps = {
+    projectUuid: string | undefined;
+    tableName: string | undefined;
+    metricName: string | undefined;
+};
+
+/**
+ * Hook that fetches metric data, executes the query, and builds visualization config
+ *
+ * This is the single source of truth for MetricExploreModalV2's data layer:
+ * 1. Fetches metric field metadata
+ * 2. Fetches explore schema (for ItemsMap)
+ * 3. Builds and executes MetricQuery
+ * 4. Returns everything VisualizationProvider needs
+ */
+export function useMetricVisualization({
+    projectUuid,
+    tableName,
+    metricName,
+}: UseMetricVisualizationProps): MetricVisualizationResult {
+    // 1. Fetch metric field metadata
+    const metricFieldQuery = useMetric({
+        projectUuid,
+        tableName,
+        metricName,
+    });
+
+    // 2. Fetch explore schema (needed for ItemsMap with proper field types)
+    const exploreQuery = useExplore(tableName);
+
+    // 3. Build MetricQuery & Start executing
+    const metricQuery = useMemo(() => {
+        if (!metricFieldQuery.data) return undefined;
+        return buildMetricQueryFromField(metricFieldQuery.data);
+    }, [metricFieldQuery.data]);
+
+    const queryArgs = useMemo<QueryResultsProps | null>(() => {
+        if (!projectUuid || !tableName || !metricQuery) return null;
+        return {
+            projectUuid,
+            tableId: tableName,
+            query: metricQuery,
+        };
+    }, [projectUuid, tableName, metricQuery]);
+
+    const [{ query: createQuery, queryResults }] = useQueryExecutor(
+        queryArgs,
+        [], // no missing parameters
+        !!queryArgs,
+    );
+
+    // 4. Build properties for VisualizationProvider
+    const chartConfig = useMemo<ChartConfig>(() => {
+        if (!metricQuery || !metricFieldQuery.data) {
+            return { type: ChartType.CARTESIAN, config: undefined };
+        }
+        return buildLineChartConfig(metricQuery, metricFieldQuery.data.label);
+    }, [metricQuery, metricFieldQuery.data]);
+
+    const resultsData = useMemo(
+        () => ({
+            ...queryResults,
+            metricQuery: createQuery.data?.metricQuery,
+            fields: createQuery.data?.fields ?? {},
+        }),
+        [queryResults, createQuery.data?.metricQuery, createQuery.data?.fields],
+    );
+
+    const columnOrder = useMemo(() => {
+        if (!metricQuery) return [];
+        return [...metricQuery.dimensions, ...metricQuery.metrics];
+    }, [metricQuery]);
+
+    const isLoading =
+        metricFieldQuery.isLoading ||
+        exploreQuery.isLoading ||
+        createQuery.isFetching ||
+        queryResults.isFetchingFirstPage;
+
+    const hasData = Boolean(
+        tableName &&
+            exploreQuery.data &&
+            metricQuery &&
+            createQuery.data?.fields &&
+            queryResults.rows.length > 0,
+    );
+
+    const error =
+        metricFieldQuery.error ||
+        exploreQuery.error ||
+        createQuery.error ||
+        queryResults.error ||
+        null;
+
+    return {
+        metricField: metricFieldQuery.data,
+        explore: exploreQuery.data,
+        metricQuery,
+        chartConfig,
+        resultsData,
+        columnOrder,
+        isLoading,
+        hasData,
+        error,
+    };
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [PROD-2536: Metrics Explorer (mini): Add 'Open in Explorer' and 'Save chart' flows](https://linear.app/lightdash/issue/PROD-2536/metrics-explorer-mini-add-open-in-explorer-and-save-chart-flows)


### Description:
Implements the visualization component for the Metrics Catalog Explorer modal. This PR replaces the placeholder visualization with a functional ECharts implementation using VisualizationProvider and LightdashVisualization components.

Key changes:
- Created a new `useMetricVisualization` hook that handles all data fetching, query execution, and chart configuration
- Integrated the visualization with the organization's color palette settings
- Added proper loading states and data handling
- Simplified the modal component by moving complex logic to the dedicated hook
- Implemented a line chart visualization that shows metrics over time

