### PR TITLE
feat: add service account support for MCP service

### DIFF
--- a/examples/api/mcp.http
+++ b/examples/api/mcp.http
@@ -14,6 +14,8 @@ GET http://localhost:8080/api/v1/logout
 POST http://localhost:3000/api/v1/mcp
 Content-Type: application/json
 Accept: application/json, text/event-stream
+#Authorization: Bearer ldsvc_21848ce9572ed4cdca1f15841c6a82b2
+Authorization: ApiKey ldpat_f55936ebb63b5cb70e83ac6c18621514
 
 {
     "jsonrpc": "2.0",
@@ -27,7 +29,8 @@ Accept: application/json, text/event-stream
 POST http://localhost:3000/api/v1/mcp
 Content-Type: application/json
 Accept: application/json, text/event-stream
-Authorization: ApiKey ldpat_ff90d7cb9e1f374e2fd8b3678128c6bf
+Authorization: Bearer ldsvc_21848ce9572ed4cdca1f15841c6a82b2
+#Authorization: ApiKey ldpat_f55936ebb63b5cb70e83ac6c18621514
 
 
 {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -16,6 +16,7 @@ import {
     OauthAccount,
     ParameterError,
     QueryExecutionContext,
+    ServiceAcctAccount,
     SessionUser,
     ToolFindContentArgs,
     toolFindContentArgsSchema,
@@ -105,7 +106,7 @@ type McpServiceArguments = {
 
 export type ExtraContext = {
     user: SessionUser;
-    account: OauthAccount | ApiKeyAccount;
+    account: OauthAccount | ApiKeyAccount | ServiceAcctAccount;
     /** User attribute overrides passed via X-Lightdash-User-Attributes header */
     headerUserAttributes?: UserAttributeValueMap;
 };

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -12,6 +12,7 @@ import {
     LightdashError,
     MissingConfigError,
     OauthAccount,
+    ServiceAcctAccount,
     UserAttributeValueMap,
 } from '@lightdash/common';
 import {
@@ -182,6 +183,22 @@ mcpRouter.all(
                     authReq.auth = {
                         token: apiKeyAuth.authentication.source,
                         clientId: 'API key', // hardcoded client and scopes for PAT authentication
+                        scopes: ['mcp:read', 'mcp:write'],
+                        extra,
+                    };
+                }
+
+                if (req.user && req.account?.isServiceAccount()) {
+                    const serviceAccountAuth =
+                        req.account as ServiceAcctAccount;
+                    const extra: ExtraContext = {
+                        user: req.user,
+                        account: serviceAccountAuth,
+                        headerUserAttributes,
+                    };
+                    authReq.auth = {
+                        token: serviceAccountAuth.authentication.source,
+                        clientId: 'Service account', // hardcoded client and scopes for Service Account authentication
                         scopes: ['mcp:read', 'mcp:write'],
                         extra,
                     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

<img width="1075" height="369" alt="image" src="https://github.com/user-attachments/assets/f6cdaf31-6098-4a30-8a38-f3c5e6ffae31" />


### Description:
Add support for service account authentication in MCP (Model Control Plane) service. This PR extends the authentication types to include `ServiceAcctAccount` alongside existing `OauthAccount` and `ApiKeyAccount` types, allowing service accounts to properly authenticate with the MCP router.