### PR TITLE
style: migrate to mantine 8 and add coming-soon-features

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.module.css
@@ -1,0 +1,43 @@
+/* MetricExploreModalV2.module.css */
+
+.modalContent {
+    overflow: hidden;
+}
+
+.modalHeader {
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
+}
+
+.kbd {
+    background: #575656;
+    color: white;
+    border-radius: 5px;
+    border: 1px solid #2b2b2a;
+}
+
+.navActionIcon {
+    border: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.modalBody {
+    display: flex;
+    flex: 1;
+}
+
+.sidebarContainer {
+    position: relative;
+}
+
+.disabledOverlay {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.clearButton {
+    visibility: hidden;
+}
+
+.clearButton:hover {
+    background-color: var(--mantine-color-ldGray-1);
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [PROD-2536: Metrics Explorer (mini): Add 'Open in Explorer' and 'Save chart' flows](https://linear.app/lightdash/issue/PROD-2536/metrics-explorer-mini-add-open-in-explorer-and-save-chart-flows)


### Description:
Implemented a new sidebar UI for the MetricExploreModalV2 component with filtering, segmentation, and comparison capabilities. The sidebar is currently disabled but visually present with a "Coming soon" tooltip overlay. 

Added new components:
- MetricExploreFilter
- MetricExploreSegmentationPicker
- MetricExploreComparisonSection

Created a dedicated CSS module for styling the modal with proper spacing, borders, and hover states. The modal now has a three-panel layout with navigation controls and improved keyboard shortcuts.
