### PR TITLE
feat: allow new pop comparison on metric explore modal v2

### DIFF
--- a/packages/common/src/types/periodOverPeriodComparison.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.ts
@@ -1,3 +1,8 @@
+import { v4 as uuidv4 } from 'uuid';
+import { getItemId } from '../utils/item';
+import { timeFrameConfigs } from '../utils/timeFrames';
+import { type Metric } from './field';
+import { type AdditionalMetric } from './metricQuery';
 import { TimeFrames } from './timeFrames';
 
 type PreviousPeriod = {
@@ -53,3 +58,78 @@ export const isSupportedPeriodOverPeriodGranularity = (
 
 export const buildPopAdditionalMetricName = (baseMetricName: string) =>
     `${baseMetricName}__pop`;
+
+export const getPopPeriodLabel = (
+    granularity: TimeFrames,
+    periodOffset: number,
+) => {
+    const label = timeFrameConfigs[granularity]?.getLabel() || granularity;
+    return periodOffset === 1
+        ? `Previous ${String(label).toLowerCase()}`
+        : `${periodOffset} ${String(label).toLowerCase()}s ago`;
+};
+
+export const buildPopAdditionalMetric = ({
+    metric,
+    timeDimensionId,
+    granularity,
+    periodOffset,
+}: {
+    metric: Pick<
+        Metric,
+        | 'table'
+        | 'name'
+        | 'label'
+        | 'description'
+        | 'type'
+        | 'sql'
+        | 'round'
+        | 'compact'
+        | 'format'
+    >;
+    timeDimensionId: string;
+    granularity: TimeFrames;
+    periodOffset: number;
+}): { additionalMetric: AdditionalMetric; metricId: string } => {
+    const baseMetricId = getItemId(metric);
+    const popName = buildPopAdditionalMetricName(metric.name);
+    const popMetricId = getItemId({ table: metric.table, name: popName });
+
+    const additionalMetric: AdditionalMetric = {
+        uuid: uuidv4(),
+        table: metric.table,
+        name: popName,
+        label: `${metric.label} (${getPopPeriodLabel(
+            granularity,
+            periodOffset,
+        )})`,
+        description: metric.description,
+        type: metric.type,
+        sql: metric.sql,
+        hidden: true,
+        round: metric.round,
+        compact: metric.compact,
+        format: metric.format,
+        generationType: 'periodOverPeriod',
+        baseMetricId,
+        timeDimensionId,
+        granularity,
+        periodOffset,
+    };
+
+    return { additionalMetric, metricId: popMetricId };
+};
+
+// Granularity order from finest to coarsest (lower index = finer)
+const GRANULARITY_ORDER: TimeFrames[] = [
+    TimeFrames.DAY,
+    TimeFrames.WEEK,
+    TimeFrames.MONTH,
+    TimeFrames.QUARTER,
+    TimeFrames.YEAR,
+];
+
+export const getGranularityRank = (granularity: TimeFrames): number => {
+    const index = GRANULARITY_ORDER.indexOf(granularity);
+    return index === -1 ? Infinity : index;
+};

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -103,8 +103,6 @@ const ContextMenu: FC<ContextMenuProps> = ({
         if (!item || !isMetric(item)) return false;
         const expectedPopName = buildPopAdditionalMetricName(item.name);
         const expectedPopId = `${item.table}_${expectedPopName}`;
-        console.log('expectedPopId', expectedPopId);
-        console.log('additionalMetrics', additionalMetrics);
         return additionalMetrics?.some((am) => getItemId(am) === expectedPopId);
     }, [item, additionalMetrics]);
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -5,7 +5,6 @@ import {
     getFilterDimensionsForMetric,
     getSegmentDimensionsForMetric,
     type CatalogField,
-    type ChartConfig,
     type FilterRule,
     type MetricExplorerDateRange,
     type MetricExplorerQuery,
@@ -180,6 +179,7 @@ export const MetricExploreModalV2: FC<Props> = ({
         chartConfig,
         resultsData,
         columnOrder,
+        computedSeries,
         isLoading,
         hasData,
     } = useMetricVisualization({
@@ -192,11 +192,6 @@ export const MetricExploreModalV2: FC<Props> = ({
         dateRange,
         comparison: query.comparison,
     });
-
-    // Track the expanded chart config -> used to let the VisualizationProvider re-render with the new chart config, e.g. calculation of series & color assignment
-    const [expandedChartConfig, setExpandedChartConfig] = useState<
-        ChartConfig | undefined
-    >(undefined);
 
     const metricsWithTimeDimensionsQuery = useCatalogMetricsWithTimeDimensions({
         projectUuid,
@@ -264,10 +259,6 @@ export const MetricExploreModalV2: FC<Props> = ({
         ['ArrowUp', handleGoToPreviousMetric],
         ['ArrowDown', handleGoToNextMetric],
     ]);
-
-    const handleChartConfigChange = useCallback((newConfig: ChartConfig) => {
-        setExpandedChartConfig(newConfig);
-    }, []);
 
     const handleSegmentDimensionChange = useCallback(
         (value: string | null) => {
@@ -517,10 +508,7 @@ export const MetricExploreModalV2: FC<Props> = ({
                                     >
                                         <VisualizationProvider
                                             resultsData={resultsData}
-                                            chartConfig={
-                                                expandedChartConfig ??
-                                                chartConfig
-                                            }
+                                            chartConfig={chartConfig}
                                             columnOrder={columnOrder}
                                             initialPivotDimensions={
                                                 segmentDimensionId
@@ -530,10 +518,8 @@ export const MetricExploreModalV2: FC<Props> = ({
                                             colorPalette={colorPalette}
                                             isLoading={isLoading}
                                             onSeriesContextMenu={undefined}
-                                            onChartConfigChange={
-                                                handleChartConfigChange
-                                            }
                                             pivotTableMaxColumnLimit={60}
+                                            computedSeries={computedSeries}
                                         >
                                             <LightdashVisualization />
                                         </VisualizationProvider>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [PROD-1164: Refactor PoP backend so that previous period fields are metrics](https://linear.app/lightdash/issue/PROD-1164/refactor-pop-backend-so-that-previous-period-fields-are-metrics)

### Description:
Refactored Period-over-Period (PoP) comparison functionality to improve maintainability and fix visualization issues:

1. Extracted PoP utility functions into a dedicated file `popAdditionalMetricUtils.ts` for better code organization
2. Fixed an issue where PoP comparison lines weren't showing in the metric explorer visualization
3. Improved chart config handling to prevent PoP series from being dropped when chart config changes
4. Added synchronization between metric queries and chart configuration to ensure consistent visualization
5. Replaced the previous implementation with a more robust approach using additional metrics

This change ensures that Period-over-Period comparisons are properly displayed in charts and maintains consistency between the metric query and visualization.

![image.png](https://app.graphite.com/user-attachments/assets/97e6f71f-0eb0-49ae-96d5-be52ff36d309.png)

