### PR TITLE
feat: add pagination to the schedulers modal

### DIFF
--- a/packages/backend/src/controllers/dashboardController.ts
+++ b/packages/backend/src/controllers/dashboardController.ts
@@ -2,6 +2,7 @@ import {
     ApiErrorPayload,
     ApiPromoteDashboardResponse,
     ApiPromotionChangesResponse,
+    KnexPaginateArgs,
     type ApiCreateDashboardSchedulerResponse,
     type ApiDashboardSchedulersResponse,
 } from '@lightdash/common';
@@ -11,6 +12,7 @@ import {
     OperationId,
     Path,
     Post,
+    Query,
     Request,
     Response,
     Route,
@@ -77,6 +79,14 @@ export class DashboardController extends BaseController {
         };
     }
 
+    /**
+     * Get all schedulers for a dashboard
+     * @summary List dashboard schedulers
+     * @param dashboardUuid The uuid of the dashboard
+     * @param req express request
+     * @param pageSize number of items per page
+     * @param page page number
+     */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/schedulers')
@@ -84,13 +94,24 @@ export class DashboardController extends BaseController {
     async getDashboardSchedulers(
         @Path() dashboardUuid: string,
         @Request() req: express.Request,
+        @Query() pageSize?: number,
+        @Query() page?: number,
     ): Promise<ApiDashboardSchedulersResponse> {
         this.setStatus(200);
+
+        let paginateArgs: KnexPaginateArgs | undefined;
+        if (pageSize && page) {
+            paginateArgs = {
+                page,
+                pageSize,
+            };
+        }
+
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .getSchedulers(req.user!, dashboardUuid),
+                .getSchedulers(req.user!, dashboardUuid, paginateArgs),
         };
     }
 

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -8,6 +8,7 @@ import {
     ApiPromotionChangesResponse,
     ApiSuccessEmpty,
     DateZoom,
+    KnexPaginateArgs,
     QueryExecutionContext,
     SortField,
     type ApiCreateSavedChartSchedulerResponse,
@@ -22,6 +23,7 @@ import {
     OperationId,
     Path,
     Post,
+    Query,
     Request,
     Response,
     Route,
@@ -394,6 +396,14 @@ export class SavedChartController extends BaseController {
         };
     }
 
+    /**
+     * Get all schedulers for a saved chart
+     * @summary List chart schedulers
+     * @param chartUuid The uuid of the chart
+     * @param req express request
+     * @param pageSize number of items per page
+     * @param page page number
+     */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/schedulers')
@@ -401,13 +411,24 @@ export class SavedChartController extends BaseController {
     async getSavedChartSchedulers(
         @Path() chartUuid: string,
         @Request() req: express.Request,
+        @Query() pageSize?: number,
+        @Query() page?: number,
     ): Promise<ApiSavedChartSchedulersResponse> {
         this.setStatus(200);
+
+        let paginateArgs: KnexPaginateArgs | undefined;
+        if (pageSize && page) {
+            paginateArgs = {
+                page,
+                pageSize,
+            };
+        }
+
         return {
             status: 'ok',
             results: await this.services
                 .getSavedChartService()
-                .getSchedulers(req.user!, chartUuid),
+                .getSchedulers(req.user!, chartUuid, paginateArgs),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15886,8 +15886,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SchedulerAndTargets' },
+                    ref: 'KnexPaginatedData_SchedulerAndTargets-Array_',
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
@@ -17694,7 +17693,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17704,7 +17703,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17714,7 +17713,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17727,7 +17726,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -20975,8 +20974,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 results: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SchedulerAndTargets' },
+                    ref: 'KnexPaginatedData_SchedulerAndTargets-Array_',
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
@@ -36883,6 +36881,8 @@ export function RegisterRoutes(app: Router) {
             dataType: 'string',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+        page: { in: 'query', name: 'page', dataType: 'double' },
     };
     app.get(
         '/api/v1/saved/:chartUuid/schedulers',
@@ -43939,6 +43939,8 @@ export function RegisterRoutes(app: Router) {
             dataType: 'string',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+        page: { in: 'query', name: 'page', dataType: 'double' },
     };
     app.get(
         '/api/v1/dashboards/:dashboardUuid/schedulers',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16551,10 +16551,7 @@
             "ApiSavedChartSchedulersResponse": {
                 "properties": {
                     "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/SchedulerAndTargets"
-                        },
-                        "type": "array"
+                        "$ref": "#/components/schemas/KnexPaginatedData_SchedulerAndTargets-Array_"
                     },
                     "status": {
                         "type": "string",
@@ -18476,22 +18473,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -21724,10 +21721,7 @@
             "ApiDashboardSchedulersResponse": {
                 "properties": {
                     "results": {
-                        "items": {
-                            "$ref": "#/components/schemas/SchedulerAndTargets"
-                        },
-                        "type": "array"
+                        "$ref": "#/components/schemas/KnexPaginatedData_SchedulerAndTargets-Array_"
                     },
                     "status": {
                         "type": "string",
@@ -31495,15 +31489,38 @@
                         }
                     }
                 },
+                "description": "Get all schedulers for a saved chart",
+                "summary": "List chart schedulers",
                 "tags": ["Charts"],
                 "security": [],
                 "parameters": [
                     {
+                        "description": "The uuid of the chart",
                         "in": "path",
                         "name": "chartUuid",
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "description": "number of items per page",
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "description": "page number",
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
                         }
                     }
                 ]
@@ -36846,15 +36863,38 @@
                         }
                     }
                 },
+                "description": "Get all schedulers for a dashboard",
+                "summary": "List dashboard schedulers",
                 "tags": ["Dashboards"],
                 "security": [],
                 "parameters": [
                     {
+                        "description": "The uuid of the dashboard",
                         "in": "path",
                         "name": "dashboardUuid",
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "description": "number of items per page",
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "description": "page number",
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
                         }
                     }
                 ]

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -507,8 +507,9 @@ export class SchedulerModel {
 
     async getChartSchedulers(
         savedChartUuid: string,
-    ): Promise<SchedulerAndTargets[]> {
-        const schedulers = SchedulerModel.getBaseSchedulerQuery(this.database)
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
+        const query = SchedulerModel.getBaseSchedulerQuery(this.database)
             .where(`${SchedulerTableName}.saved_chart_uuid`, savedChartUuid)
             .orderBy([
                 {
@@ -520,13 +521,23 @@ export class SchedulerModel {
                     order: 'asc',
                 },
             ]);
-        return this.getSchedulersWithTargets(await schedulers);
+
+        const { pagination, data } = await KnexPaginate.paginate(
+            query,
+            paginateArgs,
+        );
+
+        return {
+            pagination,
+            data: await this.getSchedulersWithTargets(data),
+        };
     }
 
     async getDashboardSchedulers(
         dashboardUuid: string,
-    ): Promise<SchedulerAndTargets[]> {
-        const schedulers = SchedulerModel.getBaseSchedulerQuery(this.database)
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
+        const query = SchedulerModel.getBaseSchedulerQuery(this.database)
             .where(`${SchedulerTableName}.dashboard_uuid`, dashboardUuid)
             .orderBy([
                 {
@@ -538,7 +549,16 @@ export class SchedulerModel {
                     order: 'asc',
                 },
             ]);
-        return this.getSchedulersWithTargets(await schedulers);
+
+        const { pagination, data } = await KnexPaginate.paginate(
+            query,
+            paginateArgs,
+        );
+
+        return {
+            pagination,
+            data: await this.getSchedulersWithTargets(data),
+        };
     }
 
     async getScheduler(schedulerUuid: string): Promise<Scheduler> {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -13,6 +13,8 @@ import {
     DashboardVersionedFields,
     ExploreType,
     ForbiddenError,
+    KnexPaginateArgs,
+    KnexPaginatedData,
     ParameterError,
     PossibleAbilities,
     SchedulerAndTargets,
@@ -1064,9 +1066,13 @@ export class DashboardService
     async getSchedulers(
         user: SessionUser,
         dashboardUuid: string,
-    ): Promise<SchedulerAndTargets[]> {
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
         await this.checkCreateScheduledDeliveryAccess(user, dashboardUuid);
-        return this.schedulerModel.getDashboardSchedulers(dashboardUuid);
+        return this.schedulerModel.getDashboardSchedulers(
+            dashboardUuid,
+            paginateArgs,
+        );
     }
 
     async createScheduler(

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -655,7 +655,12 @@ export class RenameService extends BaseService {
             const chartSchedulerPromises = chartSummaries.map((chart) =>
                 this.schedulerModel.getChartSchedulers(chart.uuid),
             );
-            const chartSchedulers = await Promise.all(chartSchedulerPromises);
+            const chartSchedulersResults = await Promise.all(
+                chartSchedulerPromises,
+            );
+            const chartSchedulers = chartSchedulersResults.map(
+                (result) => result.data,
+            );
             const alerts = chartSchedulers
                 .flat()
                 .filter((scheduler) => scheduler.thresholds !== undefined);
@@ -680,8 +685,11 @@ export class RenameService extends BaseService {
                 (dashboard) =>
                     this.schedulerModel.getDashboardSchedulers(dashboard.uuid),
             );
-            const dashboardSchedulers = await Promise.all(
+            const dashboardSchedulersResults = await Promise.all(
                 dashboardSchedulerPromises,
+            );
+            const dashboardSchedulers = dashboardSchedulersResults.map(
+                (result) => result.data,
             );
             const dashboardSchedulerChanges = dashboardSchedulers
                 .flat()

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -14,6 +14,8 @@ import {
     ExploreType,
     ForbiddenError,
     GoogleSheetsTransientError,
+    KnexPaginateArgs,
+    KnexPaginatedData,
     MissingConfigError,
     NotFoundError,
     ParameterError,
@@ -1084,9 +1086,10 @@ export class SavedChartService
     async getSchedulers(
         user: SessionUser,
         chartUuid: string,
-    ): Promise<SchedulerAndTargets[]> {
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
         await this.checkCreateScheduledDeliveryAccess(user, chartUuid);
-        return this.schedulerModel.getChartSchedulers(chartUuid);
+        return this.schedulerModel.getChartSchedulers(chartUuid, paginateArgs);
     }
 
     async createScheduler(

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,5 +1,6 @@
 import { type FilterableDimension } from './field';
 import { type DashboardFilters } from './filter';
+import { type KnexPaginatedData } from './knex-paginate';
 import { type DashboardParameters } from './parameters';
 import {
     type ChartKind,
@@ -348,7 +349,7 @@ export type ApiCreateDashboardWithChartsResponse = {
 
 export type ApiDashboardSchedulersResponse = {
     status: 'ok';
-    results: SchedulerAndTargets[];
+    results: KnexPaginatedData<SchedulerAndTargets[]>;
 };
 
 export type ApiCreateDashboardSchedulerResponse = {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -4,6 +4,7 @@ import { type DateZoom } from './api/paginatedQuery';
 import { type ConditionalFormattingConfig } from './conditionalFormatting';
 import { type ChartSourceType } from './content';
 import { type CompactOrAlias, type FieldId } from './field';
+import { type KnexPaginatedData } from './knex-paginate';
 import { type MetricQuery, type MetricQueryRequest } from './metricQuery';
 import { type ParametersValuesMap } from './parameters';
 import type { SchedulerAndTargets } from './scheduler';
@@ -958,7 +959,7 @@ export type SkippedReplaceCustomFields = {
 
 export type ApiSavedChartSchedulersResponse = {
     status: 'ok';
-    results: SchedulerAndTargets[];
+    results: KnexPaginatedData<SchedulerAndTargets[]>;
 };
 
 export type ApiCreateSavedChartSchedulerResponse = {

--- a/packages/frontend/src/features/dashboardTabs/DeleteTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabs/DeleteTabModal.tsx
@@ -57,7 +57,7 @@ export const TabDeleteModal: FC<DeleteProps> = ({
     const affectedSchedulers = useMemo(() => {
         if (!schedulers) return [];
 
-        return schedulers.filter((scheduler) => {
+        return schedulers.data.filter((scheduler) => {
             if (isDashboardScheduler(scheduler) && scheduler.selectedTabs) {
                 return scheduler.selectedTabs.includes(tab.uuid);
             }

--- a/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersList.tsx
@@ -30,7 +30,9 @@ const SchedulersList: FC<Props> = ({
     const { data: schedulers, isInitialLoading, error } = schedulersQuery;
     const [schedulerUuid, setSchedulerUuid] = useState<string>();
 
-    const { deliverySchedulers, alertSchedulers } = (schedulers ?? []).reduce<{
+    const { deliverySchedulers, alertSchedulers } = (
+        schedulers?.data ?? []
+    ).reduce<{
         deliverySchedulers: SchedulerAndTargets[];
         alertSchedulers: SchedulerAndTargets[];
     }>(

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -88,7 +88,7 @@ type Props = { chartUuid: string } & Pick<MantineModalProps, 'onClose'>;
 export const SyncModalView: FC<Props> = ({ chartUuid, onClose }) => {
     const { data } = useChartSchedulers(chartUuid);
     const { setAction, setCurrentSchedulerUuid } = useSyncModal();
-    const googleSheetsSyncs = data?.filter(
+    const googleSheetsSyncs = data?.data.filter(
         ({ format }) => format === SchedulerFormat.GSHEETS,
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/PROD-2662/i-want-to-search-the-list-of-scheduled-deliveries-for-charts-and

### Description:
Added pagination support to the dashboard and chart scheduler APIs. This change allows clients to request a specific page and page size when fetching schedulers, improving performance for dashboards or charts with many schedulers.

The implementation:
- Added optional `pageSize` and `page` query parameters to the scheduler endpoints
- Updated the scheduler model to support pagination in the database queries
- Modified the API response types to return paginated data
- Updated frontend components to handle the new paginated response format

This change maintains backward compatibility with existing clients while providing better performance for applications with large numbers of schedulers.