### PR TITLE
feat: allow filter by in metric explore modal v2

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.module.css
@@ -29,11 +29,6 @@
     position: relative;
 }
 
-.disabledOverlay {
-    opacity: 0.6;
-    pointer-events: none;
-}
-
 .clearButton {
     visibility: hidden;
 }

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -5,6 +5,7 @@ import {
     getFilterDimensionsForMetric,
     getSegmentDimensionsForMetric,
     type CatalogField,
+    type FilterRule,
     type MetricExplorerQuery,
     type TimeDimensionConfig,
 } from '@lightdash/common';
@@ -111,6 +112,8 @@ export const MetricExploreModalV2: FC<Props> = ({
         TimeDimensionConfig | undefined
     >();
 
+    const [filterRule, setFilterRule] = useState<FilterRule | undefined>();
+
     const [query, setQuery] = useState<MetricExplorerQuery>({
         comparison: MetricExplorerComparison.NONE,
         segmentDimension: null,
@@ -123,11 +126,12 @@ export const MetricExploreModalV2: FC<Props> = ({
     // Reset override when navigating to a different metric
     const resetQueryState = useCallback(() => {
         setTimeDimensionOverride(undefined);
+        setFilterRule(undefined);
         setQuery({
             comparison: MetricExplorerComparison.NONE,
             segmentDimension: null,
         });
-    }, [setTimeDimensionOverride, setQuery]);
+    }, [setTimeDimensionOverride, setFilterRule, setQuery]);
 
     // Update navigateToMetric to reset state
     const navigateToMetricWithReset = useCallback(
@@ -172,6 +176,7 @@ export const MetricExploreModalV2: FC<Props> = ({
         metricName,
         timeDimensionOverride,
         segmentDimensionId,
+        filterRule,
         comparison: query.comparison,
     });
 
@@ -250,6 +255,13 @@ export const MetricExploreModalV2: FC<Props> = ({
             });
         },
         [setQuery],
+    );
+
+    const handleFilterApply = useCallback(
+        (nextFilterRule: FilterRule | undefined) => {
+            setFilterRule(nextFilterRule);
+        },
+        [setFilterRule],
     );
 
     return (
@@ -376,25 +388,11 @@ export const MetricExploreModalV2: FC<Props> = ({
                             className={styles.sidebarContainer}
                         >
                             <Stack gap="xl" w="100%">
-                                <Box pos="relative">
-                                    <Box className={styles.disabledOverlay}>
-                                        <MetricExploreFilter
-                                            dimensions={
-                                                availableFilterByDimensions
-                                            }
-                                            onFilterApply={() => {}}
-                                        />
-                                    </Box>
-                                    <Box pos="absolute" inset={0}>
-                                        <Tooltip
-                                            label="Coming soon"
-                                            position="right"
-                                            withinPortal
-                                        >
-                                            <Box w="100%" h="100%" />
-                                        </Tooltip>
-                                    </Box>
-                                </Box>
+                                <MetricExploreFilter
+                                    dimensions={availableFilterByDimensions}
+                                    onFilterApply={handleFilterApply}
+                                    key={`${tableName}-${metricName}`}
+                                />
 
                                 <MetricExploreSegmentationPicker
                                     query={query}

--- a/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useMetricVisualization.ts
@@ -8,6 +8,8 @@ import {
     TimeFrames,
     type ApiError,
     type ChartConfig,
+    type FilterRule,
+    type Filters,
     type MetricQuery,
     type MetricWithAssociatedTimeDimension,
     type TimeDimensionConfig,
@@ -24,6 +26,7 @@ const buildMetricQueryFromField = (
     field: MetricWithAssociatedTimeDimension,
     timeDimensionOverride?: TimeDimensionConfig,
     segmentDimensionId?: string | null,
+    filterRule?: FilterRule,
     comparison?: MetricExplorerComparison,
 ): MetricQuery => {
     const timeDimensionConfig = timeDimensionOverride ?? field.timeDimension;
@@ -51,11 +54,20 @@ const buildMetricQueryFromField = (
         (d): d is string => Boolean(d),
     );
 
+    const filters: Filters = filterRule
+        ? {
+              dimensions: {
+                  id: filterRule.id,
+                  and: [filterRule],
+              },
+          }
+        : {};
+
     return {
         exploreName: field.table,
         dimensions,
         metrics: [getItemId(field)],
-        filters: {},
+        filters,
         sorts: [],
         limit: 5000,
         tableCalculations: [],
@@ -133,6 +145,7 @@ type UseMetricVisualizationProps = {
     metricName: string | undefined;
     timeDimensionOverride?: TimeDimensionConfig;
     segmentDimensionId?: string | null;
+    filterRule?: FilterRule;
     comparison?: MetricExplorerComparison;
 };
 
@@ -151,6 +164,7 @@ export function useMetricVisualization({
     metricName,
     timeDimensionOverride,
     segmentDimensionId,
+    filterRule,
     comparison,
 }: UseMetricVisualizationProps): MetricVisualizationResult {
     // 1. Fetch metric field metadata
@@ -175,12 +189,14 @@ export function useMetricVisualization({
             metricFieldQuery.data,
             timeDimensionConfig,
             segmentDimensionId,
+            filterRule,
             comparison,
         );
     }, [
         metricFieldQuery.data,
         timeDimensionConfig,
         segmentDimensionId,
+        filterRule,
         comparison,
     ]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue//metrics-explorer-mini-add-open-in-explorer-and-save-chart-flows

### Description:
Enables the filter functionality in the Metric Explorer modal that was previously disabled. This PR removes the overlay that was marking the filter component as "Coming soon" and implements the necessary state management to apply filters to metric visualizations. The implementation includes:

- Adding a `filterRule` state in the `MetricExploreModalV2` component
- Implementing the `handleFilterApply` callback to update the filter state
- Modifying the `buildMetricQueryFromField` function to include filter rules in the query
- Resetting filter state when navigating between metrics

[CleanShot 2026-01-22 at 12.55.00.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0794cfeb-2ad7-405b-b682-bd98f53abe13.mp4" />](https://app.graphite.com/user-attachments/video/0794cfeb-2ad7-405b-b682-bd98f53abe13.mp4)

