### PR TITLE
feat: add meta-query detection to skip forwarding agent selection queries

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -16,6 +16,11 @@ const AgentSelectionSchema = z.object({
     confidence: z
         .enum(['high', 'medium', 'low'])
         .describe('Confidence level in the selection'),
+    shouldSkipForwardingQuery: z
+        .boolean()
+        .describe(
+            'Set to true for meta-queries about agent selection itself (e.g., "what agents are available"). Set to false for actual data questions that should be forwarded to the selected agent.',
+        ),
 });
 
 export type AgentSelectionResult = z.infer<typeof AgentSelectionSchema>;
@@ -76,6 +81,7 @@ export async function selectBestAgent(
             agentUuid: agents[0].uuid,
             reasoning: 'Only one agent available',
             confidence: 'high',
+            shouldSkipForwardingQuery: false,
         };
     }
 
@@ -113,6 +119,13 @@ Selection Guidelines:
 - Consider agents that have answered similar questions before
 - If no perfect match, choose the most general-purpose agent
 - Be confident in your choice, but indicate lower confidence if the match is uncertain
+
+Meta-Query Detection (shouldSkipForwardingQuery):
+- Set shouldSkipForwardingQuery to TRUE for queries about agent selection itself:
+  * "What agents are available?"
+  * "Show me the available agents"
+- Set shouldSkipForwardingQuery to FALSE for actual data/analytics questions
+- When shouldSkipForwardingQuery is TRUE, set confidence to 'low' to show the agent selector UI
 
 You must select exactly ONE agent from the list above by providing its exact UUID.`,
             },
@@ -153,6 +166,7 @@ export async function selectBestAgentWithContext(
                 agentUuid: agents[0].uuid,
                 reasoning: `Selected agent "${selection.agentUuid}" not found. Defaulting to first available agent.`,
                 confidence: 'low',
+                shouldSkipForwardingQuery: false,
             },
         };
     }

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -410,6 +410,7 @@ export function getAgentSelectionBlocks(
     agents: AiAgent[],
     channelId: string,
     projectMap?: Map<string, string>,
+    shouldSkipForwardingQuery = false,
 ): (Block | KnownBlock)[] {
     if (agents.length === 0) {
         return [
@@ -462,6 +463,7 @@ export function getAgentSelectionBlocks(
                         value: JSON.stringify({
                             agentUuid: agent.uuid,
                             channelId,
+                            shouldSkipForwardingQuery,
                         }),
                     })),
                 };
@@ -523,6 +525,7 @@ export function getAgentSelectionBlocks(
                         value: JSON.stringify({
                             agentUuid: agent.uuid,
                             channelId,
+                            shouldSkipForwardingQuery,
                         }),
                     })),
                 },


### PR DESCRIPTION
closes [#19650](https://github.com/lightdash/lightdash/issues/19650)

### Description:

Added support for detecting and handling meta-queries about agent selection in Slack. When users ask questions like "What agents are available?" the system now identifies these as meta-queries, shows agent selection dropdown and skips forwarding them to an agent.

![CleanShot 2026-01-22 at 11.52.03@2x.png](https://app.graphite.com/user-attachments/assets/5678edf8-d434-4f6e-827a-5b0a86fa2bee.png)

conversation stops after selection, to avoid forwarding the question to the selected agent

[CleanShot 2026-01-22 at 11.51.04.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/a4b6cef3-65b0-4303-a804-5ce2adbeadb4.mp4" />](https://app.graphite.com/user-attachments/video/a4b6cef3-65b0-4303-a804-5ce2adbeadb4.mp4)

_otherwise, without skipping

![CleanShot 2026-01-22 at 11.53.41@2x.png](https://app.graphite.com/user-attachments/assets/0d8fc694-7649-4b05-9e6b-019d7b0031a4.png)