### PR TITLE
feat: add explore from here link button on explore modal v2

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -24,10 +24,10 @@ import { useVisualizationContext } from '../../../../../components/LightdashVisu
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
+import { getOpenInExploreUrl } from '../../../../../utils/getOpenInExploreUrl';
 import { useSetArtifactVersionVerified } from '../../hooks/useAiAgentArtifacts';
 import { useAiAgentPermission } from '../../hooks/useAiAgentPermission';
 import { useSavePromptQuery } from '../../hooks/useProjectAiAgents';
-import { getOpenInExploreUrl } from '../../utils/getOpenInExploreUrl';
 
 type Props = {
     projectUuid: string;

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -26,15 +26,17 @@ import { useHotkeys } from '@mantine/hooks';
 import {
     IconChevronDown,
     IconChevronUp,
+    IconExternalLink,
     IconInfoCircle,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import LightdashVisualization from '../../../components/LightdashVisualization';
 import VisualizationProvider from '../../../components/LightdashVisualization/VisualizationProvider';
 import MetricQueryDataProvider from '../../../components/MetricQueryData/MetricQueryDataProvider';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { getOpenInExploreUrl } from '../../../utils/getOpenInExploreUrl';
 import { useAppSelector } from '../../sqlRunner/store/hooks';
 import { useCatalogFilterDimensions } from '../hooks/useCatalogFilterDimensions';
 import { useCatalogMetricsWithTimeDimensions } from '../hooks/useCatalogMetricsWithTimeDimensions';
@@ -212,6 +214,16 @@ export const MetricExploreModalV2: FC<Props> = ({
         [segmentDimensionsQuery.data, currentMetric],
     );
 
+    const openInExploreUrl = useMemo(() => {
+        if (!metricQuery || !chartConfig) return undefined;
+        return getOpenInExploreUrl({
+            metricQuery,
+            projectUuid,
+            columnOrder,
+            chartConfig,
+        });
+    }, [metricQuery, projectUuid, columnOrder, chartConfig]);
+
     // Keyboard navigation
     useHotkeys([
         ['ArrowUp', handleGoToPreviousMetric],
@@ -287,7 +299,45 @@ export const MetricExploreModalV2: FC<Props> = ({
                             />
                         </Tooltip>
                     </Group>
-                    <Modal.CloseButton />
+                    <Group gap="xs">
+                        <Tooltip
+                            label="Explore from here"
+                            position="bottom"
+                            disabled={!openInExploreUrl}
+                        >
+                            {openInExploreUrl ? (
+                                <Button
+                                    component={Link}
+                                    to={openInExploreUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    variant="default"
+                                    size="xs"
+                                    radius="md"
+                                    leftSection={
+                                        <MantineIcon icon={IconExternalLink} />
+                                    }
+                                >
+                                    Explore from here
+                                </Button>
+                            ) : (
+                                <Button
+                                    component="button"
+                                    type="button"
+                                    variant="default"
+                                    size="xs"
+                                    radius="md"
+                                    leftSection={
+                                        <MantineIcon icon={IconExternalLink} />
+                                    }
+                                    disabled
+                                >
+                                    Explore from here
+                                </Button>
+                            )}
+                        </Tooltip>
+                        <Modal.CloseButton />
+                    </Group>
                 </Modal.Header>
 
                 <Modal.Body

--- a/packages/frontend/src/utils/getOpenInExploreUrl.ts
+++ b/packages/frontend/src/utils/getOpenInExploreUrl.ts
@@ -1,5 +1,5 @@
 import type { ChartConfig, MetricQuery } from '@lightdash/common';
-import { getExplorerUrlFromCreateSavedChartVersion } from '../../../../hooks/useExplorerRoute';
+import { getExplorerUrlFromCreateSavedChartVersion } from '../hooks/useExplorerRoute';
 
 export const getOpenInExploreUrl = ({
     metricQuery,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/ZAP-217/metrics-explorer-mini-add-open-in-explorer-and-save-chart-flows

### Description:

Added an "Explore from here" button to the Metrics Catalog modal, allowing users to open the current metric visualization in the Explorer. This reuses the `getOpenInExploreUrl` utility which has been moved from the AI Copilot feature to a common location so it can be shared across components.

[CleanShot 2026-01-22 at 10.39.05.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/dce00e27-6879-4ba9-a0a6-36dda1c3d57d.mp4" />](https://app.graphite.com/user-attachments/video/dce00e27-6879-4ba9-a0a6-36dda1c3d57d.mp4)
