### PR TITLE
fix: implement stream backpressure handling for file uploads

### DIFF
--- a/packages/backend/src/utils/streamUtils.ts
+++ b/packages/backend/src/utils/streamUtils.ts
@@ -1,0 +1,17 @@
+import { Writable } from 'stream';
+
+/**
+ * Write data to a stream with backpressure handling.
+ * Waits for the drain event if the write buffer is full.
+ */
+export async function writeWithBackpressure(
+    stream: Writable,
+    data: string,
+): Promise<void> {
+    const canContinue = stream.write(data);
+    if (!canContinue) {
+        await new Promise<void>((resolve) => {
+            stream.once('drain', resolve);
+        });
+    }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Improves stream handling with proper backpressure management to prevent memory issues during large file uploads. This PR:

- Adds a reusable `writeWithBackpressure` utility function
- Increases the PassThrough buffer size for S3 uploads
- Fixes potential deadlock in S3 uploads by starting the upload immediately
- Implements proper stream pause/resume logic in the CSV service
- Refactors stream writing in S3 clients to handle backpressure correctly

These changes will help prevent memory exhaustion when processing large datasets by ensuring data flows at a sustainable rate through the streaming pipeline.

<details>
<summary>Demo</summary>

> This is downloading 1.5 mil rows. 

### Before

https://github.com/user-attachments/assets/cb383cae-dff9-450a-a66e-77e18f911aac

### After
Both take around 2 min long! so we don't compromise the speed of data export, however querying is slower now with current settings `highWaterMark: 16 * 1024 * 1024` -- at the cost of stable memory. I think we can tweak it in case it's too slow.

https://github.com/user-attachments/assets/6c3b6de4-cfb5-4cee-9d29-154b7a602c2e


</details>