### PR TITLE
fix: move rudderstack props from base to custom props

### DIFF
--- a/packages/backend/src/@types/rudder-sdk-node.d.ts
+++ b/packages/backend/src/@types/rudder-sdk-node.d.ts
@@ -1,3 +1,5 @@
+// NOTE: RudderStack drops any non-standard properties declared at the top level of an event.
+// https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/
 declare module '@rudderstack/rudder-sdk-node' {
     import { AnyType } from '@lightdash/common';
 
@@ -22,8 +24,6 @@ declare module '@rudderstack/rudder-sdk-node' {
     }
     export interface Track {
         userId?: string;
-        organizationId?: string;
-        projectId?: string;
         anonymousId?: string;
         event: string;
         properties?: Record<string, AnyType>;

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -988,6 +988,8 @@ export type SchedulerJobEvent = BaseTrack & {
     anonymousId: string;
     properties: {
         jobId: string;
+        organizationId: string;
+        projectId: string;
         schedulerId: string | undefined;
         groupId: string | undefined;
         sendNow?: boolean;
@@ -1005,6 +1007,8 @@ export type SchedulerNotificationJobEvent = BaseTrack & {
     anonymousId: string;
     properties: {
         jobId: string;
+        organizationId: string;
+        projectId: string;
         schedulerId?: string;
         schedulerTargetId?: string;
         groupId: string | undefined;

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -302,11 +302,11 @@ export class SchedulerClient {
             this.analytics.track({
                 event: 'scheduler_job.deleted',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: context.organizationUuid,
-                projectId: context.projectUuid,
                 userId: context.userUuid,
                 properties: {
                     jobId: id,
+                    organizationId: context.organizationUuid,
+                    projectId: context.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: id,
                 },
@@ -367,11 +367,11 @@ export class SchedulerClient {
         this.analytics.track({
             event: 'scheduler_job.created',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: scheduler.organizationUuid,
-            projectId: scheduler.projectUuid,
             userId: scheduler.userUuid,
             properties: {
                 jobId: id,
+                organizationId: scheduler.organizationUuid,
+                projectId: scheduler.projectUuid,
                 schedulerId: schedulerUuid,
                 groupId: id,
             },
@@ -406,11 +406,11 @@ export class SchedulerClient {
         this.analytics.track({
             event: 'scheduler_notification_job.created',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: traceProperties.organizationUuid,
-            projectId: traceProperties.projectUuid,
             userId: traceProperties.userUuid,
             properties: {
                 jobId: id,
+                organizationId: traceProperties.organizationUuid,
+                projectId: traceProperties.projectUuid,
                 schedulerId: scheduler.schedulerUuid,
                 schedulerTargetId: undefined,
                 groupId: jobGroup,
@@ -516,11 +516,11 @@ export class SchedulerClient {
         this.analytics.track({
             event: 'scheduler_notification_job.created',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: traceProperties.organizationUuid,
-            projectId: traceProperties.projectUuid,
             userId: traceProperties.userUuid,
             properties: {
                 jobId: id,
+                organizationId: traceProperties.organizationUuid,
+                projectId: traceProperties.projectUuid,
                 schedulerId: schedulerUuid,
                 schedulerTargetId: targetUuid,
                 groupId: jobGroup,
@@ -565,11 +565,11 @@ export class SchedulerClient {
         this.analytics.track({
             event: 'scheduler_notification_job.created',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: traceProperties.organizationUuid,
-            projectId: traceProperties.projectUuid,
             userId: traceProperties.userUuid,
             properties: {
                 jobId: id,
+                organizationId: traceProperties.organizationUuid,
+                projectId: traceProperties.projectUuid,
                 schedulerId: scheduler.schedulerUuid,
                 groupId: jobGroup,
                 type: 'slack',
@@ -617,11 +617,11 @@ export class SchedulerClient {
         this.analytics.track({
             event: 'scheduler_notification_job.created',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: traceProperties.organizationUuid,
-            projectId: traceProperties.projectUuid,
             userId: traceProperties.userUuid,
             properties: {
                 jobId: id,
+                organizationId: traceProperties.organizationUuid,
+                projectId: traceProperties.projectUuid,
                 schedulerId: scheduler.schedulerUuid,
                 groupId: jobGroup,
                 type: 'email',
@@ -669,11 +669,11 @@ export class SchedulerClient {
         this.analytics.track({
             event: 'scheduler_notification_job.created',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: traceProperties.organizationUuid,
-            projectId: traceProperties.projectUuid,
             userId: traceProperties.userUuid,
             properties: {
                 jobId: id,
+                organizationId: traceProperties.organizationUuid,
+                projectId: traceProperties.projectUuid,
                 schedulerId: scheduler.schedulerUuid,
                 groupId: jobGroup,
                 type: 'msteams',

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -852,11 +852,11 @@ export default class SchedulerTask {
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: notification.organizationUuid,
-            projectId: notification.projectUuid,
             userId: notification.userUuid,
             properties: {
                 jobId,
+                organizationId: notification.organizationUuid,
+                projectId: notification.projectUuid,
                 schedulerId: schedulerUuid,
                 schedulerTargetId: schedulerSlackTargetUuid,
                 groupId: notification.jobGroup,
@@ -1079,11 +1079,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     schedulerTargetId: schedulerSlackTargetUuid,
                     groupId: notification.jobGroup,
@@ -1117,12 +1117,12 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     error: `${e}`,
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     schedulerTargetId: schedulerSlackTargetUuid,
                     groupId: notification.jobGroup,
@@ -1182,11 +1182,11 @@ export default class SchedulerTask {
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: notification.organizationUuid,
-            projectId: notification.projectUuid,
             userId: notification.userUuid,
             properties: {
                 jobId,
+                organizationId: notification.organizationUuid,
+                projectId: notification.projectUuid,
                 schedulerId: schedulerUuid,
                 schedulerTargetId: schedulerMsTeamsTargetUuid,
                 groupId: notification.jobGroup,
@@ -1321,11 +1321,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     schedulerTargetId: schedulerMsTeamsTargetUuid,
                     groupId: notification.jobGroup,
@@ -1359,12 +1359,12 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     error: `${e}`,
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     schedulerTargetId: schedulerMsTeamsTargetUuid,
                     groupId: notification.jobGroup,
@@ -2028,11 +2028,11 @@ export default class SchedulerTask {
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: notification.organizationUuid,
-            projectId: notification.projectUuid,
             userId: notification.userUuid,
             properties: {
                 jobId,
+                organizationId: notification.organizationUuid,
+                projectId: notification.projectUuid,
                 schedulerId: schedulerUuid,
                 schedulerTargetId: schedulerEmailTargetUuid,
                 groupId: notification.jobGroup,
@@ -2217,11 +2217,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     schedulerTargetId: schedulerEmailTargetUuid,
                     groupId: notification.jobGroup,
@@ -2255,12 +2255,12 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     error: `${e}`,
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     schedulerTargetId: schedulerEmailTargetUuid,
                     groupId: notification.jobGroup,
@@ -2369,11 +2369,11 @@ export default class SchedulerTask {
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: notification.organizationUuid,
-            projectId: notification.projectUuid,
             userId: notification.userUuid,
             properties: {
                 jobId,
+                organizationId: notification.organizationUuid,
+                projectId: notification.projectUuid,
                 schedulerId: schedulerUuid,
                 schedulerTargetId: undefined,
                 groupId: notification.jobGroup,
@@ -2698,11 +2698,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     schedulerTargetId: undefined,
                     groupId: notification.jobGroup,
@@ -2731,12 +2731,12 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     error: `${e}`,
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     schedulerTargetId: undefined,
                     groupId: notification.jobGroup,
@@ -2981,11 +2981,11 @@ export default class SchedulerTask {
         this.analytics.track({
             event: 'scheduler_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: schedulerPayload.organizationUuid,
-            projectId: schedulerPayload.projectUuid,
             userId: schedulerPayload.userUuid,
             properties: {
                 jobId,
+                organizationId: schedulerPayload.organizationUuid,
+                projectId: schedulerPayload.projectUuid,
                 schedulerId: schedulerUuid,
                 groupId: jobId,
                 sendNow: schedulerUuid === undefined,
@@ -3117,11 +3117,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: schedulerPayload.organizationUuid,
-                projectId: schedulerPayload.projectUuid,
                 userId: schedulerPayload.userUuid,
                 properties: {
                     jobId,
+                    organizationId: schedulerPayload.organizationUuid,
+                    projectId: schedulerPayload.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: jobId,
                     isThresholdAlert: scheduler.thresholds !== undefined,
@@ -3134,11 +3134,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: schedulerPayload.organizationUuid,
-                projectId: schedulerPayload.projectUuid,
                 userId: schedulerPayload.userUuid,
                 properties: {
                     jobId,
+                    organizationId: schedulerPayload.organizationUuid,
+                    projectId: schedulerPayload.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: jobId,
                     error: `${e}`,
@@ -3477,11 +3477,11 @@ export default class SchedulerTask {
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: notification.organizationUuid,
-            projectId: notification.projectUuid,
             userId: notification.userUuid,
             properties: {
                 jobId,
+                organizationId: notification.organizationUuid,
+                projectId: notification.projectUuid,
                 schedulerId: schedulerUuid,
                 groupId: notification.jobGroup,
                 type: 'slack',
@@ -3556,11 +3556,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'slack',
@@ -3591,11 +3591,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'slack',
@@ -3633,11 +3633,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'slack',
@@ -3687,11 +3687,11 @@ export default class SchedulerTask {
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: notification.organizationUuid,
-            projectId: notification.projectUuid,
             userId: notification.userUuid,
             properties: {
                 jobId,
+                organizationId: notification.organizationUuid,
+                projectId: notification.projectUuid,
                 schedulerId: schedulerUuid,
                 groupId: notification.jobGroup,
                 type: 'email',
@@ -3766,11 +3766,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'email',
@@ -3801,11 +3801,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'email',
@@ -3848,11 +3848,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'email',
@@ -3902,11 +3902,11 @@ export default class SchedulerTask {
         this.analytics.track({
             event: 'scheduler_notification_job.started',
             anonymousId: LightdashAnalytics.anonymousId,
-            organizationId: notification.organizationUuid,
-            projectId: notification.projectUuid,
             userId: notification.userUuid,
             properties: {
                 jobId,
+                organizationId: notification.organizationUuid,
+                projectId: notification.projectUuid,
                 schedulerId: schedulerUuid,
                 groupId: notification.jobGroup,
                 type: 'msteams',
@@ -3982,11 +3982,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'msteams',
@@ -4017,11 +4017,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.failed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'msteams',
@@ -4059,11 +4059,11 @@ export default class SchedulerTask {
             this.analytics.track({
                 event: 'scheduler_notification_job.completed',
                 anonymousId: LightdashAnalytics.anonymousId,
-                organizationId: notification.organizationUuid,
-                projectId: notification.projectUuid,
                 userId: notification.userUuid,
                 properties: {
                     jobId,
+                    organizationId: notification.organizationUuid,
+                    projectId: notification.projectUuid,
                     schedulerId: schedulerUuid,
                     groupId: notification.jobGroup,
                     type: 'msteams',


### PR DESCRIPTION
### Description:
I was under the wrong assumption that we could extend the top level event properties.
Fixing this mistake by adding the recently added props to the `properties` field, where they belong.