### PR TITLE
feat: add dimension filtering controls for metrics in Metrics Explorer

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -119,6 +119,8 @@ models:
                 WHEN ${TABLE}.order_date >= ${lightdash.parameters.date_dim_parameter}
                   THEN 'param is smaller'
               END
+            spotlight:
+              filter_by: false
         type: string
       - name: date_custom_param_test
         description: "Example of custom date"
@@ -131,6 +133,8 @@ models:
                 WHEN ${TABLE}.order_date >= ${lightdash.parameters.date_custom_parameter}
                   THEN 'I feel great!!!'
               END
+            spotlight:
+              filter_by: false
         type: string
       - name: order_date
         description: Date (UTC) that the order was placed
@@ -193,6 +197,11 @@ models:
                 type: percent_of_total
                 sql: ${total_order_amount}
                 format: "#,##0.00%"
+                spotlight:
+                  filter_by:
+                    - status
+                    - currency
+                    - date_dim_param_test # to test that metric filter_by overrides dimension filter_by: false
               amount_running_total:
                 type: running_total
                 sql: ${total_order_amount}

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -9,6 +9,7 @@ import {
     convertToAiHints,
     Explore,
     getBasicType,
+    isMetric,
     type Tag,
 } from '@lightdash/common';
 import { DbCatalog } from '../../../database/entities/catalog';
@@ -46,6 +47,9 @@ const parseFieldFromMetricOrDimension = (
     catalogSearchUuid: catalogArgs.catalogSearchUuid,
     icon: catalogArgs.icon,
     searchRank: catalogArgs.searchRank,
+    ...(isMetric(field) && field.spotlight?.filterBy
+        ? { spotlightFilterBy: field.spotlight.filterBy }
+        : {}),
 });
 
 export const parseFieldsFromCompiledTable = (

--- a/packages/common/src/compiler/lightdashProjectConfig.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.ts
@@ -7,11 +7,13 @@ import type { LightdashProjectConfig } from '../types/lightdashProjectConfig';
  * Get the spotlight configuration for a resource
  * @param visibility - The visibility of the resource
  * @param categories - The categories of the resource
+ * @param filterBy - Dimension IDs allowlist for filtering (metrics only)
  * @returns The spotlight configuration for the resource
  */
 export const getSpotlightConfigurationForResource = (
     visibility?: LightdashProjectConfig['spotlight']['default_visibility'],
     categories?: string[],
+    filterBy?: string[],
 ): Pick<Explore, 'spotlight'> | Pick<Metric, 'spotlight'> => {
     if (visibility === undefined) {
         return {};
@@ -21,6 +23,7 @@ export const getSpotlightConfigurationForResource = (
         spotlight: {
             visibility,
             categories,
+            ...(filterBy ? { filterBy } : {}),
         },
     };
 };

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -205,6 +205,9 @@ const convertDimension = (
         ...(meta.dimension?.ai_hint
             ? { aiHint: convertToAiHints(meta.dimension.ai_hint) }
             : {}),
+        ...(meta.dimension?.spotlight?.filter_by === false
+            ? { spotlight: { filterBy: false } }
+            : {}),
     };
 };
 

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -328,6 +328,13 @@
                                                             "type": "string"
                                                         },
                                                         "description": "An array of categories for the metric in Spotlight"
+                                                    },
+                                                    "filter_by": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "An array of dimension names that are allowed for filtering this metric in the Metrics Explorer"
                                                     }
                                                 },
                                                 "anyOf": [
@@ -339,6 +346,11 @@
                                                     {
                                                         "required": [
                                                             "categories"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "filter_by"
                                                         ]
                                                     }
                                                 ]
@@ -831,6 +843,13 @@
                                                                         "type": "string"
                                                                     },
                                                                     "description": "An array of categories for the metric in Spotlight"
