### PR TITLE
fix: change catalog field filtering from whereIn to unnest arrays

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -890,14 +890,16 @@ export class CatalogModel {
                 catalogItemsQuery = catalogItemsQuery.andWhere(
                     function allowedFieldsFiltering() {
                         if (allowedFields.length > 0) {
-                            // Use PostgreSQL's row comparison: (table_name, name) IN (VALUES ...)
-                            // This allows fields from joined tables to be found even if they're indexed
-                            // under a different cached_explore_uuid than the primary explore
+                            // Use unnest with two arrays to avoid creating thousands of bind parameters
+                            // This is much more efficient than VALUES (?, ?), (?, ?), ...
+                            const tableNames = allowedFields.map(([t]) => t);
+                            const fieldNames = allowedFields.map(([, n]) => n);
+
                             void this.whereRaw(
-                                `(${CatalogTableName}.table_name, ${CatalogTableName}.name) IN (VALUES ${allowedFields
-                                    .map(() => '(?, ?)')
-                                    .join(', ')})`,
-                                allowedFields.flat(),
+                                `(${CatalogTableName}.table_name, ${CatalogTableName}.name) IN (
+                                    SELECT * FROM unnest(?::text[], ?::text[]) AS t(table_name, field_name)
+                                )`,
+                                [tableNames, fieldNames],
                             );
                         } else {
                             // No fields allowed, return no results


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2259](https://linear.app/lightdash/issue/PROD-2259/sql-error-when-counting-usage-for-spotlight-metrics)

Sentry Issue: [LIGHTDASH-BACKEND-B5D](https://lightdash.sentry.io/issues/7038967902/?referrer=Linear)

### Description:

Optimizes SQL query performance in the CatalogModel by replacing the VALUES clause with PostgreSQL's `unnest` function when filtering allowed fields. This approach significantly reduces the number of bind parameters, making the query more efficient when dealing with large numbers of fields.