### PR TITLE
feat: add owner filtering to metrics catalog

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -21,6 +21,8 @@ models:
             description: The customer who placed this order (many orders can belong to one customer)
         metrics:
           completion_percentage:
+            spotlight:
+              owner: demo@lightdash.com
             type: number
             sql: ${total_completed_order_amount}/${total_order_amount}
             format: percent
@@ -88,6 +90,8 @@ models:
                 show_underlying_values:
                   - amount
                   - customers.first_name
+                spotlight:
+                  owner: demo2@lightdash.com
               fulfillment_rate_with_format_expression:
                 type: average
                 format: "#,##0.0%"
@@ -200,6 +204,7 @@ models:
                 sql: ${total_order_amount}
                 format: "#,##0.00%"
                 spotlight:
+                  owner: demo@lightdash.com
                   filter_by:
                     - status
                     - currency

--- a/examples/full-jaffle-shop-demo/dbt/models/payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.yml
@@ -5,6 +5,8 @@ models:
     config:
       tags: ["core", "ai"]
       meta:
+        spotlight:
+          owner: demo@lightdash.com
         sets:
           base_set:
             fields:
@@ -44,6 +46,8 @@ models:
           meta:
             metrics:
               total_revenue:
+                spotlight:
+                  owner: demo2@lightdash.com
                 type: sum
                 description: Sum of all payments
                 # E2E tests rely on these values

