### PR TITLE
feat: configure signup URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
             - TURBO_TOKEN=${TURBO_TOKEN}
             - TURBO_TEAM=${TURBO_TEAM}
             - TURBO_API=${TURBO_API}
+            - SIGNUP_URL=${SIGNUP_URL}
         volumes:
             - '${DBT_PROJECT_DIR}:/usr/app/dbt'
         ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -96,6 +96,7 @@ x-lightdash-environment: &lightdash-environment
     TURBO_TOKEN: ${TURBO_TOKEN}
     TURBO_TEAM: ${TURBO_TEAM}
     TURBO_API: ${TURBO_API}
+    SIGNUP_URL: ${SIGNUP_URL}
 
 x-lightdash-base: &lightdash-base
     build: *lightdash-build

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -182,6 +182,7 @@ export const lightdashConfigMock: LightdashConfig = {
         },
     },
     staticIp: '',
+    signupUrl: undefined,
     trustProxy: false,
     mode: LightdashMode.DEFAULT,
     license: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -793,6 +793,7 @@ export type LightdashConfig = {
     headway: HeadwayConfig;
     siteUrl: string;
     staticIp: string;
+    signupUrl: string | undefined;
     lightdashCloudInstance: string | undefined;
     k8s: {
         nodeName: string | undefined;
@@ -1508,6 +1509,7 @@ export const parseConfig = (): LightdashConfig => {
         },
         siteUrl,
         staticIp: process.env.STATIC_IP || '',
+        signupUrl: process.env.SIGNUP_URL,
         lightdashCloudInstance: process.env.LIGHTDASH_CLOUD_INSTANCE,
         k8s: {
             nodeName: process.env.K8S_NODE_NAME,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -14,6 +14,7 @@ export const BaseResponse: HealthState = {
     localDbtEnabled: true,
     siteUrl: 'https://test.lightdash.cloud',
     staticIp: '',
+    signupUrl: undefined,
     hasEmailClient: false,
     hasExtendedUsageAnalytics: false,
     hasMicrosoftTeams: false,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -113,6 +113,7 @@ export class HealthService extends BaseService {
             },
             siteUrl: this.lightdashConfig.siteUrl,
             staticIp: this.lightdashConfig.staticIp,
+            signupUrl: this.lightdashConfig.signupUrl,
             posthog: this.lightdashConfig.posthog,
             query: {
                 csvCellsLimit: this.lightdashConfig.query.csvCellsLimit,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -385,6 +385,7 @@ export type HealthState = {
         enabled: boolean;
     };
     staticIp: string;
+    signupUrl: string | undefined;
     query: {
         maxLimit: number;
         defaultLimit: number;

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -302,7 +302,11 @@ const Login: FC<{}> = () => {
                         )}
                         <Text mx="auto" mt="md">
                             Don't have an account?{' '}
-                            <Anchor href="/register">Sign up</Anchor>
+                            <Anchor
+                                href={health.data?.signupUrl || '/register'}
+                            >
+                                Sign up
+                            </Anchor>
                         </Text>
                     </Stack>
                 </form>

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -38,6 +38,7 @@ export default function mockHealthResponse(
         },
         siteUrl: 'http://localhost:3000',
         staticIp: '',
+        signupUrl: undefined,
         posthog: undefined,
         query: {
             maxPageSize: 2500,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19490

### Description:
Allows bypass of the default `/register` sign up URL when not using the default registration/login facility.

<img width="882" height="188" alt="image" src="https://github.com/user-attachments/assets/fdb5df6c-554d-4be0-8210-fcb90605e8f0" />
