### PR TITLE
fix: quote base table in funnel query sql

### DIFF
--- a/packages/backend/src/services/FunnelService/FunnelService.ts
+++ b/packages/backend/src/services/FunnelService/FunnelService.ts
@@ -321,7 +321,8 @@ ORDER BY ${breakdownField ? 'breakdown_value, ' : ''}step_order
             fieldMap,
             timestampFieldId,
         );
-        const baseTable = explore.tables[explore.baseTable].sqlTable;
+        const baseTableSql = explore.tables[explore.baseTable].sqlTable;
+        const baseTableName = explore.baseTable;
 
         // Get SQL builder based on warehouse type (no credentials needed for SQL generation)
         const credentials =
@@ -334,9 +335,11 @@ ORDER BY ${breakdownField ? 'breakdown_value, ' : ''}step_order
         const thirtyDaysAgo = new Date();
         thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
+        const quoteChar = sqlBuilder.getFieldQuoteChar();
+
         const sql = `
             SELECT DISTINCT ${eventField.compiledSql} AS event_name
-            FROM ${baseTable}
+            FROM ${baseTableSql} AS ${quoteChar}${baseTableName}${quoteChar}
             WHERE ${eventField.compiledSql} IS NOT NULL
               AND ${timestampField.compiledSql} >= ${sqlBuilder.castToTimestamp(
             thirtyDaysAgo,


### PR DESCRIPTION
The base table wasn't quoted in SQL - causing errors in snowflake because by default the table will be named in upper case

```sql
SELECT "lowercase_table".hello
FROM lowercase_table -- actually becomes LOWERCASE_TABLE
```

The following is the correct way:

```sql
SELECT "lowercase_table".hello
FROM lowercase_table AS "lowercase_table"
```