### PR TITLE
feat: allow segment by in metric explore modal v2

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
@@ -23,6 +23,7 @@ import { useMetric } from './useMetricsCatalog';
 const buildMetricQueryFromField = (
     field: MetricWithAssociatedTimeDimension,
     timeDimensionOverride?: TimeDimensionConfig,
+    segmentDimensionId?: string | null,
     comparison?: MetricExplorerComparison,
 ): MetricQuery => {
     const timeDimensionConfig = timeDimensionOverride ?? field.timeDimension;
@@ -46,9 +47,13 @@ const buildMetricQueryFromField = (
         timeDimensionConfig &&
         timeDimensionName;
 
+    const dimensions = [timeDimensionFieldId, segmentDimensionId].filter(
+        (d): d is string => Boolean(d),
+    );
+
     return {
         exploreName: field.table,
-        dimensions: timeDimensionFieldId ? [timeDimensionFieldId] : [],
+        dimensions,
         metrics: [getItemId(field)],
         filters: {},
         sorts: [],
@@ -127,6 +132,7 @@ type UseMetricVisualizationProps = {
     tableName: string | undefined;
     metricName: string | undefined;
     timeDimensionOverride?: TimeDimensionConfig;
+    segmentDimensionId?: string | null;
     comparison?: MetricExplorerComparison;
 };
 
@@ -144,6 +150,7 @@ export function useMetricVisualization({
     tableName,
     metricName,
     timeDimensionOverride,
+    segmentDimensionId,
     comparison,
 }: UseMetricVisualizationProps): MetricVisualizationResult {
     // 1. Fetch metric field metadata
@@ -167,9 +174,15 @@ export function useMetricVisualization({
         return buildMetricQueryFromField(
             metricFieldQuery.data,
             timeDimensionConfig,
+            segmentDimensionId,
             comparison,
         );
-    }, [metricFieldQuery.data, timeDimensionConfig, comparison]);
+    }, [
+        metricFieldQuery.data,
+        timeDimensionConfig,
+        segmentDimensionId,
+        comparison,
+    ]);
 
     const queryArgs = useMemo<QueryResultsProps | null>(() => {
         if (!projectUuid || !tableName || !metricQuery) return null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue//metrics-explorer-mini-add-open-in-explorer-and-save-chart-flows

### Description:
Implemented segmentation functionality in the Metric Explorer modal. Users can now select a segment dimension to analyze metrics across different categories. The implementation includes:

- Added segmentDimensionId state tracking in the MetricExploreModalV2 component
- Enabled the MetricExploreSegmentationPicker component with proper handlers
- Updated the useMetricVisualization hook to include segment dimensions in metric queries
- Added pivot column support in the results table to display segmented data
- Moved the segmentation picker outside the disabled overlay to make it accessible

This change allows users to break down metrics by different dimensions, providing more detailed analysis capabilities in the metrics explorer.

[CleanShot 2026-01-22 at 12.32.58.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/032a3a97-f210-42f6-8939-d676a1122c8c.mp4" />](https://app.graphite.com/user-attachments/video/032a3a97-f210-42f6-8939-d676a1122c8c.mp4)

