### PR TITLE
feat: add screenshot readiness tracking for Explore pages in Slack unfurls

### DIFF
--- a/packages/backend/src/services/UnfurlService/CLAUDE.md
+++ b/packages/backend/src/services/UnfurlService/CLAUDE.md
@@ -47,10 +47,13 @@ ScreenshotReadyIndicator                    page.waitForSelector(
 
 **Pages that render the indicator:**
 
-| Page | Component | Location |
-|------|-----------|----------|
-| Dashboards | `MinimalDashboard.tsx` | `/minimal/projects/:projectUuid/dashboards/:dashboardUuid` |
-| Single Charts | `MinimalSavedExplorer.tsx` | `/minimal/projects/:projectUuid/saved/:savedQueryUuid` |
+| Page | Component | URL Pattern | Notes |
+|------|-----------|-------------|-------|
+| Dashboards | `MinimalDashboard.tsx` | `/minimal/projects/:projectUuid/dashboards/:dashboardUuid` | Uses minimal page |
+| Single Charts | `MinimalSavedExplorer.tsx` | `/minimal/projects/:projectUuid/saved/:savedQueryUuid` | Uses minimal page |
+| Explore (unsaved charts) | `Explorer/index.tsx` | `/projects/:projectUuid/tables/:tableName` | Uses full page, screenshots only the visualization |
+
+For EXPLORE pages, the indicator is rendered in the regular `Explorer` component (not a minimal page). The UnfurlService screenshots only the `[data-testid="visualization"]` element, so the sidebar and other UI elements are excluded from the screenshot.
 
 **Tile types that signal readiness:**
 
@@ -77,11 +80,12 @@ The indicator shows `data-status="completed-with-errors"` when any tile has erro
 
 **Frontend:**
 - `packages/frontend/src/components/common/ScreenshotReadyIndicator.tsx` - Hidden DOM element
-- `packages/frontend/src/providers/Dashboard/DashboardProvider.tsx` - Tracks tile counts
+- `packages/frontend/src/providers/Dashboard/DashboardProvider.tsx` - Tracks tile counts for dashboards
 - `packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx` - Saved chart tiles
 - `packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx` - SQL chart tiles
-- `packages/frontend/src/pages/MinimalDashboard.tsx` - Dashboard page
-- `packages/frontend/src/pages/MinimalSavedExplorer.tsx` - Single chart page
+- `packages/frontend/src/pages/MinimalDashboard.tsx` - Dashboard page (minimal)
+- `packages/frontend/src/pages/MinimalSavedExplorer.tsx` - Single chart page (minimal)
+- `packages/frontend/src/components/Explorer/index.tsx` - Explore page (full page, indicator for Slack unfurls)
 
 **Common:**
 - `packages/common/src/constants/screenshot.ts` - `SCREENSHOT_READY_INDICATOR_ID`, `SCREENSHOT_SELECTORS`
@@ -99,3 +103,43 @@ If adding a new chart tile type that should be tracked for screenshot readiness:
 2. Call `markTileScreenshotReady(tile.uuid)` when the tile finishes loading successfully
 3. Call `markTileScreenshotErrored(tile.uuid)` when the tile encounters an error (including deleted state)
 4. Handle the deleted state explicitly (when the underlying resource UUID is null/undefined)
+
+## Slack Unfurls vs Scheduled Deliveries
+
+The UnfurlService handles screenshots for two different use cases with different image storage mechanisms:
+
+### Scheduled Deliveries
+
+Used for dashboard/chart schedulers that send emails or Slack messages on a schedule.
+
+- Triggered by `SchedulerService` → `SlackClient.postImageToSlack()` or email delivery
+- Image is uploaded directly to Slack via `files.uploadV2` API (for Slack deliveries)
+- For email, images are attached to the email or hosted temporarily
+
+### Slack Unfurls (Link Previews)
+
+When a user shares a Lightdash URL in Slack, Slack requests a preview image.
+
+- Triggered by `SlackController.getUnfurl()` → `UnfurlService.unfurlImage()`
+- Slack needs a publicly accessible URL to fetch the image
+
+**Image Storage:**
+
+1. **With S3 enabled** (`S3Service` configured):
+   - Image uploaded to S3: `s3Client.uploadImage(buffer, imageId)`
+   - Returns S3 URL for Slack to fetch
+
+2. **Without S3** (local storage):
+   - Image saved to `/tmp/${imageId}.png`
+   - Served via `/api/v1/slack/image/${downloadFileId}`
+   - Uses `DownloadFileModel.createDownloadFile()` to create a temporary download token
+   - Token has expiration for security
+
+**Key Methods:**
+- `unfurlImage()` - Creates screenshot and returns image URL for Slack unfurls
+- `unfurlDetails()` - Returns metadata (title, description) without screenshot
+
+**Files:**
+- `SlackController.ts` - `/api/v1/slack/image/:nanoId` endpoint serves local images
+- `S3Service.ts` - Handles S3 uploads when configured
+- `DownloadFileModel.ts` - Manages temporary download tokens for local images

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1253,17 +1253,17 @@ export class UnfurlService extends BaseService {
                                 ...(sqlPivotPromises || []),
                             ];
                         } else if (
-                            lightdashPage === LightdashPage.CHART ||
-                            lightdashPage === LightdashPage.EXPLORE
+                            !useScreenshotReadyIndicator &&
+                            (lightdashPage === LightdashPage.CHART ||
+                                lightdashPage === LightdashPage.EXPLORE)
                         ) {
-                            if (!useScreenshotReadyIndicator) {
-                                chartResultsPromises = [
-                                    this.waitForPaginatedResultsResponse(
-                                        page,
-                                        useScreenshotReadyIndicator,
-                                    ),
-                                ]; // NOTE: No await here
-                            }
+                            // Legacy behavior: wait for API response
+                            chartResultsPromises = [
+                                this.waitForPaginatedResultsResponse(
+                                    page,
+                                    false,
+                                ),
+                            ]; // NOTE: No await here
                         }
 
                         await page.goto(url, {
@@ -1331,11 +1331,7 @@ export class UnfurlService extends BaseService {
                             });
                         }
 
