### PR TITLE
fix: pagination in schedulers table

### DIFF
--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -297,7 +297,7 @@ export const usePaginatedSchedulers = ({
             filters,
             includeLatestRun,
         ],
-        queryFn: async ({ pageParam = 0 }) => {
+        queryFn: async ({ pageParam = 1 }) => {
             return getPaginatedSchedulers(
                 projectUuid,
                 {
@@ -312,9 +312,9 @@ export const usePaginatedSchedulers = ({
             );
         },
         getNextPageParam: (_lastGroup, groups) => {
-            const currentPage = groups.length - 1;
+            const currentPage = groups.length;
             const totalPages = _lastGroup.pagination?.totalPageCount ?? 0;
-            return currentPage < totalPages - 1 ? currentPage + 1 : undefined;
+            return currentPage < totalPages ? currentPage + 1 : undefined;
         },
         keepPreviousData: true,
         refetchOnWindowFocus: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2612/slow-scheduled-delivery-query

### Description:

This PR adds:
- Default starting page set to 1 so that pagination actually works, previously it was relying on 0 which is `falsy` and would fetch all results, leading to a slow query

**Steps to test**
1. Add many schedulers to your database
2. Go to settings > scheduled deliveries & syncs