### PR TITLE
fix: improve metric catalog metric popularity overview modal

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7290,11 +7290,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7790,11 +7790,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7809,11 +7809,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7828,11 +7828,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7847,11 +7847,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7866,11 +7866,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14875,6 +14875,25 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PartialFailureType.MISSING_TARGETS': {
+        dataType: 'refEnum',
+        enums: ['missing_targets'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MissingTargetsPartialFailure: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                type: {
+                    ref: 'PartialFailureType.MISSING_TARGETS',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PartialFailure: {
         dataType: 'refAlias',
         type: {
@@ -14882,6 +14901,7 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { ref: 'DashboardChartPartialFailure' },
                 { ref: 'DashboardSqlChartPartialFailure' },
+                { ref: 'MissingTargetsPartialFailure' },
             ],
             validators: {},
         },
@@ -21363,12 +21383,19 @@ const models: TsoaRoute.Models = {
         type: { ref: 'CatalogMetadata', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ChartSummary.uuid-or-name-or-spaceUuid-or-spaceName-or-dashboardName-or-dashboardUuid-or-chartKind_':
+    'Pick_ChartSummary.uuid-or-name-or-description-or-spaceUuid-or-spaceName-or-dashboardName-or-dashboardUuid-or-chartKind_':
         {
             dataType: 'refAlias',
             type: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
+                    description: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     name: { dataType: 'string', required: true },
                     uuid: { dataType: 'string', required: true },
                     spaceUuid: { dataType: 'string', required: true },
@@ -21409,8 +21436,18 @@ const models: TsoaRoute.Models = {
                 charts: {
                     dataType: 'array',
                     array: {
-                        dataType: 'refAlias',
-                        ref: 'Pick_ChartSummary.uuid-or-name-or-spaceUuid-or-spaceName-or-dashboardName-or-dashboardUuid-or-chartKind_',
+                        dataType: 'intersection',
+                        subSchemas: [
+                            {
+                                ref: 'Pick_ChartSummary.uuid-or-name-or-description-or-spaceUuid-or-spaceName-or-dashboardName-or-dashboardUuid-or-chartKind_',
+                            },
+                            {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    viewsCount: { dataType: 'double' },
+                                },
+                            },
+                        ],
                     },
                     required: true,
                 },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8168,19 +8168,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -15453,6 +15440,19 @@
                 ],
                 "type": "object"
             },
+            "PartialFailureType.MISSING_TARGETS": {
+                "enum": ["missing_targets"],
+                "type": "string"
+            },
+            "MissingTargetsPartialFailure": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/PartialFailureType.MISSING_TARGETS"
+                    }
+                },
+                "required": ["type"],
+                "type": "object"
+            },
             "PartialFailure": {
                 "anyOf": [
                     {
@@ -15460,6 +15460,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/DashboardSqlChartPartialFailure"
+                    },
+                    {
+                        "$ref": "#/components/schemas/MissingTargetsPartialFailure"
                     }
                 ]
             },
@@ -22112,8 +22115,11 @@
             "ApiCatalogMetadataResults": {
                 "$ref": "#/components/schemas/CatalogMetadata"
             },
