### PR TITLE
fix: respect the color gradient in maps

### DIFF
--- a/packages/frontend/src/components/SimpleMap/constants.ts
+++ b/packages/frontend/src/components/SimpleMap/constants.ts
@@ -1,0 +1,4 @@
+// Opacity for map fills - used for regions, markers, and legend
+export const MAP_FILL_WITH_DATA_OPACITY = 0.7;
+export const MAP_FILL_NO_DATA_OPACITY = 0.5;
+export const MAP_FILL_NO_BASE_MAP_OPACITY = 1;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-1065/maps-should-have-more-color-picking-control

### Description:
Refactored map color handling to improve consistency and maintainability:

- Created a new constants file with `MAP_FILL_OPACITY` (0.7) to standardize opacity across regions, markers, and legend
- Implemented a more robust color scale system using `createColorScale` function that properly interpolates between colors
- Added memoized color scales for both scatter points and choropleth regions to improve performance
- Replaced direct color calculation with the new scale functions
- Fixed edge cases for single color or empty color arrays

This change ensures consistent coloring across the map visualization while making the code more maintainable.

![CleanShot 2026-01-21 at 16.49.33.png](https://app.graphite.com/user-attachments/assets/61ea03fc-f4b7-4379-8614-33a2bd2fbeb2.png)

