### PR TITLE
feat: configure help menu icon behavior

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
             - TURBO_TEAM=${TURBO_TEAM}
             - TURBO_API=${TURBO_API}
             - SIGNUP_URL=${SIGNUP_URL}
+            - HELP_MENU_URL=${HELP_MENU_URL}
         volumes:
             - '${DBT_PROJECT_DIR}:/usr/app/dbt'
         ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -97,6 +97,7 @@ x-lightdash-environment: &lightdash-environment
     TURBO_TEAM: ${TURBO_TEAM}
     TURBO_API: ${TURBO_API}
     SIGNUP_URL: ${SIGNUP_URL}
+    HELP_MENU_URL: ${HELP_MENU_URL}
 
 x-lightdash-base: &lightdash-base
     build: *lightdash-build

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -183,6 +183,7 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     staticIp: '',
     signupUrl: undefined,
+    helpMenuUrl: undefined,
     trustProxy: false,
     mode: LightdashMode.DEFAULT,
     license: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -794,6 +794,7 @@ export type LightdashConfig = {
     siteUrl: string;
     staticIp: string;
     signupUrl: string | undefined;
+    helpMenuUrl: string | undefined;
     lightdashCloudInstance: string | undefined;
     k8s: {
         nodeName: string | undefined;
@@ -1511,6 +1512,7 @@ export const parseConfig = (): LightdashConfig => {
             enabled: process.env.HEADWAY_ENABLED !== 'false',
         },
         siteUrl,
+        helpMenuUrl: process.env.HELP_MENU_URL,
         staticIp: process.env.STATIC_IP || '',
         signupUrl: process.env.SIGNUP_URL,
         lightdashCloudInstance: process.env.LIGHTDASH_CLOUD_INSTANCE,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -15,6 +15,7 @@ export const BaseResponse: HealthState = {
     siteUrl: 'https://test.lightdash.cloud',
     staticIp: '',
     signupUrl: undefined,
+    helpMenuUrl: undefined,
     hasEmailClient: false,
     hasExtendedUsageAnalytics: false,
     hasMicrosoftTeams: false,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -114,6 +114,7 @@ export class HealthService extends BaseService {
             siteUrl: this.lightdashConfig.siteUrl,
             staticIp: this.lightdashConfig.staticIp,
             signupUrl: this.lightdashConfig.signupUrl,
+            helpMenuUrl: this.lightdashConfig.helpMenuUrl,
             posthog: this.lightdashConfig.posthog,
             query: {
                 csvCellsLimit: this.lightdashConfig.query.csvCellsLimit,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -386,6 +386,7 @@ export type HealthState = {
     };
     staticIp: string;
     signupUrl: string | undefined;
+    helpMenuUrl: string | undefined;
     query: {
         maxLimit: number;
         defaultLimit: number;

--- a/packages/frontend/src/components/NavBar/HelpMenu.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu.tsx
@@ -23,6 +23,25 @@ const HelpMenu: FC = () => {
 
     const { show: showIntercom } = useIntercom();
 
+    const helpMenuUrl = health.data?.helpMenuUrl;
+
+    // If helpMenuUrl is set, render a button that opens the URL in a new tab
+    if (helpMenuUrl) {
+        return (
+            <Button
+                aria-label="Help"
+                variant="default"
+                size="xs"
+                component="a"
+                href={helpMenuUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                <MantineIcon icon={IconHelp} />
+            </Button>
+        );
+    }
+
     return (
         <Menu
             withArrow

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -39,6 +39,7 @@ export default function mockHealthResponse(
         siteUrl: 'http://localhost:3000',
         staticIp: '',
         signupUrl: undefined,
+        helpMenuUrl: undefined,
         posthog: undefined,
         query: {
             maxPageSize: 2500,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/19298

### Description:
Allows bypass of the default Help drop down menu, and instead open the configured URL.
<img width="89" height="49" alt="image" src="https://github.com/user-attachments/assets/49578b4d-dae5-47bd-b9d7-b12d4f49fa9a" />

Similar to https://github.com/lightdash/lightdash/pull/19602, allow navigation to internal documentation instead of the default Help options.