### PR TITLE
chore: don't setIsScreenshotReady to true before explore is available

### DIFF
--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -83,9 +83,12 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const [isScreenshotReady, setIsScreenshotReady] = useState(false);
         const hasSignaledReady = useRef(false);
 
+        const { data: explore } = useExplore(tableName);
+
         useEffect(() => {
             if (hasSignaledReady.current) return;
             if (!tableName) return;
+            if (!explore) return;
 
             const isSuccessfullyLoaded = !isLoadingQueryResults;
             if (!isSuccessfullyLoaded && !hasQueryError) {
@@ -94,9 +97,7 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
 
             setIsScreenshotReady(true);
             hasSignaledReady.current = true;
-        }, [tableName, isLoadingQueryResults, hasQueryError]);
-
-        const { data: explore } = useExplore(tableName);
+        }, [tableName, isLoadingQueryResults, hasQueryError, explore]);
 
         const { data: { parameterReferences } = {}, isError } = useCompiledSql({
             enabled: !!tableName,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

When sharing the URL of Explorer in Slack, sometimes the image would be cut off like this:

![slack-image-DGg1GLpcKOnC67-uCs2E6.png](https://app.graphite.com/user-attachments/assets/62b5048b-6c20-4fc1-bc88-2ee848429372.png)

### Description:
Fixed a race condition in the Explorer component by moving the `useExplore` hook call before the `useEffect` and adding `explore` as a dependency to the effect. This ensures the screenshot readiness state is only set when both the table name is available and the explore data has been loaded.