### PR TITLE
feat: enable PoP on metrics explorer modal v2

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.module.css
@@ -38,6 +38,10 @@
     visibility: hidden;
 }
 
+.clearButton[data-visible='true'] {
+    visibility: visible;
+}
+
 .clearButton:hover {
     background-color: var(--mantine-color-ldGray-1);
 }

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -31,6 +31,7 @@ type Props = {
         MetricWithAssociatedTimeDimension[],
         unknown
     >;
+    canCompareToAnotherMetric?: boolean;
 };
 
 export const MetricExploreComparison: FC<Props> = ({
@@ -38,6 +39,7 @@ export const MetricExploreComparison: FC<Props> = ({
     query,
     onQueryChange,
     metricsWithTimeDimensionsQuery,
+    canCompareToAnotherMetric = true,
 }) => {
     const { classes } = useSelectStyles();
 
@@ -109,138 +111,156 @@ export const MetricExploreComparison: FC<Props> = ({
                         tooltipLabel:
                             'Show data from the same period in the previous year',
                     },
-                    {
-                        type: MetricExplorerComparison.DIFFERENT_METRIC,
-                        icon: IconStack,
-                        label: 'Compare to another metric',
-                        tooltipLabel: `Compare "${baseMetricLabel}" to another metric`,
-                    },
-                ].map((comparison) => (
-                    <Tooltip
-                        key={comparison.type}
-                        label={comparison.tooltipLabel}
-                        variant="xs"
-                        position="right"
-                        withinPortal
-                    >
-                        <Paper
-                            p="sm"
-                            withBorder
-                            radius="md"
-                            sx={(theme) => ({
-                                cursor: 'pointer',
-                                transition: `all ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                                '&[data-with-border="true"]': {
-                                    border:
-                                        query.comparison === comparison.type
-                                            ? `1px solid ${theme.colors.indigo[5]}`
-                                            : `1px solid ${theme.colors.ldGray[2]}`,
-                                },
-                                '&:hover': {
-                                    backgroundColor:
-                                        theme.colorScheme === 'dark'
-                                            ? theme.colors.ldDark[3]
-                                            : theme.colors.ldGray[0],
-                                },
-                                backgroundColor:
-                                    query.comparison === comparison.type
-                                        ? theme.colorScheme === 'dark'
-                                            ? theme.colors.ldDark[2]
-                                            : theme.fn.lighten(
-                                                  theme.colors.ldGray[1],
-                                                  0.3,
-                                              )
-                                        : theme.colors.background[0],
-                            })}
-                            onClick={() =>
-                                handleComparisonChange(comparison.type)
-                            }
+                    canCompareToAnotherMetric
+                        ? {
+                              type: MetricExplorerComparison.DIFFERENT_METRIC,
+                              icon: IconStack,
+                              label: 'Compare to another metric',
+                              tooltipLabel: `Compare "${baseMetricLabel}" to another metric`,
+                          }
+                        : null,
+                ]
+                    .filter(
+                        (
+                            comparison,
+                        ): comparison is NonNullable<typeof comparison> =>
+                            comparison !== null,
+                    )
+                    .map((comparison) => (
+                        <Tooltip
+                            key={comparison.type}
+                            label={comparison.tooltipLabel}
+                            variant="xs"
+                            position="right"
+                            withinPortal
                         >
-                            <Stack>
-                                <Group align="center" noWrap position="apart">
-                                    <Group noWrap>
-                                        <Paper p="xs" radius="md" withBorder>
-                                            <MantineIcon
-                                                icon={comparison.icon}
-                                            />
-                                        </Paper>
-
-                                        <Text color="ldGray.7" fw={500}>
-                                            {comparison.label}
-                                        </Text>
-                                    </Group>
-                                    <Radio
-                                        value={comparison.type}
-                                        size="xs"
-                                        color="indigo"
-                                    />
-                                </Group>
-
-                                {comparison.type ===
-                                    MetricExplorerComparison.DIFFERENT_METRIC &&
-                                    query.comparison ===
-                                        MetricExplorerComparison.DIFFERENT_METRIC &&
-                                    (metricsWithTimeDimensionsQuery.isLoading ||
-                                    (metricsWithTimeDimensionsQuery.isSuccess &&
-                                        metricsWithTimeDimensionsQuery.data
-                                            .length > 0) ? (
-                                        <Select
-                                            placeholder="Select a metric"
-                                            searchable
-                                            radius="md"
-                                            size="xs"
-                                            data={
-                                                metricsWithTimeDimensionsQuery.data?.map(
-                                                    (metric) => ({
-                                                        value: getItemId(
-                                                            metric,
-                                                        ),
-                                                        label: metric.label,
-                                                        group: metric.tableLabel,
-                                                    }),
-                                                ) ?? []
-                                            }
-                                            value={getItemId(query.metric)}
-                                            onChange={handleMetricChange}
-                                            itemComponent={SelectItem}
-                                            // this does not work as expected in Mantine 6
-                                            data-disabled={
-                                                !metricsWithTimeDimensionsQuery.isSuccess
-                                            }
-                                            rightSection={
-                                                metricsWithTimeDimensionsQuery.isLoading ? (
-                                                    <Loader
-                                                        size="xs"
-                                                        color="ldGray.5"
-                                                    />
-                                                ) : undefined
-                                            }
-                                            classNames={{
-                                                input: classes.input,
-                                                item: classes.item,
-                                                rightSection:
-                                                    classes.rightSection,
-                                                dropdown: classes.dropdown,
-                                            }}
-                                        />
-                                    ) : (
-                                        <Text span c="ldGray.7" fz={13}>
-                                            Only metrics with a time dimension
-                                            defined in the .yml can be compared.{' '}
-                                            <Anchor
-                                                c="ldGray.9"
-                                                fw={500}
-                                                target="_blank"
-                                                href="https://docs.lightdash.com/guides/metrics-catalog/#configuring-default-time-settings-in-yml"
+                            <Paper
+                                p="sm"
+                                withBorder
+                                radius="md"
+                                sx={(theme) => ({
+                                    cursor: 'pointer',
+                                    transition: `all ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                                    '&[data-with-border="true"]': {
+                                        border:
+                                            query.comparison === comparison.type
+                                                ? `1px solid ${theme.colors.indigo[5]}`
+                                                : `1px solid ${theme.colors.ldGray[2]}`,
+                                    },
+                                    '&:hover': {
+                                        backgroundColor:
+                                            theme.colorScheme === 'dark'
+                                                ? theme.colors.ldDark[3]
+                                                : theme.colors.ldGray[0],
+                                    },
+                                    backgroundColor:
+                                        query.comparison === comparison.type
+                                            ? theme.colorScheme === 'dark'
+                                                ? theme.colors.ldDark[2]
+                                                : theme.fn.lighten(
+                                                      theme.colors.ldGray[1],
+                                                      0.3,
+                                                  )
+                                            : theme.colors.background[0],
+                                })}
+                                onClick={() =>
+                                    handleComparisonChange(comparison.type)
+                                }
+                            >
+                                <Stack>
+                                    <Group
+                                        align="center"
+                                        noWrap
+                                        position="apart"
+                                    >
+                                        <Group noWrap>
+                                            <Paper
+                                                p="xs"
+                                                radius="md"
+                                                withBorder
                                             >
-                                                Learn more
-                                            </Anchor>
-                                        </Text>
-                                    ))}
-                            </Stack>
-                        </Paper>
-                    </Tooltip>
-                ))}
+                                                <MantineIcon
+                                                    icon={comparison.icon}
+                                                />
+                                            </Paper>
+
+                                            <Text color="ldGray.7" fw={500}>
+                                                {comparison.label}
+                                            </Text>
+                                        </Group>
+                                        <Radio
+                                            value={comparison.type}
+                                            size="xs"
+                                            color="indigo"
+                                        />
+                                    </Group>
+
+                                    {comparison.type ===
+                                        MetricExplorerComparison.DIFFERENT_METRIC &&
+                                        query.comparison ===
+                                            MetricExplorerComparison.DIFFERENT_METRIC &&
+                                        (metricsWithTimeDimensionsQuery.isLoading ||
+                                        (metricsWithTimeDimensionsQuery.isSuccess &&
+                                            metricsWithTimeDimensionsQuery.data
+                                                .length > 0) ? (
+                                            <Select
+                                                placeholder="Select a metric"
+                                                searchable
+                                                radius="md"
+                                                size="xs"
+                                                data={
+                                                    metricsWithTimeDimensionsQuery.data?.map(
+                                                        (metric) => ({
+                                                            value: getItemId(
+                                                                metric,
+                                                            ),
+                                                            label: metric.label,
+                                                            group: metric.tableLabel,
+                                                        }),
+                                                    ) ?? []
+                                                }
+                                                value={getItemId(query.metric)}
+                                                onChange={handleMetricChange}
+                                                itemComponent={SelectItem}
+                                                // this does not work as expected in Mantine 6
+                                                data-disabled={
+                                                    !metricsWithTimeDimensionsQuery.isSuccess
+                                                }
+                                                rightSection={
+                                                    metricsWithTimeDimensionsQuery.isLoading ? (
+                                                        <Loader
+                                                            size="xs"
+                                                            color="ldGray.5"
+                                                        />
+                                                    ) : undefined
+                                                }
+                                                classNames={{
+                                                    input: classes.input,
+                                                    item: classes.item,
+                                                    rightSection:
+                                                        classes.rightSection,
+                                                    dropdown: classes.dropdown,
+                                                }}
+                                            />
+                                        ) : (
+                                            <Text span c="ldGray.7" fz={13}>
+                                                Only metrics with a time
+                                                dimension defined in the .yml
+                                                can be compared.{' '}
+                                                <Anchor
+                                                    c="ldGray.9"
+                                                    fw={500}
+                                                    target="_blank"
+                                                    href="https://docs.lightdash.com/guides/metrics-catalog/#configuring-default-time-settings-in-yml"
+                                                >
+                                                    Learn more
+                                                </Anchor>
+                                            </Text>
+                                        ))}
+                                </Stack>
+                            </Paper>
+                        </Tooltip>
+                    ))}
             </Stack>
         </Radio.Group>
     );

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -37,6 +37,7 @@ type Props = {
     timeInterval: TimeFrames;
     onTimeIntervalChange: (timeInterval: TimeFrames) => void;
     isFetching: boolean;
+    disabled?: boolean;
 };
 
 export const MetricExploreDatePicker: FC<Props> = ({
@@ -48,6 +49,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
     onTimeIntervalChange,
     setTimeDimensionOverride,
     isFetching,
+    disabled = false,
 }) => {
     const { track } = useTracking();
     const userUuid = useAppSelector(
@@ -150,7 +152,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
             <Popover.Target>
                 <Group position="apart" w="fill-available" noWrap>
                     <SegmentedControl
-                        disabled={isFetching}
+                        disabled={isFetching || disabled}
                         size="xs"
                         h={32}
                         data={customWithPresets}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Enables the comparison feature in the Metric Explorer modal, allowing users to compare metrics with previous periods. This PR:

- Implements the "Clear" button functionality for comparison selections
- Makes the Clear button visible when a comparison is active
- Enables the "Previous Period" comparison option to compare with the same period last year
- Properly resets query state when navigating between metrics
- Enables fetching metrics with time dimensions when needed for comparisons
- Removes the disabled overlay from the comparison section

![image.png](https://app.graphite.com/user-attachments/assets/f2f02fbb-1eeb-4fb9-82e7-ff8cc551bd98.png)

