### PR TITLE
feat: add clear button for dashboard filters and auto-disable when empty

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -326,7 +326,6 @@ const FilterStringAutoComplete: FC<Props> = ({
                 })}
                 disableSelectedItemFiltering
                 searchable
-                clearable={singleValue}
                 clearSearchOnChange
                 {...rest}
                 searchValue={search}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -139,10 +139,20 @@ const FilterConfiguration: FC<Props> = ({
                 // When a disabled filter has a value set, it should be enabled by setting it to false
                 const isNewFilterDisabled =
                     newFilterRule.disabled && !hasFilterValueSet(newFilterRule);
-                return { ...newFilterRule, disabled: isNewFilterDisabled };
+
+                // In view mode: if values cleared and not required, set to "any value"
+                const shouldDisableInViewMode =
+                    !isEditMode &&
+                    !newFilterRule.required &&
+                    !hasFilterValueSet(newFilterRule);
+
+                return {
+                    ...newFilterRule,
+                    disabled: isNewFilterDisabled || shouldDisableInViewMode,
+                };
             });
         },
-        [setDraftFilterRule],
+        [setDraftFilterRule, isEditMode],
     );
     const sqlChartTilesMetadata = useDashboardContext(
         (c) => c.sqlChartTilesMetadata,


### PR DESCRIPTION
Closes: [PROD-761](https://linear.app/lightdash/issue/PROD-761/in-view-mode-i-cant-remove-filter-values-when-a-default-value-was)

### Description:

Added a clear button to dashboard filters in view mode, allowing users to reset filter values without having to delete them manually. When a filter value is cleared in view mode and the filter is not required, it will automatically be set to "any value" (disabled state).

Also removed the `clearable` prop from `FilterStringAutoComplete` component as it's now handled by the new clear button functionality.