### PR TITLE
feat: add support for joins in custom maps

### DIFF
--- a/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
+++ b/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
@@ -364,9 +364,15 @@ const useLeafletMapConfig = ({
             mapType,
             geoJsonUrl: getGeoJsonUrl(mapType, customGeoJsonUrl),
             // Determine the geoJsonPropertyKey to use
-            // Default to 'code' for US states, 'ISO3166-1-Alpha-3' for world
+            // For custom maps, use configured key directly
+            // For built-in maps, validate against known property keys
             geoJsonPropertyKey: (() => {
-                // Define valid keys for each map type
+                // For custom maps, use the configured key directly (no whitelist)
+                if (mapType === MapChartLocation.CUSTOM) {
+                    return configGeoJsonPropertyKey || 'name';
+                }
+
+                // Define valid keys for each built-in map type
                 const usaValidKeys = ['code', 'name'];
                 const worldValidKeys = [
                     'ISO3166-1-Alpha-3',

--- a/packages/frontend/src/hooks/useGeoJsonProperties.ts
+++ b/packages/frontend/src/hooks/useGeoJsonProperties.ts
@@ -1,0 +1,184 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import * as topojson from 'topojson-client';
+import type { Topology } from 'topojson-specification';
+
+export type GeoJsonPropertiesResult = {
+    properties: string[];
+    suggestedProperty: string | null;
+};
+
+/**
+ * Priority order for auto-suggesting a property:
+ * 1. 'name' (case-insensitive) - most common identifier
+ * 2. 'code' (case-insensitive) - common for administrative regions
+ * 3. 'id' (case-insensitive) - generic identifier
+ * 4. First property in the list
+ */
+const findSuggestedProperty = (properties: string[]): string | null => {
+    if (properties.length === 0) return null;
+
+    const priorityPatterns = ['name', 'code', 'id'];
+
+    for (const pattern of priorityPatterns) {
+        const match = properties.find((prop) => prop.toLowerCase() === pattern);
+        if (match) return match;
+    }
+
+    return properties[0];
+};
+
+/**
+ * Extracts unique property keys from all features in a GeoJSON FeatureCollection.
+ * For TopoJSON, converts to GeoJSON first.
+ */
+const extractPropertiesFromGeoJson = (
+    data: unknown,
+): GeoJsonPropertiesResult => {
+    let features: GeoJSON.Feature[] = [];
+
+    // Handle TopoJSON
+    if (
+        typeof data === 'object' &&
+        data !== null &&
+        'type' in data &&
+        (data as { type: string }).type === 'Topology' &&
+        'objects' in data
+    ) {
+        const topology = data as Topology;
+        const objectKey = Object.keys(topology.objects)[0];
+        const geoJson = topojson.feature(
+            topology,
+            topology.objects[objectKey],
+        ) as GeoJSON.FeatureCollection;
+        features = geoJson.features || [];
+    }
+    // Handle GeoJSON FeatureCollection
+    else if (
+        typeof data === 'object' &&
+        data !== null &&
+        'type' in data &&
+        (data as { type: string }).type === 'FeatureCollection' &&
+        'features' in data
+    ) {
+        features = ((data as { features: unknown[] }).features ||
+            []) as GeoJSON.Feature[];
+    }
+
+    // Collect all unique property keys across all features
+    const propertySet = new Set<string>();
+    features.forEach((feature) => {
+        if (feature.properties) {
+            Object.keys(feature.properties).forEach((key) => {
+                propertySet.add(key);
+            });
+        }
+    });
+
+    const properties = Array.from(propertySet).sort();
+    const suggestedProperty = findSuggestedProperty(properties);
+
+    return { properties, suggestedProperty };
+};
+
+/**
+ * Fetches a GeoJSON URL and extracts available property keys.
+ * Works with both GeoJSON and TopoJSON formats.
+ */
+const fetchGeoJsonProperties = async (
+    geoJsonUrl: string,
+): Promise<GeoJsonPropertiesResult> => {
+    // Include credentials for authenticated proxy requests
+    const response = await fetch(geoJsonUrl, {
+        credentials: 'include',
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        console.error(
+            `[useGeoJsonProperties] Failed to fetch GeoJSON: ${response.status}`,
+            errorText,
+        );
+        throw new Error(`Failed to fetch GeoJSON: ${response.status}`);
+    }
+
+    let data: unknown;
+    try {
+        data = await response.json();
+    } catch (parseError) {
+        console.error(
+            '[useGeoJsonProperties] Failed to parse GeoJSON as JSON:',
+            parseError,
+        );
+        throw new Error('Failed to parse GeoJSON: invalid JSON');
+    }
+
+    const result = extractPropertiesFromGeoJson(data);
+
+    if (result.properties.length === 0) {
+        console.warn(
+            '[useGeoJsonProperties] No properties found in GeoJSON. Data type:',
+            typeof data === 'object' && data !== null
+                ? (data as { type?: string }).type
+                : typeof data,
+        );
+    }
+
+    return result;
+};
+
+/**
+ * Hook to fetch GeoJSON properties from a URL.
+ * Returns the list of available property keys and a suggested default.
+ *
+ * @param geoJsonUrl - The URL to fetch (can be proxied or local)
+ * @param options - Additional TanStack Query options
+ */
+export const useGeoJsonProperties = (
+    geoJsonUrl: string | null | undefined,
+    options?: Omit<
+        UseQueryOptions<GeoJsonPropertiesResult, Error>,
+        'queryKey' | 'queryFn' | 'enabled'
+    >,
+) => {
+    return useQuery<GeoJsonPropertiesResult, Error>({
+        queryKey: ['geojson_properties', geoJsonUrl],
+        queryFn: () => fetchGeoJsonProperties(geoJsonUrl!),
+        enabled: !!geoJsonUrl,
+        staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+        retry: 1, // Only retry once for external resources
+        ...options,
+    });
+};
+
+/**
+ * Helper to find the best matching property for a given column name.
+ * Uses case-insensitive matching.
+ *
+ * @param properties - Available GeoJSON property keys
+ * @param columnName - The data column name to match against
+ * @returns The matching property or null if no match found
+ */
+export const findMatchingProperty = (
+    properties: string[],
+    columnName: string | undefined,
+): string | null => {
+    if (!columnName || properties.length === 0) return null;
+
+    const normalizedColumnName = columnName.toLowerCase();
+
+    // Exact match (case-insensitive)
+    const exactMatch = properties.find(
+        (prop) => prop.toLowerCase() === normalizedColumnName,
+    );
+    if (exactMatch) return exactMatch;
+
+    // Partial match - column name contains property or vice versa
+    const partialMatch = properties.find(
+        (prop) =>
+            normalizedColumnName.includes(prop.toLowerCase()) ||
+            prop.toLowerCase().includes(normalizedColumnName),
+    );
+    if (partialMatch) return partialMatch;
+
+    return null;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19444, PROD-2484

### Description:

Adds support for setting up joins with custom map shapes. With this change, users can join the shapes in their geojson to columns in their data. 

A typical geojson file includes a property section for each shape (area), for example:

```
"properties": {
        "cod_prov": "07",
        "name": "Illes Balears",
        "cod_ccaa": "03",
}
```
This PR parses custom JSON provided by the user and allows them to chose which of these properties maps to a column in their data. 

**To test**
- Build a query with `Tables/Geo`
- Include `State province name` and `Customer count sum` fields
- Switch the viz to map
- Choose Map type = Area
- Use 'custom region'
- Add [this geo data URL](https://raw.githubusercontent.com/codeforgermany/click_that_hood/refs/heads/main/public/data/spain-provinces.geojson)(Spains provinces)
- The 'Map join field' should be populated by the properties in the json ✅ 
- Choose 'name'
- Chose 'State province name' in the 'Data join field'
- You should see one province in Spain get colored in ✅ (at the moment we only have US data which accidentally matches here, I'm going to add more)

<img width="418" height="344" alt="Screenshot 2026-01-20 at 14 58 25" src="https://github.com/user-attachments/assets/9e2483b3-a2a5-4121-9e92-ca80685d338c" />
