### PR TITLE
fix: Metric catalog explore name tooltip cut-off on hover

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -253,6 +253,7 @@ export const MetricsCatalogColumnName = forwardRef<HTMLDivElement, Props>(
                         openDelay={300}
                         maw={250}
                         fz="xs"
+                        withinPortal
                     >
                         <Highlight
                             highlight={table.getState().globalFilter || ''}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added `withinPortal` prop to the Tooltip component in MetricsCatalogColumnName to ensure tooltips are properly rendered within a portal. This prevents tooltip positioning issues when they appear inside containers with `overflow: hidden` or other CSS that might clip the tooltip content.
