### PR TITLE
fix: force category axis for vertical bar charts with numeric data

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -239,10 +239,21 @@ const getAxisType = ({
     };
 
     const topAxisType = inferAxisType(topAxisXId, true);
-    const bottomAxisType =
+
+    // Vertical bar chart needs the type 'category' in the bottom X axis when using numeric data
+    // Without this, bars are positioned at exact numeric values causing overlap with Y-axis
+    const defaultBottomAxisType =
         bottomAxisXId === EMPTY_X_AXIS
             ? 'category'
             : inferAxisType(bottomAxisXId, true);
+    const bottomAxisType =
+        !validCartesianConfig.layout.flipAxes &&
+        defaultBottomAxisType === 'value' &&
+        validCartesianConfig.eChartsConfig.series?.some(
+            (serie) => serie.type === CartesianSeriesType.BAR,
+        )
+            ? 'category'
+            : defaultBottomAxisType;
 
     // horizontal bar chart needs the type 'category' in the left/right axis
     const defaultRightAxisType = inferAxisType(rightAxisYId, false);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2733: Numeric custom dimension on X-axis causes bar overlap and uneven padding](https://linear.app/lightdash/issue/PROD-2733/numeric-custom-dimension-on-x-axis-causes-bar-overlap-and-uneven)

### Description:
Fix vertical bar chart positioning with numeric data by enforcing 'category' type for bottom X-axis. This prevents bars from overlapping with the Y-axis when using numeric values, similar to how horizontal bar charts already handle the left/right axis.