### PR TITLE
fix: Force virtualizer to re-measure when data changes

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -329,6 +329,16 @@ const InfiniteResourceTable = ({
         setTableData(flatData);
     }, [flatData]);
 
+    // Force virtualizer to re-measure when data changes, fixing rendering issues
+    // with single items after browser back navigation
+    useEffect(() => {
+        if (tableData.length > 0 && rowVirtualizerInstanceRef.current) {
+            requestAnimationFrame(() => {
+                rowVirtualizerInstanceRef.current?.measure();
+            });
+        }
+    }, [tableData.length]);
+
     const totalResults = useMemo(() => {
         if (!data) return 0;
         // Return total results from the last page, this should be the same but still we want to have the latest value


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19213

### Description:
The `InfiniteResourceTable` component uses mantine-react-table with row virtualization enabled. When the component remounts after browser back navigation, React Query provides cached data immediately via `keepPreviousData: true`. However, the virtualizer fails to properly measure and render rows in this scenario - particularly when there's only a single row.

This appears to be a timing issue where the virtualizer's internal measurements become stale or aren't triggered when the component mounts with pre-existing data. With multiple rows, the virtualizer recovers during its normal render cycle, but with a single row it doesn't.


### Testing:
This issue can be reproduced reliably given 2 conditions:
- Disable Reacts strict mode
- Test with 1 table item. E.g. 1 chart in a space.

#### Before:

https://github.com/user-attachments/assets/4e549655-2b35-4a15-b238-6fa5ab136c97



#### After:


https://github.com/user-attachments/assets/31e3262d-bd60-4e1f-a05f-e88b86aad2b5

