### PR TITLE
fix: use fallback logic for empty string timezone

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -698,9 +698,9 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                     <Text fz="xs" c="ldGray.6">
                         {getHumanReadableCronExpression(
                             item.cron,
-                            item.timezone ??
-                                item.projectSchedulerTimezone ??
-                                project?.schedulerTimezone ??
+                            item.timezone ||
+                                item.projectSchedulerTimezone ||
+                                project?.schedulerTimezone ||
                                 'UTC',
                         )}
                     </Text>


### PR DESCRIPTION
### Description:
Just noticed on our analytics instance that we're crashing due to timezone empty string values. This was recently introduced by me, as I didn't consider that we could have empty string as a value, as the column in the db is nullable.

<img width="2551" height="1649" alt="Screenshot 2026-01-27 at 10 03 10" src="https://github.com/user-attachments/assets/997a1c69-23fc-4438-b5c9-ec67789c0164" />