### PR TITLE
feat: support compare to another metric in metric explore modal v2

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -282,6 +282,7 @@ export class CatalogController extends BaseController {
     async getMetricsWithTimeDimensions(
         @Path() projectUuid: string,
         @Request() req: express.Request,
+        @Query() tableName?: string,
     ): Promise<ApiMetricsWithAssociatedTimeDimensionResponse> {
         this.setStatus(200);
 
@@ -291,6 +292,7 @@ export class CatalogController extends BaseController {
                 req.user!,
                 projectUuid,
                 CatalogSearchContext.SPOTLIGHT,
+                tableName,
             );
 
         return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -44795,6 +44795,7 @@ export function RegisterRoutes(app: Router) {
             dataType: 'string',
         },
         req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        tableName: { in: 'query', name: 'tableName', dataType: 'string' },
     };
     app.get(
         '/api/v1/projects/:projectUuid/dataCatalog/metrics-with-time-dimensions',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -37598,6 +37598,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "tableName",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ]
             }

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -1316,6 +1316,7 @@ export class CatalogService<
         user: SessionUser,
         projectUuid: string,
         context: CatalogSearchContext,
+        tableName?: string,
     ): Promise<MetricWithAssociatedTimeDimension[]> {
         const { organizationUuid } = await this.projectModel.getSummary(
             projectUuid,
@@ -1338,6 +1339,7 @@ export class CatalogService<
         const allCatalogMetrics = await this.catalogModel.search({
             projectUuid,
             userAttributes,
+            ...(tableName ? { exploreName: tableName } : {}),
             context,
             catalogSearch: {
                 type: CatalogType.Field,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV1.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV1.tsx
@@ -149,6 +149,7 @@ export const MetricExploreModalV1: FC<Props> = ({
 
     const metricsWithTimeDimensionsQuery = useCatalogMetricsWithTimeDimensions({
         projectUuid,
+        tableName,
         options: {
             enabled:
                 query.comparison === MetricExplorerComparison.DIFFERENT_METRIC,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModalV2.tsx
@@ -191,14 +191,10 @@ export const MetricExploreModalV2: FC<Props> = ({
         filterRule,
         dateRange,
         comparison: query.comparison,
-    });
-
-    const metricsWithTimeDimensionsQuery = useCatalogMetricsWithTimeDimensions({
-        projectUuid,
-        options: {
-            enabled:
-                query.comparison === MetricExplorerComparison.DIFFERENT_METRIC,
-        },
+        compareMetric:
+            query.comparison === MetricExplorerComparison.DIFFERENT_METRIC
+                ? query.metric
+                : null,
     });
 
     const filterDimensionsQuery = useCatalogFilterDimensions({
@@ -214,6 +210,15 @@ export const MetricExploreModalV2: FC<Props> = ({
         tableName,
         options: {
             enabled: !!projectUuid && !!tableName,
+        },
+    });
+
+    const metricsWithTimeDimensionsQuery = useCatalogMetricsWithTimeDimensions({
+        projectUuid,
+        tableName,
+        options: {
+            enabled:
+                query.comparison === MetricExplorerComparison.DIFFERENT_METRIC,
         },
     });
 
@@ -461,8 +466,6 @@ export const MetricExploreModalV2: FC<Props> = ({
                                         metricsWithTimeDimensionsQuery={
                                             metricsWithTimeDimensionsQuery
                                         }
-                                        // TODO: enable this when it's implemented
-                                        canCompareToAnotherMetric={false}
                                     />
                                 </Stack>
                             </Stack>

--- a/packages/frontend/src/features/metricsCatalog/hooks/useCatalogMetricsWithTimeDimensions.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useCatalogMetricsWithTimeDimensions.ts
@@ -4,15 +4,24 @@ import { lightdashApi } from '../../../api';
 
 type GetMetricsWithTimeDimensionArgs = {
     projectUuid?: string;
+    tableName?: string;
 };
 
 const getMetricsWithTimeDimensions = async ({
     projectUuid,
+    tableName,
 }: UseMetricsWithTimeDimensionArgs) => {
+    const params = new URLSearchParams(
+        Object.entries({
+            ...(tableName ? { tableName } : {}),
+        }),
+    );
     return lightdashApi<
         ApiMetricsWithAssociatedTimeDimensionResponse['results']
     >({
-        url: `/projects/${projectUuid}/dataCatalog/metrics-with-time-dimensions`,
+        url: `/projects/${projectUuid}/dataCatalog/metrics-with-time-dimensions${
+            params.toString() ? `?${params.toString()}` : ''
+        }`,
         method: 'GET',
         body: undefined,
     });
@@ -26,11 +35,17 @@ type UseMetricsWithTimeDimensionArgs = GetMetricsWithTimeDimensionArgs & {
 
 export const useCatalogMetricsWithTimeDimensions = ({
     projectUuid,
+    tableName,
     options,
 }: UseMetricsWithTimeDimensionArgs) => {
     return useQuery({
-        queryKey: [projectUuid, 'catalog', 'metricsWithTimeDimensions'],
-        queryFn: () => getMetricsWithTimeDimensions({ projectUuid }),
+        queryKey: [
+            projectUuid,
+            'catalog',
+            'metricsWithTimeDimensions',
+            tableName,
+        ],
+        queryFn: () => getMetricsWithTimeDimensions({ projectUuid, tableName }),
         ...options,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [ZAP-217: Metrics Explorer (mini): Add 'Open in Explorer' and 'Save chart' flows](https://linear.app/lightdash/issue/ZAP-217/metrics-explorer-mini-add-open-in-explorer-and-save-chart-flows)

### Description:

Added the ability to filter metrics by table name in the metrics-with-time-dimensions API endpoint. This enhancement allows the MetricExploreModal to show only metrics from the same table when comparing different metrics.

The implementation:
1. Added an optional `tableName` query parameter to the API endpoint
2. Updated the CatalogService to filter metrics by table name when provided
3. Modified the frontend components to pass the table name when fetching metrics for comparison
4. Enhanced the metric visualization logic to properly handle different metric comparisons

This change improves the user experience when comparing metrics by showing only relevant options from the same table.