### PR TITLE
chore: pass context metrics explorer to query execution

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
@@ -3,6 +3,7 @@ import {
     ChartType,
     getFieldIdForDateDimension,
     getItemId,
+    QueryExecutionContext,
     type ApiError,
     type ChartConfig,
     type MetricQuery,
@@ -165,6 +166,7 @@ export function useMetricVisualization({
             projectUuid,
             tableId: tableName,
             query: metricQuery,
+            context: QueryExecutionContext.METRICS_EXPLORER,
         };
     }, [projectUuid, tableName, metricQuery]);
 

--- a/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
+++ b/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
@@ -6,6 +6,7 @@ import {
     type FieldId,
     type MetricQuery,
     type ParametersValuesMap,
+    type QueryExecutionContext,
     type SavedChartDAO,
 } from '@lightdash/common';
 import type { QueryResultsProps } from '../useQueryResults';
@@ -26,7 +27,7 @@ export function buildQueryArgs(options: {
     parameters: ParametersValuesMap | undefined;
     isEditMode: boolean;
     viewModeQueryArgs?:
-        | { chartUuid: string; context?: string }
+        | { chartUuid: string; context?: QueryExecutionContext }
         | { chartUuid: string; chartVersionUuid: string };
     dateZoomGranularity?: DateGranularity;
     minimal: boolean;

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -39,7 +39,7 @@ export type QueryResultsProps = {
     chartUuid?: string;
     chartVersionUuid?: string;
     dateZoomGranularity?: DateGranularity;
-    context?: string;
+    context?: QueryExecutionContext;
     invalidateCache?: boolean;
     parameters?: ParametersValuesMap;
     pivotConfiguration?: PivotConfiguration;
@@ -150,7 +150,7 @@ const executeAsyncQuery = (
         return executeAsyncMetricQuery(
             data.projectUuid,
             {
-                context: QueryExecutionContext.EXPLORE,
+                context: data.context ?? QueryExecutionContext.EXPLORE,
                 query: {
                     ...data.query,
                     limit: queryLimit,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [PROD-2536: Metrics Explorer (mini): Add 'Open in Explorer' and 'Save chart' flows](https://linear.app/lightdash/issue/PROD-2536/metrics-explorer-mini-add-open-in-explorer-and-save-chart-flows)

### Description:
Added support for passing the `QueryExecutionContext.METRICS_EXPLORER` context when executing metric queries from the metrics catalog. This ensures that queries from the metrics explorer are properly identified in the system, distinguishing them from regular explore queries.

The PR updates the context parameter type from `string` to the more specific `QueryExecutionContext` enum type across multiple files for better type safety.
