### PR TITLE
fix: initial stack setting not being taken into account when reload explorer

### DIFF
--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -201,9 +201,19 @@ const useCartesianChartConfig = ({
               }
             : initialChartConfig?.eChartsConfig,
     );
-    const isInitiallyStacked = (dirtyEchartsConfig?.series || []).some(
-        (series: Series) => series.stack !== undefined,
-    );
+
+    const isInitiallyStacked = useMemo(() => {
+        // First check the layout's stack property (persisted setting)
+        const layoutStack = initialChartConfig?.layout?.stack;
+        if (layoutStack !== undefined) {
+            return layoutStack !== StackType.NONE && layoutStack !== false;
+        }
+        // Fall back to checking if any series has stack property
+        return (dirtyEchartsConfig?.series || []).some(
+            (series: Series) => series.stack !== undefined,
+        );
+    }, [dirtyEchartsConfig?.series, initialChartConfig?.layout?.stack]);
+
     const [isStacked, setIsStacked] = useState<boolean>(isInitiallyStacked);
 
     const setLegend = useCallback((legend: EchartsLegend) => {
@@ -605,8 +615,8 @@ const useCartesianChartConfig = ({
                     stack === true
                         ? StackType.NORMAL
                         : stack === false
-                        ? StackType.NONE
-                        : stack,
+                          ? StackType.NONE
+                          : stack,
             }));
 
             setDirtyEchartsConfig(
@@ -941,8 +951,8 @@ const useCartesianChartConfig = ({
                                     ? serie.encode.yRef
                                     : serie.encode.xRef
                                 : dirtyLayout?.flipAxes
-                                ? serie.encode.xRef
-                                : serie.encode.yRef;
+                                  ? serie.encode.xRef
+                                  : serie.encode.yRef;
                         return {
                             fieldId: axis.field,
                             data: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/GLITCH-141/bar-charts-sometimes-lose-the-stacking-setting

### Description:
Improved stacked chart detection by prioritizing the layout's stack property over series stack property. This ensures that persisted stack settings are properly respected when initializing chart configurations.

This ensures consistent stacking behavior when charts are loaded from saved configurations.

**How to repro**
1. Go to [unsaved chart](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/orders?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_order_source%22%2C%22orders_status%22%2C%22orders_shipping_method%22%5D%2C%22metrics%22%3A%5B%22orders_total_order_amount%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_total_order_amount%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22orders_status%22%2C%22orders_shipping_method%22%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_order_source%22%2C%22orders_status%22%2C%22orders_shipping_method%22%2C%22orders_total_order_amount%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_order_source%22%2C%22yField%22%3A%5B%22orders_total_order_amount%22%5D%2C%22stack%22%3A%22stack100%22%7D%2C%22eChartsConfig%22%3A%7B%7D%7D%7D%7D&isExploreFromHere=true) with 2 group by dimensions
2. Set stacking in chart config
3. Reload the page

**Before**

![CleanShot 2026-01-20 at 13.31.04.gif](https://app.graphite.com/user-attachments/assets/cc0c50cb-f575-4a30-b94f-eaa12a0ad110.gif)

**After**

![CleanShot 2026-01-20 at 13.29.42.gif](https://app.graphite.com/user-attachments/assets/a8e03cd3-0d0a-4d08-9eda-a067c29407bd.gif)

