### PR TITLE
refactor: rename runMiniMetricQuery to runAsyncQuery and remove redundant params

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -136,7 +136,7 @@ import {
     FindFieldFn,
     GetPromptFn,
     ListExploresFn,
-    RunMiniMetricQueryFn,
+    RunAsyncQueryFn,
     SearchFieldValuesFn,
     SendFileFn,
     StoreReasoningFn,
@@ -2641,9 +2641,9 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             return webOrSlackPrompt;
         };
 
-        const runMiniMetricQuery: RunMiniMetricQueryFn = (metricQuery) =>
+        const runAsyncQuery: RunAsyncQueryFn = (metricQuery) =>
             wrapSentryTransaction(
-                'AiAgent.runMiniMetricQuery',
+                'AiAgent.runAsyncQuery',
                 metricQuery,
                 async () => {
                     const agentSettings = await this.getAgentSettings(
@@ -2866,7 +2866,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             findExplores,
             updateProgress,
             getPrompt,
-            runMiniMetricQuery,
+            runAsyncQuery,
             sendFile,
             storeToolCall,
             storeToolResults,
@@ -2941,7 +2941,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             findExplores,
             updateProgress,
             getPrompt,
-            runMiniMetricQuery,
+            runAsyncQuery,
             sendFile,
             storeToolCall,
             storeToolResults,
@@ -2991,7 +2991,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             findContent,
             findFields,
             findExplores,
-            runMiniMetricQuery,
+            runAsyncQuery,
             getPrompt,
             sendFile,
             storeToolCall,

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -72,7 +72,7 @@ import {
     FindContentFn,
     FindExploresFn,
     FindFieldFn,
-    RunMiniMetricQueryFn,
+    RunAsyncQueryFn,
     SearchFieldValuesFn,
 } from '../ai/types/aiAgentDependencies';
 import { AgentContext } from '../ai/utils/AgentContext';
@@ -735,14 +735,14 @@ export class McpService extends BaseService {
                     projectUuid,
                 );
 
-                const { agentContext, runMiniMetricQuery } =
+                const { agentContext, runAsyncQuery } =
                     await this.getRunMetricQueryDependencies(
                         argsWithProject,
                         extra as McpProtocolContext,
                     );
 
                 const runMetricQueryTool = getRunMetricQuery({
-                    runMiniMetricQuery,
+                    runAsyncQuery,
                     maxLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
                 });
 
@@ -1256,7 +1256,7 @@ export class McpService extends BaseService {
         context: McpProtocolContext,
     ): Promise<{
         agentContext: AgentContext;
-        runMiniMetricQuery: RunMiniMetricQueryFn;
+        runAsyncQuery: RunAsyncQueryFn;
     }> {
         const { user, account } = context.authInfo!.extra;
         const { organizationUuid } = user;
@@ -1295,9 +1295,8 @@ export class McpService extends BaseService {
         );
         const agentContext = new AgentContext(explores);
 
-        const runMiniMetricQuery: RunMiniMetricQueryFn = async (
+        const runAsyncQuery: RunAsyncQueryFn = async (
             metricQuery,
-            maxLimit,
             additionalMetrics,
         ) =>
             this.asyncQueryService.executeMetricQueryAndGetResults({
@@ -1310,7 +1309,7 @@ export class McpService extends BaseService {
                 context: QueryExecutionContext.MCP,
             });
 
-        return { agentContext, runMiniMetricQuery };
+        return { agentContext, runAsyncQuery };
     }
 
     async getSearchFieldValuesFunction(

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -90,7 +90,7 @@ const getAgentTools = (
 
     const runQuery = getRunQuery({
         updateProgress: dependencies.updateProgress,
-        runMiniMetricQuery: dependencies.runMiniMetricQuery,
+        runAsyncQuery: dependencies.runAsyncQuery,
         getPrompt: dependencies.getPrompt,
         sendFile: dependencies.sendFile,
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,

--- a/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runMetricQuery.ts
@@ -13,7 +13,7 @@ import { tool } from 'ai';
 import { stringify } from 'csv-stringify/sync';
 import { CsvService } from '../../../../services/CsvService/CsvService';
 import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
-import type { RunMiniMetricQueryFn } from '../types/aiAgentDependencies';
+import type { RunAsyncQueryFn } from '../types/aiAgentDependencies';
 import { AgentContext } from '../utils/AgentContext';
 import { populateCustomMetricsSQL } from '../utils/populateCustomMetricsSQL';
 import { serializeData } from '../utils/serializeData';
@@ -29,12 +29,12 @@ import {
 } from '../utils/validators';
 
 type Dependencies = {
-    runMiniMetricQuery: RunMiniMetricQueryFn;
+    runAsyncQuery: RunAsyncQueryFn;
     maxLimit: number;
 };
 
 export const getRunMetricQuery = ({
-    runMiniMetricQuery,
+    runAsyncQuery,
     maxLimit,
 }: Dependencies) => {
     const validateVizTool = (
@@ -105,9 +105,8 @@ export const getRunMetricQuery = ({
                     ),
                 });
 
-                const results = await runMiniMetricQuery(
+                const results = await runAsyncQuery(
                     query,
-                    maxLimit,
                     populateCustomMetricsSQL(vizTool.customMetrics, explore),
                 );
 

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -17,7 +17,7 @@ import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
 import type {
     CreateOrUpdateArtifactFn,
     GetPromptFn,
-    RunMiniMetricQueryFn,
+    RunAsyncQueryFn,
     SendFileFn,
     UpdateProgressFn,
 } from '../types/aiAgentDependencies';
@@ -43,7 +43,7 @@ import {
 
 type Dependencies = {
     updateProgress: UpdateProgressFn;
-    runMiniMetricQuery: RunMiniMetricQueryFn;
+    runAsyncQuery: RunAsyncQueryFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
@@ -148,7 +148,7 @@ export const validateRunQueryTool = (
 
 export const getRunQuery = ({
     updateProgress,
-    runMiniMetricQuery,
+    runAsyncQuery,
     getPrompt,
     sendFile,
     createOrUpdateArtifact,
@@ -221,9 +221,8 @@ export const getRunQuery = ({
                     ),
                 };
 
-                const queryResults = await runMiniMetricQuery(
+                const queryResults = await runAsyncQuery(
                     metricQuery,
-                    maxLimit,
                     populateCustomMetricsSQL(queryTool.customMetrics, explore),
                 );
 

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -10,7 +10,7 @@ import {
     GetExploreCompilerFn,
     GetPromptFn,
     ListExploresFn,
-    RunMiniMetricQueryFn,
+    RunAsyncQueryFn,
     SearchFieldValuesFn,
     SendFileFn,
     StoreReasoningFn,
@@ -61,7 +61,7 @@ export type AiAgentDependencies = {
     findExplores: FindExploresFn;
     findFields: FindFieldFn;
     getExploreCompiler: GetExploreCompilerFn;
-    runMiniMetricQuery: RunMiniMetricQueryFn;
+    runAsyncQuery: RunAsyncQueryFn;
     getPrompt: GetPromptFn;
     sendFile: SendFileFn;
     updatePrompt: UpdatePromptFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -78,9 +78,8 @@ export type UpdateProgressFn = (progress: string) => Promise<void>;
 
 export type GetPromptFn = () => Promise<SlackPrompt | AiWebAppPrompt>;
 
-export type RunMiniMetricQueryFn = (
+export type RunAsyncQueryFn = (
     metricQuery: AiMetricQueryWithFilters,
-    maxLimit: number,
     additionalMetrics?: AdditionalMetric[],
 ) => Promise<{
     rows: Record<string, AnyType>[];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Renamed `RunMiniMetricQueryFn` to `RunAsyncQueryFn` across the codebase to better reflect its purpose. This change includes:

1. Updating the function type definition in `aiAgentDependencies.ts`
2. Removing the unused `maxLimit` parameter from the function signature
3. Updating all references to this function in various services and tools
4. Updating the Sentry transaction name from 'AiAgent.runMiniMetricQuery' to 'AiAgent.runAsyncQuery'
