### PR TITLE
feat: add segment_by spotlight configuration for metrics explorer

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -121,6 +121,7 @@ models:
               END
             spotlight:
               filter_by: false
+              segment_by: false
         type: string
       - name: date_custom_param_test
         description: "Example of custom date"
@@ -135,6 +136,7 @@ models:
               END
             spotlight:
               filter_by: false
+              segment_by: false
         type: string
       - name: order_date
         description: Date (UTC) that the order was placed
@@ -202,6 +204,11 @@ models:
                     - status
                     - currency
                     - date_dim_param_test # to test that metric filter_by overrides dimension filter_by: false
+                  segment_by:
+                    - is_completed
+                    - order_source
+                    - order_priority
+                    - date_custom_param_test # to test that metric segment_by overrides dimension segment_by: false
               amount_running_total:
                 type: running_total
                 sql: ${total_order_amount}

--- a/packages/backend/src/models/CatalogModel/utils/parser.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.ts
@@ -50,6 +50,9 @@ const parseFieldFromMetricOrDimension = (
     ...(isMetric(field) && field.spotlight?.filterBy
         ? { spotlightFilterBy: field.spotlight.filterBy }
         : {}),
+    ...(isMetric(field) && field.spotlight?.segmentBy
+        ? { spotlightSegmentBy: field.spotlight.segmentBy }
+        : {}),
 });
 
 export const parseFieldsFromCompiledTable = (

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -29,9 +29,9 @@ import {
     UserAttributeValueMap,
     convertToAiHints,
     getAvailableCompareMetrics,
-    getAvailableSegmentDimensions,
     getAvailableTimeDimensionsFromTables,
     getDefaultTimeDimension,
+    getTypeValidSegmentDimensions,
     hasIntersection,
     isExploreError,
     type ApiMetricsTreeEdgePayload,
@@ -1400,7 +1400,8 @@ export class CatalogService<
             .map((d) => explore?.tables?.[tableName]?.dimensions?.[d.name])
             .filter((d): d is CompiledDimension => d !== undefined);
 
-        return getAvailableSegmentDimensions(allDimensions);
+        // Return type-valid dimensions only - frontend applies spotlight filtering with metric allowlist
+        return getTypeValidSegmentDimensions(allDimensions);
     }
 
     async deleteMetricsTreeEdge(

--- a/packages/common/src/compiler/lightdashProjectConfig.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.ts
@@ -8,12 +8,14 @@ import type { LightdashProjectConfig } from '../types/lightdashProjectConfig';
  * @param visibility - The visibility of the resource
  * @param categories - The categories of the resource
  * @param filterBy - Dimension IDs allowlist for filtering (metrics only)
+ * @param segmentBy - Dimension IDs allowlist for segmenting (metrics only)
  * @returns The spotlight configuration for the resource
  */
 export const getSpotlightConfigurationForResource = (
     visibility?: LightdashProjectConfig['spotlight']['default_visibility'],
     categories?: string[],
     filterBy?: string[],
+    segmentBy?: string[],
 ): Pick<Explore, 'spotlight'> | Pick<Metric, 'spotlight'> => {
     if (visibility === undefined) {
         return {};
@@ -24,6 +26,7 @@ export const getSpotlightConfigurationForResource = (
             visibility,
             categories,
             ...(filterBy ? { filterBy } : {}),
+            ...(segmentBy ? { segmentBy } : {}),
         },
     };
 };

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -205,8 +205,18 @@ const convertDimension = (
         ...(meta.dimension?.ai_hint
             ? { aiHint: convertToAiHints(meta.dimension.ai_hint) }
             : {}),
-        ...(meta.dimension?.spotlight?.filter_by === false
-            ? { spotlight: { filterBy: false } }
+        ...(meta.dimension?.spotlight?.filter_by === false ||
+        meta.dimension?.spotlight?.segment_by === false
+            ? {
+                  spotlight: {
+                      ...(meta.dimension?.spotlight?.filter_by === false && {
+                          filterBy: false,
+                      }),
+                      ...(meta.dimension?.spotlight?.segment_by === false && {
+                          segmentBy: false,
+                      }),
+                  },
+              }
             : {}),
     };
 };

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -335,6 +335,13 @@
                                                             "type": "string"
                                                         },
                                                         "description": "An array of dimension names that are allowed for filtering this metric in the Metrics Explorer"
+                                                    },
+                                                    "segment_by": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
                                                     }
                                                 },
                                                 "anyOf": [
@@ -351,6 +358,11 @@
                                                     {
                                                         "required": [
                                                             "filter_by"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "required": [
+                                                            "segment_by"
                                                         ]
                                                     }
                                                 ]
@@ -850,6 +862,13 @@
                                                                         "type": "string"
                                                                     },
                                                                     "description": "An array of dimension names that are allowed for filtering this metric in the Metrics Explorer"
