### PR TITLE
chore: add error to `scheduler_job.failed` event

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -991,6 +991,7 @@ export type SchedulerJobEvent = BaseTrack & {
         schedulerId: string | undefined;
         sendNow?: boolean;
         isThresholdAlert?: boolean;
+        error?: string;
     };
 };
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3126,6 +3126,7 @@ export default class SchedulerTask {
                 properties: {
                     jobId,
                     schedulerId: schedulerUuid,
+                    error: `${e}`,
                 },
             });
             await this.schedulerService.logSchedulerJob({


### PR DESCRIPTION
### Description:
I did a double take on the scheduler events we're currently tracking and I noticed that the `scheduler_job.failed` event doesn't track the error at all.

This is just the very basic initial implementation, same as the current one for `scheduler_notification_job.failed`: https://github.com/lightdash/lightdash/blob/8562f66cb342da2453d45cad0606a943fa154b38/packages/backend/src/scheduler/SchedulerTask.ts#L1122
