### PR TITLE
chore: refactor available destinations to be calculated on the filter component

### DIFF
--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -40,17 +40,12 @@ import {
 } from 'react';
 import { Link } from 'react-router';
 import ConfirmSendNowModal from '../../features/scheduler/components/ConfirmSendNowModal';
-import {
-    useLogsFilters,
-    type DestinationType,
-} from '../../features/scheduler/hooks/useLogsFilters';
+import { useLogsFilters } from '../../features/scheduler/hooks/useLogsFilters';
 import {
     useFetchRunLogs,
     useSchedulerRuns,
     useSendNowSchedulerByUuid,
 } from '../../features/scheduler/hooks/useScheduler';
-import useHealth from '../../hooks/health/useHealth';
-import { useGetSlack } from '../../hooks/slack/useSlack';
 import LoadingState from '../common/LoadingState';
 import MantineIcon from '../common/MantineIcon';
 import ResourceEmptyState from '../common/ResourceView/ResourceEmptyState';
@@ -237,25 +232,6 @@ const LogsTable: FC<LogsTableProps> = ({
         },
         [childLogsMap, fetchRunLogsMutation],
     );
-
-    const health = useHealth();
-    const slack = useGetSlack();
-    const organizationHasSlack = !!slack.data?.organizationUuid;
-
-    // Compute available destinations based on integrations
-    const availableDestinations = useMemo<DestinationType[]>(() => {
-        const destinations: DestinationType[] = [];
-        if (health.data?.hasEmailClient) {
-            destinations.push('email');
-        }
-        if (organizationHasSlack) {
-            destinations.push('slack');
-        }
-        if (health.data?.hasMicrosoftTeams) {
-            destinations.push('msteams');
-        }
-        return destinations;
-    }, [health.data, organizationHasSlack]);
 
     // Compute available schedulers from runs (unique schedulers)
     const availableSchedulers = useMemo(() => {
@@ -577,7 +553,6 @@ const LogsTable: FC<LogsTableProps> = ({
                 currentResultsCount={totalFetched}
                 hasActiveFilters={hasActiveFilters}
                 resetFilters={resetFilters}
-                availableDestinations={availableDestinations}
                 availableSchedulers={availableSchedulers}
             />
         ),

--- a/packages/frontend/src/components/SchedulersView/LogsTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTopToolbar.tsx
@@ -9,10 +9,7 @@ import {
 } from '@mantine-8/core';
 import { IconTrash } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
-import {
-    type DestinationType,
-    type useLogsFilters,
-} from '../../features/scheduler/hooks/useLogsFilters';
+import { type useLogsFilters } from '../../features/scheduler/hooks/useLogsFilters';
 import MantineIcon from '../common/MantineIcon';
 import CreatedByFilter from './filters/CreatedByFilter';
 import DestinationFilter from './filters/DestinationFilter';
@@ -42,7 +39,6 @@ interface LogsTopToolbarProps
     > {
     isFetching: boolean;
     currentResultsCount: number;
-    availableDestinations: DestinationType[];
     availableSchedulers: Scheduler[];
     projectUuid: string;
 }
@@ -61,7 +57,6 @@ export const LogsTopToolbar: FC<LogsTopToolbarProps> = memo(
         setSelectedSchedulerUuid,
         hasActiveFilters,
         resetFilters,
-        availableDestinations,
         availableSchedulers,
         projectUuid,
     }) => {
@@ -127,7 +122,6 @@ export const LogsTopToolbar: FC<LogsTopToolbarProps> = memo(
                     <DestinationFilter
                         selectedDestinations={selectedDestinations}
                         setSelectedDestinations={setSelectedDestinations}
-                        availableDestinations={availableDestinations}
                     />
                 </Group>
 

--- a/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
@@ -10,10 +10,7 @@ import {
 } from '@mantine-8/core';
 import { IconTrash, IconUserEdit } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
-import {
-    type DestinationType,
-    type useSchedulerFilters,
-} from '../../features/scheduler/hooks/useSchedulerFilters';
+import { type useSchedulerFilters } from '../../features/scheduler/hooks/useSchedulerFilters';
 import MantineIcon from '../common/MantineIcon';
 import CreatedByFilter from './filters/CreatedByFilter';
 import DestinationFilter from './filters/DestinationFilter';
@@ -39,7 +36,6 @@ type SchedulerTopToolbarProps = GroupProps &
         currentResultsCount: number;
         hasActiveFilters?: boolean;
         onClearFilters?: () => void;
-        availableDestinations: DestinationType[];
         projectUuid: string;
         // Bulk selection props
         selectedCount?: number;
@@ -62,7 +58,6 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
         currentResultsCount,
         hasActiveFilters,
         onClearFilters,
-        availableDestinations,
         selectedCount = 0,
         onBulkReassign,
         projectUuid,
@@ -120,7 +115,6 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
                     <DestinationFilter
                         selectedDestinations={selectedDestinations}
                         setSelectedDestinations={setSelectedDestinations}
-                        availableDestinations={availableDestinations}
                     />
                 </Group>
 

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -51,12 +51,7 @@ import {
 } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { usePaginatedSchedulers } from '../../features/scheduler/hooks/useScheduler';
-import {
-    useSchedulerFilters,
-    type DestinationType,
-} from '../../features/scheduler/hooks/useSchedulerFilters';
-import useHealth from '../../hooks/health/useHealth';
-import { useGetSlack } from '../../hooks/slack/useSlack';
+import { useSchedulerFilters } from '../../features/scheduler/hooks/useSchedulerFilters';
 import { useIsTruncated } from '../../hooks/useIsTruncated';
 import { useProject } from '../../hooks/useProject';
 import GSheetsSvg from '../../svgs/google-sheets.svg?react';
@@ -242,25 +237,6 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
     useEffect(() => {
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
-
-    const health = useHealth();
-    const slack = useGetSlack();
-    const organizationHasSlack = !!slack.data?.organizationUuid;
-
-    // Compute available destinations based on integrations
-    const availableDestinations = useMemo<DestinationType[]>(() => {
-        const destinations: DestinationType[] = [];
-        if (health.data?.hasEmailClient) {
-            destinations.push('email');
-        }
-        if (organizationHasSlack) {
-            destinations.push('slack');
-        }
-        if (health.data?.hasMicrosoftTeams) {
-            destinations.push('msteams');
-        }
-        return destinations;
-    }, [health.data, organizationHasSlack]);
 
     const sorting = useMemo<MRT_SortingState>(
         () => [{ id: sortField, desc: sortDirection === 'desc' }],
@@ -842,7 +818,6 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                     currentResultsCount={totalFetched}
                     hasActiveFilters={hasActiveFilters}
                     onClearFilters={resetFilters}
-                    availableDestinations={availableDestinations}
                     selectedCount={selectedRows.length}
                     onBulkReassign={handleBulkReassign}
                 />

--- a/packages/frontend/src/components/SchedulersView/filters/DestinationFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/DestinationFilter.tsx
@@ -8,14 +8,15 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { type FC } from 'react';
+import { useMemo, type FC } from 'react';
 import { type DestinationType } from '../../../features/scheduler/hooks/useSchedulerFilters';
+import useHealth from '../../../hooks/health/useHealth';
+import { useGetSlack } from '../../../hooks/slack/useSlack';
 import classes from './FormatFilter.module.css';
 
 interface DestinationFilterProps {
     selectedDestinations: DestinationType[];
     setSelectedDestinations: (destinations: DestinationType[]) => void;
-    availableDestinations: DestinationType[];
 }
 
 const DESTINATION_LABELS: Record<DestinationType, string> = {
@@ -27,8 +28,25 @@ const DESTINATION_LABELS: Record<DestinationType, string> = {
 const DestinationFilter: FC<DestinationFilterProps> = ({
     selectedDestinations,
     setSelectedDestinations,
-    availableDestinations,
 }) => {
+    const health = useHealth();
+    const slack = useGetSlack();
+    const organizationHasSlack = !!slack.data?.organizationUuid;
+
+    // Compute available destinations based on integrations
+    const availableDestinations = useMemo<DestinationType[]>(() => {
+        const destinations: DestinationType[] = [];
+        if (health.data?.hasEmailClient) {
+            destinations.push('email');
+        }
+        if (organizationHasSlack) {
+            destinations.push('slack');
+        }
+        if (health.data?.hasMicrosoftTeams) {
+            destinations.push('msteams');
+        }
+        return destinations;
+    }, [health.data, organizationHasSlack]);
     const hasSelectedDestinations = selectedDestinations.length > 0;
 
     return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Refactored the destination filter logic in the Schedulers view to improve code organization. Moved the `availableDestinations` computation from parent components (LogsTable and SchedulersTable) directly into the DestinationFilter component where it's used. This eliminates prop drilling and centralizes the integration-based destination logic in a single location.

The change makes the code more maintainable by:
1. Removing unnecessary prop passing through multiple components
2. Encapsulating the destination availability logic within the component that needs it
3. Ensuring consistent destination filtering behavior across different views

AI: I've refactored this to follow the single responsibility principle, with each component only handling what it needs to know about.