### PR TITLE
feat: add anyAttributes support for OR logic in user permissions

### DIFF
--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.mocks.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.mocks.ts
@@ -264,3 +264,153 @@ export const EXPLORE_FILTERED_WITH_ACCESS_LEVEL_1_2_3: Explore = {
         ...EXPLORE_WITH_TABLE_AND_DIMENSION_REQUIRED_ATTRIBUTES.tables,
     },
 };
+
+// ============================================================================
+// anyAttributes mocks (OR logic)
+// ============================================================================
+
+// Table with anyAttributes - user needs ANY of these attributes (OR logic)
+export const EXPLORE_WITH_TABLE_ANY_ATTRIBUTES: Explore = {
+    ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES,
+    tables: {
+        orders: {
+            ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables.orders!,
+            anyAttributes: {
+                department: ['sales', 'finance'],
+            },
+        },
+        payments: {
+            ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables.payments!,
+            anyAttributes: {
+                role: 'analyst',
+            },
+        },
+    },
+};
+
+// Dimension with anyAttributes
+export const EXPLORE_WITH_DIMENSION_ANY_ATTRIBUTES: Explore = {
+    ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES,
+    tables: {
+        orders: {
+            ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables.orders!,
+        },
+        payments: {
+            ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables.payments!,
+            dimensions: {
+                ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables.payments!
+                    .dimensions,
+                name: {
+                    ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables.payments!
+                        .dimensions.name!,
+                    anyAttributes: {
+                        department: ['hr', 'finance'],
+                    },
+                },
+            },
+        },
+    },
+};
+
+// Table with BOTH requiredAttributes (AND) and anyAttributes (OR)
+export const EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES: Explore = {
+    ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES,
+    tables: {
+        orders: {
+            ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables.orders!,
+            requiredAttributes: {
+                access_level: '1',
+            },
+            anyAttributes: {
+                department: ['sales', 'marketing'],
+            },
+        },
+        payments: {
+            ...EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES.tables.payments!,
+            requiredAttributes: {
+                access_level: '2',
+            },
+            anyAttributes: {
+                role: ['analyst', 'admin'],
+            },
+        },
+    },
+};
+
+// Combined: table with required and dimension with any
+export const EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES: Explore = {
+    ...EXPLORE_WITH_TABLE_ANY_ATTRIBUTES,
+    tables: {
+        orders: {
+            ...EXPLORE_WITH_TABLE_ANY_ATTRIBUTES.tables.orders!,
+        },
+        payments: {
+            ...EXPLORE_WITH_TABLE_ANY_ATTRIBUTES.tables.payments!,
+            dimensions: {
+                ...EXPLORE_WITH_TABLE_ANY_ATTRIBUTES.tables.payments!
+                    .dimensions,
+                name: {
+                    ...EXPLORE_WITH_TABLE_ANY_ATTRIBUTES.tables.payments!
+                        .dimensions.name!,
+                    anyAttributes: {
+                        department: 'hr',
+                    },
+                },
+            },
+        },
+    },
+};
+
+// Expected filtered result when user has role=analyst (matches payments/base table anyAttributes)
+// but NOT department in sales/finance (so orders is filtered out)
+export const EXPLORE_FILTERED_WITH_ROLE_ANALYST: Explore = {
+    ...EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
+    joinedTables: [],
+    tables: {
+        payments: {
+            ...EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables.payments!,
+            metrics: {
+                total_revenue:
+                    EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables
+                        .payments!.metrics.total_revenue!,
+            },
+            dimensions: {
+                // Note: dim_amount_diff is excluded because it references orders table
+                amount: EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables
+                    .payments!.dimensions.amount!,
+            },
+        },
+    },
+    unfilteredTables: {
+        ...EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables,
+    },
+};
+
+// Expected filtered result when user has both department=sales and role=analyst
+export const EXPLORE_FILTERED_WITH_SALES_AND_ANALYST: Explore = {
+    ...EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
+    tables: {
+        orders: EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables.orders!,
+        payments: {
+            ...EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables.payments!,
+            dimensions: {
+                amount: EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables
+                    .payments!.dimensions.amount!,
+                dim_amount_diff:
+                    EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables
+                        .payments!.dimensions.dim_amount_diff!,
+            },
+        },
+    },
+    unfilteredTables: {
+        ...EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables,
+    },
+};
+
+// Expected filtered result when user has department=hr (matches dimension anyAttributes)
+export const EXPLORE_FILTERED_WITH_SALES_ANALYST_HR: Explore = {
+    ...EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
+    unfilteredTables: {
+        ...EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES.tables,
+    },
+};

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
@@ -2,15 +2,24 @@ import {
     EXPLORE_FILTERED_WITH_ACCESS_LEVEL_1_2,
     EXPLORE_FILTERED_WITH_ACCESS_LEVEL_1_2_3,
     EXPLORE_FILTERED_WITH_ACCESS_LEVEL_2,
+    EXPLORE_FILTERED_WITH_ROLE_ANALYST,
+    EXPLORE_FILTERED_WITH_SALES_ANALYST_HR,
+    EXPLORE_FILTERED_WITH_SALES_AND_ANALYST,
+    EXPLORE_WITH_DIMENSION_ANY_ATTRIBUTES,
     EXPLORE_WITH_DIMENSION_REQUIRED_ATTRIBUTES,
     EXPLORE_WITH_NO_REQUIRED_ATTRIBUTES,
+    EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
     EXPLORE_WITH_TABLE_AND_DIMENSION_REQUIRED_ATTRIBUTES,
+    EXPLORE_WITH_TABLE_ANY_ATTRIBUTES,
+    EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES,
     EXPLORE_WITH_TABLE_REQUIRED_ATTRIBUTES,
 } from './UserAttributeUtil.mocks';
 import {
+    checkUserAttributesAccess,
     doesExploreMatchRequiredAttributes,
     exploreHasFilteredAttribute,
     getFilteredExplore,
+    hasAnyUserAttributes,
     hasUserAttribute,
     hasUserAttributes,
 } from './UserAttributeUtils';
