### PR TITLE
fix: hide explore button from metric explore modal v2 if insufficient permissions

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -70,6 +70,9 @@ export const MetricExploreModalV2: FC<Props> = ({
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
+    const canExploreFromHere = useAppSelector(
+        (state) => state.metricsCatalog.abilities.canManageExplore,
+    );
 
     const { tableName, metricName } = useParams<{
         tableName: string;
@@ -350,11 +353,11 @@ export const MetricExploreModalV2: FC<Props> = ({
                     </Group>
                     <Group gap="xs">
                         <Tooltip
-                            label="Explore from here"
+                            label="Continue exploring this metric further"
                             position="bottom"
-                            disabled={!openInExploreUrl}
+                            disabled={!openInExploreUrl || !canExploreFromHere}
                         >
-                            {openInExploreUrl ? (
+                            {openInExploreUrl && canExploreFromHere ? (
                                 <Button
                                     component={Link}
                                     to={openInExploreUrl}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: linear.app/lightdash/issue//metrics-explorer-mini-add-open-in-explorer-and-save-chart-flows

### Description:

Added a permission check for the "Explore from here" button in the Metric Explore Modal. The button now only appears for users who have the `canManageExplore` ability. Also updated the tooltip text to "Continue exploring this metric further" to better describe the action.