### PR TITLE
feat: improve empty space at bottom of ai agent edit page

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -363,7 +363,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             <AppShell.Main
                 pt={0}
                 pr={0}
-                pb={0}
+                pb="emptySpace"
                 mih={`calc(100vh - ${navbarHeight}px)`}
                 bg="ldGray.0"
             >

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -89,6 +89,8 @@ export const getMantine8ThemeOverride = (
         spacing: {
             ...legacyTheme.spacing,
             xxs: `0.125rem`,
+            // Large padding for page bottoms to allow scrolling past last elements
+            emptySpace: `6rem`,
         },
 
         components: {


### PR DESCRIPTION
### Description:
Added bottom padding to the AI Agent edit page to improve scrolling experience. Created a new `emptySpace` spacing value (6rem) in the Mantine theme that allows users to scroll past the last elements on the page, providing better visibility and interaction with content at the bottom of the page.

![CleanShot 2026-01-21 at 11.31.34@2x.png](https://app.graphite.com/user-attachments/assets/27d3787d-0ed4-4af5-a37c-86864363a111.png)

_Before_
![CleanShot 2026-01-21 at 11.31.50@2x.png](https://app.graphite.com/user-attachments/assets/98cee1c5-d340-40d6-b37c-c755f3d119c3.png)