@@ -179,5 +188,316 @@ describe('hasUserAttributes', () => {
         expect(hasUserAttributes({ test: '1' }, { test: ['1'] })).toStrictEqual(
             true,
         );
+    });
+});
+
+describe('hasAnyUserAttributes', () => {
+    test('should be true if anyAttributes object is empty', () => {
+        expect(hasAnyUserAttributes({}, { test: ['1'] })).toStrictEqual(true);
+        expect(hasAnyUserAttributes({}, {})).toStrictEqual(true);
+    });
+    test('should be true if user has ANY matching attribute (OR logic)', () => {
+        // User has 'sales' which matches one of the allowed values
+        expect(
+            hasAnyUserAttributes(
+                { department: ['sales', 'finance'] },
+                { department: ['sales'] },
+            ),
+        ).toStrictEqual(true);
+        // User has 'finance' which matches one of the allowed values
+        expect(
+            hasAnyUserAttributes(
+                { department: ['sales', 'finance'] },
+                { department: ['finance'] },
+            ),
+        ).toStrictEqual(true);
+        // User has both, still passes
+        expect(
+            hasAnyUserAttributes(
+                { department: ['sales', 'finance'] },
+                { department: ['sales', 'finance'] },
+            ),
+        ).toStrictEqual(true);
+    });
+    test('should be true if user matches ANY of multiple attribute conditions', () => {
+        // User has department=sales but not role=admin - should pass OR logic
+        expect(
+            hasAnyUserAttributes(
+                { department: 'sales', role: 'admin' },
+                { department: ['sales'] },
+            ),
+        ).toStrictEqual(true);
+        // User has role=admin but not department=sales - should pass OR logic
+        expect(
+            hasAnyUserAttributes(
+                { department: 'sales', role: 'admin' },
+                { role: ['admin'] },
+            ),
+        ).toStrictEqual(true);
+    });
+    test('should be false if user has NONE of the required attributes', () => {
+        expect(
+            hasAnyUserAttributes(
+                { department: ['sales', 'finance'] },
+                { department: ['hr'] },
+            ),
+        ).toStrictEqual(false);
+        expect(
+            hasAnyUserAttributes({ department: 'sales' }, { role: ['admin'] }),
+        ).toStrictEqual(false);
+        expect(
+            hasAnyUserAttributes(
+                { department: 'sales', role: 'admin' },
+                { department: ['hr'], role: ['analyst'] },
+            ),
+        ).toStrictEqual(false);
+    });
+    test('should work with single string value in anyAttributes', () => {
+        expect(
+            hasAnyUserAttributes({ role: 'admin' }, { role: ['admin'] }),
+        ).toStrictEqual(true);
+        expect(
+            hasAnyUserAttributes({ role: 'admin' }, { role: ['analyst'] }),
+        ).toStrictEqual(false);
+    });
+});
+
+describe('checkUserAttributesAccess', () => {
+    test('should return true when both required and any are undefined', () => {
+        expect(
+            checkUserAttributesAccess(undefined, undefined, {}),
+        ).toStrictEqual(true);
+        expect(
+            checkUserAttributesAccess(undefined, undefined, { test: ['1'] }),
+        ).toStrictEqual(true);
+    });
+    test('should return true when only required is defined and matches', () => {
+        expect(
+            checkUserAttributesAccess({ test: '1' }, undefined, {
+                test: ['1'],
+            }),
+        ).toStrictEqual(true);
+    });
+    test('should return false when only required is defined and does not match', () => {
+        expect(
+            checkUserAttributesAccess({ test: '2' }, undefined, {
+                test: ['1'],
+            }),
+        ).toStrictEqual(false);
+    });
+    test('should return true when only any is defined and matches', () => {
+        expect(
+            checkUserAttributesAccess(
+                undefined,
+                { role: 'admin' },
+                {
+                    role: ['admin'],
+                },
+            ),
+        ).toStrictEqual(true);
+        expect(
+            checkUserAttributesAccess(
+                undefined,
+                { role: ['admin', 'analyst'] },
+                {
+                    role: ['analyst'],
+                },
+            ),
+        ).toStrictEqual(true);
+    });
+    test('should return false when only any is defined and does not match', () => {
+        expect(
+            checkUserAttributesAccess(
+                undefined,
+                { role: 'admin' },
+                {
+                    role: ['analyst'],
+                },
+            ),
+        ).toStrictEqual(false);
+    });
+    test('should return true when both are defined and both match', () => {
+        expect(
+            checkUserAttributesAccess(
+                { access_level: '2' },
+                { department: ['sales', 'finance'] },
+                { access_level: ['2'], department: ['sales'] },
+            ),
+        ).toStrictEqual(true);
+    });
+    test('should return false when required matches but any does not', () => {
+        expect(
+            checkUserAttributesAccess(
+                { access_level: '2' },
+                { department: ['sales', 'finance'] },
+                { access_level: ['2'], department: ['hr'] },
+            ),
+        ).toStrictEqual(false);
+    });
+    test('should return false when any matches but required does not', () => {
+        expect(
+            checkUserAttributesAccess(
+                { access_level: '3' },
+                { department: ['sales', 'finance'] },
+                { access_level: ['2'], department: ['sales'] },
+            ),
+        ).toStrictEqual(false);
+    });
+});
+
+describe('doesExploreMatchRequiredAttributes with anyAttributes', () => {
+    test('should return true when anyAttributes match', () => {
+        expect(
+            doesExploreMatchRequiredAttributes(
+                undefined,
+                EXPLORE_WITH_TABLE_ANY_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_ANY_ATTRIBUTES.baseTable
+                ].anyAttributes,
+                { role: ['analyst'] },
+            ),
+        ).toStrictEqual(true);
+    });
+    test('should return false when anyAttributes do not match', () => {
+        expect(
+            doesExploreMatchRequiredAttributes(
+                undefined,
+                EXPLORE_WITH_TABLE_ANY_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_ANY_ATTRIBUTES.baseTable
+                ].anyAttributes,
+                { role: ['admin'] },
+            ),
+        ).toStrictEqual(false);
+    });
+    test('should return true when both required and any attributes match', () => {
+        expect(
+            doesExploreMatchRequiredAttributes(
+                EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.baseTable
+                ].requiredAttributes,
+                EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.baseTable
+                ].anyAttributes,
+                { access_level: ['2'], role: ['analyst'] },
+            ),
+        ).toStrictEqual(true);
+    });
+    test('should return false when required matches but any does not', () => {
+        expect(
+            doesExploreMatchRequiredAttributes(
+                EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.baseTable
+                ].requiredAttributes,
+                EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.tables[
+                    EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.baseTable
+                ].anyAttributes,
+                { access_level: ['2'], role: ['viewer'] },
+            ),
+        ).toStrictEqual(false);
+    });
+});
+
+describe('exploreHasFilteredAttribute with anyAttributes', () => {
+    test('should detect when table has anyAttributes', () => {
+        expect(
+            exploreHasFilteredAttribute(EXPLORE_WITH_TABLE_ANY_ATTRIBUTES),
+        ).toStrictEqual(true);
+    });
+    test('should detect when dimension has anyAttributes', () => {
+        expect(
+            exploreHasFilteredAttribute(EXPLORE_WITH_DIMENSION_ANY_ATTRIBUTES),
+        ).toStrictEqual(true);
+    });
+    test('should detect when table has both required and any attributes', () => {
+        expect(
+            exploreHasFilteredAttribute(
+                EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES,
+            ),
+        ).toStrictEqual(true);
+    });
+});
+
+describe('getFilteredExplore with anyAttributes', () => {
+    test('should throw error if user does not have permission for base table anyAttributes', () => {
+        // Base table is payments which requires role=analyst
+        // User only has department=hr, so they can't access the base table
+        expect(() =>
+            getFilteredExplore(
+                EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
+                {
+                    department: ['hr'],
+                },
+            ),
+        ).toThrow("You don't have authorization to access this explore");
+    });
+    test('should throw when user has wrong attribute for base table', () => {
+        // Base table is payments which requires role=analyst
+        // User only has department=sales (matches orders but not payments)
+        expect(() =>
+            getFilteredExplore(
+                EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
+                {
+                    department: ['sales'],
+                },
+            ),
+        ).toThrow("You don't have authorization to access this explore");
+    });
+    test('should filter tables when user matches payments but not orders', () => {
+        // User has role=analyst, matches payments (base table) but not orders (needs department in sales/finance)
+        // dim_amount_diff references orders, so it's also filtered out
+        expect(
+            getFilteredExplore(
+                EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
+                {
+                    role: ['analyst'],
+                },
+            ),
+        ).toStrictEqual(EXPLORE_FILTERED_WITH_ROLE_ANALYST);
+    });
+    test('should include both tables when user has both attributes', () => {
+        // User has department=sales and role=analyst
+        expect(
+            getFilteredExplore(
+                EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
+                {
+                    department: ['sales'],
+                    role: ['analyst'],
+                },
+            ),
+        ).toStrictEqual(EXPLORE_FILTERED_WITH_SALES_AND_ANALYST);
+    });
+    test('should filter dimensions based on anyAttributes', () => {
+        // User has department=sales, role=analyst, and department=hr (matches dimension)
+        expect(
+            getFilteredExplore(
+                EXPLORE_WITH_TABLE_AND_DIMENSION_ANY_ATTRIBUTES,
+                {
+                    department: ['sales', 'hr'],
+                    role: ['analyst'],
+                },
+            ),
+        ).toStrictEqual(EXPLORE_FILTERED_WITH_SALES_ANALYST_HR);
+    });
+    test('should work with combined requiredAttributes and anyAttributes', () => {
+        // User needs access_level=2 (required) AND role=analyst or admin (any)
+        expect(
+            getFilteredExplore(EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES, {
+                access_level: ['1', '2'],
+                department: ['sales'],
+                role: ['analyst'],
+            }),
+        ).toStrictEqual({
+            ...EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES,
+            unfilteredTables: {
+                ...EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES.tables,
+            },
+        });
+    });
+    test('should throw when required matches but any does not for base table', () => {
+        expect(() =>
+            getFilteredExplore(EXPLORE_WITH_TABLE_REQUIRED_AND_ANY_ATTRIBUTES, {
+                access_level: ['2'],
+                department: ['hr'], // Does not match payments anyAttributes (needs analyst/admin role)
+            }),
+        ).toThrow("You don't have authorization to access this explore");
     });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->Description:

Earlier we added support for "anyAttributes" (OR logic) in user attribute filtering. This allows configuring tables and dimensions to require users to have ANY of a set of attributes, rather than ALL attributes.

This PR adds test coverage for the functions added in the previous PR.