### PR TITLE
feat: validate spotlight dimension references in metrics

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -45,6 +45,7 @@ import {
     validateParameterNames,
     validateParameterReferences,
 } from './parameters';
+import { validateSpotlightDimensionRefs } from './spotlight';
 
 // exclude lightdash prefix from variable pattern
 export const lightdashVariablePattern =
@@ -688,6 +689,10 @@ export class ExploreCompiler {
 
         const showUnderlyingValues =
             ExploreCompiler.expandShowUnderlyingValueSets(metric, tables);
+
+        // Validate spotlight dimension references
+        validateSpotlightDimensionRefs(metric, tables);
+
         const tablesRequiredAttributes = Array.from(
             compiledMetric.tablesReferences,
         ).reduce<Record<string, Record<string, string | string[]>>>(

--- a/packages/common/src/compiler/spotlight.ts
+++ b/packages/common/src/compiler/spotlight.ts
@@ -1,0 +1,28 @@
+import { CompileError } from '../types/errors';
+import { type Table } from '../types/explore';
+import { type Metric } from '../types/field';
+
+/**
+ * Validates that spotlight.filter_by and spotlight.segment_by reference existing dimensions
+ */
+export const validateSpotlightDimensionRefs = (
+    metric: Metric,
+    tables: Record<string, Table>,
+): void => {
+    const currentTable = tables[metric.table];
+    if (!currentTable) return;
+
+    const validateRefs = (refs: string[] | undefined, propertyName: string) => {
+        if (!refs) return;
+        refs.forEach((dimName) => {
+            if (!currentTable.dimensions[dimName]) {
+                throw new CompileError(
+                    `Metric "${metric.name}" has spotlight.${propertyName} reference to unknown dimension: "${dimName}"`,
+                );
+            }
+        });
+    };
+
+    validateRefs(metric.spotlight?.filterBy, 'filter_by');
+    validateRefs(metric.spotlight?.segmentBy, 'segment_by');
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: ZAP-201

### Description:

Added validation for spotlight dimension references in metrics. The PR introduces a new function `validateSpotlightDimensionRefs` that checks if dimensions referenced in `spotlight.filter_by` and `spotlight.segment_by` actually exist in the table. If a reference points to a non-existent dimension, it throws a CompileError with a descriptive message.