--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -7,6 +7,7 @@ import {
     ApiGetMetricPeek,
     ApiMetricsCatalog,
     ApiSegmentDimensionsResponse,
+    CatalogOwner,
     getItemId,
     type ApiFilterDimensionsResponse,
     type ApiGetMetricsTree,
@@ -198,6 +199,7 @@ export class CatalogController extends BaseController {
         @Query() categories?: ApiCatalogSearch['catalogTags'],
         @Query() categoriesFilterMode?: CatalogCategoryFilterMode,
         @Query() tables?: ApiCatalogSearch['tables'],
+        @Query() ownerUserUuids?: ApiCatalogSearch['ownerUserUuids'],
     ): Promise<ApiMetricsCatalog> {
         this.setStatus(200);
 
@@ -228,6 +230,7 @@ export class CatalogController extends BaseController {
                     catalogTags: categories,
                     catalogTagsFilterMode: categoriesFilterMode,
                     tables,
+                    ownerUserUuids,
                 },
                 sortArgs,
             );
@@ -536,6 +539,30 @@ export class CatalogController extends BaseController {
         const results = await this.services
             .getCatalogService()
             .hasMetricsInCatalog(req.user!, projectUuid);
+
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Get distinct metric owners for filter dropdown
+     * @summary List metric owners
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/metrics/owners')
+    @OperationId('getMetricOwners')
+    async getMetricOwners(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<{ status: 'ok'; results: CatalogOwner[] }> {
+        this.setStatus(200);
+
+        const results = await this.services
+            .getCatalogService()
+            .getMetricOwners(req.user!, projectUuid);
 
         return {
             status: 'ok',

--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -25,6 +25,7 @@ export type DbCatalog = {
     yaml_tags: string[] | null;
     ai_hints: string[] | null;
     joined_tables: string[] | null;
+    owner_user_uuid: string | null;
 };
 
 export type DbCatalogIn = Pick<
@@ -43,6 +44,7 @@ export type DbCatalogIn = Pick<
     | 'yaml_tags'
     | 'ai_hints'
     | 'joined_tables'
+    | 'owner_user_uuid'
 >;
 export type DbCatalogRemove = Pick<DbCatalog, 'project_uuid' | 'name'>;
 export type DbCatalogUpdate = Partial<
@@ -64,9 +66,9 @@ export type CatalogTable = Knex.CompositeTableType<
 >;
 
 // Utility to get the column name in the `catalog` table from a `CatalogItem` property
-// Also accepts 'tableLabel' which is only in CatalogField but needed for sorting
+// Also accepts 'tableLabel' and 'owner' which are only in CatalogField but needed for sorting/filtering
 export function getDbCatalogColumnFromCatalogProperty(
-    property: keyof CatalogItem | 'tableLabel',
+    property: keyof CatalogItem | 'tableLabel' | 'owner',
 ): keyof DbCatalog {
     switch (property) {
         case 'name':
@@ -89,6 +91,8 @@ export function getDbCatalogColumnFromCatalogProperty(
             return 'icon';
         case 'tableLabel':
             return 'table_name';
+        case 'owner':
+            return 'owner_user_uuid';
         case 'searchRank':
         case 'categories':
         case 'tags':

--- a/packages/backend/src/database/migrations/20260121123908_add_owner_to_catalog_search.ts
+++ b/packages/backend/src/database/migrations/20260121123908_add_owner_to_catalog_search.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+const CatalogTableName = 'catalog_search';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(CatalogTableName, (table) => {
+        table
+            .uuid('owner_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+        table.index('owner_user_uuid', 'idx_catalog_search_owner_user_uuid');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(CatalogTableName, (table) => {
+        table.dropColumn('owner_user_uuid');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5060,6 +5060,7 @@ const models: TsoaRoute.Models = {
             spotlight: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
+                    owner: { dataType: 'string' },
                     segmentBy: {
                         dataType: 'array',
                         array: { dataType: 'string' },
@@ -5327,6 +5328,7 @@ const models: TsoaRoute.Models = {
                 spotlight: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        owner: { dataType: 'string' },
                         categories: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -7313,11 +7315,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7405,7 +7407,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7428,7 +7430,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                chartUsage:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7458,12 +7460,6 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required:
-                                                                                                        true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -7471,6 +7467,12 @@ const models: TsoaRoute.Models = {
                                                                                                         required:
                                                                                                             true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required:
+                                                                                                        true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7674,7 +7676,7 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7697,7 +7699,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    chartUsage:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7727,12 +7729,6 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required:
-                                                                                                            true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -7740,6 +7736,12 @@ const models: TsoaRoute.Models = {
                                                                                                             required:
                                                                                                                 true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required:
+                                                                                                            true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -7813,11 +7815,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7832,11 +7834,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7851,11 +7853,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7870,11 +7872,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7889,11 +7891,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13568,6 +13570,7 @@ const models: TsoaRoute.Models = {
             'description',
             'categories',
             'chartUsage',
+            'owner',
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -18180,6 +18183,13 @@ const models: TsoaRoute.Models = {
                         {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
+                                owner: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'undefined' },
+                                    ],
+                                },
                                 categories: {
                                     dataType: 'union',
                                     subSchemas: [
@@ -20757,6 +20767,13 @@ const models: TsoaRoute.Models = {
                         {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
+                                owner: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'undefined' },
+                                    ],
+                                },
                                 categories: {
                                     dataType: 'union',
                                     subSchemas: [
@@ -21129,6 +21146,20 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CatalogOwner: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                email: { dataType: 'string', required: true },
+                lastName: { dataType: 'string', required: true },
+                firstName: { dataType: 'string', required: true },
+                userUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CatalogField: {
         dataType: 'refAlias',
         type: {
@@ -21141,6 +21172,14 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        owner: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'CatalogOwner' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
                         spotlightSegmentBy: {
                             dataType: 'array',
                             array: { dataType: 'string' },
@@ -44217,6 +44256,12 @@ export function RegisterRoutes(app: Router) {
             dataType: 'array',
             array: { dataType: 'string' },
         },
+        ownerUserUuids: {
+            in: 'query',
+            name: 'ownerUserUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
     };
     app.get(
         '/api/v1/projects/:projectUuid/dataCatalog/metrics',
@@ -45000,6 +45045,66 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'hasMetricsInCatalog',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsCatalogController_getMetricOwners: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/dataCatalog/metrics/owners',
+        ...fetchMiddlewares<RequestHandler>(CatalogController),
+        ...fetchMiddlewares<RequestHandler>(
+            CatalogController.prototype.getMetricOwners,
+        ),
+
+        async function CatalogController_getMetricOwners(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsCatalogController_getMetricOwners,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any = await container.get<CatalogController>(
+                    CatalogController,
+                );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getMetricOwners',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5705,6 +5705,9 @@
                     },
                     "spotlight": {
                         "properties": {
+                            "owner": {
+                                "type": "string"
+                            },
                             "segmentBy": {
                                 "items": {
                                     "type": "string"
@@ -5990,6 +5993,9 @@
                     },
                     "spotlight": {
                         "properties": {
+                            "owner": {
+                                "type": "string"
+                            },
                             "categories": {
                                 "items": {
                                     "type": "string"
@@ -8205,6 +8211,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -8220,12 +8239,12 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -8233,10 +8252,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8245,8 +8264,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8340,12 +8359,12 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "searchRank": {
+                                                                                    "chartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -8353,10 +8372,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8365,8 +8384,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -13982,7 +14001,8 @@
                     "tableLabel",
                     "description",
                     "categories",
-                    "chartUsage"
+                    "chartUsage",
+                    "owner"
                 ],
                 "type": "string"
             },
@@ -18921,6 +18941,9 @@
                     },
                     "spotlight": {
                         "properties": {
+                            "owner": {
+                                "type": "string"
+                            },
                             "categories": {
                                 "items": {
                                     "type": "string"
@@ -21518,6 +21541,9 @@
                     },
                     "spotlight": {
                         "properties": {
+                            "owner": {
+                                "type": "string"
+                            },
                             "categories": {
                                 "items": {
                                     "type": "string"
@@ -21885,6 +21911,24 @@
                     }
                 ]
             },
+            "CatalogOwner": {
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "userUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["email", "lastName", "firstName", "userUuid"],
+                "type": "object"
+            },
             "CatalogField": {
                 "allOf": [
                     {
@@ -21895,6 +21939,14 @@
                     },
                     {
                         "properties": {
+                            "owner": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/CatalogOwner"
+                                    }
+                                ],
+                                "nullable": true
+                            },
                             "spotlightSegmentBy": {
                                 "items": {
                                     "type": "string"
@@ -21976,6 +22028,7 @@
                             }
                         },
                         "required": [
+                            "owner",
                             "aiHints",
                             "icon",
                             "categories",
@@ -24345,7 +24398,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2360.0",
+        "version": "0.2364.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -37102,6 +37155,17 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "ownerUserUuids",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
                     }
                 ]
             }
@@ -37666,6 +37730,61 @@
                     }
                 },
                 "description": "Check if there are any metrics in catalog",
+                "tags": ["Catalog"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/dataCatalog/metrics/owners": {
+            "get": {
+                "operationId": "getMetricOwners",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "results": {
+                                            "items": {
+                                                "$ref": "#/components/schemas/CatalogOwner"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": ["ok"],
+                                            "nullable": false
+                                        }
+                                    },
+                                    "required": ["results", "status"],
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get distinct metric owners for filter dropdown",
+                "summary": "List metric owners",
                 "tags": ["Catalog"],
                 "security": [],
                 "parameters": [

--- a/packages/backend/src/models/CatalogModel/utils/parser.test.ts
+++ b/packages/backend/src/models/CatalogModel/utils/parser.test.ts
@@ -21,6 +21,7 @@ const createDbCatalog = (
     yaml_tags: null,
     ai_hints: null,
     joined_tables: null,
+    owner_user_uuid: null,
     ...overrides,
 });
 

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -469,10 +469,11 @@ export class ExploreCompiler {
             sqlPath,
             databricksCompute,
             ...(aiHint ? { aiHint } : {}),
-            ...getSpotlightConfigurationForResource(
-                spotlightVisibility,
-                spotlightCategories,
-            ),
+            ...getSpotlightConfigurationForResource({
+                visibility: spotlightVisibility,
+                categories: spotlightCategories,
+                owner: meta.spotlight?.owner,
+            }),
             ...(meta.parameters && Object.keys(meta.parameters).length > 0
                 ? { parameters: meta.parameters }
                 : {}),

--- a/packages/common/src/compiler/lightdashProjectConfig.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.ts
@@ -3,20 +3,26 @@ import type { Explore } from '../types/explore';
 import type { Metric } from '../types/field';
 import type { LightdashProjectConfig } from '../types/lightdashProjectConfig';
 
+type SpotlightConfigArgs = {
+    visibility?: LightdashProjectConfig['spotlight']['default_visibility'];
+    categories?: string[];
+    filterBy?: string[];
+    segmentBy?: string[];
+    owner?: string;
+};
+
 /**
  * Get the spotlight configuration for a resource
- * @param visibility - The visibility of the resource
- * @param categories - The categories of the resource
- * @param filterBy - Dimension IDs allowlist for filtering (metrics only)
- * @param segmentBy - Dimension IDs allowlist for segmenting (metrics only)
- * @returns The spotlight configuration for the resource
  */
-export const getSpotlightConfigurationForResource = (
-    visibility?: LightdashProjectConfig['spotlight']['default_visibility'],
-    categories?: string[],
-    filterBy?: string[],
-    segmentBy?: string[],
-): Pick<Explore, 'spotlight'> | Pick<Metric, 'spotlight'> => {
+export const getSpotlightConfigurationForResource = ({
+    visibility,
+    categories,
+    filterBy,
+    segmentBy,
+    owner,
+}: SpotlightConfigArgs):
+    | Pick<Explore, 'spotlight'>
+    | Pick<Metric, 'spotlight'> => {
     if (visibility === undefined) {
         return {};
     }
@@ -27,6 +33,7 @@ export const getSpotlightConfigurationForResource = (
             categories,
             ...(filterBy ? { filterBy } : {}),
             ...(segmentBy ? { segmentBy } : {}),
+            ...(owner ? { owner } : {}),
         },
     };
 };

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -415,10 +415,11 @@ const convertDbtMetricToLightdashMetric = (
                       : [metric.meta.tags],
               }
             : {}),
-        ...getSpotlightConfigurationForResource(
-            spotlightVisibility,
-            spotlightCategories,
-        ),
+        ...getSpotlightConfigurationForResource({
+            visibility: spotlightVisibility,
+            categories: spotlightCategories,
+            owner: metric.meta?.spotlight?.owner,
+        }),
     };
 };
 
@@ -722,6 +723,7 @@ export const convertTable = (
                                     spotlightConfig.default_visibility,
                             },
                             modelCategories: meta.spotlight?.categories,
+                            modelOwner: meta.spotlight?.owner,
                         }),
                     ],
                 ),
@@ -754,6 +756,7 @@ export const convertTable = (
                         spotlightConfig.default_visibility,
                 },
                 modelCategories: meta.spotlight?.categories,
+                modelOwner: meta.spotlight?.owner,
             }),
         ]),
     );

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -342,6 +342,10 @@
                                                             "type": "string"
                                                         },
                                                         "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
+                                                    },
+                                                    "owner": {
+                                                        "type": "string",
+                                                        "description": "Email of the metric owner"
                                                     }
                                                 },
                                                 "anyOf": [
@@ -364,6 +368,9 @@
                                                         "required": [
                                                             "segment_by"
                                                         ]
+                                                    },
+                                                    {
+                                                        "required": ["owner"]
                                                     }
                                                 ]
                                             }
@@ -407,11 +414,16 @@
                                             "type": "string"
                                         },
                                         "description": "An optional array of categories for all metrics in this model in Spotlight"
+                                    },
+                                    "owner": {
+                                        "type": "string",
+                                        "description": "Email of the model owner (inherited by all metrics)"
                                     }
                                 },
                                 "anyOf": [
                                     { "required": ["visibility"] },
-                                    { "required": ["categories"] }
+                                    { "required": ["categories"] },
+                                    { "required": ["owner"] }
                                 ]
                             },
                             "primary_key": {
@@ -869,6 +881,10 @@
                                                                         "type": "string"
                                                                     },
                                                                     "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
+                                                                },
+                                                                "owner": {
+                                                                    "type": "string",
+                                                                    "description": "Email of the metric owner"
                                                                 }
                                                             },
                                                             "anyOf": [
@@ -890,6 +906,11 @@
                                                                 {
                                                                     "required": [
                                                                         "segment_by"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "required": [
+                                                                        "owner"
                                                                     ]
                                                                 }
                                                             ]
@@ -1499,13 +1520,18 @@
                                             "type": "string"
                                         },
                                         "description": "An array of dimension names that are allowed for segmenting this metric in the Metrics Explorer"
+                                    },
+                                    "owner": {
+                                        "type": "string",
+                                        "description": "Email of the metric owner"
                                     }
                                 },
                                 "anyOf": [
                                     { "required": ["visibility"] },
                                     { "required": ["categories"] },
                                     { "required": ["filter_by"] },
-                                    { "required": ["segment_by"] }
+                                    { "required": ["segment_by"] },
+                                    { "required": ["owner"] }
                                 ]
                             }
                         }

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -45,6 +45,7 @@ export type ApiCatalogSearch = {
     catalogTags?: string[];
     catalogTagsFilterMode?: CatalogCategoryFilterMode;
     tables?: string[];
+    ownerUserUuids?: string[];
 };
 
 type EmojiIcon = {
@@ -58,6 +59,14 @@ type CustomIcon = {
 export type CatalogItemIcon = EmojiIcon | CustomIcon;
 
 export const UNCATEGORIZED_TAG_UUID = '__uncategorized__';
+export const UNASSIGNED_OWNER = '__unassigned__';
+
+export type CatalogOwner = {
+    userUuid: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+};
 
 export const isEmojiIcon = (icon: CatalogItemIcon | null): icon is EmojiIcon =>
     Boolean(icon && 'unicode' in icon);
@@ -85,6 +94,7 @@ export type CatalogField = Pick<
         searchRank?: number;
         spotlightFilterBy?: string[]; // dimension IDs allowlist (metrics only)
         spotlightSegmentBy?: string[]; // dimension IDs allowlist (metrics only)
+        owner: CatalogOwner | null; // resolved metric owner
     };
 
 export type CatalogTable = Pick<

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -93,6 +93,7 @@ export type Explore = {
     spotlight?: {
         visibility: LightdashProjectConfig['spotlight']['default_visibility'];
         categories?: string[]; // yaml_reference
+        owner?: string; // model owner email (inherited by metrics)
     };
     aiHint?: string | string[];
     parameters?: LightdashProjectConfig['parameters'];

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -763,6 +763,7 @@ export interface Metric extends Field {
         categories?: string[]; // yaml_reference
         filterBy?: string[]; // dimension IDs allowlist
         segmentBy?: string[]; // dimension IDs allowlist
+        owner?: string; // metric owner email
     };
     aiHint?: string | string[];
 }

--- a/packages/common/src/types/spotlightTableConfig.ts
+++ b/packages/common/src/types/spotlightTableConfig.ts
@@ -5,6 +5,7 @@ export enum SpotlightTableColumns {
     DESCRIPTION = 'description',
     CATEGORIES = 'categories',
     CHART_USAGE = 'chartUsage',
+    OWNER = 'owner',
 }
 
 type ColumnConfig = Array<{
@@ -24,4 +25,5 @@ export const DEFAULT_SPOTLIGHT_TABLE_COLUMN_CONFIG: ColumnConfig = [
     { column: SpotlightTableColumns.DESCRIPTION, isVisible: true },
     { column: SpotlightTableColumns.CATEGORIES, isVisible: true },
     { column: SpotlightTableColumns.CHART_USAGE, isVisible: true },
+    { column: SpotlightTableColumns.OWNER, isVisible: false },
 ];

--- a/packages/e2e/cypress/e2e/api/catalog.cy.ts
+++ b/packages/e2e/cypress/e2e/api/catalog.cy.ts
@@ -1,4 +1,4 @@
-import { AnyType, SEED_PROJECT, type CatalogField } from '@lightdash/common';
+import { SEED_PROJECT, type CatalogField } from '@lightdash/common';
 import { chartMock } from '../../support/mocks';
 import { createChartAndUpdateDashboard, createDashboard } from './dashboard.cy';
 
@@ -61,6 +61,7 @@ describe('Lightdash catalog all tables and fields', () => {
                 icon: null,
                 aiHints: null,
                 fieldValueType: 'string',
+                owner: null,
             });
 
             const metric = resp.body.results.find(
@@ -83,6 +84,7 @@ describe('Lightdash catalog all tables and fields', () => {
                 icon: null,
                 aiHints: null,
                 fieldValueType: 'sum',
+                owner: null,
             });
         });
     });

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnOwner.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnOwner.tsx
@@ -1,0 +1,41 @@
+import { type CatalogField } from '@lightdash/common';
+import { Group, Paper, Text, Tooltip } from '@mantine-8/core';
+import { type MRT_Row } from 'mantine-react-table';
+import { type FC } from 'react';
+import { LightdashUserAvatar } from '../../../components/Avatar';
+
+type Props = {
+    row: MRT_Row<CatalogField>;
+};
+
+export const MetricsCatalogColumnOwner: FC<Props> = ({ row }) => {
+    const owner = row.original.owner;
+
+    if (!owner) {
+        return (
+            <Text
+                fz="sm"
+                c="ldGray.5"
+                fs="italic"
+                style={{ cursor: 'default' }}
+            >
+                Unassigned
+            </Text>
+        );
+    }
+
+    const displayName = `${owner.firstName} ${owner.lastName}`;
+
+    return (
+        <Tooltip label={owner.email} openDelay={300}>
+            <Paper px="xs" w="fit-content" style={{ cursor: 'default' }}>
+                <Group gap="two" wrap="nowrap" maw="200px">
+                    <LightdashUserAvatar size={16} name={displayName} />
+                    <Text fz="sm" fw={600} c="ldGray.9" truncate>
+                        {displayName}
+                    </Text>
+                </Group>
+            </Paper>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -1,7 +1,7 @@
 import { SpotlightTableColumns, type CatalogField } from '@lightdash/common';
 import { Box, Button, Flex, Group, Text } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
-import { IconPlus } from '@tabler/icons-react';
+import { IconPlus, IconUser } from '@tabler/icons-react';
 import { type MRT_ColumnDef } from 'mantine-react-table';
 import { useMemo } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -26,6 +26,7 @@ import { MetricChartUsageButton } from './MetricChartUsageButton';
 import { MetricsCatalogCategoryForm } from './MetricsCatalogCategoryForm';
 import { MetricsCatalogColumnDescription } from './MetricsCatalogColumnDescription';
 import { MetricsCatalogColumnName } from './MetricsCatalogColumnName';
+import { MetricsCatalogColumnOwner } from './MetricsCatalogColumnOwner';
 
 export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
     {
@@ -328,5 +329,24 @@ export const MetricsCatalogColumns: MRT_ColumnDef<CatalogField>[] = [
             </MetricCatalogColumnHeaderCell>
         ),
         Cell: ({ row }) => <MetricChartUsageButton row={row} />,
+    },
+    {
+        accessorKey: SpotlightTableColumns.OWNER,
+        header: 'Owner',
+        enableSorting: true,
+        enableEditing: false,
+        size: 200,
+        minSize: 100,
+        Header: ({ column }) => (
+            <MetricCatalogColumnHeaderCell
+                Icon={() => (
+                    <MantineIcon icon={IconUser} size={14} color="ldGray.5" />
+                )}
+                tooltipLabel="Metric owner defined in the YAML file"
+            >
+                {column.columnDef.header}
+            </MetricCatalogColumnHeaderCell>
+        ),
+        Cell: ({ row }) => <MetricsCatalogColumnOwner row={row} />,
     },
 ];

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -34,6 +34,7 @@ import {
     setCategoryFilterMode,
     setCategoryFilters,
     setOrganizationUuid,
+    setOwnerFilters,
     setProjectUuid,
     setSearch,
     setTableFilters,
@@ -186,6 +187,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
     const searchParam = useSearchParams('search');
     const sortingParam = useSearchParams('sortBy');
     const sortDirectionParam = useSearchParams('sortDirection');
+    const ownerUserUuidParam = useSearchParams('ownerUserUuid');
 
     const categories = useAppSelector(
         (state) => state.metricsCatalog.categoryFilters,
@@ -199,6 +201,9 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
     const search = useAppSelector((state) => state.metricsCatalog.search);
     const tableSorting = useAppSelector(
         (state) => state.metricsCatalog.tableSorting,
+    );
+    const ownerFilters = useAppSelector(
+        (state) => state.metricsCatalog.ownerFilters,
     );
 
     const organizationUuid = useAppSelector(
@@ -272,10 +277,13 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
         const urlSortDirectionParam = sortDirectionParam
             ? decodeURIComponent(sortDirectionParam)
             : undefined;
+        const urlOwnerUserUuids =
+            ownerUserUuidParam?.split(',').map(decodeURIComponent) || [];
 
         dispatch(setCategoryFilters(urlCategories));
         dispatch(setCategoryFilterMode(urlCategoriesFilterMode));
         dispatch(setTableFilters(urlTables));
+        dispatch(setOwnerFilters(urlOwnerUserUuids));
         dispatch(setSearch(urlSearch));
 
         if (urlSortByParam) {
@@ -292,6 +300,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
         categoriesParam,
         categoriesFilterModeParam,
         tablesParam,
+        ownerUserUuidParam,
         dispatch,
         searchParam,
         sortingParam,
@@ -341,11 +350,21 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
             );
         }
 
+        if (ownerFilters.length > 0) {
+            queryParams.set(
+                'ownerUserUuid',
+                ownerFilters.map(encodeURIComponent).join(','),
+            );
+        } else {
+            queryParams.delete('ownerUserUuid');
+        }
+
         void navigate({ search: queryParams.toString() }, { replace: true });
     }, [
         categories,
         categoryFilterMode,
         tableFilters,
+        ownerFilters,
         search,
         tableSorting,
         navigate,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTable.tsx
@@ -56,6 +56,7 @@ import {
     setCategoryFilterMode,
     setCategoryFilters,
     setColumnConfig,
+    setOwnerFilters,
     setSearch,
     setTableFilters,
     setTableSorting,
@@ -96,6 +97,9 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
     const tableFilters = useAppSelector(
         (state) => state.metricsCatalog.tableFilters,
     );
+    const ownerFilters = useAppSelector(
+        (state) => state.metricsCatalog.ownerFilters,
+    );
     const { canManageTags, canManageMetricsTree } = useAppSelector(
         (state) => state.metricsCatalog.abilities,
     );
@@ -134,6 +138,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
         categories: categoryFilters,
         categoriesFilterMode: categoryFilterMode,
         tables: tableFilters,
+        ownerUserUuids: ownerFilters,
         // TODO: Handle multiple sorting - this needs to be enabled and handled later in the backend
         ...(stateTableSorting.length > 0 && {
             sortBy: stateTableSorting[0].id as keyof CatalogItem,
@@ -230,6 +235,10 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
         dispatch(setCategoryFilterMode(mode));
     };
 
+    const handleSetOwnerFilters = (selectedOwners: string[]) => {
+        dispatch(setOwnerFilters(selectedOwners));
+    };
+
     // Reusable paper props to avoid duplicate when rendering tree view
     const mantinePaperProps: PaperProps = useMemo(
         () => ({
@@ -302,7 +311,8 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
             !hasNextPage &&
             !search &&
             categoryFilters.length === 0 &&
-            tableFilters.length === 0
+            tableFilters.length === 0 &&
+            ownerFilters.length === 0
         );
     }, [
         flatData,
@@ -311,6 +321,7 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
         search,
         categoryFilters,
         tableFilters,
+        ownerFilters,
         hasNextPage,
     ]);
 
@@ -527,6 +538,8 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                     setCategoryFilterMode={handleSetCategoryFilterMode}
                     selectedTables={tableFilters}
                     setSelectedTables={handleSetTableFilters}
+                    selectedOwners={ownerFilters}
+                    setSelectedOwners={handleSetOwnerFilters}
                     position="apart"
                     p={`${theme.spacing.lg} ${theme.spacing.xl}`}
                     showCategoriesFilter={canManageTags || dataHasCategories}
@@ -681,6 +694,8 @@ export const MetricsTable: FC<MetricsTableProps> = ({ metricCatalogView }) => {
                             setCategoryFilterMode={handleSetCategoryFilterMode}
                             selectedTables={tableFilters}
                             setSelectedTables={handleSetTableFilters}
+                            selectedOwners={ownerFilters}
+                            setSelectedOwners={handleSetOwnerFilters}
                             position="apart"
                             p={`${theme.spacing.lg} ${theme.spacing.xl}`}
                             showCategoriesFilter={

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/OwnersFilter.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/OwnersFilter.tsx
@@ -1,0 +1,254 @@
+import { UNASSIGNED_OWNER, type CatalogOwner } from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    Checkbox,
+    Group,
+    Popover,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import { clsx } from '@mantine/core';
+import { IconSearch, IconUser, IconX } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useAppSelector } from '../../../sqlRunner/store/hooks';
+import { useMetricOwners } from '../../hooks/useMetricOwners';
+import styles from './CategoriesFilter.module.css';
+
+type OwnersFilterProps = {
+    selectedOwners: string[];
+    setSelectedOwners: (owners: string[]) => void;
+};
+
+const getOwnerDisplayName = (owner: CatalogOwner) =>
+    `${owner.firstName} ${owner.lastName}`;
+
+const OwnersFilter: FC<OwnersFilterProps> = ({
+    selectedOwners,
+    setSelectedOwners,
+}) => {
+    const projectUuid = useAppSelector(
+        (state) => state.metricsCatalog.projectUuid,
+    );
+    const [searchValue, setSearchValue] = useState('');
+
+    const { data: owners, isLoading } = useMetricOwners({ projectUuid });
+
+    // Filter owners by search (name or email)
+    const filteredOwners = useMemo(() => {
+        if (!owners) return [];
+        if (!searchValue) return owners;
+        const searchLower = searchValue.toLowerCase();
+        return owners.filter(
+            (owner) =>
+                getOwnerDisplayName(owner)
+                    .toLowerCase()
+                    .includes(searchLower) ||
+                owner.email.toLowerCase().includes(searchLower),
+        );
+    }, [owners, searchValue]);
+
+    const hasSelectedOwners = selectedOwners.length > 0;
+
+    const ownerNames = useMemo(() => {
+        const unassigned = selectedOwners.includes(UNASSIGNED_OWNER);
+        const selectedUserUuids = selectedOwners.filter(
+            (o) => o !== UNASSIGNED_OWNER,
+        );
+        const names =
+            owners
+                ?.filter((o) => selectedUserUuids.includes(o.userUuid))
+                .map(getOwnerDisplayName) ?? [];
+
+        return names.concat(unassigned ? ['Unassigned'] : []).join(', ');
+    }, [selectedOwners, owners]);
+
+    const buttonLabel = hasSelectedOwners ? ownerNames : 'All owners';
+
+    return (
+        <Group gap={2}>
+            <Popover width={300} position="bottom-start" shadow="sm">
+                <Popover.Target>
+                    <Tooltip
+                        withinPortal
+                        label="Filter metrics by owner"
+                        openDelay={200}
+                        maw={250}
+                        fz="xs"
+                    >
+                        <Button
+                            h={32}
+                            c="ldGray.7"
+                            fw={500}
+                            fz="sm"
+                            variant="default"
+                            radius="md"
+                            py="xs"
+                            px="sm"
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconUser}
+                                    size="md"
+                                    color={
+                                        hasSelectedOwners
+                                            ? 'indigo.5'
+                                            : 'ldGray.5'
+                                    }
+                                />
+                            }
+                            loading={isLoading}
+                            className={clsx(
+                                styles.filterButton,
+                                hasSelectedOwners &&
+                                    styles.filterButtonSelected,
+                            )}
+                            classNames={{
+                                label: styles.filterButtonLabel,
+                            }}
+                        >
+                            {buttonLabel}
+                        </Button>
+                    </Tooltip>
+                </Popover.Target>
+                <Popover.Dropdown p="sm">
+                    <Stack gap={4}>
+                        <Text fz="xs" c="ldGray.6" fw={600}>
+                            Filter by owner:
+                        </Text>
+
+                        {(owners?.length ?? 0) > 5 && (
+                            <TextInput
+                                size="xs"
+                                placeholder="Search owners..."
+                                value={searchValue}
+                                onChange={(e) =>
+                                    setSearchValue(e.currentTarget.value)
+                                }
+                                rightSection={
+                                    searchValue ? (
+                                        <ActionIcon
+                                            size="xs"
+                                            onClick={() => setSearchValue('')}
+                                        >
+                                            <MantineIcon icon={IconX} />
+                                        </ActionIcon>
+                                    ) : (
+                                        <MantineIcon
+                                            icon={IconSearch}
+                                            color="ldGray.5"
+                                        />
+                                    )
+                                }
+                            />
+                        )}
+
+                        {owners?.length === 0 && (
+                            <Text fz="xs" fw={500} c="ldGray.6">
+                                No owners configured yet. Add spotlight.owner in
+                                your metric or model YAML to assign owners.
+                            </Text>
+                        )}
+
+                        <Stack
+                            gap="xs"
+                            mah={300}
+                            mt="xxs"
+                            className={styles.scrollableList}
+                        >
+                            {filteredOwners.map((owner) => (
+                                <Checkbox
+                                    key={owner.userUuid}
+                                    label={getOwnerDisplayName(owner)}
+                                    checked={selectedOwners.includes(
+                                        owner.userUuid,
+                                    )}
+                                    size="xs"
+                                    classNames={{
+                                        body: styles.checkbox,
+                                        input: styles.checkboxInput,
+                                    }}
+                                    onChange={() => {
+                                        if (
+                                            selectedOwners.includes(
+                                                owner.userUuid,
+                                            )
+                                        ) {
+                                            setSelectedOwners(
+                                                selectedOwners.filter(
+                                                    (o) => o !== owner.userUuid,
+                                                ),
+                                            );
+                                        } else {
+                                            setSelectedOwners([
+                                                ...selectedOwners,
+                                                owner.userUuid,
+                                            ]);
+                                        }
+                                    }}
+                                />
+                            ))}
+                            {!searchValue && (owners?.length ?? 0) > 0 && (
+                                <Checkbox
+                                    label="Unassigned"
+                                    checked={selectedOwners.includes(
+                                        UNASSIGNED_OWNER,
+                                    )}
+                                    fw={500}
+                                    size="xs"
+                                    classNames={{
+                                        body: styles.checkbox,
+                                        input: styles.checkboxInput,
+                                    }}
+                                    onChange={() => {
+                                        if (
+                                            selectedOwners.includes(
+                                                UNASSIGNED_OWNER,
+                                            )
+                                        ) {
+                                            setSelectedOwners(
+                                                selectedOwners.filter(
+                                                    (o) =>
+                                                        o !== UNASSIGNED_OWNER,
+                                                ),
+                                            );
+                                        } else {
+                                            setSelectedOwners([
+                                                ...selectedOwners,
+                                                UNASSIGNED_OWNER,
+                                            ]);
+                                        }
+                                    }}
+                                />
+                            )}
+                            {filteredOwners.length === 0 &&
+                                (owners?.length ?? 0) > 0 && (
+                                    <Text fz="xs" c="ldGray.5">
+                                        No owners match your search.
+                                    </Text>
+                                )}
+                        </Stack>
+                    </Stack>
+                </Popover.Dropdown>
+            </Popover>
+            {hasSelectedOwners && (
+                <Tooltip label="Clear all owner filters">
+                    <ActionIcon
+                        size="xs"
+                        color="ldGray.5"
+                        variant="subtle"
+                        onClick={() => {
+                            setSelectedOwners([]);
+                        }}
+                    >
+                        <MantineIcon icon={IconX} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+        </Group>
+    );
+};
+
+export default OwnersFilter;

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -69,6 +69,7 @@ import {
 } from '../../store/metricsCatalogSlice';
 import { MetricCatalogView } from '../../types';
 import CategoriesFilter from './CategoriesFilter';
+import OwnersFilter from './OwnersFilter';
 import SegmentedControlHoverCard from './SegmentedControlHoverCard';
 import TableFilter from './TableFilter';
 type MetricsTableTopToolbarProps = GroupProps & {
@@ -82,6 +83,8 @@ type MetricsTableTopToolbarProps = GroupProps & {
     setCategoryFilterMode: (mode: CatalogCategoryFilterMode) => void;
     selectedTables: string[];
     setSelectedTables: (tables: string[]) => void;
+    selectedOwners: string[];
+    setSelectedOwners: (owners: string[]) => void;
     totalResults: number;
     isValidMetricsNodeCount: boolean;
     isValidMetricsEdgeCount: boolean;
@@ -164,6 +167,8 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
         setCategoryFilterMode,
         selectedTables,
         setSelectedTables,
+        selectedOwners,
+        setSelectedOwners,
         showCategoriesFilter,
         isValidMetricsTree,
         isValidMetricsNodeCount,
@@ -412,6 +417,11 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                     <TableFilter
                         selectedTables={selectedTables}
                         setSelectedTables={setSelectedTables}
+                    />
+
+                    <OwnersFilter
+                        selectedOwners={selectedOwners}
+                        setSelectedOwners={setSelectedOwners}
                     />
                 </Group>
                 <Group spacing="xs">

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricOwners.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricOwners.tsx
@@ -1,0 +1,27 @@
+import { type ApiError, type CatalogOwner } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const getMetricOwners = async ({
+    projectUuid,
+}: {
+    projectUuid: string;
+}): Promise<CatalogOwner[]> => {
+    return lightdashApi<CatalogOwner[]>({
+        url: `/projects/${projectUuid}/dataCatalog/metrics/owners`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useMetricOwners = ({
+    projectUuid,
+}: {
+    projectUuid: string | undefined;
+}) => {
+    return useQuery<CatalogOwner[], ApiError>({
+        queryKey: ['metric-owners', projectUuid],
+        queryFn: () => getMetricOwners({ projectUuid: projectUuid! }),
+        enabled: !!projectUuid,
+    });
+};

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricsCatalog.tsx
@@ -19,6 +19,7 @@ type UseMetricsCatalogOptions = {
     categories?: string[];
     categoriesFilterMode?: CatalogCategoryFilterMode;
     tables?: string[];
+    ownerUserUuids?: string[];
     sortBy?: ApiSort['sort'] | 'name' | 'chartUsage';
     sortDirection?: ApiSort['order'];
 };
@@ -31,6 +32,7 @@ const getMetricsCatalog = async ({
     categories,
     categoriesFilterMode,
     tables,
+    ownerUserUuids,
     paginateArgs,
     sortBy,
     sortDirection,
@@ -45,6 +47,7 @@ const getMetricsCatalog = async ({
     | 'tables'
     | 'sortBy'
     | 'sortDirection'
+    | 'ownerUserUuids'
 >) => {
     const urlParams = new URLSearchParams({
         ...(paginateArgs
@@ -71,6 +74,12 @@ const getMetricsCatalog = async ({
         tables.forEach((table) => urlParams.append('tables', table));
     }
 
+    if (ownerUserUuids && ownerUserUuids.length > 0) {
+        ownerUserUuids.forEach((ownerUserUuid) =>
+            urlParams.append('ownerUserUuids', ownerUserUuid),
+        );
+    }
+
     return lightdashApi<ApiMetricsCatalog['results']>({
         url: `/projects/${projectUuid}/dataCatalog/metrics${
             urlParams.toString() ? `?${urlParams.toString()}` : ''
@@ -88,6 +97,7 @@ export const useMetricsCatalog = ({
     categories,
     categoriesFilterMode,
     tables,
+    ownerUserUuids,
     pageSize,
 }: UseMetricsCatalogOptions & Pick<KnexPaginateArgs, 'pageSize'>) => {
     const queryClient = useQueryClient();
@@ -102,6 +112,7 @@ export const useMetricsCatalog = ({
             categories,
             categoriesFilterMode,
             tables,
+            ownerUserUuids,
         ],
         queryFn: ({ pageParam }) =>
             getMetricsCatalog({
@@ -112,6 +123,7 @@ export const useMetricsCatalog = ({
                 categories,
                 categoriesFilterMode,
                 tables,
+                ownerUserUuids,
                 paginateArgs: {
                     page: pageParam ?? 1,
                     pageSize,

--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -34,6 +34,7 @@ type MetricsCatalogState = {
     categoryFilters: CatalogField['categories'][number]['tagUuid'][];
     categoryFilterMode: CatalogCategoryFilterMode;
     tableFilters: string[];
+    ownerFilters: string[];
     search: string | undefined;
     tableSorting: MRT_SortingState;
     popovers: {
@@ -77,6 +78,7 @@ const initialState: MetricsCatalogState = {
     categoryFilters: [],
     categoryFilterMode: CatalogCategoryFilterMode.OR,
     tableFilters: [],
+    ownerFilters: [],
     search: undefined,
     tableSorting: [
         {
@@ -117,6 +119,7 @@ const initialState: MetricsCatalogState = {
             [SpotlightTableColumns.DESCRIPTION]: false,
             [SpotlightTableColumns.CATEGORIES]: false,
             [SpotlightTableColumns.METRIC]: false,
+            [SpotlightTableColumns.OWNER]: false,
         },
     },
 };
@@ -161,6 +164,9 @@ export const metricsCatalogSlice = createSlice({
         },
         setTableFilters: (state, action: PayloadAction<string[]>) => {
             state.tableFilters = action.payload;
+        },
+        setOwnerFilters: (state, action: PayloadAction<string[]>) => {
+            state.ownerFilters = action.payload;
         },
         setSearch: (state, action: PayloadAction<string | undefined>) => {
             state.search = action.payload;
@@ -238,6 +244,7 @@ export const {
     setCategoryFilters,
     setCategoryFilterMode,
     setTableFilters,
+    setOwnerFilters,
     setOrganizationUuid,
     setAbility,
     setUser,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-212: Metrics Catalog: Add Metric Owner column (YAML-defined) and make it filterable](https://linear.app/lightdash/issue/ZAP-212/metrics-catalog-add-metric-owner-column-yaml-defined-and-make-it)

### Description:

This PR adds support for metric owners in the Metrics Catalog. Owners can be defined in the YAML files using the `spotlight.owner` property at either the metric or model level.

Key changes:

- Added `owner` field to the catalog database schema
- Added support for filtering metrics by owner in the Metrics Catalog UI
- Added a new API endpoint to fetch distinct metric owners
- Updated the YAML schema to support owner definition at both metric and model levels
- Added owner column to the Metrics Catalog table (hidden by default)
