### PR TITLE
fix: add onChartConfigChange to compute series in Metric explore modal v2

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -5,6 +5,7 @@ import {
     getFilterDimensionsForMetric,
     getSegmentDimensionsForMetric,
     type CatalogField,
+    type ChartConfig,
     type FilterRule,
     type MetricExplorerDateRange,
     type MetricExplorerQuery,
@@ -192,6 +193,11 @@ export const MetricExploreModalV2: FC<Props> = ({
         comparison: query.comparison,
     });
 
+    // Track the expanded chart config -> used to let the VisualizationProvider re-render with the new chart config, e.g. calculation of series & color assignment
+    const [expandedChartConfig, setExpandedChartConfig] = useState<
+        ChartConfig | undefined
+    >(undefined);
+
     const metricsWithTimeDimensionsQuery = useCatalogMetricsWithTimeDimensions({
         projectUuid,
         options: {
@@ -258,6 +264,10 @@ export const MetricExploreModalV2: FC<Props> = ({
         ['ArrowUp', handleGoToPreviousMetric],
         ['ArrowDown', handleGoToNextMetric],
     ]);
+
+    const handleChartConfigChange = useCallback((newConfig: ChartConfig) => {
+        setExpandedChartConfig(newConfig);
+    }, []);
 
     const handleSegmentDimensionChange = useCallback(
         (value: string | null) => {
@@ -507,7 +517,10 @@ export const MetricExploreModalV2: FC<Props> = ({
                                     >
                                         <VisualizationProvider
                                             resultsData={resultsData}
-                                            chartConfig={chartConfig}
+                                            chartConfig={
+                                                expandedChartConfig ??
+                                                chartConfig
+                                            }
                                             columnOrder={columnOrder}
                                             initialPivotDimensions={
                                                 segmentDimensionId
@@ -517,7 +530,9 @@ export const MetricExploreModalV2: FC<Props> = ({
                                             colorPalette={colorPalette}
                                             isLoading={isLoading}
                                             onSeriesContextMenu={undefined}
-                                            onChartConfigChange={undefined}
+                                            onChartConfigChange={
+                                                handleChartConfigChange
+                                            }
                                             pivotTableMaxColumnLimit={60}
                                         >
                                             <LightdashVisualization />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description:


Added support for chart configuration changes in the MetricExploreModalV2 component. This implementation tracks expanded chart configurations through a new state variable and passes the configuration to the VisualizationProvider, allowing it to re-render with updated settings like series calculations and color assignments. Also implemented a handler function to update the chart configuration when changes occur.

locally (was working previously, but colours weren't computed correctly)
![Screenshot 2026-01-23 at 12.32.57.png](https://app.graphite.com/user-attachments/assets/6bab3e9b-6e06-451b-95a5-e562e2d7d121.png)

on prod (series' colors aren't computed, so they look empty) -> had to follow same pattern as done in `AiVisualizationRenderer`

![Screenshot 2026-01-23 at 12.33.18.png](https://app.graphite.com/user-attachments/assets/b3a77fa5-ee87-4a71-b0c3-b5ab115937d6.png)