-            "Pick_ChartSummary.uuid-or-name-or-spaceUuid-or-spaceName-or-dashboardName-or-dashboardUuid-or-chartKind_": {
+            "Pick_ChartSummary.uuid-or-name-or-description-or-spaceUuid-or-spaceName-or-dashboardName-or-dashboardUuid-or-chartKind_": {
                 "properties": {
+                    "description": {
+                        "type": "string"
+                    },
                     "name": {
                         "type": "string"
                     },
@@ -22153,7 +22159,20 @@
                 "properties": {
                     "charts": {
                         "items": {
-                            "$ref": "#/components/schemas/Pick_ChartSummary.uuid-or-name-or-spaceUuid-or-spaceName-or-dashboardName-or-dashboardUuid-or-chartKind_"
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/Pick_ChartSummary.uuid-or-name-or-description-or-spaceUuid-or-spaceName-or-dashboardName-or-dashboardUuid-or-chartKind_"
+                                },
+                                {
+                                    "properties": {
+                                        "viewsCount": {
+                                            "type": "number",
+                                            "format": "double"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
                         },
                         "type": "array"
                     }
@@ -24256,7 +24275,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2351.0",
+        "version": "0.2354.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -728,7 +728,8 @@ export class SavedChartModel {
                                            order by ${SavedChartVersionsTableName}.created_at desc
                                            limit 1)`),
             )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid);
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .orderBy(`${SavedChartsTableName}.views_count`, 'desc');
     }
 
     async getChartCountPerField(projectUuid: string, fieldIds: string[]) {
@@ -1552,6 +1553,7 @@ export class SavedChartModel {
                 dashboardName: `${DashboardsTableName}.name`,
                 updatedAt: `saved_queries.last_version_updated_at`,
                 slug: `saved_queries.slug`,
+                viewsCount: 'saved_queries.views_count',
             })
             .leftJoin(
                 DashboardsTableName,

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -786,6 +786,7 @@ export class CatalogService<
             (chart) => ({
                 name: chart.name,
                 uuid: chart.uuid,
+                description: chart.description,
                 spaceUuid: chart.spaceUuid,
                 spaceName: chart.spaceName,
                 dashboardName: chart.dashboardName,
@@ -821,10 +822,13 @@ export class CatalogService<
             chartSummaries.map((chart) => ({
                 name: chart.name,
                 uuid: chart.uuid,
+                description: chart.description,
                 spaceUuid: chart.spaceUuid,
                 spaceName: chart.spaceName,
                 dashboardName: chart.dashboardName,
                 dashboardUuid: chart.dashboardUuid,
+                chartKind: chart.chartKind,
+                viewsCount: chart.viewsCount,
             })) ?? [];
 
         return { charts: chartAnalytics };

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -161,16 +161,19 @@ export type CatalogMetadata = {
 export type ApiCatalogMetadataResults = CatalogMetadata;
 
 export type CatalogAnalytics = {
-    charts: Pick<
+    charts: (Pick<
         ChartSummary,
         | 'uuid'
         | 'name'
+        | 'description'
         | 'spaceUuid'
         | 'spaceName'
         | 'dashboardName'
         | 'dashboardUuid'
         | 'chartKind'
-    >[];
+    > & {
+        viewsCount?: number;
+    })[];
 };
 export type ApiCatalogAnalyticsResults = CatalogAnalytics;
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.module.css
@@ -1,0 +1,18 @@
+.chartRow {
+    display: flex;
+    gap: var(--mantine-spacing-sm);
+    align-items: flex-start;
+    padding: var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+
+    &:hover {
+        background-color: var(--mantine-color-ldGray-0);
+
+        @mixin dark {
+            background-color: var(--mantine-color-ldDark-5);
+        }
+    }
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageModal.tsx
@@ -1,15 +1,106 @@
-import { Anchor, List, Stack, Text } from '@mantine-8/core';
-import { IconDeviceAnalytics } from '@tabler/icons-react';
+import { type ApiCatalogAnalyticsResults } from '@lightdash/common';
+import { Avatar, Box, Group, Stack, Text } from '@mantine-8/core';
+import {
+    IconDeviceAnalytics,
+    IconEye,
+    IconFolder,
+    IconLayoutDashboard,
+} from '@tabler/icons-react';
 import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal, {
     type MantineModalProps,
 } from '../../../components/common/MantineModal';
+import { getChartIcon } from '../../../components/common/ResourceIcon/utils';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useMetricChartAnalytics } from '../hooks/useMetricChartAnalytics';
+import styles from './MetricChartUsageModal.module.css';
 
 type Props = Pick<MantineModalProps, 'opened' | 'onClose'>;
+
+type ChartListProps = {
+    projectUuid: string;
+    analytics: ApiCatalogAnalyticsResults;
+    onChartClick: (chartUuid: string) => void;
+};
+
+const ChartList: FC<ChartListProps> = ({
+    projectUuid,
+    analytics,
+    onChartClick,
+}) => {
+    return (
+        <Stack gap={0}>
+            {analytics.charts.map((chart) => (
+                <Box
+                    key={chart.uuid}
+                    component={Link}
+                    to={`/projects/${projectUuid}/saved/${chart.uuid}`}
+                    target="_blank"
+                    className={styles.chartRow}
+                    onClick={() => onChartClick(chart.uuid)}
+                >
+                    <Avatar size="sm" color="blue" radius="xl">
+                        <MantineIcon icon={getChartIcon(chart.chartKind)} />
+                    </Avatar>
+                    <Stack gap={2} miw={0}>
+                        <Text fz="sm" fw={500}>
+                            {chart.name}
+                        </Text>
+                        {chart.description && (
+                            <Text fz="xs" c="dimmed" lineClamp={2}>
+                                {chart.description}
+                            </Text>
+                        )}
+                        <Group gap={4} wrap="nowrap">
+                            <MantineIcon
+                                color="ldGray.6"
+                                icon={IconFolder}
+                                size={14}
+                            />
+                            <Text fz="xs" c="ldGray.6">
+                                {chart.spaceName}
+                            </Text>
+                            {chart.dashboardUuid && (
+                                <>
+                                    <Text c="ldGray.6" fz="xs">
+                                        /
+                                    </Text>
+                                    <MantineIcon
+                                        color="ldGray.6"
+                                        icon={IconLayoutDashboard}
+                                        size={14}
+                                    />
+                                    <Text fz="xs" c="ldGray.6">
+                                        {chart.dashboardName}
+                                    </Text>
+                                </>
+                            )}
+                            {chart.viewsCount !== undefined && (
+                                <>
+                                    <Text c="ldGray.6" fz="xs">
+                                        ·
+                                    </Text>
+                                    <MantineIcon
+                                        color="ldGray.6"
+                                        icon={IconEye}
+                                        size={14}
+                                    />
+                                    <Text fz="xs" c="ldGray.6">
+                                        {chart.viewsCount}
+                                    </Text>
+                                </>
+                            )}
+                        </Group>
+                    </Stack>
+                </Box>
+            ))}
+        </Stack>
+    );
+};
 
 export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
     const { track } = useTracking();
@@ -32,6 +123,20 @@ export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
         field: activeMetric?.name,
     });
 
+    const handleChartClick = (chartUuid: string) => {
+        track({
+            name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED,
+            properties: {
+                userId: userUuid,
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                metricName: activeMetric?.name,
+                tableName: activeMetric?.tableName,
+                chartId: chartUuid,
+            },
+        });
+    };
+
     return (
         <MantineModal
             opened={opened}
@@ -39,45 +144,23 @@ export const MetricChartUsageModal: FC<Props> = ({ opened, onClose }) => {
             title="Metric Usage"
             icon={IconDeviceAnalytics}
             cancelLabel={false}
+            size="xl"
         >
-            <Stack gap="xs">
-                <Text>This metric is used in the following charts:</Text>
+            <Stack gap="sm">
                 {isLoading ? (
                     <Text size="sm" c="dimmed">
                         Loading...
                     </Text>
-                ) : analytics?.charts.length === 0 ? (
+                ) : !analytics || analytics.charts.length === 0 ? (
                     <Text size="sm" c="dimmed">
                         No charts found using this metric
                     </Text>
                 ) : (
-                    <List pl="sm">
-                        {analytics?.charts.map((chart) => (
-                            <List.Item key={chart.uuid} fz="sm">
-                                <Anchor
-                                    href={`/projects/${projectUuid}/saved/${chart.uuid}`}
-                                    target="_blank"
-                                    onClick={() => {
-                                        track({
-                                            name: EventName.METRICS_CATALOG_CHART_USAGE_CHART_CLICKED,
-                                            properties: {
-                                                userId: userUuid,
-                                                organizationId:
-                                                    organizationUuid,
-                                                projectId: projectUuid,
-                                                metricName: activeMetric?.name,
-                                                tableName:
-                                                    activeMetric?.tableName,
-                                                chartId: chart.uuid,
-                                            },
-                                        });
-                                    }}
-                                >
-                                    {chart.name}
-                                </Anchor>
-                            </List.Item>
-                        ))}
-                    </List>
+                    <ChartList
+                        projectUuid={projectUuid!}
+                        analytics={analytics}
+                        onChartClick={handleChartClick}
+                    />
                 )}
             </Stack>
         </MantineModal>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2534: Metrics Catalog: Improve popularity modal UI/layout](https://linear.app/lightdash/issue/PROD-2534/metrics-catalog-improve-popularity-modal-uilayout)

### Description:

Enhanced the Metric Usage Modal with a more detailed and user-friendly interface. The modal now displays charts in a visually appealing list format with additional information including:

- Chart descriptions
- Space and dashboard hierarchy
- View counts for each chart
- Chart type icons

Charts are now ordered by view count (most viewed first) to highlight the most popular usages of a metric.

![CleanShot 2026-01-20 at 18.36.47@2x.png](https://app.graphite.com/user-attachments/assets/d412cbec-4411-450c-b7cc-9b2d076bf616.png)

