### PR TITLE
docs: update Mantine documentation link to LLM-friendly format

### DIFF
--- a/.claude/skills/frontend-style-guide/SKILL.md
+++ b/.claude/skills/frontend-style-guide/SKILL.md
@@ -216,6 +216,4 @@ const MyComponent = () => {
 
 ## Mantine Documentation
 
-Component props and APIs: `https://mantine.dev/core/[component-name]/`
-
-**Tip**: In your IDE, hover over a component or use Go to Definition to see all available props.
+List of all components and links to their documentation in LLM-friendly format: `https://mantine.dev/llms.txt`


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Updated the Mantine documentation reference in the frontend style guide to point to the new LLM-friendly format URL (`https://mantine.dev/llms.txt`) instead of the previous component-specific URL pattern and IDE tip.