### PR TITLE
feat: allow bigquery sso by default

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -43,8 +43,6 @@ export enum FeatureFlags {
      */
     AiCustomViz = 'ai-custom-viz',
 
-    BigquerySSO = 'bigquery-sso',
-
     /**
      * Use workers for async query execution
      */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19641

### Description:
Removes the BigquerySSO feature flag and makes BigQuery SSO authentication the default option. This change:

- Removes the `BigquerySSO` feature flag from the feature flags enum
- Updates the BigQuery form to always show SSO authentication options without checking for the feature flag
- Sets SSO as the default authentication method for BigQuery connections
- Makes the "Require users to provide their own credentials" option always visible in advanced settings