### PR TITLE
fix: use colorsio with oklab colorspace for the gradients

### DIFF
--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -2,7 +2,7 @@ import { MapChartLocation, MapChartType } from '@lightdash/common';
 import { Box, Divider, Stack, Text, UnstyledButton } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconMap } from '@tabler/icons-react';
-import { scaleLinear, scaleSqrt } from 'd3-scale';
+import { scaleSqrt } from 'd3-scale';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import {
@@ -32,6 +32,7 @@ import useLeafletMapConfig, {
     type TooltipFieldInfo,
 } from '../../hooks/leaflet/useLeafletMapConfig';
 import useToaster from '../../hooks/toaster/useToaster';
+import { createMultiColorScale } from '../../utils/colorUtils';
 import { isMapVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import LoadingChart from '../common/LoadingChart';
@@ -436,20 +437,6 @@ type SimpleMapProps = {
     onScreenshotError?: () => void;
 };
 
-// Helper to create a color scale that interpolates between colors
-const createColorScale = (min: number, max: number, colors: string[]) => {
-    if (colors.length === 0) return () => '#888888';
-    if (colors.length === 1) return () => colors[0];
-    if (max === min) return () => colors[Math.floor(colors.length / 2)];
-
-    // Create domain points that map evenly across the value range
-    const domain = colors.map(
-        (_, i) => min + (i / (colors.length - 1)) * (max - min),
-    );
-
-    return scaleLinear<string>().domain(domain).range(colors).clamp(true);
-};
-
 const SimpleMap: FC<SimpleMapProps> = memo(
     ({ onScreenshotReady, onScreenshotError, ...props }) => {
         const { isLoading, visualizationConfig, resultsData, leafletMapRef } =
@@ -657,7 +644,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
         // Memoized color scale for scatter points
         const scatterColorScale = useMemo(() => {
             if (!mapConfig) return null;
-            return createColorScale(
+            return createMultiColorScale(
                 scatterValueRange.min,
                 scatterValueRange.max,
                 mapConfig.colors.scale,
@@ -752,7 +739,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
         // Memoized color scale for choropleth regions
         const regionColorScale = useMemo(() => {
             if (!mapConfig) return null;
-            return createColorScale(
+            return createMultiColorScale(
                 regionValueRange.min,
                 regionValueRange.max,
                 mapConfig.colors.scale,

--- a/packages/frontend/src/components/common/GradientBar.tsx
+++ b/packages/frontend/src/components/common/GradientBar.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mantine-8/core';
-import { scaleLinear } from 'd3-scale';
 import { useMemo, type FC } from 'react';
+import { interpolateMultiColor } from '../../utils/colorUtils';
 
 type GradientBarProps = {
     colors: string[];
@@ -9,7 +9,7 @@ type GradientBarProps = {
     opacity?: number;
 };
 
-/** Number of samples to take from D3 interpolation for smooth CSS gradient */
+/** Number of samples to take for smooth CSS gradient */
 const GRADIENT_SAMPLES = 20;
 
 const GradientBar: FC<GradientBarProps> = ({
@@ -18,25 +18,15 @@ const GradientBar: FC<GradientBarProps> = ({
     borderRadius = 2,
     opacity,
 }) => {
-    // Use D3's scaleLinear for accurate color interpolation matching the map
     const gradientStops = useMemo(() => {
         if (colors.length === 0) return '';
         if (colors.length === 1) return colors[0];
-
-        // Create D3 color scale with piecewise interpolation
-        const domain = colors.map(
-            (_, i) => i / (colors.length - 1), // 0 to 1
-        );
-        const colorScale = scaleLinear<string>()
-            .domain(domain)
-            .range(colors)
-            .clamp(true);
 
         // Generate sampled color stops for smooth gradient
         const stops: string[] = [];
         for (let i = 0; i <= GRADIENT_SAMPLES; i++) {
             const t = i / GRADIENT_SAMPLES;
-            const color = colorScale(t);
+            const color = interpolateMultiColor(colors, t);
             const percent = t * 100;
             stops.push(`${color} ${percent}%`);
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/19625

### Description:
Improved color interpolation for maps by replacing D3's scaleLinear with a custom implementation using colorjs.io. The new approach:

- Extracts color scaling logic into reusable utility functions in colorUtils.ts
- Uses perceptually uniform color spaces (oklab) for better data visualization
- Maintains consistent color interpolation between map elements and gradient legends
- Implements piecewise linear interpolation between color stops for smoother gradients

This change ensures more accurate and visually pleasing color transitions in both map visualizations and gradient bars.

<img width="1600" height="574" alt="CleanShot 2026-01-22 at 10 59 27" src="https://github.com/user-attachments/assets/1e1e0588-5630-4d98-98c2-9a30850505d9" />
