### PR TITLE
fix: schedulerUuid not being cleared after delete modal confirm

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerDeleteModal.tsx
@@ -1,5 +1,5 @@
 import { getDefaultZIndex, Loader, Stack, Text } from '@mantine-8/core';
-import { useCallback, useEffect, type FC } from 'react';
+import { useCallback, type FC } from 'react';
 import ErrorState from '../../../components/common/ErrorState';
 import MantineModal, {
     type MantineModalProps,
@@ -22,15 +22,10 @@ export const SchedulerDeleteModal: FC<SchedulerDeleteModalProps> = ({
     const scheduler = useScheduler(schedulerUuid);
     const mutation = useSchedulersDeleteMutation();
 
-    useEffect(() => {
-        if (mutation.isSuccess) {
-            onConfirm();
-        }
-    }, [mutation.isSuccess, onConfirm]);
-
-    const handleConfirm = useCallback(() => {
-        mutation.mutate(schedulerUuid);
-    }, [mutation, schedulerUuid]);
+    const handleConfirm = useCallback(async () => {
+        await mutation.mutateAsync(schedulerUuid);
+        onConfirm();
+    }, [mutation, schedulerUuid, onConfirm]);
 
     return (
         <MantineModal


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Refactored the `SchedulerDeleteModal` component to use async/await pattern with `mutateAsync` instead of relying on `useEffect` to handle successful mutations. This fixes an issue where the callback wasn't being called after the mutation.

**Before**

![CleanShot 2026-01-26 at 18.08.05.gif](https://app.graphite.com/user-attachments/assets/aa102d56-6972-44d6-a2bd-23cc01c40197.gif)

**After**

![CleanShot 2026-01-26 at 18.06.57.gif](https://app.graphite.com/user-attachments/assets/63f3a7dd-8442-4b06-bb71-fe39e831dc2f.gif)

