### PR TITLE
chore: cleanup project assignment for admin user

### DIFF
--- a/packages/e2e/cypress/e2e/api/roles.cy.ts
+++ b/packages/e2e/cypress/e2e/api/roles.cy.ts
@@ -556,6 +556,16 @@ describe('Roles API Tests', () => {
     });
 
     describe('Project Access Management', () => {
+        afterEach(() => {
+            // Clean up project access for SEED_ORG_1_ADMIN to avoid polluting other tests
+            cy.login();
+            cy.request({
+                url: `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/user/${SEED_ORG_1_ADMIN.user_uuid}`,
+                method: 'DELETE',
+                failOnStatusCode: false,
+            });
+        });
+
         it('should get project access information', () => {
             cy.request({
                 url: `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Added an `afterEach` cleanup hook in the Project Access Management test suite to prevent test pollution. The hook logs in and deletes project access assignments for the SEED_ORG_1_ADMIN user after each test, ensuring that tests don't interfere with each other.

**Steps to reproduce**
1. Run `roles.cy.ts`
2. Run `projectPermissions.cy.ts`

**Before**
<img width="649" height="551" alt="CleanShot 2026-01-26 at 15 57 55" src="https://github.com/user-attachments/assets/af175777-bdbb-4873-ad87-19da98868906" />

**After**
<img width="543" height="93" alt="CleanShot 2026-01-26 at 15 59 14" src="https://github.com/user-attachments/assets/bacb1fa6-5273-4eeb-bf69-9989cb5ec0ec" />


test-backend