+                                                                },
+                                                                "filter_by": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "description": "An array of dimension names that are allowed for filtering this metric in the Metrics Explorer"
                                                                 }
                                                             },
                                                             "anyOf": [
@@ -842,6 +861,11 @@
                                                                 {
                                                                     "required": [
                                                                         "categories"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "required": [
+                                                                        "filter_by"
                                                                     ]
                                                                 }
                                                             ]
@@ -1038,6 +1062,17 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                "spotlight": {
+                                                    "type": "object",
+                                                    "description": "Configure dimension visibility in the Metrics Explorer",
+                                                    "properties": {
+                                                        "filter_by": {
+                                                            "type": "boolean",
+                                                            "description": "Whether this dimension can be used for filtering in the Metrics Explorer. Defaults to true."
+                                                        }
+                                                    },
+                                                    "required": ["filter_by"]
                                                 }
                                             }
                                         },
@@ -1423,11 +1458,19 @@
                                             "type": "string"
                                         },
                                         "description": "An array of categories for the metric in Spotlight"
+                                    },
+                                    "filter_by": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "An array of dimension names that are allowed for filtering this metric in the Metrics Explorer"
                                     }
                                 },
                                 "anyOf": [
                                     { "required": ["visibility"] },
-                                    { "required": ["categories"] }
+                                    { "required": ["categories"] },
+                                    { "required": ["filter_by"] }
                                 ]
                             }
                         }

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -77,6 +77,7 @@ export type CatalogField = Pick<
         icon: CatalogItemIcon | null;
         aiHints: string[] | null;
         searchRank?: number;
+        spotlightFilterBy?: string[]; // dimension IDs allowlist (metrics only)
     };
 
 export type CatalogTable = Pick<

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -200,6 +200,9 @@ export type DbtColumnLightdashDimension = {
         height?: number;
         fit?: string;
     };
+    spotlight?: {
+        filter_by?: boolean; // default true
+    };
 } & DbtLightdashFieldTags;
 
 export type DbtColumnLightdashAdditionalDimension = Omit<
@@ -230,6 +233,7 @@ export type DbtColumnLightdashMetric = {
             LightdashProjectConfig['spotlight']
         >['default_visibility'];
         categories?: string[]; // yaml_reference
+        filter_by?: string[]; // dimension IDs allowlist
     };
     ai_hint?: string | string[];
 } & DbtLightdashFieldTags;