-                        if (
-                            chartResultsPromises &&
-                            !useScreenshotReadyIndicator
-                        ) {
-                            // We wait after navigating to the page
+                        if (chartResultsPromises) {
                             await Promise.allSettled(chartResultsPromises);
                         }
                     } catch (e) {
@@ -1360,7 +1356,7 @@ export class UnfurlService extends BaseService {
                             },
                         );
                         this.logger.info(
-                            'Screenshot ready indicator found - dashboard is ready',
+                            'Screenshot ready indicator found - page is ready',
                         );
                     } else {
                         if (lightdashPage === LightdashPage.DASHBOARD) {

--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -17,7 +17,6 @@ const VegaEmbed = lazy(async () => {
 
 type Props = {
     className?: string;
-    'data-testid'?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
 };
@@ -119,7 +118,6 @@ const CustomVisualization: FC<Props> = ({
 
     return (
         <div
-            data-testid={props['data-testid']}
             className={props.className}
             style={{
                 minHeight: 'inherit',

--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -31,7 +31,6 @@ type FunnelChartProps = Omit<EChartsReactProps, 'option'> & {
     isInDashboard: boolean;
     $shouldExpand?: boolean;
     className?: string;
-    'data-testid'?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
 };
@@ -122,7 +121,6 @@ const FunnelChart: FC<FunnelChartProps> = memo(
             <>
                 <EChartsReact
                     ref={chartRef}
-                    data-testid={props['data-testid']}
                     className={props.className}
                     style={
                         props.$shouldExpand

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -51,134 +51,129 @@ const LightdashVisualization = memo(
 
             if (apiErrorDetail) {
                 return (
-                    <EmptyState
-                        icon={
-                            // Icon consistent with SuboptimalState in charts
-                            <MantineIcon
-                                color="ldGray.5"
-                                size="xxl"
-                                icon={IconChartBarOff}
-                            />
-                        }
-                        h="100%"
-                        w="100%"
-                        justify="center"
-                        title="Unable to load visualization"
-                        description={
-                            <Fragment>
-                                <Text style={{ whiteSpace: 'pre-wrap' }}>
-                                    {apiErrorDetail.message || ''}
-                                </Text>
-                                {apiErrorDetail.data.documentationUrl && (
-                                    <Fragment>
-                                        <br />
-                                        <Anchor
-                                            href={
-                                                apiErrorDetail.data
-                                                    .documentationUrl
-                                            }
-                                            target="_blank"
-                                            rel="noreferrer"
-                                        >
-                                            Learn how to resolve this in our
-                                            documentation →
-                                        </Anchor>
-                                    </Fragment>
-                                )}
-                            </Fragment>
-                        }
-                    ></EmptyState>
+                    <div
+                        ref={ref}
+                        className={className}
+                        data-testid={props['data-testid']}
+                    >
+                        <EmptyState
+                            icon={
+                                // Icon consistent with SuboptimalState in charts
+                                <MantineIcon
+                                    color="ldGray.5"
+                                    size="xxl"
+                                    icon={IconChartBarOff}
+                                />
+                            }
+                            h="100%"
+                            w="100%"
+                            justify="center"
+                            title="Unable to load visualization"
+                            description={
+                                <Fragment>
+                                    <Text style={{ whiteSpace: 'pre-wrap' }}>
+                                        {apiErrorDetail.message || ''}
+                                    </Text>
+                                    {apiErrorDetail.data.documentationUrl && (
+                                        <Fragment>
+                                            <br />
+                                            <Anchor
+                                                href={
+                                                    apiErrorDetail.data
+                                                        .documentationUrl
+                                                }
+                                                target="_blank"
+                                                rel="noreferrer"
+                                            >
+                                                Learn how to resolve this in our
+                                                documentation →
+                                            </Anchor>
+                                        </Fragment>
+                                    )}
+                                </Fragment>
+                            }
+                        ></EmptyState>
+                    </div>
                 );
             }
 
+            // Render chart content based on type
+            let chartContent: React.ReactNode;
+
             switch (visualizationConfig.chartType) {
                 case ChartType.BIG_NUMBER:
-                    return (
+                    chartContent = (
                         <SimpleStatistic
                             minimal={minimal}
-                            className={className}
-                            data-testid={props['data-testid']}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
-                            {...props}
                         />
                     );
+                    break;
                 case ChartType.TABLE:
-                    return (
+                    chartContent = (
                         <SimpleTable
                             tileUuid={tileUuid}
                             minimal={minimal}
                             isDashboard={!!isDashboard}
-                            className={className}
                             $shouldExpand
-                            data-testid={props['data-testid']}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
-                            {...props}
                         />
                     );
+                    break;
                 case ChartType.CARTESIAN:
-                    return (
+                    chartContent = (
                         <SimpleChart
-                            className={className}
                             isInDashboard={!!isDashboard}
                             $shouldExpand
-                            data-testid={props['data-testid']}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
-                            {...props}
                         />
                     );
+                    break;
                 case ChartType.PIE:
-                    return (
+                    chartContent = (
                         <SimplePieChart
-                            className={className}
                             isInDashboard={!!isDashboard}
                             $shouldExpand
-                            data-testid={props['data-testid']}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
-                            {...props}
                         />
                     );
+                    break;
                 case ChartType.FUNNEL:
-                    return (
+                    chartContent = (
                         <FunnelChart
-                            className={className}
                             isInDashboard={!!isDashboard}
                             $shouldExpand
-                            data-testid={props['data-testid']}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
-                            {...props}
                         />
                     );
+                    break;
                 case ChartType.TREEMAP:
-                    return (
+                    chartContent = (
                         <SimpleTreemap
-                            className={className}
                             isInDashboard={!!isDashboard}
                             $shouldExpand
-                            data-testid={props['data-testid']}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
-                            {...props}
                         />
                     );
+                    break;
                 case ChartType.GAUGE:
-                    return (
+                    chartContent = (
                         <SimpleGauge
-                            className={className}
                             isInDashboard={isDashboard}
                             $shouldExpand
-                            data-testid={props['data-testid']}
                             onScreenshotReady={onScreenshotReady}
                             onScreenshotError={onScreenshotError}
-                            {...props}
                         />
                     );
+                    break;
                 case ChartType.MAP:
-                    return (
+                    chartContent = (
                         <Suspense
                             fallback={
                                 <SuboptimalState
@@ -188,42 +183,47 @@ const LightdashVisualization = memo(
                             }
                         >
                             <LazySimpleMap
-                                className={className}
                                 isInDashboard={isDashboard}
                                 $shouldExpand
-                                data-testid={props['data-testid']}
                                 onScreenshotReady={onScreenshotReady}
                                 onScreenshotError={onScreenshotError}
-                                {...props}
                             />
                         </Suspense>
                     );
+                    break;
                 case ChartType.CUSTOM:
-                    return (
-                        <div
-                            ref={ref}
-                            style={{
-                                width: '100%',
-                                height: '100%',
-                                display: 'flex',
-                                flexDirection: 'column',
-                            }}
-                        >
-                            <CustomVisualization
-                                data-testid={props['data-testid']}
-                                className={className}
-                                onScreenshotReady={onScreenshotReady}
-                                onScreenshotError={onScreenshotError}
-                            />
-                        </div>
+                    chartContent = (
+                        <CustomVisualization
+                            onScreenshotReady={onScreenshotReady}
+                            onScreenshotError={onScreenshotError}
+                        />
                     );
-
+                    break;
                 default:
                     return assertUnreachable(
                         visualizationConfig,
                         `Chart type is not implemented`,
                     );
             }
+
+            // Wrap in a div to ensure data-testid and ref are on a DOM element
+            // (some chart components like echarts-for-react don't forward these props)
+            return (
+                <div
+                    ref={ref}
+                    className={className}
+                    data-testid={props['data-testid']}
+                    style={{
+                        width: '100%',
+                        height: '100%',
+                        minHeight: 'inherit',
+                        display: 'flex',
+                        flexDirection: 'column',
+                    }}
+                >
+                    {chartContent}
+                </div>
+            );
         },
     ),
 );

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -74,7 +74,6 @@ type SimpleChartProps = Omit<EChartsReactProps, 'option'> & {
     isInDashboard: boolean;
     $shouldExpand?: boolean;
     className?: string;
-    'data-testid'?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
 };
@@ -335,7 +334,6 @@ const SimpleChart: FC<SimpleChartProps> = memo(
 
         return (
             <EChartsReact
-                data-testid={props['data-testid']}
                 className={props.className}
                 style={
                     props.$shouldExpand

--- a/packages/frontend/src/components/SimpleGauge/index.tsx
+++ b/packages/frontend/src/components/SimpleGauge/index.tsx
@@ -23,7 +23,6 @@ type SimpleGaugeProps = Omit<EChartsReactProps, 'option'> & {
     isInDashboard: boolean;
     $shouldExpand?: boolean;
     className?: string;
-    'data-testid'?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
 };
@@ -170,7 +169,6 @@ const SimpleGauge: FC<SimpleGaugeProps> = memo(
             <>
                 <EChartsReact
                     ref={chartRef}
-                    data-testid={props['data-testid']}
                     className={props.className}
                     style={
                         props.$shouldExpand

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -424,7 +424,6 @@ type SimpleMapProps = {
     isInDashboard: boolean;
     $shouldExpand?: boolean;
     className?: string;
-    'data-testid'?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
 };
@@ -657,8 +656,8 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     point.value === null
                         ? 0.5
                         : max === min
-                        ? 0.5
-                        : (point.value - min) / (max - min);
+                          ? 0.5
+                          : (point.value - min) / (max - min);
                 return [point.lat, point.lon, scale];
             });
         }, [scatterData, scatterValueRange]);
@@ -898,7 +897,6 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                 <div
                     className={`${classes.container} ${props.className ?? ''}`}
                     data-should-expand={props.$shouldExpand}
-                    data-testid={props['data-testid']}
                     style={
                         mapConfig.backgroundColor
                             ? ({
@@ -997,7 +995,6 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                 <div
                     className={`${classes.container} ${props.className ?? ''}`}
                     data-should-expand={props.$shouldExpand}
-                    data-testid={props['data-testid']}
                     style={
                         mapConfig.backgroundColor
                             ? ({

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -30,7 +30,6 @@ type SimplePieChartProps = Omit<EChartsReactProps, 'option'> & {
     isInDashboard: boolean;
     $shouldExpand?: boolean;
     className?: string;
-    'data-testid'?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
 };
@@ -115,7 +114,6 @@ const SimplePieChart: FC<SimplePieChartProps> = memo(
             <>
                 <EChartsReact
                     ref={chartRef}
-                    data-testid={props['data-testid']}
                     className={props.className}
                     style={
                         props.$shouldExpand

--- a/packages/frontend/src/components/SimpleTreemap/index.tsx
+++ b/packages/frontend/src/components/SimpleTreemap/index.tsx
@@ -21,7 +21,6 @@ type SimpleTreemapProps = Omit<EChartsReactProps, 'option'> & {
     isInDashboard: boolean;
     $shouldExpand?: boolean;
     className?: string;
-    'data-testid'?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
 };
@@ -64,7 +63,6 @@ const SimpleTreemap: FC<SimpleTreemapProps> = memo(
             <>
                 <EChartsReact
                     ref={chartRef}
-                    data-testid={props['data-testid']}
                     className={props.className}
                     style={
                         props.$shouldExpand


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-151

### Description:
Add screenshot readiness indicator to Explore pages for Slack unfurls

This PR adds support for the screenshot readiness indicator on Explore pages, enabling proper Slack unfurls for unsaved charts. Previously, only dashboards and saved charts had this indicator.

Key changes:
- Added the indicator to the Explorer component to signal when visualizations are ready
- Updated the UnfurlService to properly handle the indicator on Explore pages
- Improved the documentation with details about Slack unfurls vs scheduled deliveries
- Refactored visualization components to properly apply data-testid attributes at the container level

This ensures consistent behavior across all chart types when shared in Slack.