### PR TITLE
fix: improve map legend to show the gradient

### DIFF
--- a/packages/frontend/src/components/SimpleMap/MapLegend.tsx
+++ b/packages/frontend/src/components/SimpleMap/MapLegend.tsx
@@ -1,55 +1,46 @@
-import {
-    Compact,
-    CustomFormatType,
-    applyCustomFormat,
-} from '@lightdash/common';
+import { Box, Group, Text } from '@mantine-8/core';
 import { type FC } from 'react';
+import GradientBar from '../common/GradientBar';
 // eslint-disable-next-line css-modules/no-unused-class
 import classes from './SimpleMap.module.css';
 
 type MapLegendProps = {
     colors: string[];
-    min: number;
-    max: number;
+    formattedMin: string;
+    formattedMax: string;
+    label?: string;
+    opacity?: number;
 };
 
-const MapLegend: FC<MapLegendProps> = ({ colors, min, max }) => {
-    // Format numbers for display using Lightdash's compact formatter
-    const formatValue = (value: number): string => {
-        const absValue = Math.abs(value);
-        let compact: Compact | undefined;
-
-        if (absValue >= 1000000000) {
-            compact = Compact.BILLIONS;
-        } else if (absValue >= 1000000) {
-            compact = Compact.MILLIONS;
-        } else if (absValue >= 1000) {
-            compact = Compact.THOUSANDS;
-        }
-
-        return applyCustomFormat(value, {
-            type: CustomFormatType.NUMBER,
-            compact,
-            round: compact ? 1 : Number.isInteger(value) ? 0 : 2,
-        });
-    };
-
+const MapLegend: FC<MapLegendProps> = ({
+    colors,
+    formattedMin,
+    formattedMax,
+    label,
+    opacity,
+}) => {
     return (
-        <div className={classes.legend}>
-            <div className={classes.legendGradient}>
-                {colors.map((color, index) => (
-                    <div
-                        key={index}
-                        className={classes.legendColorStop}
-                        style={{ backgroundColor: color }}
-                    />
-                ))}
-            </div>
-            <div className={classes.legendLabels}>
-                <span>{formatValue(min)}</span>
-                <span>{formatValue(max)}</span>
-            </div>
-        </div>
+        <Box className={classes.legend}>
+            {label && (
+                <Text fz="xs" fw={500} c="ldGray.7" mb={4}>
+                    {label}
+                </Text>
+            )}
+            <GradientBar
+                colors={colors}
+                height={12}
+                borderRadius={4}
+                opacity={opacity}
+            />
+            <Group justify="space-between">
+                <Text span fz="xs" c="ldGray.6">
+                    {formattedMin}
+                </Text>
+                <Text span fz="xs" c="ldGray.6">
+                    {formattedMax}
+                </Text>
+            </Group>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/components/SimpleMap/SimpleMap.module.css
+++ b/packages/frontend/src/components/SimpleMap/SimpleMap.module.css
@@ -73,21 +73,6 @@
     flex: 1;
 }
 
-.legendLabels {
-    display: flex;
-    justify-content: space-between;
-    margin-top: var(--mantine-spacing-xs);
-    font-size: var(--mantine-font-size-xs);
-
-    @mixin light {
-        color: var(--mantine-color-ldGray-7);
-    }
-
-    @mixin dark {
-        color: var(--mantine-color-ldGray-3);
-    }
-}
-
 /*
  * Custom styles for Leaflet zoom controls
  * Note: Using :global() because Leaflet renders its own DOM elements outside React.

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -672,8 +672,8 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     point.value === null
                         ? 0.5
                         : max === min
-                        ? 0.5
-                        : (point.value - min) / (max - min);
+                          ? 0.5
+                          : (point.value - min) / (max - min);
                 return [point.lat, point.lon, scale];
             });
         }, [scatterData, scatterValueRange]);
@@ -1004,8 +1004,10 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     {mapConfig.showLegend && mapConfig.valueRange && (
                         <MapLegend
                             colors={mapConfig.colors.scale}
-                            min={mapConfig.valueRange.min}
-                            max={mapConfig.valueRange.max}
+                            formattedMin={mapConfig.valueRange.formattedMin}
+                            formattedMax={mapConfig.valueRange.formattedMax}
+                            label={mapConfig.valueFieldLabel ?? undefined}
+                            opacity={fillOpacityWithData}
                         />
                     )}
                 </div>
@@ -1072,8 +1074,10 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     {mapConfig.showLegend && mapConfig.valueRange && (
                         <MapLegend
                             colors={mapConfig.colors.scale}
-                            min={mapConfig.valueRange.min}
-                            max={mapConfig.valueRange.max}
+                            formattedMin={mapConfig.valueRange.formattedMin}
+                            formattedMax={mapConfig.valueRange.formattedMax}
+                            label={mapConfig.valueFieldLabel ?? undefined}
+                            opacity={fillOpacityWithData}
                         />
                     )}
                 </div>

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
@@ -19,12 +19,13 @@ import {
     Stack,
     Switch,
     Text,
-} from '@mantine/core';
-import { useHover } from '@mantine/hooks';
+} from '@mantine-8/core';
+import { useHover } from '@mantine-8/hooks';
 import { IconPlus, IconX } from '@tabler/icons-react';
 import { memo, useMemo, type FC } from 'react';
 import { DEFAULT_MAP_COLORS } from '../../../hooks/useMapChartConfig';
 import FieldSelect from '../../common/FieldSelect';
+import GradientBar from '../../common/GradientBar';
 import { isMapVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import ColorSelector from '../ColorSelector';
@@ -48,7 +49,7 @@ const ColorItem: FC<ColorItemProps> = ({
     const { hovered, ref } = useHover();
 
     return (
-        <Stack spacing={4} align="center">
+        <Stack gap="xs" align="center">
             <Text size="xs" fw={500} h={16}>
                 {label || '\u00A0'}
             </Text>
@@ -151,7 +152,7 @@ export const Display: FC = memo(() => {
                 <Config.Section>
                     <Config.Heading>Colors</Config.Heading>
                     {!isHeatmap && (
-                        <Config.Section>
+                        <Config.Group>
                             <FieldSelect
                                 label="Color based on"
                                 placeholder="Select field (optional)"
@@ -166,60 +167,65 @@ export const Display: FC = memo(() => {
                                 }
                                 hasGrouping
                                 clearable
-                                mb="sm"
                             />
-                        </Config.Section>
+                        </Config.Group>
                     )}
                     {showColorRange && (
-                        <>
-                            <Config.Label>Color range</Config.Label>
-                            <Group spacing="xs" align="flex-start">
-                                {colors.map((color, index) => {
-                                    const isFirst = index === 0;
-                                    const isLast = index === colors.length - 1;
-                                    const label = isFirst
-                                        ? 'Low'
-                                        : isLast
-                                        ? 'High'
-                                        : '';
-                                    // Can only remove middle colors (not first or last)
-                                    const canRemove =
-                                        !isFirst &&
-                                        !isLast &&
-                                        colors.length > 2;
+                        <Config.Group mb="xs">
+                            <Stack w="100%" gap="xs">
+                                <Config.Label>Color range</Config.Label>
+                                <Group gap="xs" align="flex-start">
+                                    {colors.map((color, index) => {
+                                        const isFirst = index === 0;
+                                        const isLast =
+                                            index === colors.length - 1;
+                                        const label = isFirst
+                                            ? 'Low'
+                                            : isLast
+                                            ? 'High'
+                                            : '';
+                                        // Can only remove middle colors (not first or last)
+                                        const canRemove =
+                                            !isFirst &&
+                                            !isLast &&
+                                            colors.length > 2;
 
-                                    return (
-                                        <ColorItem
-                                            key={index}
-                                            color={color}
-                                            label={label}
-                                            canRemove={canRemove}
-                                            onColorChange={(newColor) =>
-                                                updateColor(index, newColor)
-                                            }
-                                            onRemove={() => removeColor(index)}
-                                        />
-                                    );
-                                })}
-                                {canAddColor && (
-                                    <Stack spacing={4} align="center">
-                                        <Text size="xs" fw={500} h={16}>
-                                            {'\u00A0'}
-                                        </Text>
-                                        <ActionIcon
-                                            size="sm"
-                                            variant="light"
-                                            onClick={addColor}
-                                        >
-                                            <IconPlus size={14} />
-                                        </ActionIcon>
-                                    </Stack>
-                                )}
-                            </Group>
-                        </>
+                                        return (
+                                            <ColorItem
+                                                key={index}
+                                                color={color}
+                                                label={label}
+                                                canRemove={canRemove}
+                                                onColorChange={(newColor) =>
+                                                    updateColor(index, newColor)
+                                                }
+                                                onRemove={() =>
+                                                    removeColor(index)
+                                                }
+                                            />
+                                        );
+                                    })}
+                                    {canAddColor && (
+                                        <Stack gap={4} align="center">
+                                            <Text size="xs" fw={500} h={16}>
+                                                {'\u00A0'}
+                                            </Text>
+                                            <ActionIcon
+                                                size="sm"
+                                                variant="light"
+                                                onClick={addColor}
+                                            >
+                                                <IconPlus size={14} />
+                                            </ActionIcon>
+                                        </Stack>
+                                    )}
+                                </Group>
+                                <GradientBar colors={colors} />
+                            </Stack>
+                        </Config.Group>
                     )}
                     {!showColorRange && !isAreaMap && (
-                        <>
+                        <Config.Group>
                             <Config.Label>Color</Config.Label>
                             <ColorSelector
                                 color={colors[Math.floor(colors.length / 2)]}
@@ -232,7 +238,7 @@ export const Display: FC = memo(() => {
                                     );
                                 }}
                             />
-                        </>
+                        </Config.Group>
                     )}
                     {isAreaMap && (
                         <Config.Group>

--- a/packages/frontend/src/components/common/GradientBar.tsx
+++ b/packages/frontend/src/components/common/GradientBar.tsx
@@ -1,0 +1,63 @@
+import { Box } from '@mantine-8/core';
+import { scaleLinear } from 'd3-scale';
+import { useMemo, type FC } from 'react';
+
+type GradientBarProps = {
+    colors: string[];
+    height?: number;
+    borderRadius?: number;
+    opacity?: number;
+};
+
+/** Number of samples to take from D3 interpolation for smooth CSS gradient */
+const GRADIENT_SAMPLES = 20;
+
+const GradientBar: FC<GradientBarProps> = ({
+    colors,
+    height = 4,
+    borderRadius = 2,
+    opacity,
+}) => {
+    // Use D3's scaleLinear for accurate color interpolation matching the map
+    const gradientStops = useMemo(() => {
+        if (colors.length === 0) return '';
+        if (colors.length === 1) return colors[0];
+
+        // Create D3 color scale with piecewise interpolation
+        const domain = colors.map(
+            (_, i) => i / (colors.length - 1), // 0 to 1
+        );
+        const colorScale = scaleLinear<string>()
+            .domain(domain)
+            .range(colors)
+            .clamp(true);
+
+        // Generate sampled color stops for smooth gradient
+        const stops: string[] = [];
+        for (let i = 0; i <= GRADIENT_SAMPLES; i++) {
+            const t = i / GRADIENT_SAMPLES;
+            const color = colorScale(t);
+            const percent = t * 100;
+            stops.push(`${color} ${percent}%`);
+        }
+
+        return stops.join(', ');
+    }, [colors]);
+
+    if (colors.length === 0) return null;
+
+    return (
+        <Box
+            h={height}
+            w="100%"
+            style={{
+                background: `linear-gradient(to right, ${gradientStops})`,
+                borderRadius,
+                ...(opacity !== undefined && { opacity }),
+                boxShadow: 'var(--mantine-shadow-subtle)',
+            }}
+        />
+    );
+};
+
+export default GradientBar;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [https://linear.app/lightdash/issue/PROD-1066/map-legend-is-very-limited](https://linear.app/lightdash/issue/PROD-1066/map-legend-is-very-limited)

### Description:

Improved the map legend with a smoother gradient display and better value formatting. The legend now:

- Uses a linear gradient instead of discrete color stops for a more visually appealing appearance
- Displays pre-formatted values instead of raw numbers
- Properly handles opacity to match the map styling
- Uses Mantine components for consistent styling with the rest of the UI
- Passes formatted min/max values from the map configuration instead of formatting them in the legend component

This change ensures that the legend values match exactly what users see in tooltips and other parts of the visualization.

<img width="1468" height="629" alt="CleanShot 2026-01-21 at 17 29 16" src="https://github.com/user-attachments/assets/0127e5f6-52b0-43f6-89bc-70e5dbe3140b" />


