### PR TITLE
fix: schedulers reassign modal missing project UUID when fetching users

### DIFF
--- a/packages/frontend/src/components/SchedulersView/ReassignSchedulerOwnerModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/ReassignSchedulerOwnerModal.tsx
@@ -94,6 +94,7 @@ const ReassignSchedulerOwnerModal: FC<ReassignSchedulerOwnerModalProps> = ({
                 </Text>
 
                 <UserSelect
+                    projectUuid={projectUuid}
                     label="New owner"
                     value={selectedUserUuid}
                     onChange={setSelectedUserUuid}

--- a/packages/frontend/src/components/common/UserSelect/index.tsx
+++ b/packages/frontend/src/components/common/UserSelect/index.tsx
@@ -25,6 +25,7 @@ type UserSelectProps = {
     disabled?: boolean;
     /** When true, only shows users with an active Google connection (refresh token) */
     requireGoogleToken?: boolean;
+    projectUuid?: string;
 };
 
 export const UserSelect: FC<UserSelectProps> = ({
@@ -35,6 +36,7 @@ export const UserSelect: FC<UserSelectProps> = ({
     placeholder = 'Search for a user...',
     disabled = false,
     requireGoogleToken = false,
+    projectUuid,
 }) => {
     const [searchValue, setSearchValue] = useState('');
     const [debouncedSearchValue] = useDebouncedValue(searchValue, 300);
@@ -51,6 +53,7 @@ export const UserSelect: FC<UserSelectProps> = ({
             searchInput: debouncedSearchValue,
             pageSize: DEFAULT_PAGE_SIZE,
             googleOidcOnly: requireGoogleToken || undefined,
+            projectUuid,
         },
         { keepPreviousData: true },
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added `projectUuid` parameter to the `UserSelect` component to filter users by project. This parameter is now passed from the `ReassignSchedulerOwnerModal` to ensure that only relevant users are displayed in the dropdown.