### PR TITLE
feat: add model.meta.owner key support

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -472,7 +472,7 @@ export class ExploreCompiler {
             ...getSpotlightConfigurationForResource({
                 visibility: spotlightVisibility,
                 categories: spotlightCategories,
-                owner: meta.spotlight?.owner,
+                owner: meta.spotlight?.owner ?? meta.owner,
             }),
             ...(meta.parameters && Object.keys(meta.parameters).length > 0
                 ? { parameters: meta.parameters }

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -723,7 +723,7 @@ export const convertTable = (
                                     spotlightConfig.default_visibility,
                             },
                             modelCategories: meta.spotlight?.categories,
-                            modelOwner: meta.spotlight?.owner,
+                            modelOwner: meta.spotlight?.owner ?? meta.owner,
                             defaultShowUnderlyingValues:
                                 meta.default_show_underlying_values,
                         }),
@@ -758,7 +758,7 @@ export const convertTable = (
                         spotlightConfig.default_visibility,
                 },
                 modelCategories: meta.spotlight?.categories,
-                modelOwner: meta.spotlight?.owner,
+                modelOwner: meta.spotlight?.owner ?? meta.owner,
                 defaultShowUnderlyingValues:
                     meta.default_show_underlying_values,
             }),

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -446,6 +446,10 @@
                                     }
                                 ]
                             },
+                            "owner": {
+                                "type": "string",
+                                "description": "Email of the model owner (inherited by all metrics). spotlight.owner takes precedence."
+                            },
                             "sql_where": {
                                 "type": "string"
                             },

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -147,6 +147,7 @@ export type DbtModelLightdashConfig = ExploreConfig &
         ai_hint?: string | string[];
         parameters?: LightdashProjectConfig['parameters'];
         primary_key?: string | string[];
+        owner?: string; // model owner email
     };
 
 export type DbtModelGroup = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2750: Support for `owner` field in dbt model meta config](https://linear.app/lightdash/issue/PROD-2750/support-for-owner-field-in-dbt-model-meta-config)

### Description:

This PR adds support for model owners in Lightdash. It introduces a new `owner` field in the model configuration schema that can be used to specify the email of the model owner. This owner is inherited by all metrics in the model.
