### PR TITLE
fix: Metrics Catalog category filter dropdown missing existing categories

### DIFF
--- a/packages/backend/src/database/entities/tags.ts
+++ b/packages/backend/src/database/entities/tags.ts
@@ -27,16 +27,18 @@ export type TagsTable = Knex.CompositeTableType<DbTag, DbTagIn, DbTagUpdate>;
 
 export const TagsTableName = 'tags';
 
-export const convertTagRow = (tag: DbTag & DbUser): Tag => ({
+export const convertTagRow = (tag: DbTag & Partial<DbUser>): Tag => ({
     tagUuid: tag.tag_uuid,
     projectUuid: tag.project_uuid,
     name: tag.name,
     color: tag.color,
     createdAt: tag.created_at,
     yamlReference: tag.yaml_reference,
-    createdBy: {
-        userUuid: tag.user_uuid,
-        firstName: tag.first_name,
-        lastName: tag.last_name,
-    },
+    createdBy: tag.user_uuid
+        ? {
+              userUuid: tag.user_uuid,
+              firstName: tag.first_name ?? '',
+              lastName: tag.last_name ?? '',
+          }
+        : null,
 });

--- a/packages/backend/src/models/TagsModel.ts
+++ b/packages/backend/src/models/TagsModel.ts
@@ -36,7 +36,7 @@ export class TagsModel {
 
     async get(tagUuid: string): Promise<Tag | undefined> {
         const tag = await this.database(TagsTableName)
-            .join(
+            .leftJoin(
                 UserTableName,
                 `${TagsTableName}.created_by_user_uuid`,
                 `${UserTableName}.user_uuid`,
@@ -48,7 +48,7 @@ export class TagsModel {
 
     async list(projectUuid: string): Promise<Tag[]> {
         const tags = await this.database(TagsTableName)
-            .join(
+            .leftJoin(
                 UserTableName,
                 `${TagsTableName}.created_by_user_uuid`,
                 `${UserTableName}.user_uuid`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2528: Metrics Catalog: Category filter dropdown missing existing categories](https://linear.app/lightdash/issue/PROD-2528/metrics-catalog-category-filter-dropdown-missing-existing-categories)
