### PR TITLE
chore: update trino-client from 0.2.6 to 0.2.9

### DIFF
--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -22,7 +22,7 @@
         "node-fetch": "^2.7.0",
         "snowflake-sdk": "~2.3.3",
         "ssh2": "^1.14.0",
-        "trino-client": "0.2.6"
+      "trino-client": "0.2.9"
     },
     "devDependencies": {
         "@types/pg": "^8.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1455,8 +1455,8 @@ importers:
         specifier: ^1.14.0
         version: 1.14.0
       trino-client:
-        specifier: 0.2.6
-        version: 0.2.6
+        specifier: 0.2.9
+        version: 0.2.9
     devDependencies:
       '@types/node-fetch':
         specifier: ^2.6.13
@@ -6861,7 +6861,6 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
-    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -14141,8 +14140,8 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
-  trino-client@0.2.6:
-    resolution: {integrity: sha512-MK+seOsnxCKASAV528xSE/15+b3tTuGxkzv9VuLfyoQsQsVoX+otT2Fo56xBwDR0iDzPuUwyGbRCd3xQE2776g==}
+  trino-client@0.2.9:
+    resolution: {integrity: sha512-bINcQxDH5v9DR1zqXtoNqnRJ5leYMyYzRuFZLsoqg4irWYPDh/4wBndC8c2x+QfNIOr6c35BtHKOwotelqSATg==}
 
   triple-beam@1.3.0:
     resolution: {integrity: sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==}
@@ -31485,7 +31484,7 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  trino-client@0.2.6:
+  trino-client@0.2.9:
     dependencies:
       axios: 1.12.2
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Upgraded trino-client from version 0.2.6 to 0.2.9 in the warehouses package to ensure we're using the latest version with bug fixes and improvements.