### PR TITLE
chore: use MantineIcon for scheduler pause modal

### DIFF
--- a/packages/frontend/src/features/scheduler/components/ConfirmPauseSchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/ConfirmPauseSchedulerModal.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mantine-8/core';
 import { IconPlayerPause } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 
 type ConfirmPauseSchedulerModalProps = {
@@ -25,7 +26,7 @@ const ConfirmPauseSchedulerModal: FC<ConfirmPauseSchedulerModalProps> = ({
             opened={opened}
             onClose={onClose}
             title={`Pause "${schedulerName}"?`}
-            icon={IconPlayerPause}
+            icon={<MantineIcon icon={IconPlayerPause} />}
             size="md"
             actions={
                 <Button onClick={onConfirm} loading={loading}>


### PR DESCRIPTION
### Description:
Closed the [last PR](https://github.com/lightdash/lightdash/pull/19580#discussion_r2713229828) too fast before Graphite gave this comment: https://github.com/lightdash/lightdash/pull/19580#discussion_r2713229828. This PR addressed it.