+                                                                },
+                                                                "segment_by": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
                                                                 }
                                                             },
                                                             "anyOf": [
@@ -866,6 +885,11 @@
                                                                 {
                                                                     "required": [
                                                                         "filter_by"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "required": [
+                                                                        "segment_by"
                                                                     ]
                                                                 }
                                                             ]
@@ -1070,9 +1094,12 @@
                                                         "filter_by": {
                                                             "type": "boolean",
                                                             "description": "Whether this dimension can be used for filtering in the Metrics Explorer. Defaults to true."
+                                                        },
+                                                        "segment_by": {
+                                                            "type": "boolean",
+                                                            "description": "Whether this dimension can be used for segmenting in the Metrics Explorer. Defaults to true."
                                                         }
-                                                    },
-                                                    "required": ["filter_by"]
+                                                    }
                                                 }
                                             }
                                         },
@@ -1465,12 +1492,20 @@
                                             "type": "string"
                                         },
                                         "description": "An array of dimension names that are allowed for filtering this metric in the Metrics Explorer"
+                                    },
+                                    "segment_by": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
                                     }
                                 },
                                 "anyOf": [
                                     { "required": ["visibility"] },
                                     { "required": ["categories"] },
-                                    { "required": ["filter_by"] }
+                                    { "required": ["filter_by"] },
+                                    { "required": ["segment_by"] }
                                 ]
                             }
                         }

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -78,6 +78,7 @@ export type CatalogField = Pick<
         aiHints: string[] | null;
         searchRank?: number;
         spotlightFilterBy?: string[]; // dimension IDs allowlist (metrics only)
+        spotlightSegmentBy?: string[]; // dimension IDs allowlist (metrics only)
     };
 
 export type CatalogTable = Pick<

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -202,6 +202,7 @@ export type DbtColumnLightdashDimension = {
     };
     spotlight?: {
         filter_by?: boolean; // default true
+        segment_by?: boolean; // default true
     };
 } & DbtLightdashFieldTags;
 
@@ -234,6 +235,7 @@ export type DbtColumnLightdashMetric = {
         >['default_visibility'];
         categories?: string[]; // yaml_reference
         filter_by?: string[]; // dimension IDs allowlist
+        segment_by?: string[]; // dimension IDs allowlist
     };
     ai_hint?: string | string[];
 } & DbtLightdashFieldTags;
@@ -594,6 +596,7 @@ export const convertModelMetric = ({
             spotlightVisibility,
             spotlightCategories,
             metric.spotlight?.filter_by,
+            metric.spotlight?.segment_by,
         ),
         ...(metric.ai_hint ? { aiHint: convertToAiHints(metric.ai_hint) } : {}),
     };

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -574,7 +574,8 @@ export interface Dimension extends Field {
         fit?: string;
     };
     spotlight?: {
-        filterBy: boolean;
+        filterBy?: boolean;
+        segmentBy?: boolean;
     };
 }
 
