### PR TITLE
fix: run pivot query on unsaved chart reload

### DIFF
--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1045,21 +1045,23 @@ const useCartesianChartConfig = ({
     ]);
 
     const validConfig: CartesianChart = useMemo(() => {
-        return isCompleteLayout(dirtyLayout) &&
-            isCompleteEchartsConfig(dirtyEchartsConfig)
-            ? {
-                  layout: dirtyLayout,
-                  eChartsConfig: {
+        // Always use the dirtyLayout and dirtyEchartsConfig when possible, fallback to the empty config if not complete.
+        return {
+            layout: isCompleteLayout(dirtyLayout)
+                ? dirtyLayout
+                : EMPTY_CARTESIAN_CHART_CONFIG.layout,
+            eChartsConfig: isCompleteEchartsConfig(dirtyEchartsConfig)
+                ? {
                       ...dirtyEchartsConfig,
                       series: dirtyEchartsConfig.series.filter(
                           (serie) => !serie.isFilteredOut,
                       ),
                       tooltip,
                       tooltipSort,
-                  },
-                  metadata: dirtyMetadata,
-              }
-            : EMPTY_CARTESIAN_CHART_CONFIG;
+                  }
+                : EMPTY_CARTESIAN_CHART_CONFIG.eChartsConfig,
+            metadata: dirtyMetadata,
+        };
     }, [dirtyLayout, dirtyEchartsConfig, dirtyMetadata, tooltip, tooltipSort]);
 
     const { dirtyChartType } = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Always preserve the `dirtyLayout` if it exists as it comes from `initialChartConfig`

Fixes an issue where on reload the pivot configuration couldn't be derived from the chart config and therefore no pivot query was run. This triggered a UI warning saying that the user needed to re-run the query to get the latest results

Use this [unsaved chart](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/orders?create_saved_chart_version=%7B%22tableName%22%3A%22orders%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22orders%22%2C%22dimensions%22%3A%5B%22orders_order_source%22%2C%22orders_status%22%2C%22orders_shipping_method%22%5D%2C%22metrics%22%3A%5B%22orders_total_order_amount%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22orders_total_order_amount%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22pivotConfig%22%3A%7B%22columns%22%3A%5B%22orders_status%22%2C%22orders_shipping_method%22%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22orders_order_source%22%2C%22orders_status%22%2C%22orders_shipping_method%22%2C%22orders_total_order_amount%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22orders_order_source%22%2C%22yField%22%3A%5B%22orders_total_order_amount%22%5D%2C%22stack%22%3A%22stack100%22%7D%2C%22eChartsConfig%22%3A%7B%7D%7D%7D%7D&isExploreFromHere=true) for testing

**Before**

![CleanShot 2026-01-20 at 15.12.56.gif](https://app.graphite.com/user-attachments/assets/b6941ad1-e3fa-4839-9539-01c1beb47676.gif)

**After**

![CleanShot 2026-01-20 at 15.10.13.gif](https://app.graphite.com/user-attachments/assets/119bb8b0-a707-4c56-9125-092933b1c449.gif)