@@ -589,6 +593,7 @@ export const convertModelMetric = ({
         ...getSpotlightConfigurationForResource(
             spotlightVisibility,
             spotlightCategories,
+            metric.spotlight?.filter_by,
         ),
         ...(metric.ai_hint ? { aiHint: convertToAiHints(metric.ai_hint) } : {}),
     };

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -573,6 +573,9 @@ export interface Dimension extends Field {
         height?: number;
         fit?: string;
     };
+    spotlight?: {
+        filterBy: boolean;
+    };
 }
 
 /**
@@ -757,6 +760,7 @@ export interface Metric extends Field {
     spotlight?: {
         visibility: LightdashProjectConfig['spotlight']['default_visibility'];
         categories?: string[]; // yaml_reference
+        filterBy?: string[]; // dimension IDs allowlist
     };
     aiHint?: string | string[];
 }
@@ -873,4 +877,3 @@ export function getCompactOptionsForFormatType(
         Compact.TRILLIONS,
     ];
 }
-

--- a/packages/common/src/utils/formatting.mock.ts
+++ b/packages/common/src/utils/formatting.mock.ts
@@ -10,8 +10,8 @@ import {
 
 export const dimension: Dimension = {
     fieldType: FieldType.DIMENSION,
-    description: undefined,
     type: DimensionType.STRING,
+    description: undefined,
     name: 'name',
     label: 'label',
     table: 'table',
@@ -22,9 +22,16 @@ export const dimension: Dimension = {
 };
 
 export const metric: Metric = {
-    ...dimension,
     fieldType: FieldType.METRIC,
     type: MetricType.COUNT,
+    description: undefined,
+    name: 'name',
+    label: 'label',
+    table: 'table',
+    tableLabel: 'tableLabel',
+    sql: 'sql',
+    hidden: false,
+    groups: [],
 };
 
 export const tableCalculation: TableCalculation = {

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -553,6 +553,30 @@ export const getAvailableSegmentDimensions = (
                 !d.timeIntervalBaseDimensionName,
         );
 
+export const getAvailableFilterDimensions = (
+    dimensions: Dimension[],
+    metricFilterByAllowlist?: string[],
+): CompiledDimension[] =>
+    dimensions
+        .filter((d): d is CompiledDimension => !!d)
+        .filter((d) => {
+            // Only string/boolean dimensions can be used for filtering
+            if (
+                d.type !== DimensionType.STRING &&
+                d.type !== DimensionType.BOOLEAN
+            ) {
+                return false;
+            }
+
+            // If metric has allowlist, use it (supersedes dimension-level)
+            if (metricFilterByAllowlist) {
+                return metricFilterByAllowlist.includes(d.name);
+            }
+
+            // Otherwise use dimension-level setting (default true)
+            return d.spotlight?.filterBy !== false;
+        });
+
 export const getAvailableCompareMetrics = (
     metrics: MetricWithAssociatedTimeDimension[],
 ): MetricWithAssociatedTimeDimension[] =>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV1.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV1.tsx
@@ -1,6 +1,6 @@
 import {
-    DimensionType,
     MetricExplorerComparison,
+    getAvailableFilterDimensions,
     getDefaultDateRangeFromInterval,
     getItemId,
     isDimension,
@@ -413,15 +413,15 @@ export const MetricExploreModalV1: FC<Props> = ({
         [],
     );
 
+    const currentMetric = metrics[currentMetricIndex];
+
     const availableFilters = useMemo(
         () =>
-            // TODO: Get filters from the query instead of segmentByData, this should include numeric dimensions as well
-            segmentDimensionsQuery.data?.filter(
-                (dimension) =>
-                    dimension.type === DimensionType.STRING ||
-                    dimension.type === DimensionType.BOOLEAN,
-            ) ?? [],
-        [segmentDimensionsQuery.data],
+            getAvailableFilterDimensions(
+                segmentDimensionsQuery.data ?? [],
+                currentMetric?.spotlightFilterBy,
+            ),
+        [segmentDimensionsQuery.data, currentMetric?.spotlightFilterBy],
     );
 
     return (

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -1,8 +1,8 @@
 import {
-    DimensionType,
     ECHARTS_DEFAULT_COLORS,
     MetricExplorerComparison,
     TimeFrames,
+    getAvailableFilterDimensions,
     getItemId,
     type CatalogField,
     type MetricExplorerQuery,
@@ -193,15 +193,15 @@ export const MetricExploreModalV2: FC<Props> = ({
         );
     }, [segmentDimensionsQuery.data]);
 
+    const currentMetric = metrics[currentMetricIndex];
+
     const availableFilters = useMemo(
         () =>
-            // Keep parity with V1: only allow filtering on string/boolean dimensions for now
-            segmentDimensionsQuery.data?.filter(
-                (dimension) =>
-                    dimension.type === DimensionType.STRING ||
-                    dimension.type === DimensionType.BOOLEAN,
-            ) ?? [],
-        [segmentDimensionsQuery.data],
+            getAvailableFilterDimensions(
+                segmentDimensionsQuery.data ?? [],
+                currentMetric?.spotlightFilterBy,
+            ),
+        [segmentDimensionsQuery.data, currentMetric?.spotlightFilterBy],
     );
 
     // Keyboard navigation


### PR DESCRIPTION
Related to: ZAP-201

### Description:
Adds the ability to control which dimensions can be used for filtering in the Metrics Explorer:

1. Added `spotlight.filter_by: false` property for dimensions to exclude them from filtering
2. Added `spotlight.filter_by: [dimension1, dimension2]` property for metrics to specify an allowlist of dimensions that can be used to filter that metric
3. Updated the Metrics Explorer to respect these configurations when displaying available filter dimensions

This feature gives users more control over the filtering experience in the Metrics Explorer, allowing them to hide dimensions that don't make sense for filtering or to restrict which dimensions can be used to filter specific metrics.