@@ -761,6 +762,7 @@ export interface Metric extends Field {
         visibility: LightdashProjectConfig['spotlight']['default_visibility'];
         categories?: string[]; // yaml_reference
         filterBy?: string[]; // dimension IDs allowlist
+        segmentBy?: string[]; // dimension IDs allowlist
     };
     aiHint?: string | string[];
 }

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV1.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV1.tsx
@@ -391,15 +391,28 @@ export const MetricExploreModalV1: FC<Props> = ({
         userUuid,
     ]);
 
+    const currentMetric = metrics[currentMetricIndex];
+
     const segmentByData = useMemo(() => {
-        return (
-            segmentDimensionsQuery.data?.map((dimension) => ({
+        const dimensions = segmentDimensionsQuery.data ?? [];
+        const metricSegmentByAllowlist = currentMetric?.spotlightSegmentBy;
+
+        return dimensions
+            .filter((dimension) => {
+                // If metric has allowlist, use it (supersedes dimension-level)
+                if (metricSegmentByAllowlist) {
+                    return metricSegmentByAllowlist.includes(dimension.name);
+                }
+
+                // Otherwise use dimension-level setting (default true)
+                return dimension.spotlight?.segmentBy !== false;
+            })
+            .map((dimension) => ({
                 value: getItemId(dimension),
                 label: dimension.label,
                 group: dimension.tableLabel,
-            })) ?? []
-        );
-    }, [segmentDimensionsQuery.data]);
+            }));
+    }, [segmentDimensionsQuery.data, currentMetric?.spotlightSegmentBy]);
 
     useHotkeys([
         ['ArrowUp', () => handleGoToPreviousMetric()],
@@ -412,8 +425,6 @@ export const MetricExploreModalV1: FC<Props> = ({
         },
         [],
     );
-
-    const currentMetric = metrics[currentMetricIndex];
 
     const availableFilters = useMemo(() => {
         // TODO: Get filters from the query instead of segmentByData, this should include numeric dimensions as well

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -183,17 +183,28 @@ export const MetricExploreModalV2: FC<Props> = ({
         },
     });
 
+    const currentMetric = metrics[currentMetricIndex];
+
     const segmentByData = useMemo(() => {
-        return (
-            segmentDimensionsQuery.data?.map((dimension) => ({
+        const dimensions = segmentDimensionsQuery.data ?? [];
+        const metricSegmentByAllowlist = currentMetric?.spotlightSegmentBy;
+
+        return dimensions
+            .filter((dimension) => {
+                // If metric has allowlist, use it (supersedes dimension-level)
+                if (metricSegmentByAllowlist) {
+                    return metricSegmentByAllowlist.includes(dimension.name);
+                }
+
+                // Otherwise use dimension-level setting (default true)
+                return dimension.spotlight?.segmentBy !== false;
+            })
+            .map((dimension) => ({
                 value: getItemId(dimension),
                 label: dimension.label,
                 group: dimension.tableLabel,
-            })) ?? []
-        );
-    }, [segmentDimensionsQuery.data]);
-
-    const currentMetric = metrics[currentMetricIndex];
+            }));
+    }, [segmentDimensionsQuery.data, currentMetric?.spotlightSegmentBy]);
 
     const availableFilters = useMemo(() => {
         // Keep parity with V1: only allow filtering on string/boolean dimensions for now


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: [ZAP-201](https://linear.app/lightdash/issue/ZAP-201)

### Description:

This PR adds support for metric-level segment_by allowlists in the Metrics Explorer. Similar to the existing filter_by functionality, this allows project developers to specify which dimensions can be used for segmenting a specific metric.

Key changes:

- Added `segment_by` property to metric spotlight configuration in YAML schema
- Added `segmentBy` property to dimension spotlight configuration to optionally disable segmenting
- Updated the Metrics Explorer to respect these allowlists when displaying segment options
- Refactored dimension filtering utilities to separate type validation from spotlight settings

This enhances the control project developers have over how metrics can be explored, ensuring users only segment by relevant dimensions.

![image](https://user-images.githubusercontent.com/12345/example-screenshot.png)