### PR TITLE
feat: hide tooltips when there is a map popup

### DIFF
--- a/packages/frontend/src/components/SimpleMap/SimpleMap.module.css
+++ b/packages/frontend/src/components/SimpleMap/SimpleMap.module.css
@@ -161,6 +161,11 @@
     }
 }
 
+/* Hide tooltips when a popup is open to reduce visual clutter */
+:global(.leaflet-container:has(.leaflet-popup)) :global(.leaflet-tooltip) {
+    display: none !important;
+}
+
 /* Match popup border-radius to tooltip (3px) and reduce horizontal padding */
 :global(.leaflet-popup-content-wrapper) {
     border-radius: 3px !important;


### PR DESCRIPTION
### Description:

Hides tooltips in maps when there is a data point selected. Showing the selected data and tooltips was noisy. 

**Note on implementation - ** this uses css instead of react to hide the tooltips. Apparently this is a very common pattern with leaflet since it does its own rendering (outside of react). And is also more performant.

Here's claude's explanation

1. Scatter maps - The <Tooltip> components ARE React (react-leaflet), so we could track popup state and conditionally render them. But we'd need shared state across all markers.
2. Area maps - The tooltips are bound via Leaflet's native layer.bindTooltip() in onEachFeature, which runs once when the layer mounts. Leaflet manages these directly, not React.

CSS handles both uniformly with one rule. A React-only solution would require:
  - Shared state to track if any popup is open
  - Passing that state to all MapMarker components
  - For area maps, either re-binding tooltips when state changes or using a separate approach

**Before**
![Kapture 2026-01-20 at 18 10 22](https://github.com/user-attachments/assets/57b0e9b7-1fb6-4177-a79e-727fce509501)

**After**
![Kapture 2026-01-20 at 18 02 20](https://github.com/user-attachments/assets/3bede05b-b3d6-4686-838d-81cba56c6fc1)
