### PR TITLE
feat: add debounce to metrics catalog search

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -47,8 +47,9 @@ import {
 } from '@tabler/icons-react';
 import isEqual from 'lodash/isEqual';
 import { type MRT_TableInstance } from 'mantine-react-table';
-import { memo, useCallback, useMemo, type FC } from 'react';
+import { memo, useCallback, useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import { useDebounce } from 'react-use';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { TotalMetricsDot } from '../../../../svgs/metricsCatalog';
@@ -70,7 +71,6 @@ import { MetricCatalogView } from '../../types';
 import CategoriesFilter from './CategoriesFilter';
 import SegmentedControlHoverCard from './SegmentedControlHoverCard';
 import TableFilter from './TableFilter';
-
 type MetricsTableTopToolbarProps = GroupProps & {
     search: string | undefined;
     setSearch: (search: string) => void;
@@ -155,8 +155,8 @@ const SortableColumn: FC<{
 
 export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
     ({
-        search,
-        setSearch,
+        search: _search,
+        setSearch: _setSearch,
         totalResults,
         selectedCategories,
         setSelectedCategories,
@@ -172,6 +172,16 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
         table,
         ...props
     }) => {
+        const [search, setSearch] = useState(_search);
+
+        useDebounce(
+            () => {
+                _setSearch(search ?? '');
+            },
+            300,
+            [search],
+        );
+
         const userUuid = useAppSelector(
             (state) => state.metricsCatalog.user?.userUuid,
         );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-199: Metrics Catalog: Search returns incomplete/incorrect results for certain queries](https://linear.app/lightdash/issue/ZAP-199/metrics-catalog-search-returns-incompleteincorrect-results-for-certain)

### Description:

Added debounce functionality to the search input in the Metrics Table Top Toolbar to improve performance by delaying the search execution until the user stops typing. This implementation uses the `useDebounce` hook from `react-use` with a 300ms delay, preventing excessive re-renders and API calls while users are actively typing.  
  
Before:  
 

[CleanShot 2026-01-22 at 13.06.29.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/88826a23-7c49-46f8-a3b2-a7c36860e738.mp4" />](https://app.graphite.com/user-attachments/video/88826a23-7c49-46f8-a3b2-a7c36860e738.mp4)

After:

[CleanShot 2026-01-22 at 13.05.23.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0b42b0ab-e05f-47f0-8e0d-0a0dfaa88088.mp4" />](https://app.graphite.com/user-attachments/video/0b42b0ab-e05f-47f0-8e0d-0a0dfaa88088.mp4)

