### PR TITLE
feat: add metric detail popover in metrics catalog

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.module.css
@@ -1,0 +1,21 @@
+.target {
+    cursor: default;
+}
+
+.tableName {
+    word-break: break-word;
+}
+
+.codeBlock {
+    overflow-y: auto;
+    font-size: var(--mantine-font-size-xs);
+    white-space: pre-wrap;
+}
+
+.compiledToggle {
+    cursor: pointer;
+}
+
+.compiledToggle:hover {
+    opacity: 0.8;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.tsx
@@ -1,0 +1,123 @@
+import { type MetricWithAssociatedTimeDimension } from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Code,
+    Divider,
+    Group,
+    HoverCard,
+    Loader,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconCode, IconTable } from '@tabler/icons-react';
+import { type FC, type ReactNode, useState } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useMetric } from '../hooks/useMetricsCatalog';
+import classes from './MetricDetailPopover.module.css';
+
+type Props = {
+    tableName: string;
+    metricName: string;
+    projectUuid: string;
+    children: ReactNode;
+};
+
+const MetricDetailContent: FC<{
+    metric: MetricWithAssociatedTimeDimension;
+}> = ({ metric }) => {
+    const [showCompiled, setShowCompiled] = useState(false);
+    const sqlToShow = showCompiled ? metric.compiledSql : metric.sql;
+
+    return (
+        <Stack gap="xs" w="300px">
+            <Group gap="xs" wrap="nowrap" justify="space-between">
+                <Group gap="xs" wrap="nowrap">
+                    <MantineIcon icon={IconTable} color="gray.6" size={14} />
+                    <Text size="sm" fw={500} className={classes.tableName}>
+                        {metric.tableLabel}
+                    </Text>
+                </Group>
+                <Badge size="xs" variant="light" color="indigo" radius="sm">
+                    {metric.type.toUpperCase()}
+                </Badge>
+            </Group>
+
+            <Divider />
+
+            <Box>
+                <Group gap="xs" mb={4} justify="space-between">
+                    <Text size="xs" c="dimmed" fw={500}>
+                        SQL
+                    </Text>
+                    <Tooltip label="Show compiled SQL" withinPortal>
+                        <Group
+                            gap={4}
+                            className={classes.compiledToggle}
+                            onClick={() => setShowCompiled((prev) => !prev)}
+                        >
+                            <MantineIcon
+                                icon={IconCode}
+                                size={12}
+                                color={showCompiled ? 'indigo.6' : 'gray.6'}
+                            />
+                            <Text
+                                size="xs"
+                                c={showCompiled ? 'indigo.6' : 'dimmed'}
+                                fw={500}
+                            >
+                                Compiled SQL
+                            </Text>
+                        </Group>
+                    </Tooltip>
+                </Group>
+                <Code block className={classes.codeBlock}>
+                    {sqlToShow}
+                </Code>
+            </Box>
+        </Stack>
+    );
+};
+
+export const MetricDetailPopover: FC<Props> = ({
+    tableName,
+    metricName,
+    projectUuid,
+    children,
+}) => {
+    const [opened, setOpened] = useState(false);
+
+    const { data: metric, isLoading } = useMetric({
+        projectUuid,
+        tableName,
+        metricName,
+        enabled: opened,
+    });
+
+    return (
+        <HoverCard
+            position="bottom-start"
+            withArrow
+            shadow="md"
+            radius="md"
+            offset={8}
+            openDelay={300}
+            closeDelay={200}
+            onOpen={() => setOpened(true)}
+            onClose={() => setOpened(false)}
+        >
+            <HoverCard.Target>
+                <Box className={classes.target}>{children}</Box>
+            </HoverCard.Target>
+            <HoverCard.Dropdown>
+                {isLoading && (
+                    <Group justify="center" p="md">
+                        <Loader size="sm" />
+                    </Group>
+                )}
+                {metric && <MetricDetailContent metric={metric} />}
+            </HoverCard.Dropdown>
+        </HoverCard>
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -7,11 +7,10 @@ import {
     Highlight,
     Paper,
     Portal,
-    Tooltip,
     getDefaultZIndex,
 } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
-import { IconTable, IconTrash } from '@tabler/icons-react';
+import { IconTrash } from '@tabler/icons-react';
 import EmojiPicker, {
     Emoji,
     EmojiStyle,
@@ -25,6 +24,7 @@ import { MetricIconPlaceholder } from '../../../svgs/metricsCatalog';
 import { EventName } from '../../../types/Events';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useUpdateCatalogItemIcon } from '../hooks/useCatalogItemIcon';
+import { MetricDetailPopover } from './MetricDetailPopover';
 
 import '../../../styles/emoji-picker-react.css';
 
@@ -237,36 +237,22 @@ export const MetricsCatalogColumnName = forwardRef<HTMLDivElement, Props>(
                             <MetricIconPlaceholder width={12} height={12} />
                         )}
                     </ActionIcon>
-                    <Tooltip
-                        label={
-                            <Group spacing={4}>
-                                <MantineIcon
-                                    color="ldGray.2"
-                                    icon={IconTable}
-                                    stroke={2.0}
-                                />
-                                {row.original.tableName}
-                            </Group>
-                        }
-                        disabled={!row.original.tableName}
-                        variant="xs"
-                        openDelay={300}
-                        maw={250}
-                        fz="xs"
-                        withinPortal
-                    >
-                        <Highlight
-                            highlight={table.getState().globalFilter || ''}
-                            fw={500}
-                            fz="sm"
-                            lh="150%"
-                            sx={{
-                                cursor: 'default',
-                            }}
+                    {projectUuid && (
+                        <MetricDetailPopover
+                            tableName={row.original.tableName}
+                            metricName={row.original.name}
+                            projectUuid={projectUuid}
                         >
-                            {row.original.label}
-                        </Highlight>
-                    </Tooltip>
+                            <Highlight
+                                highlight={table.getState().globalFilter || ''}
+                                fw={500}
+                                fz="sm"
+                                lh="150%"
+                            >
+                                {row.original.label}
+                            </Highlight>
+                        </MetricDetailPopover>
+                    )}
                 </Group>
                 <SharedEmojiPicker
                     emoji={row.original.icon}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2535: Metrics Catalog: Add option to view underlying SQL for metric calculation](https://linear.app/lightdash/issue/PROD-2535/metrics-catalog-add-option-to-view-underlying-sql-for-metric)

### Description:
Added a detailed popover for metrics in the metrics catalog. When hovering over a metric name, users can now see additional information including the table it belongs to, metric type, and SQL definition. The popover also includes a toggle to switch between viewing the original SQL and compiled SQL.

[CleanShot 2026-01-20 at 18.37.55.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d412eb58-2502-491a-b678-065d24739ea0.mp4" />](https://app.graphite.com/user-attachments/video/d412eb58-2502-491a-b678-065d24739ea0.mp4)

