### PR TITLE
feat: support filters in AI agent custom metrics

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/proposeChange.ts
+++ b/packages/backend/src/ee/services/ai/tools/proposeChange.ts
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     ChangeBase,
     convertAdditionalMetric,
+    customMetricBaseSchemaTransformed,
     Explore,
     getItemId,
     ToolProposeChangeArgs,
@@ -58,9 +59,12 @@ export const translateToolProposeChangeArgs = async (
             };
         case 'create':
             const exploreCompiler = await getExploreCompiler();
+            const transformedMetric = customMetricBaseSchemaTransformed.parse(
+                value.value.metric,
+            );
 
             const additionalMetric = populateCustomMetricSQL(
-                value.value.metric,
+                transformedMetric,
                 explore,
             );
 
@@ -72,7 +76,7 @@ export const translateToolProposeChangeArgs = async (
 
             const metric = convertAdditionalMetric({
                 additionalMetric,
-                table: explore.tables[value.value.metric.table],
+                table: explore.tables[transformedMetric.table],
             });
 
             const compiledMetric = exploreCompiler.compileMetric(

--- a/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
+++ b/packages/backend/src/ee/services/ai/utils/populateCustomMetricsSQL.ts
@@ -1,6 +1,6 @@
 import {
     AdditionalMetric,
-    CustomMetricBase,
+    CustomMetricBaseTransformed,
     getFields,
     getItemId,
     type Explore,
@@ -12,7 +12,7 @@ import {
  * but we need to populate it from the explore when executing queries
  */
 export function populateCustomMetricSQL(
-    metric: CustomMetricBase | Omit<AdditionalMetric, 'sql'>,
+    metric: CustomMetricBaseTransformed | Omit<AdditionalMetric, 'sql'>,
     explore: Explore,
 ): AdditionalMetric | null {
     const exploreFields = getFields(explore);
@@ -45,7 +45,7 @@ export function populateCustomMetricSQL(
  */
 export function populateCustomMetricsSQL(
     customMetrics:
-        | (CustomMetricBase | Omit<AdditionalMetric, 'sql'>)[]
+        | (CustomMetricBaseTransformed | Omit<AdditionalMetric, 'sql'>)[]
         | null
         | undefined,
     explore: Explore,

--- a/packages/backend/src/ee/services/ai/utils/validateSelectedFieldsExistence.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateSelectedFieldsExistence.test.ts
@@ -1,7 +1,7 @@
 import {
     MetricType,
     type AdditionalMetric,
-    type CustomMetricBase,
+    type CustomMetricBaseTransformed,
     type TableCalcsSchema,
     type TableCalculation,
 } from '@lightdash/common';
@@ -48,7 +48,7 @@ describe('validateSelectedFieldsExistence', () => {
                 'running_total_calc',
             ];
 
-            const customMetrics: CustomMetricBase[] = [
+            const customMetrics: CustomMetricBaseTransformed[] = [
                 {
                     name: 'avg_metric',
                     label: 'Average Metric',
@@ -81,7 +81,7 @@ describe('validateSelectedFieldsExistence', () => {
         it('should not throw when fields exist only in custom metrics', () => {
             const customMetricSelectedFieldIds = ['users_custom_metric'];
 
-            const customMetrics: CustomMetricBase[] = [
+            const customMetrics: CustomMetricBaseTransformed[] = [
                 {
                     name: 'custom_metric',
                     label: 'Custom Metric',

--- a/packages/backend/src/ee/services/ai/utils/validateTableCalculations.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableCalculations.test.ts
@@ -1,7 +1,7 @@
 import {
     MetricType,
     WindowFunctionType,
-    type CustomMetricBase,
+    type CustomMetricBaseTransformed,
     type TableCalcsSchema,
 } from '@lightdash/common';
 import { mockOrdersExplore } from './validationExplore.mock';
@@ -85,7 +85,7 @@ describe('validateTableCalculations', () => {
                 },
             ];
 
-            const customMetrics: CustomMetricBase[] = [
+            const customMetrics: CustomMetricBaseTransformed[] = [
                 {
                     name: 'avg_revenue',
                     label: 'Average Revenue',

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -6,7 +6,7 @@ import {
     CompiledField,
     convertAdditionalMetric,
     convertAiTableCalcsSchemaToTableCalcs,
-    CustomMetricBase,
+    CustomMetricBaseTransformed,
     dateFilterSchema,
     DependencyNode,
     detectCircularDependencies,
@@ -53,7 +53,9 @@ import { serializeData } from './serializeData';
 export function validateSelectedFieldsExistence(
     explore: Explore,
     selectedFieldIds: string[],
-    customMetrics?: (CustomMetricBase | Omit<AdditionalMetric, 'sql'>)[] | null,
+    customMetrics?:
+        | (CustomMetricBaseTransformed | Omit<AdditionalMetric, 'sql'>)[]
+        | null,
     tableCalculations?: TableCalcsSchema | TableCalculation[],
 ) {
     const exploreFieldIds = getFields(explore).map(getItemId);
@@ -91,7 +93,7 @@ ${nonExploreFields.join('\n')}
  */
 export function validateCustomMetricsDefinition(
     explore: Explore,
-    customMetrics: CustomMetricBase[] | null,
+    customMetrics: CustomMetricBaseTransformed[] | null,
 ) {
     if (!customMetrics || customMetrics.length === 0) {
         return;
@@ -287,7 +289,7 @@ ${serializeData(filterRule, 'json')}`;
 export function validateFilterRules(
     explore: Explore,
     filterRules: FilterRule[],
-    customMetrics?: CustomMetricBase[] | null,
+    customMetrics?: CustomMetricBaseTransformed[] | null,
     tableCalculations?: TableCalcsSchema | null,
 ) {
     const exploreFields = getFields(explore);
@@ -357,7 +359,7 @@ ${filterRuleErrorStrings}`;
  */
 export function validateMetricDimensionFilterPlacement(
     explore: Explore,
-    customMetrics: CustomMetricBase[] | null,
+    customMetrics: CustomMetricBaseTransformed[] | null,
     tableCalculations: TableCalcsSchema | null,
     filters?: Filters,
 ) {
@@ -538,7 +540,7 @@ export function validateSortFieldsAreSelected(
     sorts: ToolSortField[],
     selectedDimensions: string[],
     selectedMetrics: string[],
-    customMetrics?: CustomMetricBase[] | null,
+    customMetrics?: CustomMetricBaseTransformed[] | null,
     tableCalculations?: TableCalcsSchema,
 ) {
     if (!sorts || sorts.length === 0) {
@@ -590,7 +592,7 @@ export function validateFieldEntityType(
     explore: Explore,
     fieldIds: string[],
     expectedEntityType: 'dimension' | 'metric',
-    customMetrics?: CustomMetricBase[] | null,
+    customMetrics?: CustomMetricBaseTransformed[] | null,
 ) {
     const exploreFields = getFields(explore);
     const customMetricsProvided =
@@ -762,7 +764,7 @@ export function validateTableCalculations(
     tableCalcs: TableCalcsSchema,
     selectedDimensions: string[],
     selectedMetrics: string[],
-    customMetrics: CustomMetricBase[] | null,
+    customMetrics: CustomMetricBaseTransformed[] | null,
 ) {
     if (!tableCalcs?.length) return;
 

--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -1,5 +1,14 @@
+import { v4 as uuid } from 'uuid';
 import { z } from 'zod';
 import { MetricType } from '../../../types/field';
+import { type MetricFilterRule } from '../../../types/filter';
+import { type AdditionalMetric } from '../../../types/metricQuery';
+import {
+    booleanFilterSchema,
+    dateFilterSchema,
+    numberFilterSchema,
+    stringFilterSchema,
+} from './filters';
 
 const extractFieldNameFromFieldId = (
     table: string,
@@ -12,57 +21,120 @@ const extractFieldNameFromFieldId = (
     return baseDimensionName.slice(prefix.length);
 };
 
-export const customMetricBaseSchema = z
-    .object({
-        name: z
-            .string()
-            .describe(
-                'Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")',
-            ),
-        label: z
-            .string()
-            .describe(
-                'Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")',
-            ),
-        description: z
-            .string()
-            .describe(
-                'Brief explanation of what the metric represents, how it is calculated, and why it matters. Example: "Calculates the total revenue by summing all transaction amounts in the sales table."',
-            ),
-        baseDimensionName: z
-            .string()
-            .describe(
-                'Name of the base dimension/column this metric calculates from',
-            ),
-        table: z
-            .string()
-            .describe(
-                'Table name where the base column exists. Match with available dimensions in the explore.',
-            ),
-        type: z
-            .enum([
-                MetricType.AVERAGE,
-                MetricType.COUNT,
-                MetricType.COUNT_DISTINCT,
-                MetricType.MAX,
-                MetricType.MIN,
-                MetricType.SUM,
-                MetricType.PERCENTILE,
-                MetricType.MEDIAN,
-            ])
-            .describe(
-                `Choose based on the user's request. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If the base dimension type is NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If the base dimension type is BOOLEAN, use COUNT_DISTINCT, COUNT.`,
-            ),
-    })
-    .transform((data) => ({
-        ...data,
-        baseDimensionName: extractFieldNameFromFieldId(
-            data.table,
-            data.baseDimensionName,
-        ),
-    }));
+// Convert fieldId (customers_age) to fieldRef (customers.age)
+const fieldIdToFieldRef = (fieldId: string, table: string): string => {
+    const prefix = `${table}_`;
+    if (fieldId.startsWith(prefix)) {
+        return `${table}.${fieldId.slice(prefix.length)}`;
+    }
+    return `${table}.${fieldId}`;
+};
 
+const filterSchema = z.union([
+    booleanFilterSchema,
+    stringFilterSchema,
+    numberFilterSchema,
+    dateFilterSchema,
+]);
+
+const metricFilterRuleSchema = z.object({
+    filter: filterSchema,
+    table: z.string().describe('Table name this filter field belongs to'),
+});
+
+const metricFiltersSchema = z.array(metricFilterRuleSchema).nullable();
+
+const customMetricBaseSchemaV1 = z.object({
+    name: z
+        .string()
+        .describe(
+            'Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")',
+        ),
+    label: z
+        .string()
+        .describe(
+            'Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")',
+        ),
+    description: z
+        .string()
+        .describe(
+            'Brief explanation of what the metric represents, how it is calculated, and why it matters. Example: "Calculates the total revenue by summing all transaction amounts in the sales table."',
+        ),
+    baseDimensionName: z
+        .string()
+        .describe(
+            'Name of the base dimension/column this metric calculates from',
+        ),
+    table: z
+        .string()
+        .describe(
+            'Table name where the base column exists. Match with available dimensions in the explore.',
+        ),
+    type: z
+        .enum([
+            MetricType.AVERAGE,
+            MetricType.COUNT,
+            MetricType.COUNT_DISTINCT,
+            MetricType.MAX,
+            MetricType.MIN,
+            MetricType.SUM,
+            MetricType.PERCENTILE,
+            MetricType.MEDIAN,
+        ])
+        .describe(
+            `Choose based on the user's request. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If the base dimension type is NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If the base dimension type is BOOLEAN, use COUNT_DISTINCT, COUNT.`,
+        ),
+});
+
+export const customMetricBaseSchemaV2 = customMetricBaseSchemaV1.extend({
+    filters: metricFiltersSchema.describe(
+        'Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.',
+    ),
+});
+
+export const customMetricBaseSchema = z.union([
+    customMetricBaseSchemaV2,
+    customMetricBaseSchemaV1,
+]);
+
+// Type after first transform (baseDimensionName extracted, filters still in AI format)
 export type CustomMetricBase = z.infer<typeof customMetricBaseSchema>;
+
+export const customMetricBaseSchemaTransformed = customMetricBaseSchemaV2
+    .extend({
+        filters: metricFiltersSchema.default(null),
+    })
+    .transform(
+        (cm): Omit<AdditionalMetric, 'sql'> => ({
+            ...cm,
+            baseDimensionName: extractFieldNameFromFieldId(
+                cm.table,
+                cm.baseDimensionName,
+            ),
+            filters: cm.filters?.length
+                ? cm.filters.map(
+                      (f): MetricFilterRule => ({
+                          id: uuid(),
+                          target: {
+                              fieldRef: fieldIdToFieldRef(
+                                  f.filter.fieldId,
+                                  f.table,
+                              ),
+                          },
+                          operator: f.filter.operator,
+                          values: 'values' in f.filter ? f.filter.values : [],
+                          ...('settings' in f.filter
+                              ? { settings: f.filter.settings }
+                              : {}),
+                      }),
+                  )
+                : undefined,
+        }),
+    );
+
+export type CustomMetricBaseTransformed = z.infer<
+    typeof customMetricBaseSchemaTransformed
+>;
 
 export const customMetricsSchema = z
     .array(customMetricBaseSchema)
@@ -78,9 +150,21 @@ When using custom metrics:
 3. Reference it anywhere else you use fieldIds (sorts, filters, chartConfig.yAxisMetrics) using the same "table_metricname" format
 4. DO NOT use the raw metric name in metrics, sorts, filters, or chart configuration
 
+To create conditional metrics (e.g., "count of orders where status = 'completed'"):
+1. Set the appropriate aggregation type (COUNT, SUM, etc.)
+2. Add filters array with {filter, table} objects
+3. filter contains: fieldId, fieldType, fieldFilterType, operator, values
+4. Example: {name: "completed_orders", type: "COUNT", baseDimensionName: "order_id", table: "orders",
+   filters: [{table: "orders", filter: {fieldId: "orders_status", fieldType: "STRING", fieldFilterType: "string",
+   operator: "equals", values: ["completed"]}}]}
+
 For example:
 - "Show me average customer age sorted descending" →
 customMetrics: [{name: "avg_customer_age", label: "Average Customer Age", type: "AVERAGE", baseDimensionName: "age", table: "customers"}]
 metrics: ["customers_avg_customer_age"]
 sorts: [{fieldId: "customers_avg_customer_age", descending: true}]`,
     );
+
+export const customMetricsSchemaTransformed = z
+    .array(customMetricBaseSchemaTransformed)
+    .nullable();

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunMetricQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunMetricQueryArgs.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
-import { customMetricsSchema } from '../customMetrics';
+import {
+    customMetricsSchema,
+    customMetricsSchemaTransformed,
+} from '../customMetrics';
 import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
@@ -36,7 +39,9 @@ export const toolRunMetricQueryArgsSchema = createToolSchema({
 export const toolRunMetricQueryArgsSchemaTransformed =
     toolRunMetricQueryArgsSchema.transform((data) => ({
         ...data,
-        customMetrics: customMetricsSchema.parse(data.customMetrics ?? []),
+        customMetrics: customMetricsSchemaTransformed.parse(
+            data.customMetrics ?? [],
+        ),
         filters: filtersSchemaTransformed.parse(data.filters ?? null),
     }));
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
-import { customMetricsSchema } from '../customMetrics';
+import {
+    customMetricsSchema,
+    customMetricsSchemaTransformed,
+} from '../customMetrics';
 import { getFieldIdSchema } from '../fieldId';
 import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
@@ -181,6 +184,7 @@ export const toolRunQueryArgsSchemaTransformed = toolRunQueryArgsSchema
     .transform((data) => ({
         ...data,
         filters: filtersSchemaTransformed.parse(data.filters),
+        customMetrics: customMetricsSchemaTransformed.parse(data.customMetrics),
     }));
 
 export type ToolRunQueryArgsTransformed = z.infer<

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTableVizArgs.ts
@@ -4,7 +4,10 @@ import {
     legacyFollowUpToolsTransform,
 } from '../../followUpTools';
 import { AiResultType } from '../../types';
-import { customMetricsSchema } from '../customMetrics';
+import {
+    customMetricsSchema,
+    customMetricsSchemaTransformed,
+} from '../customMetrics';
 import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
@@ -59,6 +62,7 @@ export const toolTableVizArgsSchemaTransformed = toolTableVizArgsSchema
     })
     .transform((data) => ({
         ...data,
+        customMetrics: customMetricsSchemaTransformed.parse(data.customMetrics),
         followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolTimeSeriesArgs.ts
@@ -4,7 +4,10 @@ import {
     legacyFollowUpToolsTransform,
 } from '../../followUpTools';
 import { AiResultType } from '../../types';
-import { customMetricsSchema } from '../customMetrics';
+import {
+    customMetricsSchema,
+    customMetricsSchemaTransformed,
+} from '../customMetrics';
 import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
@@ -64,6 +67,7 @@ export const toolTimeSeriesArgsSchemaTransformed = toolTimeSeriesArgsSchema
     })
     .transform((data) => ({
         ...data,
+        customMetrics: customMetricsSchemaTransformed.parse(data.customMetrics),
         followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolVerticalBarArgs.ts
@@ -4,7 +4,10 @@ import {
     legacyFollowUpToolsTransform,
 } from '../../followUpTools';
 import { AiResultType } from '../../types';
-import { customMetricsSchema } from '../customMetrics';
+import {
+    customMetricsSchema,
+    customMetricsSchemaTransformed,
+} from '../customMetrics';
 import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
@@ -59,6 +62,7 @@ export const toolVerticalBarArgsSchemaTransformed = toolVerticalBarArgsSchema
     })
     .transform((data) => ({
         ...data,
+        customMetrics: customMetricsSchemaTransformed.parse(data.customMetrics),
         followUpTools: legacyFollowUpToolsTransform(data.followUpTools),
     }));
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/QueryResultToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/QueryResultToolCallDescription.tsx
@@ -1,10 +1,10 @@
-import { type ToolRunQueryArgsTransformed } from '@lightdash/common';
+import { type ToolRunQueryArgs } from '@lightdash/common';
 import { Badge, Group, Text } from '@mantine-8/core';
 import type { FC } from 'react';
 import { formatFieldName } from '../utils/formatFieldName';
 
 type QueryResultToolCallDescriptionProps = Pick<
-    ToolRunQueryArgsTransformed,
+    ToolRunQueryArgs,
     | 'title'
     | 'queryConfig'
     | 'chartConfig'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2683: AI agents cannot create custom metrics with filters](https://linear.app/lightdash/issue/PROD-2683/ai-agents-cannot-create-custom-metrics-with-filters)

### Description:

Added support for conditional metrics in AI tools by enhancing the custom metrics schema. This allows users to create metrics with filters (e.g., "count of orders where status = 'completed'").

The implementation includes:

- Extended the custom metrics schema to support filters
- Added transformation logic to convert AI-formatted filters to the internal MetricFilterRule format
- Updated all tool schemas to use the transformed custom metrics
- Added field reference conversion utilities to properly format filter references
