### PR TITLE
fix: handle missing columns in metrics catalog table configuration

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
+++ b/packages/frontend/src/features/metricsCatalog/store/metricsCatalogSlice.ts
@@ -63,10 +63,20 @@ export function convertStateToTableColumnConfig(
 export function convertTableColumnConfigToState(
     columnConfig: SpotlightTableConfig['columnConfig'],
 ): MetricsCatalogState['columnConfig'] {
+    // Merge with defaults to ensure all columns exist (handles old configs missing new columns)
+    const mergedConfig = DEFAULT_SPOTLIGHT_TABLE_COLUMN_CONFIG.map(
+        (defaultCol) => {
+            const savedCol = columnConfig.find(
+                (c) => c.column === defaultCol.column,
+            );
+            return savedCol ?? defaultCol;
+        },
+    );
+
     return {
-        columnOrder: columnConfig.map((column) => column.column),
+        columnOrder: mergedConfig.map((column) => column.column),
         columnVisibility: Object.fromEntries(
-            columnConfig.map((column) => [column.column, column.isVisible]),
+            mergedConfig.map((column) => [column.column, column.isVisible]),
         ),
     };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixed a bug in the metrics catalog where old saved column configurations would not include newly added columns. The fix merges saved configurations with the default configuration to ensure all columns exist, even if they were added after the user's configuration was saved.
