### PR TITLE
refactor: create useClientFeatureFlag and useServerFeatureFlag hooks

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -100,7 +100,6 @@ import { useOrganization } from '../../hooks/organization/useOrganization';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
 import {
@@ -108,6 +107,7 @@ import {
     type InfiniteQueryResults,
 } from '../../hooks/useQueryResults';
 import { useDuplicateChartMutation } from '../../hooks/useSavedQuery';
+import { useClientFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { useCreateShareMutation } from '../../hooks/useShare';
 import { useAccount } from '../../hooks/user/useAccount';
 import { Can } from '../../providers/Ability';
@@ -152,7 +152,7 @@ const ExportGoogleSheet: FC<ExportGoogleSheetProps> = ({
             metricQuery: savedChart.metricQuery,
             columnOrder: savedChart.tableConfig.columnOrder,
             showTableNames: isTableChartConfig(savedChart.chartConfig.config)
-                ? (savedChart.chartConfig.config.showTableNames ?? false)
+                ? savedChart.chartConfig.config.showTableNames ?? false
                 : true,
             customLabels: getCustomLabelsFromTableConfig(
                 savedChart.chartConfig.config,
@@ -504,7 +504,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const { data: account } = useAccount();
     const { organizationUuid } = account?.organization || {};
 
-    const showExecutionTime = useFeatureFlagEnabled(
+    const showExecutionTime = useClientFeatureFlag(
         FeatureFlags.ShowExecutionTime,
     );
     const { isDashboardRedesignEnabled } = useDashboardUIPreference();
@@ -1467,7 +1467,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                 getDownloadQueryUuid={getDownloadQueryUuid}
                 showTableNames={
                     isTableChartConfig(chart.chartConfig.config)
-                        ? (chart.chartConfig.config.showTableNames ?? false)
+                        ? chart.chartConfig.config.showTableNames ?? false
                         : true
                 }
                 chartName={title || chart.name}
@@ -1747,7 +1747,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     getDownloadQueryUuid={getDownloadQueryUuid}
                     showTableNames={
                         isTableChartConfig(chart.chartConfig.config)
-                            ? (chart.chartConfig.config.showTableNames ?? false)
+                            ? chart.chartConfig.config.showTableNames ?? false
                             : true
                     }
                     chartName={title || chart.name}

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -37,8 +37,8 @@ import {
     EditVirtualViewModal,
 } from '../../../features/virtualView';
 import { useExplore } from '../../../hooks/useExplore';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -68,7 +68,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
     const projectUuid = useProjectUuid();
     const isGitProject = useIsGitProject(projectUuid ?? '');
-    const { data: editYamlInUiFlag } = useFeatureFlag(
+    const { data: editYamlInUiFlag } = useServerFeatureFlag(
         FeatureFlags.EditYamlInUi,
     );
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -31,9 +31,9 @@ import {
     useExplorerDispatch,
 } from '../../../../../features/explorer/store';
 import useToaster from '../../../../../hooks/toaster/useToaster';
-import { useFeatureFlagEnabled } from '../../../../../hooks/useFeatureFlagEnabled';
 import { useFilteredFields } from '../../../../../hooks/useFilters';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
+import { useClientFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -72,7 +72,7 @@ const TreeSingleNodeActions: FC<Props> = ({
         return isDimension(item) ? getCustomMetricType(item.type) : [];
     }, [item]);
 
-    const isWriteBackCustomBinDimensionsEnabled = useFeatureFlagEnabled(
+    const isWriteBackCustomBinDimensionsEnabled = useClientFeatureFlag(
         FeatureFlags.WriteBackCustomBinDimensions,
     );
 

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -10,8 +10,8 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../../../features/explorer/store';
-import { useFeatureFlagEnabled } from '../../../../../hooks/useFeatureFlagEnabled';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
+import { useClientFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -41,7 +41,7 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     const allCustomDimensions = useExplorerSelector(selectCustomDimensions);
 
     // Feature flag for bin dimensions write-back
-    const isWriteBackCustomBinDimensionsEnabled = useFeatureFlagEnabled(
+    const isWriteBackCustomBinDimensionsEnabled = useClientFeatureFlag(
         FeatureFlags.WriteBackCustomBinDimensions,
     );
 

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -2,7 +2,6 @@ import { subject } from '@casl/ability';
 import { FeatureFlags, isTimeZone } from '@lightdash/common';
 import { Badge, Box, Button, Group, Tooltip } from '@mantine/core';
 import { IconAlertCircle, IconArrowLeft } from '@tabler/icons-react';
-import { useFeatureFlagEnabled } from 'posthog-js/react';
 import { memo, useEffect, useMemo, type FC } from 'react';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import {
@@ -19,6 +18,7 @@ import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../hooks/useExplorerRoute';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
 import { Can } from '../../../providers/Ability';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
@@ -128,8 +128,7 @@ const ExplorerHeader: FC = memo(() => {
         };
     }, [getHasDashboardChanges]);
 
-    // FEATURE FLAG: this component doesn't appear when the feature flag is disabled
-    const userTimeZonesEnabled = useFeatureFlagEnabled(
+    const userTimeZonesEnabled = useClientFeatureFlag(
         FeatureFlags.EnableUserTimezones,
     );
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResults.tsx
@@ -17,11 +17,11 @@ import {
 import { useColumns } from '../../../hooks/useColumns';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import type {
     useGetReadyQueryResults,
     useInfiniteQueryResults,
 } from '../../../hooks/useQueryResults';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
 import Table from '../../common/Table';
@@ -82,7 +82,7 @@ export const ExplorerResults = memo(() => {
         missingRequiredParameters,
     } = useExplorerQuery();
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -20,8 +20,8 @@ import {
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
@@ -109,7 +109,7 @@ const ResultsCard: FC = memo(() => {
         [getDownloadQueryUuid],
     );
 
-    const showPeriodOverPeriod = useFeatureFlagEnabled(
+    const showPeriodOverPeriod = useClientFeatureFlag(
         FeatureFlags.PeriodOverPeriod,
     );
 

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -66,10 +66,10 @@ import useDashboardStorage from '../../../hooks/dashboard/useDashboardStorage';
 import { useChartPinningMutation } from '../../../hooks/pinning/useChartPinningMutation';
 import { useContentAction } from '../../../hooks/useContent';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useProject } from '../../../hooks/useProject';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
+import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import {
@@ -97,7 +97,7 @@ import SaveChartButton from '../SaveChartButton';
 import { TitleBreadCrumbs } from './TitleBreadcrumbs';
 
 const SavedChartsHeader: FC = () => {
-    const userTimeZonesEnabled = useFeatureFlagEnabled(
+    const userTimeZonesEnabled = useClientFeatureFlag(
         FeatureFlags.EnableUserTimezones,
     );
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationWarning.tsx
@@ -10,8 +10,8 @@ import { Badge, List, Tooltip } from '@mantine-8/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import isEqual from 'lodash/isEqual';
 import { useMemo, type FC } from 'react';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import { type InfiniteQueryResults } from '../../../hooks/useQueryResults';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 
 export type PivotMismatchWarningProps = {
@@ -35,7 +35,7 @@ const VisualizationWarning: FC<PivotMismatchWarningProps> = ({
     isLoading,
     maxColumnLimit,
 }) => {
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -23,7 +23,7 @@ import {
     IconTable,
 } from '@tabler/icons-react';
 import { memo, useMemo, type FC, type ReactNode } from 'react';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { BetaBadge } from '../../common/BetaBadge';
 import {
     COLLAPSABLE_CARD_BUTTON_PROPS,
@@ -53,7 +53,7 @@ const VisualizationCardOptions: FC = memo(() => {
         resultsData,
         pivotDimensions,
     } = useVisualizationContext();
-    const isMapsEnabled = useFeatureFlagEnabled(FeatureFlags.Maps);
+    const isMapsEnabled = useClientFeatureFlag(FeatureFlags.Maps);
     const disabled = isLoading || !resultsData || resultsData.rows.length <= 0;
 
     const cartesianConfig = useMemo(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -34,12 +34,12 @@ import {
     calculateSeriesLikeIdentifier,
     isGroupedSeries,
 } from '../../hooks/useChartColorConfig/utils';
-import {
-    useFeatureFlag,
-    useFeatureFlagEnabled,
-} from '../../hooks/useFeatureFlagEnabled';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
 import { type InfiniteQueryResults } from '../../hooks/useQueryResults';
+import {
+    useClientFeatureFlag,
+    useServerFeatureFlag,
+} from '../../hooks/useServerOrClientFeatureFlag';
 import { type EChartsReact } from '../EChartsReactWrapper';
 import { type EchartsSeriesClickEvent } from '../SimpleChart';
 import VisualizationBigNumberConfig from './VisualizationBigNumberConfig';
@@ -145,7 +145,7 @@ const VisualizationProvider: FC<
         InfiniteQueryResults & { metricQuery?: MetricQuery; fields?: ItemsMap }
     >();
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 
@@ -255,7 +255,7 @@ const VisualizationProvider: FC<
         [calculateKeyColorAssignment, itemsMap],
     );
 
-    const isCalculateSeriesColorEnabled = useFeatureFlagEnabled(
+    const isCalculateSeriesColorEnabled = useClientFeatureFlag(
         FeatureFlags.CalculateSeriesColor,
     );
 

--- a/packages/frontend/src/components/ProjectAccess/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/index.tsx
@@ -4,7 +4,7 @@ import { Anchor, Button, Group, Stack, Tabs, Text } from '@mantine/core';
 import { IconPlus, IconUser, IconUsersGroup } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { ProjectGroupAccess } from '../../features/projectGroupAccess';
-import { useFeatureFlag } from '../../hooks/useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../providers/Ability';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
@@ -16,7 +16,7 @@ interface ProjectUserAccessProps {
 
 const ProjectUserAccess: FC<ProjectUserAccessProps> = ({ projectUuid }) => {
     const { user } = useApp();
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -27,7 +27,7 @@ import {
     useBigqueryDatasets,
     useIsBigQueryAuthenticated,
 } from '../../../hooks/useBigquerySSO';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
+import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
 import FormCollapseButton from '../FormCollapseButton';
@@ -121,7 +121,7 @@ const BigQueryForm: FC<{
     const health = useHealth();
     const isAdcEnabled = health.data?.auth.google?.enableGCloudADC;
 
-    const isSsoEnabled = useFeatureFlagEnabled(FeatureFlags.BigquerySSO);
+    const isSsoEnabled = useClientFeatureFlag(FeatureFlags.BigquerySSO);
     // Fetching databases can only happen if user is authenticated
     // if user authenticates, and change to private_key
     // We will not make any queries, in case private_key is different

--- a/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
@@ -3,7 +3,7 @@ import { Card, Group, Stack, Text } from '@mantine/core';
 import { IconArchive, IconLayoutDashboard } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
-import { useFeatureFlagEnabled } from '../../hooks/useFeatureFlagEnabled';
+import { useClientFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../common/MantineIcon';
 
 interface ProjectUserAccessProps {
@@ -13,7 +13,7 @@ interface ProjectUserAccessProps {
 const SettingsUsageAnalytics: FC<ProjectUserAccessProps> = ({
     projectUuid,
 }) => {
-    const isUnusedContentDashboardEnabled = useFeatureFlagEnabled(
+    const isUnusedContentDashboardEnabled = useClientFeatureFlag(
         FeatureFlags.UnusedContentDashboard,
     );
 

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -37,7 +37,7 @@ import {
     useUpdateSlackAppCustomSettingsMutation,
 } from '../../../hooks/slack/useSlack';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import slackSvg from '../../../svgs/slack.svg';
 import { BetaBadge } from '../../common/BetaBadge';
 import { ComingSoonBadge } from '../../common/ComingSoonBadge';
@@ -72,10 +72,10 @@ const formSchema = z.object({
 
 const SlackSettingsPanel: FC = () => {
     const { activeProjectUuid } = useActiveProjectUuid();
-    const { data: aiCopilotFlag } = useFeatureFlag(
+    const { data: aiCopilotFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.AiCopilot,
     );
-    const { data: multiAgentChannelFlag } = useFeatureFlag(
+    const { data: multiAgentChannelFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.MultiAgentChannel,
     );
     const { data: slackInstallation, isInitialLoading } = useGetSlack();

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -24,9 +24,9 @@ import {
     IconUsersPlus,
 } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import {
     useCreateUserAtributesMutation,
     useUpdateUserAtributesMutation,
@@ -40,7 +40,7 @@ const UserAttributeModal: FC<{
     allUserAttributes: UserAttribute[];
     onClose: () => void;
 }> = ({ opened, userAttribute, allUserAttributes, onClose }) => {
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -21,7 +21,7 @@ import {
 import { useState, type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import {
     useUserAttributes,
     useUserAttributesDeleteMutation,
@@ -116,7 +116,7 @@ const UserListItem: FC<{
 const UserAttributesPanel: FC = () => {
     const { classes } = useTableStyles();
     const { user } = useApp();
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
     const [showAddAttributeModal, addAttributeModal] = useDisclosure(false);

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -39,10 +39,10 @@ import {
     type FC,
     type UIEvent,
 } from 'react';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import { useUpsertOrganizationUserRoleAssignmentMutation } from '../../../hooks/useOrganizationRoles';
 import { useInfiniteOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import InviteSuccess from './InviteSuccess';
@@ -73,7 +73,7 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
         setInviteSuccessFor(userUuid);
     }, []);
 
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mantine-8/core';
 import { IconInfoCircle, IconUsers, IconUsersGroup } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import ForbiddenPanel from '../../ForbiddenPanel';
 import MantineIcon from '../../common/MantineIcon';
@@ -19,7 +19,7 @@ import UsersView from './UsersView';
 
 const UsersAndGroupsPanel: FC = () => {
     const { user } = useApp();
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -12,7 +12,7 @@ import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useDeepCompareEffect } from 'react-use';
-import { useFeatureFlagEnabled } from '../../../../hooks/useFeatureFlagEnabled';
+import { useClientFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import DocumentationHelpButton from '../../../DocumentationHelpButton';
 import { isCustomVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -192,7 +192,7 @@ export const ConfigTabs: React.FC = memo(() => {
         EditorProps['options'] | undefined
     >();
 
-    const isAiEnabled = useFeatureFlagEnabled(FeatureFlags.AiCustomViz);
+    const isAiEnabled = useClientFeatureFlag(FeatureFlags.AiCustomViz);
     useDeepCompareEffect(() => {
         /** Creates a container that belongs to body, outside of the sidebar
          * so we can place the autocomplete tooltip and it doesn't overflow

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeaderV1.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeaderV1.tsx
@@ -46,8 +46,8 @@ import {
 import { DashboardSchedulersModal } from '../../../features/scheduler';
 import { getSchedulerUuidFromUrlParams } from '../../../features/scheduler/utils';
 import { useDashboardPinningMutation } from '../../../hooks/pinning/useDashboardPinningMutation';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useProject } from '../../../hooks/useProject';
+import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -110,7 +110,7 @@ const DashboardHeaderV1 = ({
     setAddingTab,
     onEditClicked,
 }: DashboardHeaderProps) => {
-    const isDashboardSummariesEnabled = useFeatureFlagEnabled(
+    const isDashboardSummariesEnabled = useClientFeatureFlag(
         'ai-dashboard-summary' as FeatureFlags,
     );
 

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeaderV2.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeaderV2.tsx
@@ -45,8 +45,8 @@ import {
 import { DashboardSchedulersModal } from '../../../features/scheduler';
 import { getSchedulerUuidFromUrlParams } from '../../../features/scheduler/utils';
 import { useDashboardPinningMutation } from '../../../hooks/pinning/useDashboardPinningMutation';
-import { useFeatureFlagEnabled } from '../../../hooks/useFeatureFlagEnabled';
 import { useProject } from '../../../hooks/useProject';
+import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -90,7 +90,7 @@ const DashboardHeaderV2 = ({
     onEditClicked,
     className,
 }: DashboardHeaderProps) => {
-    const isDashboardSummariesEnabled = useFeatureFlagEnabled(
+    const isDashboardSummariesEnabled = useClientFeatureFlag(
         'ai-dashboard-summary' as FeatureFlags,
     );
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -40,9 +40,9 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { SlackChannelSelect } from '../../../../components/common/SlackChannelSelect';
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
-import { useFeatureFlag } from '../../../../hooks/useFeatureFlagEnabled';
 import { useOrganizationGroups } from '../../../../hooks/useOrganizationGroups';
 import { useProject } from '../../../../hooks/useProject';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { UserAccessMultiSelect } from '../../../components/UserAccessMultiSelect';
 import AiExploreAccessTree from '../../../pages/AiAgents/AiExploreAccessTree';
@@ -128,7 +128,7 @@ export const AiAgentFormSetup = ({
     const { data: slackInstallation, isLoading: isLoadingSlackInstallation } =
         useGetSlack();
 
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 
@@ -136,7 +136,7 @@ export const AiAgentFormSetup = ({
         userGroupsFeatureFlagQuery.isSuccess &&
         userGroupsFeatureFlagQuery.data.enabled;
 
-    const agentReasoningFeatureFlagQuery = useFeatureFlag(
+    const agentReasoningFeatureFlagQuery = useServerFeatureFlag(
         CommercialFeatureFlags.AgentReasoning,
     );
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
@@ -1,6 +1,6 @@
 import { CommercialFeatureFlags } from '@lightdash/common';
 import { useActiveProject } from '../../../../hooks/useActiveProject';
-import { useFeatureFlag } from '../../../../hooks/useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { useAiAgentPermission } from './useAiAgentPermission';
 import { useAiOrganizationSettings } from './useAiOrganizationSettings';
@@ -35,7 +35,9 @@ export const useAiAgentButtonVisibility = () => {
         projectUuid,
     });
 
-    const aiCopilotFlagQuery = useFeatureFlag(CommercialFeatureFlags.AiCopilot);
+    const aiCopilotFlagQuery = useServerFeatureFlag(
+        CommercialFeatureFlags.AiCopilot,
+    );
 
     if (
         agentsQuery.isLoading ||

--- a/packages/frontend/src/ee/features/ambientAi/hooks/useAmbientAiEnabled.ts
+++ b/packages/frontend/src/ee/features/ambientAi/hooks/useAmbientAiEnabled.ts
@@ -1,6 +1,6 @@
 import { CommercialFeatureFlags } from '@lightdash/common';
 import useHealth from '../../../../hooks/health/useHealth';
-import { useFeatureFlag } from '../../../../hooks/useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 
 /**
  * Checks if the ambient ai is enabled.
@@ -8,7 +8,7 @@ import { useFeatureFlag } from '../../../../hooks/useFeatureFlagEnabled';
  */
 export const useAmbientAiEnabled = () => {
     const { data: health } = useHealth();
-    const { data: aiCopilotFlag } = useFeatureFlag(
+    const { data: aiCopilotFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.AiCopilot,
     );
     return health?.ai.isAmbientAiEnabled || aiCopilotFlag?.enabled;

--- a/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
+++ b/packages/frontend/src/features/comments/hooks/useDashboardCommentsCheck.ts
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { type UserWithAbility } from '../../../hooks/user/useUser';
 
 export const useDashboardCommentsCheck = (
@@ -15,7 +15,7 @@ export const useDashboardCommentsCheck = (
         'DashboardComments',
     );
 
-    const { data: dashboardCommentsFeatureFlag } = useFeatureFlag(
+    const { data: dashboardCommentsFeatureFlag } = useServerFeatureFlag(
         FeatureFlags.DashboardComments,
     );
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal.tsx
@@ -1,7 +1,7 @@
 import { FeatureFlags, type CatalogField } from '@lightdash/common';
 import { type ModalProps } from '@mantine/core';
 import { type FC } from 'react';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { MetricExploreModalV1 } from './MetricExploreModalV1';
 import { MetricExploreModalV2 } from './MetricExploreModalV2';
 
@@ -16,7 +16,7 @@ type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
  * V2: New implementation using VisualizationProvider + echarts
  */
 export const MetricExploreModal: FC<Props> = (props) => {
-    const metricExploreModalV2Flag = useFeatureFlag(
+    const metricExploreModalV2Flag = useServerFeatureFlag(
         FeatureFlags.MetricsCatalogEchartsVisualization,
     );
     const isEchartsEnabled = metricExploreModalV2Flag.data?.enabled === true;

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
@@ -13,13 +13,13 @@ import { useMemo, type FC } from 'react';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { useFeatureFlag } from '../../../hooks/useFeatureFlagEnabled';
 import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
 import { useOrganizationRoles } from '../../../hooks/useOrganizationRoles';
 import {
     useProjectGroupRoleAssignments,
     useUpsertProjectGroupRoleAssignmentMutation,
 } from '../../../hooks/useProjectGroupRoles';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import useApp from '../../../providers/App/useApp';
 import { TrackPage } from '../../../providers/Tracking/TrackingProvider';
@@ -43,7 +43,7 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
     const { cx, classes } = useTableStyles();
     const { showToastSuccess } = useToaster();
 
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -2,9 +2,8 @@ import { CartesianSeriesType, getItemMap } from '@lightdash/common';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
-vi.mock('../useFeatureFlagEnabled', () => ({
-    useFeatureFlag: async () => ({ data: { enabled: false } }),
-    useFeatureFlagEnabled: async () => false,
+vi.mock('../useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: async () => ({ data: { enabled: false } }),
 }));
 
 import useCartesianChartConfig from './useCartesianChartConfig';

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -28,8 +28,8 @@ import {
     getMarkLineAxis,
     type ReferenceLineField,
 } from '../../components/common/ReferenceLine';
-import { useFeatureFlag } from '../useFeatureFlagEnabled';
 import type { InfiniteQueryResults } from '../useQueryResults';
+import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import {
     getExpectedSeriesMap,
     mergeExistingAndExpectedSeries,
@@ -743,7 +743,7 @@ const useCartesianChartConfig = ({
         [getOldTableCalculationMetadataIndex, tableCalculationsMetadata],
     );
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartDownload.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartDownload.ts
@@ -9,7 +9,7 @@ import { lightdashApi } from '../../api';
 import { Limit } from '../../components/ExportResults/types';
 import { pollForResults } from '../../features/queryRunner/executeQuery';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
-import { useFeatureFlag } from '../useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
 export const useDashboardChartDownload = (
@@ -31,7 +31,7 @@ export const useDashboardChartDownload = (
         (c) => c.dateZoomGranularity,
     );
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -17,9 +17,9 @@ import { lightdashApi } from '../../api';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import { convertDateDashboardFilters } from '../../utils/dateFilter';
 import { useExplore } from '../useExplore';
-import { useFeatureFlag } from '../useFeatureFlagEnabled';
 import { useSavedQuery } from '../useSavedQuery';
 import useSearchParams from '../useSearchParams';
+import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
 const executeAsyncDashboardChartQuery = async (
@@ -164,7 +164,7 @@ export const useDashboardChartReadyQuery = (
         setChartsWithDateZoomApplied,
     ]);
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardUIPreference.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardUIPreference.ts
@@ -5,7 +5,7 @@ import { useParams } from 'react-router';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
-import { useFeatureFlag } from '../useFeatureFlagEnabled';
+import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 
 export type DashboardUIVersion = 'v1' | 'v2';
 
@@ -29,7 +29,7 @@ export const useDashboardUIPreference = () => {
         defaultValue: 'v1',
     });
 
-    const { data: dashboardRedesignFlag } = useFeatureFlag(
+    const { data: dashboardRedesignFlag } = useServerFeatureFlag(
         FeatureFlags.DashboardRedesign,
     );
     const isDashboardRedesignFlagEnabled =

--- a/packages/frontend/src/hooks/useExplorerQuery.test.tsx
+++ b/packages/frontend/src/hooks/useExplorerQuery.test.tsx
@@ -11,8 +11,8 @@ vi.mock('./useExplore', () => ({
     useExplore: vi.fn(() => ({ data: null })),
 }));
 
-vi.mock('./useFeatureFlagEnabled', () => ({
-    useFeatureFlag: vi.fn(() => ({ data: { enabled: false } })),
+vi.mock('./useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(() => ({ data: { enabled: false } })),
 }));
 
 vi.mock('./parameters/useParameters', () => ({

--- a/packages/frontend/src/hooks/useExplorerQuery.ts
+++ b/packages/frontend/src/hooks/useExplorerQuery.ts
@@ -9,12 +9,12 @@ import {
     useExplorerSelector,
 } from '../features/explorer/store';
 import { useExplorerQueryManager } from './useExplorerQueryManager';
-import { useFeatureFlag } from './useFeatureFlagEnabled';
 import {
     executeQueryAndWaitForResults,
     useCancelQuery,
     type QueryResultsProps,
 } from './useQueryResults';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
 
 /**
  * Public API for Explorer query management
@@ -41,7 +41,7 @@ export const useExplorerQuery = () => {
     const unpivotedQueryArgs = useExplorerSelector(selectUnpivotedQueryArgs);
     const unpivotedEnabled = !!unpivotedQueryArgs;
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/hooks/useExplorerQueryEffects.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryEffects.ts
@@ -22,7 +22,7 @@ import {
     useExplorerSelector,
 } from '../features/explorer/store';
 import { useExplorerQueryManager } from './useExplorerQueryManager';
-import { useFeatureFlag } from './useFeatureFlagEnabled';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
 
 /**
  * Effects layer for Explorer query orchestration
@@ -55,7 +55,7 @@ export const useExplorerQueryEffects = ({
     const fromDashboard = useExplorerSelector(selectFromDashboard);
     const isExploreFromHere = useExplorerSelector(selectIsExploreFromHere);
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -23,7 +23,7 @@ import { useQueryExecutor } from '../providers/Explorer/useQueryExecutor';
 import { buildQueryArgs } from './explorer/buildQueryArgs';
 import { useExplore } from './useExplore';
 import { useDateZoomGranularitySearch } from './useExplorerRoute';
-import { useFeatureFlag } from './useFeatureFlagEnabled';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
 
 /**
  * Manager hook for Explorer query state
@@ -87,7 +87,7 @@ export const useExplorerQueryManager = () => {
         refetchOnMount: false,
         refetchOnWindowFocus: false,
     });
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/hooks/useProjectUsersWithRoles.ts
+++ b/packages/frontend/src/hooks/useProjectUsersWithRoles.ts
@@ -12,10 +12,10 @@ import {
 } from '@lightdash/common';
 import { useMemo } from 'react';
 import { useProjectGroupAccessList } from '../features/projectGroupAccess/hooks/useProjectGroupAccess';
-import { useFeatureFlag } from './useFeatureFlagEnabled';
 import { useOrganizationGroups } from './useOrganizationGroups';
 import { useOrganizationUsers } from './useOrganizationUsers';
 import { useProjectAccess } from './useProjectAccess';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
 
 export type ProjectUserWithRole = Omit<OrganizationMemberProfile, 'role'> & {
     inheritedRole: InheritedRoles | undefined;
@@ -32,7 +32,7 @@ export const useProjectUsersWithRoles = (
         paginateArgs?: KnexPaginateArgs;
     },
 ) => {
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -28,8 +28,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { lightdashApi } from '../api';
 import { pollForResults } from '../features/queryRunner/executeQuery';
 import { convertDateFilters } from '../utils/dateFilter';
-import { useFeatureFlag } from './useFeatureFlagEnabled';
 import useQueryError from './useQueryError';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
 
 export type QueryResultsProps = {
     projectUuid: string;
@@ -211,7 +211,7 @@ export const useGetReadyQueryResults = (
         return missingRequiredParameters.length === 0;
     }, [data, missingRequiredParameters]);
 
-    const { data: useSqlPivotResults } = useFeatureFlag(
+    const { data: useSqlPivotResults } = useServerFeatureFlag(
         FeatureFlags.UseSqlPivotResults,
     );
 

--- a/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
+++ b/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
@@ -9,17 +9,25 @@ import { useFeatureFlagEnabled as useFeatureFlagEnabledPosthog } from 'posthog-j
 import { lightdashApi } from '../api';
 
 /**
- * Thin wrapper around posthog's useFeatureFlagEnabled hook that is aware
- * of our FeatureFlags enum.
+ * Use Client Feature Flag to get the feature flag from the client directly from posthog.
+ *
+ * @param featureFlag - The feature flag to get.
+ * @returns boolean if the feature flag is enabled.
  */
-export const useFeatureFlagEnabled = (
+export const useClientFeatureFlag = (
     featureFlag: FeatureFlags | CommercialFeatureFlags,
 ) => useFeatureFlagEnabledPosthog(featureFlag) === true;
 
 /**
- * Use our own endpoint to get the feature flag from multiple sources.
+ * Use Server Feature Flag to get the feature flag from the server.
+ * This is useful to:
+ * - Get the feature flag from the server (which works well on shared instances)
+ * - When implemented, get a mix of Posthog and Environment variables feature flags (not always implemented)
+ *
+ * @param featureFlagId - The feature flag to get.
+ * @returns The feature flag.
  */
-export const useFeatureFlag = (featureFlagId: string) => {
+export const useServerFeatureFlag = (featureFlagId: string) => {
     return useQuery<FeatureFlag, ApiError>(
         ['feature-flag', featureFlagId],
         () => {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -66,11 +66,11 @@ import { CustomRoleEdit } from '../ee/pages/customRoles/CustomRoleEdit';
 import { CustomRoles } from '../ee/pages/customRoles/CustomRoles';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
-import {
-    useFeatureFlag,
-    useFeatureFlagEnabled,
-} from '../hooks/useFeatureFlagEnabled';
 import { useProject } from '../hooks/useProject';
+import {
+    useClientFeatureFlag,
+    useServerFeatureFlag,
+} from '../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
@@ -80,11 +80,11 @@ import ProjectSettings from './ProjectSettings';
 import classes from './Settings.module.css';
 
 const Settings: FC = () => {
-    const { data: embeddingEnabled } = useFeatureFlag(
+    const { data: embeddingEnabled } = useServerFeatureFlag(
         CommercialFeatureFlags.Embedding,
     );
 
-    const { data: isScimTokenManagementEnabled } = useFeatureFlag(
+    const { data: isScimTokenManagementEnabled } = useServerFeatureFlag(
         CommercialFeatureFlags.Scim,
     );
 
@@ -94,7 +94,7 @@ const Settings: FC = () => {
             aiOrganizationSettingsQuery.data?.isCopilotEnabled) ||
         aiOrganizationSettingsQuery.data?.isTrial;
 
-    const isServiceAccountFeatureFlagEnabled = useFeatureFlagEnabled(
+    const isServiceAccountFeatureFlagEnabled = useClientFeatureFlag(
         CommercialFeatureFlags.ServiceAccounts,
     );
 
@@ -109,7 +109,7 @@ const Settings: FC = () => {
 
     const isCustomRolesEnabled = health?.isCustomRolesEnabled;
 
-    const userGroupsFeatureFlagQuery = useFeatureFlag(
+    const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
 
@@ -150,7 +150,7 @@ const Settings: FC = () => {
     const isServiceAccountsEnabled =
         health?.isServiceAccountEnabled || isServiceAccountFeatureFlagEnabled;
 
-    const isWarehouseCredentialsFeatureFlagEnabled = useFeatureFlagEnabled(
+    const isWarehouseCredentialsFeatureFlagEnabled = useClientFeatureFlag(
         CommercialFeatureFlags.OrganizationWarehouseCredentials,
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Refactored feature flag hooks to improve clarity and organization:

1. Renamed `useFeatureFlagEnabled` to `useClientFeatureFlag` to clearly indicate it retrieves flags directly from PostHog client-side
2. Renamed `useFeatureFlag` to `useServerFeatureFlag` to indicate it fetches flags from the server
3. Updated all imports and usages across the codebase to use the new hook names
4. Added improved documentation to explain when to use each hook:
   - `useClientFeatureFlag`: For client-side feature flags from PostHog
   - `useServerFeatureFlag`: For server-side feature flags that work well on shared instances

This change makes the distinction between client and server feature flags more explicit, improving code readability and maintainability.