### PR TITLE
chore: build pop from additionalMetrics

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -154,7 +154,6 @@ export class QueryController extends BaseController {
             timezone: body.query.timezone,
             metricOverrides: body.query.metricOverrides,
             dimensionOverrides: body.query.dimensionOverrides,
-            periodOverPeriod: body.query.periodOverPeriod,
         };
 
         const results = await this.services

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -11,6 +11,8 @@ import {
     detectCircularDependencies,
     Explore,
     ExploreCompiler,
+    getItemId,
+    isPeriodOverPeriodAdditionalMetric,
     isPostCalculationMetricType,
     isSqlTableCalculation,
     isTemplateTableCalculation,
@@ -18,7 +20,6 @@ import {
     MetricQuery,
     MetricType,
     PivotConfiguration,
-    POP_PREVIOUS_PERIOD_SUFFIX,
     TableCalculation,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
@@ -292,15 +293,14 @@ export const compileMetricQuery = ({
 }: CompileMetricQueryArgs): CompiledMetricQuery => {
     const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
 
+    const popMetricIds = (metricQuery.additionalMetrics ?? [])
+        .filter(isPeriodOverPeriodAdditionalMetric)
+        .map(getItemId);
+
     const validFieldIds = [
         ...metricQuery.dimensions,
-        ...metricQuery.metrics.reduce<string[]>((acc2, metric) => {
-            acc2.push(metric);
-            if (metricQuery.periodOverPeriod) {
-                acc2.push(`${metric}${POP_PREVIOUS_PERIOD_SUFFIX}`);
-            }
-            return acc2;
-        }, []),
+        ...metricQuery.metrics,
+        ...popMetricIds,
     ];
 
     const compiledAdditionalMetrics = (metricQuery.additionalMetrics || []).map(

--- a/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnpivotedColumns.ts
@@ -1,39 +1,15 @@
-import {
-    getBaseFieldIdFromPop,
-    ResultColumns,
-    WarehouseResults,
-} from '@lightdash/common';
-
-type GetUnpivotedColumnsOptions = {
-    /**
-     * Set of metric field IDs that have period-over-period comparison enabled.
-     * When provided, columns matching the PoP naming convention will have
-     * popMetadata added to indicate their relationship to the base metric.
-     */
-    popEnabledMetrics?: Set<string>;
-};
+import { ResultColumns, WarehouseResults } from '@lightdash/common';
 
 export function getUnpivotedColumns(
     unpivotedColumns: ResultColumns,
     fields: WarehouseResults['fields'],
-    options?: GetUnpivotedColumnsOptions,
 ): ResultColumns {
-    const { popEnabledMetrics } = options ?? {};
-
     if (!Object.keys(unpivotedColumns).length && fields) {
         return Object.entries(fields).reduce<ResultColumns>(
             (acc, [key, value]) => {
-                const baseFieldId = getBaseFieldIdFromPop(key);
-                const isPopColumn =
-                    baseFieldId !== null &&
-                    popEnabledMetrics?.has(baseFieldId) === true;
-
                 acc[key] = {
                     reference: key,
                     type: value.type,
-                    ...(isPopColumn && baseFieldId
-                        ? { popMetadata: { baseFieldId } }
-                        : {}),
                 };
                 return acc;
             },

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -159,9 +159,4 @@ export type RunAsyncWarehouseQueryArgs = {
     };
     pivotConfiguration?: PivotConfiguration;
     originalColumns?: ResultColumns;
-    /**
-     * Set of metric field IDs that have period-over-period comparison enabled.
-     * Used to add popMetadata to the corresponding ResultColumns.
-     */
-    popEnabledMetrics?: Set<string>;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Refactored period-over-period (PoP) comparison to use metric-level PoP instead of query-level PoP. This change removes the `periodOverPeriod` property from the query and instead relies on additional metrics with PoP configuration.

The implementation now:
- Identifies PoP metrics by their relationship to base metrics
- Generates SQL for PoP metrics only when explicitly selected
- Maintains proper mapping between base metrics and their PoP counterparts
- Validates PoP configuration to ensure consistency within a query
- Ensures the time dimension used for comparison is selected in the query

This approach provides more flexibility for PoP analysis while simplifying the query structure.