### PR TITLE
fix: column limit calculation to match legacy pivoting

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -162,7 +162,7 @@ describe('PivotQueryBuilder', () => {
 
             // Should apply limits and column constraints
             expect(result).toContain('WHERE "row_index" <= 100');
-            expect(result).toContain('"column_index" <= 99');
+            expect(result).toContain('"column_index" <= 100');
 
             // Should join with total_columns for metadata
             expect(result).toContain('CROSS JOIN total_columns t');
@@ -228,7 +228,7 @@ describe('PivotQueryBuilder', () => {
 
             const result = builder.toSql({ columnLimit: 100 });
 
-            // With 3 value columns: (100-1)/3 = 33 max columns per value column
+            // With 3 value columns: 100/3 = 33 max columns per value column
             expect(result).toContain('"column_index" <= 33');
         });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -134,17 +134,14 @@ export class PivotQueryBuilder {
      * Calculates the maximum number of columns allowed per value column.
      * @param valuesColumns - The value columns configuration
      * @param columnLimit - Maximum total columns allowed
-     * @param indexColumnsCount - Number of index columns (can be multiple)
      * @returns Maximum columns per value to stay within pivot column limits
      */
     private static calculateMaxColumnsPerValueColumn(
         valuesColumns: PivotConfiguration['valuesColumns'],
         columnLimit: number,
-        indexColumnsCount: number,
     ): number {
         const valueColumnsCount = valuesColumns?.length || 1;
-        const remainingColumns = columnLimit - indexColumnsCount; // Account for all index columns
-        return Math.floor(remainingColumns / valueColumnsCount);
+        return Math.floor(columnLimit / valueColumnsCount);
     }
 
     /**
@@ -890,7 +887,6 @@ export class PivotQueryBuilder {
                 PivotQueryBuilder.calculateMaxColumnsPerValueColumn(
                     valuesColumns,
                     columnLimit,
-                    indexColumns.length,
                 );
 
             // Keep leading space to avoid SQL syntax errors


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/PROD-2634/pivot-table-column-limit-documentation-and-behavior-needs

## Summary

- Fixed pivot column limit calculation in backend SQL pivoting to match the legacy frontend pivoting behavior
- Previously, the backend was subtracting index columns from the column limit before calculating max pivot columns, causing fewer columns to be shown when adding index dimensions

## Problem

When using backend SQL pivoting (with the `UseSqlPivotResults` feature flag), adding index dimensions to a pivot table would result in missing columns/groups compared to the legacy frontend pivoting.

**Root cause:** The backend calculation in `PivotQueryBuilder.calculateMaxColumnsPerValueColumn()` was subtracting `indexColumnsCount` from `columnLimit` before dividing by value columns count:

```typescript
// Before (backend)
const remainingColumns = columnLimit - indexColumnsCount;
return Math.floor(remainingColumns / valueColumnsCount);

While the frontend in `pivotQueryResults.ts` counts only pivot columns against the limit, not index columns:

// Frontend - columnCount is only pivot columns
if (columnCount > options.maxColumns) {
    throw new Error(`Cannot pivot results with more than ${options.maxColumns} columns...`);
}

Example with maxColumnLimit = 100, 1 metric, 50 pivot values:
| Index Columns | Frontend Max Pivot Cols | Backend Max Pivot Cols (before fix) |
|---------------|-------------------------|-------------------------------------|
| 0             | 100                     | 100                                 |
| 2             | 100                     | 98                                  |
| 5             | 100                     | 95                                  |