### PR TITLE
feat: add AND/OR filter mode for metric catalog categories

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -13,6 +13,7 @@ import {
     type ApiMetricsWithAssociatedTimeDimensionResponse,
     type ApiSort,
     type ApiSuccessEmpty,
+    type CatalogCategoryFilterMode,
     type CatalogItemIcon,
     type KnexPaginateArgs,
 } from '@lightdash/common';
@@ -194,6 +195,7 @@ export class CatalogController extends BaseController {
         @Query() sort?: ApiSort['sort'],
         @Query() order?: ApiSort['order'],
         @Query() categories?: ApiCatalogSearch['catalogTags'],
+        @Query() categoriesFilterMode?: CatalogCategoryFilterMode,
         @Query() tables?: ApiCatalogSearch['tables'],
     ): Promise<ApiMetricsCatalog> {
         this.setStatus(200);
@@ -223,6 +225,7 @@ export class CatalogController extends BaseController {
                 {
                     searchQuery: search,
                     catalogTags: categories,
+                    catalogTagsFilterMode: categoriesFilterMode,
                     tables,
                 },
                 sortArgs,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7866,11 +7866,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -21525,6 +21525,11 @@ const models: TsoaRoute.Models = {
             ],
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CatalogCategoryFilterMode: {
+        dataType: 'refEnum',
+        enums: ['and', 'or'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiGetMetricPeek: {
@@ -44153,6 +44158,11 @@ export function RegisterRoutes(app: Router) {
             name: 'categories',
             dataType: 'array',
             array: { dataType: 'string' },
+        },
+        categoriesFilterMode: {
+            in: 'query',
+            name: 'categoriesFilterMode',
+            ref: 'CatalogCategoryFilterMode',
         },
         tables: {
             in: 'query',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8364,19 +8364,6 @@
                                                 },
                                                 "required": ["status"],
                                                 "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
                                             }
                                         ]
                                     },
@@ -22250,6 +22237,10 @@
                 "type": "string",
                 "enum": ["asc", "desc"]
             },
+            "CatalogCategoryFilterMode": {
+                "enum": ["and", "or"],
+                "type": "string"
+            },
             "ApiGetMetricPeek": {
                 "properties": {
                     "results": {
@@ -24288,7 +24279,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2357.5",
+        "version": "0.2357.7",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -37025,6 +37016,14 @@
                             "items": {
                                 "type": "string"
                             }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "categoriesFilterMode",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/CatalogCategoryFilterMode"
                         }
                     },
                     {

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -839,7 +839,12 @@ export class CatalogService<
         projectUuid: string,
         context: CatalogSearchContext,
         paginateArgs?: KnexPaginateArgs,
-        { searchQuery, catalogTags, tables }: ApiCatalogSearch = {},
+        {
+            searchQuery,
+            catalogTags,
+            catalogTagsFilterMode,
+            tables,
+        }: ApiCatalogSearch = {},
         sortArgs?: ApiSort,
     ): Promise<KnexPaginatedData<CatalogField[]>> {
         const { organizationUuid } = await this.projectModel.getSummary(
@@ -869,6 +874,7 @@ export class CatalogService<
                 type: CatalogType.Field,
                 filter: CatalogFilter.Metrics,
                 catalogTags,
+                catalogTagsFilterMode,
                 tables,
             },
             context,

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -33,11 +33,17 @@ export type CatalogSelection = {
     field?: string;
 };
 
+export enum CatalogCategoryFilterMode {
+    AND = 'and',
+    OR = 'or',
+}
+
 export type ApiCatalogSearch = {
     searchQuery?: string;
     type?: CatalogType;
     filter?: CatalogFilter;
     catalogTags?: string[];
+    catalogTagsFilterMode?: CatalogCategoryFilterMode;
     tables?: string[];
 };
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -2,6 +2,7 @@ import {
     MAX_METRICS_TREE_NODE_COUNT,
     SpotlightTableColumns,
     assertUnreachable,
+    type CatalogCategoryFilterMode,
     type CatalogItem,
 } from '@lightdash/common';
 import {
@@ -52,6 +53,7 @@ import {
 import { useMetricsTree } from '../hooks/useMetricsTree';
 import { useSpotlightTableConfig } from '../hooks/useSpotlightTable';
 import {
+    setCategoryFilterMode,
     setCategoryFilters,
     setColumnConfig,
     setSearch,
@@ -87,6 +89,9 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
     );
     const categoryFilters = useAppSelector(
         (state) => state.metricsCatalog.categoryFilters,
+    );
+    const categoryFilterMode = useAppSelector(
+        (state) => state.metricsCatalog.categoryFilterMode,
     );
     const tableFilters = useAppSelector(
         (state) => state.metricsCatalog.tableFilters,
@@ -127,6 +132,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
         pageSize: 50,
         search: deferredSearch,
         categories: categoryFilters,
+        categoriesFilterMode: categoryFilterMode,
         tables: tableFilters,
         // TODO: Handle multiple sorting - this needs to be enabled and handled later in the backend
         ...(stateTableSorting.length > 0 && {
@@ -218,6 +224,10 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
 
     const handleSetTableFilters = (selectedTables: string[]) => {
         dispatch(setTableFilters(selectedTables));
+    };
+
+    const handleSetCategoryFilterMode = (mode: CatalogCategoryFilterMode) => {
+        dispatch(setCategoryFilterMode(mode));
     };
 
     // Reusable paper props to avoid duplicate when rendering tree view
@@ -513,6 +523,8 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                     totalResults={totalResults}
                     selectedCategories={categoryFilters}
                     setSelectedCategories={handleSetCategoryFilters}
+                    categoryFilterMode={categoryFilterMode}
+                    setCategoryFilterMode={handleSetCategoryFilterMode}
                     selectedTables={tableFilters}
                     setSelectedTables={handleSetTableFilters}
                     position="apart"
@@ -665,6 +677,8 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                             totalResults={totalResults}
                             selectedCategories={categoryFilters}
                             setSelectedCategories={handleSetCategoryFilters}
+                            categoryFilterMode={categoryFilterMode}
+                            setCategoryFilterMode={handleSetCategoryFilterMode}
                             selectedTables={tableFilters}
                             setSelectedTables={handleSetTableFilters}
                             position="apart"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/CategoriesFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/CategoriesFilter.tsx
@@ -1,10 +1,15 @@
-import { UNCATEGORIZED_TAG_UUID, type CatalogField } from '@lightdash/common';
+import {
+    CatalogCategoryFilterMode,
+    UNCATEGORIZED_TAG_UUID,
+    type CatalogField,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Button,
     Checkbox,
     Group,
     Popover,
+    SegmentedControl,
     Stack,
     Text,
     TextInput,
@@ -24,11 +29,15 @@ type CategoriesFilterProps = {
     setSelectedCategories: (
         categories: CatalogField['categories'][number]['tagUuid'][],
     ) => void;
+    categoryFilterMode: CatalogCategoryFilterMode;
+    setCategoryFilterMode: (mode: CatalogCategoryFilterMode) => void;
 };
 
 const CategoriesFilter: FC<CategoriesFilterProps> = ({
     selectedCategories,
     setSelectedCategories,
+    categoryFilterMode,
+    setCategoryFilterMode,
 }) => {
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
@@ -114,10 +123,37 @@ const CategoriesFilter: FC<CategoriesFilterProps> = ({
                     </Tooltip>
                 </Popover.Target>
                 <Popover.Dropdown p="sm">
-                    <Stack gap={4}>
-                        <Text fz="xs" c="ldGray.6" fw={600}>
-                            Filter by categories:
-                        </Text>
+                    <Stack gap="sm">
+                        <Group justify="space-between">
+                            <Text fz="xs" c="ldGray.6" fw={600} span>
+                                Filter by categories:
+                            </Text>
+
+                            {selectedCategories.length > 1 &&
+                                !selectedCategories.includes(
+                                    UNCATEGORIZED_TAG_UUID,
+                                ) && (
+                                    <SegmentedControl
+                                        size="xs"
+                                        value={categoryFilterMode}
+                                        onChange={(value) =>
+                                            setCategoryFilterMode(
+                                                value as CatalogCategoryFilterMode,
+                                            )
+                                        }
+                                        data={[
+                                            {
+                                                label: 'Any',
+                                                value: CatalogCategoryFilterMode.OR,
+                                            },
+                                            {
+                                                label: 'All',
+                                                value: CatalogCategoryFilterMode.AND,
+                                            },
+                                        ]}
+                                    />
+                                )}
+                        </Group>
 
                         {(categories?.length ?? 0) > 5 && (
                             <TextInput
@@ -155,7 +191,6 @@ const CategoriesFilter: FC<CategoriesFilterProps> = ({
                         <Stack
                             gap="xs"
                             mah={300}
-                            mt="xxs"
                             className={styles.scrollableList}
                         >
                             {filteredCategories.map((category) => (

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -17,6 +17,7 @@ import { CSS } from '@dnd-kit/utilities';
 import {
     DEFAULT_SPOTLIGHT_TABLE_COLUMN_CONFIG,
     SpotlightTableColumns,
+    type CatalogCategoryFilterMode,
     type CatalogField,
 } from '@lightdash/common';
 import {
@@ -77,6 +78,8 @@ type MetricsTableTopToolbarProps = GroupProps & {
     setSelectedCategories: (
         categories: CatalogField['categories'][number]['tagUuid'][],
     ) => void;
+    categoryFilterMode: CatalogCategoryFilterMode;
+    setCategoryFilterMode: (mode: CatalogCategoryFilterMode) => void;
     selectedTables: string[];
     setSelectedTables: (tables: string[]) => void;
     totalResults: number;
@@ -157,6 +160,8 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
         totalResults,
         selectedCategories,
         setSelectedCategories,
+        categoryFilterMode,
+        setCategoryFilterMode,
         selectedTables,
         setSelectedTables,
         showCategoriesFilter,
@@ -388,6 +393,8 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                         <CategoriesFilter
                             selectedCategories={selectedCategories}
                             setSelectedCategories={setSelectedCategories}
+                            categoryFilterMode={categoryFilterMode}
+                            setCategoryFilterMode={setCategoryFilterMode}
                         />
                     )}
 

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
@@ -3,6 +3,7 @@ import {
     type ApiGetMetricPeek,
     type ApiMetricsCatalog,
     type ApiSort,
+    type CatalogCategoryFilterMode,
     type KnexPaginateArgs,
 } from '@lightdash/common';
 import {
@@ -16,6 +17,7 @@ type UseMetricsCatalogOptions = {
     projectUuid?: string;
     search?: string;
     categories?: string[];
+    categoriesFilterMode?: CatalogCategoryFilterMode;
     tables?: string[];
     sortBy?: ApiSort['sort'] | 'name' | 'chartUsage';
     sortDirection?: ApiSort['order'];
@@ -27,6 +29,7 @@ const getMetricsCatalog = async ({
     projectUuid,
     search,
     categories,
+    categoriesFilterMode,
     tables,
     paginateArgs,
     sortBy,
@@ -36,7 +39,12 @@ const getMetricsCatalog = async ({
     paginateArgs?: KnexPaginateArgs;
 } & Pick<
     UseMetricsCatalogOptions,
-    'search' | 'categories' | 'tables' | 'sortBy' | 'sortDirection'
+    | 'search'
+    | 'categories'
+    | 'categoriesFilterMode'
+    | 'tables'
+    | 'sortBy'
+    | 'sortDirection'
 >) => {
     const urlParams = new URLSearchParams({
         ...(paginateArgs
@@ -54,6 +62,9 @@ const getMetricsCatalog = async ({
         categories.forEach((category) =>
             urlParams.append('categories', category),
         );
+        if (categoriesFilterMode) {
+            urlParams.set('categoriesFilterMode', categoriesFilterMode);
+        }
     }
 
     if (tables && tables.length > 0) {
@@ -75,6 +86,7 @@ export const useMetricsCatalog = ({
     sortBy,
     sortDirection,
     categories,
+    categoriesFilterMode,
     tables,
     pageSize,
 }: UseMetricsCatalogOptions & Pick<KnexPaginateArgs, 'pageSize'>) => {
@@ -88,6 +100,7 @@ export const useMetricsCatalog = ({
             sortBy,
             sortDirection,
             categories,
+            categoriesFilterMode,
             tables,
         ],
         queryFn: ({ pageParam }) =>
@@ -97,6 +110,7 @@ export const useMetricsCatalog = ({
                 sortBy,
                 sortDirection,
                 categories,
+                categoriesFilterMode,
                 tables,
                 paginateArgs: {
                     page: pageParam ?? 1,

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -1,6 +1,8 @@
 import {
+    CatalogCategoryFilterMode,
     DEFAULT_SPOTLIGHT_TABLE_COLUMN_CONFIG,
     SpotlightTableColumns,
+    UNCATEGORIZED_TAG_UUID,
     type CatalogField,
     type SpotlightTableConfig,
 } from '@lightdash/common';
@@ -30,6 +32,7 @@ type MetricsCatalogState = {
     projectUuid: string | undefined;
     organizationUuid: string | undefined;
     categoryFilters: CatalogField['categories'][number]['tagUuid'][];
+    categoryFilterMode: CatalogCategoryFilterMode;
     tableFilters: string[];
     search: string | undefined;
     tableSorting: MRT_SortingState;
@@ -72,6 +75,7 @@ const initialState: MetricsCatalogState = {
     projectUuid: undefined,
     organizationUuid: undefined,
     categoryFilters: [],
+    categoryFilterMode: CatalogCategoryFilterMode.OR,
     tableFilters: [],
     search: undefined,
     tableSorting: [
@@ -141,6 +145,19 @@ export const metricsCatalogSlice = createSlice({
             >,
         ) => {
             state.categoryFilters = action.payload;
+            // Reset to OR when cleared or uncategorized selected (AND doesn't apply)
+            if (
+                action.payload.length === 0 ||
+                action.payload.includes(UNCATEGORIZED_TAG_UUID)
+            ) {
+                state.categoryFilterMode = CatalogCategoryFilterMode.OR;
+            }
+        },
+        setCategoryFilterMode: (
+            state,
+            action: PayloadAction<CatalogCategoryFilterMode>,
+        ) => {
+            state.categoryFilterMode = action.payload;
         },
         setTableFilters: (state, action: PayloadAction<string[]>) => {
             state.tableFilters = action.payload;
@@ -219,6 +236,7 @@ export const {
     setActiveMetric,
     setProjectUuid,
     setCategoryFilters,
+    setCategoryFilterMode,
     setTableFilters,
     setOrganizationUuid,
     setAbility,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2530: Metrics Catalog: Support AND/OR logic when combining filters](https://linear.app/lightdash/issue/PROD-2530/metrics-catalog-support-andor-logic-when-combining-filters)

### Description:

This PR adds a new "AND" filter mode for categories in the metrics catalog. When multiple categories are selected, users can now choose between:

- "Any" (OR) mode: Shows metrics that match any of the selected categories (default)
- "All" (AND) mode: Shows only metrics that match all selected categories
