### PR TITLE
fix: make the Map dashboard tile full-width

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -1345,7 +1345,10 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                         </>
                     )
                 }
-                fullWidth={chart.chartConfig.type === ChartType.TABLE}
+                fullWidth={
+                    chart.chartConfig.type === ChartType.TABLE ||
+                    chart.chartConfig.type === ChartType.MAP
+                }
                 {...props}
             >
                 <>
@@ -1671,7 +1674,10 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                         </>
                     ) : undefined
                 }
-                fullWidth={chart.chartConfig.type === ChartType.TABLE}
+                fullWidth={
+                    chart.chartConfig.type === ChartType.TABLE ||
+                    chart.chartConfig.type === ChartType.MAP
+                }
                 {...props}
             >
                 <>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR updates the `DashboardChartTile` component to set the `fullWidth` property to true for both TABLE and MAP chart types. Previously, only TABLE charts were displayed in full width mode.


![image.png](https://app.graphite.com/user-attachments/assets/ace7c0ea-4f30-48a7-a6f4-d87018c87df2.png)

