### PR TITLE
feat: improve visual feedback on scheduled delivery toggle

### DIFF
--- a/packages/frontend/src/features/scheduler/components/ConfirmPauseSchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/ConfirmPauseSchedulerModal.tsx
@@ -9,6 +9,7 @@ type ConfirmPauseSchedulerModalProps = {
     loading?: boolean;
     onClose: () => void;
     onConfirm: () => void;
+    description: string;
 };
 
 const ConfirmPauseSchedulerModal: FC<ConfirmPauseSchedulerModalProps> = ({
@@ -17,6 +18,7 @@ const ConfirmPauseSchedulerModal: FC<ConfirmPauseSchedulerModalProps> = ({
     loading,
     onClose,
     onConfirm,
+    description,
 }) => {
     return (
         <MantineModal
@@ -30,7 +32,7 @@ const ConfirmPauseSchedulerModal: FC<ConfirmPauseSchedulerModalProps> = ({
                     Pause
                 </Button>
             }
-            description="This will pause the scheduled delivery. It will not run until it is enabled again."
+            description={description}
         />
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
@@ -105,7 +105,7 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
                             maw={130}
                             label={
                                 scheduler.enabled
-                                    ? 'Toggle off to temporarily pause scheduled delivery'
+                                    ? 'Toggle off to temporarily pause the scheduled delivery'
                                     : 'Scheduled delivery paused. Toggle on to resume'
                             }
                         >
@@ -181,6 +181,7 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
                     handleToggle(false);
                     setIsConfirmPauseOpen(false);
                 }}
+                description="This will pause the scheduled delivery. It will not run until it is enabled again."
             />
         </Paper>
     );

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -50,8 +50,8 @@ const ToggleSyncEnabled: FC<{ scheduler: Scheduler }> = ({ scheduler }) => {
                 maw={130}
                 label={
                     scheduler.enabled
-                        ? 'Toggle off to temporarily pause scheduled delivery'
-                        : 'Scheduled delivery paused. Toggle on to resume'
+                        ? 'Toggle off to temporarily pause the sync'
+                        : 'Sync paused. Toggle on to resume'
                 }
             >
                 <Box mr="sm">
@@ -77,6 +77,7 @@ const ToggleSyncEnabled: FC<{ scheduler: Scheduler }> = ({ scheduler }) => {
                     setSchedulerEnabled(false);
                     setIsConfirmPauseOpen(false);
                 }}
+                description="This will pause the sync. It will not run until it is enabled again."
             />
         </>
     );


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19570

### Description:
This PR implements 2 of the 3 considerations of the issue linked above:


Suggestion 1
> Update the toggle label and/or add a tooltip to clarify its **function.**

✅ Commit 1

> Consider adding a warning or info message when sync is disabled, explaining that scheduled syncs will not run.

✅ Commit 2

Suggestion 3
> Add a toggle to enable or disable syncs and deliveries from the admin panel

❌ I think we should treat this one more as a feature request rather than a quick hotfix. I think it's not immediately clear where to integrate this functionality. E.g. maybe it should be part of the edit dialog, or just in the menu drop down.


### Testing:

Scheduled Deliveries:

https://github.com/user-attachments/assets/9f030b09-8484-49e1-87b1-49c8ca0dee14


Google Sync:

https://github.com/user-attachments/assets/d9adc121-e2f1-4d0b-a2bd-94a9f7d0efd7






