### PR TITLE
chore: include DEMO mode in siteUrl tracking and add window location data

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1615,7 +1615,8 @@ export class LightdashAnalytics extends Analytics {
                 version: VERSION,
                 mode: lightdashConfig.mode,
                 siteUrl:
-                    lightdashConfig.mode === LightdashMode.CLOUD_BETA
+                    lightdashConfig.mode === LightdashMode.CLOUD_BETA ||
+                    lightdashConfig.mode === LightdashMode.DEMO
                         ? lightdashConfig.siteUrl
                         : null,
                 installId: process.env.LIGHTDASH_INSTALL_ID || uuidv4(),

--- a/packages/frontend/src/providers/Tracking/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/Tracking/TrackingProvider.tsx
@@ -43,7 +43,7 @@ const TrackingProviderMain: FC<React.PropsWithChildren<TrackingData>> = ({
                 name: LIGHTDASH_APP_NAME,
                 version,
                 build: version,
-            } as any as rudderSDK.apiObject),
+            }) as any as rudderSDK.apiObject,
         [version],
     );
 
@@ -53,11 +53,11 @@ const TrackingProviderMain: FC<React.PropsWithChildren<TrackingData>> = ({
             category,
             type,
             hostname: window.location.hostname,
-            url: null,
-            path: null,
+            url: window.location.href,
+            path: window.location.pathname,
             referrer: null,
             initial_referrer: null,
-            search: null,
+            search: window.location.search,
             tab_url: null,
         }),
         [],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2399

### Description:

This PR enhances tracking functionality in two ways:

1. Includes the site URL in analytics for DEMO mode, similar to how it's already handled for CLOUD_BETA mode.
2. Improves browser tracking data by capturing actual URL information instead of null values:
    - Adds window.location.href for the URL
    - Adds window.location.pathname for the path
    - Adds window.location.search for search parameters

These changes will provide more complete analytics data for both demo environments and general user tracking.